### PR TITLE
Improve upload reliability with accurate bytesize calculation

### DIFF
--- a/.changeset/short-owls-drop.md
+++ b/.changeset/short-owls-drop.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Fix theme file size calculation to improve upload batching reliability

--- a/packages/theme/src/cli/utilities/theme-uploader.ts
+++ b/packages/theme/src/cli/utilities/theme-uploader.ts
@@ -357,10 +357,14 @@ function calculateLocalChecksums(localThemeFileSystem: ThemeFileSystem): Checksu
   const checksums: ChecksumWithSize[] = []
 
   localThemeFileSystem.files.forEach((file, key) => {
+    // Text files: use UTF-8 byte count
+    // Binary files: use base64 length
+    const size = file.value ? Buffer.byteLength(file.value, 'utf8') : file.attachment?.length ?? 0
+
     checksums.push({
       key,
       checksum: file.checksum,
-      size: file.stats?.size ?? 0,
+      size,
     })
   })
 


### PR DESCRIPTION
### WHY are these changes introduced?

Our theme uploader could create asset batches that were larger than the 1MB limit we set. This was caused by inaccurate calculation of the files containing multi-byte UTF-8 characters such as emojis or accented letters (e.g `é`, `ü`, `ñ`). We may see this more often with internationalized content

EX: `🍕🍕🍕🍕🍕` under the current calculation is measured as `10` characters but is actually 20 bytes.


### WHAT is this pull request doing?

- For all text based assets (.liquid, .json, .js) we use `Buffer.byteLength` to get the true byte size of the content.
- For binary assets (.png, .jpg) we continue the way it was before - calculating the size based on the length of the Base64-encoded string.

The changes should allow us to pack batches more reliably.

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
