### PR TITLE
Attempt at fixing flaky test

### DIFF
--- a/packages/app/src/cli/services/app-logs/logs-command/ui/components/hooks/useSelfAdjustingInterval.test.tsx
+++ b/packages/app/src/cli/services/app-logs/logs-command/ui/components/hooks/useSelfAdjustingInterval.test.tsx
@@ -43,7 +43,7 @@ describe('useSelfAdjustingInterval', () => {
   })
 
   test('calls callback immediately and sets up next interval', async () => {
-    const callback = vi.fn().mockResolvedValue({retryIntervalMs: 1000})
+    const callback = vi.fn(() => Promise.resolve({retryIntervalMs: 1000}))
 
     renderHook(() => useSelfAdjustingInterval(callback))
 
@@ -59,9 +59,9 @@ describe('useSelfAdjustingInterval', () => {
   test('adjusts interval based on callback return value', async () => {
     const callback = vi
       .fn()
-      .mockResolvedValueOnce({retryIntervalMs: 1000})
-      .mockResolvedValueOnce({retryIntervalMs: 2000})
-      .mockResolvedValueOnce({retryIntervalMs: null})
+      .mockImplementationOnce(() => Promise.resolve({retryIntervalMs: 1000}))
+      .mockImplementationOnce(() => Promise.resolve({retryIntervalMs: 2000}))
+      .mockImplementationOnce(() => Promise.resolve({retryIntervalMs: null}))
     renderHook(() => useSelfAdjustingInterval(callback))
 
     // Initial call
@@ -82,7 +82,7 @@ describe('useSelfAdjustingInterval', () => {
   })
 
   test('deals with the callback throwing an error', async () => {
-    const callback = vi.fn().mockRejectedValue(new Error('test error'))
+    const callback = vi.fn(() => Promise.reject(new Error('test error')))
     const {lastResult} = renderHook(() => useSelfAdjustingInterval(callback))
 
     await vi.advanceTimersByTimeAsync(0)
@@ -91,7 +91,7 @@ describe('useSelfAdjustingInterval', () => {
   })
 
   test('cleans up timeout on unmount', async () => {
-    const callback = vi.fn().mockResolvedValue({retryIntervalMs: 1000})
+    const callback = vi.fn(() => Promise.resolve({retryIntervalMs: 1000}))
 
     const {unmount} = renderHook(() => useSelfAdjustingInterval(callback))
 


### PR DESCRIPTION
### WHY are these changes introduced?

Improves the test code by using more explicit Promise implementations instead of mock return values.

This is in response to this flaky test run: https://github.com/Shopify/cli/actions/runs/17729330606/job/50376928926

### WHAT is this pull request doing?

Refactors the mock implementations in `useSelfAdjustingInterval.test.tsx` to use explicit Promise implementations:

- Replaces `.mockResolvedValue()` with `vi.fn(() => Promise.resolve())`
- Replaces `.mockResolvedValueOnce()` with `mockImplementationOnce(() => Promise.resolve())`
- Replaces `.mockRejectedValue()` with `vi.fn(() => Promise.reject())`

This approach provides more explicit control over the Promise behavior in tests.

### How to test your changes?

1. Run the test suite for the app-logs component
2. Verify all tests pass with the updated mock implementations
3. Ensure the test coverage remains the same

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes