### PR TITLE
Fix error when the store doesn't have a URL

### DIFF
--- a/packages/app/src/cli/api/graphql/business-platform-organizations/generated/fetch_dev_store_by_domain.ts
+++ b/packages/app/src/cli/api/graphql/business-platform-organizations/generated/fetch_dev_store_by_domain.ts
@@ -20,6 +20,7 @@ export type FetchDevStoreByDomainQuery = {
           storeType?: Types.Store | null
           primaryDomain?: string | null
           shortName?: string | null
+          url?: string | null
         }
       }[]
     } | null
@@ -107,6 +108,7 @@ export const FetchDevStoreByDomain = {
                                   {kind: 'Field', name: {kind: 'Name', value: 'storeType'}},
                                   {kind: 'Field', name: {kind: 'Name', value: 'primaryDomain'}},
                                   {kind: 'Field', name: {kind: 'Name', value: 'shortName'}},
+                                  {kind: 'Field', name: {kind: 'Name', value: 'url'}},
                                   {kind: 'Field', name: {kind: 'Name', value: '__typename'}},
                                 ],
                               },

--- a/packages/app/src/cli/api/graphql/business-platform-organizations/queries/fetch_dev_store_by_domain.graphql
+++ b/packages/app/src/cli/api/graphql/business-platform-organizations/queries/fetch_dev_store_by_domain.graphql
@@ -11,6 +11,7 @@
             storeType
             primaryDomain
             shortName
+            url
           }
         }
       }

--- a/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
@@ -1292,11 +1292,12 @@ function mapBusinessPlatformStoresToOrganizationStores(
 ): OrganizationStore[] {
   return storesArray.map((store: ShopNode) => {
     const {externalId, primaryDomain, name, url} = store
-    if (!url) throw new BugError('The selected store does not have a valid URL')
+    const shopDomain = url ?? primaryDomain
+    if (!shopDomain) throw new BugError('The selected store does not have a valid URL')
     return {
       shopId: externalId ? idFromEncodedGid(externalId) : undefined,
       link: primaryDomain,
-      shopDomain: normalizeStoreFqdn(url),
+      shopDomain: normalizeStoreFqdn(shopDomain),
       shopName: name,
       transferDisabled: true,
       convertableToPartnerTest: true,


### PR DESCRIPTION
### WHY are these changes introduced?

Some stores don't have a valid URL, use `primaryDomain` as fallback

### WHAT is this pull request doing?

Modifies the `mapBusinessPlatformStoresToOrganizationStores` function to use the primary domain as a fallback when the URL is not available. 

### How to test your changes?

1. Try to use the CLI with a store that has a primary domain but no URL (not sure how to force this)
2. Verify that the operation completes successfully without throwing the "The selected store does not have a valid URL" error

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes