### PR TITLE
Update migration mutations to accept registration id or registration uuid based on which client we are using

### DIFF
--- a/packages/app/src/cli/api/graphql/extension_migrate_app_module.ts
+++ b/packages/app/src/cli/api/graphql/extension_migrate_app_module.ts
@@ -1,8 +1,11 @@
 import {gql} from 'graphql-request'
 
+// eslint-disable-next-line @shopify/cli/no-inline-graphql
 export const MigrateAppModuleMutation = gql`
-  mutation MigrateAppModule($apiKey: String!, $registrationId: ID!, $type: String!) {
-    migrateAppModule(input: {apiKey: $apiKey, registrationId: $registrationId, type: $type}) {
+  mutation MigrateAppModule($apiKey: String!, $registrationId: ID, $registrationUuid: String, $type: String!) {
+    migrateAppModule(
+      input: {apiKey: $apiKey, registrationId: $registrationId, registrationUuid: $registrationUuid, type: $type}
+    ) {
       migratedAppModule
       userErrors {
         field
@@ -14,7 +17,8 @@ export const MigrateAppModuleMutation = gql`
 
 export interface MigrateAppModuleVariables {
   apiKey: string
-  registrationId: string
+  registrationId?: string
+  registrationUuid?: string
   type: string
 }
 

--- a/packages/app/src/cli/api/graphql/extension_migrate_flow_extension.ts
+++ b/packages/app/src/cli/api/graphql/extension_migrate_flow_extension.ts
@@ -1,8 +1,11 @@
 import {gql} from 'graphql-request'
 
+// eslint-disable-next-line @shopify/cli/no-inline-graphql
 export const MigrateFlowExtensionMutation = gql`
-  mutation MigrateFlowExtension($apiKey: String!, $registrationId: ID!) {
-    migrateFlowExtension(input: {apiKey: $apiKey, registrationId: $registrationId}) {
+  mutation MigrateFlowExtension($apiKey: String!, $registrationId: ID, $registrationUuid: String) {
+    migrateFlowExtension(
+      input: {apiKey: $apiKey, registrationId: $registrationId, registrationUuid: $registrationUuid}
+    ) {
       migratedFlowExtension
       userErrors {
         field
@@ -14,7 +17,8 @@ export const MigrateFlowExtensionMutation = gql`
 
 export interface MigrateFlowExtensionVariables {
   apiKey: string
-  registrationId: string
+  registrationId?: string
+  registrationUuid?: string
 }
 
 export interface MigrateFlowExtensionSchema {

--- a/packages/app/src/cli/api/graphql/extension_migrate_to_ui_extension.ts
+++ b/packages/app/src/cli/api/graphql/extension_migrate_to_ui_extension.ts
@@ -1,8 +1,11 @@
 import {gql} from 'graphql-request'
 
+// eslint-disable-next-line @shopify/cli/no-inline-graphql
 export const MigrateToUiExtensionQuery = gql`
-  mutation MigrateToUiExtension($apiKey: String!, $registrationId: ID!) {
-    migrateToUiExtension(input: {apiKey: $apiKey, registrationId: $registrationId}) {
+  mutation MigrateToUiExtension($apiKey: String!, $registrationId: ID, $registrationUuid: String) {
+    migrateToUiExtension(
+      input: {apiKey: $apiKey, registrationId: $registrationId, registrationUuid: $registrationUuid}
+    ) {
       migratedToUiExtension
       userErrors {
         field
@@ -14,7 +17,8 @@ export const MigrateToUiExtensionQuery = gql`
 
 export interface MigrateToUiExtensionVariables {
   apiKey: string
-  registrationId: string
+  registrationId?: string
+  registrationUuid?: string
 }
 
 export interface MigrateToUiExtensionSchema {

--- a/packages/app/src/cli/services/context/identifiers-extensions.test.ts
+++ b/packages/app/src/cli/services/context/identifiers-extensions.test.ts
@@ -885,12 +885,12 @@ describe('ensureExtensionsIds: Migrates extension', () => {
       },
     })
 
-    expect(migrateExtensionsToUIExtension).toBeCalledWith(
+    expect(migrateExtensionsToUIExtension).toBeCalledWith({
       extensionsToMigrate,
-      opts.appId,
+      appId: opts.appId,
       remoteExtensions,
-      expect.any(PartnersClient),
-    )
+      migrationClient: expect.any(PartnersClient),
+    })
   })
 })
 

--- a/packages/app/src/cli/services/context/identifiers-extensions.ts
+++ b/packages/app/src/cli/services/context/identifiers-extensions.ts
@@ -61,31 +61,31 @@ export async function ensureExtensionsIds(
 
   // Migration is only supported in partners client
   const clientName = options.developerPlatformClient.clientName
-  const migrationsClient = clientName === ClientName.Partners ? options.developerPlatformClient : new PartnersClient()
+  const migrationClient = clientName === ClientName.Partners ? options.developerPlatformClient : new PartnersClient()
 
   let didMigrateDashboardExtensions = false
 
   if (uiExtensionsToMigrate.length > 0) {
     const confirmedMigration = await extensionMigrationPrompt(uiExtensionsToMigrate)
     if (!confirmedMigration) throw new AbortSilentError()
-    remoteExtensions = await migrateExtensionsToUIExtension(
-      uiExtensionsToMigrate,
-      options.appId,
+    remoteExtensions = await migrateExtensionsToUIExtension({
+      extensionsToMigrate: uiExtensionsToMigrate,
+      appId: options.appId,
       remoteExtensions,
-      migrationsClient,
-    )
+      migrationClient,
+    })
     didMigrateDashboardExtensions = true
   }
 
   if (flowExtensionsToMigrate.length > 0) {
     const confirmedMigration = await extensionMigrationPrompt(flowExtensionsToMigrate, false)
     if (!confirmedMigration) throw new AbortSilentError()
-    const newRemoteExtensions = await migrateFlowExtensions(
-      flowExtensionsToMigrate,
-      options.appId,
-      dashboardExtensions,
-      migrationsClient,
-    )
+    const newRemoteExtensions = await migrateFlowExtensions({
+      extensionsToMigrate: flowExtensionsToMigrate,
+      appId: options.appId,
+      remoteExtensions: dashboardExtensions,
+      migrationClient,
+    })
     remoteExtensions = remoteExtensions.concat(newRemoteExtensions)
     didMigrateDashboardExtensions = true
   }
@@ -93,13 +93,13 @@ export async function ensureExtensionsIds(
   if (marketingToMigrate.length > 0) {
     const confirmedMigration = await extensionMigrationPrompt(marketingToMigrate, false)
     if (!confirmedMigration) throw new AbortSilentError()
-    const newRemoteExtensions = await migrateAppModules(
-      marketingToMigrate,
-      options.appId,
-      'marketing_activity',
-      dashboardExtensions,
-      migrationsClient,
-    )
+    const newRemoteExtensions = await migrateAppModules({
+      extensionsToMigrate: marketingToMigrate,
+      appId: options.appId,
+      type: 'marketing_activity',
+      remoteExtensions: dashboardExtensions,
+      migrationClient,
+    })
     remoteExtensions = remoteExtensions.concat(newRemoteExtensions)
     didMigrateDashboardExtensions = true
   }
@@ -107,13 +107,13 @@ export async function ensureExtensionsIds(
   if (paymentsToMigrate.length > 0) {
     const confirmedMigration = await extensionMigrationPrompt(paymentsToMigrate, false)
     if (!confirmedMigration) throw new AbortSilentError()
-    const newRemoteExtensions = await migrateAppModules(
-      paymentsToMigrate,
-      options.appId,
-      'payments_extension',
-      dashboardExtensions,
-      migrationsClient,
-    )
+    const newRemoteExtensions = await migrateAppModules({
+      extensionsToMigrate: paymentsToMigrate,
+      appId: options.appId,
+      type: 'payments_extension',
+      remoteExtensions: dashboardExtensions,
+      migrationClient,
+    })
     remoteExtensions = remoteExtensions.concat(newRemoteExtensions)
     didMigrateDashboardExtensions = true
   }
@@ -121,13 +121,13 @@ export async function ensureExtensionsIds(
   if (subscriptionLinksToMigrate.length > 0) {
     const confirmedMigration = await extensionMigrationPrompt(subscriptionLinksToMigrate, false)
     if (!confirmedMigration) throw new AbortSilentError()
-    const newRemoteExtensions = await migrateAppModules(
-      subscriptionLinksToMigrate,
-      options.appId,
-      'subscription_link_extension',
-      dashboardExtensions,
-      migrationsClient,
-    )
+    const newRemoteExtensions = await migrateAppModules({
+      extensionsToMigrate: subscriptionLinksToMigrate,
+      appId: options.appId,
+      type: 'subscription_link_extension',
+      remoteExtensions: dashboardExtensions,
+      migrationClient,
+    })
     remoteExtensions = remoteExtensions.concat(newRemoteExtensions)
     didMigrateDashboardExtensions = true
   }
@@ -135,13 +135,13 @@ export async function ensureExtensionsIds(
   if (adminLinkExtensionsToMigrate.length > 0) {
     const confirmedMigration = await extensionMigrationPrompt(adminLinkExtensionsToMigrate, false)
     if (!confirmedMigration) throw new AbortSilentError()
-    const newRemoteExtensions = await migrateAppModules(
-      adminLinkExtensionsToMigrate,
-      options.appId,
-      'admin_link',
-      dashboardExtensions,
-      migrationsClient,
-    )
+    const newRemoteExtensions = await migrateAppModules({
+      extensionsToMigrate: adminLinkExtensionsToMigrate,
+      appId: options.appId,
+      type: 'admin_link',
+      remoteExtensions: dashboardExtensions,
+      migrationClient,
+    })
     remoteExtensions = remoteExtensions.concat(newRemoteExtensions)
     didMigrateDashboardExtensions = true
   }

--- a/packages/app/src/cli/services/dev/migrate-to-ui-extension.ts
+++ b/packages/app/src/cli/services/dev/migrate-to-ui-extension.ts
@@ -7,14 +7,23 @@ import {LocalRemoteSource} from '../context/id-matching.js'
 import {DeveloperPlatformClient} from '../../utilities/developer-platform-client.js'
 import {AbortError} from '@shopify/cli-kit/node/error'
 
-export async function migrateExtensionsToUIExtension(
-  extensionsToMigrate: LocalRemoteSource[],
-  appId: string,
-  remoteExtensions: RemoteSource[],
-  developerPlatformClient: DeveloperPlatformClient,
-) {
+export async function migrateExtensionsToUIExtension(options: {
+  extensionsToMigrate: LocalRemoteSource[]
+  appId: string
+  remoteExtensions: RemoteSource[]
+  migrationClient: DeveloperPlatformClient
+}) {
+  const {extensionsToMigrate, appId, remoteExtensions, migrationClient} = options
+
   await Promise.all(
-    extensionsToMigrate.map(({remote}) => migrateExtensionToUIExtension(appId, remote.id, developerPlatformClient)),
+    extensionsToMigrate.map(({remote}) =>
+      migrateExtensionToUIExtension({
+        apiKey: appId,
+        registrationId: undefined,
+        registrationUuid: remote.uuid,
+        migrationClient,
+      }),
+    ),
   )
 
   return remoteExtensions.map((extension) => {
@@ -28,17 +37,21 @@ export async function migrateExtensionsToUIExtension(
   })
 }
 
-async function migrateExtensionToUIExtension(
-  apiKey: MigrateToUiExtensionVariables['apiKey'],
-  registrationId: MigrateToUiExtensionVariables['registrationId'],
-  developerPlatformClient: DeveloperPlatformClient,
-) {
+async function migrateExtensionToUIExtension(options: {
+  apiKey: MigrateToUiExtensionVariables['apiKey']
+  registrationId: MigrateToUiExtensionVariables['registrationId']
+  registrationUuid: MigrateToUiExtensionVariables['registrationUuid']
+  migrationClient: DeveloperPlatformClient
+}) {
+  const {apiKey, registrationId, registrationUuid, migrationClient} = options
+
   const variables: MigrateToUiExtensionVariables = {
     apiKey,
     registrationId,
+    registrationUuid,
   }
 
-  const result: MigrateToUiExtensionSchema = await developerPlatformClient.migrateToUiExtension(variables)
+  const result: MigrateToUiExtensionSchema = await migrationClient.migrateToUiExtension(variables)
 
   if (result?.migrateToUiExtension?.userErrors?.length > 0) {
     const errors = result.migrateToUiExtension.userErrors.map((error) => error.message).join(', ')


### PR DESCRIPTION
### WHY are these changes introduced?

Note: Do not merge until changes to [Core](https://app.graphite.dev/github/pr/shop/world/133641) and [Partners](https://app.graphite.dev/github/pr/Shopify/partners/60107) have been merged

To support extension migration using both registration ID and UUID, allowing compatibility with the App Management API.

### WHAT is this pull request doing?

Updates GraphQL mutations for extension migration to accept either `registrationId` or `registrationUuid` as parameters:
- Modifies `MigrateAppModuleMutation`, `MigrateFlowExtensionMutation`, and `MigrateToUiExtensionQuery` to support both ID types
- Makes `registrationId` and `registrationUuid` optional in the respective variable interfaces
- Updates migration service functions to conditionally use UUID when working with the App Management API client

### How to test your changes?

1. Test extension migration using the Partner Dashboard API (should use registrationId)
2. Test extension migration using the App Management API (should use registrationUuid)
3. Verify both migration paths successfully migrate extensions

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes