### PR TITLE
Fix webhooks appearing as updated all the time

### DIFF
--- a/packages/app/src/cli/services/context/breakdown-extensions.ts
+++ b/packages/app/src/cli/services/context/breakdown-extensions.ts
@@ -214,6 +214,19 @@ async function resolveRemoteConfigExtensionIdentifiersBreakdown(
       }
       return subscription
     })
+
+    // Sort webhook subscriptions by uri & topics in both baseline and remote config
+    // Ensuring that deepCompare will not fail if the order is different
+    baselineConfig.webhooks.subscriptions.sort((webhookA, webhookB) => {
+      const keyA = webhookA.uri + (webhookA.topics?.sort().join(',') ?? '')
+      const keyB = webhookB.uri + (webhookB.topics?.sort().join(',') ?? '')
+      return keyA.localeCompare(keyB)
+    })
+    remoteConfig.webhooks?.subscriptions?.sort((webhookA, webhookB) => {
+      const keyA = webhookA.uri + (webhookA.topics?.sort().join(',') ?? '')
+      const keyB = webhookB.uri + (webhookB.topics?.sort().join(',') ?? '')
+      return keyA.localeCompare(keyB)
+    })
   }
 
   const diffConfigContent = buildDiffConfigContent(baselineConfig, remoteConfig, app.configSchema)


### PR DESCRIPTION
### WHY are these changes introduced?

To ensure webhook subscriptions are properly compared during app configuration breakdown, regardless of the order of subscriptions or topics.

### WHAT is this pull request doing?

Enhances the `configExtensionsIdentifiersBreakdown` function to normalize webhook subscriptions by:

1. Sorting webhook subscriptions by URI
2. Sorting topics within each subscription

This prevents false positives when comparing local and remote configurations that have the same webhook subscriptions but in different orders.

### How to test your changes?

1. Create an app with multiple webhook subscriptions
2. Deploy the app
3. Modify the order of webhook subscriptions in your app configuration without changing their content
4. Run `shopify app deploy` and verify that no changes are detected for webhooks

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev)changes