### PR TITLE
Fix theme package folder structure

### DIFF
--- a/packages/cli-kit/src/public/node/archiver.integration.test.ts
+++ b/packages/cli-kit/src/public/node/archiver.integration.test.ts
@@ -26,7 +26,7 @@ describe('zip', () => {
 
       // Then
       const archiveEntries = await readArchiveFiles(zipPath)
-      const expectedEntries = withExplicitDirectoryEntries(structure)
+      const expectedEntries = ['extensions/', 'extensions/first/', 'extensions/first/main.js', 'test.json']
       expect(expectedEntries.sort()).toEqual(archiveEntries.sort())
     })
   })
@@ -50,7 +50,10 @@ describe('zip', () => {
 
       // Then
       const archiveEntries = await readArchiveFiles(zipPath)
-      const expectedEntries = withExplicitDirectoryEntries([`extensions/first/main.js`])
+
+      expect(archiveEntries).toContain('extensions/')
+      expect(archiveEntries).toContain('extensions/first/')
+      const expectedEntries = ['extensions/', 'extensions/first/', 'extensions/first/main.js']
       expect(expectedEntries.sort()).toEqual(archiveEntries.sort())
     })
   })
@@ -158,20 +161,4 @@ async function readArchiveFiles(zipPath: string) {
   await archive.close()
 
   return archiveEntries
-}
-
-function withExplicitDirectoryEntries(files: string[]): string[] {
-  const entries = new Set<string>()
-  for (const file of files) {
-    entries.add(file)
-    let currentDir = dirname(file)
-    while (currentDir && currentDir !== '.' && currentDir !== '/') {
-      const dirEntry = currentDir.endsWith('/') ? currentDir : `${currentDir}/`
-      entries.add(dirEntry)
-      const parent = dirname(currentDir)
-      if (parent === currentDir) break
-      currentDir = parent
-    }
-  }
-  return Array.from(entries)
 }

--- a/packages/cli-kit/src/public/node/archiver.integration.test.ts
+++ b/packages/cli-kit/src/public/node/archiver.integration.test.ts
@@ -26,7 +26,8 @@ describe('zip', () => {
 
       // Then
       const archiveEntries = await readArchiveFiles(zipPath)
-      expect(structure.sort()).toEqual(archiveEntries.sort())
+      const expectedEntries = withExplicitDirectoryEntries(structure)
+      expect(expectedEntries.sort()).toEqual(archiveEntries.sort())
     })
   })
 
@@ -49,7 +50,8 @@ describe('zip', () => {
 
       // Then
       const archiveEntries = await readArchiveFiles(zipPath)
-      expect([`extensions/first/main.js`]).toEqual(archiveEntries)
+      const expectedEntries = withExplicitDirectoryEntries([`extensions/first/main.js`])
+      expect(expectedEntries.sort()).toEqual(archiveEntries.sort())
     })
   })
 })
@@ -156,4 +158,20 @@ async function readArchiveFiles(zipPath: string) {
   await archive.close()
 
   return archiveEntries
+}
+
+function withExplicitDirectoryEntries(files: string[]): string[] {
+  const entries = new Set<string>()
+  for (const file of files) {
+    entries.add(file)
+    let currentDir = dirname(file)
+    while (currentDir && currentDir !== '.' && currentDir !== '/') {
+      const dirEntry = currentDir.endsWith('/') ? currentDir : `${currentDir}/`
+      entries.add(dirEntry)
+      const parent = dirname(currentDir)
+      if (parent === currentDir) break
+      currentDir = parent
+    }
+  }
+  return Array.from(entries)
 }

--- a/packages/cli-kit/src/public/node/archiver.ts
+++ b/packages/cli-kit/src/public/node/archiver.ts
@@ -52,24 +52,21 @@ export async function zip(options: ZipOptions): Promise<void> {
     })
     archive.pipe(output)
 
-    // Find parent directories to add explicitly to the archive
     const directoriesToAdd = new Set<string>()
     for (const filePath of pathsToZip) {
-      const relPath = relativePath(inputDirectory, filePath)
-      collectParentDirectories(relPath, directoriesToAdd)
+      const fileRelativePath = relativePath(inputDirectory, filePath)
+      collectParentDirectories(fileRelativePath, directoriesToAdd)
     }
 
-    // Add directories, parents before children
     const sortedDirs = Array.from(directoriesToAdd).sort((left, right) => left.localeCompare(right))
     for (const dir of sortedDirs) {
       const dirName = dir.endsWith('/') ? dir : `${dir}/`
       archive.append(Buffer.alloc(0), {name: dirName})
     }
 
-    // Add files
     for (const filePath of pathsToZip) {
-      const rel = relativePath(inputDirectory, filePath)
-      if (filePath && rel) archive.file(filePath, {name: rel})
+      const fileRelativePath = relativePath(inputDirectory, filePath)
+      if (filePath && fileRelativePath) archive.file(filePath, {name: fileRelativePath})
     }
 
     // eslint-disable-next-line @typescript-eslint/no-floating-promises

--- a/packages/cli-kit/src/public/node/archiver.ts
+++ b/packages/cli-kit/src/public/node/archiver.ts
@@ -1,4 +1,4 @@
-import {relativePath, joinPath} from './path.js'
+import {relativePath, joinPath, dirname} from './path.js'
 import {glob, removeFile} from './fs.js'
 import {outputDebug, outputContent, outputToken} from '../../public/node/output.js'
 import archiver from 'archiver'
@@ -52,14 +52,39 @@ export async function zip(options: ZipOptions): Promise<void> {
     })
     archive.pipe(output)
 
+    // Find parent directories to add explicitly to the archive
+    const directoriesToAdd = new Set<string>()
     for (const filePath of pathsToZip) {
-      const fileRelativePath = relativePath(inputDirectory, filePath)
-      archive.file(filePath, {name: fileRelativePath})
+      const relPath = relativePath(inputDirectory, filePath)
+      collectParentDirectories(relPath, directoriesToAdd)
+    }
+
+    // Add directories, parents before children
+    const sortedDirs = Array.from(directoriesToAdd).sort((left, right) => left.localeCompare(right))
+    for (const dir of sortedDirs) {
+      const dirName = dir.endsWith('/') ? dir : `${dir}/`
+      archive.append(Buffer.alloc(0), {name: dirName})
+    }
+
+    // Add files
+    for (const filePath of pathsToZip) {
+      const rel = relativePath(inputDirectory, filePath)
+      if (filePath && rel) archive.file(filePath, {name: rel})
     }
 
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
     archive.finalize()
   })
+}
+
+function collectParentDirectories(fileRelativePath: string, accumulator: Set<string>): void {
+  let currentDir = dirname(fileRelativePath)
+  while (currentDir && currentDir !== '.' && currentDir !== '/') {
+    accumulator.add(currentDir)
+    const parent = dirname(currentDir)
+    if (parent === currentDir) break
+    currentDir = parent
+  }
 }
 
 export interface BrotliOptions {
@@ -133,7 +158,7 @@ export async function brotliCompress(options: BrotliOptions): Promise<void> {
           // eslint-disable-next-line @typescript-eslint/no-floating-promises
           archive.finalize()
         })
-        .catch((error) => reject(error))
+        .catch((error) => reject(error instanceof Error ? error : new Error(String(error))))
     })
 
     const tarContent = readFileSync(tempTarPath)

--- a/packages/theme/src/cli/services/package.test.ts
+++ b/packages/theme/src/cli/services/package.test.ts
@@ -191,7 +191,10 @@ async function readArchiveFiles(zipPath: string) {
   await expect(fileExists(zipPath)).resolves.toBeTruthy()
   // eslint-disable-next-line @babel/new-cap
   const archive = new StreamZip.async({file: zipPath})
-  const archiveEntries = Object.keys(await archive.entries())
+  const entries = await archive.entries()
+  const archiveEntries = Object.values(entries)
+    .filter((entry: any) => !entry.isDirectory)
+    .map((entry: any) => entry.name)
   await archive.close()
 
   return archiveEntries


### PR DESCRIPTION
### WHY are these changes introduced?

Closes: https://github.com/Shopify/cli/issues/6205

Uploading a zip created by `theme package` could fail validation when uploading to a shopify store. Some validators expect folders to be present as explicit entries in the zip, not just implied by the files inside them.

### WHAT is this pull request doing?

Right now, theme package zips the files it finds, but doesn’t add the folders themselves as entries. This can trigger validation errors.

This PR updates the process to:
- Collect the folder paths for the files we’re zipping
- Add those folders to the zip first (as metadata)
- Add the files
This makes the zip include the folder info validators look for. In the reported case, unzipping and re-zipping with the macOS archiver worked because it preserved that folder structure metadata.

### How to test your changes?

#### To replicate the old and new behaviour
- Build the main branch or use a recent version of the CLI
- Run `theme package` on a theme
- Run `unzip -l <your_theme> | grep "sections"` on the zipped theme
You should see an output like:
```bash
unzip -l Lose-1.0.0.zip | grep "sections"
     1201  03-11-2025 19:12   sections/custom-section.liquid
      167  03-11-2025 19:21   sections/group.liquid
      663  03-31-2025 19:41   sections/layout-header-test.liquid
```
- Build this PR's branch `package-fix`
- Run `theme package` on a theme
- Run `unzip -l <your_theme> | grep "sections"` on the zipped theme
You should see the parent folder listed in the metadata in the output
```bash
❯ unzip -l Lose-1.0.0.zip | grep "sections"
        0  08-18-2025 18:13   sections/ <----- This should show up for you
     1201  03-11-2025 19:12   sections/custom-section.liquid
      167  03-11-2025 19:21   sections/group.liquid
      663  03-31-2025 19:41   sections/layout-header-test.liquid
```

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
