### PR TITLE
Remove bundling feature

### DIFF
--- a/packages/app/src/cli/api/graphql/app-management/generated/specifications.ts
+++ b/packages/app/src/cli/api/graphql/app-management/generated/specifications.ts
@@ -16,6 +16,7 @@ export type FetchSpecificationsQuery = {
     uidStrategy:
       | {appModuleLimit: number; isClientProvided: boolean}
       | {appModuleLimit: number; isClientProvided: boolean}
+      | {appModuleLimit: number; isClientProvided: boolean}
     validationSchema?: {jsonSchema: string} | null
   }[]
 }

--- a/packages/app/src/cli/models/extensions/extension-instance.ts
+++ b/packages/app/src/cli/models/extensions/extension-instance.ts
@@ -342,7 +342,7 @@ export class ExtensionInstance<TConfiguration extends BaseConfigType = BaseConfi
   }
 
   async build(options: ExtensionBuildOptions): Promise<void> {
-    const mode = this.buildMode(options)
+    const mode = this.buildMode(options.environment)
 
     switch (mode) {
       case 'theme':
@@ -363,10 +363,7 @@ export class ExtensionInstance<TConfiguration extends BaseConfigType = BaseConfi
   }
 
   async buildForBundle(options: ExtensionBuildOptions, bundleDirectory: string, outputId?: string) {
-    if (this.features.includes('bundling')) {
-      // Modules that are going to be inclued in the bundle should be built in the bundle directory
-      this.outputPath = this.getOutputPathForDirectory(bundleDirectory, outputId)
-    }
+    this.outputPath = this.getOutputPathForDirectory(bundleDirectory, outputId)
 
     await this.build(options)
     if (this.isThemeExtension) {
@@ -380,11 +377,9 @@ export class ExtensionInstance<TConfiguration extends BaseConfigType = BaseConfi
   async copyIntoBundle(options: ExtensionBuildOptions, bundleDirectory: string, extensionUuid?: string) {
     const defaultOutputPath = this.outputPath
 
-    if (this.features.includes('bundling')) {
-      this.outputPath = this.getOutputPathForDirectory(bundleDirectory, extensionUuid)
-    }
+    this.outputPath = this.getOutputPathForDirectory(bundleDirectory, extensionUuid)
 
-    const buildMode = this.buildMode(options)
+    const buildMode = this.buildMode(options.environment)
 
     if (this.isThemeExtension) {
       await bundleThemeExtension(this, options)
@@ -464,14 +459,14 @@ export class ExtensionInstance<TConfiguration extends BaseConfigType = BaseConfi
     await this.specification.contributeToSharedTypeFile?.(this, typeDefinitionsByFile)
   }
 
-  private buildMode(options: ExtensionBuildOptions): BuildMode {
+  buildMode(environment: 'production' | 'development'): BuildMode {
     if (this.isThemeExtension) {
       return 'theme'
     } else if (this.isFunctionExtension) {
       return 'function'
     } else if (this.features.includes('esbuild')) {
       return 'ui'
-    } else if (this.specification.identifier === 'flow_template' && options.environment === 'production') {
+    } else if (this.specification.identifier === 'flow_template' && environment === 'production') {
       return 'flow'
     }
 

--- a/packages/app/src/cli/models/extensions/specification.integration.test.ts
+++ b/packages/app/src/cli/models/extensions/specification.integration.test.ts
@@ -31,7 +31,7 @@ describe('allLocalSpecs', () => {
 describe('createContractBasedModuleSpecification', () => {
   test('creates a specification with the given identifier', () => {
     // When
-    const got = createContractBasedModuleSpecification('test', ['bundling'])
+    const got = createContractBasedModuleSpecification('test', ['localization'])
 
     // Then
     expect(got).toMatchObject(
@@ -41,7 +41,7 @@ describe('createContractBasedModuleSpecification', () => {
         uidStrategy: 'uuid',
       }),
     )
-    expect(got.appModuleFeatures()).toEqual(['bundling'])
+    expect(got.appModuleFeatures()).toEqual(['localization'])
   })
 })
 

--- a/packages/app/src/cli/models/extensions/specification.ts
+++ b/packages/app/src/cli/models/extensions/specification.ts
@@ -17,7 +17,6 @@ export type ExtensionFeature =
   | 'ui_preview'
   | 'function'
   | 'theme'
-  | 'bundling'
   | 'cart_url'
   | 'esbuild'
   | 'single_js_entry_path'

--- a/packages/app/src/cli/models/extensions/specifications/checkout_post_purchase.ts
+++ b/packages/app/src/cli/models/extensions/specifications/checkout_post_purchase.ts
@@ -13,7 +13,7 @@ const checkoutPostPurchaseSpec = createExtensionSpecification({
   dependency,
   partnersWebIdentifier: 'post_purchase',
   schema: CheckoutPostPurchaseSchema,
-  appModuleFeatures: (_) => ['ui_preview', 'bundling', 'cart_url', 'esbuild', 'single_js_entry_path'],
+  appModuleFeatures: (_) => ['ui_preview', 'cart_url', 'esbuild', 'single_js_entry_path'],
   deployConfig: async (config, _) => {
     return {metafields: config.metafields ?? []}
   },

--- a/packages/app/src/cli/models/extensions/specifications/checkout_ui_extension.ts
+++ b/packages/app/src/cli/models/extensions/specifications/checkout_ui_extension.ts
@@ -20,14 +20,7 @@ const checkoutSpec = createExtensionSpecification({
   identifier: 'checkout_ui_extension',
   dependency,
   schema: CheckoutSchema,
-  appModuleFeatures: (_) => [
-    'ui_preview',
-    'bundling',
-    'cart_url',
-    'esbuild',
-    'single_js_entry_path',
-    'generates_source_maps',
-  ],
+  appModuleFeatures: (_) => ['ui_preview', 'cart_url', 'esbuild', 'single_js_entry_path', 'generates_source_maps'],
   deployConfig: async (config, directory) => {
     return {
       extension_points: config.extension_points,

--- a/packages/app/src/cli/models/extensions/specifications/flow_action.ts
+++ b/packages/app/src/cli/models/extensions/specifications/flow_action.ts
@@ -44,7 +44,7 @@ const flowActionSpecification = createExtensionSpecification({
   // ensure that the extension configuration is uploaded after registration in
   // https://github.com/Shopify/cli/blob/73ac91c0f40be0a57d1b18cb34254b12d3a071af/packages/app/src/cli/services/deploy.ts#L107
   // Should be removed after unified deployment is 100% rolled out
-  appModuleFeatures: (_) => ['bundling'],
+  appModuleFeatures: (_) => [],
   deployConfig: async (config, extensionPath) => {
     return {
       title: config.name,

--- a/packages/app/src/cli/models/extensions/specifications/flow_template.ts
+++ b/packages/app/src/cli/models/extensions/specifications/flow_template.ts
@@ -48,7 +48,7 @@ const FlowTemplateExtensionSchema = BaseSchemaWithHandle.extend({
 const flowTemplateSpec = createExtensionSpecification({
   identifier: 'flow_template',
   schema: FlowTemplateExtensionSchema,
-  appModuleFeatures: (_) => ['ui_preview', 'bundling'],
+  appModuleFeatures: (_) => ['ui_preview'],
   deployConfig: async (config, extensionPath) => {
     return {
       template_handle: config.handle,

--- a/packages/app/src/cli/models/extensions/specifications/flow_trigger.ts
+++ b/packages/app/src/cli/models/extensions/specifications/flow_trigger.ts
@@ -43,7 +43,7 @@ const flowTriggerSpecification = createExtensionSpecification({
   // ensure that the extension configuration is uploaded after registration in
   // https://github.com/Shopify/cli/blob/73ac91c0f40be0a57d1b18cb34254b12d3a071af/packages/app/src/cli/services/deploy.ts#L107
   // Should be removed after unified deployment is 100% rolled out
-  appModuleFeatures: (_) => ['bundling'],
+  appModuleFeatures: (_) => [],
   deployConfig: async (config, extensionPath) => {
     return {
       title: config.name,

--- a/packages/app/src/cli/models/extensions/specifications/function.ts
+++ b/packages/app/src/cli/models/extensions/specifications/function.ts
@@ -80,7 +80,7 @@ const functionSpec = createExtensionSpecification({
     'pickup_point_delivery_option_generator',
   ],
   schema: FunctionExtensionSchema,
-  appModuleFeatures: (_) => ['function', 'bundling'],
+  appModuleFeatures: (_) => ['function'],
   deployConfig: async (config, directory, apiKey) => {
     let inputQuery: string | undefined
     const moduleId = randomUUID()

--- a/packages/app/src/cli/models/extensions/specifications/pos_ui_extension.ts
+++ b/packages/app/src/cli/models/extensions/specifications/pos_ui_extension.ts
@@ -10,7 +10,7 @@ const posUISpec = createExtensionSpecification({
   identifier: 'pos_ui_extension',
   dependency,
   schema: BaseSchema.extend({name: zod.string()}),
-  appModuleFeatures: (_) => ['ui_preview', 'bundling', 'esbuild', 'single_js_entry_path'],
+  appModuleFeatures: (_) => ['ui_preview', 'esbuild', 'single_js_entry_path'],
   deployConfig: async (config, directory) => {
     const result = await getDependencyVersion(dependency, directory)
     if (result === 'not_found') throw new BugError(`Dependency ${dependency} not found`)

--- a/packages/app/src/cli/models/extensions/specifications/product_subscription.ts
+++ b/packages/app/src/cli/models/extensions/specifications/product_subscription.ts
@@ -11,7 +11,7 @@ const productSubscriptionSpec = createExtensionSpecification({
   dependency,
   graphQLType: 'subscription_management',
   schema: BaseSchema,
-  appModuleFeatures: (_) => ['ui_preview', 'bundling', 'esbuild', 'single_js_entry_path'],
+  appModuleFeatures: (_) => ['ui_preview', 'esbuild', 'single_js_entry_path'],
   deployConfig: async (_, directory) => {
     const result = await getDependencyVersion(dependency, directory)
     if (result === 'not_found') throw new BugError(`Dependency ${dependency} not found`)

--- a/packages/app/src/cli/models/extensions/specifications/tax_calculation.ts
+++ b/packages/app/src/cli/models/extensions/specifications/tax_calculation.ts
@@ -22,7 +22,7 @@ const TaxCalculationsSchema = BaseSchema.extend({
 const spec = createExtensionSpecification({
   identifier: 'tax_calculation',
   schema: TaxCalculationsSchema,
-  appModuleFeatures: (_) => ['bundling'],
+  appModuleFeatures: (_) => [],
   deployConfig: async (config, _) => {
     return {
       production_api_base_url: config.production_api_base_url,

--- a/packages/app/src/cli/models/extensions/specifications/theme.ts
+++ b/packages/app/src/cli/models/extensions/specifications/theme.ts
@@ -13,7 +13,7 @@ const themeSpec = createExtensionSpecification({
   partnersWebIdentifier: 'theme_app_extension',
   graphQLType: 'theme_app_extension',
   appModuleFeatures: (_) => {
-    return ['bundling', 'theme']
+    return ['theme']
   },
   deployConfig: async () => {
     return {theme_extension: {files: {}}}

--- a/packages/app/src/cli/models/extensions/specifications/ui_extension.ts
+++ b/packages/app/src/cli/models/extensions/specifications/ui_extension.ts
@@ -84,7 +84,7 @@ const uiExtensionSpec = createExtensionSpecification({
   dependency,
   schema: UIExtensionSchema,
   appModuleFeatures: (config) => {
-    const basic: ExtensionFeature[] = ['ui_preview', 'bundling', 'esbuild', 'generates_source_maps']
+    const basic: ExtensionFeature[] = ['ui_preview', 'esbuild', 'generates_source_maps']
     const needsCart =
       config?.extension_points?.find((extensionPoint) => {
         return getExtensionPointTargetSurface(extensionPoint.target) === 'checkout'

--- a/packages/app/src/cli/models/extensions/specifications/web_pixel_extension.ts
+++ b/packages/app/src/cli/models/extensions/specifications/web_pixel_extension.ts
@@ -30,7 +30,7 @@ const webPixelSpec = createExtensionSpecification({
   dependency,
   partnersWebIdentifier: 'web_pixel',
   schema: WebPixelSchema,
-  appModuleFeatures: (_) => ['bundling', 'esbuild', 'single_js_entry_path'],
+  appModuleFeatures: (_) => ['esbuild', 'single_js_entry_path'],
   deployConfig: async (config, _) => {
     return {
       runtime_context: config.runtime_context,

--- a/packages/app/src/cli/services/deploy.ts
+++ b/packages/app/src/cli/services/deploy.ts
@@ -201,7 +201,7 @@ export async function deploy(options: DeployOptions) {
   let uploadExtensionsBundleResult!: UploadExtensionsBundleOutput
 
   try {
-    const bundle = app.allExtensions.some((ext) => ext.features.includes('bundling'))
+    const bundle = app.allExtensions.some((ext) => ext.buildMode('production') !== 'none')
     let bundlePath: string | undefined
 
     if (bundle) {


### PR DESCRIPTION
### WHY are these changes introduced?

Removes the `bundling` feature flag from extension specifications, as it's no longer needed to determine if an extension should be bundled.

### WHAT is this pull request doing?

- Removes the `bundling` feature flag from all extension specifications
- Makes the `buildMode` method public so it can be used to determine if an extension should be bundled
- Updates the deploy service to use the `buildMode` method instead of checking for the `bundling` feature
- Simplifies the bundle path logic by always setting the output path for extensions being bundled

### How to test your changes?

1. Deploy an app with various extension types to verify bundling still works properly
2. Verify that extensions are correctly bundled during deployment

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev)changes