### PR TITLE
Move buildMode to specification

### DIFF
--- a/packages/app/src/cli/models/extensions/extension-instance.ts
+++ b/packages/app/src/cli/models/extensions/extension-instance.ts
@@ -45,8 +45,6 @@ export const CONFIG_EXTENSION_IDS: string[] = [
   WebhooksSpecIdentifier,
 ]
 
-type BuildMode = 'theme' | 'function' | 'ui' | 'flow' | 'tax_calculation' | 'none'
-
 /**
  * Class that represents an instance of a local extension
  * Before creating this class we've validated that:
@@ -342,7 +340,7 @@ export class ExtensionInstance<TConfiguration extends BaseConfigType = BaseConfi
   }
 
   async build(options: ExtensionBuildOptions): Promise<void> {
-    const mode = this.buildMode(options.environment)
+    const mode = this.specification.buildConfig.mode
 
     switch (mode) {
       case 'theme':
@@ -379,7 +377,7 @@ export class ExtensionInstance<TConfiguration extends BaseConfigType = BaseConfi
 
     this.outputPath = this.getOutputPathForDirectory(bundleDirectory, extensionUuid)
 
-    const buildMode = this.buildMode(options.environment)
+    const buildMode = this.specification.buildConfig.mode
 
     if (this.isThemeExtension) {
       await bundleThemeExtension(this, options)
@@ -457,25 +455,6 @@ export class ExtensionInstance<TConfiguration extends BaseConfigType = BaseConfi
 
   async contributeToSharedTypeFile(typeDefinitionsByFile: Map<string, Set<string>>) {
     await this.specification.contributeToSharedTypeFile?.(this, typeDefinitionsByFile)
-  }
-
-  buildMode(environment: 'production' | 'development'): BuildMode {
-    if (this.isThemeExtension) {
-      return 'theme'
-    } else if (this.isFunctionExtension) {
-      return 'function'
-    } else if (this.features.includes('esbuild')) {
-      return 'ui'
-    } else if (this.specification.identifier === 'flow_template' && environment === 'production') {
-      return 'flow'
-    }
-
-    // Workaround for tax_calculations because they remote spec NEEDS a valid js file to be included.
-    if (this.type === 'tax_calculation') {
-      return 'tax_calculation'
-    }
-
-    return 'none'
   }
 
   private buildHandle() {

--- a/packages/app/src/cli/models/extensions/specification.ts
+++ b/packages/app/src/cli/models/extensions/specification.ts
@@ -46,6 +46,9 @@ export interface Asset {
   content: string
 }
 
+interface BuildConfig {
+  mode: 'ui' | 'theme' | 'flow' | 'function' | 'tax_calculation' | 'none'
+}
 /**
  * Extension specification with all the needed properties and methods to load an extension.
  */
@@ -59,6 +62,7 @@ export interface ExtensionSpecification<TConfiguration extends BaseConfigType = 
   surface: string
   registrationLimit: number
   experience: ExtensionExperience
+  buildConfig: BuildConfig
   dependency?: string
   graphQLType?: string
   getBundleExtensionStdinContent?: (config: TConfiguration) => {main: string; assets?: Asset[]}
@@ -186,6 +190,7 @@ export function createExtensionSpecification<TConfiguration extends BaseConfigTy
     experience: spec.experience ?? 'extension',
     uidStrategy: spec.uidStrategy ?? (spec.experience === 'configuration' ? 'single' : 'uuid'),
     getDevSessionUpdateMessages: spec.getDevSessionUpdateMessages,
+    buildConfig: spec.buildConfig ?? {mode: 'none'},
   }
   const merged = {...defaults, ...spec}
 

--- a/packages/app/src/cli/models/extensions/specifications/checkout_post_purchase.ts
+++ b/packages/app/src/cli/models/extensions/specifications/checkout_post_purchase.ts
@@ -14,6 +14,7 @@ const checkoutPostPurchaseSpec = createExtensionSpecification({
   partnersWebIdentifier: 'post_purchase',
   schema: CheckoutPostPurchaseSchema,
   appModuleFeatures: (_) => ['ui_preview', 'cart_url', 'esbuild', 'single_js_entry_path'],
+  buildConfig: {mode: 'ui'},
   deployConfig: async (config, _) => {
     return {metafields: config.metafields ?? []}
   },

--- a/packages/app/src/cli/models/extensions/specifications/checkout_ui_extension.ts
+++ b/packages/app/src/cli/models/extensions/specifications/checkout_ui_extension.ts
@@ -21,6 +21,7 @@ const checkoutSpec = createExtensionSpecification({
   dependency,
   schema: CheckoutSchema,
   appModuleFeatures: (_) => ['ui_preview', 'cart_url', 'esbuild', 'single_js_entry_path', 'generates_source_maps'],
+  buildConfig: {mode: 'ui'},
   deployConfig: async (config, directory) => {
     return {
       extension_points: config.extension_points,

--- a/packages/app/src/cli/models/extensions/specifications/flow_template.ts
+++ b/packages/app/src/cli/models/extensions/specifications/flow_template.ts
@@ -49,6 +49,7 @@ const flowTemplateSpec = createExtensionSpecification({
   identifier: 'flow_template',
   schema: FlowTemplateExtensionSchema,
   appModuleFeatures: (_) => ['ui_preview'],
+  buildConfig: {mode: 'flow'},
   deployConfig: async (config, extensionPath) => {
     return {
       template_handle: config.handle,

--- a/packages/app/src/cli/models/extensions/specifications/function.ts
+++ b/packages/app/src/cli/models/extensions/specifications/function.ts
@@ -81,6 +81,7 @@ const functionSpec = createExtensionSpecification({
   ],
   schema: FunctionExtensionSchema,
   appModuleFeatures: (_) => ['function'],
+  buildConfig: {mode: 'function'},
   deployConfig: async (config, directory, apiKey) => {
     let inputQuery: string | undefined
     const moduleId = randomUUID()

--- a/packages/app/src/cli/models/extensions/specifications/pos_ui_extension.ts
+++ b/packages/app/src/cli/models/extensions/specifications/pos_ui_extension.ts
@@ -11,6 +11,7 @@ const posUISpec = createExtensionSpecification({
   dependency,
   schema: BaseSchema.extend({name: zod.string()}),
   appModuleFeatures: (_) => ['ui_preview', 'esbuild', 'single_js_entry_path'],
+  buildConfig: {mode: 'ui'},
   deployConfig: async (config, directory) => {
     const result = await getDependencyVersion(dependency, directory)
     if (result === 'not_found') throw new BugError(`Dependency ${dependency} not found`)

--- a/packages/app/src/cli/models/extensions/specifications/product_subscription.ts
+++ b/packages/app/src/cli/models/extensions/specifications/product_subscription.ts
@@ -12,6 +12,7 @@ const productSubscriptionSpec = createExtensionSpecification({
   graphQLType: 'subscription_management',
   schema: BaseSchema,
   appModuleFeatures: (_) => ['ui_preview', 'esbuild', 'single_js_entry_path'],
+  buildConfig: {mode: 'ui'},
   deployConfig: async (_, directory) => {
     const result = await getDependencyVersion(dependency, directory)
     if (result === 'not_found') throw new BugError(`Dependency ${dependency} not found`)

--- a/packages/app/src/cli/models/extensions/specifications/tax_calculation.ts
+++ b/packages/app/src/cli/models/extensions/specifications/tax_calculation.ts
@@ -23,6 +23,7 @@ const spec = createExtensionSpecification({
   identifier: 'tax_calculation',
   schema: TaxCalculationsSchema,
   appModuleFeatures: (_) => [],
+  buildConfig: {mode: 'tax_calculation'},
   deployConfig: async (config, _) => {
     return {
       production_api_base_url: config.production_api_base_url,

--- a/packages/app/src/cli/models/extensions/specifications/theme.ts
+++ b/packages/app/src/cli/models/extensions/specifications/theme.ts
@@ -12,6 +12,7 @@ const themeSpec = createExtensionSpecification({
   schema: BaseSchema,
   partnersWebIdentifier: 'theme_app_extension',
   graphQLType: 'theme_app_extension',
+  buildConfig: {mode: 'theme'},
   appModuleFeatures: (_) => {
     return ['theme']
   },

--- a/packages/app/src/cli/models/extensions/specifications/ui_extension.ts
+++ b/packages/app/src/cli/models/extensions/specifications/ui_extension.ts
@@ -83,6 +83,7 @@ const uiExtensionSpec = createExtensionSpecification({
   identifier: 'ui_extension',
   dependency,
   schema: UIExtensionSchema,
+  buildConfig: {mode: 'ui'},
   appModuleFeatures: (config) => {
     const basic: ExtensionFeature[] = ['ui_preview', 'esbuild', 'generates_source_maps']
     const needsCart =

--- a/packages/app/src/cli/models/extensions/specifications/web_pixel_extension.ts
+++ b/packages/app/src/cli/models/extensions/specifications/web_pixel_extension.ts
@@ -31,6 +31,7 @@ const webPixelSpec = createExtensionSpecification({
   partnersWebIdentifier: 'web_pixel',
   schema: WebPixelSchema,
   appModuleFeatures: (_) => ['esbuild', 'single_js_entry_path'],
+  buildConfig: {mode: 'ui'},
   deployConfig: async (config, _) => {
     return {
       runtime_context: config.runtime_context,

--- a/packages/app/src/cli/services/build/extension.ts
+++ b/packages/app/src/cli/services/build/extension.ts
@@ -60,11 +60,9 @@ export interface ExtensionBuildOptions {
  * @param options - Build options.
  */
 export async function buildThemeExtension(extension: ExtensionInstance, options: ExtensionBuildOptions): Promise<void> {
-  if (options.environment === 'development') return
-
   options.stdout.write(`Running theme check on your Theme app extension...`)
   const offenses = await runThemeCheck(extension.directory)
-  options.stdout.write(offenses)
+  if (offenses) options.stdout.write(offenses)
 }
 
 /**

--- a/packages/app/src/cli/services/deploy.ts
+++ b/packages/app/src/cli/services/deploy.ts
@@ -201,7 +201,7 @@ export async function deploy(options: DeployOptions) {
   let uploadExtensionsBundleResult!: UploadExtensionsBundleOutput
 
   try {
-    const bundle = app.allExtensions.some((ext) => ext.buildMode('production') !== 'none')
+    const bundle = app.allExtensions.some((ext) => ext.specification.buildConfig.mode !== 'none')
     let bundlePath: string | undefined
 
     if (bundle) {

--- a/packages/app/src/cli/services/extensions/bundle.ts
+++ b/packages/app/src/cli/services/extensions/bundle.ts
@@ -80,7 +80,6 @@ export async function bundleThemeExtension(
 
 export async function bundleFlowTemplateExtension(extension: ExtensionInstance): Promise<void> {
   const files = await flowTemplateExtensionFiles(extension)
-
   await Promise.all(
     files.map(function (filepath) {
       const relativePathName = relativePath(extension.directory, filepath)


### PR DESCRIPTION
# Refactor extension build mode into specification

### WHY are these changes introduced?

This refactors how extension build modes are determined, moving the logic from the `ExtensionInstance` class to the extension specifications themselves.

### WHAT is this pull request doing?

- Removes the `buildMode` method from `ExtensionInstance` class
- Adds a `buildConfig` property to the `ExtensionSpecification` interface with a `mode` field
- Updates all extension specifications to explicitly define their build mode
- Updates code that previously called `buildMode()` to use `specification.buildConfig.mode` instead
- Improves theme extension build process to only output theme check offenses when they exist

### How to test your changes?

1. Build different types of extensions to ensure they still build correctly
2. Deploy an app with extensions to verify the build mode is correctly determined
3. Test theme extensions specifically to ensure theme check works as expected

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible documentation changes