### PR TITLE
Record retryable requests to monorail for theme commands

### DIFF
--- a/.changeset/curvy-bears-raise.md
+++ b/.changeset/curvy-bears-raise.md
@@ -1,5 +1,0 @@
----
-'@shopify/cli-kit': patch
----
-
-Added optional property for recording retryable requests in theme commands

--- a/packages/cli-kit/src/private/node/api.test.ts
+++ b/packages/cli-kit/src/private/node/api.test.ts
@@ -416,7 +416,7 @@ describe('retryAwareRequest', () => {
         url: 'https://themes.example.com/api',
         useNetworkLevelRetry: true,
         maxRetryTimeMs: 10000,
-        recordThemeCommandRetries: true,
+        recordCommandRetries: true,
       },
       undefined,
       {
@@ -471,7 +471,7 @@ describe('retryAwareRequest', () => {
         url: 'https://app.example.com/api',
         useNetworkLevelRetry: true,
         maxRetryTimeMs: 10000,
-        recordThemeCommandRetries: false,
+        recordCommandRetries: false,
       },
       undefined,
       {
@@ -528,7 +528,7 @@ describe('retryAwareRequest', () => {
         url: 'https://themes.example.com/upload',
         useNetworkLevelRetry: true,
         maxRetryTimeMs: 10000,
-        recordThemeCommandRetries: true,
+        recordCommandRetries: true,
       },
       undefined,
       {
@@ -584,7 +584,7 @@ describe('retryAwareRequest', () => {
         url: 'https://themes.example.com/auth',
         useNetworkLevelRetry: true,
         maxRetryTimeMs: 10000,
-        recordThemeCommandRetries: true,
+        recordCommandRetries: true,
       },
       undefined,
       {

--- a/packages/cli-kit/src/private/node/api.ts
+++ b/packages/cli-kit/src/private/node/api.ts
@@ -18,11 +18,11 @@ export type NetworkRetryBehaviour =
   | {
       useNetworkLevelRetry: true
       maxRetryTimeMs: number
-      recordThemeCommandRetries?: boolean
+      recordCommandRetries?: boolean
     }
   | {
       useNetworkLevelRetry: false
-      recordThemeCommandRetries?: boolean
+      recordCommandRetries?: boolean
     }
 
 type RequestOptions<T> = {
@@ -153,8 +153,8 @@ async function runRequestWithNetworkLevelRetry<T extends {headers: Headers; stat
         throw err
       }
 
-      // Record theme command retries
-      if (requestOptions.recordThemeCommandRetries) {
+      // Record command retries
+      if (requestOptions.recordCommandRetries) {
         recordRetry(requestOptions.url, `network-retry:${(err as Error).message}`)
       }
 
@@ -380,8 +380,8 @@ ${result.sanitizedHeaders}
     }
     retriesUsed += 1
 
-    // Record theme command retries
-    if (requestOptions.recordThemeCommandRetries) {
+    // Record command retries
+    if (requestOptions.recordCommandRetries) {
       recordRetry(requestOptions.url, `http-retry-${retriesUsed}:${result.status}:`)
     }
 

--- a/packages/cli-kit/src/public/node/themes/api.ts
+++ b/packages/cli-kit/src/public/node/themes/api.ts
@@ -37,7 +37,7 @@ const THEME_API_NETWORK_BEHAVIOUR: RequestModeInput = {
   useNetworkLevelRetry: true,
   useAbortSignal: false,
   maxRetryTimeMs: 90 * 1000,
-  recordThemeCommandRetries: true,
+  recordCommandRetries: true,
 }
 
 export async function fetchTheme(id: number, session: AdminSession): Promise<Theme | undefined> {


### PR DESCRIPTION
### WHY are these changes introduced?

Follow up to: https://github.com/Shopify/cli/pull/6451

Now that we will be getting data for failed commands, we should also gather data during retryable network events.

We want to record retries for: 
- Transient level [retries](https://github.com/Shopify/cli/blob/45fe1ee39f8f08d6a2750977904ab01c98c9261c/packages/cli-kit/src/private/node/api.ts#L82)
- HTTP level retries (`429`, `401`..)


### WHAT is this pull request doing?

Add an optional property in `NetworkRetryBehaviour` that will record these kinds of events only if they are theme commands. App command logging will remain the same as it currently is.

### How to test your changes?

Running the tests is the easiest. `pnpm vitest run packages/cli-kit/src/private/node/api.test.ts`

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
