### PR TITLE
Query for app module id and use as registration id

### DIFF
--- a/packages/app/src/cli/api/graphql/app-management/generated/active-app-release-from-api-key.ts
+++ b/packages/app/src/cli/api/graphql/app-management/generated/active-app-release-from-api-key.ts
@@ -19,6 +19,7 @@ export type ActiveAppReleaseFromApiKeyQuery = {
       version: {
         name: string
         appModules: {
+          id: number
           uuid: string
           userIdentifier: string
           handle: string
@@ -77,6 +78,7 @@ export const ActiveAppReleaseFromApiKey = {
       selectionSet: {
         kind: 'SelectionSet',
         selections: [
+          {kind: 'Field', name: {kind: 'Name', value: 'id'}},
           {kind: 'Field', name: {kind: 'Name', value: 'uuid'}},
           {kind: 'Field', name: {kind: 'Name', value: 'userIdentifier'}},
           {kind: 'Field', name: {kind: 'Name', value: 'handle'}},

--- a/packages/app/src/cli/api/graphql/app-management/generated/active-app-release.ts
+++ b/packages/app/src/cli/api/graphql/app-management/generated/active-app-release.ts
@@ -19,6 +19,7 @@ export type ActiveAppReleaseQuery = {
       version: {
         name: string
         appModules: {
+          id: number
           uuid: string
           userIdentifier: string
           handle: string
@@ -41,6 +42,7 @@ export type AppVersionInfoFragment = {
     version: {
       name: string
       appModules: {
+        id: number
         uuid: string
         userIdentifier: string
         handle: string
@@ -53,6 +55,7 @@ export type AppVersionInfoFragment = {
 }
 
 export type ReleasedAppModuleFragment = {
+  id: number
   uuid: string
   userIdentifier: string
   handle: string
@@ -71,6 +74,7 @@ export const ReleasedAppModuleFragmentDoc = {
       selectionSet: {
         kind: 'SelectionSet',
         selections: [
+          {kind: 'Field', name: {kind: 'Name', value: 'id'}},
           {kind: 'Field', name: {kind: 'Name', value: 'uuid'}},
           {kind: 'Field', name: {kind: 'Name', value: 'userIdentifier'}},
           {kind: 'Field', name: {kind: 'Name', value: 'handle'}},
@@ -171,6 +175,7 @@ export const AppVersionInfoFragmentDoc = {
       selectionSet: {
         kind: 'SelectionSet',
         selections: [
+          {kind: 'Field', name: {kind: 'Name', value: 'id'}},
           {kind: 'Field', name: {kind: 'Name', value: 'uuid'}},
           {kind: 'Field', name: {kind: 'Name', value: 'userIdentifier'}},
           {kind: 'Field', name: {kind: 'Name', value: 'handle'}},
@@ -239,6 +244,7 @@ export const ActiveAppRelease = {
       selectionSet: {
         kind: 'SelectionSet',
         selections: [
+          {kind: 'Field', name: {kind: 'Name', value: 'id'}},
           {kind: 'Field', name: {kind: 'Name', value: 'uuid'}},
           {kind: 'Field', name: {kind: 'Name', value: 'userIdentifier'}},
           {kind: 'Field', name: {kind: 'Name', value: 'handle'}},

--- a/packages/app/src/cli/api/graphql/app-management/generated/app-version-by-id.ts
+++ b/packages/app/src/cli/api/graphql/app-management/generated/app-version-by-id.ts
@@ -13,6 +13,7 @@ export type AppVersionByIdQuery = {
     id: string
     metadata: {message?: string | null; versionTag?: string | null}
     appModules: {
+      id: number
       uuid: string
       userIdentifier: string
       handle: string
@@ -27,6 +28,7 @@ export type VersionInfoFragment = {
   id: string
   metadata: {message?: string | null; versionTag?: string | null}
   appModules: {
+    id: number
     uuid: string
     userIdentifier: string
     handle: string
@@ -76,6 +78,7 @@ export const VersionInfoFragmentDoc = {
       selectionSet: {
         kind: 'SelectionSet',
         selections: [
+          {kind: 'Field', name: {kind: 'Name', value: 'id'}},
           {kind: 'Field', name: {kind: 'Name', value: 'uuid'}},
           {kind: 'Field', name: {kind: 'Name', value: 'userIdentifier'}},
           {kind: 'Field', name: {kind: 'Name', value: 'handle'}},
@@ -144,6 +147,7 @@ export const AppVersionById = {
       selectionSet: {
         kind: 'SelectionSet',
         selections: [
+          {kind: 'Field', name: {kind: 'Name', value: 'id'}},
           {kind: 'Field', name: {kind: 'Name', value: 'uuid'}},
           {kind: 'Field', name: {kind: 'Name', value: 'userIdentifier'}},
           {kind: 'Field', name: {kind: 'Name', value: 'handle'}},

--- a/packages/app/src/cli/api/graphql/app-management/generated/app-version-by-tag.ts
+++ b/packages/app/src/cli/api/graphql/app-management/generated/app-version-by-tag.ts
@@ -13,6 +13,7 @@ export type AppVersionByTagQuery = {
     id: string
     metadata: {message?: string | null; versionTag?: string | null}
     appModules: {
+      id: number
       uuid: string
       userIdentifier: string
       handle: string
@@ -68,6 +69,7 @@ export const AppVersionByTag = {
       selectionSet: {
         kind: 'SelectionSet',
         selections: [
+          {kind: 'Field', name: {kind: 'Name', value: 'id'}},
           {kind: 'Field', name: {kind: 'Name', value: 'uuid'}},
           {kind: 'Field', name: {kind: 'Name', value: 'userIdentifier'}},
           {kind: 'Field', name: {kind: 'Name', value: 'handle'}},

--- a/packages/app/src/cli/api/graphql/app-management/generated/create-app-version.ts
+++ b/packages/app/src/cli/api/graphql/app-management/generated/create-app-version.ts
@@ -15,6 +15,7 @@ export type CreateAppVersionMutation = {
     version?: {
       id: string
       appModules: {
+        id: number
         uuid: string
         userIdentifier: string
         handle: string
@@ -147,6 +148,7 @@ export const CreateAppVersion = {
       selectionSet: {
         kind: 'SelectionSet',
         selections: [
+          {kind: 'Field', name: {kind: 'Name', value: 'id'}},
           {kind: 'Field', name: {kind: 'Name', value: 'uuid'}},
           {kind: 'Field', name: {kind: 'Name', value: 'userIdentifier'}},
           {kind: 'Field', name: {kind: 'Name', value: 'handle'}},

--- a/packages/app/src/cli/api/graphql/app-management/queries/active-app-release.graphql
+++ b/packages/app/src/cli/api/graphql/app-management/queries/active-app-release.graphql
@@ -27,6 +27,7 @@ fragment AppVersionInfo on App {
 }
 
 fragment ReleasedAppModule on AppModule {
+  id
   uuid
   userIdentifier
   handle

--- a/packages/app/src/cli/utilities/developer-platform-client/app-management-client.test.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/app-management-client.test.ts
@@ -78,6 +78,7 @@ const templateDisallowedByBetaFlag: GatedExtensionTemplate = {
 
 function moduleFromExtension(extension: ExtensionInstance) {
   return {
+    id: 1,
     uuid: extension.uid,
     userIdentifier: extension.uid,
     handle: extension.handle,

--- a/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
@@ -1334,7 +1334,7 @@ function mapBusinessPlatformStoresToOrganizationStores(
 
 function appModuleVersion(mod: ReleasedAppModuleFragment): Required<AppModuleVersion> {
   return {
-    registrationId: mod.userIdentifier,
+    registrationId: mod.id.toString(),
     registrationUuid: mod.uuid,
     registrationTitle: mod.handle,
     type: mod.specification.externalIdentifier,


### PR DESCRIPTION
### WHY are these changes introduced?

To ensure consistent identification of app modules across the system by including the numeric `id` field in GraphQL queries.

### WHAT is this pull request doing?

- Adds the `id` field to app module queries in GraphQL schema definitions
- Updates the app module registration logic to use the numeric `id` instead of `uuid` for registration identification
- Fixes a bug where `registration.id` was incorrectly used instead of `registration.uuid` when checking for configuration extensions

### How to test your changes?

1. Run app-related commands that fetch app modules from the API
2. Verify that app modules are correctly identified and registered
3. Confirm that configuration extensions are properly categorized

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes