### PR TITLE
Allow theme pull command to be called with multiple environments

### DIFF
--- a/.changeset/tricky-bugs-float.md
+++ b/.changeset/tricky-bugs-float.md
@@ -1,0 +1,6 @@
+---
+'@shopify/theme': minor
+'@shopify/cli': minor
+---
+
+Allow theme pull command to be called with multiple environments

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -6503,6 +6503,16 @@
       "hiddenAliases": [
       ],
       "id": "theme:pull",
+      "multiEnvironmentsFlags": [
+        "store",
+        "password",
+        "path",
+        [
+          "live",
+          "development",
+          "theme"
+        ]
+      ],
       "pluginAlias": "@shopify/cli",
       "pluginName": "@shopify/cli",
       "pluginType": "core",

--- a/packages/theme/src/cli/commands/theme/pull.ts
+++ b/packages/theme/src/cli/commands/theme/pull.ts
@@ -1,10 +1,14 @@
 import {globFlags, themeFlags} from '../../flags.js'
-import ThemeCommand from '../../utilities/theme-command.js'
-import {pull, PullFlags} from '../../services/pull.js'
+import ThemeCommand, {RequiredFlags} from '../../utilities/theme-command.js'
+import {pull} from '../../services/pull.js'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
 import {Flags} from '@oclif/core'
 import {recordTiming} from '@shopify/cli-kit/node/analytics'
+import {InferredFlags} from '@oclif/core/interfaces'
+import {AdminSession} from '@shopify/cli-kit/node/session'
+import {Writable} from 'stream'
 
+type PullFlags = InferredFlags<typeof Pull.flags>
 export default class Pull extends ThemeCommand {
   static summary = 'Download your remote theme files locally.'
 
@@ -46,25 +50,16 @@ If no theme is specified, then you're prompted to select the theme to pull from 
     }),
   }
 
-  async run(): Promise<void> {
-    const {flags} = await this.parse(Pull)
-    const pullFlags: PullFlags = {
-      path: flags.path,
-      password: flags.password,
-      store: flags.store,
-      theme: flags.theme,
-      development: flags.development,
-      live: flags.live,
-      nodelete: flags.nodelete,
-      only: flags.only,
-      ignore: flags.ignore,
-      force: flags.force,
-      verbose: flags.verbose,
-      noColor: flags['no-color'],
-    }
+  static multiEnvironmentsFlags: RequiredFlags = ['store', 'password', 'path', ['live', 'development', 'theme']]
 
+  async command(
+    flags: PullFlags,
+    adminSession?: AdminSession,
+    multiEnvironment?: boolean,
+    context?: {stdout?: Writable; stderr?: Writable},
+  ) {
     recordTiming('theme-command:pull')
-    await pull(pullFlags)
+    await pull({...flags, noColor: flags['no-color']}, adminSession, multiEnvironment, context)
     recordTiming('theme-command:pull')
   }
 }

--- a/packages/theme/src/cli/services/pull.test.ts
+++ b/packages/theme/src/cli/services/pull.test.ts
@@ -70,7 +70,14 @@ describe('pull', () => {
     // Then
     expect(findDevelopmentThemeSpy).not.toHaveBeenCalled()
     expect(fetchDevelopmentThemeSpy).toHaveBeenCalledOnce()
-    expect(downloadTheme).toHaveBeenCalledWith(theme, adminSession, [], localThemeFileSystem, expect.any(Object))
+    expect(downloadTheme).toHaveBeenCalledWith(
+      theme,
+      adminSession,
+      [],
+      localThemeFileSystem,
+      expect.any(Object),
+      undefined,
+    )
   })
 
   test('should pass the development theme to downloadtheme if development flag is provided', async () => {
@@ -102,7 +109,9 @@ describe('pull', () => {
     // Then
     expect(vi.mocked(ensureDirectoryConfirmed)).toHaveBeenCalledWith(
       false,
-      'The current Git directory has uncommitted changes. Do you want to proceed?',
+      'The current Git directory has uncommitted changes.',
+      undefined,
+      undefined,
     )
   })
 


### PR DESCRIPTION
- stacked on https://github.com/Shopify/cli/pull/6361

### WHY are these changes introduced?
Previously theme `pull` could only be run with a single `--environment` flag. This PR allows `pull` to be run with multiple environments in a single command


### WHAT is this pull request doing?
- Removes flag parsing from pull commands in favour of ThemeCommand's run logic
- During multi env commands, the Ink progress bar is not displayed
- Since `pull` is exported publicly through [@shopify/cli](https://www.npmjs.com/package/@shopify/cli) to be used by packages like [shopkeeper](https://github.com/TheBeyondGroup/shopkeeper/blob/1b8a8ff30779d35dccb622977f0eebb473320cd1/src/utilities/theme.ts#L2), an auth session is created if one is not passed in from ThemeCommand (as one wouldn't be when pull is used programatically)


<details><summary>pull</summary>

https://github.com/user-attachments/assets/909c7d52-88f6-469b-ab09-5554826c742e

</details> 

### How to test your changes?


- Pull down the branch `gh pr checkout 6390` or install the snapit version
```sh
npm i -g --@shopify:registry=https://registry.npmjs.org @shopify/cli@0.0.0-snapshot-20250912162507
```

- Add a `shopify.theme.toml` file

<details><summary>Example toml</summary>

```
[environments.store1]
theme = "<theme>"
store = "<store>"
password  = "<shptka_password>"
path = "path/to/theme"

[environments.store2]
theme = "<theme>"
store = "<store>"
password  = "<shptka_password>"
path = "path/to/theme"
```
</details> 

```ts
shopify theme pull -e store1 -e store2
```
- `pull` should work as expected with no, single, and multiple `--environment` flags
- The environment name should be displayed on output

### Measuring impact

- [x] Existing analytics will cater for this addition

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
