### PR TITLE
Remove requiresOrganization from clients

### DIFF
--- a/packages/app/src/cli/models/app/app.test-data.ts
+++ b/packages/app/src/cli/models/app/app.test-data.ts
@@ -1418,7 +1418,6 @@ export function testDeveloperPlatformClient(stubs: Partial<DeveloperPlatformClie
   const clientStub: DeveloperPlatformClient = {
     clientName: ClientName.AppManagement,
     webUiName: 'Test Dashboard',
-    requiresOrganization: false,
     supportsAtomicDeployments: false,
     supportsDevSessions: stubs.supportsDevSessions ?? false,
     supportsStoreSearch: false,
@@ -1505,7 +1504,6 @@ export function testDeveloperPlatformClient(stubs: Partial<DeveloperPlatformClie
       retVal[
         key as keyof Omit<
           DeveloperPlatformClient,
-          | 'requiresOrganization'
           | 'supportsAtomicDeployments'
           | 'clientName'
           | 'webUiName'

--- a/packages/app/src/cli/services/app/config/link.ts
+++ b/packages/app/src/cli/services/app/config/link.ts
@@ -377,7 +377,6 @@ async function overwriteLocalConfigFileWithRemoteAppConfiguration(options: {
       {
         client_id: remoteApp.apiKey,
         path: configFilePath,
-        ...(developerPlatformClient.requiresOrganization ? {organization_id: remoteApp.organizationId} : {}),
         ...remoteAppConfiguration,
       },
       replaceLocalArrayStrategy,

--- a/packages/app/src/cli/utilities/developer-platform-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client.ts
@@ -220,7 +220,6 @@ export interface DeveloperPlatformClient {
   readonly clientName: ClientName
   readonly webUiName: string
   readonly supportsAtomicDeployments: boolean
-  readonly requiresOrganization: boolean
   readonly supportsDevSessions: boolean
   readonly supportsStoreSearch: boolean
   readonly organizationSource: OrganizationSource

--- a/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
@@ -184,7 +184,6 @@ export interface GatedExtensionTemplate extends ExtensionTemplate {
 export class AppManagementClient implements DeveloperPlatformClient {
   public readonly clientName = ClientName.AppManagement
   public readonly webUiName = 'Developer Dashboard'
-  public readonly requiresOrganization = true
   public readonly supportsAtomicDeployments = true
   public readonly supportsDevSessions = true
   public readonly supportsStoreSearch = true

--- a/packages/app/src/cli/utilities/developer-platform-client/partners-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/partners-client.ts
@@ -214,7 +214,6 @@ export class PartnersClient implements DeveloperPlatformClient {
   public readonly clientName = ClientName.Partners
   public readonly webUiName = 'Partner Dashboard'
   public readonly supportsAtomicDeployments = false
-  public readonly requiresOrganization = false
   public readonly supportsDevSessions = false
   public readonly supportsStoreSearch = false
   public readonly organizationSource = OrganizationSource.Partners


### PR DESCRIPTION
### WHY are these changes introduced?

Stop adding the organization_id to the toml

### WHAT is this pull request doing?

This PR removes the `requiresOrganization` property from:

- The `DeveloperPlatformClient` interface
- The `AppManagementClient` and `PartnersClient` implementations
- The test data utilities
- Removes related code in the link configuration that was using this property

### How to test your changes?

1. Run the test suite to ensure all tests pass
2. Test app linking functionality to verify it still works correctly without adding organizatation_id to the toml.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev)changes