### PR TITLE
Use localhost for all port detection + serving

### DIFF
--- a/packages/cli-kit/src/public/node/tcp.test.ts
+++ b/packages/cli-kit/src/public/node/tcp.test.ts
@@ -80,7 +80,7 @@ describe('checkPortAvailability', () => {
 
     // Then
     expect(result).toBe(true)
-    expect(port.checkPort).toHaveBeenCalledWith(portNumber, undefined)
+    expect(port.checkPort).toHaveBeenCalledWith(portNumber, 'localhost')
   })
 
   test('returns false when port is not available', async () => {
@@ -93,23 +93,6 @@ describe('checkPortAvailability', () => {
 
     // Then
     expect(result).toBe(false)
-    expect(port.checkPort).toHaveBeenCalledWith(portNumber, undefined)
-  })
-
-  test('uses 0.0.0.0 as host when HOST env var is set', async () => {
-    // Given
-    const portNumber = 3000
-    vi.stubEnv('HOST', 'localhost')
-    vi.mocked(port.checkPort).mockResolvedValue(portNumber)
-
-    // When
-    const result = await checkPortAvailability(portNumber)
-
-    // Then
-    expect(result).toBe(true)
-    expect(port.checkPort).toHaveBeenCalledWith(portNumber, '0.0.0.0')
-
-    // Cleanup
-    vi.unstubAllEnvs()
+    expect(port.checkPort).toHaveBeenCalledWith(portNumber, 'localhost')
   })
 })

--- a/packages/cli-kit/src/public/node/tcp.ts
+++ b/packages/cli-kit/src/public/node/tcp.ts
@@ -50,8 +50,8 @@ export async function checkPortAvailability(portNumber: number): Promise<boolean
 
 function host(): string | undefined {
   // The get-port-please library does not work as expected when HOST env var is defined,
-  // so explicitly set the host to 0.0.0.0 to avoid conflicts
-  return process.env.HOST ? '0.0.0.0' : undefined
+  // so explicitly set the host to localhost to avoid conflicts
+  return 'localhost'
 }
 
 /**


### PR DESCRIPTION
Followup to #6255 addressing a regression where we couldn't run multiple simultaneous dev sessions