### PR TITLE
Fix loader error for local mode

### DIFF
--- a/packages/app/src/cli/models/app/loader.test.ts
+++ b/packages/app/src/cli/models/app/loader.test.ts
@@ -479,6 +479,66 @@ wrong = "property"
     expect(app.errors).toBeUndefined()
   })
 
+  test('throws error for duplicated handles when mode is local', async () => {
+    // Given
+    await writeConfig(appConfiguration)
+
+    const blockConfiguration = `
+      api_version = "2022-07"
+
+      [[extensions]]
+      type = "checkout_post_purchase"
+      name = "my_extension_1"
+      handle = "handle-1"
+      description = "custom description"
+
+      [[extensions]]
+      type = "flow_action"
+      handle = "handle-1"
+      name = "my_extension_1_flow"
+      description = "custom description"
+      runtime_url = "https://example.com"
+      `
+    await writeBlockConfig({
+      blockConfiguration,
+      name: 'my_extension_1',
+    })
+    await writeFile(joinPath(blockPath('my_extension_1'), 'index.js'), '')
+
+    // When/Then
+    await expect(loadTestingApp({mode: 'local'})).rejects.toThrow(/Duplicated handle/)
+  })
+
+  test('does not throw error for duplicated handles when mode is report', async () => {
+    // Given
+    await writeConfig(appConfiguration)
+
+    const blockConfiguration = `
+      api_version = "2022-07"
+
+      [[extensions]]
+      type = "checkout_post_purchase"
+      name = "my_extension_1"
+      handle = "handle-1"
+      description = "custom description"
+
+      [[extensions]]
+      type = "flow_action"
+      handle = "handle-1"
+      name = "my_extension_1_flow"
+      description = "custom description"
+      runtime_url = "https://example.com"
+      `
+    await writeBlockConfig({
+      blockConfiguration,
+      name: 'my_extension_1',
+    })
+    await writeFile(joinPath(blockPath('my_extension_1'), 'index.js'), '')
+
+    // When/Then
+    await expect(loadTestingApp({mode: 'report'})).resolves.not.toThrow()
+  })
+
   test('throws if 2 or more extensions have the same handle', async () => {
     // Given
     await writeConfig(appConfiguration)

--- a/packages/app/src/cli/models/app/loader.ts
+++ b/packages/app/src/cli/models/app/loader.ts
@@ -737,11 +737,13 @@ class AppLoader<TConfig extends AppConfiguration, TModuleSpec extends ExtensionS
   }
 
   private abortOrReport<T>(errorMessage: OutputMessage, fallback: T, configurationPath: string): T {
-    if (this.mode === 'strict') {
-      throw new AbortError(errorMessage)
-    } else {
-      this.errors.addError(configurationPath, errorMessage)
-      return fallback
+    switch (this.mode) {
+      case 'strict':
+      case 'local':
+        throw new AbortError(errorMessage)
+      case 'report':
+        this.errors.addError(configurationPath, errorMessage)
+        return fallback
     }
   }
 


### PR DESCRIPTION
### WHY are these changes introduced?

This change updates the error handling behavior in the `abortOrReport` method to properly handle the 'local' mode.

### WHAT is this pull request doing?

Refactors the `abortOrReport` method in the AppLoader class to use a switch statement instead of an if/else condition, and adds handling for the 'local' mode to throw an AbortError similar to 'strict' mode.

### How to test your changes?

1. Create a ui_extension, remove the `targeting`​ section
2. Run `shopify app build`​ in `main`​ and in this `branch`​, this branch throws the proper validation error.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes