### PR TITLE
Prevent race conditions during multi environment execution

### DIFF
--- a/.changeset/calm-ears-add.md
+++ b/.changeset/calm-ears-add.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': minor
+---
+
+Ensure commands run in multiple environments use the correct store URL

--- a/.changeset/many-ties-check.md
+++ b/.changeset/many-ties-check.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': minor
+---
+
+Allow commands run in multiple environments to act on the same store URL

--- a/packages/theme/src/cli/utilities/theme-command.ts
+++ b/packages/theme/src/cli/utilities/theme-command.ts
@@ -1,6 +1,7 @@
 import {ensureThemeStore} from './theme-store.js'
 import {configurationFileName} from '../constants.js'
 import metadata from '../metadata.js'
+import {useThemeStoreContext} from '../services/local-storage.js'
 import {hashString} from '@shopify/cli-kit/node/crypto'
 import {Input} from '@oclif/core/interfaces'
 import Command, {ArgOutput, FlagOutput} from '@shopify/cli-kit/node/base-command'
@@ -153,9 +154,8 @@ export default abstract class ThemeCommand extends Command {
     environmentMap: Map<EnvironmentName, FlagValues>,
     requiredFlags: Exclude<RequiredFlags, null>,
   ) {
-    const valid: {environment: EnvironmentName; flags: FlagValues; session: AdminSession}[] = []
+    const valid: {environment: EnvironmentName; flags: FlagValues}[] = []
     const invalid: {environment: EnvironmentName; reason: string}[] = []
-    const commandName = this.constructor.name.toLowerCase()
 
     for (const [environmentName, environmentFlags] of environmentMap) {
       const validationResult = this.validConfig(environmentFlags, requiredFlags, environmentName)
@@ -165,12 +165,7 @@ export default abstract class ThemeCommand extends Command {
         continue
       }
 
-      // eslint-disable-next-line no-await-in-loop
-      const session = await this.createSession(environmentFlags)
-
-      recordEvent(`theme-command:${commandName}:multi-env:authenticated`)
-
-      valid.push({environment: environmentName, flags: environmentFlags, session})
+      valid.push({environment: environmentName, flags: environmentFlags})
     }
 
     return {valid, invalid}
@@ -227,17 +222,23 @@ export default abstract class ThemeCommand extends Command {
    * Run the command in each valid environment concurrently
    * @param validEnvironments - The valid environments to run the command in
    */
-  private async runConcurrent(
-    validEnvironments: {environment: EnvironmentName; flags: FlagValues; session: AdminSession}[],
-  ) {
+  private async runConcurrent(validEnvironments: {environment: EnvironmentName; flags: FlagValues}[]) {
     const abortController = new AbortController()
 
     await renderConcurrent({
-      processes: validEnvironments.map(({environment, flags, session}) => ({
+      processes: validEnvironments.map(({environment, flags}) => ({
         prefix: environment,
         action: async (stdout: Writable, stderr: Writable, _signal) => {
           try {
-            await this.command(flags, session, true, {stdout, stderr})
+            const store = flags.store as string
+            await useThemeStoreContext(store, async () => {
+              const session = await this.createSession(flags)
+
+              const commandName = this.constructor.name.toLowerCase()
+              recordEvent(`theme-command:${commandName}:multi-env:authenticated`)
+
+              await this.command(flags, session, true, {stdout, stderr})
+            })
 
             // eslint-disable-next-line no-catch-all/no-catch-all
           } catch (error) {


### PR DESCRIPTION
### WHY are these changes introduced?

Commands with multiple environment flags are run concurrently. This allows for quick multi env command runs (_`push` with 10 environments takes 2.5s run concurrently vs 12s sequentially!_) but introduces race conditions in commands that rely on local storage read/writes. Theme commands use local storage to keep track of the current store URL as well as each store's current development theme.

Examples:

- `shopify theme delete -e store1 -e store2 --development` An environment would sometimes try to lookup the current dev theme using the other env's store as key if the store file was overwritten before the dev theme read
- `shopify theme push -e store1-env -e another-store1-env --development` Two new dev themes were being created since both environment's local storage reads occurred before either's writes

> Something to keep an eye on: [the package](https://github.com/sindresorhus/conf) CLI uses to manage local storage doesn't technically support concurrent writes

### WHAT is this pull request doing?

- Wraps each command call in an context provider so it always knows which store its running on, eliminating the need to grab the store URL from local storage. 
- Groups environments with unique store URLs and runs those groups sequentially, preventing later called environments from reading outdated values

### How to test your changes?

- Install the snap build that contains these changes as well as `delete` multi env logic

```
npm i -g @shopify/cli@0.0.0-snapshot-20250813233940 --@shopify:registry=https://registry.npmjs.org
```
- Add a `shopify.theme.toml` file

<details><summary>Example toml</summary>

```
[environments.store1]
theme = "<theme>"
store = "<store1>"
password  = "<shptka_password>"

[environments.anotherstore1]
theme = "<theme>"
store = "<store1>"
password  = "<shptka_password>"

[environments.store2]
theme = "<theme>"
store = "<store2>"
password  = "<shptka_password>"
```

</details> 

- Running commands with multiple environments acting on the same store URL should work as expected. Currently `list`, `info`, `rename` work with multiple environments
- Development theme ID's should be read, stored, and deleted correctly from the local storage file `/Users/<username>/Library/Preferences/shopify-cli-development-theme-config-nodejs/config.json`

```sh
shopify theme push -e store1 --development
shopify theme push -e store2 --development
shopify theme delete -e store1 -e store2 --development
```

> Heads up: `shopify theme info --development` will create a new dev theme and display it's info if one does not exist, I believe this is unintended and will open a follow up PR (it's not a result of this change) 

### Measuring impact

- [x] Existing analytics will cater for this addition

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
