### PR TITLE
[Stable] Match by both type and externalType 

### DIFF
--- a/.changeset/kind-wasps-rush.md
+++ b/.changeset/kind-wasps-rush.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Fix matching logic for some extensions with Dev Dash

--- a/packages/app/src/cli/services/context/id-matching.test.ts
+++ b/packages/app/src/cli/services/context/id-matching.test.ts
@@ -59,6 +59,14 @@ const REGISTRATION_D: RemoteSource = {
   type: 'web_pixel_extension',
 }
 
+// Same as REGISTRATION_D but with a different type using external_identifier
+const REGISTRATION_D_WITH_EXTERNAL_ID: RemoteSource = {
+  uuid: 'UUID_D',
+  id: 'D',
+  title: 'EXTENSION_D',
+  type: 'web_pixel_extension_external',
+}
+
 const REGISTRATION_FUNCTION_A: RemoteSource = {
   uuid: 'FUNCTION_UUID_A',
   id: 'FUNCTION_A',
@@ -571,6 +579,28 @@ describe('automaticMatchmaking: more remote of different types than local', () =
       toCreate: [],
       toManualMatch: {local: [], remote: [REGISTRATION_B]},
     }
+    expect(got).toEqual(expected)
+  })
+})
+
+describe('automaticMatchmaking: same name but different remote type (but still matches)', () => {
+  test('matches automatically', async () => {
+    // When
+    const got = await automaticMatchmaking(
+      [EXTENSION_D],
+      [REGISTRATION_D_WITH_EXTERNAL_ID],
+      {},
+      testDeveloperPlatformClient(),
+    )
+
+    // Then
+    const expected = {
+      identifiers: {'extension-d': 'UUID_D'},
+      toConfirm: [],
+      toCreate: [],
+      toManualMatch: {local: [], remote: []},
+    }
+
     expect(got).toEqual(expected)
   })
 })

--- a/packages/app/src/cli/services/context/id-matching.ts
+++ b/packages/app/src/cli/services/context/id-matching.ts
@@ -1,6 +1,7 @@
 import {RemoteSource, LocalSource} from './identifiers.js'
 import {IdentifiersExtensions} from '../../models/app/identifiers.js'
 import {DeveloperPlatformClient} from '../../utilities/developer-platform-client.js'
+import {ExtensionInstance} from '../../models/extensions/extension-instance.js'
 import {groupBy, partition} from '@shopify/cli-kit/common/collection'
 import {uniqBy, difference} from '@shopify/cli-kit/common/array'
 import {pickBy} from '@shopify/cli-kit/common/object'
@@ -24,9 +25,14 @@ interface MatchResult {
  * Filter function to match a local and a remote source by type and handle
  */
 const sameTypeAndName = (local: LocalSource, remote: RemoteSource) => {
-  return (
-    remote.type.toLowerCase() === local.graphQLType.toLowerCase() && slugify(remote.title) === slugify(local.handle)
-  )
+  const isSameType =
+    remote.type.toLowerCase() === local.graphQLType.toLowerCase() ||
+    remote.type.toLowerCase() === (local as ExtensionInstance).externalType.toLowerCase() ||
+    remote.type.toLowerCase() === (local as ExtensionInstance).type.toLowerCase()
+
+  // In this case, remote.title represents the remote handle.
+  // This needs to be cleaned up in the future in the `AppModuleVersion` transformation
+  return isSameType && slugify(remote.title) === slugify(local.handle)
 }
 
 /**


### PR DESCRIPTION
WHY are these changes introduced?

Fixes an issue with extension type matching in the context service.

WHAT is this pull request doing?

Match extensions with both identifier​ and external_identifier​ to support the case for both Partners and Dev Dash.

How to test your changes?

Try to deploy a web-pixel extension after migration without UUIDs in the env file.

How do we know this change was effective? Please choose one:

n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

Existing analytics will cater for this addition

PR includes analytics changes to measure impact

Checklist

I've considered possible cross-platform impacts (Mac, Linux, Windows)

I've considered possible [documentation](https://shopify.dev/)changes