### PR TITLE
Fix duplicated dashboard extensions in deploy prompt

### DIFF
--- a/packages/app/src/cli/services/dev/migrate-app-module.ts
+++ b/packages/app/src/cli/services/dev/migrate-app-module.ts
@@ -97,7 +97,7 @@ export async function migrateAppModules(options: {
 }) {
   const {extensionsToMigrate, appId, type, remoteExtensions, migrationClient} = options
 
-  const migratedIDs = await Promise.all(
+  await Promise.all(
     extensionsToMigrate.map(({remote}) =>
       migrateAppModule({
         apiKey: appId,
@@ -109,8 +109,9 @@ export async function migrateAppModules(options: {
     ),
   )
 
+  const migratedUUIDs = extensionsToMigrate.map(({remote}) => remote.uuid)
   return remoteExtensions
-    .filter((extension) => migratedIDs.includes(extension.id))
+    .filter((extension) => migratedUUIDs.includes(extension.uuid))
     .map((extension) => {
       return {
         ...extension,

--- a/packages/app/src/cli/services/dev/migrate-flow-extension.ts
+++ b/packages/app/src/cli/services/dev/migrate-flow-extension.ts
@@ -15,7 +15,7 @@ export async function migrateFlowExtensions(options: {
 }) {
   const {extensionsToMigrate, appId, remoteExtensions, migrationClient} = options
 
-  const migratedIDs = await Promise.all(
+  await Promise.all(
     extensionsToMigrate.map(({remote}) =>
       migrateFlowExtension({
         apiKey: appId,
@@ -31,8 +31,9 @@ export async function migrateFlowExtensions(options: {
     ['flow_trigger_definition', 'FLOW_TRIGGER'],
   ])
 
+  const migratedUUIDs = extensionsToMigrate.map(({remote}) => remote.uuid)
   return remoteExtensions
-    .filter((extension) => migratedIDs.includes(extension.id))
+    .filter((extension) => migratedUUIDs.includes(extension.uuid))
     .map((extension) => {
       return {
         ...extension,

--- a/packages/app/src/cli/services/dev/migrate-to-ui-extension.ts
+++ b/packages/app/src/cli/services/dev/migrate-to-ui-extension.ts
@@ -27,7 +27,7 @@ export async function migrateExtensionsToUIExtension(options: {
   )
 
   return remoteExtensions.map((extension) => {
-    if (extensionsToMigrate.some(({remote}) => remote.id === extension.id)) {
+    if (extensionsToMigrate.some(({remote}) => remote.uuid === extension.uuid)) {
       return {
         ...extension,
         type: 'UI_EXTENSION',


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes an issue with extension migration where the code was incorrectly filtering migrated extensions by ID instead of UUID, but in the new API the `ID`​ is empty.

### WHAT is this pull request doing?

This PR fixes how migrated extensions are tracked and returned:

1. In `migrateAppModules`, `migrateFlowExtensions` and in `migrateToUIExtension`  changes the filtering logic to use UUID instead of ID to properly identify migrated extensions.

### How to test your changes?

1. Start from CLI with a new partners app
2. Add a subscription_link extension from the dashboard
3. Deploy from the CLI (still to partners) to create a version that includes the dashboard extension
4. Migrate your app
5. Deploy again from the CLI -> accept the import & migration
6. Should see a normal prompt where all the extensions are “UPDATED” and there are none added/removed.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible documentation changes