### PR TITLE
Remove hydrogen packages from CLI docs

### DIFF
--- a/docs/cli/architecture.md
+++ b/docs/cli/architecture.md
@@ -17,9 +17,14 @@ and that you can find the component you are looking for more easily.
 | Package | Description | Examples |
 | ------- | ----------- | ------ |
 | @shopify/create-app | Contains an executable that guides the user through the process of creating a new Shopify app | Executable and init command |
-| @shopify/create-hydrogen | Contains an executable that guides the user through the process of creating a new Hydrogen storefront | Executable and init command |
 | @shopify/cli | Contains the CLI executable that glues all the commands provided by the features under it | Executable and init command |
 | @shopify/app | Contains the logic for creating, building, serving, and deploying Shopify apps | Commands, App model, Deployment tool. |
 | @shopify/theme |  Contains the logic for creating, building, and pushing themes. | Commands, Theme server and checker. |
-| @shopify/hydrogen |  Contains the logic for building Hydrogen storefronts | Commands, Theme server and checker. |
 | @shopify/cli-kit | Contains models and utilities that are shared across all the features | Authentication handler, Admin API Client, Session manager. |
+
+<br/>
+
+`@shopify/hydrogen` and `@shopify/create-hydrogen` packages used to be part of this repository, but they have been moved. For details about these packages, please visit:
+
+- [@shopify/hydrogen](https://github.com/Shopify/hydrogen/tree/main/packages/hydrogen)
+- [@shopify/create-hydrogen](https://github.com/Shopify/hydrogen/tree/main/packages/create-hydrogen)


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Hydrogen packages were still in the CLI docs

### WHAT is this pull request doing?

Remove the two entries from the table in the architecture page

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev)changes