### PR TITLE
Don't stop dev until the analytics event is sent

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,7 +21,7 @@
     "**/node_modules": true
   },
   "editor.formatOnSave": false,
-  "eslint.validate": ["javascript", "javascriptreact", "typescript"],
+  "eslint.validate": ["javascript", "javascriptreact", "typescript", "typescriptreact"],
   "[javascript]": {
     "editor.formatOnSave": true,
     "editor.defaultFormatter": "esbenp.prettier-vscode"

--- a/packages/cli-kit/src/public/node/hooks/postrun.ts
+++ b/packages/cli-kit/src/public/node/hooks/postrun.ts
@@ -5,6 +5,17 @@ import BaseCommand from '../base-command.js'
 import * as metadata from '../../../public/node/metadata.js'
 import {Command, Hook} from '@oclif/core'
 
+let postRunHookCompleted = false
+
+/**
+ * Check if post run hook has completed.
+ *
+ * @returns Whether post run hook has completed.
+ */
+export function postRunHookHasCompleted(): boolean {
+  return postRunHookCompleted
+}
+
 // This hook is called after each successful command run. More info: https://oclif.io/docs/hooks
 export const hook: Hook.Postrun = async ({config, Command}) => {
   await detectStopCommand(Command as unknown as typeof Command)
@@ -13,6 +24,7 @@ export const hook: Hook.Postrun = async ({config, Command}) => {
 
   const command = Command.id.replace(/:/g, ' ')
   outputDebug(`Completed command ${command}`)
+  postRunHookCompleted = true
 }
 
 /**


### PR DESCRIPTION
### WHY are these changes introduced?

To ensure that the post-run hook completes before the process is terminated, preventing potential issues with analytics events not being sent when a user aborts a dev session.

### WHAT is this pull request doing?

This PR modifies the process termination flow in the dev session UI to wait for post-run hooks to complete before exiting. It:

1. Adds a new function `postRunHookHasCompleted()` to check if the post-run hook has finished
2. Sets a flag when the post-run hook completes
3. Replaces the immediate process termination with a polling approach that checks if the post-run hook has completed before killing the process

### How to test your changes?

1. Start a dev session with `app dev --verbose`
2. Press Ctrl+C to abort the session
3. Verify that the process exits cleanly after the post-run hook completes
4. Check logs to ensure analytics events are properly sent before termination

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] Existing analytics will cater for this addition

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes