### PR TITLE
Preserve session alias on refresh

### DIFF
--- a/.changeset/tasty-boxes-hunt.md
+++ b/.changeset/tasty-boxes-hunt.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': patch
+---
+
+Preserve session alias on token refresh

--- a/packages/cli-kit/src/private/node/session/exchange.test.ts
+++ b/packages/cli-kit/src/private/node/session/exchange.test.ts
@@ -205,6 +205,35 @@ describe('refresh access tokens', () => {
     // Then
     return expect(got).rejects.toThrowError(AbortError)
   })
+
+  test('preserves the alias when refreshing access token', async () => {
+    // Given
+    const tokenWithAlias: IdentityToken = {
+      ...identityToken,
+      alias: 'my-custom-alias',
+    }
+    const refreshData = {
+      access_token: 'new_access_token',
+      refresh_token: 'new_refresh_token',
+      scope: 'new_scope',
+      expires_in: 7200,
+      id_token: 'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiI1Njc4LTEyMzQifQ.2OGPUmd5MTEv-J5p3Ra4mskCN0635qN8lh3p5_BcoYY',
+    }
+    const response = new Response(JSON.stringify(refreshData))
+    vi.mocked(shopifyFetch).mockResolvedValue(response)
+
+    // When
+    const result = await refreshAccessToken(tokenWithAlias)
+
+    // Then
+    expect(result.accessToken).toBe('new_access_token')
+    expect(result.refreshToken).toBe('new_refresh_token')
+    expect(result.scopes).toEqual(['new_scope'])
+    // Original userId is preserved
+    expect(result.userId).toBe('1234-5678')
+    // Alias is preserved
+    expect(result.alias).toBe('my-custom-alias')
+  })
 })
 
 const tokenExchangeMethods = [

--- a/packages/cli-kit/src/private/node/session/exchange.ts
+++ b/packages/cli-kit/src/private/node/session/exchange.ts
@@ -65,7 +65,7 @@ export async function refreshAccessToken(currentToken: IdentityToken): Promise<I
   }
   const tokenResult = await tokenRequest(params)
   const value = tokenResult.mapError(tokenRequestErrorHandler).valueOrBug()
-  return buildIdentityToken(value, currentToken.userId)
+  return buildIdentityToken(value, currentToken.userId, currentToken.alias)
 }
 
 /**
@@ -237,7 +237,11 @@ async function tokenRequest(params: {
   return err({error: payload.error, store: params.store})
 }
 
-function buildIdentityToken(result: TokenRequestResult, existingUserId?: string): IdentityToken {
+function buildIdentityToken(
+  result: TokenRequestResult,
+  existingUserId?: string,
+  existingAlias?: string,
+): IdentityToken {
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const userId = existingUserId ?? (result.id_token ? jose.decodeJwt(result.id_token).sub! : undefined)
 
@@ -251,6 +255,7 @@ function buildIdentityToken(result: TokenRequestResult, existingUserId?: string)
     expiresAt: new Date(Date.now() + result.expires_in * 1000),
     scopes: result.scope.split(' '),
     userId,
+    alias: existingAlias,
   }
 }
 


### PR DESCRIPTION
### WHY are these changes introduced?

When a session is refreshed and something changes (like a new scope/app), the stored alias is replaced by the user ID

### WHAT is this pull request doing?

Preserves the alias stored after login when refreshing the session

| Before | After |
|--------|--------|
| <img width="647" height="452" alt="before" src="https://github.com/user-attachments/assets/092a3449-bc10-4798-a164-53ad8401e763" /> | <img width="628" height="492" alt="after" src="https://github.com/user-attachments/assets/798aa2a4-43bb-4e20-815a-3e1fd4c8fe7d" /> | 

### How to test your changes?

- `npm i -g --@shopify:registry=https://registry.npmjs.org @shopify/cli@0.0.0-snapshot-20251003131338`
- `shopify auth login`
- `shopify theme list`
- `shopify auth login`

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
