### PR TITLE
Add support for env_build_repository in the create-app package

### DIFF
--- a/packages/create-app/bin/bundle.js
+++ b/packages/create-app/bin/bundle.js
@@ -28,6 +28,10 @@ esBuild({
   outdir: './dist',
   platform: 'node',
   format: 'esm',
+  define: {
+    // Injected during build to detect fork vs original repo
+    'process.env.SHOPIFY_CLI_BUILD_REPO': JSON.stringify(process.env.SHOPIFY_CLI_BUILD_REPO || 'unknown'),
+  },
   sourcemap: true,
   inject: ['../../bin/bundling/cjs-shims.js'],
   external,


### PR DESCRIPTION
### WHY are these changes introduced?

To enable detection of whether the CLI "create-app" is being run from a fork or the original repository during build time.

### WHAT is this pull request doing?

We already had this for the main package, we are adding it now to the create-app package.

### How to test your changes?

Create a snapshot, validate that stats from that snapshot include env_build_repository

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes