### PR TITLE
Specify localhost for GraphiQL server

### DIFF
--- a/packages/app/src/cli/services/dev/graphiql/server.ts
+++ b/packages/app/src/cli/services/dev/graphiql/server.ts
@@ -222,5 +222,5 @@ export function setupGraphiQLServer({
     }
     res.end()
   })
-  return app.listen(port, () => stdout.write(`GraphiQL server started on port ${port}`))
+  return app.listen(port, 'localhost', () => stdout.write(`GraphiQL server started on port ${port}`))
 }


### PR DESCRIPTION
## Summary
Updates server configuration

## Test plan
- Run `shopify app dev`
- Verify GraphiQL still works at localhost

🤖 Generated with [Claude Code](https://claude.ai/code)