### PR TITLE
Add support for webhook actions attribute

### DIFF
--- a/packages/app/src/cli/models/app/loader.test.ts
+++ b/packages/app/src/cli/models/app/loader.test.ts
@@ -3303,6 +3303,22 @@ describe('WebhooksSchema', () => {
     expect(parsedConfiguration.webhooks).toMatchObject(webhookConfig)
   })
 
+  test('accepts webhook subscription with actions', async () => {
+    const webhookConfig: WebhooksConfig = {
+      api_version: '2024-01',
+      subscriptions: [
+        {
+          topics: ['products/create'],
+          uri: 'https://example.com/webhooks',
+          actions: ['create'],
+        },
+      ],
+    }
+    const {abortOrReport, parsedConfiguration} = await setupParsing({}, webhookConfig)
+    expect(abortOrReport).not.toHaveBeenCalled()
+    expect(parsedConfiguration.webhooks).toMatchObject(webhookConfig)
+  })
+
   async function setupParsing(errorObj: zod.ZodIssue | {}, webhookConfigOverrides: WebhooksConfig) {
     const err = Array.isArray(errorObj) ? errorObj : [errorObj]
     const expectedFormatted = outputContent`\n${outputToken.errorText(

--- a/packages/app/src/cli/models/extensions/specifications/app_config_webhook_schemas/webhook_subscription_schema.ts
+++ b/packages/app/src/cli/models/extensions/specifications/app_config_webhook_schemas/webhook_subscription_schema.ts
@@ -13,6 +13,7 @@ export const WebhookSubscriptionSchema = zod.object({
       invalid_type_error: 'Value must be string[]',
     })
     .optional(),
+  actions: zod.array(zod.string({invalid_type_error: 'Value must be a string'})).optional(),
   uri: zod.preprocess((arg) => removeTrailingSlash(arg as string), WebhookSubscriptionUriValidation, {
     required_error: 'Missing value at',
   }),

--- a/packages/app/src/cli/models/extensions/specifications/app_config_webhook_subscription.ts
+++ b/packages/app/src/cli/models/extensions/specifications/app_config_webhook_subscription.ts
@@ -11,6 +11,7 @@ interface TransformedWebhookSubscription {
   api_version: string
   uri: string
   topic: string
+  actions: string[]
   compliance_topics?: string[]
   include_fields?: string[]
   filter?: string
@@ -19,6 +20,7 @@ interface TransformedWebhookSubscription {
 
 export const SingleWebhookSubscriptionSchema = zod.object({
   topic: zod.string(),
+  actions: zod.array(zod.string({invalid_type_error: 'Value must be a string'})).optional(),
   api_version: zod.string(),
   uri: zod.preprocess(removeTrailingSlash as (arg: unknown) => unknown, WebhookSubscriptionUriValidation, {
     required_error: 'Missing value at',

--- a/packages/app/src/cli/models/extensions/specifications/types/app_config_webhook.ts
+++ b/packages/app/src/cli/models/extensions/specifications/types/app_config_webhook.ts
@@ -1,6 +1,7 @@
 export interface WebhookSubscription {
   uri: string
   topics?: string[]
+  actions?: string[]
   compliance_topics?: string[]
   include_fields?: string[]
   filter?: string


### PR DESCRIPTION
### WHY are these changes introduced?

Shopify is introducing new webhook topics that separate the subject from the action (e.g., `"product"` instead of `"products/update"`). These new topics require app developers to specify a list of actions (`create`, `update`, or `delete`) separately in the webhook subscription configuration. This feature is
currently gated behind a beta flag and not yet available publicly.

Related change in Shopify: https://app.graphite.dev/github/pr/shop/world/246191/Add-actions-to-apps-webhook-subscriptions

### WHAT is this pull request doing?

Adds support for the optional `actions` attribute in webhook subscription configurations. This allows app developers using the new beta webhook topics to specify actions like:

```toml
[[webhooks.subscriptions]]
topics = [ "product" ]
actions = [ "update" ]
uri = "/webhooks/product"
```

Changes include:
- Added actions field (optional string array) to webhook subscription schemas
- Added validation for the actions attribute in webhook configurations
- Added test coverage for webhook subscriptions with actions

Note: This field is only applicable to new webhook topics and existing topics will continue to work without the actions field.

Verdict flag: https://experiments.shopify.com/flags/f_webhook_nextgen_event_broker

### How to test your changes?

1. Enable the beta flag for new webhook topics in your test environment
2. Create or modify a Shopify app's shopify.app.toml config file
3. Add a webhook subscription with the actions field:
```
[webhooks]
api_version = "unstable" # you need unstable version for accessing beta flag gated API change

  [[webhooks.subscriptions]]
  topics = [ "app/uninstalled" ]
  uri = "/webhooks/app/uninstalled"

  [[webhooks.subscriptions]]
  topics = [ "app/scopes_update" ]
  uri = "/webhooks/app/scopes_update"

  [[webhooks.subscriptions]]
  topics = [ "product" ]
  actions = [ "update" ]
  uri = "/webhooks/product"
  payload_query = "query { shop { name } }"
```
5. Run the CLI commands that parse the app configuration (e.g., shopify app dev)
6. Verify that the configuration is accepted without validation errors
7. Verify that webhook subscriptions without actions still work correctly

### Post-release steps

Documentation will be updated on shopify.dev when this feature is released publicly (currently gated by beta flag).

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes