### PR TITLE
Theme monorail event reporting

### DIFF
--- a/.changeset/nervous-oranges-travel.md
+++ b/.changeset/nervous-oranges-travel.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Moved analytics logging in theme command layer to ensure we properly log all events

--- a/packages/theme/src/cli/utilities/theme-command.ts
+++ b/packages/theme/src/cli/utilities/theme-command.ts
@@ -100,6 +100,7 @@ export default abstract class ThemeCommand extends Command {
       recordEvent(`theme-command:${commandName}:single-env:authenticated`)
 
       await this.command(flags, session)
+      await this.logAnalyticsData(session)
       return
     }
 
@@ -262,6 +263,7 @@ export default abstract class ThemeCommand extends Command {
                 recordEvent(`theme-command:${commandName}:multi-env:authenticated`)
 
                 await this.command(flags, session, true, {stdout, stderr})
+                await this.logAnalyticsData(session)
               })
 
               // eslint-disable-next-line no-catch-all/no-catch-all
@@ -305,7 +307,6 @@ export default abstract class ThemeCommand extends Command {
     const store = flags.store as string
     const password = flags.password as string
     const session = await ensureAuthenticatedThemes(ensureThemeStore({store}), password)
-    await this.logAnalyticsData(session)
 
     return session
   }
@@ -360,7 +361,9 @@ export default abstract class ThemeCommand extends Command {
     })
   }
 
-  private async logAnalyticsData(session: AdminSession): Promise<void> {
+  private async logAnalyticsData(session?: AdminSession): Promise<void> {
+    if (!session) return
+
     const data = compileData()
 
     await addPublicMetadata(() => ({


### PR DESCRIPTION
### WHY are these changes introduced?

We were not getting certain theme event data reporting in monorail due to when we fired off the event. I swear it actually works this time.

### WHAT is this pull request doing?

Moved logging data after a command is run within the `theme-command` layer.

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
