### PR TITLE
Make bind address configurable for app dev server

### DIFF
--- a/packages/app/src/cli/commands/app/dev.ts
+++ b/packages/app/src/cli/commands/app/dev.ts
@@ -87,6 +87,11 @@ If you're using the Ruby app template, then you need to complete the following s
       default: false,
       exclusive: ['tunnel-url'],
     }),
+    host: Flags.string({
+      description: 'Set which network interface the web server listens on. The default value is localhost.',
+      env: 'SHOPIFY_FLAG_HOST',
+      default: 'localhost',
+    }),
     'localhost-port': Flags.integer({
       description: 'Port to use for localhost.',
       env: 'SHOPIFY_FLAG_LOCALHOST_PORT',
@@ -174,6 +179,7 @@ If you're using the Ruby app template, then you need to complete the following s
       notify: flags.notify,
       graphiqlPort: flags['graphiql-port'],
       graphiqlKey: flags['graphiql-key'],
+      host: flags.host,
       tunnel: tunnelMode,
     }
 

--- a/packages/app/src/cli/services/dev.ts
+++ b/packages/app/src/cli/services/dev.ts
@@ -69,6 +69,7 @@ export interface DevOptions {
   notify?: string
   graphiqlPort?: number
   graphiqlKey?: string
+  host: string
 }
 
 export async function dev(commandOptions: DevOptions) {

--- a/packages/app/src/cli/services/dev/processes/setup-dev-processes.test.ts
+++ b/packages/app/src/cli/services/dev/processes/setup-dev-processes.test.ts
@@ -1,4 +1,4 @@
-import {DevConfig, setupDevProcesses, startProxyServer} from './setup-dev-processes.js'
+import {DevConfig, setupDevProcesses, proxyService} from './setup-dev-processes.js'
 import {subscribeAndStartPolling} from './app-logs-polling.js'
 import {sendWebhook} from './uninstall-webhook.js'
 import {WebProcess, launchWebProcess} from './web.js'
@@ -95,6 +95,7 @@ describe('setup-dev-processes', () => {
       commandConfig: new Config({root: ''}),
       skipDependenciesInstallation: false,
       tunnel: {mode: 'auto'},
+      host: 'localhost',
     }
     const network: DevConfig['network'] = {
       proxyUrl: 'https://example.com/proxy',
@@ -281,7 +282,7 @@ describe('setup-dev-processes', () => {
     expect(proxyServerProcess).toMatchObject({
       type: 'proxy-server',
       prefix: 'proxy',
-      function: startProxyServer,
+      function: proxyService,
       options: {
         port: 444,
         localhostCert: {
@@ -311,6 +312,7 @@ describe('setup-dev-processes', () => {
       commandConfig: new Config({root: ''}),
       skipDependenciesInstallation: false,
       tunnel: {mode: 'auto'},
+      host: 'localhost',
     }
     const network: DevConfig['network'] = {
       proxyUrl: 'https://example.com/proxy',
@@ -384,6 +386,7 @@ describe('setup-dev-processes', () => {
       commandConfig: new Config({root: ''}),
       skipDependenciesInstallation: false,
       tunnel: {mode: 'auto'},
+      host: 'localhost',
     }
     const network: DevConfig['network'] = {
       proxyUrl: 'https://example.com/proxy',
@@ -480,6 +483,7 @@ describe('setup-dev-processes', () => {
       commandConfig: new Config({root: ''}),
       skipDependenciesInstallation: false,
       tunnel: {mode: 'auto'},
+      host: 'localhost',
     }
     const network: DevConfig['network'] = {
       proxyUrl: 'https://example.com/proxy',
@@ -566,6 +570,7 @@ describe('setup-dev-processes', () => {
       commandConfig: new Config({root: ''}),
       skipDependenciesInstallation: false,
       tunnel: {mode: 'auto'},
+      host: 'localhost',
     }
     const network: DevConfig['network'] = {
       proxyUrl: 'https://example.com/proxy',

--- a/packages/app/src/cli/services/dev/processes/setup-dev-processes.ts
+++ b/packages/app/src/cli/services/dev/processes/setup-dev-processes.ts
@@ -30,6 +30,7 @@ interface ProxyServerProcess
     port: number
     rules: {[key: string]: string}
     localhostCert?: LocalhostCert
+    host: string
   }> {
   type: 'proxy-server'
 }
@@ -251,11 +252,12 @@ async function setPortsAndAddProxyProcess(
     newProcesses.push({
       type: 'proxy-server',
       prefix: 'proxy',
-      function: startProxyServer,
+      function: proxyService,
       options: {
         port: proxyPort,
         rules: allRules,
         localhostCert: reverseProxyCert,
+        host: commandOptions.host,
       },
     })
   }
@@ -263,15 +265,16 @@ async function setPortsAndAddProxyProcess(
   return newProcesses
 }
 
-export const startProxyServer: DevProcessFunction<{
+export const proxyService: DevProcessFunction<{
   port: number
   rules: {[key: string]: string}
   localhostCert?: LocalhostCert
-}> = async ({abortSignal, stdout}, {port, rules, localhostCert}) => {
+  host: string
+}> = async ({abortSignal, stdout}, {port, rules, localhostCert, host}) => {
   const {server} = await getProxyingWebServer(rules, abortSignal, localhostCert, stdout)
   outputInfo(
-    `Proxy server started on port ${port} ${localhostCert ? `with certificate ${localhostCert.certPath}` : ''}`,
+    `Proxy server started on ${host}:${port} ${localhostCert ? `with certificate ${localhostCert.certPath}` : ''}`,
     stdout,
   )
-  await server.listen(port, 'localhost')
+  await server.listen(port, host)
 }


### PR DESCRIPTION

Adds configurable bind address support to the `shopify app dev` command to enable Docker container development workflows.

### Problem
- Recent CLI versions hardcode `localhost` binding for app dev servers for security
- Docker containers require `0.0.0.0` binding to accept connections from host machine
- Theme dev server already supports `--host` flag, but app dev server does not
- Breaks containerized development setups (working version was 3.83.3)

### Solution
- Add `--host` flag to `shopify app dev` command with `SHOPIFY_FLAG_HOST` env var support
- Update proxy server setup to use configurable host instead of hardcoded `'localhost'`
- Maintain secure default (`localhost`) while enabling Docker flexibility
- Match existing theme dev server pattern for consistency

## Changes Made

### 1. Added host flag to app dev command
- **File**: `packages/app/src/cli/commands/app/dev.ts`
- Added `--host` flag with environment variable support
- Default: `localhost` (maintains security)
- Override: `0.0.0.0` (enables Docker containers)

### 2. Updated proxy server to use configurable host
- **File**: `packages/app/src/cli/services/dev/processes/setup-dev-processes.ts`
- Changed hardcoded `'localhost'` to use passed host parameter
- Added host parameter to proxy server setup function

## Usage Examples

### For Docker containers:
```bash
SHOPIFY_FLAG_HOST=0.0.0.0 shopify app dev
# or
shopify app dev --host=0.0.0.0
```

### For normal development (default):
```bash
shopify app dev  # Still binds to localhost by default
```

## Testing

- [ ] Verify default behavior unchanged (binds to localhost)
- [ ] Verify `--host=0.0.0.0` enables external connections
- [ ] Verify `SHOPIFY_FLAG_HOST` environment variable works
- [ ] Test Docker container setup with port forwarding
- [ ] Ensure backwards compatibility

## Risk Assessment

- **Low risk**: Changes follow existing CLI patterns
- **Backwards compatible**: Default behavior unchanged
- **Security maintained**: Still defaults to localhost
- **Consistent**: Matches theme dev server implementation

## Related Issues

- Fixes #6355
- Addresses Docker container development workflows
- Maintains parity with theme dev server host configuration