### PR TITLE
Do not require auth for `app config use`

### DIFF
--- a/.changeset/chilly-seahorses-call.md
+++ b/.changeset/chilly-seahorses-call.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Do not require authentication for shopify app config use

--- a/packages/app/src/cli/commands/app/config/use.ts
+++ b/packages/app/src/cli/commands/app/config/use.ts
@@ -1,8 +1,8 @@
 import {appFlags} from '../../../flags.js'
 import {checkFolderIsValidApp} from '../../../models/app/loader.js'
-import {linkedAppContext} from '../../../services/app-context.js'
+import {localAppContext} from '../../../services/app-context.js'
 import use from '../../../services/app/config/use.js'
-import AppLinkedCommand, {AppLinkedCommandOutput} from '../../../utilities/app-linked-command.js'
+import AppUnlinkedCommand, {AppUnlinkedCommandOutput} from '../../../utilities/app-unlinked-command.js'
 import {Args} from '@oclif/core'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
 
@@ -10,7 +10,7 @@ import {globalFlags} from '@shopify/cli-kit/node/cli'
 // `--config` flag, because we're passing it as an argument.
 const {config, ...appFlagsWithoutConfig} = appFlags
 
-export default class ConfigUse extends AppLinkedCommand {
+export default class ConfigUse extends AppUnlinkedCommand {
   static summary = 'Activate an app configuration.'
 
   static descriptionWithMarkdown = `Sets default configuration when you run app-related CLI commands. If you omit the \`config-name\` parameter, then you'll be prompted to choose from the configuration files in your project.`
@@ -32,18 +32,16 @@ export default class ConfigUse extends AppLinkedCommand {
     }),
   }
 
-  public async run(): Promise<AppLinkedCommandOutput> {
+  public async run(): Promise<AppUnlinkedCommandOutput> {
     const {flags, args} = await this.parse(ConfigUse)
+
+    const app = await localAppContext({
+      directory: flags.path,
+      userProvidedConfigName: args.config,
+    })
 
     await checkFolderIsValidApp(flags.path)
     await use({directory: flags.path, configName: args.config, reset: flags.reset})
-
-    const {app} = await linkedAppContext({
-      directory: flags.path,
-      clientId: undefined,
-      forceRelink: false,
-      userProvidedConfigName: args.config,
-    })
 
     return {app}
   }


### PR DESCRIPTION
### WHY are these changes introduced?

Related to https://github.com/shop/issues-develop/issues/412
Related to https://shopify.slack.com/archives/C030LHFCA5T/p1756321896429259

We require authentication for `shopify auth config use`, but we don't really use it

### WHAT is this pull request doing?

Removes the requirement

### How to test your changes?

- `shopify auth logout`
- `shopify app config use`

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
