### PR TITLE
Fixed store names not parsing correctly in multi-env theme commands

### DIFF
--- a/.changeset/pretty-clocks-develop.md
+++ b/.changeset/pretty-clocks-develop.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Fixed issue with theme.toml files that have a store name without the full domain from being parsed in multi-environment mode

--- a/packages/theme/src/cli/utilities/theme-command.ts
+++ b/packages/theme/src/cli/utilities/theme-command.ts
@@ -18,6 +18,7 @@ import {recordEvent, compileData} from '@shopify/cli-kit/node/analytics'
 import {addPublicMetadata, addSensitiveMetadata} from '@shopify/cli-kit/node/metadata'
 import {cwd, joinPath} from '@shopify/cli-kit/node/path'
 import {fileExistsSync} from '@shopify/cli-kit/node/fs'
+import {normalizeStoreFqdn} from '@shopify/cli-kit/node/context/fqdn'
 import type {Writable} from 'stream'
 
 export interface FlagValues {
@@ -149,6 +150,11 @@ export default abstract class ThemeCommand extends Command {
         from: flags.path as string,
         silent: true,
       })
+
+      if (environmentFlags?.store && typeof environmentFlags.store === 'string') {
+        // eslint-disable-next-line no-await-in-loop
+        environmentFlags.store = await normalizeStoreFqdn(environmentFlags.store)
+      }
 
       environmentMap.set(environmentName, {
         ...flags,


### PR DESCRIPTION
### WHY are these changes introduced?

Follow up from https://github.com/Shopify/cli/pull/5874#issuecomment-3238374866

When parsing `shopify.theme.toml`'s in multi environment mode we skip normalizing stores that happens [here](https://github.com/Shopify/cli/blob/3a2f619ddd070597ce4b944b58a4c9c9f2d5b8cc/packages/theme/src/cli/flags.ts#L27)

It should take a store like `mystore` and append `myshopify.com` to it. 

### WHAT is this pull request doing?

Add `normalizeStoreFqdn` to the `loadEnvironments` method in the theme command layer. It will append the right domain to the store.

### How to test your changes?
_Replicate the bug_
In the current version of the CLI (4.84.1) or on main
- Create or update your `shopify.theme.toml` by only referencing the store name
```bash
[environments.store1]
store = "first-store.myshopify.com" 
password = "shptka_*"
theme = "123456"
[environments.store2]
store = "second-store" <-- Remove "myshopify.com"
password = "shptka_*"
theme = "123456"
```
Run a command that supports multi-env like `shopify theme list -e store1 -e store2`. You should see an error with the store that doesn't have `myshopify.com`

_Test with the bug fix_
- Pull down the branch `multi-env-store-toml`
- Build the branch
- Run `shopify theme list -e store1 -e store2` with the same `.toml` file.
### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
