### PR TITLE
Webhook subscriptions shouldnt block dev

### DIFF
--- a/packages/app/src/cli/services/dev.test.ts
+++ b/packages/app/src/cli/services/dev.test.ts
@@ -108,6 +108,31 @@ describe('blockIfMigrationIncomplete', () => {
     await expect(blockIfMigrationIncomplete(devConfig)).resolves.toBeUndefined()
   })
 
+  test('does nothing remote extensions dont have uids but are webhook subscriptions', async () => {
+    const developerPlatformClient = testDeveloperPlatformClient({
+      supportsDevSessions: true,
+      async appExtensionRegistrations() {
+        return {
+          app: {
+            extensionRegistrations: [
+              {id: '', uuid: 'u1', title: 'Ext 1', type: 'webhook_subscription'},
+              {id: '2', uuid: 'u2', title: 'Ext 2', type: 'web_pixel_extension'},
+            ],
+            configurationRegistrations: [],
+            dashboardManagedExtensionRegistrations: [],
+          },
+        } as any
+      },
+    })
+
+    const devConfig = {
+      ...baseConfig(),
+      developerPlatformClient,
+    } as any
+
+    await expect(blockIfMigrationIncomplete(devConfig)).resolves.toBeUndefined()
+  })
+
   test('throws AbortError when some remote extensions are missing ids (not migrated)', async () => {
     const developerPlatformClient = testDeveloperPlatformClient({
       supportsDevSessions: true,

--- a/packages/app/src/cli/services/dev.ts
+++ b/packages/app/src/cli/services/dev.ts
@@ -242,7 +242,12 @@ export async function blockIfMigrationIncomplete(devConfig: DevConfig) {
   if (!developerPlatformClient.supportsDevSessions) return
 
   const extensions = (await developerPlatformClient.appExtensionRegistrations(remoteApp)).app.extensionRegistrations
-  if (!extensions.every((extension) => extension.id)) {
+  if (
+    !extensions
+      // Ignore webhook subscriptions because they do need UIDs but shouldn't block dev
+      .filter((extension) => extension.type.toLowerCase() !== 'webhook_subscription')
+      .every((extension) => extension.id)
+  ) {
     const message = ['Your app has extensions which need to be assigned', {command: 'uid'}, 'identifiers.']
     const nextSteps = [
       'You must first map IDs to your existing extensions by running',


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes an issue where webhook subscriptions were incorrectly blocking the dev command due to missing UIDs.

### WHAT is this pull request doing?

Modifies the `blockIfMigrationIncomplete` function to ignore webhook subscriptions when checking if extensions have assigned UIDs. Webhook subscriptions do need UIDs but shouldn't block the dev command from proceeding.

### How to test your changes?

1. Create an app with webhook subscriptions
2. Run the dev command
3. Verify that the dev command doesn't block due to webhook subscriptions missing UIDs

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev)changes