### PR TITLE
Adding function target to app logs

### DIFF
--- a/packages/app/src/cli/services/app-logs/dev/poll-app-logs.test.ts
+++ b/packages/app/src/cli/services/app-logs/dev/poll-app-logs.test.ts
@@ -61,6 +61,7 @@ const FUNCTION_PAYLOAD = {
   function_id: 'e57b4d31-2038-49ff-a0a1-1eea532414f7',
   logs: LOGS,
   fuel_consumed: 512436,
+  target: 'test.run',
   export: 'run',
 }
 const FAILURE_PAYLOAD = {
@@ -71,6 +72,7 @@ const FAILURE_PAYLOAD = {
   function_id: 'e57b4d31-2038-49ff-a0a1-1eea532414f7',
   logs: LOGS,
   error_type: FUNCTION_ERROR,
+  target: 'test.run',
   export: 'run',
 }
 

--- a/packages/app/src/cli/services/app-logs/logs-command/ui/components/Logs.test.tsx
+++ b/packages/app/src/cli/services/app-logs/logs-command/ui/components/Logs.test.tsx
@@ -86,6 +86,7 @@ const appLogFunctionRunOutputs = ({
     logs: LOGS,
     functionId: FUNCTION_ID,
     fuelConsumed: FUEL_CONSUMED,
+    target: 'test.run',
     errorMessage: 'errorMessage',
     errorType: 'errorType',
     inputQueryVariablesMetafieldValue: '{"key":"value"}',

--- a/packages/app/src/cli/services/app-logs/logs-command/ui/components/hooks/usePollAppLogs.test.tsx
+++ b/packages/app/src/cli/services/app-logs/logs-command/ui/components/hooks/usePollAppLogs.test.tsx
@@ -37,6 +37,7 @@ const OUTPUT = {test: 'output'}
 const INPUT = {test: 'input'}
 const INPUT_BYTES = 10
 const OUTPUT_BYTES = 10
+const TARGET = 'test.run'
 
 const NETWORK_ACCESS_HTTP_REQUEST = {
   url: 'https://api.example.com/hello',
@@ -100,6 +101,7 @@ const POLL_APP_LOGS_FOR_LOGS_RESPONSE = {
         function_id: FUNCTION_ID,
         logs: LOGS,
         fuel_consumed: FUEL_CONSUMED,
+        target: TARGET,
       }),
       log_type: LOG_TYPE,
       cursor: RETURNED_CURSOR,

--- a/packages/app/src/cli/services/app-logs/types.ts
+++ b/packages/app/src/cli/services/app-logs/types.ts
@@ -36,6 +36,7 @@ export class FunctionRunLog {
   logs: string
   functionId: string
   fuelConsumed: number
+  target: string
   errorMessage: string | null
   errorType: string | null
   inputQueryVariablesMetafieldValue: unknown
@@ -51,6 +52,7 @@ export class FunctionRunLog {
     logs,
     functionId,
     fuelConsumed,
+    target,
     errorMessage,
     errorType,
     inputQueryVariablesMetafieldValue,
@@ -65,6 +67,7 @@ export class FunctionRunLog {
     logs: string
     functionId: string
     fuelConsumed: number
+    target: string
     errorMessage: string | null
     errorType: string | null
     inputQueryVariablesMetafieldValue: unknown
@@ -79,6 +82,7 @@ export class FunctionRunLog {
     this.logs = logs
     this.functionId = functionId
     this.fuelConsumed = fuelConsumed
+    this.target = target
     this.errorMessage = errorMessage
     this.errorType = errorType
     this.inputQueryVariablesMetafieldValue = inputQueryVariablesMetafieldValue

--- a/packages/app/src/cli/services/app-logs/utils.ts
+++ b/packages/app/src/cli/services/app-logs/utils.ts
@@ -45,6 +45,7 @@ export function parseFunctionRunPayload(payload: string): FunctionRunLog {
     logs: parsedPayload.logs,
     functionId: parsedPayload.function_id,
     fuelConsumed: parsedPayload.fuel_consumed,
+    target: parsedPayload.target,
     errorMessage: parsedPayload.error_message,
     errorType: parsedPayload.error_type,
     inputQueryVariablesMetafieldValue: parsedIqvValue,


### PR DESCRIPTION
Fixes https://github.com/orgs/shop/projects/147/views/9?pane=issue&itemId=126561836&issue=shop%7Cissues-shopifyvm%7C568

### WHY are these changes introduced?

Adding target to function app logs so we can use these logs as test fixtures for wasm level testing. Having target in log fixture will help us know which schema to run validations against during testing.

### WHAT is this pull request doing?

Updates the FunctionRunLog type to also have target in it so the target gets added to the log file that is created during app dev.
I couldn't find many spots to add/modify a unit test for this change, I think the closest I came to finding one was `pollAppLogs.test.tsx` which I have updated, but I was able to tophat this. 

### How to test your changes?

I was able to successfully tophat by using my branch to run a function in dev mode, then looking at the log file generated, it had the target in it. 

- dev cd cli
- git checkout sd.write_target_in_app_logs
- dev up
- pnpm clean && pnpm install
- Create app with cart validation function
- pnpm run shopify app dev --path <path to app>
- trigger function run and capture the log json file name and cat its contents, target should be present.

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
