### PR TITLE
Only create sessions for multi env commands that require authentication

### DIFF
--- a/.changeset/large-otters-dream.md
+++ b/.changeset/large-otters-dream.md
@@ -1,0 +1,6 @@
+---
+'@shopify/cli-kit': minor
+'@shopify/theme': minor
+---
+
+Commands that don't require authentication should not create sessions when ran with multiple environments


### PR DESCRIPTION
- Blocked by https://github.com/Shopify/cli/pull/6301 

### WHY are these changes introduced?

Previously, all commands run with multiple environments attempted to create a session object with store URL and password. This PR ensures that commands that do no accept a password and don't need to be authenticated (like `check`, `init`, `package`, and `language-server`) will not try to create a session

### WHAT is this pull request doing?

- Makes session creation conditional on whether a command accepts a password
- Adds `requiresAuth` boolean to valid environment type and DRYs it up by creating an `ValidEnvironment` interface

### How to test your changes?

- Install the snap build that contains these changes as well as `check` multi env logic

```
npm i -g @shopify/cli@0.0.0-snapshot-20250827192106 --@shopify:registry=https://registry.npmjs.org
```
- Add a `shopify.theme.toml` file

<details><summary>Example toml</summary>

```
[environments.store1]
theme = "<theme>"
store = "<store1>"

[environments.store2]
theme = "<theme>"
store = "<store2>"
```

</details> 

- Running `check` (from the above snapbuild) should work as expected, and not error if no password is provided
- Currently only `list`, `info`, `rename`, and `delete` work with multiple environments, these should error when provided no password or an incorrect

```sh
shopify theme check -e store1 -e store2
```

### Measuring impact

- [x] Existing analytics will cater for this addition

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
