### PR TITLE
[Themes] Prevent injecting theme-hot-reload in web pixels

### DIFF
--- a/packages/theme/src/cli/utilities/theme-environment/proxy.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/proxy.ts
@@ -23,6 +23,7 @@ const IGNORED_ENDPOINTS = [
   '/shopify/monorail',
   '/mini-profiler-resources',
   '/web-pixels-manager',
+  '/web-pixels@',
   '/wpm',
   '/services/',
 ]


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Reported by @karreiro 

<img width="1279" height="397" alt="image" src="https://github.com/user-attachments/assets/83529f90-0b3d-4ea4-be22-f3212eb0ba18" />


We were seeing errors when accessing localStorage from theme-hot-reload. Turns out this happens because the CLI is injecting the theme-hot-reload script in the `/web-pixels` document.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

I'm adding this pathname to the ignore list since we are already ignoring `/web-pixels-manager` as well.

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

Check `shopify theme dev` with a theme that injects web pixels (e.g. Horizon). The error should disappear with this fix.

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
