### PR TITLE
add payload-query field to wehook-module

### DIFF
--- a/packages/app/src/cli/models/app/loader.test.ts
+++ b/packages/app/src/cli/models/app/loader.test.ts
@@ -3309,6 +3309,22 @@ describe('WebhooksSchema', () => {
     expect(abortOrReport).toHaveBeenCalledWith(expectedFormatted, {}, 'tmp')
   })
 
+  test('accepts webhook subscription with payload_query', async () => {
+    const webhookConfig: WebhooksConfig = {
+      api_version: '2024-01',
+      subscriptions: [
+        {
+          topics: ['products/create'],
+          uri: 'https://example.com/webhooks',
+          payload_query: 'query { product { id title } }',
+        },
+      ],
+    }
+    const {abortOrReport, parsedConfiguration} = await setupParsing({}, webhookConfig)
+    expect(abortOrReport).not.toHaveBeenCalled()
+    expect(parsedConfiguration.webhooks).toMatchObject(webhookConfig)
+  })
+
   async function setupParsing(errorObj: zod.ZodIssue | {}, webhookConfigOverrides: WebhooksConfig) {
     const err = Array.isArray(errorObj) ? errorObj : [errorObj]
     const expectedFormatted = outputContent`\n${outputToken.errorText(

--- a/packages/app/src/cli/models/extensions/specifications/app_config_webhook_schemas/webhook_subscription_schema.ts
+++ b/packages/app/src/cli/models/extensions/specifications/app_config_webhook_schemas/webhook_subscription_schema.ts
@@ -18,7 +18,7 @@ export const WebhookSubscriptionSchema = zod.object({
   }),
   include_fields: zod.array(zod.string({invalid_type_error: 'Value must be a string'})).optional(),
   filter: zod.string({invalid_type_error: 'Value must be a string'}).optional(),
-  payload_query: zod.string({invalid_type_error: 'Value must be a string'}).optional(),
+  payload_query: zod.string({invalid_type_error: 'Value must be a string'}).trim().min(1).optional(),
 
   compliance_topics: zod
     .array(

--- a/packages/app/src/cli/models/extensions/specifications/app_config_webhook_subscription.ts
+++ b/packages/app/src/cli/models/extensions/specifications/app_config_webhook_subscription.ts
@@ -14,6 +14,7 @@ interface TransformedWebhookSubscription {
   compliance_topics?: string[]
   include_fields?: string[]
   filter?: string
+  payload_query?: string
 }
 
 export const SingleWebhookSubscriptionSchema = zod.object({
@@ -24,7 +25,7 @@ export const SingleWebhookSubscriptionSchema = zod.object({
   }),
   include_fields: zod.array(zod.string({invalid_type_error: 'Value must be a string'})).optional(),
   filter: zod.string({invalid_type_error: 'Value must be a string'}).optional(),
-  payload_query: zod.string({invalid_type_error: 'Value must be a string'}).optional(),
+  payload_query: zod.string({invalid_type_error: 'Value must be a string'}).trim().min(1).optional(),
 })
 
 /* this transforms webhooks remotely to be accepted by the TOML

--- a/packages/app/src/cli/models/extensions/specifications/types/app_config_webhook.ts
+++ b/packages/app/src/cli/models/extensions/specifications/types/app_config_webhook.ts
@@ -4,6 +4,7 @@ export interface WebhookSubscription {
   compliance_topics?: string[]
   include_fields?: string[]
   filter?: string
+  payload_query?: string
 }
 
 interface PrivacyComplianceConfig {


### PR DESCRIPTION
### WHY are these changes introduced?

To support the `payload_query` field in webhook subscriptions, allowing developers to specify GraphQL queries for webhook payloads.

### WHAT is this pull request doing?

Adding support for the `payload_query` field in webhook subscription schemas. This field allows developers to define a GraphQL query that determines what data is included in webhook payloads, giving more control over the webhook response structure.


### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes