### PR TITLE
Modify request behaviour of devSessionCreate to slow-request

### DIFF
--- a/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
@@ -1007,6 +1007,7 @@ export class AppManagementClient implements DeveloperPlatformClient {
       query: DevSessionCreate,
       shopFqdn,
       variables: {appId: appIdNumber, assetsUrl: assetsUrl ?? ''},
+      requestOptions: {requestMode: 'slow-request'},
     })
   }
 

--- a/packages/cli-kit/src/public/node/api/app-dev.ts
+++ b/packages/cli-kit/src/public/node/api/app-dev.ts
@@ -1,4 +1,5 @@
 import {graphqlRequestDoc, UnauthorizedHandler} from './graphql.js'
+import {RequestOptions} from './app-management.js'
 import {appDevFqdn, normalizeStoreFqdn} from '../context/fqdn.js'
 import {serviceEnvironment} from '../../../private/node/context/service.js'
 import Bottleneck from 'bottleneck'
@@ -26,6 +27,7 @@ export interface AppDevRequestOptions<TResult, TVariables extends Variables> {
   token: string
   unauthorizedHandler: UnauthorizedHandler
   variables?: TVariables
+  requestOptions?: RequestOptions
 }
 /**
  * Executes an org-scoped GraphQL query against the App Management API.
@@ -53,6 +55,7 @@ export async function appDevRequestDoc<TResult, TVariables extends Variables>(
       addedHeaders,
       variables: options.variables,
       unauthorizedHandler: options.unauthorizedHandler,
+      preferredBehaviour: options.requestOptions?.requestMode,
     }),
   )
 


### PR DESCRIPTION
### WHY are these changes introduced?

Avoid timeouts when starting a new dev session with many extensions.

### WHAT is this pull request doing?

This PR adds the ability to specify a `requestMode` option when creating a dev session. Specifically:

1. Sets the `requestMode` to `'slow-request'` for dev session creation

### How to test your changes?.

Easy way to test:
1. Run `app dev` with this env var: `SHOPIFY_CLI_MAX_REQUEST_TIME_FOR_NETWORK_CALLS=3000`
(You'd need around 10 ui_extensions)
2. See that if you run from `main`, this always crashes with "user aborted the request". Add more extensions if it doesn't.
3. See that it never crashes from this branch no matter the number of extensions.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes