### PR TITLE
Rename development stores

### DIFF
--- a/docs-shopify.dev/commands/app-dev.doc.ts
+++ b/docs-shopify.dev/commands/app-dev.doc.ts
@@ -3,7 +3,7 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs'
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'app dev',
-  description: `Builds and previews your app on a development store, and watches for changes. [Read more about testing apps locally](/docs/apps/build/cli-for-apps/test-apps-locally).`,
+  description: `Builds and previews your app on a dev store, and watches for changes. [Read more about testing apps locally](/docs/apps/build/cli-for-apps/test-apps-locally).`,
   overviewPreviewDescription: `Run the app.`,
   type: 'command',
   isVisualComponent: false,

--- a/docs-shopify.dev/commands/app-info.doc.ts
+++ b/docs-shopify.dev/commands/app-info.doc.ts
@@ -5,7 +5,7 @@ const data: ReferenceEntityTemplateSchema = {
   name: 'app info',
   description: `The information returned includes the following:
 
-  - The app and development store or Plus sandbox store that's used when you run the [dev](/docs/api/shopify-cli/app/app-dev) command. You can reset these configurations using [\`dev --reset\`](/docs/api/shopify-cli/app/app-dev#flags-propertydetail-reset).
+  - The app and dev store that's used when you run the [dev](/docs/api/shopify-cli/app/app-dev) command. You can reset these configurations using [\`dev --reset\`](/docs/api/shopify-cli/app/app-dev#flags-propertydetail-reset).
   - The [structure](/docs/apps/tools/cli/structure) of your app project.
   - The [access scopes](/docs/api/usage) your app has requested.
   - System information, including the package manager and version of Shopify CLI used in the project.`,

--- a/docs-shopify.dev/generated/generated_docs_data.json
+++ b/docs-shopify.dev/generated/generated_docs_data.json
@@ -524,7 +524,7 @@
   },
   {
     "name": "app dev",
-    "description": "Builds and previews your app on a development store, and watches for changes. [Read more about testing apps locally](/docs/apps/build/cli-for-apps/test-apps-locally).",
+    "description": "Builds and previews your app on a dev store, and watches for changes. [Read more about testing apps locally](/docs/apps/build/cli-for-apps/test-apps-locally).",
     "overviewPreviewDescription": "Run the app.",
     "type": "command",
     "isVisualComponent": false,
@@ -1651,7 +1651,7 @@
   },
   {
     "name": "app info",
-    "description": "The information returned includes the following:\n\n  - The app and development store or Plus sandbox store that's used when you run the [dev](/docs/api/shopify-cli/app/app-dev) command. You can reset these configurations using [`dev --reset`](/docs/api/shopify-cli/app/app-dev#flags-propertydetail-reset).\n  - The [structure](/docs/apps/tools/cli/structure) of your app project.\n  - The [access scopes](/docs/api/usage) your app has requested.\n  - System information, including the package manager and version of Shopify CLI used in the project.",
+    "description": "The information returned includes the following:\n\n  - The app and dev store that's used when you run the [dev](/docs/api/shopify-cli/app/app-dev) command. You can reset these configurations using [`dev --reset`](/docs/api/shopify-cli/app/app-dev#flags-propertydetail-reset).\n  - The [structure](/docs/apps/tools/cli/structure) of your app project.\n  - The [access scopes](/docs/api/usage) your app has requested.\n  - System information, including the package manager and version of Shopify CLI used in the project.",
     "overviewPreviewDescription": "Print basic information about your app and extensions.",
     "type": "command",
     "isVisualComponent": false,

--- a/packages/app/src/cli/commands/app/dev.ts
+++ b/packages/app/src/cli/commands/app/dev.ts
@@ -13,7 +13,7 @@ import {addPublicMetadata} from '@shopify/cli-kit/node/metadata'
 export default class Dev extends AppLinkedCommand {
   static summary = 'Run the app.'
 
-  static descriptionWithMarkdown = `Builds and previews your app on a development store, and watches for changes. [Read more about testing apps locally](https://shopify.dev/docs/apps/build/cli-for-apps/test-apps-locally).`
+  static descriptionWithMarkdown = `Builds and previews your app on a dev store, and watches for changes. [Read more about testing apps locally](https://shopify.dev/docs/apps/build/cli-for-apps/test-apps-locally).`
 
   static description = this.descriptionWithoutMarkdown()
 

--- a/packages/app/src/cli/commands/app/info.ts
+++ b/packages/app/src/cli/commands/app/info.ts
@@ -12,7 +12,7 @@ export default class AppInfo extends AppLinkedCommand {
 
   static descriptionWithMarkdown = `The information returned includes the following:
 
-  - The app and development store or Plus sandbox store that's used when you run the [dev](https://shopify.dev/docs/api/shopify-cli/app/app-dev) command. You can reset these configurations using [\`dev --reset\`](https://shopify.dev/docs/api/shopify-cli/app/app-dev#flags-propertydetail-reset).
+  - The app and dev store that's used when you run the [dev](https://shopify.dev/docs/api/shopify-cli/app/app-dev) command. You can reset these configurations using [\`dev --reset\`](https://shopify.dev/docs/api/shopify-cli/app/app-dev#flags-propertydetail-reset).
   - The [structure](https://shopify.dev/docs/apps/tools/cli/structure) of your app project.
   - The [access scopes](https://shopify.dev/docs/api/usage) your app has requested.
   - System information, including the package manager and version of Shopify CLI used in the project.`

--- a/packages/app/src/cli/prompts/dev.ts
+++ b/packages/app/src/cli/prompts/dev.ts
@@ -126,7 +126,7 @@ export async function selectStorePrompt({
 
 export async function confirmConversionToTransferDisabledStorePrompt(): Promise<boolean> {
   return renderConfirmationPrompt({
-    message: `Make this store transfer-disabled? For security, once you use a development store to preview an app locally, the store can never be transferred to a merchant to use as a production store.`,
+    message: `Make this store transfer-disabled? For security, once you use a dev store to preview an app locally, the store can never be transferred to a merchant to use as a production store.`,
     confirmationMessage: 'Yes, make this store transfer-disabled permanently',
     cancellationMessage: 'No, select another store',
     defaultValue: false,

--- a/packages/app/src/cli/services/dev/graphiql/templates/unauthorized.tsx
+++ b/packages/app/src/cli/services/dev/graphiql/templates/unauthorized.tsx
@@ -60,9 +60,7 @@ const polarisUnauthorizedContent = renderToStaticMarkup(
                 <Text variant="headingMd" as="h2">
                   Install your app to access GraphiQL
                 </Text>
-                <p>
-                  The GraphiQL Explorer relies on your app being installed on your development store to access its data.
-                </p>
+                <p>The GraphiQL Explorer relies on your app being installed on your dev store to access its data.</p>
                 <p id="card-cta">
                   <Button id="app-install-button">Install your app</Button>
                 </p>

--- a/packages/app/src/cli/services/generate/template-fixtures/checkout-extension/README.md.liquid
+++ b/packages/app/src/cli/services/generate/template-fixtures/checkout-extension/README.md.liquid
@@ -4,7 +4,7 @@ Checkout UI extensions let app developers build custom functionality that mercha
 
 ## Prerequisites
 
-Before you start building your extension, make sure that you’ve created a [development store](https://shopify.dev/docs/apps/tools/development-stores) with the [checkout extensibility developer preview](https://shopify.dev/docs/api/release-notes/developer-previews#previewing-new-features).
+Before you start building your extension, make sure that you’ve created a [dev store](https://shopify.dev/docs/apps/tools/development-stores) with the [checkout extensibility developer preview](https://shopify.dev/docs/api/release-notes/developer-previews#previewing-new-features).
 
 ## Your new Extension
 

--- a/packages/cli-kit/src/private/node/session/exchange.ts
+++ b/packages/cli-kit/src/private/node/session/exchange.ts
@@ -213,7 +213,7 @@ function tokenRequestErrorHandler({error, store}: {error: string; store?: string
   if (error === 'invalid_target') {
     return new InvalidTargetError(invalidTargetErrorMessage, '', [
       'Ensure you have logged in to the store using the Shopify admin at least once.',
-      'Ensure you are the store owner, or have a staff account if you are attempting to log in to a development store.',
+      'Ensure you are the store owner, or have a staff account if you are attempting to log in to a dev store.',
       'Ensure you are using the permanent store domain, not a vanity domain.',
     ])
   }

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -245,7 +245,7 @@ FLAGS
 DESCRIPTION
   Run the app.
 
-  Builds and previews your app on a development store, and watches for changes. "Read more about testing apps locally"
+  Builds and previews your app on a dev store, and watches for changes. "Read more about testing apps locally"
   (https://shopify.dev/docs/apps/build/cli-for-apps/test-apps-locally).
 ```
 
@@ -534,9 +534,9 @@ DESCRIPTION
 
   The information returned includes the following:
 
-  - The app and development store or Plus sandbox store that's used when you run the "dev"
-  (https://shopify.dev/docs/api/shopify-cli/app/app-dev) command. You can reset these configurations using "`dev
-  --reset`" (https://shopify.dev/docs/api/shopify-cli/app/app-dev#flags-propertydetail-reset).
+  - The app and dev store that's used when you run the "dev" (https://shopify.dev/docs/api/shopify-cli/app/app-dev)
+  command. You can reset these configurations using "`dev --reset`"
+  (https://shopify.dev/docs/api/shopify-cli/app/app-dev#flags-propertydetail-reset).
   - The "structure" (https://shopify.dev/docs/apps/tools/cli/structure) of your app project.
   - The "access scopes" (https://shopify.dev/docs/api/usage) your app has requested.
   - System information, including the package manager and version of Shopify CLI used in the project.

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -372,8 +372,8 @@
       "args": {
       },
       "customPluginName": "@shopify/app",
-      "description": "Builds and previews your app on a development store, and watches for changes. \"Read more about testing apps locally\" (https://shopify.dev/docs/apps/build/cli-for-apps/test-apps-locally).",
-      "descriptionWithMarkdown": "Builds and previews your app on a development store, and watches for changes. [Read more about testing apps locally](https://shopify.dev/docs/apps/build/cli-for-apps/test-apps-locally).",
+      "description": "Builds and previews your app on a dev store, and watches for changes. \"Read more about testing apps locally\" (https://shopify.dev/docs/apps/build/cli-for-apps/test-apps-locally).",
+      "descriptionWithMarkdown": "Builds and previews your app on a dev store, and watches for changes. [Read more about testing apps locally](https://shopify.dev/docs/apps/build/cli-for-apps/test-apps-locally).",
       "flags": {
         "checkout-cart-url": {
           "description": "Resource URL for checkout UI extension. Format: \"/cart/{productVariantID}:{productQuantity}\"",
@@ -1570,8 +1570,8 @@
       "args": {
       },
       "customPluginName": "@shopify/app",
-      "description": "The information returned includes the following:\n\n  - The app and development store or Plus sandbox store that's used when you run the \"dev\" (https://shopify.dev/docs/api/shopify-cli/app/app-dev) command. You can reset these configurations using \"`dev --reset`\" (https://shopify.dev/docs/api/shopify-cli/app/app-dev#flags-propertydetail-reset).\n  - The \"structure\" (https://shopify.dev/docs/apps/tools/cli/structure) of your app project.\n  - The \"access scopes\" (https://shopify.dev/docs/api/usage) your app has requested.\n  - System information, including the package manager and version of Shopify CLI used in the project.",
-      "descriptionWithMarkdown": "The information returned includes the following:\n\n  - The app and development store or Plus sandbox store that's used when you run the [dev](https://shopify.dev/docs/api/shopify-cli/app/app-dev) command. You can reset these configurations using [`dev --reset`](https://shopify.dev/docs/api/shopify-cli/app/app-dev#flags-propertydetail-reset).\n  - The [structure](https://shopify.dev/docs/apps/tools/cli/structure) of your app project.\n  - The [access scopes](https://shopify.dev/docs/api/usage) your app has requested.\n  - System information, including the package manager and version of Shopify CLI used in the project.",
+      "description": "The information returned includes the following:\n\n  - The app and dev store that's used when you run the \"dev\" (https://shopify.dev/docs/api/shopify-cli/app/app-dev) command. You can reset these configurations using \"`dev --reset`\" (https://shopify.dev/docs/api/shopify-cli/app/app-dev#flags-propertydetail-reset).\n  - The \"structure\" (https://shopify.dev/docs/apps/tools/cli/structure) of your app project.\n  - The \"access scopes\" (https://shopify.dev/docs/api/usage) your app has requested.\n  - System information, including the package manager and version of Shopify CLI used in the project.",
+      "descriptionWithMarkdown": "The information returned includes the following:\n\n  - The app and dev store that's used when you run the [dev](https://shopify.dev/docs/api/shopify-cli/app/app-dev) command. You can reset these configurations using [`dev --reset`](https://shopify.dev/docs/api/shopify-cli/app/app-dev#flags-propertydetail-reset).\n  - The [structure](https://shopify.dev/docs/apps/tools/cli/structure) of your app project.\n  - The [access scopes](https://shopify.dev/docs/api/usage) your app has requested.\n  - System information, including the package manager and version of Shopify CLI used in the project.",
       "flags": {
         "client-id": {
           "description": "The Client ID of your app.",


### PR DESCRIPTION
### WHY are these changes introduced?

Related to https://github.com/shop/issues-develop/issues/21402

### WHAT is this pull request doing?

Renames some `development store` references to  `dev store`

### How to test your changes?

CI, doc, manual tests

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
