### PR TITLE
Send correct uid in manifest during deploy

### DIFF
--- a/packages/app/src/cli/models/extensions/extension-instance.ts
+++ b/packages/app/src/cli/models/extensions/extension-instance.ts
@@ -436,11 +436,10 @@ export class ExtensionInstance<TConfiguration extends BaseConfigType = BaseConfi
     const uuid = this.isUUIDStrategyExtension
       ? identifiers.extensions[this.localIdentifier]!
       : identifiers.extensionsNonUuidManaged[this.localIdentifier]!
-    const uid = this.isUUIDStrategyExtension ? this.uid : uuid
 
     return {
       ...result,
-      uid,
+      uid: this.uid,
       uuid,
       specificationIdentifier: developerPlatformClient.toExtensionGraphQLType(this.graphQLType),
     }


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes bug found [here](https://shopify.slack.com/archives/C07JNNJT273/p1755022319130109)

Simplifies the logic for determining the `uid` value in the extension instance response.

### WHAT is this pull request doing?

Removes unnecessary variable assignment by directly using `this.uid` in the return object instead of conditionally assigning it to a temporary variable.

### How to test your changes?

1. Run extension commands that use the extension instance response
2. Verify that extensions are properly identified with the correct uid
3. Ensure that both UUID strategy extensions and non-UUID managed extensions work as expected

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes