### PR TITLE
Update community forums link

### DIFF
--- a/docs-shopify.dev/generated/generated_static_pages.json
+++ b/docs-shopify.dev/generated/generated_static_pages.json
@@ -95,7 +95,7 @@
         "type": "Generic",
         "anchorLink": "help",
         "title": "Where to get help",
-        "sectionContent": "\n- [Shopify Community Forums](https://community.shopify.com/) - Visit our forums to connect with the community and learn more about Shopify CLI development.\n- [Open a GitHub issue](https://github.com/shopify/cli/issues) - To report bugs or request new features, open an issue in the Shopify CLI repository.\n"
+        "sectionContent": "\n- [Shopify Community Forums](https://community.shopify.dev/c/shopify-cli-libraries/14) - Visit our forums to connect with the community and learn more about Shopify CLI development.\n- [Open a GitHub issue](https://github.com/shopify/cli/issues) - To report bugs or request new features, open an issue in the Shopify CLI repository.\n"
       },
       {
         "type": "Resource",

--- a/docs-shopify.dev/static/cli.doc.ts
+++ b/docs-shopify.dev/static/cli.doc.ts
@@ -109,7 +109,7 @@ Or, run the \`help\` command to get this information right in your terminal.
       anchorLink: 'help',
       title: 'Where to get help',
       sectionContent: `
-- [Shopify Community Forums](https://community.shopify.com/) - Visit our forums to connect with the community and learn more about Shopify CLI development.
+- [Shopify Community Forums](https://community.shopify.dev/c/shopify-cli-libraries/14) - Visit our forums to connect with the community and learn more about Shopify CLI development.
 - [Open a GitHub issue](https://github.com/shopify/cli/issues) - To report bugs or request new features, open an issue in the Shopify CLI repository.
 `,
     },

--- a/packages/app/src/cli/api/graphql/app-management/generated/specifications.ts
+++ b/packages/app/src/cli/api/graphql/app-management/generated/specifications.ts
@@ -16,6 +16,7 @@ export type FetchSpecificationsQuery = {
     uidStrategy:
       | {appModuleLimit: number; isClientProvided: boolean}
       | {appModuleLimit: number; isClientProvided: boolean}
+      | {appModuleLimit: number; isClientProvided: boolean}
     validationSchema?: {jsonSchema: string} | null
   }[]
 }


### PR DESCRIPTION
### WHY are these changes introduced?

The current link to the Shopify Community Forums in the CLI documentation is pointing to the general community page instead of the specific CLI section.

### WHAT is this pull request doing?

Updates the Shopify Community Forums link in the CLI documentation to point to the specific CLI & Libraries category (https://community.shopify.dev/c/shopify-cli-libraries/14) instead of the general community page.

### How to test your changes?

1. Navigate to the CLI documentation
2. Check that the "Shopify Community Forums" link in the "Where to get help" section now points to https://community.shopify.dev/c/shopify-cli-libraries/14

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes