### PR TITLE
WIP Remove second setting of package-manager

### DIFF
--- a/bin/create-test-app.js
+++ b/bin/create-test-app.js
@@ -191,7 +191,6 @@ program
 
         log(`Creating new app in '${appPath}'...`);
         initArgs.push("--local");
-        initArgs.push(`--package-manager=${nodePackageManager}`);
         await nodeExec(["create-app"], initArgs, defaultOpts);
 
         // there are some bugs with lockfiles and local references


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

`bin/create-test-app` was failing with the following error:

```
╭─ error ───────────────────────────────────────────────────────────────────────────────────────────────────╮
│                                                                                                           │
│  Flag --package-manager can only be specified once                                                        │
│                                                                                                           │
╰───────────────────────────────────────────────────────────────────────────────────────────────────────────╯

 ELIFECYCLE  Command failed with exit code 2.
file:///Users/pablolopezvaldes/src/github.com/Shopify/cli/node_modules/.pnpm/execa@7.2.0/node_modules/execa/lib/error.js:60
                error = new Error(message);
                        ^

Error: Command failed with exit code 2: pnpm run create-app --template=remix --name=nightly-app-2025-08-21 --path=/Users/pablolopezvaldes/Desktop --flavor=javascript --local --package-manager=pnpm
```

### WHAT is this pull request doing?

Removes the second setting of `package-manager`

### How to test your changes?

Run `bin/create-test-app` and it should not fail because of this

### Measuring impact

How do we know this change was effective? Please choose one:

- [X] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
