### PR TITLE
Add events for `shopify theme info`

### DIFF
--- a/packages/theme/src/cli/services/info.ts
+++ b/packages/theme/src/cli/services/info.ts
@@ -6,6 +6,7 @@ import {themeEditorUrl, themePreviewUrl} from '@shopify/cli-kit/node/themes/urls
 import {Theme} from '@shopify/cli-kit/node/themes/types'
 import {AdminSession} from '@shopify/cli-kit/node/session'
 import {AlertCustomSection, InlineToken} from '@shopify/cli-kit/node/ui'
+import {recordEvent} from '@shopify/cli-kit/node/analytics'
 
 interface ThemeInfo {
   theme: {
@@ -60,8 +61,11 @@ export async function fetchDevInfo(config: {cliVersion: string}): Promise<AlertC
 }
 
 function devConfigSection(): AlertCustomSection {
-  const store = getThemeStore() || 'Not configured'
+  const store = getThemeStore() ?? 'Not configured'
   const developmentTheme = getDevelopmentTheme()
+
+  recordEvent(`theme-command:info:dev-theme-loaded:${developmentTheme}`)
+
   return tabularSection('Theme Configuration', [
     ['Store', store],
     ['Development Theme ID', developmentTheme ? `#${developmentTheme}` : {subdued: 'Not set'}],


### PR DESCRIPTION
### WHY are these changes introduced?

This PR adds events to improve o11y in the `shopify theme info` commands.

### WHAT is this pull request doing?

Building on the component from https://github.com/Shopify/cli/pull/6184, this PR introduces event tracking for the `shopify theme info` command.

### How to test your changes

- Add a `console.log(compileData())` at the end of the command of the `info` command
- Verify that the expected events are being stored

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug fix
- [x] Existing analytics will capture this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes