### PR TITLE
Improve error message when multiple web configs are found

### DIFF
--- a/packages/app/src/cli/models/app/loader.test.ts
+++ b/packages/app/src/cli/models/app/loader.test.ts
@@ -578,7 +578,18 @@ wrong = "property"
     await writeWebConfiguration({webDirectory: anotherWebDirectory, role: 'backend'})
 
     // Then
-    await expect(loadTestingApp()).rejects.toThrow()
+    try {
+      await loadTestingApp()
+      expect.fail('Expected loadTestingApp to throw an error')
+    } catch (error) {
+      if (!(error instanceof AbortError)) {
+        throw error
+      }
+      expect(error.message).toContain('You can only have one "web" configuration file with the [33mbackend[39m role')
+      expect(error.message).toContain('Conflicting configurations found at:')
+      expect(error.message).toContain(joinPath(webDirectory, configurationFileNames.web))
+      expect(error.message).toContain(joinPath(anotherWebDirectory, configurationFileNames.web))
+    }
   })
 
   test('throws an error if there are multiple frontends', async () => {
@@ -590,7 +601,18 @@ wrong = "property"
     await writeWebConfiguration({webDirectory: anotherWebDirectory, role: 'frontend'})
 
     // Then
-    await expect(loadTestingApp()).rejects.toThrow()
+    try {
+      await loadTestingApp()
+      expect.fail('Expected loadTestingApp to throw an error')
+    } catch (error) {
+      if (!(error instanceof AbortError)) {
+        throw error
+      }
+      expect(error.message).toContain('You can only have one "web" configuration file with the [33mfrontend[39m role')
+      expect(error.message).toContain('Conflicting configurations found at:')
+      expect(error.message).toContain(joinPath(webDirectory, configurationFileNames.web))
+      expect(error.message).toContain(joinPath(anotherWebDirectory, configurationFileNames.web))
+    }
   })
 
   test('loads the app with custom located web blocks', async () => {

--- a/packages/app/src/cli/models/app/loader.ts
+++ b/packages/app/src/cli/models/app/loader.ts
@@ -428,12 +428,17 @@ class AppLoader<TConfig extends AppConfiguration, TModuleSpec extends ExtensionS
   private validateWebs(webs: Web[]): void {
     ;[WebType.Backend, WebType.Frontend].forEach((webType) => {
       const websOfType = webs.filter((web) => web.configuration.roles.includes(webType))
-      if (websOfType[1]) {
+      if (websOfType.length > 1) {
+        const conflictingPaths = websOfType.map((web) => joinPath(web.directory, configurationFileNames.web))
+        const pathsList = conflictingPaths.map((path) => `  ${path}`).join('\n')
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        const lastConflictingPath = conflictingPaths[conflictingPaths.length - 1]!
         this.abortOrReport(
-          outputContent`You can only have one web with the ${outputToken.yellow(webType)} role in your app`,
+          outputContent`You can only have one "web" configuration file with the ${outputToken.yellow(
+            webType,
+          )} role in your app.\n\nConflicting configurations found at:\n${pathsList}`,
           undefined,
-
-          joinPath(websOfType[1].directory, configurationFileNames.web),
+          lastConflictingPath,
         )
       }
     })


### PR DESCRIPTION
### WHY are these changes introduced?

Improves error messages when multiple web configuration files with the same role are detected in an app.

Fixes: https://github.com/Shopify/cli/issues/6472

### WHAT is this pull request doing?

Enhances the error handling when multiple web configurations with the same role (frontend or backend) are found:

- Provides more detailed error messages that list all conflicting configuration file paths
- Improves test cases to verify the specific error message content instead of just checking that an error was thrown
- Makes the validation logic more robust by checking the actual length of conflicting webs

### How to test your changes?

1. Create an app with multiple web configuration files that have the same role (either frontend or backend)
2. Run the app and verify that the error message clearly shows all conflicting file paths
3. Ensure the error message contains the role type and the specific paths to the conflicting files

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes