### PR TITLE
Fix concurrency issue in downloadBinary

### DIFF
--- a/.changeset/healthy-coins-walk.md
+++ b/.changeset/healthy-coins-walk.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Fix concurrency issue with downloading Functions binaries

--- a/packages/app/src/cli/services/function/binaries.test.ts
+++ b/packages/app/src/cli/services/function/binaries.test.ts
@@ -141,6 +141,26 @@ describe('javy', () => {
     expect(fetch).toHaveBeenCalledOnce()
     await expect(fileExists(javy.path)).resolves.toBeTruthy()
   })
+
+  test('handles concurrent downloads of Javy', async () => {
+    // Given
+    await removeFile(javy.path)
+    await expect(fileExists(javy.path)).resolves.toBeFalsy()
+    vi.mocked(fetch).mockResolvedValue(new Response(gzipSync('javy binary')))
+
+    // When
+    await Promise.all([
+      downloadBinary(javy),
+      downloadBinary(javy),
+      downloadBinary(javy),
+      downloadBinary(javy),
+      downloadBinary(javy),
+    ])
+
+    // Then
+    expect(fetch).toHaveBeenCalledOnce()
+    await expect(fileExists(javy.path)).resolves.toBeTruthy()
+  })
 })
 
 describe('javy-plugin', () => {

--- a/packages/app/src/cli/services/function/binaries.ts
+++ b/packages/app/src/cli/services/function/binaries.ts
@@ -203,12 +203,52 @@ export function trampolineBinary() {
   return _trampoline
 }
 
+const downloadsInProgress = new Map<string, Promise<void>>()
+
 export async function downloadBinary(bin: DownloadableBinary) {
   const isDownloaded = await fileExists(bin.path)
   if (isDownloaded) {
     return
   }
 
+  // Downloads cannot run concurrently with `exec` since the `moveFile`
+  // operation is not atomic. It will delete the destination file if it exists
+  // which will cause `exec` to break if it tries to execute the file before
+  // the source file has been moved.
+  // We prevent downloads from happening concurrently with `exec` by enforcing
+  // that only one download happens for an executable. If we get here, we check
+  // if a download is in progress, wait for it to finish, and return without
+  // downloading again. If it's not in progress, then we start the download.
+  const downloadPromise = downloadsInProgress.get(bin.path)
+  if (downloadPromise) {
+    await downloadPromise
+    // Return now since we can assume it's downloaded. If it's not, an exception should've
+    // been thrown before which will cause the user-level operation to fail anyway.
+    return
+  }
+
+  // Do not perform any `await`s until we've called `downloadsInProgress.set`.
+  // Calling `await` before that can cause a different JS task to become active
+  // and start a concurrent download for this binary.
+
+  // My mental model is `performDownload` without the `await` will run
+  // synchronously until the first `await` in the function and then
+  // immediately return the promise which we then immediately store. Since JS
+  // doesn't have preemptive concurrency, we should be able to safely assume a
+  // different task in the task queue will not run in between starting
+  // `downloadFn` and the `set` operation on the following line.
+  const downloadOp = performDownload(bin)
+  downloadsInProgress.set(bin.path, downloadOp)
+  // Ensure we clean the entry if there's a failure.
+  try {
+    // Wait for the download to finish
+    await downloadOp
+  } finally {
+    downloadsInProgress.delete(bin.path)
+  }
+}
+
+async function performDownload(bin: DownloadableBinary) {
   const url = bin.downloadUrl(process.platform, process.arch)
   outputDebug(`Downloading ${bin.name} ${bin.version} from ${url} to ${bin.path}`)
   const dir = dirname(bin.path)


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

There is an issue some Function developers are seeing when running `shopify app build` where trying to execute trampoline binary resulted in an `ENOENT` error message when trying to spawn `shopify-function-trampoline-v1.0.2`. While investigating, I discovered that [the `moveFile` operation we perform while downloading a binary](shopify-function-trampoline-v1.0.2) is *not* atomic. If the destination file exists, the underlying library will delete the destination file before performing the move. This _could_ result in an `ENOENT` when trying to spawn that executable file if the timing is just right.

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

This introduces a check to ensure only one JS task at a time tries to download a specific binary and waits if there is a download in progress for that library. I've added a lot of code comments because it is likely not obvious to every reader of the code how or why this approach works without them and there's no good way to structure the code to be more self-documenting.

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->
`pnpm shopify app build --path <path_to_project_with_functions>`

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [x] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
