### PR TITLE
Use vitest forks strategy for CI consistency

### DIFF
--- a/configurations/vite.config.ts
+++ b/configurations/vite.config.ts
@@ -13,7 +13,7 @@ interface ConfigOptions {
   poolStrategy: 'threads' | 'forks'
 }
 
-export default function config(packagePath: string, {poolStrategy}: ConfigOptions = {poolStrategy: 'threads'}) {
+export default function config(packagePath: string, {poolStrategy}: ConfigOptions = {poolStrategy: 'forks'}) {
   // always treat environment as one that doesn't support hyperlinks -- otherwise assertions are hard to keep consistent
   process.env.FORCE_HYPERLINK = '0'
   process.env.FORCE_COLOR = '1'


### PR DESCRIPTION
### WHY are these changes introduced?

The default pool strategy for Vite configuration is currently set to 'threads', but we need to change it to 'forks' to improve test reliability and performance, particularly in CI.

### WHAT is this pull request doing?

Changes the default pool strategy in the Vite configuration from 'threads' to 'forks' per https://vitest.dev/guide/improving-performance.html#pool which indicates that this helps with segfaults and hanging processes.

What this doesn't address is aborts due to timeouts, but we can try adjusting timeouts separately.

### How to test your changes?

1. Run the test suite to ensure all tests pass with the new default pool strategy
2. Verify that build processes complete successfully
3. Check for any performance differences between the old and new strategy

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes