### PR TITLE
Throw an AbortError when running typegen for non-JS function

### DIFF
--- a/packages/app/src/cli/services/function/build.ts
+++ b/packages/app/src/cli/services/function/build.ts
@@ -127,7 +127,7 @@ export async function buildGraphqlTypes(
   options: JSFunctionBuildOptions,
 ) {
   if (!fun.isJavaScript) {
-    throw new Error('GraphQL types can only be built for JavaScript functions')
+    throw new AbortError('GraphQL types can only be built for JavaScript functions')
   }
 
   return runWithTimer('cmd_all_timing_network_ms')(async () => {


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/shop/issues-shopifyvm/issues/683

GraphQL type generation through the CLI is only supported for JavaScript functions. If a user tried to run the `typegen` command for a non-JS function, we threw an `Error`. This is acceptable behaviour, except the base `Error` is reported to us as a bug. Instead, we should treat this as an unrecoverable error, but not a bug, with `AbortError`.

### WHAT is this pull request doing?

This PR updates the use of `Error` to `AbortError`

### How to test your changes?

Run `pnpm shopify app function typegen` on a non-JS function

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
