### PR TITLE
Add error message and file to ExtensionPayload interface

### DIFF
--- a/.changeset/khaki-crews-help.md
+++ b/.changeset/khaki-crews-help.md
@@ -1,0 +1,6 @@
+---
+'@shopify/ui-extensions-server-kit': patch
+'@shopify/app': patch
+---
+
+Added optional `error` property to ExtensionPayload which include the `message` and `file`

--- a/packages/app/src/cli/services/dev/extension.ts
+++ b/packages/app/src/cli/services/dev/extension.ts
@@ -148,6 +148,11 @@ export async function devUIExtensions(options: ExtensionDevOptions): Promise<voi
       if (!event.extension.isPreviewable) continue
       const status = event.buildResult?.status === 'ok' ? 'success' : 'error'
 
+      const error =
+        event.buildResult?.status === 'error'
+          ? {message: event.buildResult.error, file: event.buildResult.file}
+          : undefined
+
       switch (event.type) {
         case EventType.Created:
           payloadOptions.extensions.push(event.extension)
@@ -159,7 +164,7 @@ export async function devUIExtensions(options: ExtensionDevOptions): Promise<voi
           await payloadStore.addExtension(event.extension, bundlePath)
           break
         case EventType.Updated:
-          await payloadStore.updateExtension(event.extension, payloadOptions, bundlePath, {status})
+          await payloadStore.updateExtension(event.extension, payloadOptions, bundlePath, {status, error})
           break
         case EventType.Deleted:
           payloadOptions.extensions = payloadOptions.extensions.filter((ext) => ext.devUUID !== event.extension.devUUID)

--- a/packages/app/src/cli/services/dev/extension/payload/models.ts
+++ b/packages/app/src/cli/services/dev/extension/payload/models.ts
@@ -60,6 +60,10 @@ export interface UIExtensionPayload {
     hidden: boolean
     status: ExtensionAssetBuildStatus
     localizationStatus: ExtensionAssetBuildStatus
+    error?: {
+      message: string
+      file?: string
+    }
   }
   extensionPoints: string[] | null | DevNewExtensionPointSchema[]
   localization: Localization | null

--- a/packages/ui-extensions-server-kit/src/types.ts
+++ b/packages/ui-extensions-server-kit/src/types.ts
@@ -130,6 +130,10 @@ export interface ExtensionPayload {
       name: string
       version: string
     }
+    error?: {
+      message: string
+      file?: string
+    }
   }
   uuid: string
   version: string


### PR DESCRIPTION
Part of https://github.com/shop/issues-retail/issues/17789

[POS counterpart PR](https://app.graphite.dev/github/pr/Shopify/pos-next-react-native/68178/Add-build-error-handling-for-UI-extensions-in-development-mode)

### WHY are these changes introduced?

Expands the `ExtensionPayload`​ interface to include more detailed errors for local extension builds.

```
development: {
  // ... other properties
  error?: {
    message: string
    file?: string
  }
}

message: A string describing the error (e.g., "Unexpected \"}\"")
file: The file path where the error occurred (e.g., "../pos-e2e-ui-extension/extensions/remote-dom-sandbox/src/Tile.tsx")
```

### WHAT is this pull request doing?

- Enhances the `ExtensionBuildResult` type to include an optional `file` property that indicates which file contains the error
- Extracts more detailed error information from esbuild errors, including the specific error message and file location
- Passes error details through the extension update process to the UI
- Displays actual error messages from build results instead of generic messages
- Fixes a potential issue in the file server middleware by checking if a file exists before checking if it's a directory
- Adds an `Error` status to the `Status` enum in the UI extensions server kit

In this video, on POS we now can parse the payload to detect build errors
[demo_cli_builds.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/user-attachments/thumbnails/685fc7f0-46f0-47e5-8ff5-4b05c85a1fc3.mov" />](https://app.graphite.dev/user-attachments/video/685fc7f0-46f0-47e5-8ff5-4b05c85a1fc3.mov)

### How to test your changes?

1. Checkout [feature CLI branch](https://app.graphite.dev/github/pr/Shopify/cli/6387/Add-error-message-and-type-to-ExtensionPayload-interface)
2. Run `pnpm shopify app dev --path ../my-app`
3. Checkout this [POS branch](https://app.graphite.dev/github/pr/Shopify/pos-next-react-native/68178/Add-build-error-handling-for-UI-extensions-in-development-mode), `dev extension 'deeplink_url'`
4. Force some errors on your extension. The payload will also contain the error message and file line.
5. Observe error screens for all extension targets

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes