### PR TITLE
Fix uid generation for new extensions

### DIFF
--- a/packages/app/src/cli/services/generate/extension.test.ts
+++ b/packages/app/src/cli/services/generate/extension.test.ts
@@ -264,6 +264,7 @@ describe('initialize a extension', async () => {
           name,
           handle: slugify(name),
           flavor,
+          uid: 'ba7c20a9-578d-6fee-8cd2-044af992dabd92d8bbfe',
         })
       })
     },


### PR DESCRIPTION
### WHY are these changes introduced?

To ensure consistent and deterministic UUID generation for extensions based on their names, rather than using random UUIDs.

### WHAT is this pull request doing?

- Generates new UID based on the slugified extension name (which is equal to the `handle`) instead of random values

### How to test your changes?

1. Generate an extension with name “x”, see the `uid`​
2. Delete the extension
3. Generate a new extension with the same name, see that the `uid`​s are the same

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev)changes