### PR TITLE
Add documentation links to migration-related banners

### DIFF
--- a/packages/app/src/cli/prompts/uid-mapping-error.ts
+++ b/packages/app/src/cli/prompts/uid-mapping-error.ts
@@ -1,0 +1,28 @@
+import {AbortError} from '@shopify/cli-kit/node/error'
+
+export function throwUidMappingError() {
+  const message = ['Your app has extensions which need to be assigned', {command: 'uid'}, 'identifiers.']
+  const nextStep = [
+    'You must first map IDs to your existing extensions by running',
+    {command: 'shopify app deploy'},
+    'interactively, without',
+    {command: '--force'},
+    ', to finish the migration.',
+  ]
+  const customSection = {
+    title: 'Reference',
+    body: {
+      list: {
+        items: [
+          {
+            link: {
+              label: 'Migrating from the Partner Dashboard',
+              url: 'https://shopify.dev/docs/apps/build/dev-dashboard/migrate-from-partners',
+            },
+          },
+        ],
+      },
+    },
+  }
+  throw new AbortError(message, undefined, [nextStep], [customSection])
+}

--- a/packages/app/src/cli/services/context/breakdown-extensions.ts
+++ b/packages/app/src/cli/services/context/breakdown-extensions.ts
@@ -20,10 +20,10 @@ import {ExtensionSpecification} from '../../models/extensions/specification.js'
 import {rewriteConfiguration} from '../app/write-app-configuration-file.js'
 import {AppConfigurationUsedByCli} from '../../models/extensions/specifications/types/app_config.js'
 import {removeTrailingSlash} from '../../models/extensions/specifications/validation/common.js'
+import {throwUidMappingError} from '../../prompts/uid-mapping-error.js'
 import {deepCompare, deepDifference} from '@shopify/cli-kit/common/object'
 import {encodeToml} from '@shopify/cli-kit/node/toml'
 import {zod} from '@shopify/cli-kit/node/schema'
-import {AbortError} from '@shopify/cli-kit/node/error'
 
 export interface ConfigExtensionIdentifiersBreakdown {
   existingFieldNames: string[]
@@ -68,15 +68,7 @@ export async function extensionsIdentifiersDeployBreakdown(options: EnsureDeploy
     const unMigratedextensions = remoteExtensionsRegistrations.app.extensionRegistrations.filter((ext) => !ext.id)
 
     if (unMigratedextensions.length > 0) {
-      const message = ['Your app has extensions which need to be assigned', {command: 'uid'}, 'identifiers.']
-      const nextSteps = [
-        'You must first map IDs to your existing extensions by running',
-        {command: 'shopify app deploy'},
-        'interactively, without',
-        {command: '--force'},
-        'to finish the migration.',
-      ]
-      throw new AbortError(message, nextSteps)
+      throwUidMappingError()
     }
   }
 

--- a/packages/app/src/cli/services/deploy.test.ts
+++ b/packages/app/src/cli/services/deploy.test.ts
@@ -653,6 +653,18 @@ describe('deploy', () => {
             "• Commit to source control to ensure your extension IDs aren't regenerated on the next deploy.",
           ],
         },
+        {
+          title: 'Reference',
+          body: [
+            '• ',
+            {
+              link: {
+                label: 'Migrating from the Partner Dashboard',
+                url: 'https://shopify.dev/docs/apps/build/dev-dashboard/migrate-from-partners',
+              },
+            },
+          ],
+        },
       ],
     })
   })

--- a/packages/app/src/cli/services/deploy.ts
+++ b/packages/app/src/cli/services/deploy.ts
@@ -329,7 +329,21 @@ async function outputCompletionMessage({
     }
 
     body.push("• Commit to source control to ensure your extension IDs aren't regenerated on the next deploy.")
-    customSections = [{title: 'Next steps', body}]
+    customSections = [
+      {title: 'Next steps', body},
+      {
+        title: 'Reference',
+        body: [
+          '• ',
+          {
+            link: {
+              label: 'Migrating from the Partner Dashboard',
+              url: 'https://shopify.dev/docs/apps/build/dev-dashboard/migrate-from-partners',
+            },
+          },
+        ],
+      },
+    ]
   }
 
   if (release) {

--- a/packages/app/src/cli/services/dev.ts
+++ b/packages/app/src/cli/services/dev.ts
@@ -37,6 +37,7 @@ import {AppConfigurationUsedByCli} from '../models/extensions/specifications/typ
 import {RemoteAwareExtensionSpecification} from '../models/extensions/specification.js'
 import {ports} from '../constants.js'
 import {generateCertificate} from '../utilities/mkcert.js'
+import {throwUidMappingError} from '../prompts/uid-mapping-error.js'
 import {Config} from '@oclif/core'
 import {AbortController} from '@shopify/cli-kit/node/abort'
 import {checkPortAvailability, getAvailableTCPPort} from '@shopify/cli-kit/node/tcp'
@@ -248,15 +249,7 @@ export async function blockIfMigrationIncomplete(devConfig: DevConfig) {
       .filter((extension) => extension.type.toLowerCase() !== 'webhook_subscription')
       .every((extension) => extension.id)
   ) {
-    const message = ['Your app has extensions which need to be assigned', {command: 'uid'}, 'identifiers.']
-    const nextSteps = [
-      'You must first map IDs to your existing extensions by running',
-      {command: 'shopify app deploy'},
-      'interactively, without',
-      {command: '--force'},
-      'to finish the migration.',
-    ]
-    throw new AbortError(message, nextSteps)
+    throwUidMappingError()
   }
 }
 


### PR DESCRIPTION
### WHY are these changes introduced?

Migration-related banners lack context on the migration and required steps.

### WHAT is this pull request doing?

Adds documentation links to the banners.

<img width="1520" height="690" alt="image" src="https://github.com/user-attachments/assets/34fb48e5-26fd-46a5-82ec-886c789831bf" />

<img width="1504" height="452" alt="image" src="https://github.com/user-attachments/assets/addc3413-8644-4d8b-bde9-37fc35a371d1" />


### How to test your changes?

Either use this branch to complete a migration (including error states with `app dev` and `app deploy --force`), or temporarily modify conditions around the banner code to force their display.
