### PR TITLE
Prevent `shopify app dev` sessions from opening multiple tabs in the browser during re-authentication

### DIFF
--- a/.changeset/slow-emus-reply.md
+++ b/.changeset/slow-emus-reply.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Prevent `shopify app dev` sessions from opening multiple tabs in the browser during re-authentication

--- a/packages/cli-kit/src/public/node/session.ts
+++ b/packages/cli-kit/src/public/node/session.ts
@@ -181,6 +181,7 @@ ${outputToken.json(scopes)}
  * @param password - Password generated from Theme Access app.
  * @param scopes - Optional array of extra scopes to authenticate with.
  * @param forceRefresh - Optional flag to force a refresh of the token.
+ * @param options - Optional extra options to use.
  * @returns The access token and store.
  */
 export async function ensureAuthenticatedThemes(
@@ -188,6 +189,7 @@ export async function ensureAuthenticatedThemes(
   password: string | undefined,
   scopes: AdminAPIScope[] = [],
   forceRefresh = false,
+  options: EnsureAuthenticatedAdditionalOptions = {},
 ): Promise<AdminSession> {
   outputDebug(outputContent`Ensuring that the user is authenticated with the Theme API with the following scopes:
 ${outputToken.json(scopes)}
@@ -199,7 +201,7 @@ ${outputToken.json(scopes)}
     setLastSeenUserIdAfterAuth(nonRandomUUID(password))
     return session
   }
-  return ensureAuthenticatedAdmin(store, scopes, forceRefresh)
+  return ensureAuthenticatedAdmin(store, scopes, forceRefresh, options)
 }
 
 /**

--- a/packages/theme/src/cli/utilities/theme-environment/dev-server-session.test.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/dev-server-session.test.ts
@@ -2,11 +2,12 @@ import {
   abortOnMissingRequiredFile,
   getStorefrontSessionCookiesWithVerification,
   initializeDevServerSession,
+  fetchDevServerSession,
 } from './dev-server-session.js'
 import {getStorefrontSessionCookies, ShopifyEssentialError} from './storefront-session.js'
 import {ensureAuthenticatedStorefront, ensureAuthenticatedThemes} from '@shopify/cli-kit/node/session'
 import {fetchThemeAssets, themeDelete} from '@shopify/cli-kit/node/themes/api'
-import {describe, expect, test, vi, beforeEach} from 'vitest'
+import {describe, expect, test, vi, beforeEach, afterEach} from 'vitest'
 import {AbortError} from '@shopify/cli-kit/node/error'
 import {outputContent, outputToken} from '@shopify/cli-kit/node/output'
 
@@ -86,7 +87,40 @@ describe('verifyRequiredFilesExist', () => {
 })
 
 describe('dev server session', async () => {
+  describe('fetchDevServerSession', async () => {
+    test('calls ensureAuthenticatedThemes with noPrompt: true', async () => {
+      // Given
+      vi.mocked(ensureAuthenticatedStorefront).mockResolvedValue('storefront_token')
+      vi.mocked(getStorefrontSessionCookies).mockResolvedValue({
+        _shopify_essential: ':AABBCCDDEEFFGGHH==123:',
+        storefront_digest: 'digest_value',
+      })
+      vi.mocked(ensureAuthenticatedThemes).mockResolvedValue({
+        token: 'token_1',
+        storeFqdn,
+      })
+
+      // When
+      await fetchDevServerSession(themeId, adminSession, 'admin-password')
+
+      // Then
+      expect(ensureAuthenticatedThemes).toHaveBeenCalledWith(storeFqdn, 'admin-password', [], false, {noPrompt: true})
+    })
+  })
+
   describe('initializeDevServerSession', async () => {
+    let setIntervalSpy: any
+
+    beforeEach(() => {
+      vi.useFakeTimers()
+      setIntervalSpy = vi.spyOn(global, 'setInterval')
+    })
+
+    afterEach(() => {
+      vi.useRealTimers()
+      setIntervalSpy.mockRestore()
+    })
+
     test('returns a session', async () => {
       // Given
       vi.mocked(ensureAuthenticatedStorefront).mockResolvedValue('storefront_token')
@@ -115,6 +149,26 @@ describe('dev server session', async () => {
           token: 'token_1',
         }),
       )
+    })
+
+    test('sets up auto-refresh with 5 second interval', async () => {
+      // Given
+      vi.mocked(ensureAuthenticatedStorefront).mockResolvedValue('storefront_token')
+      vi.mocked(getStorefrontSessionCookies).mockResolvedValue({
+        _shopify_essential: ':AABBCCDDEEFFGGHH==123:',
+        storefront_digest: 'digest_value',
+      })
+      vi.mocked(ensureAuthenticatedThemes).mockResolvedValue({
+        token: 'token_1',
+        storeFqdn,
+      })
+
+      // When
+      const session = await initializeDevServerSession(themeId, adminSession)
+
+      // Then
+      expect(setIntervalSpy).toHaveBeenCalledWith(expect.any(Function), 5000)
+      expect(session.refresh).toBeDefined()
     })
 
     test('returns a refreshable session', async () => {

--- a/packages/theme/src/cli/utilities/theme-environment/dev-server-session.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/dev-server-session.ts
@@ -66,7 +66,7 @@ export async function fetchDevServerSession(
 ): Promise<DevServerSession> {
   const baseUrl = buildBaseStorefrontUrl(adminSession)
 
-  const session = await ensureAuthenticatedThemes(adminSession.storeFqdn, adminPassword, [])
+  const session = await ensureAuthenticatedThemes(adminSession.storeFqdn, adminPassword, [], false, {noPrompt: true})
   const storefrontToken = await ensureAuthenticatedStorefront([], adminPassword)
   const sessionCookies = await getStorefrontSessionCookiesWithVerification(
     baseUrl,


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes: https://community.shopify.dev/t/returning-to-shopify-app-dev-session-creates-a-dozen-browser-tabs/19620

This PR prevents `shopify app dev` sessions from opening multiple tabs in the browser during re-authentication.

### WHAT is this pull request doing?

This PR updates the `ensureAuthenticatedThemes` API to support a `noPrompt` mode. We use this new mode during session refreshes.

While it's debatable whether refreshing the (Admin) session every 30 minutes is necessary, theme app extensions and themes need to keep a session alive across multiple services (Storefront), each with different timeout settings and dependencies. So, we're refreshing all at once for consistency.

### How to test your changes?

- Run `app dev` for some hours and notice that multiple tab no longer open

### Post-release steps

N/A

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
