### PR TITLE
Fix GH actions for dependabot

### DIFF
--- a/.github/workflows/shopify-cli.yml
+++ b/.github/workflows/shopify-cli.yml
@@ -213,6 +213,7 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
       - name: Post the knip results
+        if: github.event.pull_request.user.login != 'dependabot[bot]'
         uses: codex-/knip-reporter@f717532b6707d95de06b9bb2eb8ece46393f018f # pin@v2
         with:
           verbose: true
@@ -220,7 +221,7 @@ jobs:
   pr-platform-agnostic-graphql-schema:
     name: '[PR] Check graphql-codegen has been run'
     runs-on: ${{ matrix.os }}
-    if: ${{ github.event_name == 'pull_request' }}
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.user.login != 'dependabot[bot]' }}
     timeout-minutes: 30
     strategy:
       matrix:


### PR DESCRIPTION
### WHY are these changes introduced?

Some GH actions are not compatible with Dependabot, specifically the ones that require write permissions like `knip-reporter`

### WHAT is this pull request doing?

- Run `knip`​ but don’t post the results in the PR (don’t run the last step).
- Don’t run the `graphql-schema`​ action, it’s not needed for dependabot PRs.

### How to test your changes?

1. Create a PR with these changes
2. Verify that CI workflow runs correctly for regular PRs
3. Verify that Dependabot PRs skip the specified checks

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes