### PR TITLE
Remove deprecated print action target uniqueness validator

### DIFF
--- a/.changeset/beige-masks-joke.md
+++ b/.changeset/beige-masks-joke.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Remove redundant Admin print action extension uniqueness validator

--- a/packages/app/src/cli/models/app/loader.test.ts
+++ b/packages/app/src/cli/models/app/loader.test.ts
@@ -509,51 +509,6 @@ wrong = "property"
     await expect(loadTestingApp()).rejects.toThrow(/Duplicated handle/)
   })
 
-  test('throws an error if the app has more than one print action with the same target', async () => {
-    // Given
-    await writeConfig(appConfiguration)
-
-    const blockConfiguration = `
-      api_version = "2022-07"
-
-      [[extensions]]
-      type = "ui_extension"
-      name = "my_extension_1"
-      handle = "handle-1"
-      description = "custom description"
-
-      [[extensions.targeting]]
-      module = "./src/ActionExtension.js"
-      target = "admin.product-details.print-action.render"
-
-      [[extensions]]
-      type = "ui_extension"
-      handle = "handle-2"
-      name = "my_extension_2"
-      description = "custom description"
-
-      [[extensions.targeting]]
-      module = "./src/ActionExtension.js"
-      target = "admin.product-details.print-action.render"
-      `
-    await writeBlockConfig({
-      blockConfiguration,
-      name: 'my_extension_1',
-    })
-
-    // Create a temporary ActionExtension.js file
-    const extensionDirectory = joinPath(tmpDir, 'extensions', 'my_extension_1', 'src')
-    await mkdir(extensionDirectory)
-
-    const tempFilePath = joinPath(extensionDirectory, 'ActionExtension.js')
-    await writeFile(tempFilePath, '/* ActionExtension.js content */')
-
-    // When
-    await expect(loadTestingApp()).rejects.toThrow(
-      `A single target can't support two print action extensions from the same app. Point your extensions at different targets, or remove an extension.\n\nThe following extensions both target admin.product-details.print-action.render:\n  · handle-1\n  · handle-2`,
-    )
-  })
-
   test('throws an error if the extension configuration is unified and doesnt include a handle', async () => {
     // Given
     await writeConfig(appConfiguration, {

--- a/packages/app/src/cli/models/extensions/specifications/ui_extension.ts
+++ b/packages/app/src/cli/models/extensions/specifications/ui_extension.ts
@@ -33,8 +33,6 @@ export interface BuildManifest {
 
 const missingExtensionPointsMessage = 'No extension targets defined, add a `targeting` field to your configuration'
 
-export type UIExtensionSchemaType = zod.infer<typeof UIExtensionSchema>
-
 export const UIExtensionSchema = BaseSchema.extend({
   name: zod.string(),
   type: zod.literal('ui_extension'),


### PR DESCRIPTION
### WHY are these changes introduced?

Removes the validation for print action extensions uniqueness, which is no longer needed as it's handled elsewhere now

Closes https://github.com/shop/issues-admin-extensibility/issues/1160

### WHAT is this pull request doing?

This PR removes the temporary code that was validating that there is only a single print action extension per target in an app. The validation logic and its corresponding test have been removed, as this validation is likely now handled by core validation mechanisms.

Specifically:
- Removes the `validatePrintActionExtensionsUniqueness` method from the `AppLoader` class
- Removes the test that verified this validation was working
- Removes the `printTargets` array that was used for the validation
- Removes an unused import for `UIExtensionSchemaType`

### How to test your changes?

1. Update the CLI version to `export const CLI_KIT_VERSION = '3.85.3'`
1. Generate a print action extension `pnpm shopify app generate extension --template admin_print --path <your-app-directory>`
2. Generate another print action extension `shopify app generate extension --template admin_print  --path <your-app-directory>` without changing the target
3. Run `pnpm shopify app dev --path <your-app-directory>`
4. Verify that you get a uniqueness error for the duplicated print action targets

![image.png](https://app.graphite.dev/user-attachments/assets/5f26c4fe-45d8-40bc-815f-5f5f7af7b922.png)

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes