### PR TITLE
Fix URL generation for release message

### DIFF
--- a/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
@@ -1234,7 +1234,7 @@ async function appDeepLink({
 }
 
 export async function versionDeepLink(organizationId: string, appId: string, versionId: string): Promise<string> {
-  const appLink = await appDeepLink({organizationId, id: appId})
+  const appLink = await appDeepLink({organizationId: numberFromGid(organizationId).toString(), id: appId})
   return `${appLink}/versions/${numberFromGid(versionId)}`
 }
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes an issue with the app deep link generation where the organization ID was not being properly converted to a string, potentially causing incorrect URL formation.

### WHAT is this pull request doing?

Modifies the `appDeepLink` function to explicitly convert the organization ID to a string after extracting the number from the GID, ensuring the URL is correctly formatted.

### How to test your changes?

1. Generate an app deep link using the `appDeepLink` function
2. Verify that the URL contains the correct organization ID in string format
3. Confirm the link properly navigates to the expected app in the developer dashboard

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev)changes