### PR TITLE
Change how Webhook Subscription UID is generated

### DIFF
--- a/packages/app/src/cli/models/extensions/extension-instance.test.ts
+++ b/packages/app/src/cli/models/extensions/extension-instance.test.ts
@@ -531,12 +531,24 @@ describe('draftMessages', async () => {
       expect(extensionInstance.uid).toBe(nonRandomUUID(extensionInstance.handle))
     })
 
-    test('returns non-random UUID based on handle when strategy is dynamic', async () => {
+    test('returns a custom string when strategy is dynamic and it is a webhook subscription extension without filters', async () => {
       // Given
       const extensionInstance = await testSingleWebhookSubscriptionExtension()
-
       // Then
-      expect(extensionInstance.uid).toBe(nonRandomUUID(extensionInstance.handle))
+      expect(extensionInstance.uid).toBe('orders/delete::undefined::https://my-app.com/webhooks')
+    })
+
+    test('returns a custom string when strategy is dynamic and it is a webhook subscription extension with filters', async () => {
+      // Given
+      const extensionInstance = await testSingleWebhookSubscriptionExtension({
+        config: {
+          topic: 'orders/delete',
+          uri: 'https://my-app.com/webhooks',
+          filter: '123',
+        },
+      })
+      // Then
+      expect(extensionInstance.uid).toBe('orders/delete::123::https://my-app.com/webhooks')
     })
   })
 })

--- a/packages/app/src/cli/models/extensions/schemas.ts
+++ b/packages/app/src/cli/models/extensions/schemas.ts
@@ -1,6 +1,7 @@
 import {zod} from '@shopify/cli-kit/node/schema'
 
 export const MAX_EXTENSION_HANDLE_LENGTH = 50
+export const MAX_UID_LENGTH = 250
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type ZodSchemaType<T> = zod.ZodType<T, any, any>


### PR DESCRIPTION
### WHY are these changes introduced?

To improve the uniqueness and readability of webhook subscription extension UIDs by generating them based on their configuration details rather than using a generic UUID.

### WHAT is this pull request doing?

Modifies the UID generation strategy for webhook subscription extensions:

- When using the 'dynamic' strategy, webhook subscription extensions now generate UIDs in the format `topic::filter::uri`
- Adds a maximum UID length constraint of 250 characters
- Updates tests to verify the new UID format for webhook subscriptions both with and without filters

### How to test your changes?

1. Create a webhook subscription extension with a topic and URI
2. Verify that the generated UID follows the format `topic::filter::uri`
3. Create another webhook subscription with filters and confirm the filter value is included in the UID

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev)changes