### PR TITLE
Use updated destinations API for ListOrganizations

### DIFF
--- a/packages/app/src/cli/api/graphql/business-platform-destinations/generated/organizations.ts
+++ b/packages/app/src/cli/api/graphql/business-platform-destinations/generated/organizations.ts
@@ -6,7 +6,10 @@ import {TypedDocumentNode as DocumentNode} from '@graphql-typed-document-node/co
 export type ListOrganizationsQueryVariables = Types.Exact<{[key: string]: never}>
 
 export type ListOrganizationsQuery = {
-  currentUserAccount?: {uuid: string; organizations: {nodes: {id: string; name: string}[]}} | null
+  currentUserAccount?: {
+    uuid: string
+    organizationsWithAccessToDestination: {nodes: {id: string; name: string}[]}
+  } | null
 }
 
 export const ListOrganizations = {
@@ -28,12 +31,12 @@ export const ListOrganizations = {
                 {kind: 'Field', name: {kind: 'Name', value: 'uuid'}},
                 {
                   kind: 'Field',
-                  name: {kind: 'Name', value: 'organizations'},
+                  name: {kind: 'Name', value: 'organizationsWithAccessToDestination'},
                   arguments: [
                     {
                       kind: 'Argument',
-                      name: {kind: 'Name', value: 'hasAccessToDestination'},
-                      value: {kind: 'EnumValue', value: 'DEVELOPER_DASHBOARD'},
+                      name: {kind: 'Name', value: 'destination'},
+                      value: {kind: 'EnumValue', value: 'APPS_CLI'},
                     },
                   ],
                   selectionSet: {

--- a/packages/app/src/cli/api/graphql/business-platform-destinations/queries/organizations.graphql
+++ b/packages/app/src/cli/api/graphql/business-platform-destinations/queries/organizations.graphql
@@ -1,7 +1,7 @@
 query ListOrganizations {
   currentUserAccount {
     uuid
-    organizations(hasAccessToDestination: DEVELOPER_DASHBOARD) {
+    organizationsWithAccessToDestination(destination: APPS_CLI) {
       nodes {
         id
         name

--- a/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
@@ -361,7 +361,7 @@ export class AppManagementClient implements DeveloperPlatformClient {
   async organizations(): Promise<Organization[]> {
     const organizationsResult = await this.businessPlatformRequest({query: ListOrganizations})
     if (!organizationsResult.currentUserAccount) return []
-    return organizationsResult.currentUserAccount.organizations.nodes.map((org) => ({
+    return organizationsResult.currentUserAccount.organizationsWithAccessToDestination.nodes.map((org) => ({
       id: idFromEncodedGid(org.id),
       businessName: `${org.name} (Dev Dashboard)`,
       source: this.organizationSource,


### PR DESCRIPTION
### WHY are these changes introduced?

Requires: 
1. https://github.com/shop/world/pull/147625 to ship to production.
2. Downstack PR: https://github.com/Shopify/cli/pull/6284

Once (1) ships, this PR can the updated GraphQL schema to access Dev Platform organizations to which the user has access.

### WHAT is this pull request doing?

Just updating a single GraphQL call with new syntax.

### How to test your changes?

1. Check out https://github.com/shop/world/pull/147625 locally + dev up all the servers.
2. `dev cd organizations` / `dev c`
3. You may want to `Access::UserPermission.create(organization_id: 1, organization_user_id: 1, namespace: "organization", handle: "develop_apps
", organization_access: true, store_access_type: "all_stores")` to make the testing work more obviously (shows multiple orgs when you run `app init`). This is necessary because database seeds are still pre-RBAC for some local dev orgs, even though in production this is no longer the case.

Then in the CLI: `SHOPIFY_CLI_NEVER_USE_PARTNERS_API=1 SHOPIFY_SERVICE_ENV=local pnpm run shopify app init --path="$HOME/src/tmp" --template=remix --flavor=javascript` and notice that you see two organizations in the list. If you see orgs, this is working.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
