### PR TITLE
Fix extension matching after changing the handle post-migration

### DIFF
--- a/packages/app/src/cli/services/context/id-matching.test.ts
+++ b/packages/app/src/cli/services/context/id-matching.test.ts
@@ -14,56 +14,56 @@ const REGISTRATION_A: RemoteSource = {
   uuid: 'UUID_A',
   id: 'A',
   title: 'EXTENSION_A',
-  type: 'CHECKOUT_POST_PURCHASE',
+  type: 'checkout_post_purchase',
 }
 
 const REGISTRATION_A_2: RemoteSource = {
   uuid: 'UUID_A_2',
   id: 'A_2',
   title: 'EXTENSION_A_2',
-  type: 'CHECKOUT_POST_PURCHASE',
+  type: 'checkout_post_purchase',
 }
 
 const REGISTRATION_A_3: RemoteSource = {
   uuid: 'UUID_A_3',
   id: 'A_3',
   title: 'EXTENSION_A_3',
-  type: 'CHECKOUT_POST_PURCHASE',
+  type: 'checkout_post_purchase',
 }
 
 const REGISTRATION_A_4: RemoteSource = {
   uuid: 'UUID_A_4',
   id: 'A_4',
   title: 'EXTENSION_A_4',
-  type: 'CHECKOUT_POST_PURCHASE',
+  type: 'checkout_post_purchase',
 }
 
 const REGISTRATION_B: RemoteSource = {
   uuid: 'UUID_B',
   id: 'B',
   title: 'EXTENSION_B',
-  type: 'SUBSCRIPTION_MANAGEMENT',
+  type: 'subscription_management',
 }
 
 const REGISTRATION_C: RemoteSource = {
   uuid: 'UUID_C',
   id: 'C',
   title: 'EXTENSION_C',
-  type: 'THEME_APP_EXTENSION',
+  type: 'theme_app_extension',
 }
 
 const REGISTRATION_D: RemoteSource = {
   uuid: 'UUID_D',
   id: 'D',
   title: 'EXTENSION_D',
-  type: 'WEB_PIXEL_EXTENSION',
+  type: 'web_pixel_extension',
 }
 
 const REGISTRATION_FUNCTION_A: RemoteSource = {
   uuid: 'FUNCTION_UUID_A',
   id: 'FUNCTION_A',
   title: 'FUNCTION A',
-  type: 'FUNCTION',
+  type: 'function',
   draftVersion: {
     config: JSON.stringify({
       legacy_function_id: 'LEGACY_FUNCTION_ULID_A',

--- a/packages/app/src/cli/services/context/id-matching.ts
+++ b/packages/app/src/cli/services/context/id-matching.ts
@@ -153,7 +153,8 @@ function matchByUniqueType(
   const localGroups = groupBy(localSources, 'graphQLType')
   const localUnique = Object.values(pickBy(localGroups, (group, _key) => group.length === 1)).flat()
 
-  const remoteGroups = groupBy(remoteSources, 'type')
+  const remoteWithNormalizedType = remoteSources.map((remote) => ({...remote, type: remote.type.toLowerCase()}))
+  const remoteGroups = groupBy(remoteWithNormalizedType, 'type')
   const remoteUniqueMap = pickBy(remoteGroups, (group, _key) => group.length === 1)
 
   const toConfirm: {local: LocalSource; remote: RemoteSource}[] = []
@@ -163,7 +164,7 @@ function matchByUniqueType(
   // - find a corresponding unique remote source and ask the user to confirm
   // - create it from scratch
   for (const local of localUnique) {
-    const remote = remoteUniqueMap[local.graphQLType]
+    const remote = remoteUniqueMap[local.graphQLType.toLowerCase()]
     if (remote && remote[0]) {
       toConfirm.push({local, remote: remote[0]})
     } else {
@@ -176,11 +177,11 @@ function matchByUniqueType(
   // it means that we need to create them.
   const localDuplicated = difference(localSources, localUnique)
   const remotePending = difference(
-    remoteSources,
+    remoteWithNormalizedType,
     toConfirm.map((elem) => elem.remote),
   )
   const [localPending, localToCreate] = partition(localDuplicated, (local) =>
-    remotePending.map((remote) => remote.type).includes(local.graphQLType),
+    remotePending.map((remote) => remote.type.toLowerCase()).includes(local.graphQLType.toLowerCase()),
   )
   toCreate.push(...localToCreate)
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fix a bug if you change the handle before the first deploy post-migration.

### WHAT is this pull request doing?

Normalizes extension type case by converting remote source types to lowercase before comparison. This ensures that case differences between local and remote extension types (like `CHECKOUT_POST_PURCHASE` vs `checkout_post_purchase`) don't prevent proper matching.

The changes include:

- Converting remote source types to lowercase in the `matchByUniqueType` function
- Updating test fixtures to use lowercase extension types to match the actual API response format

### How to test your changes?

1. Having an app in Partners with extensions (and at least 1 version deployed)
2. Migrate the app
3. Update the extension handle
4. Deploy to dev dash
5. You should see a prompt to confirm a manual match with the new handle (only the first time)

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible documentation changes