### PR TITLE
No longer raise password errors when users use custom app passwords on `shopify theme pull/push` commands

### DIFF
--- a/.changeset/dull-cycles-brush.md
+++ b/.changeset/dull-cycles-brush.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+No longer raise password errors when users use custom app passwords on `shopify theme pull/push` commands

--- a/packages/theme/src/cli/commands/theme/console.ts
+++ b/packages/theme/src/cli/commands/theme/console.ts
@@ -2,6 +2,7 @@ import {themeFlags} from '../../flags.js'
 import ThemeCommand from '../../utilities/theme-command.js'
 import {ensureThemeStore} from '../../utilities/theme-store.js'
 import {ensureReplEnv, initializeRepl} from '../../services/console.js'
+import {validateThemePassword} from '../../services/flags-validation.js'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
 import {ensureAuthenticatedThemes} from '@shopify/cli-kit/node/session'
 import {Flags} from '@oclif/core'
@@ -33,6 +34,9 @@ export default class Console extends ThemeCommand {
 
   async run() {
     const {flags} = await this.parse(Console)
+
+    validateThemePassword(flags.password)
+
     const store = ensureThemeStore(flags)
     const {url, password: themeAccessPassword} = flags
 

--- a/packages/theme/src/cli/commands/theme/dev.ts
+++ b/packages/theme/src/cli/commands/theme/dev.ts
@@ -5,6 +5,7 @@ import {dev} from '../../services/dev.js'
 import {DevelopmentThemeManager} from '../../utilities/development-theme-manager.js'
 import {findOrSelectTheme} from '../../utilities/theme-selector.js'
 import {metafieldsPull} from '../../services/metafields-pull.js'
+import {validateThemePassword} from '../../services/flags-validation.js'
 import {Flags} from '@oclif/core'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
 import {Theme} from '@shopify/cli-kit/node/themes/types'
@@ -125,6 +126,8 @@ You can run this command only in a directory that matches the [default Shopify t
     const parsed = await this.parse(Dev)
     let flags = parsed.flags as typeof parsed.flags & FlagValues
     const {ignore = [], only = []} = flags
+
+    validateThemePassword(flags.password)
 
     const store = ensureThemeStore(flags)
     const adminSession = await ensureAuthenticatedThemes(store, flags.password)

--- a/packages/theme/src/cli/commands/theme/profile.ts
+++ b/packages/theme/src/cli/commands/theme/profile.ts
@@ -4,6 +4,7 @@ import {profile} from '../../services/profile.js'
 import {ensureThemeStore} from '../../utilities/theme-store.js'
 import {findOrSelectTheme} from '../../utilities/theme-selector.js'
 import {renderTasksToStdErr} from '../../utilities/theme-ui.js'
+import {validateThemePassword} from '../../services/flags-validation.js'
 import {ensureAuthenticatedThemes} from '@shopify/cli-kit/node/session'
 import {Flags} from '@oclif/core'
 import {globalFlags, jsonFlag} from '@shopify/cli-kit/node/cli'
@@ -42,6 +43,9 @@ export default class Profile extends ThemeCommand {
 
   async run(): Promise<void> {
     const {flags} = await this.parse(Profile)
+
+    validateThemePassword(flags.password)
+
     const store = ensureThemeStore(flags)
     const {password: themeAccessPassword} = flags
 

--- a/packages/theme/src/cli/flags.ts
+++ b/packages/theme/src/cli/flags.ts
@@ -1,6 +1,5 @@
 import {Flags} from '@oclif/core'
 import {normalizeStoreFqdn} from '@shopify/cli-kit/node/context/fqdn'
-import {AbortError} from '@shopify/cli-kit/node/error'
 import {resolvePath, cwd} from '@shopify/cli-kit/node/path'
 
 /**
@@ -18,13 +17,6 @@ export const themeFlags = {
   password: Flags.string({
     description: 'Password generated from the Theme Access app.',
     env: 'SHOPIFY_CLI_THEME_TOKEN',
-    parse: async (input) => {
-      if (input.startsWith('shptka_')) {
-        return input
-      }
-
-      throw new AbortError('Invalid password. Please generate a new password from the Theme Access app.')
-    },
   }),
   store: Flags.string({
     char: 's',

--- a/packages/theme/src/cli/services/flags-validation.test.ts
+++ b/packages/theme/src/cli/services/flags-validation.test.ts
@@ -1,0 +1,37 @@
+import {validateThemePassword} from './flags-validation.js'
+import {describe, expect, test} from 'vitest'
+import {AbortError} from '@shopify/cli-kit/node/error'
+
+describe('validateThemePassword', () => {
+  describe('valid cases', () => {
+    test('should not throw when password is undefined or empty string', () => {
+      expect(() => validateThemePassword(undefined)).not.toThrow()
+      expect(() => validateThemePassword('')).not.toThrow()
+    })
+
+    test('should not throw when password starts with shptka_', () => {
+      expect(() => validateThemePassword('shptka_valid_token')).not.toThrow()
+      expect(() => validateThemePassword('shptka_')).not.toThrow()
+      expect(() => validateThemePassword('shptka_abc123')).not.toThrow()
+    })
+  })
+
+  describe('invalid cases', () => {
+    test('should throw AbortError when password does not start with shptka_', () => {
+      expect(() => validateThemePassword('valid-password')).toThrow(AbortError)
+      expect(() => validateThemePassword('theme_token_123')).toThrow(AbortError)
+      expect(() => validateThemePassword('shpat_abc123def456')).toThrow(AbortError)
+    })
+
+    test('should throw when shptka_ appears but not at the start', () => {
+      expect(() => validateThemePassword('prefix_shptka_suffix')).toThrow(AbortError)
+      expect(() => validateThemePassword('some_shptka_token')).toThrow(AbortError)
+    })
+
+    test('should throw correct error message for non-shptka_ passwords', () => {
+      expect(() => validateThemePassword('invalid_token')).toThrow(
+        'Invalid password. Please generate a new password from the Theme Access app.',
+      )
+    })
+  })
+})

--- a/packages/theme/src/cli/services/flags-validation.ts
+++ b/packages/theme/src/cli/services/flags-validation.ts
@@ -1,0 +1,23 @@
+import {AbortError} from '@shopify/cli-kit/node/error'
+
+/**
+ * Validates that a theme password uses the required shptka_ format.
+ *
+ * Commands like `shopify theme dev`, `shopify theme console`, and
+ * `shopify theme profile` require passwords from the Theme Access app or
+ * standard authentication, as these commands rely on Storefront APIs that only
+ * work with Theme Access authentication.
+ *
+ * Legacy authentication methods are still supported in `shopify theme pull`
+ * and `shopify theme push` for backwards compatibility.
+ *
+ * @param password - the password to validate
+ * @throws AbortError when password doesn't start with 'shptka_'
+ */
+export function validateThemePassword(password?: string): void {
+  if (!password) return
+
+  if (password.startsWith('shptka_')) return
+
+  throw new AbortError('Invalid password. Please generate a new password from the Theme Access app.')
+}


### PR DESCRIPTION
### WHY are these changes introduced?

We no longer raise password errors when users use custom app passwords with the `shopify theme pull` or `push` commands.

### WHAT is this pull request doing?

This change moves logic from `packages/theme/src/cli/flags.ts` to the specific commands that do not support custom app password authentication. The legacy method is only supported on certain commands.

### How to test your changes?

- Run `shopify theme dev --password <custom_app_password>`
    - You should see an error.
- Run `shopify theme push --password <custom_app_password>`
    - The command should work as expected.

### Post-release steps

N/A

### Measuring impact

How will we know this change was effective? Please choose one:

- [ ] N/A – this doesn't require measurement, such as a linting rule or a minor bug fix
- [x] Existing analytics will report on this addition
- [ ] This PR includes analytics changes to measure impact

### Checklist

- [x] I've considered any possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered whether [documentation](https://shopify.dev) changes are needed