### PR TITLE
Abort theme command if path doesn't exist

### DIFF
--- a/.changeset/big-ducks-joke.md
+++ b/.changeset/big-ducks-joke.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': minor
+---
+
+Abort theme commands if path doesn't exist

--- a/packages/theme/src/cli/flags.test.ts
+++ b/packages/theme/src/cli/flags.test.ts
@@ -1,0 +1,45 @@
+import {themeFlags} from './flags.js'
+import {describe, expect, test} from 'vitest'
+import Command from '@shopify/cli-kit/node/base-command'
+import {inTemporaryDirectory} from '@shopify/cli-kit/node/fs'
+import {cwd, resolvePath} from '@shopify/cli-kit/node/path'
+import {mockAndCaptureOutput} from '@shopify/cli-kit/node/testing/output'
+
+class MockCommand extends Command {
+  static flags = {
+    ...themeFlags,
+  }
+
+  async run(): Promise<{[flag: string]: unknown}> {
+    const {flags} = await this.parse(MockCommand)
+    return flags
+  }
+
+  async catch(): Promise<void> {}
+}
+
+describe('themeFlags', () => {
+  describe('path', () => {
+    test('defaults to the current working directory', async () => {
+      const flags = await MockCommand.run([])
+
+      expect(flags.path).toEqual(cwd())
+    })
+
+    test('can be expclitly provided', async () => {
+      await inTemporaryDirectory(async (tmpDir) => {
+        const flags = await MockCommand.run(['--path', tmpDir])
+
+        expect(flags.path).toEqual(resolvePath(tmpDir))
+      })
+    })
+
+    test("renders an error message and exists when the path doesn't exist", async () => {
+      const mockOutput = mockAndCaptureOutput()
+
+      await MockCommand.run(['--path', 'boom'])
+
+      expect(mockOutput.error()).toMatch("A path was explicitly provided but doesn't exist")
+    })
+  })
+})

--- a/packages/theme/src/cli/index.test.ts
+++ b/packages/theme/src/cli/index.test.ts
@@ -1,7 +1,0 @@
-import {describe, expect, test} from 'vitest'
-
-describe('it works', () => {
-  test('is true', () => {
-    expect(true).toBe(true)
-  })
-})

--- a/packages/theme/src/cli/utilities/theme-command.test.ts
+++ b/packages/theme/src/cli/utilities/theme-command.test.ts
@@ -6,6 +6,7 @@ import {AdminSession, ensureAuthenticatedThemes} from '@shopify/cli-kit/node/ses
 import {loadEnvironment} from '@shopify/cli-kit/node/environments'
 import {renderConcurrent, renderConfirmationPrompt, renderError} from '@shopify/cli-kit/node/ui'
 import {fileExistsSync} from '@shopify/cli-kit/node/fs'
+import {AbortError} from '@shopify/cli-kit/node/error'
 import type {Writable} from 'stream'
 
 vi.mock('@shopify/cli-kit/node/session')
@@ -121,6 +122,7 @@ describe('ThemeCommand', () => {
     }
     vi.mocked(ensureThemeStore).mockReturnValue('test-store.myshopify.com')
     vi.mocked(ensureAuthenticatedThemes).mockResolvedValue(mockSession)
+    vi.mocked(fileExistsSync).mockReturnValue(true)
   })
 
   describe('run', () => {
@@ -206,6 +208,16 @@ describe('ThemeCommand', () => {
           showTimestamps: true,
         }),
       )
+    })
+
+    test("throws an AbortError if the path doesn't exist", async () => {
+      await CommandConfig.load()
+      const command = new TestThemeCommand([], CommandConfig)
+
+      vi.mocked(fileExistsSync).mockReturnValue(false)
+
+      await expect(command.run()).rejects.toThrow(AbortError)
+      expect(fileExistsSync).toHaveBeenCalledWith('current/working/directory')
     })
   })
 
@@ -483,7 +495,6 @@ describe('ThemeCommand', () => {
       const environmentConfig = {store: 'store.myshopify.com'}
       vi.mocked(loadEnvironment).mockResolvedValue(environmentConfig)
       vi.mocked(renderConfirmationPrompt).mockResolvedValue(true)
-      vi.mocked(fileExistsSync).mockReturnValue(true)
 
       await CommandConfig.load()
       const command = new TestThemeCommand(

--- a/packages/theme/src/cli/utilities/theme-command.ts
+++ b/packages/theme/src/cli/utilities/theme-command.ts
@@ -14,6 +14,7 @@ import {
   renderError,
 } from '@shopify/cli-kit/node/ui'
 import {AbortController} from '@shopify/cli-kit/node/abort'
+import {AbortError} from '@shopify/cli-kit/node/error'
 import {recordEvent, compileData} from '@shopify/cli-kit/node/analytics'
 import {addPublicMetadata, addSensitiveMetadata} from '@shopify/cli-kit/node/metadata'
 import {cwd, joinPath} from '@shopify/cli-kit/node/path'
@@ -99,6 +100,10 @@ export default abstract class ThemeCommand extends Command {
       const commandName = this.constructor.name.toLowerCase()
 
       recordEvent(`theme-command:${commandName}:single-env:authenticated`)
+
+      if (flags.path && !fileExistsSync(flags.path)) {
+        throw new AbortError(`Path does not exist: ${flags.path}`)
+      }
 
       await this.command(flags, session)
       await this.logAnalyticsData(session)


### PR DESCRIPTION
### WHY are these changes introduced?

We're seeing quite a few unhandled errors due to the command being run on a path that doesn't exist. Instead of blowing up let's catch the missing path early and let the user know.

### WHAT is this pull request doing?

Modifies `ThemeCommand` to check the path and to see if it exists. We throw two different errors depending on whether the user explicitly provided the path or not.

### How to test your changes?

> [!NOTE]
> Right now this only works for commands that have been migrated to multi-environment support but soon that will be all of them!

```sh
npm i -g --@shopify:registry=https://registry.npmjs.org @shopify/cli@0.0.0-snapshot-20250916000226
shopify theme info --path foobarbaz
```

You should see an error:

```
➜  <theme> git:(main) shopify theme info --path foooooo
╭─ error ────────────────────────────────────────────────────────────────────────────────────╮
│                                                                                            │
│  A path was explicitly provided and does not exist. Please check the path and try again:   │
│  /Users/graygilmore/repos/<theme>/foooooo                                                  │
│                                                                                            │
╰────────────────────────────────────────────────────────────────────────────────────────────╯
```