### PR TITLE
Fix token refresh for Business Platform API

### DIFF
--- a/.changeset/tall-olives-tie.md
+++ b/.changeset/tall-olives-tie.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Fix automatic token refresh in some situations to avoid 401 errors

--- a/packages/app/src/cli/utilities/developer-platform-client.test.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client.test.ts
@@ -67,9 +67,9 @@ describe('createUnauthorizedHandler', () => {
     expect(mockClient.unsafeRefreshToken).toHaveBeenCalledTimes(1)
   })
 
-  test('returns appManagement token when tokenType is appManagement', async () => {
+  test('returns default token when tokenType is default', async () => {
     const mockClient = createMockClient()
-    const handler = createUnauthorizedHandler(mockClient, 'appManagement')
+    const handler = createUnauthorizedHandler(mockClient, 'default')
 
     const result = await handler.handler()
 

--- a/packages/app/src/cli/utilities/developer-platform-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client.ts
@@ -296,9 +296,18 @@ export interface DeveloperPlatformClient {
 
 const inProgressRefreshes = new WeakMap<DeveloperPlatformClient, Promise<string>>()
 
+/**
+ * Creates an unauthorized handler for a developer platform client that will refresh the token
+ * and return the appropriate token based on the token type.
+ * If the tokenType is 'businessPlatform', the handler will return the business platform token.
+ * Otherwise, it will return the default token (App Management API or Partners API).
+ * @param client - The developer platform client.
+ * @param tokenType - The type of token to return ('default' or 'businessPlatform')
+ * @returns The unauthorized handler.
+ */
 export function createUnauthorizedHandler(
   client: DeveloperPlatformClient,
-  tokenType: 'appManagement' | 'businessPlatform' = 'appManagement',
+  tokenType: 'default' | 'businessPlatform' = 'default',
 ): UnauthorizedHandler {
   return {
     type: 'token_refresh',

--- a/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
@@ -273,7 +273,7 @@ export class AppManagementClient implements DeveloperPlatformClient {
           cacheExtraKey: userId,
         },
         token: businessPlatformToken,
-        unauthorizedHandler: this.createUnauthorizedHandler(),
+        unauthorizedHandler: this.createUnauthorizedHandler('businessPlatform'),
       })
 
       if (getPartnersToken() && userInfoResult.currentUserAccount) {
@@ -856,7 +856,7 @@ export class AppManagementClient implements DeveloperPlatformClient {
       token: await this.businessPlatformToken(),
       organizationId: String(numberFromGid(orgId)),
       variables,
-      unauthorizedHandler: this.createUnauthorizedHandler(),
+      unauthorizedHandler: this.createUnauthorizedHandler('appManagement'),
     })
     const provisionResult = fullResult.organizationUserProvisionShopAccess
     if (!provisionResult.success) {
@@ -1057,7 +1057,7 @@ export class AppManagementClient implements DeveloperPlatformClient {
       token: await this.businessPlatformToken(),
       organizationId,
       variables,
-      unauthorizedHandler: this.createUnauthorizedHandler(),
+      unauthorizedHandler: this.createUnauthorizedHandler('appManagement'),
     })
     const result: {[flag: (typeof allBetaFlags)[number]]: boolean} = {}
     allBetaFlags.forEach((flag) => {
@@ -1072,7 +1072,7 @@ export class AppManagementClient implements DeveloperPlatformClient {
     return appManagementRequestDoc({
       ...options,
       token: await this.token(),
-      unauthorizedHandler: this.createUnauthorizedHandler(),
+      unauthorizedHandler: this.createUnauthorizedHandler('appManagement'),
     })
   }
 
@@ -1082,7 +1082,7 @@ export class AppManagementClient implements DeveloperPlatformClient {
     return appDevRequestDoc({
       ...options,
       token: await this.token(),
-      unauthorizedHandler: this.createUnauthorizedHandler(),
+      unauthorizedHandler: this.createUnauthorizedHandler('appManagement'),
     })
   }
 
@@ -1092,7 +1092,7 @@ export class AppManagementClient implements DeveloperPlatformClient {
     return businessPlatformRequestDoc({
       ...options,
       token: await this.businessPlatformToken(),
-      unauthorizedHandler: this.createUnauthorizedHandler(),
+      unauthorizedHandler: this.createUnauthorizedHandler('businessPlatform'),
     })
   }
 
@@ -1102,7 +1102,7 @@ export class AppManagementClient implements DeveloperPlatformClient {
     return businessPlatformOrganizationsRequestDoc({
       ...options,
       token: await this.businessPlatformToken(),
-      unauthorizedHandler: this.createUnauthorizedHandler(),
+      unauthorizedHandler: this.createUnauthorizedHandler('businessPlatform'),
     })
   }
 
@@ -1112,7 +1112,7 @@ export class AppManagementClient implements DeveloperPlatformClient {
     return functionsRequestDoc<TResult, TVariables>({
       ...options,
       token: await this.token(),
-      unauthorizedHandler: this.createUnauthorizedHandler(),
+      unauthorizedHandler: this.createUnauthorizedHandler('appManagement'),
     })
   }
 
@@ -1122,12 +1122,14 @@ export class AppManagementClient implements DeveloperPlatformClient {
     return webhooksRequestDoc<TResult, TVariables>({
       ...options,
       token: await this.token(),
-      unauthorizedHandler: this.createUnauthorizedHandler(),
+      unauthorizedHandler: this.createUnauthorizedHandler('appManagement'),
     })
   }
 
-  private createUnauthorizedHandler(): UnauthorizedHandler {
-    return createUnauthorizedHandler(this)
+  private createUnauthorizedHandler(
+    tokenType: 'appManagement' | 'businessPlatform' = 'appManagement',
+  ): UnauthorizedHandler {
+    return createUnauthorizedHandler(this, tokenType)
   }
 }
 

--- a/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
@@ -856,7 +856,7 @@ export class AppManagementClient implements DeveloperPlatformClient {
       token: await this.businessPlatformToken(),
       organizationId: String(numberFromGid(orgId)),
       variables,
-      unauthorizedHandler: this.createUnauthorizedHandler('appManagement'),
+      unauthorizedHandler: this.createUnauthorizedHandler(),
     })
     const provisionResult = fullResult.organizationUserProvisionShopAccess
     if (!provisionResult.success) {
@@ -1057,7 +1057,7 @@ export class AppManagementClient implements DeveloperPlatformClient {
       token: await this.businessPlatformToken(),
       organizationId,
       variables,
-      unauthorizedHandler: this.createUnauthorizedHandler('appManagement'),
+      unauthorizedHandler: this.createUnauthorizedHandler(),
     })
     const result: {[flag: (typeof allBetaFlags)[number]]: boolean} = {}
     allBetaFlags.forEach((flag) => {
@@ -1072,7 +1072,7 @@ export class AppManagementClient implements DeveloperPlatformClient {
     return appManagementRequestDoc({
       ...options,
       token: await this.token(),
-      unauthorizedHandler: this.createUnauthorizedHandler('appManagement'),
+      unauthorizedHandler: this.createUnauthorizedHandler(),
     })
   }
 
@@ -1082,7 +1082,7 @@ export class AppManagementClient implements DeveloperPlatformClient {
     return appDevRequestDoc({
       ...options,
       token: await this.token(),
-      unauthorizedHandler: this.createUnauthorizedHandler('appManagement'),
+      unauthorizedHandler: this.createUnauthorizedHandler(),
     })
   }
 
@@ -1112,7 +1112,7 @@ export class AppManagementClient implements DeveloperPlatformClient {
     return functionsRequestDoc<TResult, TVariables>({
       ...options,
       token: await this.token(),
-      unauthorizedHandler: this.createUnauthorizedHandler('appManagement'),
+      unauthorizedHandler: this.createUnauthorizedHandler(),
     })
   }
 
@@ -1122,13 +1122,11 @@ export class AppManagementClient implements DeveloperPlatformClient {
     return webhooksRequestDoc<TResult, TVariables>({
       ...options,
       token: await this.token(),
-      unauthorizedHandler: this.createUnauthorizedHandler('appManagement'),
+      unauthorizedHandler: this.createUnauthorizedHandler(),
     })
   }
 
-  private createUnauthorizedHandler(
-    tokenType: 'appManagement' | 'businessPlatform' = 'appManagement',
-  ): UnauthorizedHandler {
+  private createUnauthorizedHandler(tokenType: 'default' | 'businessPlatform' = 'default'): UnauthorizedHandler {
     return createUnauthorizedHandler(this, tokenType)
   }
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/shop/issues-develop/issues/21223

We keep seeing some [unhandled 401 errors like this](https://observe.shopify.io/goto/CctwZi6NR?orgId=1), that shouldn't be happening.

When the CLI gets a 401, it tries to get a new token (by refreshing or starting the full authentication flow) and then retries the request.

The problem is that the retry after the refresh process was always using the App Management API token, but if the query was against Business Platform API, then it was obviously getting another 401, that was reported.

### WHAT is this pull request doing?

Pass the API type to the refresh function, so that it returns the proper token for each one.

### How to test your changes?

The token must become invalid right before a Business Platform request, so it's not easy to reproduce. I faked it this way:
- Add a breakpoint [here](https://github.com/Shopify/cli/blob/2ef801b5b1c476e0c9510e550e5f7178eb582d45/packages/app/src/cli/commands/app/dev.ts#L134)
- Run `p shopify app dev`
- When it the debugger stops, update the value of `appContextResult.developerPlatformClient.session.businessPlatformToken` to `wrong`
- Continue
- On main, it should return a 401. With this branch, it should work.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
