### PR TITLE
Update CLI version to 3.84.1

### DIFF
--- a/packages/cli-kit/src/public/common/version.ts
+++ b/packages/cli-kit/src/public/common/version.ts
@@ -1,1 +1,1 @@
-export const CLI_KIT_VERSION = '3.84.0'
+export const CLI_KIT_VERSION = '3.84.1'


### PR DESCRIPTION
### WHY are these changes introduced?

After releasing a patch, the main branch doesn't get the version update, which is not a problem normally.

But we have a new version check in the server, requiring 3.84.1 for App Management API, and it's causing errors when using the main branch and also on CI.

### WHAT is this pull request doing?

Manually update the static version in main.

### How to test your changes?

`p shopify version`

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
