### PR TITLE
Open specific template URL in theme editor shortcut

### DIFF
--- a/.changeset/metal-lemons-reflect.md
+++ b/.changeset/metal-lemons-reflect.md
@@ -1,0 +1,10 @@
+---
+'@shopify/theme': patch
+---
+
+Editor shortcut (e) will now navigate to your most recently viewed template
+
+Hitting `e` while your server is running (`shopify theme dev`) will now open
+the theme editor in the Admin to the most recently rendered template that you
+viewed in the browser (e.g. if you have multiple tabs open it will use the
+one that was rendered most recently).

--- a/packages/theme/src/cli/services/dev.ts
+++ b/packages/theme/src/cli/services/dev.ts
@@ -83,6 +83,7 @@ export async function dev(options: DevOptions) {
     localThemeExtensionFileSystem,
     directory: options.directory,
     type: 'theme',
+    lastRequestedPath: '',
     options: {
       themeEditorSync: options['theme-editor-sync'],
       host,
@@ -132,7 +133,12 @@ export async function dev(options: DevOptions) {
         openURLSafely(urls.preview, 'theme preview')
         break
       case 'e':
-        openURLSafely(urls.themeEditor, 'theme editor')
+        openURLSafely(
+          ctx.lastRequestedPath === '/'
+            ? urls.themeEditor
+            : `${urls.themeEditor}&previewPath=${encodeURIComponent(ctx.lastRequestedPath)}`,
+          'theme editor',
+        )
         break
       case 'g':
         openURLSafely(urls.giftCard, 'gift card preview')

--- a/packages/theme/src/cli/utilities/theme-environment/hot-reload/server.test.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/hot-reload/server.test.ts
@@ -542,6 +542,7 @@ function createTestContext(options?: {files?: [string, string][]}) {
       storeFqdn: 'my-store.myshopify.com',
       sessionCookies: {},
     },
+    lastRequestedPath: '',
     localThemeFileSystem,
     localThemeExtensionFileSystem,
     directory: 'tmp',

--- a/packages/theme/src/cli/utilities/theme-environment/html.test.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/html.test.ts
@@ -35,7 +35,29 @@ describe('getHtmlHandler', async () => {
     options: {},
     localThemeExtensionFileSystem: emptyThemeExtFileSystem(),
     localThemeFileSystem: emptyThemeFileSystem(),
+    lastRequestedPath: '',
   } as unknown as DevServerContext
+
+  test('sets lastRequestedPath to the rendering URL', async () => {
+    const handler = getHtmlHandler(theme, ctx)
+
+    expect(ctx.lastRequestedPath).toStrictEqual('')
+
+    const event = createH3Event('GET', '/search?q=foo&options%5Bprefix%5D=last')
+
+    vi.mocked(render).mockResolvedValueOnce(
+      new Response('', {
+        status: 200,
+        headers: {
+          'x-request-id': 'test-request-id',
+        },
+      }),
+    )
+
+    await handler(event)
+
+    expect(ctx.lastRequestedPath).toStrictEqual('/search?q=foo&options%5Bprefix%5D=last')
+  })
 
   test('the development server session recovers when a theme id mismatch occurs', async () => {
     // Given

--- a/packages/theme/src/cli/utilities/theme-environment/html.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/html.ts
@@ -23,6 +23,8 @@ export function getHtmlHandler(theme: Theme, ctx: DevServerContext): EventHandle
   return defineEventHandler((event) => {
     const [browserPathname = '/', browserSearch = ''] = event.path.split('?')
 
+    ctx.lastRequestedPath = event.path
+
     const shouldRenderUploadErrorPage =
       ctx.options.errorOverlay !== 'silent' && ctx.localThemeFileSystem.uploadErrors.size > 0
 

--- a/packages/theme/src/cli/utilities/theme-environment/theme-environment.test.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/theme-environment.test.ts
@@ -86,6 +86,7 @@ describe('setupDevServer', () => {
       storeFqdn: 'my-store.myshopify.com',
       sessionCookies: {},
     },
+    lastRequestedPath: '',
     localThemeFileSystem,
     localThemeExtensionFileSystem,
     directory: 'tmp',

--- a/packages/theme/src/cli/utilities/theme-environment/types.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/types.ts
@@ -86,6 +86,11 @@ export interface DevServerContext {
   type: 'theme' | 'theme-extension'
 
   /**
+   * Tracks the last requested HTML path for keyboard shortcuts.
+   */
+  lastRequestedPath: string
+
+  /**
    * Additional options for the development server.
    */
   options: {

--- a/packages/theme/src/cli/utilities/theme-ext-environment/theme-ext-server.ts
+++ b/packages/theme/src/cli/utilities/theme-ext-environment/theme-ext-server.ts
@@ -81,6 +81,7 @@ async function contextDevServerContext(
     localThemeExtensionFileSystem,
     directory,
     type: 'theme-extension',
+    lastRequestedPath: '',
     options: {
       themeEditorSync: false,
       noDelete: false,


### PR DESCRIPTION
### WHY are these changes introduced?

- Closes https://github.com/Shopify/cli/issues/5176

Uses the most recent rendered page to determine which template to open in the theme editor in the Admin. This is helpful for when you're working on a specific template (or even product) and want to make changes in the editor.

We're able to simply forward the URL because the theme editor uses the exact path in the `previewPath` query param to determine which template to load.

### How to test your changes?

```
npm i -g --@shopify:registry=https://registry.npmjs.org @shopify/cli@0.0.0-snapshot-20251010170603
```

1. Start a dev server (`shopify theme dev`)
3. While the running server is focused, hit `e`
4. You should see the theme editor open (unchanged existing behaviour)
5. Open your local preview `t` and navigate to a different template (e.g. a product)
6. While the running server is focused, hit `e`
7. You should see the theme editor open to the product template with the specific product you were looking at selected
8. Rinse and repeat for any of the other pages you want to test!

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
