### PR TITLE
Fix theme analytics logging even when a command fails

### DIFF
--- a/packages/theme/src/cli/utilities/theme-command.ts
+++ b/packages/theme/src/cli/utilities/theme-command.ts
@@ -88,8 +88,11 @@ export default abstract class ThemeCommand extends Command {
         throw new AbortError(`Path does not exist: ${flags.path}`)
       }
 
-      await this.command(flags, session, false, args)
-      await this.logAnalyticsData(session)
+      try {
+        await this.command(flags, session, false, args)
+      } finally {
+        await this.logAnalyticsData(session)
+      }
       return
     }
 
@@ -267,8 +270,11 @@ export default abstract class ThemeCommand extends Command {
                 const commandName = this.constructor.name.toLowerCase()
                 recordEvent(`theme-command:${commandName}:multi-env:authenticated`)
 
-                await this.command(flags, session, true, {}, {stdout, stderr})
-                await this.logAnalyticsData(session)
+                try {
+                  await this.command(flags, session, true, {}, {stdout, stderr})
+                } finally {
+                  await this.logAnalyticsData(session)
+                }
               })
 
               // eslint-disable-next-line no-catch-all/no-catch-all
@@ -371,7 +377,6 @@ export default abstract class ThemeCommand extends Command {
     if (!session) return
 
     const data = compileData()
-
     await addPublicMetadata(() => ({
       store_fqdn_hash: hashString(session.storeFqdn),
 


### PR DESCRIPTION
We are not collecting analytics when a theme command fails. This is because we put our logging after our `await command` and on failure, the promise stops and we never get to our logging method.

### WHAT is this pull request doing?

Wrap theme commands in `try/finally` blocks to ensure analytics are logged regardless of command success or failure. 

### How to test your changes?

You can throw an error in a theme command on main and try to console log the analytics event in `theme-command`
Build this branch and do the same, you should see our logs.

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
