### PR TITLE
Unify manifest generation for app-managament deploy

### DIFF
--- a/packages/app/src/cli/services/deploy.test.ts
+++ b/packages/app/src/cli/services/deploy.test.ts
@@ -95,6 +95,11 @@ describe('deploy', () => {
 
     // Then
     expect(uploadExtensionsBundle).toHaveBeenCalledWith({
+      appManifest: {
+        name: 'App',
+        handle: '',
+        modules: [],
+      },
       appId: 'app-id',
       apiKey: 'api-key',
       name: app.name,
@@ -153,6 +158,7 @@ describe('deploy', () => {
   test('deploys the app with no extensions', async () => {
     const app = testAppLinked({allExtensions: []})
     vi.mocked(renderTextPrompt).mockResolvedValueOnce('')
+    const appManifest = await app.manifest(undefined)
 
     // When
     await testDeployBundle({
@@ -163,6 +169,7 @@ describe('deploy', () => {
 
     // Then
     expect(uploadExtensionsBundle).toHaveBeenCalledWith({
+      appManifest,
       appId: 'app-id',
       apiKey: 'api-key',
       name: app.name,
@@ -186,6 +193,21 @@ describe('deploy', () => {
 
     // Then
     expect(uploadExtensionsBundle).toHaveBeenCalledWith({
+      appManifest: {
+        name: 'App',
+        handle: '',
+        modules: [
+          {
+            type: 'web_pixel_extension_external',
+            handle: 'test-ui-extension',
+            uid: 'test-ui-extension-uid',
+            uuid: 'test-ui-extension',
+            assets: 'test-ui-extension-uid',
+            target: '',
+            config: expect.any(Object),
+          },
+        ],
+      },
       appId: 'app-id',
       apiKey: 'api-key',
       name: app.name,
@@ -219,6 +241,21 @@ describe('deploy', () => {
 
     // Then
     expect(uploadExtensionsBundle).toHaveBeenCalledWith({
+      appManifest: {
+        name: 'App',
+        handle: '',
+        modules: [
+          {
+            type: 'theme_external',
+            handle: 'theme-extension-name',
+            uid: undefined,
+            uuid: 'theme-extension-name',
+            assets: undefined,
+            target: '',
+            config: expect.any(Object),
+          },
+        ],
+      },
       appId: 'app-id',
       apiKey: 'api-key',
       name: app.name,
@@ -270,6 +307,21 @@ describe('deploy', () => {
 
     // Then
     expect(uploadExtensionsBundle).toHaveBeenCalledWith({
+      appManifest: {
+        name: 'App',
+        handle: '',
+        modules: [
+          {
+            type: 'function_external',
+            handle: 'test-function-extension',
+            uid: undefined,
+            uuid: 'test-function-extension',
+            assets: undefined,
+            target: '',
+            config: expect.any(Object),
+          },
+        ],
+      },
       appId: 'app-id',
       apiKey: 'api-key',
       name: app.name,
@@ -305,6 +357,30 @@ describe('deploy', () => {
 
     // Then
     expect(uploadExtensionsBundle).toHaveBeenCalledWith({
+      appManifest: {
+        name: 'App',
+        handle: '',
+        modules: [
+          {
+            type: 'web_pixel_extension_external',
+            handle: 'test-ui-extension',
+            uid: 'test-ui-extension-uid',
+            uuid: 'test-ui-extension',
+            assets: 'test-ui-extension-uid',
+            target: '',
+            config: expect.any(Object),
+          },
+          {
+            type: 'theme_external',
+            handle: 'theme-extension-name',
+            uid: undefined,
+            uuid: 'theme-extension-name',
+            assets: undefined,
+            target: '',
+            config: expect.any(Object),
+          },
+        ],
+      },
       appId: 'app-id',
       apiKey: 'api-key',
       name: app.name,
@@ -352,6 +428,21 @@ describe('deploy', () => {
 
     // Then
     expect(uploadExtensionsBundle).toHaveBeenCalledWith({
+      appManifest: {
+        name: 'App',
+        handle: '',
+        modules: [
+          {
+            type: 'point_of_sale_external',
+            handle: 'point_of_sale',
+            uid: 'point_of_sale',
+            uuid: undefined,
+            assets: 'point_of_sale',
+            target: '',
+            config: expect.any(Object),
+          },
+        ],
+      },
       appId: 'app-id',
       apiKey: 'api-key',
       name: app.name,
@@ -390,6 +481,21 @@ describe('deploy', () => {
 
     // Then
     expect(uploadExtensionsBundle).toHaveBeenCalledWith({
+      appManifest: {
+        name: 'App',
+        handle: '',
+        modules: [
+          {
+            type: 'point_of_sale_external',
+            handle: 'point_of_sale',
+            uid: 'point_of_sale',
+            uuid: undefined,
+            assets: 'point_of_sale',
+            target: '',
+            config: expect.any(Object),
+          },
+        ],
+      },
       appId: 'app-id',
       apiKey: 'api-key',
       name: app.name,

--- a/packages/app/src/cli/services/deploy.ts
+++ b/packages/app/src/cli/services/deploy.ts
@@ -207,6 +207,8 @@ export async function deploy(options: DeployOptions) {
       await mkdir(dirname(bundlePath))
     }
 
+    const appManifest = await app.manifest(identifiers)
+
     await bundleAndBuildExtensions({
       app,
       bundlePath,
@@ -240,6 +242,7 @@ export async function deploy(options: DeployOptions) {
           )
 
           uploadExtensionsBundleResult = await uploadExtensionsBundle({
+            appManifest,
             appId: remoteApp.id,
             apiKey,
             name: app.name,

--- a/packages/app/src/cli/services/deploy/upload.test.ts
+++ b/packages/app/src/cli/services/deploy/upload.test.ts
@@ -1,5 +1,5 @@
 import {deploymentErrorsToCustomSections, uploadExtensionsBundle} from './upload.js'
-import {testDeveloperPlatformClient} from '../../models/app/app.test-data.js'
+import {testApp, testDeveloperPlatformClient} from '../../models/app/app.test-data.js'
 import {AppDeploySchema, AppDeployVariables} from '../../api/graphql/app_deploy.js'
 import {describe, expect, test, vi} from 'vitest'
 import {inTemporaryDirectory, writeFile} from '@shopify/cli-kit/node/fs'
@@ -8,6 +8,9 @@ import {joinPath} from '@shopify/cli-kit/node/path'
 
 vi.mock('@shopify/cli-kit/node/http')
 vi.mock('@shopify/cli-kit/node/crypto')
+
+const app = testApp()
+const appManifest = await app.manifest(undefined)
 
 describe('uploadExtensionsBundle', () => {
   test('calls a mutation on partners', async () => {
@@ -20,6 +23,7 @@ describe('uploadExtensionsBundle', () => {
       // When
       await writeFile(joinPath(tmpDir, 'test.zip'), '')
       await uploadExtensionsBundle({
+        appManifest,
         appId: '1',
         apiKey: 'app-id',
         name: 'appName',
@@ -35,6 +39,7 @@ describe('uploadExtensionsBundle', () => {
 
       // Then
       expect(developerPlatformClient.deploy).toHaveBeenCalledWith({
+        appManifest,
         appId: '1',
         apiKey: 'app-id',
         name: 'appName',
@@ -64,6 +69,7 @@ describe('uploadExtensionsBundle', () => {
       // When
       await writeFile(joinPath(tmpDir, 'test.zip'), '')
       await uploadExtensionsBundle({
+        appManifest,
         appId: '1',
         apiKey: 'app-id',
         name: 'appName',
@@ -81,6 +87,7 @@ describe('uploadExtensionsBundle', () => {
 
       // Then
       expect(developerPlatformClient.deploy).toHaveBeenCalledWith({
+        appManifest,
         appId: '1',
         apiKey: 'app-id',
         name: 'appName',
@@ -108,6 +115,7 @@ describe('uploadExtensionsBundle', () => {
     vi.mocked<any>(formData).mockReturnValue(mockedFormData)
     // When
     await uploadExtensionsBundle({
+      appManifest,
       appId: '1',
       apiKey: 'app-id',
       name: 'appName',
@@ -121,6 +129,7 @@ describe('uploadExtensionsBundle', () => {
 
     // Then
     expect(developerPlatformClient.deploy).toHaveBeenCalledWith({
+      appManifest,
       appId: '1',
       apiKey: 'app-id',
       name: 'appName',
@@ -221,6 +230,7 @@ describe('uploadExtensionsBundle', () => {
       // Then
       try {
         await uploadExtensionsBundle({
+          appManifest,
           appId: '1',
           apiKey: 'app-id',
           name: 'appName',
@@ -323,6 +333,7 @@ describe('uploadExtensionsBundle', () => {
 
       // When
       const result = await uploadExtensionsBundle({
+        appManifest,
         appId: '1',
         apiKey: 'app-id',
         name: 'appName',

--- a/packages/app/src/cli/services/deploy/upload.ts
+++ b/packages/app/src/cli/services/deploy/upload.ts
@@ -3,11 +3,14 @@ import {AppDeploySchema, AppModuleSettings} from '../../api/graphql/app_deploy.j
 
 import {AppDeployOptions, DeveloperPlatformClient} from '../../utilities/developer-platform-client.js'
 import {getUploadURL, uploadToGCS} from '../bundle.js'
+import {AppManifest} from '../../models/app/app.js'
 import {AbortError} from '@shopify/cli-kit/node/error'
 import {AlertCustomSection, ListToken, TokenItem} from '@shopify/cli-kit/node/ui'
 import {partition} from '@shopify/cli-kit/common/collection'
 
 interface UploadExtensionsBundleOptions {
+  appManifest: AppManifest
+
   /** The ID of the application */
   appId: string
 
@@ -87,6 +90,7 @@ export async function uploadExtensionsBundle(
   }
 
   const variables: AppDeployOptions = {
+    appManifest: options.appManifest,
     appId: options.appId,
     apiKey: options.apiKey,
     name: options.name,

--- a/packages/app/src/cli/utilities/developer-platform-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client.ts
@@ -144,6 +144,7 @@ export type AppVersionWithContext = AppVersion & {
 }
 
 export type AppDeployOptions = AppDeployVariables & {
+  appManifest: AppManifest
   appId: string
   organizationId: string
   name: string

--- a/packages/app/src/cli/utilities/developer-platform-client/app-management-client.test.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/app-management-client.test.ts
@@ -724,15 +724,20 @@ describe('deploy', () => {
     const versionTag = '1.0.0'
     const message = 'Test deploy'
     const commitReference = 'https://github.com/org/repo/commit/123'
-    const appModules = [
-      {
-        uid: 'branding',
-        config: JSON.stringify({name: 'Test App'}),
-        handle: 'test-app',
-        specificationIdentifier: BrandingSpecIdentifier,
-        context: 'unused-context',
-      },
-    ]
+    const manifest = {
+      name: 'Test App',
+      handle: 'test-app',
+      modules: [
+        {
+          type: BrandingSpecIdentifier,
+          handle: 'test-app',
+          uid: 'branding',
+          assets: 'branding',
+          target: 'unused-context',
+          config: {name: 'Test App'},
+        },
+      ],
+    }
 
     const mockResponse = {
       appVersionCreate: {
@@ -756,10 +761,11 @@ describe('deploy', () => {
 
     // When
     await client.deploy({
+      appManifest: manifest,
       apiKey: 'api-key',
       appId: 'gid://shopify/App/123',
       name: 'Test App',
-      appModules,
+      appModules: [],
       organizationId: 'gid://shopify/Organization/123',
       versionTag,
       message,
@@ -776,6 +782,7 @@ describe('deploy', () => {
         version: {
           source: {
             name: 'Test App',
+            handle: 'test-app',
             modules: [
               {
                 uid: 'branding',
@@ -783,170 +790,7 @@ describe('deploy', () => {
                 handle: 'test-app',
                 config: {name: 'Test App'},
                 target: 'unused-context',
-              },
-            ],
-          },
-        },
-        metadata: {
-          versionTag,
-          message,
-          sourceControlUrl: commitReference,
-        },
-      },
-      requestOptions: {requestMode: 'slow-request'},
-      unauthorizedHandler: {
-        handler: expect.any(Function),
-        type: 'token_refresh',
-      },
-    })
-  })
-
-  test('includes the target property when context is provided', async () => {
-    // Given
-    const versionTag = '1.0.0'
-    const message = 'Test deploy'
-    const commitReference = 'https://github.com/org/repo/commit/123'
-    const appModules = [
-      {
-        uid: 'payments_extension uuid',
-        config: JSON.stringify({name: 'Test App'}),
-        handle: 'test-app',
-        specificationIdentifier: 'payments_extension',
-        context: 'payments.offsite.render',
-      },
-    ]
-
-    const mockResponse = {
-      appVersionCreate: {
-        version: {
-          id: 'gid://shopify/Version/1',
-          metadata: {
-            versionTag,
-            message,
-            sourceControlUrl: commitReference,
-          },
-          appModules: [
-            {
-              uuid: 'some_uuid',
-            },
-          ],
-        },
-        userErrors: [],
-      },
-    }
-    vi.mocked(appManagementRequestDoc).mockResolvedValueOnce(mockResponse)
-
-    // When
-    await client.deploy({
-      apiKey: 'api-key',
-      appId: 'gid://shopify/App/123',
-      name: 'Test App',
-      appModules,
-      organizationId: 'gid://shopify/Organization/123',
-      versionTag,
-      message,
-      commitReference,
-      skipPublish: true,
-    })
-
-    // Then
-    expect(vi.mocked(appManagementRequestDoc)).toHaveBeenCalledWith({
-      query: expect.anything(),
-      token: 'token',
-      variables: {
-        appId: 'gid://shopify/App/123',
-        version: {
-          source: {
-            name: 'Test App',
-            modules: [
-              {
-                uid: 'payments_extension uuid',
-                type: 'payments_extension',
-                handle: 'test-app',
-                config: {name: 'Test App'},
-                target: 'payments.offsite.render',
-              },
-            ],
-          },
-        },
-        metadata: {
-          versionTag,
-          message,
-          sourceControlUrl: commitReference,
-        },
-      },
-      requestOptions: {requestMode: 'slow-request'},
-      unauthorizedHandler: {
-        handler: expect.any(Function),
-        type: 'token_refresh',
-      },
-    })
-  })
-
-  test('does not include target property when context is empty', async () => {
-    // Given
-    const versionTag = '1.0.0'
-    const message = 'Test deploy'
-    const commitReference = 'https://github.com/org/repo/commit/123'
-    const appModules = [
-      {
-        uid: 'branding',
-        config: JSON.stringify({name: 'Test App'}),
-        handle: 'test-app',
-        specificationIdentifier: BrandingSpecIdentifier,
-        context: '',
-      },
-    ]
-
-    const mockResponse = {
-      appVersionCreate: {
-        version: {
-          id: 'gid://shopify/Version/1',
-          metadata: {
-            versionTag,
-            message,
-            sourceControlUrl: commitReference,
-          },
-          appModules: [
-            {
-              uuid: 'some_uuid',
-            },
-          ],
-        },
-        userErrors: [],
-      },
-    }
-    vi.mocked(appManagementRequestDoc).mockResolvedValueOnce(mockResponse)
-
-    // When
-    await client.deploy({
-      apiKey: 'api-key',
-      appId: 'gid://shopify/App/123',
-      name: 'Test App',
-      appModules,
-      organizationId: 'gid://shopify/Organization/123',
-      versionTag,
-      message,
-      commitReference,
-      skipPublish: true,
-    })
-
-    // Then
-    expect(vi.mocked(appManagementRequestDoc)).toHaveBeenCalledWith({
-      query: expect.anything(),
-      token: 'token',
-      variables: {
-        appId: 'gid://shopify/App/123',
-        version: {
-          source: {
-            name: 'Test App',
-            modules: [
-              {
-                uid: 'branding',
-                type: BrandingSpecIdentifier,
-                handle: 'test-app',
-                config: {name: 'Test App'},
-                // The target property should not be present
+                assets: 'branding',
               },
             ],
           },
@@ -982,6 +826,7 @@ describe('deploy', () => {
 
     // When
     await client.deploy({
+      appManifest: {name: 'Test App', handle: 'test-app', modules: []},
       apiKey: 'api-key',
       appId: 'gid://shopify/App/123',
       name: 'Test App',
@@ -1002,60 +847,6 @@ describe('deploy', () => {
         },
         metadata: expect.any(Object),
       },
-      requestOptions: {requestMode: 'slow-request'},
-      unauthorizedHandler: {
-        handler: expect.any(Function),
-        type: 'token_refresh',
-      },
-    })
-  })
-
-  test('updates name from branding module if present', async () => {
-    // Given
-    const appModules = [
-      {
-        uuid: 'branding',
-        config: JSON.stringify({name: 'Updated App Name'}),
-        handle: 'branding',
-        specificationIdentifier: BrandingSpecIdentifier,
-        context: 'unused-context',
-      },
-    ]
-    const mockResponse = {
-      appVersionCreate: {
-        version: {
-          id: 'gid://shopify/Version/1',
-          metadata: {},
-          appModules: [],
-        },
-        userErrors: [],
-      },
-    }
-    vi.mocked(appManagementRequestDoc).mockResolvedValueOnce(mockResponse)
-
-    // When
-    await client.deploy({
-      apiKey: 'api-key',
-      appId: 'gid://shopify/App/123',
-      name: 'Original Name',
-      appModules,
-      organizationId: 'gid://shopify/Organization/123',
-      versionTag: '1.0.0',
-      skipPublish: true,
-    })
-
-    // Then
-    expect(vi.mocked(appManagementRequestDoc)).toHaveBeenCalledWith({
-      query: expect.anything(),
-      token: 'token',
-      variables: expect.objectContaining({
-        version: {
-          source: {
-            name: 'Updated App Name',
-            modules: expect.any(Array),
-          },
-        },
-      }),
       requestOptions: {requestMode: 'slow-request'},
       unauthorizedHandler: {
         handler: expect.any(Function),
@@ -1087,6 +878,7 @@ describe('deploy', () => {
 
     // When
     const result = await client.deploy({
+      appManifest: {name: 'Test App', handle: 'test-app', modules: []},
       apiKey: 'api-key',
       appId: 'gid://shopify/App/123',
       name: 'Test App',
@@ -1121,6 +913,7 @@ describe('deploy', () => {
 
     // When
     const result = await client.deploy({
+      appManifest: {name: 'Test App', handle: 'test-app', modules: []},
       apiKey: 'api-key',
       appId: 'gid://shopify/App/123',
       name: 'Test App',


### PR DESCRIPTION
# Include App Manifest in Deploy API Calls

### WHY are these changes introduced?

The current deployment process has a custom manifest generation function for cases when there are no assets. We need to unify manifest generation to a single place to avoid inconsistencies.

### WHAT is this pull request doing?

This PR enhances the deployment process by:

- Including the app manifest in the `uploadExtensionsBundle` function parameters
- Passing the app manifest through to the Developer Platform Client's deploy method
- Simplifying the module transformation logic by using the manifest directly instead of reconstructing it from individual modules

### How to test your changes?

1. Deploy an app with various extension types (UI, theme, function, etc.) (and also without extensions)
2. Verify that the deployment succeeds and the app manifest is correctly included in the API calls
3. Check that all extension types are properly represented in the deployed app

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible documentation changes