### PR TITLE
Remove git dir after initializing new theme

### DIFF
--- a/.changeset/hip-pots-allow.md
+++ b/.changeset/hip-pots-allow.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Remove .git dir after initializing new theme

--- a/packages/theme/src/cli/services/init.test.ts
+++ b/packages/theme/src/cli/services/init.test.ts
@@ -95,7 +95,7 @@ describe('cloneRepo()', async () => {
     expect(removeGitRemote).toHaveBeenCalledWith(destination)
   })
 
-  test('removes .github directory from skeleton theme after cloning when it exists', async () => {
+  test('removes .github & .git directories from skeleton theme after cloning when it exists', async () => {
     // Given
     const repoUrl = 'https://github.com/Shopify/skeleton-theme.git'
     const destination = 'destination'
@@ -107,6 +107,8 @@ describe('cloneRepo()', async () => {
     // Then
     expect(fileExists).toHaveBeenCalledWith('destination/.github')
     expect(rmdir).toHaveBeenCalledWith('destination/.github')
+    expect(fileExists).toHaveBeenCalledWith('destination/.git')
+    expect(rmdir).toHaveBeenCalledWith('destination/.git')
   })
 })
 

--- a/packages/theme/src/cli/services/init.ts
+++ b/packages/theme/src/cli/services/init.ts
@@ -24,17 +24,16 @@ async function downloadRepository(repoUrl: string, destination: string, latestTa
           shallow: true,
         })
         await removeGitRemote(destination)
-        await removeSkeletonGitHubFolder(destination)
+        await removeDirectory(joinPath(destination, '.github'))
+        await removeDirectory(joinPath(destination, '.git'))
       },
     },
   ])
 }
 
-async function removeSkeletonGitHubFolder(destination: string) {
-  const githubDir = joinPath(destination, '.github')
-
-  if (await fileExists(githubDir)) {
-    await rmdir(githubDir)
+async function removeDirectory(path: string) {
+  if (await fileExists(path)) {
+    await rmdir(path)
   }
 }
 


### PR DESCRIPTION
### WHY are these changes introduced?

- Deleting `.git` dir after a new theme is created from `shopify theme init`

### WHAT is this pull request doing?

- removing `git` dir same as we do with `github` dir

### How to test your changes?

- `shopify theme init`
- `cd <theme>`
- `ls -la`
  - ensure `.git` and `.github` directories dont exist

### Post-release steps

n/a

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
