### PR TITLE
Modify config update message for legacy install flow

### DIFF
--- a/.changeset/poor-ghosts-mix.md
+++ b/.changeset/poor-ghosts-mix.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Modify app access config update message for legacy install flow

--- a/packages/app/src/cli/models/app/app.test-data.ts
+++ b/packages/app/src/cli/models/app/app.test-data.ts
@@ -325,6 +325,7 @@ export async function testAppConfigExtensions(emptyConfig = false, directory?: s
 export async function testAppAccessConfigExtension(
   emptyConfig = false,
   directory?: string,
+  useLegacyInstallFlow = true,
 ): Promise<ExtensionInstance> {
   const configuration = emptyConfig
     ? ({} as unknown as BaseConfigType)
@@ -334,7 +335,7 @@ export async function testAppAccessConfigExtension(
         },
         access_scopes: {
           scopes: 'read_products,write_products',
-          use_legacy_install_flow: true,
+          use_legacy_install_flow: useLegacyInstallFlow,
         },
         auth: {
           redirect_urls: ['https://example.com/auth/callback'],

--- a/packages/app/src/cli/models/extensions/specifications/app_config_app_access.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/app_config_app_access.test.ts
@@ -112,9 +112,118 @@ describe('app_config_app_access', () => {
       expect(result).toEqual(['Access scopes auto-granted: write_orders, read_inventory'])
     })
 
-    test('should return default message when no scopes are provided', async () => {
+    test('should return managed install flow empty scopes message when no access_scopes are provided', async () => {
       // Given
       const config = {
+        auth: {
+          redirect_urls: ['https://example.com/auth/callback'],
+        },
+      }
+
+      // When
+      const result = await spec.getDevSessionUpdateMessages!(config)
+
+      // Then
+      expect(result).toEqual(['App has been installed'])
+    })
+
+    test('should return legacy install flow message when use_legacy_install_flow is true', async () => {
+      // Given
+      const config = {
+        access_scopes: {
+          scopes: 'read_products,write_products',
+          use_legacy_install_flow: true,
+        },
+        auth: {
+          redirect_urls: ['https://example.com/auth/callback'],
+        },
+      }
+
+      // When
+      const result = await spec.getDevSessionUpdateMessages!(config)
+
+      // Then
+      expect(result).toEqual(['Using legacy install flow - access scopes are not auto-granted'])
+    })
+
+    test('should return legacy install flow message even with required_scopes when use_legacy_install_flow is true', async () => {
+      // Given
+      const config = {
+        access_scopes: {
+          required_scopes: ['write_orders', 'read_inventory'],
+          use_legacy_install_flow: true,
+        },
+        auth: {
+          redirect_urls: ['https://example.com/auth/callback'],
+        },
+      }
+
+      // When
+      const result = await spec.getDevSessionUpdateMessages!(config)
+
+      // Then
+      expect(result).toEqual(['Using legacy install flow - access scopes are not auto-granted'])
+    })
+
+    test('should return normal scopes message when use_legacy_install_flow is false', async () => {
+      // Given
+      const config = {
+        access_scopes: {
+          scopes: 'read_products,write_products',
+          use_legacy_install_flow: false,
+        },
+        auth: {
+          redirect_urls: ['https://example.com/auth/callback'],
+        },
+      }
+
+      // When
+      const result = await spec.getDevSessionUpdateMessages!(config)
+
+      // Then
+      expect(result).toEqual(['Access scopes auto-granted: read_products, write_products'])
+    })
+
+    test('should return legacy install flow message when both scopes and required_scopes are nil', async () => {
+      // Given
+      const config = {
+        access_scopes: {},
+        auth: {
+          redirect_urls: ['https://example.com/auth/callback'],
+        },
+      }
+
+      // When
+      const result = await spec.getDevSessionUpdateMessages!(config)
+
+      // Then
+      expect(result).toEqual(['Using legacy install flow - access scopes are not auto-granted'])
+    })
+
+    test('should handle empty string scopes', async () => {
+      // Given
+      const config = {
+        access_scopes: {
+          scopes: '',
+        },
+        auth: {
+          redirect_urls: ['https://example.com/auth/callback'],
+        },
+      }
+
+      // When
+      const result = await spec.getDevSessionUpdateMessages!(config)
+
+      // Then
+      expect(result).toEqual(['App has been installed'])
+    })
+
+    test('should handle empty array required_scopes', async () => {
+      // Given
+      const config = {
+        access_scopes: {
+          required_scopes: [],
+        },
         auth: {
           redirect_urls: ['https://example.com/auth/callback'],
         },

--- a/packages/app/src/cli/models/extensions/specifications/app_config_app_access.ts
+++ b/packages/app/src/cli/models/extensions/specifications/app_config_app_access.ts
@@ -47,6 +47,14 @@ const appAccessSpec = createConfigExtensionSpecification({
   schema: AppAccessSchema,
   transformConfig: AppAccessTransformConfig,
   getDevSessionUpdateMessages: async (config) => {
+    const hasAccessModule = config.access_scopes !== undefined
+    const isLegacyInstallFlow = config.access_scopes?.use_legacy_install_flow === true
+    const hasNoScopes = config.access_scopes?.scopes == null && config.access_scopes?.required_scopes == null
+
+    if (isLegacyInstallFlow || (hasAccessModule && hasNoScopes)) {
+      return [`Using legacy install flow - access scopes are not auto-granted`]
+    }
+
     const scopesString = config.access_scopes?.scopes
       ? config.access_scopes.scopes
           .split(',')
@@ -54,7 +62,7 @@ const appAccessSpec = createConfigExtensionSpecification({
           .join(', ')
       : config.access_scopes?.required_scopes?.join(', ')
 
-    return [scopesString ? `Access scopes auto-granted: ${scopesString}` : `App has been installed`]
+    return scopesString ? [`Access scopes auto-granted: ${scopesString}`] : [`App has been installed`]
   },
   patchWithAppDevURLs: (config, urls) => {
     if (urls.redirectUrlWhitelist) {

--- a/packages/app/src/cli/services/dev/processes/dev-session/dev-session-process.test.ts
+++ b/packages/app/src/cli/services/dev/processes/dev-session/dev-session-process.test.ts
@@ -186,7 +186,7 @@ describe('pushUpdatesForDevSession', () => {
   test('handles scope changes and displays updated message', async () => {
     // Given
     vi.mocked(buildAppURLForWeb).mockResolvedValue('https://test.myshopify.com/admin/apps/test')
-    const appAccess = await testAppAccessConfigExtension()
+    const appAccess = await testAppAccessConfigExtension(false, undefined, false)
     const event = {extensionEvents: [{type: 'updated', extension: appAccess}], app}
     const contextSpy = vi.spyOn(outputContext, 'useConcurrentOutputContext')
 


### PR DESCRIPTION
### WHY are these changes introduced?
- https://github.com/shop/issues-develop/issues/21124

To improve the developer experience by providing clear messaging when using the legacy install flow for app access scopes.

### WHAT is this pull request doing?

When `use_legacy_install_flow` is set to `true`, developers will see a specific message indicating that access scopes are not auto-granted during development. 

### How to test your changes?

1. Modify app TOML
```
scopes="write_products"
use_legacy_install_flow: true
``` 
2. Run `shopify app dev`
3. Verify that the message "Using legacy install flow - access scopes are not auto-granted" appears
4. Change to `use_legacy_install_flow: false` and verify that the normal scopes message appears instead

## Tophatting

### Behaviour before -- confusing message since scopes are not auto granted for legacy installed apps
![09-46-ue97j-nxdka.png](https://app.graphite.dev/user-attachments/assets/95b352c2-d8c7-4158-a00b-db7e4f687e43.png)

### Behaviour after --- Legacy install flow apps with scopes in TOML but message is clearer
![09-42-en0dm-1br0h.png](https://app.graphite.dev/user-attachments/assets/b643d46d-bee7-42d8-a4a0-d33f7deb31e8.png)

### Behaviour after --- managed install apps with auto granted scopes
![09-44-gkmqa-n0hki.png](https://app.graphite.dev/user-attachments/assets/cb46530e-b899-4408-be1a-1cbfc847f1c3.png)

