### PR TITLE
Avoid problems with theme extensions self built by external vite

### DIFF
--- a/packages/cli-kit/src/public/node/archiver.integration.test.ts
+++ b/packages/cli-kit/src/public/node/archiver.integration.test.ts
@@ -66,7 +66,6 @@ describe('brotliCompress', () => {
       const brotliPath = joinPath(tmpDir, 'output.br')
       const outputDirectoryName = 'output'
       const outputDirectoryPath = joinPath(tmpDir, outputDirectoryName)
-      const extractPath = joinPath(tmpDir, 'extract')
       const testContent = 'test content'
 
       // Create test file


### PR DESCRIPTION

### WHY are these changes introduced?

The current archiving functionality in `zip` and `brotliCompress` methods doesn't handle race conditions where files might be deleted during the archiving process. This can lead to errors and failed builds when files are removed while the archiving is in progress.

### WHAT is this pull request doing?

Improves the archiving process to gracefully handle files that are deleted during the archiving operation:

1. Modifies the `zip` and `brotliCompress` functions to read file content immediately before adding to the archive
2. Adds error handling to skip files that are deleted during the archiving process
3. Adds comprehensive tests to verify the new behavior works correctly

### How to test your changes?

[theme-test.zip](https://github.com/user-attachments/files/23263944/theme-test.zip)

1. Download the included zip with a test them app.
2. Run `shopify app dev --path path/to./the/downloaded/app` in a terminal
3. Within the app folder run `pnpm theme-extension:dev` to run vite
4. In a new terminal window, within the theme extension folder run the script rapid-changes.sh included in the zip.
These steps will start a never ending loop of changes to the extension files in batches of a random size which will eventually trigger the error we are trying to reproduce.

Once the error is reproduced running dev with the latest CLI, to test the changes go to the CLI repo, checkout this branch, and run `pnpm shopify app dev --path path/to./the/downloaded/app` (don't forget to close the previously started dev session).

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes