### PR TITLE
Add start_verification_session_url field to custom onsite payments schema

### DIFF
--- a/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/custom_onsite_payments_app_extension_schema.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/custom_onsite_payments_app_extension_schema.test.ts
@@ -111,6 +111,72 @@ describe('CustomOnsitePaymentsAppExtensionSchema', () => {
       ]),
     )
   })
+
+  test('validates a configuration with valid start_verification_session_url', async () => {
+    // Given
+    const configWithVerificationUrl = {
+      ...config,
+      start_verification_session_url: 'https://example.com/verify',
+    }
+
+    // When
+    const {success} = CustomOnsitePaymentsAppExtensionSchema.safeParse(configWithVerificationUrl)
+
+    // Then
+    expect(success).toBe(true)
+  })
+
+  test('validates a configuration without start_verification_session_url', async () => {
+    // Given
+    const configWithoutVerificationUrl = {
+      ...config,
+      start_verification_session_url: undefined,
+    }
+
+    // When
+    const {success} = CustomOnsitePaymentsAppExtensionSchema.safeParse(configWithoutVerificationUrl)
+
+    // Then
+    expect(success).toBe(true)
+  })
+
+  test('returns an error if start_verification_session_url is not a valid URL', async () => {
+    // When/Then
+    expect(() =>
+      CustomOnsitePaymentsAppExtensionSchema.parse({
+        ...config,
+        start_verification_session_url: 'not-a-valid-url',
+      }),
+    ).toThrowError(
+      new zod.ZodError([
+        {
+          validation: 'url',
+          code: zod.ZodIssueCode.invalid_string,
+          message: 'Invalid url',
+          path: ['start_verification_session_url'],
+        },
+      ]),
+    )
+  })
+
+  test('returns an error if start_verification_session_url is an empty string', async () => {
+    // When/Then
+    expect(() =>
+      CustomOnsitePaymentsAppExtensionSchema.parse({
+        ...config,
+        start_verification_session_url: '',
+      }),
+    ).toThrowError(
+      new zod.ZodError([
+        {
+          validation: 'url',
+          code: zod.ZodIssueCode.invalid_string,
+          message: 'Invalid url',
+          path: ['start_verification_session_url'],
+        },
+      ]),
+    )
+  })
 })
 
 describe('customOnsitePaymentsAppExtensionDeployConfig', () => {
@@ -142,6 +208,38 @@ describe('customOnsitePaymentsAppExtensionDeployConfig', () => {
       checkout_payment_method_fields: config.checkout_payment_method_fields,
       modal_payment_method_fields: config.modal_payment_method_fields,
       ui_extension_handle: config.ui_extension_handle,
+    })
+  })
+
+  test('maps start_verification_session_url when provided in extension configuration', async () => {
+    // Given
+    const configWithVerificationUrl = {
+      ...config,
+      start_verification_session_url: 'https://example.com/verify',
+    }
+
+    // When
+    const result = await customOnsitePaymentsAppExtensionDeployConfig(configWithVerificationUrl)
+
+    // Then
+    expect(result).toMatchObject({
+      start_verification_session_url: 'https://example.com/verify',
+    })
+  })
+
+  test('does not include start_verification_session_url when not provided in extension configuration', async () => {
+    // Given
+    const configWithoutVerificationUrl = {
+      ...config,
+      start_verification_session_url: undefined,
+    }
+
+    // When
+    const result = await customOnsitePaymentsAppExtensionDeployConfig(configWithoutVerificationUrl)
+
+    // Then
+    expect(result).toMatchObject({
+      start_verification_session_url: undefined,
     })
   })
 })

--- a/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/custom_onsite_payments_app_extension_schema.ts
+++ b/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/custom_onsite_payments_app_extension_schema.ts
@@ -26,6 +26,7 @@ export const CustomOnsitePaymentsAppExtensionSchema = BasePaymentsAppExtensionSc
     supports_oversell_protection: zod.boolean().optional(),
     modal_payment_method_fields: zod.array(zod.object({})).optional(),
     ui_extension_handle: zod.string().optional(),
+    start_verification_session_url: zod.string().url().optional(),
     checkout_payment_method_fields: zod
       .array(
         zod.object({
@@ -58,6 +59,7 @@ export interface CustomOnsitePaymentsAppExtensionDeployConfigType extends BasePa
   supports_3ds: boolean
 
   // CustomOnsite-specific fields
+  start_verification_session_url?: string
   update_payment_session_url?: string
   multiple_capture?: boolean
   supports_oversell_protection?: boolean
@@ -85,6 +87,7 @@ export function customOnsiteDeployConfigToCLIConfig(
     void_session_url: config.start_void_session_url,
     confirmation_callback_url: config.confirmation_callback_url,
     update_payment_session_url: config.update_payment_session_url,
+    start_verification_session_url: config.start_verification_session_url,
     merchant_label: config.merchant_label,
     supports_oversell_protection: config.supports_oversell_protection,
     supports_3ds: config.supports_3ds,
@@ -114,6 +117,7 @@ export async function customOnsitePaymentsAppExtensionDeployConfig(
     start_void_session_url: config.void_session_url,
     confirmation_callback_url: config.confirmation_callback_url,
     update_payment_session_url: config.update_payment_session_url,
+    start_verification_session_url: config.start_verification_session_url,
     merchant_label: config.merchant_label,
     supports_oversell_protection: config.supports_oversell_protection,
     supports_3ds: config.supports_3ds,


### PR DESCRIPTION
Allows alternative / custom onsite payment extensions to support verifications.