### PR TITLE
Don't delete the env file after the first deploy post migration

### DIFF
--- a/packages/app/src/cli/services/deploy.ts
+++ b/packages/app/src/cli/services/deploy.ts
@@ -12,7 +12,7 @@ import {reloadApp} from '../models/app/loader.js'
 import {ExtensionRegistration} from '../api/graphql/all_app_extension_registrations.js'
 import {getTomls} from '../utilities/app/config/getTomls.js'
 import {renderInfo, renderSuccess, renderTasks, renderConfirmationPrompt, isTTY} from '@shopify/cli-kit/node/ui'
-import {fileExistsSync, mkdir, removeFile} from '@shopify/cli-kit/node/fs'
+import {mkdir} from '@shopify/cli-kit/node/fs'
 import {joinPath, dirname} from '@shopify/cli-kit/node/path'
 import {outputNewline, outputInfo, formatPackageManagerCommand} from '@shopify/cli-kit/node/output'
 import {getArrayRejectingUndefined} from '@shopify/cli-kit/common/array'
@@ -267,9 +267,6 @@ export async function deploy(options: DeployOptions) {
 
     await renderTasks(tasks)
 
-    // Delete the .env file after the first successful deploy to the Dev Dashboard
-    if (didMigrateExtensionsToDevDash && uploadExtensionsBundleResult.versionTag) await deleteEnvFile(app)
-
     await outputCompletionMessage({
       app,
       release,
@@ -288,10 +285,6 @@ export async function deploy(options: DeployOptions) {
   }
 
   return {app}
-}
-
-async function deleteEnvFile(app: AppLinkedInterface) {
-  if (app.dotenv && fileExistsSync(app.dotenv.path)) await removeFile(app.dotenv.path)
 }
 
 async function outputCompletionMessage({


### PR DESCRIPTION
### WHY are these changes introduced?

Removes the automatic deletion of the `.env` file after a successful deployment to the Dev Dashboard.

### How to test your changes?

1. Migreate a new app
2. Deploy to dev dash and see that the .env file is not deleted

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev)changes