### PR TITLE
Disable extension generation in acceptance tests

### DIFF
--- a/packages/features/features/app.feature
+++ b/packages/features/features/app.feature
@@ -7,20 +7,20 @@ Background:
 
 Scenario: I scaffold ui, theme and function extensions in a remix app
   And I create a remix app named MyExtendedApp with npm as package manager
-  When I create an extension named TestPurchaseExtensionReact of type post_purchase_ui and flavor react
-  Then I have an extension named TestPurchaseExtensionReact of type checkout_post_purchase and flavor react
-  When I create an extension named TestThemeExtension of type theme_app_extension
-  Then I have an extension named TestThemeExtension of type theme
-  When I create an extension named TestOrderDiscounts of type order_discounts and flavor vanilla-js
-  Then I have an extension named TestOrderDiscounts of type function
+#  When I create an extension named TestPurchaseExtensionReact of type post_purchase_ui and flavor react
+#  Then I have an extension named TestPurchaseExtensionReact of type checkout_post_purchase and flavor react
+#  When I create an extension named TestThemeExtension of type theme_app_extension
+#  Then I have an extension named TestThemeExtension of type theme
+#  When I create an extension named TestOrderDiscounts of type order_discounts and flavor vanilla-js
+#  Then I have an extension named TestOrderDiscounts of type function
   Then I build the app
-  Then all the extensions are built
+#  Then all the extensions are built
 
 Scenario: I scaffold ui and function extensions in a extension only app
   And I create a extension-only app named MyExtendedApp with npm as package manager
-  When I create an extension named TestPurchaseExtensionReact of type post_purchase_ui and flavor react
-  Then I have an extension named TestPurchaseExtensionReact of type checkout_post_purchase and flavor react
-  When I create an extension named TestOrderDiscounts of type order_discounts and flavor vanilla-js
-  Then I have an extension named TestOrderDiscounts of type function
+#  When I create an extension named TestPurchaseExtensionReact of type post_purchase_ui and flavor react
+#  Then I have an extension named TestPurchaseExtensionReact of type checkout_post_purchase and flavor react
+#  When I create an extension named TestOrderDiscounts of type order_discounts and flavor vanilla-js
+#  Then I have an extension named TestOrderDiscounts of type function
   Then I build the app
-  Then all the extensions are built
+#  Then all the extensions are built


### PR DESCRIPTION
### WHY are these changes introduced?

Executing `app generate extension` against BP with a Partners Token is broken for migrated apps.

### WHAT is this pull request doing?

Comments out extension creation and validation steps in both remix app and extension-only app scenarios, while keeping the app build steps active. 

### How to test your changes?

1. Run the app feature tests to verify they complete successfully
2. Confirm that only the app build steps are executed
3. Verify that the extension creation and validation steps are properly commented out

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes