### PR TITLE
allow for advertise URLs for theme extension and graphiql

### DIFF
--- a/packages/app/src/cli/commands/app/dev.ts
+++ b/packages/app/src/cli/commands/app/dev.ts
@@ -100,6 +100,11 @@ If you're using the Ruby app template, then you need to complete the following s
       description: 'Local port of the theme app extension development server.',
       env: 'SHOPIFY_FLAG_THEME_APP_EXTENSION_PORT',
     }),
+    'theme-app-extension-advertise-url': Flags.string({
+      hidden: false,
+      description: 'The URL shown in the terminal when the theme app extension development server is running.',
+      env: 'SHOPIFY_FLAG_THEME_APP_EXTENSION_ADVERTISE_URL',
+    }),
     notify: Flags.string({
       description:
         'The file path or URL. The file path is to a file that you want updated on idle. The URL path is where you want a webhook posted to report on file changes.',
@@ -109,6 +114,11 @@ If you're using the Ruby app template, then you need to complete the following s
       hidden: true,
       description: 'Local port of the GraphiQL development server.',
       env: 'SHOPIFY_FLAG_GRAPHIQL_PORT',
+    }),
+    'graphiql-advertise-url': Flags.string({
+      hidden: true,
+      description: 'The URL shown in the terminal when the GraphiQL development server is running.',
+      env: 'SHOPIFY_FLAG_GRAPHIQL_ADVERTISE_URL',
     }),
     'graphiql-key': Flags.string({
       hidden: true,
@@ -171,8 +181,10 @@ If you're using the Ruby app template, then you need to complete the following s
       checkoutCartUrl: flags['checkout-cart-url'],
       theme: flags.theme,
       themeExtensionPort: flags['theme-app-extension-port'],
+      themeExtensionAdvertiseUrl: flags['theme-app-extension-advertise-url'],
       notify: flags.notify,
       graphiqlPort: flags['graphiql-port'],
+      graphiqlAdvertiseUrl: flags['graphiql-advertise-url'],
       graphiqlKey: flags['graphiql-key'],
       tunnel: tunnelMode,
     }

--- a/packages/app/src/cli/services/dev.ts
+++ b/packages/app/src/cli/services/dev.ts
@@ -65,8 +65,10 @@ export interface DevOptions {
   tunnel: TunnelMode
   theme?: string
   themeExtensionPort?: number
+  themeExtensionAdvertiseUrl?: string
   notify?: string
   graphiqlPort?: number
+  graphiqlAdvertiseUrl?: string
   graphiqlKey?: string
 }
 
@@ -177,6 +179,7 @@ async function prepareForDev(commandOptions: DevOptions): Promise<DevConfig> {
     network,
     partnerUrlsUpdated,
     graphiqlPort,
+    graphiqlAdvertiseUrl: commandOptions.graphiqlAdvertiseUrl,
     graphiqlKey: commandOptions.graphiqlKey,
   }
 }
@@ -437,6 +440,7 @@ async function launchDevProcesses({
     previewUrl,
     graphiqlUrl,
     graphiqlPort: config.graphiqlPort,
+    graphiqlAdvertiseUrl: config.graphiqlAdvertiseUrl,
     app,
     abortController,
     developerPreview: developerPreviewController(apiKey, developerPlatformClient),

--- a/packages/app/src/cli/services/dev/processes/setup-dev-processes.ts
+++ b/packages/app/src/cli/services/dev/processes/setup-dev-processes.ts
@@ -68,6 +68,7 @@ export interface DevConfig {
   network: DevNetworkOptions
   partnerUrlsUpdated: boolean
   graphiqlPort: number
+  graphiqlAdvertiseUrl?: string
   graphiqlKey?: string
 }
 
@@ -81,6 +82,7 @@ export async function setupDevProcesses({
   commandOptions,
   network,
   graphiqlPort,
+  graphiqlAdvertiseUrl,
   graphiqlKey,
 }: DevConfig): Promise<{
   processes: DevProcesses
@@ -104,7 +106,7 @@ export async function setupDevProcesses({
   const previewURL = anyPreviewableExtensions ? devConsoleURL : appPreviewUrl
 
   const graphiqlURL = shouldRenderGraphiQL
-    ? `http://localhost:${graphiqlPort}/graphiql${graphiqlKey ? `?key=${graphiqlKey}` : ''}`
+    ? graphiqlAdvertiseUrl ?? `http://localhost:${graphiqlPort}/graphiql${graphiqlKey ? `?key=${graphiqlKey}` : ''}`
     : undefined
 
   const devSessionStatusManager = new DevSessionStatusManager({isReady: false, previewURL, graphiqlURL})
@@ -173,6 +175,7 @@ export async function setupDevProcesses({
       storeFqdn,
       theme: commandOptions.theme,
       themeExtensionPort: commandOptions.themeExtensionPort,
+      themeExtensionAdvertiseUrl: commandOptions.themeExtensionAdvertiseUrl,
     }),
     setupSendUninstallWebhookProcess({
       webs: reloadedApp.webs,

--- a/packages/app/src/cli/services/dev/processes/theme-app-extension.test.ts
+++ b/packages/app/src/cli/services/dev/processes/theme-app-extension.test.ts
@@ -167,6 +167,60 @@ describe('setupPreviewThemeAppExtensionsProcess', () => {
       orderedNextSteps: true,
     })
   })
+
+  test('Returns a different theme extension URL if custom advertise URL is provided', async () => {
+    // Given
+    const mockTheme = {id: 123} as Theme
+    vi.mocked(fetchTheme).mockResolvedValue(mockTheme)
+
+    const storeFqdn = 'test.myshopify.com'
+    const theme = '123'
+    const remoteApp = testOrganizationApp()
+    const localApp = testApp({allExtensions: [await testThemeExtensions()]})
+
+    // When
+    const result = await setupPreviewThemeAppExtensionsProcess({
+      localApp,
+      remoteApp,
+      storeFqdn,
+      theme,
+      themeExtensionAdvertiseUrl: 'https://foo-proxy.example.com',
+    })
+
+    // Then
+    expect(result).toBeDefined()
+    expect(renderInfo).toBeCalledWith({
+      headline: 'The theme app extension development server is ready.',
+      nextSteps: [
+        [
+          {
+            link: {
+              label: 'Install your app in your development store',
+              url: 'https://partners.shopify.com/1/apps/1/test',
+            },
+          },
+        ],
+        [
+          {
+            link: {
+              label: 'Setup your theme app extension in the host theme',
+              url: 'https://test.myshopify.com/admin/themes/123/editor',
+            },
+          },
+        ],
+        [
+          'Preview your theme app extension at',
+          {
+            link: {
+              label: 'https://foo-proxy.example.com',
+              url: 'https://foo-proxy.example.com',
+            },
+          },
+        ],
+      ],
+      orderedNextSteps: true,
+    })
+  })
 })
 
 describe('findOrCreateHostTheme', () => {

--- a/packages/app/src/cli/services/dev/processes/theme-app-extension.ts
+++ b/packages/app/src/cli/services/dev/processes/theme-app-extension.ts
@@ -26,6 +26,7 @@ interface HostThemeSetupOptions {
   storeFqdn: string
   theme?: string
   themeExtensionPort?: number
+  themeExtensionAdvertiseUrl?: string
 }
 
 export interface PreviewThemeAppExtensionsProcess extends BaseProcess<ThemeAppExtensionServerOptions> {
@@ -84,8 +85,8 @@ export async function setupPreviewThemeAppExtensionsProcess(
         'Preview your theme app extension at',
         {
           link: {
-            label: `http://127.0.0.1:${themeExtensionPort}`,
-            url: `http://127.0.0.1:${themeExtensionPort}`,
+            label: options.themeExtensionAdvertiseUrl ?? `http://127.0.0.1:${themeExtensionPort}`,
+            url: options.themeExtensionAdvertiseUrl ?? `http://127.0.0.1:${themeExtensionPort}`,
           },
         },
       ],

--- a/packages/app/src/cli/services/dev/ui.tsx
+++ b/packages/app/src/cli/services/dev/ui.tsx
@@ -14,6 +14,7 @@ export async function renderDev({
   abortController,
   graphiqlUrl,
   graphiqlPort,
+  graphiqlAdvertiseUrl,
   developerPreview,
   shopFqdn,
   devSessionStatusManager,
@@ -58,6 +59,7 @@ export async function renderDev({
         app={app}
         graphiqlUrl={graphiqlUrl}
         graphiqlPort={graphiqlPort}
+        graphiqlAdvertiseUrl={graphiqlAdvertiseUrl}
         developerPreview={developerPreview}
         isEditionWeek={isEditionWeek()}
         shopFqdn={shopFqdn}

--- a/packages/app/src/cli/services/dev/ui/components/Dev.tsx
+++ b/packages/app/src/cli/services/dev/ui/components/Dev.tsx
@@ -27,6 +27,7 @@ export interface DevProps {
   previewUrl: string
   graphiqlUrl?: string
   graphiqlPort: number
+  graphiqlAdvertiseUrl?: string
   app: {
     canEnablePreviewMode: boolean
     developmentStorePreviewEnabled?: boolean
@@ -54,6 +55,7 @@ const Dev: FunctionComponent<DevProps> = ({
   previewUrl,
   graphiqlUrl = '',
   graphiqlPort,
+  graphiqlAdvertiseUrl,
   app,
   pollingTime = 5000,
   developerPreview,
@@ -264,7 +266,7 @@ const Dev: FunctionComponent<DevProps> = ({
                 </Text>
                 {graphiqlUrl ? (
                   <Text>
-                    GraphiQL URL: <Link url={localhostGraphiqlUrl} />
+                    GraphiQL URL: <Link url={graphiqlAdvertiseUrl ?? localhostGraphiqlUrl} />
                   </Text>
                 ) : null}
               </>


### PR DESCRIPTION
This PR reopens https://github.com/Shopify/cli/pull/5587

### WHY are these changes introduced?

We're working on a feature that allows users to run Shopify CLI in our isolated cloud container and let them access processes like the theme extension dev server and GraphiQL via our proxy. However, the GraphiQL and theme extension URLs show a hardcoded localhost URL in the terminal.

Therefore, we would like to introduce two new arguments: theme-app-extension-advertise-url and graphiql-advertise-url to the Shopify CLI, so that we can change the URL outputs via environment variables, and users can visit the modified links shown in the remote terminal.

### WHAT is this pull request doing?

Introduces two new arguments when running the app dev command:

theme-app-extension-advertise-url - Change the theme extension dev server URL shown in the terminal
graphiql-advertise-url - Change the GraphiQL URL shown in the terminal
Before:

<img width="2058" height="818" alt="428419138-0380ba49-3ce4-4243-b5b6-72a4e8546b0c" src="https://github.com/user-attachments/assets/13447a03-002d-43d5-ae01-20cd85bf161f" />



After:

<img width="2082" height="836" alt="428419170-8d768775-c45c-4232-a9c8-41c1f677b6ad" src="https://github.com/user-attachments/assets/64393b1a-dc15-4816-9ead-db3629ea2ef2" />

Note: this Shopify doc (https://shopify.dev/docs/api/shopify-cli/app/app-dev) might also need to include these two new arguments, but I'm not entirely sure how, so no doc-related change is included for now. Please let me know, and I'll fix the doc side.

### How to test your changes?

Include the two arguments in the function/component that outputs the URLs, then ensure the URLs shown in the output are not localhost.

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
