### PR TITLE
Auto logout if current credentials are invalid

### DIFF
--- a/packages/cli-kit/src/private/node/session.test.ts
+++ b/packages/cli-kit/src/private/node/session.test.ts
@@ -14,7 +14,7 @@ import {
   InvalidGrantError,
 } from './session/exchange.js'
 import {allDefaultScopes} from './session/scopes.js'
-import {store as secureStore, fetch as secureFetch} from './session/store.js'
+import {store as secureStore, fetch as secureFetch, remove as secureRemove} from './session/store.js'
 
 import {ApplicationToken, IdentityToken, Session} from './session/schema.js'
 import {validateSession} from './session/validate.js'
@@ -151,18 +151,18 @@ describe('ensureAuthenticated when previous session is invalid', () => {
     expect(secureFetch).toHaveBeenCalledOnce()
   })
 
-  test('throws an error if there is no session and prompting is disabled', async () => {
+  test('throws an error and logs out if there is no session and prompting is disabled,', async () => {
     // Given
     vi.mocked(validateSession).mockResolvedValueOnce('needs_full_auth')
     vi.mocked(secureFetch).mockResolvedValue(undefined)
 
     // When
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    expect(ensureAuthenticated(defaultApplications, process.env, {noPrompt: true})).rejects.toThrow(
+    await expect(ensureAuthenticated(defaultApplications, process.env, {noPrompt: true})).rejects.toThrow(
       `The currently available CLI credentials are invalid.
 
 The CLI is currently unable to prompt for reauthentication.`,
     )
+    expect(secureRemove).toHaveBeenCalled()
 
     // Then
     await expect(getLastSeenAuthMethod()).resolves.toEqual('none')


### PR DESCRIPTION
### WHY are these changes introduced?

To ensure that when authentication fails and prompting is disabled, the CLI properly logs out the user to prevent potential issues with invalid credentials.

If your current credentials are totally expired, refreshing is not possible, you need to login again.

### WHAT is this pull request doing?

This PR modifies the authentication flow to call `logout()` when authentication fails and prompting is disabled. It ensures that invalid credentials are properly cleaned up, preventing potential issues with subsequent commands.

### How to test your changes?

1. Run any command that requires authentication
2. Go to the Web, logout and change your account's password
3. Run any command now, you should see the warning on Invalid Credentials.
4. Run the command again -> you need to authenticate again and it works.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes