### PR TITLE
Add strict validations for UIDs

### DIFF
--- a/packages/app/src/cli/models/extensions/schemas.test.ts
+++ b/packages/app/src/cli/models/extensions/schemas.test.ts
@@ -1,0 +1,57 @@
+import {BaseSchema, MAX_UID_LENGTH} from './schemas.js'
+import {describe, expect, test} from 'vitest'
+
+const validUIDTestCases = [
+  ['valid-uid-123', 'UID with alphanumeric characters and hyphens'],
+  ['validuid', 'UID with only letters'],
+  ['123456', 'UID with only numbers'],
+  ['valid-uid-with-many-hyphens', 'UID with multiple hyphens in the middle'],
+  ['valid_uid', 'UID with underscore'],
+  ['valid.uid', 'UID with dot'],
+  ['valid()uid', 'UID with parentheses'],
+  ['valid{}uid', 'UID with curly braces'],
+  ['valid$uid', 'UID with dollar sign'],
+  ['a'.repeat(MAX_UID_LENGTH), 'UID at maximum length'],
+]
+
+const invalidUIDTestCases = [
+  ['', "UID can't be empty"],
+  ['   ', "UID can't be empty"],
+  ['a'.repeat(MAX_UID_LENGTH + 1), `UID can't exceed ${MAX_UID_LENGTH} characters`],
+  ['a'.repeat(MAX_UID_LENGTH + 50), `UID can't exceed ${MAX_UID_LENGTH} characters`],
+  ['invalid uid', 'UID can only contain alphanumeric characters and hyphens'],
+  ['invalid@uid!', 'UID can only contain alphanumeric characters and hyphens'],
+  ['invalid/uid', 'UID can only contain alphanumeric characters and hyphens'],
+  ['-invalid-uid', "UID can't start or end with a hyphen"],
+  ['invalid-uid-', "UID can't start or end with a hyphen"],
+  ['-invalid-uid-', "UID can't start or end with a hyphen"],
+  ['-', "UID can't start or end with a hyphen"],
+  ['-----', "UID can't start or end with a hyphen"],
+]
+
+describe('UIDSchema', () => {
+  describe('valid UIDs', () => {
+    test.each(validUIDTestCases)('accepts %s (%s)', (uid) => {
+      const result = BaseSchema.safeParse({uid})
+      expect(result.success).toBe(true)
+    })
+
+    test('trims whitespace from UID', () => {
+      const result = BaseSchema.safeParse({uid: '  valid-uid  '})
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.uid).toBe('valid-uid')
+      }
+    })
+  })
+
+  describe('invalid UIDs', () => {
+    test.each(invalidUIDTestCases)('rejects "%s" with error: %s', (uid, expectedError) => {
+      const result = BaseSchema.safeParse({uid})
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.issues[0]?.message).toBe(expectedError)
+      }
+    })
+  })
+})

--- a/packages/app/src/cli/models/extensions/schemas.ts
+++ b/packages/app/src/cli/models/extensions/schemas.ts
@@ -88,13 +88,20 @@ const HandleSchema = zod
   .max(MAX_EXTENSION_HANDLE_LENGTH, `Handle can't exceed ${MAX_EXTENSION_HANDLE_LENGTH} characters`)
   .regex(/^[a-zA-Z0-9-]*$/, 'Handle can only contain alphanumeric characters and hyphens')
   .refine((handle) => !handle.startsWith('-') && !handle.endsWith('-'), "Handle can't start or end with a hyphen")
-  .refine((handle) => [...handle].some((char) => char !== '-'), "Handle can't be all hyphens")
+
+const UIDSchema = zod
+  .string()
+  .trim()
+  .nonempty("UID can't be empty")
+  .max(MAX_UID_LENGTH, `UID can't exceed ${MAX_UID_LENGTH} characters`)
+  .regex(/^[a-zA-Z0-9-${}.()_`]*$/, 'UID can only contain alphanumeric characters and hyphens')
+  .refine((uid) => !uid.startsWith('-') && !uid.endsWith('-'), "UID can't start or end with a hyphen")
 
 export const BaseSchema = zod.object({
   name: zod.string().optional(),
   type: zod.string().optional(),
   handle: HandleSchema.optional(),
-  uid: zod.string().optional(),
+  uid: UIDSchema.optional(),
   description: zod.string().optional(),
   api_version: ApiVersionSchema.optional(),
   extension_points: zod.any().optional(),


### PR DESCRIPTION
### WHY are these changes introduced?

To enforce consistent validation rules for UIDs in extension schemas, similar to how handles are validated.

### WHAT is this pull request doing?

Adds a new `UIDSchema` validation using Zod that enforces:
- Non-empty UIDs
- Maximum length constraints
- Alphanumeric characters and hyphens only
- No hyphens at the start or end
- Not all hyphens

The schema is then applied to the `uid` field in the `BaseSchema` object.

### How to test your changes?

1. Try creating extensions with various UID formats:
   - Valid: `my-extension-123`
   - Invalid: `-invalid-uid`, `invalid-uid-`, `-----`, `special@characters`
2. Verify that validation errors are properly displayed for invalid UIDs
3. Confirm that existing valid UIDs continue to work as expected

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes