### PR TITLE
fix(actions): shell command built from environment values

### DIFF
--- a/bin/pin-github-actions.js
+++ b/bin/pin-github-actions.js
@@ -4,9 +4,9 @@ import glob from 'fast-glob'
 import {fileURLToPath} from 'url'
 import path from 'node:path'
 import utils from 'util'
-import {exec} from 'child_process'
+import {execFile} from 'child_process'
 
-export const execute = utils.promisify(exec)
+export const execute = utils.promisify(execFile)
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
@@ -29,7 +29,18 @@ async function doIt() {
   const pinGithubAction = `${__dirname}/../node_modules/.bin/pin-github-action`
   for (const githubYml of githubYmls) {
     await execute(
-      `GH_ADMIN_TOKEN=${githubAccessToken} ${pinGithubAction} ${githubYml} --allow="actions/*" --allow-empty`,
+      pinGithubAction,
+      [
+        githubYml,
+        '--allow=actions/*',
+        '--allow-empty',
+      ],
+      {
+        env: {
+          ...process.env,
+          GH_ADMIN_TOKEN: githubAccessToken,
+        },
+      }
     )
     process.stdout.write('.')
   }


### PR DESCRIPTION
Dynamically constructing a shell command with values from the local environment, such as file paths, may inadvertently change the meaning of the shell command. Such changes can occur when an environment value contains characters that the shell interprets in a special way, for instance quotes and spaces. This can result in the shell command misbehaving, or even allowing a malicious user to execute arbitrary commands on the system. 

fix the problem, we should avoid constructing a shell command string with interpolated values and passing it to `exec`. Instead, we should use `execFile` (or its promisified version), which allows us to pass the command and its arguments as separate parameters, avoiding shell interpretation of the arguments. For environment variables, we can pass them via the `env` option. Specifically:

- Replace the use of `execute` (which is a promisified `exec`) with a promisified version of `execFile`.
- Change the command invocation to pass the command (`pinGithubAction`) and its arguments (`githubYml`, `--allow=...`, etc.) as an array.
- Pass the environment variable `GH_ADMIN_TOKEN` via the `env` option, extending `process.env`.
- Update the definition of `execute` to use `execFile` instead of `exec`.

All changes are within `bin/pin-github-actions.js`:
- Update the import to include `execFile`.
- Update the definition of `execute` to use `execFile`.
- Update the command invocation in the loop to use argument array and `env` option.

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [x] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
