### PR TITLE
Adjust timeouts for long-running tests

### DIFF
--- a/packages/app/src/cli/services/function/build.test.ts
+++ b/packages/app/src/cli/services/function/build.test.ts
@@ -69,7 +69,7 @@ beforeEach(async () => {
 })
 
 describe('buildGraphqlTypes', () => {
-  test('generate types', async () => {
+  test('generate types', {timeout: 20000}, async () => {
     // Given
     const ourFunction = await testFunctionExtension({entryPath: 'src/index.js'})
 
@@ -252,7 +252,7 @@ describe('runJavy', () => {
 })
 
 describe('runWasmOpt', () => {
-  test('runs wasm-opt on the module', async () => {
+  test('runs wasm-opt on the module', {timeout: 20000}, async () => {
     // Given
     const ourFunction = await testFunctionExtension()
     const modulePath = ourFunction.outputPath
@@ -312,7 +312,7 @@ describe('runTrampoline', () => {
     expect(exec).not.toHaveBeenCalled()
   })
 
-  test('runs v1 trampoline on v1 module', async () => {
+  test('runs v1 trampoline on v1 module', {timeout: 20000}, async () => {
     // Given
     const ourFunction = await testFunctionExtension()
     const modulePath = ourFunction.outputPath
@@ -331,7 +331,7 @@ describe('runTrampoline', () => {
     ])
   })
 
-  test('runs v2 trampoline on v2 module', async () => {
+  test('runs v2 trampoline on v2 module', {timeout: 20000}, async () => {
     // Given
     const ourFunction = await testFunctionExtension()
     const modulePath = ourFunction.outputPath
@@ -414,7 +414,7 @@ describe('ExportJavyBuilder', () => {
   })
 
   describe('compile', () => {
-    test('runs javy with wit', async () => {
+    test('runs javy with wit', {timeout: 20000}, async () => {
       await inTemporaryDirectory(async (tmpDir) => {
         // Given
         const ourFunction = await testFunctionExtension()


### PR DESCRIPTION
### WHY are these changes introduced?

CI tests were timing out after 5 seconds for some tests that execute external binaries (javy, wasm-opt, trampoline) during function build tests. The default vitest timeout of 5 seconds is insufficient for tests that need to download and execute external binaries.

### WHAT is this pull request doing?

Adds explicit 20-second timeouts to tests in `packages/app/src/cli/services/function/build.test.ts` that execute external binaries:

- `generate types` - runs npm exec for GraphQL code generation
- `runs wasm-opt on the module` - executes the wasm-opt binary  
- `runs v1 trampoline on v1 module` - executes the v1 trampoline binary
- `runs v2 trampoline on v2 module` - executes the v2 trampoline binary
- `runs javy with wit` - executes Javy with additional WIT parameters

Note: The `runs javy to compile JS into Wasm` test already had a 20-second timeout and didn't need modification.

### How to test your changes?

Run the function build tests:

```bash
npm test packages/app/src/cli/services/function/build.test.ts
```

All tests should pass without timing out.

### Post-release steps

n/a

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes