### PR TITLE
Add new copy_files build mode

### DIFF
--- a/packages/app/src/cli/models/extensions/extension-instance.ts
+++ b/packages/app/src/cli/models/extensions/extension-instance.ts
@@ -20,7 +20,7 @@ import {
   buildUIExtension,
   bundleFunctionExtension,
 } from '../../services/build/extension.js'
-import {bundleThemeExtension} from '../../services/extensions/bundle.js'
+import {bundleThemeExtension, copyFilesForExtension} from '../../services/extensions/bundle.js'
 import {Identifiers} from '../app/identifiers.js'
 import {DeveloperPlatformClient} from '../../utilities/developer-platform-client.js'
 import {AppConfigurationWithoutPath} from '../app/app.js'
@@ -355,6 +355,13 @@ export class ExtensionInstance<TConfiguration extends BaseConfigType = BaseConfi
         await touchFile(this.outputPath)
         await writeFile(this.outputPath, '(()=>{})();')
         break
+      case 'copy_files':
+        return copyFilesForExtension(
+          this,
+          options,
+          this.specification.buildConfig.filePatterns,
+          this.specification.buildConfig.ignoredFilePatterns,
+        )
       case 'none':
         break
     }

--- a/packages/app/src/cli/models/extensions/specification.ts
+++ b/packages/app/src/cli/models/extensions/specification.ts
@@ -46,9 +46,9 @@ export interface Asset {
   content: string
 }
 
-interface BuildConfig {
-  mode: 'ui' | 'theme' | 'flow' | 'function' | 'tax_calculation' | 'none'
-}
+type BuildConfig =
+  | {mode: 'ui' | 'theme' | 'flow' | 'function' | 'tax_calculation' | 'none'}
+  | {mode: 'copy_files'; filePatterns: string[]; ignoredFilePatterns?: string[]}
 /**
  * Extension specification with all the needed properties and methods to load an extension.
  */

--- a/packages/app/src/cli/services/extensions/bundle.ts
+++ b/packages/app/src/cli/services/extensions/bundle.ts
@@ -5,7 +5,7 @@ import {EsbuildEnvVarRegex, environmentVariableNames} from '../../constants.js'
 import {flowTemplateExtensionFiles} from '../../utilities/extensions/flow-template.js'
 import {context as esContext, formatMessagesSync} from 'esbuild'
 import {AbortSignal} from '@shopify/cli-kit/node/abort'
-import {copyFile} from '@shopify/cli-kit/node/fs'
+import {copyFile, glob} from '@shopify/cli-kit/node/fs'
 import {joinPath, relativePath} from '@shopify/cli-kit/node/path'
 import {outputDebug} from '@shopify/cli-kit/node/output'
 import {isTruthy} from '@shopify/cli-kit/node/context/utilities'
@@ -88,6 +88,32 @@ export async function bundleFlowTemplateExtension(extension: ExtensionInstance):
       return copyFile(filepath, outputFile)
     }),
   )
+}
+
+export async function copyFilesForExtension(
+  extension: ExtensionInstance,
+  options: ExtensionBuildOptions,
+  includePatterns: string[],
+  ignoredPatterns: string[] = [],
+): Promise<void> {
+  options.stdout.write(`Copying files for extension ${extension.localIdentifier}...`)
+  const include = includePatterns.map((pattern) => joinPath('**', pattern))
+  const ignored = ignoredPatterns.map((pattern) => joinPath('**', pattern))
+  const files = await glob(include, {
+    absolute: true,
+    cwd: extension.directory,
+    ignore: ignored,
+  })
+
+  await Promise.all(
+    files.map(function (filepath) {
+      const relativePathName = relativePath(extension.directory, filepath)
+      const outputFile = joinPath(extension.outputPath, relativePathName)
+      if (filepath === outputFile) return
+      return copyFile(filepath, outputFile)
+    }),
+  )
+  options.stdout.write(`${extension.localIdentifier} successfully built`)
 }
 
 function onResult(result: Awaited<ReturnType<typeof esBuild>> | null, options: BundleOptions) {


### PR DESCRIPTION
### WHY are these changes introduced?

To support a new build mode for extensions that allows copying specific files to the output directory based on configurable patterns.

### WHAT is this pull request doing?

Adds a new `copy_files` build mode for extensions that:

- Allows specifying file patterns to include in the build output
- Supports ignoring specific file patterns
- Maintains the directory structure when copying files
- Provides appropriate build output messages

The implementation includes:

- Updated type definitions for `BuildConfig` to support the new mode
- New `copyFilesForExtension` function to handle the file copying logic
- Comprehensive tests for the new functionality
- Integration with the existing extension build system

### How to test your changes?

1. Create an extension with the following build configuration in its specification:

```
"buildConfig": {
  "mode": "copy_files",
  "filePatterns": ["*.json", "assets/**/*.png"],
  "ignoredFilePatterns": ["test/**"]
}
```

1. Run `shopify app build`
2. Verify that only files matching the patterns are copied to the output directory
3. Verify that files in ignored directories are not copied

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible documentation changes