### PR TITLE
Add grouping hash to error event handler

### DIFF
--- a/packages/cli-kit/src/public/node/error-handler.ts
+++ b/packages/cli-kit/src/public/node/error-handler.ts
@@ -133,6 +133,9 @@ export async function sendErrorToBugsnag(
           event.severity = 'error'
           event.unhandled = unhandled
           event.setUser(userId)
+          if (event?.errors?.[0]?.errorMessage && event?.errors?.[0]?.errorClass) {
+            event.groupingHash = event?.errors?.[0]?.errorMessage + event?.errors?.[0]?.errorClass
+          }
           // Attach command metadata so we know which CLI command triggered the error
           const {commandStartOptions} = metadata.getAllSensitiveMetadata()
           const {startCommand} = commandStartOptions ?? {}


### PR DESCRIPTION
### WHY are these changes introduced?

To improve error grouping in Bugsnag by creating a custom grouping hash for errors.

### WHAT is this pull request doing?

Enhances the error reporting functionality in the `sendErrorToBugsnag` method by adding a custom grouping hash. The hash combines the error message and error class, which will help group similar errors together in Bugsnag, making it easier to identify and address recurring issues.

### How to test your changes?

1. Trigger an error in the CLI that would be sent to Bugsnag
2. Verify in the Bugsnag dashboard that errors with the same message and class are grouped together
3. Compare with previous error grouping behavior to confirm improvement

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes