### PR TITLE
Fixes Shopify/cli#6515

### DIFF
--- a/packages/cli-kit/src/private/node/api.ts
+++ b/packages/cli-kit/src/private/node/api.ts
@@ -82,6 +82,8 @@ function isARetryableNetworkError(error: unknown): boolean {
       'eai_again',
       'epipe',
       'the operation was aborted',
+      'ssl/tls alert bad record mac',
+      'tlsv1 alert decode error',
     ]
     const errorMessage = error.message.toLowerCase()
     const anyMatches = networkErrorMessages.some((issueMessage) => errorMessage.includes(issueMessage))

--- a/packages/theme/src/cli/utilities/theme-uploader.ts
+++ b/packages/theme/src/cli/utilities/theme-uploader.ts
@@ -32,8 +32,8 @@ type FileBatch = ChecksumWithSize[]
  */
 // Limits for Bulk Requests
 export const MAX_BATCH_FILE_COUNT = 20
-// 1MB
-export const MAX_BATCH_BYTESIZE = 1024 * 1024
+// 25KB
+export const MAX_BATCH_BYTESIZE = 25 * 1024
 export const MAX_UPLOAD_RETRY_COUNT = 2
 
 export function uploadTheme(


### PR DESCRIPTION
running a theme push: `shopify theme push`

for a shopify partner development site I'm part of is giving this cryptic error:

    request to https://company-partner-site-for-my-team.myshopify.com/admin/api/2025-10/graphql.json failed, reason: 80F845A2447F0000:error:0A0003FC:SSL routines:ssl3_read_bytes:ssl/tls alert bad record mac:ssl/record/rec_layer_s3.c:916:SSL alert number 20

after trying on several different node versions and even compiling node myself to manipulate `node -p "process.versions.openssl"` with no progress, I set up the shopify cli source and told copilot to add some debugging for the API calls. I got this push:

    pnpm build && pnpm shopify theme push --path ~/myco-shopify/company-partner-site-for-my-team/theme/live

to report:

    📡 [DEBUG] Creating GraphQL Client: https://company-partner-site-for-my-team.myshopify.com/admin/api/unstable/graphql.json
    🚀 [DEBUG] About to execute GraphQL request: query publicApiVersions {
    ✅ [DEBUG] GraphQL request succeeded: 200
    📡 [DEBUG] Creating GraphQL Client: https://company-partner-site-for-my-team.myshopify.com/admin/api/2025-10/graphql.json
    🚀 [DEBUG] About to execute GraphQL request: query getThemes($after: String) {
    ✅ [DEBUG] GraphQL request succeeded: 200

    ?  Select a theme to push to:
    ✔  Horizon

    ?  Push theme files to the live theme on company-partner-site-for-my-team.myshopify.com?
    ✔  Yes, confirm changes

    📡 [DEBUG] Creating GraphQL Client: https://company-partner-site-for-my-team.myshopify.com/admin/api/2025-10/graphql.json
    🚀 [DEBUG] About to execute GraphQL request: query getThemeFileChecksums($id: ID!, $after: String) {
    ✅ [DEBUG] GraphQL request succeeded: 200
    📡 [DEBUG] Creating GraphQL Client: https://company-partner-site-for-my-team.myshopify.com/admin/api/2025-10/graphql.json
    🚀 [DEBUG] About to execute GraphQL request: query getThemeFileChecksums($id: ID!, $after: String) {
    ✅ [DEBUG] GraphQL request succeeded: 200
    📡 [DEBUG] Creating GraphQL Client: https://company-partner-site-for-my-team.myshopify.com/admin/api/2025-10/graphql.json
    📡 [DEBUG] Creating GraphQL Client: https://company-partner-site-for-my-team.myshopify.com/admin/api/2025-10/graphql.json
    📡 [DEBUG] Creating GraphQL Client: https://company-partner-site-for-my-team.myshopify.com/admin/api/2025-10/graphql.json
    🚀 [DEBUG] About to execute GraphQL request: mutation themeFilesUpsert($files: [OnlineStoreThemeFilesUpsertFileInput!]!, $themeId: ID!) {
    🚀 [DEBUG] About to execute GraphQL request: mutation themeFilesUpsert($files: [OnlineStoreThemeFilesUpsertFileInput!]!, $themeId: ID!) {
    🚀 [DEBUG] About to execute GraphQL request: mutation themeFilesUpsert($files: [OnlineStoreThemeFilesUpsertFileInput!]!, $themeId: ID!) {
    ❌ [DEBUG] GraphQL request failed: ERR_SSL_SSL/TLS_ALERT_BAD_RECORD_MAC - request to https://company-partner-site-for-my-team.myshopify.com/admin/api/2025-10/graphql.json failed, reason: 402884F1E97F0000:error:0A0003FC:SSL routines:ssl3_read_bytes:ssl/tls alert bad record mac:ssl/record/rec_layer_s3.c:916:SSL alert number 20

    FetchError: request to https://company-partner-site-for-my-team.myshopify.com/admin/api/2025-10/graphql.json failed, reason: 402884F1E97F0000:error:0A0003FC:SSL routines:ssl3_read_bytes:ssl/tls alert bad record mac:ssl/record/rec_layer_s3.c:916:SSL alert number 20
        at ClientRequest.<anonymous> (/home/trwww/myco-shopify/shopify-cli/node_modules/.pnpm/node-fetch@2.7.0/node_modules/node-fetch/lib/index.js:1501:11)
        at ClientRequest.emit (node:events:524:28)
        at ClientRequest.emit (node:domain:489:12)
        at emitErrorEvent (node:_http_client:101:11)
        at TLSSocket.socketErrorListener (node:_http_client:504:5)
        at TLSSocket.emit (node:events:524:28)
        at TLSSocket.emit (node:domain:489:12)
        at TLSSocket._emitTLSError (node:_tls_wrap:1032:10)
        at TLSWrap.onerror (node:_tls_wrap:473:11)
     ELIFECYCLE  Command failed with exit code 1.

After stripping down the request I guessed that the problem was the size of the post body for themeFilesUpsert. I told copilot to reduce the max upload size for the batching and this PR is the result.

now the `shopify theme push` runs successfully, albeit slowly.

The reporter of the issue generously got THROTTLED in the response for their themeFilesUpsert calls... I'm jealous - but suspect this will deal with that sucessfully as well.

the api.ts change is to get retries for the HTTP errors I was getting.

<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes Shopify/cli#6515 <!-- link to issue if one exists -->

### WHAT is this pull request doing?

Reduces the max size of the requests to get Shopify themeFilesUpsert API calls working

### How to test your changes?

I don't understand how theres so few reports of this issue. Seems like almost everyone trying to push themes would hit this, but reports of it are scant on both the shopify community site and github. To test, push themes.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
