### PR TITLE
Fix deploys in partners after an un-migration

### DIFF
--- a/packages/app/src/cli/models/extensions/extension-instance.ts
+++ b/packages/app/src/cli/models/extensions/extension-instance.ts
@@ -250,10 +250,10 @@ export class ExtensionInstance<TConfiguration extends BaseConfigType = BaseConfi
     return `https://${fqdn}/${options.orgId}/apps/${options.appId}/extensions/${parnersPath}/${options.extensionId}`
   }
 
-  getOutputFolderId(registrationUuid?: string) {
-    // We want to return the UID only for Dev Dashboard apps,
-    // that's why we take it from the configuration
-    return this.configuration.uid ?? registrationUuid ?? this.handle
+  getOutputFolderId(outputId?: string) {
+    // Ideally we want to return `this.uid` always. To keep supporting Partners API we accept a value to override that.
+
+    return outputId ?? this.uid
   }
 
   // UI Specific properties
@@ -362,10 +362,10 @@ export class ExtensionInstance<TConfiguration extends BaseConfigType = BaseConfi
     }
   }
 
-  async buildForBundle(options: ExtensionBuildOptions, bundleDirectory: string, registrationUuid?: string) {
+  async buildForBundle(options: ExtensionBuildOptions, bundleDirectory: string, outputId?: string) {
     if (this.features.includes('bundling')) {
       // Modules that are going to be inclued in the bundle should be built in the bundle directory
-      this.outputPath = this.getOutputPathForDirectory(bundleDirectory, registrationUuid)
+      this.outputPath = this.getOutputPathForDirectory(bundleDirectory, outputId)
     }
 
     await this.build(options)
@@ -373,7 +373,7 @@ export class ExtensionInstance<TConfiguration extends BaseConfigType = BaseConfi
       await bundleThemeExtension(this, options)
     }
 
-    const bundleInputPath = joinPath(bundleDirectory, this.getOutputFolderId(registrationUuid))
+    const bundleInputPath = joinPath(bundleDirectory, this.getOutputFolderId(outputId))
     await this.keepBuiltSourcemapsLocally(bundleInputPath)
   }
 
@@ -400,8 +400,8 @@ export class ExtensionInstance<TConfiguration extends BaseConfigType = BaseConfi
     }
   }
 
-  getOutputPathForDirectory(directory: string, registrationUuid?: string) {
-    const id = this.getOutputFolderId(registrationUuid)
+  getOutputPathForDirectory(directory: string, outputId?: string) {
+    const id = this.getOutputFolderId(outputId)
     const outputFile = this.isThemeExtension ? '' : joinPath('dist', this.outputFileName)
     return joinPath(directory, id, outputFile)
   }

--- a/packages/app/src/cli/services/deploy.ts
+++ b/packages/app/src/cli/services/deploy.ts
@@ -183,6 +183,7 @@ export async function deploy(options: DeployOptions) {
     app,
     developerPlatformClient,
   })
+
   const release = !noRelease
   const apiKey = remoteApp.apiKey
 
@@ -205,7 +206,14 @@ export async function deploy(options: DeployOptions) {
       bundlePath = joinPath(options.app.directory, '.shopify', `deploy-bundle.${developerPlatformClient.bundleFormat}`)
       await mkdir(dirname(bundlePath))
     }
-    await bundleAndBuildExtensions({app, bundlePath, identifiers, skipBuild: options.skipBuild})
+
+    await bundleAndBuildExtensions({
+      app,
+      bundlePath,
+      identifiers,
+      skipBuild: options.skipBuild,
+      isDevDashboardApp: developerPlatformClient.supportsAtomicDeployments,
+    })
 
     let uploadTaskTitle
 

--- a/packages/app/src/cli/services/deploy/bundle.test.ts
+++ b/packages/app/src/cli/services/deploy/bundle.test.ts
@@ -64,7 +64,7 @@ describe('bundleAndBuildExtensions', () => {
       }
 
       // When
-      await bundleAndBuildExtensions({app, identifiers, bundlePath, skipBuild: false})
+      await bundleAndBuildExtensions({app, identifiers, bundlePath, skipBuild: false, isDevDashboardApp: false})
 
       // Then
       expect(extensionBundleMock).toHaveBeenCalledTimes(2)
@@ -98,7 +98,7 @@ describe('bundleAndBuildExtensions', () => {
       }
 
       // When
-      await bundleAndBuildExtensions({app, identifiers, bundlePath, skipBuild: false})
+      await bundleAndBuildExtensions({app, identifiers, bundlePath, skipBuild: false, isDevDashboardApp: false})
 
       // Then
       await expect(file.fileExists(bundlePath)).resolves.toBeTruthy()
@@ -131,7 +131,7 @@ describe('bundleAndBuildExtensions', () => {
       }
 
       // When
-      await bundleAndBuildExtensions({app, identifiers, bundlePath, skipBuild: true})
+      await bundleAndBuildExtensions({app, identifiers, bundlePath, skipBuild: true, isDevDashboardApp: false})
 
       // Then
       expect(extensionBuildMock).not.toHaveBeenCalled()
@@ -161,7 +161,7 @@ describe('bundleAndBuildExtensions', () => {
       }
 
       // When
-      await bundleAndBuildExtensions({app, identifiers, bundlePath, skipBuild: true})
+      await bundleAndBuildExtensions({app, identifiers, bundlePath, skipBuild: true, isDevDashboardApp: false})
 
       // Then
       expect(mockInstallJavy).not.toHaveBeenCalled()
@@ -189,7 +189,7 @@ describe('bundleAndBuildExtensions', () => {
       }
 
       // When
-      await bundleAndBuildExtensions({app, identifiers, bundlePath, skipBuild: false})
+      await bundleAndBuildExtensions({app, identifiers, bundlePath, skipBuild: false, isDevDashboardApp: false})
 
       // Then
       expect(mockInstallJavy).toHaveBeenCalledWith(app)
@@ -222,7 +222,7 @@ describe('bundleAndBuildExtensions', () => {
       }
 
       // When
-      await bundleAndBuildExtensions({app, identifiers, bundlePath, skipBuild: true})
+      await bundleAndBuildExtensions({app, identifiers, bundlePath, skipBuild: true, isDevDashboardApp: false})
 
       // Then
       expect(extensionBuildMock).not.toHaveBeenCalled()
@@ -282,7 +282,7 @@ describe('bundleAndBuildExtensions', () => {
       }
 
       // When
-      await bundleAndBuildExtensions({app, identifiers, bundlePath, skipBuild: true})
+      await bundleAndBuildExtensions({app, identifiers, bundlePath, skipBuild: true, isDevDashboardApp: false})
 
       // Then - verify none of the build methods were called
       expect(functionBuildMock).not.toHaveBeenCalled()

--- a/packages/app/src/cli/services/deploy/bundle.ts
+++ b/packages/app/src/cli/services/deploy/bundle.ts
@@ -13,6 +13,7 @@ interface BundleOptions {
   bundlePath?: string
   identifiers?: Identifiers
   skipBuild: boolean
+  isDevDashboardApp: boolean
 }
 
 export async function bundleAndBuildExtensions(options: BundleOptions) {
@@ -33,18 +34,23 @@ export async function bundleAndBuildExtensions(options: BundleOptions) {
       return {
         prefix: extension.localIdentifier,
         action: async (stdout: Writable, stderr: Writable, signal: AbortSignal) => {
-          const extensionIdentifier = options.identifiers?.extensions[extension.localIdentifier]
+          // This outputId is the UID for AppManagement, and UUID for Partners
+          // Comes from the matching logic in `ensureDeployContext`
+          const outputId = options.isDevDashboardApp
+            ? undefined
+            : options.identifiers?.extensions[extension.localIdentifier]
+
           if (options.skipBuild) {
             await extension.copyIntoBundle(
               {stderr, stdout, signal, app: options.app, environment: 'production'},
               bundleDirectory,
-              extensionIdentifier,
+              outputId,
             )
           } else {
             await extension.buildForBundle(
               {stderr, stdout, signal, app: options.app, environment: 'production'},
               bundleDirectory,
-              extensionIdentifier,
+              outputId,
             )
           }
         },


### PR DESCRIPTION
# Refactor extension output ID handling for better clarity and consistency

### WHY are these changes introduced?

Supporting both APIs and different kind of identifiers is tricky. This solves an edge case when un-migrating an app.

### WHAT is this pull request doing?

- Rename `registrationUuid` to `outputId` inside `getFolderOuputId`, this value is not always a registrationUuid (only for partners), so this name reflects better the actual value.
- Return `outputId` if provided, otherwise, return `this.uid`
- For the future: we should just return `this.uid`

### How to test your changes?

1. Run the bundling process for an extension with both AppManagement and Partners API
2. Verify that the output folder structure is correctly generated with the appropriate IDs
3. Ensure that existing functionality continues to work as expected

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes