### PR TITLE
Fix app proxy deploy comparison

### DIFF
--- a/packages/app/src/cli/models/extensions/specifications/app_config_app_proxy.ts
+++ b/packages/app/src/cli/models/extensions/specifications/app_config_app_proxy.ts
@@ -49,7 +49,7 @@ const AppProxyTransformConfig: CustomTransformationConfig = {
     const proxyConfig = content as {url: string; subpath: string; prefix: string}
     return {
       app_proxy: {
-        url: proxyConfig.url,
+        url: removeTrailingSlash(proxyConfig.url),
         subpath: proxyConfig.subpath,
         prefix: proxyConfig.prefix,
       },


### PR DESCRIPTION
### WHY are these changes introduced?

App proxy is showing as changed during a `deploy`, when it's not.

```
?  Release a new version of remix-extensions-no-config?

   ┃  Configuration:
   ┃  • app_proxy (updated)
```

### WHAT is this pull request doing?

Mirrors transformation of local and remote URLs by removing trailing slashes from remote config.

### How to test your changes?

1. Ensure on Dev Dash that your app proxy has an ending `/`
2. Ensure the proxy in your app.toml also has an ending `/`
3. `shopify app deploy`
4. Before, app_proxy would show as updated. Now, it should not.