### PR TITLE
Add theme related monorail events and capture storefqdn in theme comm…

### DIFF
--- a/.changeset/nasty-deers-act.md
+++ b/.changeset/nasty-deers-act.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Add store domain logging for theme commands and update monorail with new theme related even types

--- a/packages/cli-kit/src/public/node/monorail.ts
+++ b/packages/cli-kit/src/public/node/monorail.ts
@@ -145,6 +145,12 @@ export interface Schemas {
       app_web_frontend_any?: Optional<boolean>
       app_web_frontend_count?: Optional<number>
 
+      // Theme related commands
+      cmd_theme_timings?: Optional<string>
+      cmd_theme_errors?: Optional<string>
+      cmd_theme_retries?: Optional<string>
+      cmd_theme_events?: Optional<string>
+
       // Environment
       env_ci?: Optional<boolean>
       env_ci_platform?: Optional<string>

--- a/packages/theme/src/cli/metadata.ts
+++ b/packages/theme/src/cli/metadata.ts
@@ -1,0 +1,13 @@
+import {MonorailEventPublic, MonorailEventSensitive} from '@shopify/cli-kit/node/monorail'
+import {createRuntimeMetadataContainer} from '@shopify/cli-kit/node/metadata'
+import type {PickByPrefix} from '@shopify/cli-kit/common/ts/pick-by-prefix'
+
+// Include both theme-specific fields AND store fields
+type CmdFieldsFromMonorail = PickByPrefix<MonorailEventPublic, 'cmd_theme_'> &
+  PickByPrefix<MonorailEventPublic, 'store_'>
+
+type CmdSensitiveFieldsFromMonorail = PickByPrefix<MonorailEventSensitive, 'store_'>
+
+const metadata = createRuntimeMetadataContainer<CmdFieldsFromMonorail, CmdSensitiveFieldsFromMonorail>({})
+
+export default metadata


### PR DESCRIPTION
### WHY are these changes introduced?

Main problem: We aren't capturing store domains in our logging for theme commands making us unable to sort by shop
Sub problem: We may want to capture other metrics specific for theme commands in the future.

### WHAT is this pull request doing?

- Adding the new monorail events
- Setting up logging for theme commands similar to the way app commands are [setup](https://github.com/Shopify/cli/blob/main/packages/app/src/cli/metadata.ts)
- Logging store domains for theme commands

This also sets us up to expand theme analytics in the future.

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
