### PR TITLE
Ensure errors in app logging render in regular dev log stream

### DIFF
--- a/packages/app/src/cli/services/app-logs/dev/poll-app-logs.test.ts
+++ b/packages/app/src/cli/services/app-logs/dev/poll-app-logs.test.ts
@@ -379,11 +379,11 @@ describe('pollAppLogs', () => {
       organizationId: 'organizationId',
     })
 
-    expect(outputWarnSpy).toHaveBeenCalledWith('Request throttled while polling app logs.')
+    expect(outputWarnSpy).toHaveBeenCalledWith('Request throttled while polling app logs.', stdout)
     expect(vi.getTimerCount()).toEqual(1)
   })
 
-  test('displays error message, waits, and retries if error occured', async () => {
+  test('displays error message, waits, and retries if error occurred', async () => {
     // Given
     const outputDebugSpy = vi.spyOn(output, 'outputDebug')
     const outputWarnSpy = vi.spyOn(output, 'outputWarn')
@@ -406,7 +406,7 @@ describe('pollAppLogs', () => {
     })
 
     // Then
-    expect(outputWarnSpy).toHaveBeenCalledWith('Error while polling app logs.')
+    expect(outputWarnSpy).toHaveBeenCalledWith('Error while polling app logs.', stdout)
     expect(vi.getTimerCount()).toEqual(1)
   })
 
@@ -450,8 +450,8 @@ describe('pollAppLogs', () => {
 
     // When/Then
     await expect(writeAppLogsToFile).not.toHaveBeenCalled
-    expect(outputWarnSpy).toHaveBeenCalledWith('Error while polling app logs.')
-    expect(outputWarnSpy).toHaveBeenCalledWith('Retrying in 5 seconds.')
+    expect(outputWarnSpy).toHaveBeenCalledWith('Error while polling app logs.', stdout)
+    expect(outputWarnSpy).toHaveBeenCalledWith('Retrying in 5 seconds.', stdout)
     expect(outputDebugSpy).toHaveBeenCalledWith(expect.stringContaining('JSON'))
   })
 })

--- a/packages/app/src/cli/services/dev/processes/app-logs-polling.test.ts
+++ b/packages/app/src/cli/services/dev/processes/app-logs-polling.test.ts
@@ -142,6 +142,7 @@ describe('app-logs-polling', () => {
         developerPlatformClient,
         appLogsSubscribeVariables,
         'organizationId',
+        stdout,
       )
       expect(createLogsDir).toHaveBeenCalledWith(API_KEY)
       expect(pollAppLogs).toHaveBeenCalledOnce()
@@ -191,6 +192,7 @@ describe('app-logs-polling', () => {
         developerPlatformClient,
         appLogsSubscribeVariables,
         'organizationId',
+        stdout,
       )
       expect(outputDebug).toHaveBeenCalledWith('Failed to start function logs: Error: uh oh, another error', stderr)
       expect(pollAppLogs).not.toHaveBeenCalled()

--- a/packages/app/src/cli/services/dev/processes/app-logs-polling.ts
+++ b/packages/app/src/cli/services/dev/processes/app-logs-polling.ts
@@ -69,7 +69,12 @@ export const subscribeAndStartPolling: DevProcessFunction<SubscribeAndStartPolli
   {developerPlatformClient, appLogsSubscribeVariables, storeName, organizationId, appWatcher, localApp: _localApp},
 ) => {
   async function startPolling(abortSignal?: AbortSignal) {
-    const jwtToken = await subscribeToAppLogs(developerPlatformClient, appLogsSubscribeVariables, organizationId)
+    const jwtToken = await subscribeToAppLogs(
+      developerPlatformClient,
+      appLogsSubscribeVariables,
+      organizationId,
+      stdout,
+    )
 
     const apiKey = appLogsSubscribeVariables.apiKey
     await createLogsDir(apiKey)


### PR DESCRIPTION
Also fixed a negated condition linting issue.

Polling error:
<img width="1344" height="758" alt="app-log-error-in-dev-output" src="https://github.com/user-attachments/assets/9c5a4321-ff04-47f3-b984-d05476bcce30" />

Subscription error:
<img width="1512" height="573" alt="app-log-subscribe-error-in-dev-output" src="https://github.com/user-attachments/assets/04ecfac6-fd5c-4886-892a-d42bd22c8ccc" />

Confirming `app logs` output on subscription error:
<img width="1077" height="418" alt="app-log-subscribe-error-in-logs-output" src="https://github.com/user-attachments/assets/7d16a2b5-71eb-4b78-9e9c-5f5d022fea1b" />
