### PR TITLE
Attempt at fixing loader flaky tests

### DIFF
--- a/packages/app/src/cli/models/app/loader.test.ts
+++ b/packages/app/src/cli/models/app/loader.test.ts
@@ -39,8 +39,11 @@ import {zod} from '@shopify/cli-kit/node/schema'
 import colors from '@shopify/cli-kit/node/colors'
 import {showMultipleCLIWarningIfNeeded} from '@shopify/cli-kit/node/multiple-installation-warning'
 import {AbortError} from '@shopify/cli-kit/node/error'
+import {captureOutput} from '@shopify/cli-kit/node/system'
 
 vi.mock('../../services/local-storage.js')
+// Mock captureOutput to prevent executing `npm prefix` inside getPackageManager
+vi.mock('@shopify/cli-kit/node/system')
 vi.mock('../../services/app/config/use.js')
 vi.mock('@shopify/cli-kit/node/is-global')
 vi.mock('@shopify/cli-kit/node/node-package-manager', async () => ({
@@ -267,6 +270,7 @@ wrong = "property"
   test('defaults to npm as the package manager when the configuration is valid', async () => {
     // Given
     await writeConfig(appConfiguration)
+    vi.mocked(captureOutput).mockResolvedValue(tmpDir)
 
     // When
     const app = await loadTestingApp()
@@ -280,6 +284,7 @@ wrong = "property"
     await writeConfig(appConfiguration)
     const yarnLockPath = joinPath(tmpDir, yarnLockfile)
     await writeFile(yarnLockPath, '')
+    vi.mocked(captureOutput).mockResolvedValue(tmpDir)
 
     // When
     const app = await loadTestingApp()


### PR DESCRIPTION
### WHY are these changes introduced?

To fix an issue with the test environment where `npm prefix` was being executed during tests, which could lead to inconsistent test behavior.

### WHAT is this pull request doing?

Mocks the `captureOutput` function from `@shopify/cli-kit/node/system` to prevent the execution of `npm prefix` inside the `getPackageManager` function during tests. This ensures that the tests run in a controlled environment without making actual system calls.

The changes include:
- Adding a mock for `captureOutput` at the top of the test file
- Adding mock implementations in specific tests to return the expected temporary directory

### How to test your changes?

1. Run the test suite to ensure all tests pass
2. Verify that the tests no longer make actual system calls to `npm prefix`
3. Confirm that package manager detection still works correctly in the tests

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes