### PR TITLE
Ensure user provided flag values override defaults in multi env commands

### DIFF
--- a/.changeset/shy-islands-guess.md
+++ b/.changeset/shy-islands-guess.md
@@ -1,0 +1,6 @@
+---
+'@shopify/cli-kit': minor
+'@shopify/theme': minor
+---
+
+Ensure user provided flag values override defaults in commands with multiple environments

--- a/packages/cli-kit/src/public/node/base-command.ts
+++ b/packages/cli-kit/src/public/node/base-command.ts
@@ -281,7 +281,7 @@ function reportEnvironmentApplication<
  * If we parse using this configuration, the only specified flags will be those
  * the user actually passed on the command line.
  */
-function noDefaultsOptions<TFlags extends FlagOutput, TGlobalFlags extends FlagOutput, TArgs extends ArgOutput>(
+export function noDefaultsOptions<TFlags extends FlagOutput, TGlobalFlags extends FlagOutput, TArgs extends ArgOutput>(
   options: Input<TFlags, TGlobalFlags, TArgs> | undefined,
 ): Input<TFlags, TGlobalFlags, TArgs> | undefined {
   if (!options?.flags) return options


### PR DESCRIPTION
### WHY are these changes introduced?

Previously, default flag values were treated by multi environment command mapping as CLI values, which take precedence over shopify.theme.toml values. This PR ensures that flag values are selected in order:

1. User provided CLI args
2. User provided shopify.theme.toml values
3. Default flag values

### WHAT is this pull request doing?

- Creates each environment's flags obj by combining: CLI flags with defaults, shopify.theme.toml flags, and CLI flags without defaults in that order
- Displays a warning if `--path` flag is provided to the CLI during multi env runs (path defaults to `cwd` and should be set per environment in `shopify.theme.toml`)

<details><summary>shopify.theme.toml is respected over default values</summary>
 
https://github.com/user-attachments/assets/357dc2c5-59f8-48f4-bcbc-4b76eb684603
 
</details> 


<details><summary>path warning</summary>
 
<img width="702" height="292" alt="path-errors" src="https://github.com/user-attachments/assets/0826ce06-9b03-4aa6-a766-972ceecda89e" />

</details> 


### How to test your changes?

- Add a `shopify.theme.toml` file with a value that has a default like `json = true`
 
 > Heads up: globals like `no-color` and `verbose` do not seem to be respected if they come from `shopify.theme.toml` single or multi env. I'll look into this in a follow up PR

<details><summary>Example toml</summary>

```
[environments.store1]
theme = "<theme>"
store = "<store>"
password  = "<shptka_password>"
json = true

[environments.store2]
theme = "<theme>"
store = "<store>"
password  = "<shptka_password>"
```
</details> 

- Pull down the branch `gh pr checkout 6301` or install the snapit version
```sh
npm i -g @shopify/cli@0.0.0-snapshot-20250822001254 ---@shopify:registry=https://registry.npmjs.org
```
- Run `list` and you should see that the environments with `json = true` defined in the .toml print out json and other environments don't
- Using`--path` flag with multi env commands should display an error

```ts
shopify theme list -e store1 -e store2
```

### Measuring impact

- [x] Existing analytics will cater for this addition

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
