### PR TITLE
Fix `shopify app dev` to serve local assets as expected

### DIFF
--- a/.changeset/twelve-tools-exercise.md
+++ b/.changeset/twelve-tools-exercise.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Fix `shopify app dev` to serve local assets as expected

--- a/packages/theme/src/cli/services/dev.test.ts
+++ b/packages/theme/src/cli/services/dev.test.ts
@@ -1,27 +1,11 @@
-import {dev, DevOptions, openURLSafely, renderLinks} from './dev.js'
-import {setupDevServer} from '../utilities/theme-environment/theme-environment.js'
-import {mountThemeFileSystem} from '../utilities/theme-fs.js'
-import {fakeThemeFileSystem} from '../utilities/theme-fs/theme-fs-mock-factory.js'
-import {isStorefrontPasswordProtected} from '../utilities/theme-environment/storefront-session.js'
-import {ensureValidPassword} from '../utilities/theme-environment/storefront-password-prompt.js'
-import {emptyThemeExtFileSystem} from '../utilities/theme-fs-empty.js'
-import {initializeDevServerSession} from '../utilities/theme-environment/dev-server-session.js'
-import {DevServerSession} from '../utilities/theme-environment/types.js'
+import {openURLSafely, renderLinks} from './dev.js'
 import {describe, expect, test, vi} from 'vitest'
 import {buildTheme} from '@shopify/cli-kit/node/themes/factories'
 import {DEVELOPMENT_THEME_ROLE} from '@shopify/cli-kit/node/themes/utils'
-import {fetchChecksums} from '@shopify/cli-kit/node/themes/api'
 import {renderSuccess, renderWarning} from '@shopify/cli-kit/node/ui'
 import {openURL} from '@shopify/cli-kit/node/system'
 
 vi.mock('@shopify/cli-kit/node/ui')
-vi.mock('@shopify/cli-kit/node/themes/api')
-vi.mock('../utilities/theme-environment/dev-server-session.js')
-vi.mock('../utilities/theme-environment/storefront-password-prompt.js')
-vi.mock('../utilities/theme-environment/storefront-session.js')
-vi.mock('../utilities/theme-environment/theme-environment.js')
-vi.mock('../utilities/theme-fs-empty.js')
-vi.mock('../utilities/theme-fs.js')
 vi.mock('@shopify/cli-kit/node/colors', () => ({
   default: {
     bold: (str: string) => str,
@@ -35,78 +19,7 @@ vi.mock('@shopify/cli-kit/node/system', () => ({
 
 describe('dev', () => {
   const store = 'my-store.myshopify.com'
-  const adminSession = {storeFqdn: store, token: 'my-token'}
   const theme = buildTheme({id: 123, name: 'My Theme', role: DEVELOPMENT_THEME_ROLE})!
-  const options: DevOptions = {
-    adminSession,
-    directory: 'my-directory',
-    store,
-    theme,
-    force: false,
-    open: false,
-    password: 'my-token',
-    'theme-editor-sync': false,
-    'live-reload': 'hot-reload',
-    noDelete: false,
-    ignore: [],
-    only: [],
-    'error-overlay': 'default',
-  }
-
-  const session: DevServerSession = {
-    ...adminSession,
-    storefrontToken: 'token_111222333',
-    storefrontPassword: 'password',
-    sessionCookies: {
-      storefront_digest: '00001111222233334444',
-      _shopify_essential: ':00112233445566778899:',
-    },
-  }
-
-  const localThemeExtensionFileSystem = emptyThemeExtFileSystem()
-  const localThemeFileSystem = fakeThemeFileSystem('tmp', new Map())
-
-  describe('TS implementation', async () => {
-    test('calls startDevServer with the correct arguments when the `legacy` option is false', async () => {
-      // Given
-      vi.mocked(initializeDevServerSession).mockResolvedValue(session)
-      vi.mocked(isStorefrontPasswordProtected).mockResolvedValue(true)
-      vi.mocked(ensureValidPassword).mockResolvedValue('valid-password')
-      vi.mocked(fetchChecksums).mockResolvedValue([])
-      vi.mocked(mountThemeFileSystem).mockReturnValue(localThemeFileSystem)
-      vi.mocked(emptyThemeExtFileSystem).mockReturnValue(localThemeExtensionFileSystem)
-      vi.mocked(setupDevServer).mockReturnValue({
-        workPromise: Promise.resolve(),
-        renderDevSetupProgress: () => Promise.resolve(),
-        dispatchEvent: () => {},
-        serverStart: async () => ({close: async () => {}}),
-      })
-
-      const devOptions = {...options, storePassword: 'wrong-password', legacy: false, 'theme-editor-sync': true}
-
-      // When
-      await dev(devOptions)
-
-      // Then
-      expect(setupDevServer).toHaveBeenCalledWith(options.theme, {
-        session,
-        localThemeFileSystem,
-        localThemeExtensionFileSystem,
-        directory: 'my-directory',
-        options: {
-          themeEditorSync: true,
-          host: '127.0.0.1',
-          liveReload: 'hot-reload',
-          open: false,
-          port: '9292',
-          ignore: [],
-          noDelete: false,
-          only: [],
-          errorOverlay: 'default',
-        },
-      })
-    })
-  })
 
   test('renders "dev" command links', async () => {
     // Given

--- a/packages/theme/src/cli/services/dev.ts
+++ b/packages/theme/src/cli/services/dev.ts
@@ -82,6 +82,7 @@ export async function dev(options: DevOptions) {
     localThemeFileSystem,
     localThemeExtensionFileSystem,
     directory: options.directory,
+    type: 'theme',
     options: {
       themeEditorSync: options['theme-editor-sync'],
       host,

--- a/packages/theme/src/cli/services/dev.ts
+++ b/packages/theme/src/cli/services/dev.ts
@@ -18,7 +18,7 @@ import readline from 'readline'
 const DEFAULT_HOST = '127.0.0.1'
 const DEFAULT_PORT = '9292'
 
-export interface DevOptions {
+interface DevOptions {
   adminSession: AdminSession
   directory: string
   store: string

--- a/packages/theme/src/cli/utilities/theme-environment/hot-reload/server.test.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/hot-reload/server.test.ts
@@ -545,6 +545,7 @@ function createTestContext(options?: {files?: [string, string][]}) {
     localThemeFileSystem,
     localThemeExtensionFileSystem,
     directory: 'tmp',
+    type: 'theme',
     options: {
       ignore: [],
       only: [],

--- a/packages/theme/src/cli/utilities/theme-environment/local-assets.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/local-assets.ts
@@ -19,7 +19,7 @@ export function getAssetsHandler(_theme: Theme, ctx: DevServerContext) {
   return defineEventHandler(async (event) => {
     if (event.method !== 'GET') return
 
-    if (isCompiledAssetRequest(event)) {
+    if (isCompiledAssetRequest(event, ctx)) {
       return handleCompiledAssetRequest(event, ctx)
     }
 
@@ -93,8 +93,8 @@ function findLocalFile(event: H3Event, ctx: DevServerContext) {
   )
 }
 
-function isCompiledAssetRequest(event: H3Event): boolean {
-  return event.path.includes('/compiled_assets')
+function isCompiledAssetRequest(event: H3Event, ctx: DevServerContext): boolean {
+  return ctx.type === 'theme' && event.path.includes('/compiled_assets')
 }
 
 function handleCompiledAssetRequest(event: H3Event, ctx: DevServerContext) {

--- a/packages/theme/src/cli/utilities/theme-environment/types.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/types.ts
@@ -81,6 +81,11 @@ export interface DevServerContext {
   directory: string
 
   /**
+   * Identifies whether this context is for a theme or a theme extension.
+   */
+  type: 'theme' | 'theme-extension'
+
+  /**
    * Additional options for the development server.
    */
   options: {

--- a/packages/theme/src/cli/utilities/theme-ext-environment/theme-ext-server.ts
+++ b/packages/theme/src/cli/utilities/theme-ext-environment/theme-ext-server.ts
@@ -80,6 +80,7 @@ async function contextDevServerContext(
     localThemeFileSystem,
     localThemeExtensionFileSystem,
     directory,
+    type: 'theme-extension',
     options: {
       themeEditorSync: false,
       noDelete: false,


### PR DESCRIPTION
### Why are these changes being introduced?

Fixes https://github.com/Shopify/cli/issues/6224

Previously, when running the theme proxy in the context of theme app extension development, it attempted to serve compiled assets locally. However, these assets couldn't be generated or served because the host theme doesn't exist in the local file system.

### What does this pull request do?

This PR updates the `DevServerSession` to identify the context in which it is running and avoid asset generation when the proxy is running in the context of theme app extension development.

### How can you test these changes?

- Run `shopify app dev -t <horizon_theme_id>` in an app.
- Verify that Horizon loads as expected.

**Before:**

https://github.com/user-attachments/assets/b0d9f2b7-0876-4dd9-854c-fead3ab0c72e

**After:**

https://github.com/user-attachments/assets/2f6b69a0-4f45-47c5-8e82-47c4fc07f248

### Post-release steps

N/A

### Measuring impact

How will we know if this change was effective? Please select one:

- [ ] n/a – this doesn't need measurement, e.g., a linting rule or a bug fix
- [x] Existing analytics will capture this change
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes