### PR TITLE
observability for failures to identity service

### DIFF
--- a/packages/cli-kit/src/private/node/session/device-authorization.test.ts
+++ b/packages/cli-kit/src/private/node/session/device-authorization.test.ts
@@ -64,29 +64,81 @@ describe('requestDeviceAuthorization', () => {
     expect(got).toEqual(dataExpected)
   })
 
-  test('when the response is not valid JSON, throw an error', async () => {
+  test('when the response is not valid JSON, throw an error with context', async () => {
     // Given
     const response = new Response('not valid JSON')
+    Object.defineProperty(response, 'status', {value: 200})
+    Object.defineProperty(response, 'statusText', {value: 'OK'})
     vi.mocked(shopifyFetch).mockResolvedValue(response)
     vi.mocked(identityFqdn).mockResolvedValue('fqdn.com')
     vi.mocked(clientId).mockReturnValue('clientId')
 
     // When/Then
-    await expect(requestDeviceAuthorization(['scope1', 'scope2'])).rejects.toThrow(
-      'Received unexpected response from the authorization service. If this issue persists, please contact support at https://help.shopify.com',
+    await expect(requestDeviceAuthorization(['scope1', 'scope2'])).rejects.toThrowError(
+      'Received invalid response from authorization service (HTTP 200). Response could not be parsed as valid JSON. If this issue persists, please contact support at https://help.shopify.com',
     )
   })
 
-  test('when the response is empty, throw an error', async () => {
+  test('when the response is empty, throw an error with empty body message', async () => {
     // Given
     const response = new Response('')
+    Object.defineProperty(response, 'status', {value: 200})
+    Object.defineProperty(response, 'statusText', {value: 'OK'})
     vi.mocked(shopifyFetch).mockResolvedValue(response)
     vi.mocked(identityFqdn).mockResolvedValue('fqdn.com')
     vi.mocked(clientId).mockReturnValue('clientId')
 
     // When/Then
-    await expect(requestDeviceAuthorization(['scope1', 'scope2'])).rejects.toThrow(
-      'Received unexpected response from the authorization service. If this issue persists, please contact support at https://help.shopify.com',
+    await expect(requestDeviceAuthorization(['scope1', 'scope2'])).rejects.toThrowError(
+      'Received invalid response from authorization service (HTTP 200). Received empty response body. If this issue persists, please contact support at https://help.shopify.com',
+    )
+  })
+
+  test('when the response is HTML instead of JSON, throw an error with HTML detection', async () => {
+    // Given
+    const htmlResponse = '<!DOCTYPE html><html><body>Error page</body></html>'
+    const response = new Response(htmlResponse)
+    Object.defineProperty(response, 'status', {value: 404})
+    Object.defineProperty(response, 'statusText', {value: 'Not Found'})
+    vi.mocked(shopifyFetch).mockResolvedValue(response)
+    vi.mocked(identityFqdn).mockResolvedValue('fqdn.com')
+    vi.mocked(clientId).mockReturnValue('clientId')
+
+    // When/Then
+    await expect(requestDeviceAuthorization(['scope1', 'scope2'])).rejects.toThrowError(
+      'Received invalid response from authorization service (HTTP 404). The request may be malformed or unauthorized. Received HTML instead of JSON - the service endpoint may have changed. If this issue persists, please contact support at https://help.shopify.com',
+    )
+  })
+
+  test('when the server returns a 500 error with non-JSON response, throw an error with server issue message', async () => {
+    // Given
+    const response = new Response('Internal Server Error')
+    Object.defineProperty(response, 'status', {value: 500})
+    Object.defineProperty(response, 'statusText', {value: 'Internal Server Error'})
+    vi.mocked(shopifyFetch).mockResolvedValue(response)
+    vi.mocked(identityFqdn).mockResolvedValue('fqdn.com')
+    vi.mocked(clientId).mockReturnValue('clientId')
+
+    // When/Then
+    await expect(requestDeviceAuthorization(['scope1', 'scope2'])).rejects.toThrowError(
+      'Received invalid response from authorization service (HTTP 500). The service may be experiencing issues. Response could not be parsed as valid JSON. If this issue persists, please contact support at https://help.shopify.com',
+    )
+  })
+
+  test('when response.text() fails, throw an error about network/streaming issue', async () => {
+    // Given
+    const response = new Response('some content')
+    Object.defineProperty(response, 'status', {value: 200})
+    Object.defineProperty(response, 'statusText', {value: 'OK'})
+    // Mock text() to throw an error
+    response.text = vi.fn().mockRejectedValue(new Error('Network error'))
+    vi.mocked(shopifyFetch).mockResolvedValue(response)
+    vi.mocked(identityFqdn).mockResolvedValue('fqdn.com')
+    vi.mocked(clientId).mockReturnValue('clientId')
+
+    // When/Then
+    await expect(requestDeviceAuthorization(['scope1', 'scope2'])).rejects.toThrowError(
+      'Failed to read response from authorization service (HTTP 200). Network or streaming error occurred.',
     )
   })
 })


### PR DESCRIPTION
I am looking to capture more information about the following failure, which is flip flopping between p3 and p2: https://github.com/shop/issues-develop/issues/8058

Currently, any failure to parse a JSON response here manifests as a BugError with minimal information. This PR adds more precise introspection of the result and emits a more detailed error that will make its way to Observe so we can more precisely understand what is failing (the idea being, once we know what's happening we can add appropriate handling to retry/reduce noise/whatever)

PR was largely AI generated with a few nudges. I did tophat this against production (happy path) and JSON is successfully parsed.