### PR TITLE
Fix configName flag handling in config:link

### DIFF
--- a/packages/app/src/cli/services/app/config/link.ts
+++ b/packages/app/src/cli/services/app/config/link.ts
@@ -45,7 +45,6 @@ export interface LinkOptions {
   appId?: string
   organizationId?: string
   configName?: string
-  baseConfigName?: string
   developerPlatformClient?: DeveloperPlatformClient
   isNewApp?: boolean
 }
@@ -178,7 +177,7 @@ async function getAppCreationDefaultsFromLocalApp(options: LinkOptions): Promise
       specifications: await loadLocalExtensionsSpecifications(),
       directory: options.directory,
       mode: 'report',
-      userProvidedConfigName: options.baseConfigName,
+      userProvidedConfigName: options.configName,
       remoteFlags: undefined,
     })
 
@@ -253,7 +252,7 @@ async function loadLocalAppOptions(
       specifications,
       directory: options.directory,
       mode: 'report',
-      userProvidedConfigName: options.baseConfigName,
+      userProvidedConfigName: options.configName,
       remoteFlags,
     })
     const configuration = app.configuration
@@ -321,13 +320,14 @@ async function loadConfigurationFileName(
     format: 'legacy' | 'current'
   },
 ): Promise<AppConfigurationFileName> {
-  // If the user has already selected a config name, use that
-  const cache = getCachedCommandInfo()
-  if (cache?.selectedToml) return cache.selectedToml as AppConfigurationFileName
-
+  // config name from the options takes precedence over everything else
   if (options.configName) {
     return getAppConfigurationFileName(options.configName)
   }
+
+  // otherwise, use the cached config name if it exists
+  const cache = getCachedCommandInfo()
+  if (cache?.selectedToml) return cache.selectedToml as AppConfigurationFileName
 
   if (localAppInfo.format === 'legacy') {
     return configurationFileNames.app


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

The `config:link` command is ignoring the `-c` flag.

### WHAT is this pull request doing?

This PR removes the field `baseConfigName` from `LinkOptions`, and replaces its uses in the code with `configName`. `baseConfigName` was never set, and it was used to get the `-c` or `--config` flag value. 

  However, this change is not enough. When a `-c` value was provided to `config:link`, it wasn't used. Instead, the `loadConfigurationFileName` function uses the cached value from `getCachedCommandInfo`, which seems to be the TOML file from the selected app, and not from the flag option. 

<img width="1157" height="394" alt="selectedToml_from_app" src="https://github.com/user-attachments/assets/76036a86-7986-47b8-905e-38f43369e2c4" />


So I added a second code update to not call `loadConfigurationFileName` if the user provides a config file name in the `-c` flag, to directly get it from the flag.

### How to test your changes?

1. I added a unit test where the service is called with a `configName` different than the default (used in other tests)
2. Run `pnpm shopify app config link` with a config name that is not the app TOML's file that you will select later. Verify that the TOML file passed as a flag is linked to the selected app.

<img width="885" height="509" alt="config_link_fix" src="https://github.com/user-attachments/assets/7ae6c37b-4b48-4c77-a925-310a0028ccd3" />

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
