### PR TITLE
Fix dev up

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -4,7 +4,6 @@ up:
   - node:
       version: 24.1.0
       package_manager: pnpm@10.11.1
-      packages: []
   - packages:
     - jq
   - custom:


### PR DESCRIPTION
### WHY are these changes introduced?

After https://github.com/shop/world/pull/256406, `dev up` is raising this error:
```
You must specify at least one node package if the `packages:` section is present.
```

### WHAT is this pull request doing?

Removes the `packages` field under `node` in `dev.yml`, which is unneeded.

### How to test your changes?

`dev up`

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
