### PR TITLE
Show the UID in the deploy prompt

### DIFF
--- a/packages/app/src/cli/prompts/deploy-release.test.ts
+++ b/packages/app/src/cli/prompts/deploy-release.test.ts
@@ -125,7 +125,7 @@ describe('deployOrReleaseConfirmationPrompt', () => {
             {
               header: 'Extensions:',
               items: [
-                {bullet: '+', item: ['to create extension', {subdued: '(new)'}], color: 'green'},
+                {bullet: '+', item: ['to create extension (uid: uid-create)', {subdued: '(new)'}], color: 'green'},
                 {item: ['to update extension', {subdued: '(updated)'}], color: '#FF8800'},
                 'unchanged extension',
                 ['from dashboard extension', {subdued: '(from Partner Dashboard)'}],
@@ -181,7 +181,7 @@ describe('deployOrReleaseConfirmationPrompt', () => {
               header: 'Extensions:',
               helperText: 'Removing extensions can permanently delete app user data',
               items: [
-                {bullet: '+', item: ['to create extension', {subdued: '(new)'}], color: 'green'},
+                {bullet: '+', item: ['to create extension (uid: uid-create)', {subdued: '(new)'}], color: 'green'},
                 {
                   bullet: '+',
                   item: ['to create dashboard', {subdued: '(new, from Partner Dashboard)'}],
@@ -190,7 +190,7 @@ describe('deployOrReleaseConfirmationPrompt', () => {
                 {item: ['to update extension', {subdued: '(updated)'}], color: '#FF8800'},
                 'unchanged extension',
                 ['from dashboard extension', {subdued: '(from Partner Dashboard)'}],
-                {bullet: '-', item: ['remote extension', {subdued: '(removed)'}], color: 'red'},
+                {bullet: '-', item: ['remote extension (uid: uid-remove)', {subdued: '(removed)'}], color: 'red'},
                 {bullet: '-', item: ['remote dashboard', {subdued: '(removed, from Partner Dashboard)'}], color: 'red'},
               ],
             },
@@ -239,11 +239,11 @@ describe('deployOrReleaseConfirmationPrompt', () => {
             {
               header: 'Extensions:',
               items: [
-                {bullet: '+', item: ['to create extension', {subdued: '(new)'}], color: 'green'},
+                {bullet: '+', item: ['to create extension (uid: uid-create)', {subdued: '(new)'}], color: 'green'},
                 {item: ['to update extension', {subdued: '(updated)'}], color: '#FF8800'},
                 'unchanged extension',
                 ['from dashboard extension', {subdued: '(from Partner Dashboard)'}],
-                {bullet: '-', item: ['remote extension', {subdued: '(removed)'}], color: 'red'},
+                {bullet: '-', item: ['remote extension (uid: uid-remove)', {subdued: '(removed)'}], color: 'red'},
               ],
             },
           ],
@@ -284,11 +284,11 @@ describe('deployOrReleaseConfirmationPrompt', () => {
             {
               header: 'Extensions:',
               items: [
-                {bullet: '+', item: ['to create extension', {subdued: '(new)'}], color: 'green'},
+                {bullet: '+', item: ['to create extension (uid: uid-create)', {subdued: '(new)'}], color: 'green'},
                 {item: ['to update extension', {subdued: '(updated)'}], color: '#FF8800'},
                 'unchanged extension',
                 ['from dashboard extension', {subdued: '(from Partner Dashboard)'}],
-                {bullet: '-', item: ['remote extension', {subdued: '(removed)'}], color: 'red'},
+                {bullet: '-', item: ['remote extension (uid: uid-remove)', {subdued: '(removed)'}], color: 'red'},
               ],
             },
           ],
@@ -337,11 +337,11 @@ describe('deployOrReleaseConfirmationPrompt', () => {
               header: 'Extensions:',
               helperText: 'Removing extensions can permanently delete app user data',
               items: [
-                {bullet: '+', item: ['to create extension', {subdued: '(new)'}], color: 'green'},
+                {bullet: '+', item: ['to create extension (uid: uid-create)', {subdued: '(new)'}], color: 'green'},
                 {item: ['to update extension', {subdued: '(updated)'}], color: '#FF8800'},
                 'unchanged extension',
                 ['from dashboard extension', {subdued: '(from Partner Dashboard)'}],
-                {bullet: '-', item: ['remote extension', {subdued: '(removed)'}], color: 'red'},
+                {bullet: '-', item: ['remote extension (uid: uid-remove)', {subdued: '(removed)'}], color: 'red'},
               ],
             },
           ],
@@ -393,7 +393,7 @@ describe('deployOrReleaseConfirmationPrompt', () => {
             {
               header: 'Extensions:',
               items: [
-                {bullet: '+', item: ['to create extension', {subdued: '(new)'}], color: 'green'},
+                {bullet: '+', item: ['to create extension (uid: uid-create)', {subdued: '(new)'}], color: 'green'},
                 {item: ['to update extension', {subdued: '(updated)'}], color: '#FF8800'},
                 'unchanged extension',
                 ['from dashboard extension', {subdued: '(from Partner Dashboard)'}],
@@ -433,14 +433,20 @@ function renderConfirmationPromptContent(options: RenderConfirmationPromptConten
 function buildCompleteBreakdownInfo() {
   const emptyBreakdownInfo = buildEmptyBreakdownInfo()
 
-  emptyBreakdownInfo.extensionIdentifiersBreakdown.onlyRemote.push(buildExtensionBreakdownInfo('remote extension'))
-  emptyBreakdownInfo.extensionIdentifiersBreakdown.toCreate.push(buildExtensionBreakdownInfo('to create extension'))
+  emptyBreakdownInfo.extensionIdentifiersBreakdown.onlyRemote.push(
+    buildExtensionBreakdownInfo('remote extension', 'uid-remove'),
+  )
+  emptyBreakdownInfo.extensionIdentifiersBreakdown.toCreate.push(
+    buildExtensionBreakdownInfo('to create extension', 'uid-create'),
+  )
   emptyBreakdownInfo.extensionIdentifiersBreakdown.unchanged.push(
-    buildExtensionBreakdownInfo('unchanged extension'),
+    buildExtensionBreakdownInfo('unchanged extension', undefined),
     buildDashboardBreakdownInfo('from dashboard extension'),
   )
 
-  emptyBreakdownInfo.extensionIdentifiersBreakdown.toUpdate.push(buildExtensionBreakdownInfo('to update extension'))
+  emptyBreakdownInfo.extensionIdentifiersBreakdown.toUpdate.push(
+    buildExtensionBreakdownInfo('to update extension', undefined),
+  )
 
   emptyBreakdownInfo.configExtensionIdentifiersBreakdown!.existingFieldNames.push('existing field name1')
   emptyBreakdownInfo.configExtensionIdentifiersBreakdown!.existingUpdatedFieldNames.push('updating field name1')

--- a/packages/app/src/cli/prompts/deploy-release.ts
+++ b/packages/app/src/cli/prompts/deploy-release.ts
@@ -110,7 +110,11 @@ async function buildExtensionsContentPrompt(extensionsContentBreakdown: Extensio
       case 'dashboard':
         return [extension.title, {subdued: `(${preffix}from Partner Dashboard)`}]
       case 'extension':
-        return extension.title
+        if (extension.uid && extension.uid.length > 0) {
+          return `${extension.title} (uid: ${extension.uid})`
+        } else {
+          return extension.title
+        }
     }
   }
   let extensionsInfoTable

--- a/packages/app/src/cli/services/context/breakdown-extensions.test.ts
+++ b/packages/app/src/cli/services/context/breakdown-extensions.test.ts
@@ -427,7 +427,10 @@ describe('extensionsIdentifiersDeployBreakdown', () => {
         extensionIdentifiersBreakdown: {
           onlyRemote: [],
           toCreate: [],
-          unchanged: [buildExtensionBreakdownInfo('EXTENSION_A'), buildExtensionBreakdownInfo('extension-a-2')],
+          unchanged: [
+            buildExtensionBreakdownInfo('EXTENSION_A', undefined),
+            buildExtensionBreakdownInfo('extension-a-2', undefined),
+          ],
           toUpdate: [],
         },
         extensionsToConfirm,
@@ -464,8 +467,8 @@ describe('extensionsIdentifiersDeployBreakdown', () => {
         extensionIdentifiersBreakdown: {
           onlyRemote: [],
           toCreate: [
-            buildExtensionBreakdownInfo('EXTENSION_A'),
-            buildExtensionBreakdownInfo('extension-a-2'),
+            buildExtensionBreakdownInfo('EXTENSION_A', 'UUID_A'),
+            buildExtensionBreakdownInfo('extension-a-2', 'test-ui-extension-uid'),
             buildDashboardBreakdownInfo('Dashboard A'),
           ],
           toUpdate: [],
@@ -505,7 +508,10 @@ describe('extensionsIdentifiersDeployBreakdown', () => {
       expect(result).toEqual({
         extensionIdentifiersBreakdown: {
           onlyRemote: [],
-          toCreate: [buildExtensionBreakdownInfo('EXTENSION_A'), buildExtensionBreakdownInfo('extension-a-2')],
+          toCreate: [
+            buildExtensionBreakdownInfo('EXTENSION_A', 'UUID_A'),
+            buildExtensionBreakdownInfo('extension-a-2', 'test-ui-extension-uid'),
+          ],
           toUpdate: [],
           unchanged: [buildDashboardBreakdownInfo('Dashboard A')],
         },
@@ -551,9 +557,12 @@ describe('extensionsIdentifiersDeployBreakdown', () => {
       expect(result).toEqual({
         extensionIdentifiersBreakdown: {
           onlyRemote: [],
-          toCreate: [buildExtensionBreakdownInfo('extension-a-2')],
+          toCreate: [buildExtensionBreakdownInfo('extension-a-2', 'test-ui-extension-uid')],
           toUpdate: [],
-          unchanged: [buildExtensionBreakdownInfo('EXTENSION_A'), buildDashboardBreakdownInfo('Dashboard A')],
+          unchanged: [
+            buildExtensionBreakdownInfo('EXTENSION_A', undefined),
+            buildDashboardBreakdownInfo('Dashboard A'),
+          ],
         },
         extensionsToConfirm,
         remoteExtensionsRegistrations: remoteExtensionRegistrations.app,
@@ -598,11 +607,14 @@ describe('extensionsIdentifiersDeployBreakdown', () => {
         extensionIdentifiersBreakdown: {
           onlyRemote: [],
           toCreate: [
-            buildExtensionBreakdownInfo('DASH_MIGRATED_EXTENSION_A'),
-            buildExtensionBreakdownInfo('extension-a-2'),
+            buildExtensionBreakdownInfo('DASH_MIGRATED_EXTENSION_A', 'UUID_DM_A'),
+            buildExtensionBreakdownInfo('extension-a-2', 'test-ui-extension-uid'),
           ],
           toUpdate: [],
-          unchanged: [buildExtensionBreakdownInfo('EXTENSION_A'), buildDashboardBreakdownInfo('Dashboard A')],
+          unchanged: [
+            buildExtensionBreakdownInfo('EXTENSION_A', undefined),
+            buildDashboardBreakdownInfo('Dashboard A'),
+          ],
         },
         extensionsToConfirm,
         remoteExtensionsRegistrations: remoteExtensionRegistrations.app,
@@ -650,16 +662,19 @@ describe('extensionsIdentifiersDeployBreakdown', () => {
       expect(result).toEqual({
         extensionIdentifiersBreakdown: {
           onlyRemote: [
-            buildExtensionBreakdownInfo('Checkout post purchase Deleted B'),
+            buildExtensionBreakdownInfo('Checkout post purchase Deleted B', 'B'),
             buildDashboardBreakdownInfo('Dashboard Deleted B'),
           ],
           toCreate: [
-            buildExtensionBreakdownInfo('DASH_MIGRATED_EXTENSION_A'),
-            buildExtensionBreakdownInfo('extension-a-2'),
+            buildExtensionBreakdownInfo('DASH_MIGRATED_EXTENSION_A', 'UUID_DM_A'),
+            buildExtensionBreakdownInfo('extension-a-2', 'test-ui-extension-uid'),
             buildDashboardBreakdownInfo('Dashboard New'),
           ],
           toUpdate: [],
-          unchanged: [buildExtensionBreakdownInfo('EXTENSION_A'), buildDashboardBreakdownInfo('Dashboard A')],
+          unchanged: [
+            buildExtensionBreakdownInfo('EXTENSION_A', undefined),
+            buildDashboardBreakdownInfo('Dashboard A'),
+          ],
         },
         extensionsToConfirm,
         remoteExtensionsRegistrations: remoteExtensionRegistrations.app,
@@ -704,8 +719,8 @@ describe('extensionsIdentifiersDeployBreakdown', () => {
       expect(result).toEqual({
         extensionIdentifiersBreakdown: {
           onlyRemote: [],
-          toCreate: [buildExtensionBreakdownInfo('extension-a-2')],
-          toUpdate: [buildExtensionBreakdownInfo('EXTENSION_A')],
+          toCreate: [buildExtensionBreakdownInfo('extension-a-2', 'test-ui-extension-uid')],
+          toUpdate: [buildExtensionBreakdownInfo('EXTENSION_A', undefined)],
           unchanged: [buildDashboardBreakdownInfo('Dashboard A')],
         },
         extensionsToConfirm,
@@ -775,8 +790,8 @@ describe('extensionsIdentifiersReleaseBreakdown', () => {
     // Then
     expect(result).toEqual({
       extensionIdentifiersBreakdown: {
-        onlyRemote: [buildExtensionBreakdownInfo('Checkout post purchase Deleted B')],
-        toCreate: [buildExtensionBreakdownInfo('Checkout post purchase')],
+        onlyRemote: [buildExtensionBreakdownInfo('Checkout post purchase Deleted B', undefined)],
+        toCreate: [buildExtensionBreakdownInfo('Checkout post purchase', undefined)],
         toUpdate: [],
         unchanged: [buildDashboardBreakdownInfo('Dashboard A')],
       },
@@ -811,7 +826,7 @@ describe('extensionsIdentifiersReleaseBreakdown', () => {
       extensionIdentifiersBreakdown: {
         toCreate: [],
         toUpdate: [],
-        onlyRemote: [buildExtensionBreakdownInfo('Checkout post purchase Deleted B')],
+        onlyRemote: [buildExtensionBreakdownInfo('Checkout post purchase Deleted B', undefined)],
         unchanged: [],
       },
       versionDetails: versionDiff.versionDetails,

--- a/packages/app/src/cli/services/context/identifiers-extensions.ts
+++ b/packages/app/src/cli/services/context/identifiers-extensions.ts
@@ -316,10 +316,8 @@ async function createExtensions(
       // Just pretend to create the extension, as it's not necessary to do anything
       // in this case.
       result[extension.localIdentifier] = {
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        id: extension.uid!,
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        uuid: extension.uid!,
+        id: extension.uid,
+        uuid: extension.uid,
         type: extension.type,
         title: extension.handle,
       }

--- a/packages/app/src/cli/services/context/identifiers.ts
+++ b/packages/app/src/cli/services/context/identifiers.ts
@@ -32,7 +32,7 @@ export interface RemoteSource {
 }
 
 export interface LocalSource {
-  uid?: string
+  uid: string
   localIdentifier: string
   graphQLType: string
   type: string


### PR DESCRIPTION
### WHY are these changes introduced?

Make it easier to identify which extensions are being added / removed during a deploy.

### WHAT is this pull request doing?

- Show the UID of extensions in the deploy prompt when adding/removing
- Updates the extension breakdown information structure to include UIDs


![Captura de pantalla 2025-08-11 a las 17.09.07.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/nNsubxpSjsPXUKXMmDt6/58b7c4c1-c37b-40f7-9ba4-9643329f674f.png)

### How to test your changes?

1. Run a deploy command with extensions that have UIDs
2. Verify that the deploy prompt correctly shows extension titles without UIDs
3. Modify a UID manually
4. Run deploy again, see that the UID is shown in the prompt.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes