### PR TITLE
Fix issue when trying to import an already imported extension

### DIFF
--- a/packages/app/src/cli/models/app/identifiers.ts
+++ b/packages/app/src/cli/models/app/identifiers.ts
@@ -33,7 +33,7 @@ export interface Identifiers {
 }
 
 type UuidOnlyIdentifiers = Omit<Identifiers, 'extensionIds' | 'extensionsNonUuidManaged'>
-type UpdateAppIdentifiersCommand = 'dev' | 'deploy' | 'release'
+type UpdateAppIdentifiersCommand = 'dev' | 'deploy' | 'release' | 'import-extensions'
 interface UpdateAppIdentifiersOptions {
   app: AppInterface
   identifiers: UuidOnlyIdentifiers
@@ -72,9 +72,11 @@ export async function updateAppIdentifiers(
 
   const contentIsEqual = deepCompare(dotenvFile.variables, updatedVariables)
   const writeToFile =
-    !contentIsEqual &&
-    (command === 'deploy' || command === 'release') &&
-    !developerPlatformClient.supportsAtomicDeployments
+    (!contentIsEqual &&
+      (command === 'deploy' || command === 'release') &&
+      !developerPlatformClient.supportsAtomicDeployments) ||
+    command === 'import-extensions'
+
   dotenvFile.variables = updatedVariables
 
   if (writeToFile) {

--- a/packages/app/src/cli/services/deploy.test.ts
+++ b/packages/app/src/cli/services/deploy.test.ts
@@ -2,7 +2,7 @@ import {ensureDeployContext} from './context.js'
 import {deploy, importExtensionsIfNeeded} from './deploy.js'
 import {uploadExtensionsBundle} from './deploy/upload.js'
 import {bundleAndBuildExtensions} from './deploy/bundle.js'
-import {importAllExtensions, allExtensionTypes} from './import-extensions.js'
+import {importAllExtensions, allExtensionTypes, filterOutImportedExtensions} from './import-extensions.js'
 import {getExtensions} from './fetch-extensions.js'
 import {reloadApp} from '../models/app/loader.js'
 import {
@@ -75,6 +75,9 @@ beforeEach(() => {
 
   // Mock getExtensions to return empty arrays by default
   vi.mocked(getExtensions).mockResolvedValue([])
+
+  // Mock filterOutImportedExtensions to return the extensions by default
+  vi.mocked(filterOutImportedExtensions).mockImplementation((_app, extensions) => extensions)
 })
 
 describe('deploy', () => {
@@ -840,6 +843,7 @@ describe('ImportExtensionsIfNeeded', () => {
 
     vi.mocked(isTTY).mockReturnValue(true)
     vi.mocked(getExtensions).mockResolvedValue([])
+    vi.mocked(filterOutImportedExtensions).mockReturnValue([])
 
     // When
     const result = await importExtensionsIfNeeded({

--- a/packages/app/src/cli/services/deploy.ts
+++ b/packages/app/src/cli/services/deploy.ts
@@ -2,7 +2,7 @@ import {uploadExtensionsBundle, UploadExtensionsBundleOutput} from './deploy/upl
 
 import {ensureDeployContext} from './context.js'
 import {bundleAndBuildExtensions} from './deploy/bundle.js'
-import {allExtensionTypes, importAllExtensions} from './import-extensions.js'
+import {allExtensionTypes, filterOutImportedExtensions, importAllExtensions} from './import-extensions.js'
 import {getExtensions} from './fetch-extensions.js'
 import {AppLinkedInterface} from '../models/app/app.js'
 import {updateAppIdentifiers} from '../models/app/identifiers.js'
@@ -151,19 +151,21 @@ export async function importExtensionsIfNeeded(options: ImportExtensionsIfNeeded
     onlyDashboardManaged: true,
   })
 
-  if (extensions.length === 0) {
+  const extensionsNotImportedYet = filterOutImportedExtensions(options.app, extensions)
+
+  if (extensionsNotImportedYet.length === 0) {
     return app
   }
 
   if (developerPlatformClient.supportsDashboardManagedExtensions) {
     return handleSupportedDashboardExtensions({
       ...options,
-      extensions,
+      extensions: extensionsNotImportedYet,
     })
   } else {
     return handleUnsupportedDashboardExtensions({
       ...options,
-      extensions,
+      extensions: extensionsNotImportedYet,
     })
   }
 }


### PR DESCRIPTION
# Prevent import from trying to import already imported extensions.

### WHY are these changes introduced?

This PR adds functionality to filter out extensions that have already been imported into the local environment, preventing crashes and improving the extension import process.

### WHAT is this pull request doing?

- Implements `filterOutImportedExtensions` function to check if extensions are already imported
- Updates the `importExtensionsIfNeeded` function to only import extensions that aren't already in the local environment
- Ensures the `.env` file is updated when importing extensions
- Adds tests for the new filtering functionality

### How to test your changes?

1. Create an app with Dashboard extensions
2. manually run `import-extensions`​
3. Try to import extensions again -> should see “no extensions to migrate”
4. Run deploy against dev-dash -> should ask to migrate, but not to import.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev)changes