### PR TITLE
Fix wrong parameter in ensureUserAccessToStore query

### DIFF
--- a/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
@@ -877,7 +877,7 @@ export class AppManagementClient implements DeveloperPlatformClient {
     const fullResult = await businessPlatformOrganizationsRequestDoc({
       query: ProvisionShopAccess,
       token: await this.businessPlatformToken(),
-      organizationId: orgId,
+      organizationId: String(numberFromGid(orgId)),
       variables,
       unauthorizedHandler: this.createUnauthorizedHandler(),
     })


### PR DESCRIPTION
### WHY are these changes introduced?

In https://github.com/Shopify/cli/pull/6137 we refactored the way we pass organization ID to some queries, but we missed one.

### WHAT is this pull request doing?

Fix the `ensureUserAccessToStore` query to pass the `organization_id` in the right format

### How to test your changes?

- `p shopify app dev` with App Management and a non-migrated Plus account

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
