### PR TITLE
Fix app handle validation

### DIFF
--- a/packages/app/src/cli/models/extensions/schemas.ts
+++ b/packages/app/src/cli/models/extensions/schemas.ts
@@ -105,6 +105,10 @@ export const BaseSchemaWithHandle = BaseSchema.extend({
   handle: HandleSchema,
 })
 
+export const BaseSchemaWithoutHandle = BaseSchema.omit({
+  handle: true,
+})
+
 export const UnifiedSchema = zod.object({
   api_version: ApiVersionSchema.optional(),
   description: zod.string().optional(),

--- a/packages/app/src/cli/models/extensions/specifications/app_config_app_access.ts
+++ b/packages/app/src/cli/models/extensions/specifications/app_config_app_access.ts
@@ -1,10 +1,10 @@
 import {validateUrl} from '../../app/validation/common.js'
 import {TransformationConfig, createConfigExtensionSpecification} from '../specification.js'
-import {BaseSchema} from '../schemas.js'
+import {BaseSchemaWithoutHandle} from '../schemas.js'
 import {normalizeDelimitedString} from '@shopify/cli-kit/common/string'
 import {zod} from '@shopify/cli-kit/node/schema'
 
-const AppAccessSchema = BaseSchema.extend({
+const AppAccessSchema = BaseSchemaWithoutHandle.extend({
   access: zod
     .object({
       admin: zod

--- a/packages/app/src/cli/models/extensions/specifications/app_config_app_home.ts
+++ b/packages/app/src/cli/models/extensions/specifications/app_config_app_home.ts
@@ -1,9 +1,9 @@
 import {validateUrl} from '../../app/validation/common.js'
-import {BaseSchema} from '../schemas.js'
+import {BaseSchemaWithoutHandle} from '../schemas.js'
 import {TransformationConfig, createConfigExtensionSpecification} from '../specification.js'
 import {zod} from '@shopify/cli-kit/node/schema'
 
-const AppHomeSchema = BaseSchema.extend({
+const AppHomeSchema = BaseSchemaWithoutHandle.extend({
   application_url: validateUrl(zod.string({required_error: 'Valid URL is required'})),
   embedded: zod.boolean({required_error: 'Boolean is required', invalid_type_error: 'Value must be Boolean'}),
   app_preferences: zod

--- a/packages/app/src/cli/models/extensions/specifications/app_config_app_proxy.ts
+++ b/packages/app/src/cli/models/extensions/specifications/app_config_app_proxy.ts
@@ -6,11 +6,11 @@ import {
   CustomTransformationConfig,
   createConfigExtensionSpecification,
 } from '../specification.js'
-import {BaseSchema} from '../schemas.js'
+import {BaseSchemaWithoutHandle} from '../schemas.js'
 import {CurrentAppConfiguration} from '../../app/app.js'
 import {zod} from '@shopify/cli-kit/node/schema'
 
-const AppProxySchema = BaseSchema.extend({
+const AppProxySchema = BaseSchemaWithoutHandle.extend({
   app_proxy: zod
     .object({
       url: zod.preprocess(

--- a/packages/app/src/cli/models/extensions/specifications/app_config_branding.ts
+++ b/packages/app/src/cli/models/extensions/specifications/app_config_branding.ts
@@ -1,13 +1,13 @@
 import {TransformationConfig, createConfigExtensionSpecification} from '../specification.js'
-import {BaseSchema} from '../schemas.js'
+import {BaseSchemaWithoutHandle} from '../schemas.js'
 import {zod} from '@shopify/cli-kit/node/schema'
 
-const BrandingSchema = BaseSchema.extend({
+const BrandingSchema = BaseSchemaWithoutHandle.extend({
   name: zod.string({required_error: 'String is required'}).max(30, {message: 'String must be less than 30 characters'}),
   handle: zod
     .string({required_error: 'String is required'})
     .max(256, {message: 'String must be less than 256 characters long'})
-    .refine((value) => value && /^\w*(?!-)[a-z0-9-]+(?<!-)$/.test(value), {
+    .refine((value) => value && /^\w*(?!-)[_a-z0-9-]+(?<!-)$/.test(value), {
       message: "String can't contain special characters",
     })
     .optional(),

--- a/packages/app/src/cli/models/extensions/specifications/app_config_point_of_sale.ts
+++ b/packages/app/src/cli/models/extensions/specifications/app_config_point_of_sale.ts
@@ -1,8 +1,8 @@
 import {createConfigExtensionSpecification, TransformationConfig} from '../specification.js'
-import {BaseSchema} from '../schemas.js'
+import {BaseSchemaWithoutHandle} from '../schemas.js'
 import {zod} from '@shopify/cli-kit/node/schema'
 
-const PosConfigurationSchema = BaseSchema.extend({
+const PosConfigurationSchema = BaseSchemaWithoutHandle.extend({
   pos: zod
     .object({
       embedded: zod.boolean({invalid_type_error: 'Value must be Boolean'}),

--- a/packages/app/src/cli/models/extensions/specifications/app_config_webhook_schemas/webhooks_schema.ts
+++ b/packages/app/src/cli/models/extensions/specifications/app_config_webhook_schemas/webhooks_schema.ts
@@ -3,7 +3,7 @@ import {webhookValidator} from '../validation/app_config_webhook.js'
 import {WebhookSubscriptionUriValidation} from '../validation/common.js'
 import {SingleWebhookSubscriptionSchema} from '../app_config_webhook_subscription.js'
 import {mergeAllWebhooks} from '../transform/app_config_webhook.js'
-import {BaseSchema} from '../../schemas.js'
+import {BaseSchemaWithoutHandle} from '../../schemas.js'
 import {zod} from '@shopify/cli-kit/node/schema'
 
 const WebhooksConfigSchema = zod.object({
@@ -23,6 +23,6 @@ const WebhooksConfigSchema = zod.object({
 
 export type SingleWebhookSubscriptionType = zod.infer<typeof SingleWebhookSubscriptionSchema>
 
-export const WebhooksSchema = BaseSchema.extend({
+export const WebhooksSchema = BaseSchemaWithoutHandle.extend({
   webhooks: WebhooksConfigSchema.superRefine(webhookValidator),
 })


### PR DESCRIPTION
### WHY are these changes introduced?

Fix a bug where the extension handle validation was being applied to all config modules because it was in the BaseSchema.



### WHAT is this pull request doing?

- Creates a new `BaseSchemaWithoutHandle`  omitting the handle field from `BaseSchema`
- Updates app configuration extensions to use `BaseSchemaWithoutHandle` instead of `BaseSchema`:
    - App Access
    - App Home
    - App Proxy
    - Branding
    - Point of Sale
    - Webhook Schemas
- Modifies the regex pattern in Branding schema to allow underscores in handles

### How to test your changes?

1. Modify your app config toml to have an app handle with underscores
2. Deploy and see that it works.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible documentation changes