### PR TITLE
Make local servers listen on localhost

### DIFF
--- a/packages/app/src/cli/services/dev/extension/server.ts
+++ b/packages/app/src/cli/services/dev/extension/server.ts
@@ -42,6 +42,6 @@ export function setupHTTPServer(options: SetupHTTPServerOptions) {
 
   // eslint-disable-next-line @typescript-eslint/no-misused-promises
   const httpServer = createServer(httpApp)
-  httpServer.listen(options.devOptions.port)
+  httpServer.listen(options.devOptions.port, 'localhost')
   return httpServer
 }

--- a/packages/app/src/cli/services/dev/processes/setup-dev-processes.ts
+++ b/packages/app/src/cli/services/dev/processes/setup-dev-processes.ts
@@ -273,5 +273,5 @@ export const startProxyServer: DevProcessFunction<{
     `Proxy server started on port ${port} ${localhostCert ? `with certificate ${localhostCert.certPath}` : ''}`,
     stdout,
   )
-  await server.listen(port)
+  await server.listen(port, 'localhost')
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #0000

This change restricts the HTTP server and proxy server to only listen on the localhost interface, enhancing security by preventing external network access to development servers.

### WHAT is this pull request doing?

Modifies the HTTP and proxy servers to explicitly bind to 'localhost' instead of all network interfaces (0.0.0.0). This ensures that development servers are only accessible from the local machine and not exposed to external networks.

### How to test your changes?

1. Start a development server using `yarn dev`
2. Verify that the server is accessible at `http://localhost:<port>`
3. Confirm that the server is not accessible from other machines on the network

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes