### PR TITLE
Fix organization GID being used in some URLs

### DIFF
--- a/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
@@ -350,7 +350,7 @@ export class AppManagementClient implements DeveloperPlatformClient {
       title: name,
       apiKey: app.key,
       apiSecretKeys,
-      organizationId: app.organizationId,
+      organizationId: String(numberFromGid(app.organizationId)),
       grantedScopes: (appAccessModule?.config?.scopes as string[] | undefined) ?? [],
       applicationUrl: appHomeModule?.config?.app_url as string | undefined,
       flags: [],


### PR DESCRIPTION
### WHY are these changes introduced?

We recently changed from a local orgId (in the toml, a number) to use the one received from the API (a GID). This caused some issues in some places that were expecting a number without sanitazing the input.

### WHAT is this pull request doing?

Instead of chasing down everywhere where we might be missing this "sanitization", let's make sure that value coming from the API is just a number. 

If we need a GID, it will be converted later as needed.

### How to test your changes?

1. Function polling should work now.
2. app versions list should print a valid link
3. other cases where the orgId was causing a malformed URL should be fixed now

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes