### PR TITLE
Only use custom cli-hydrogen package in development

### DIFF
--- a/.changeset/modern-coins-cross.md
+++ b/.changeset/modern-coins-cross.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': minor
+---
+
+Only use custom cli-hydrogen package in CLI development environments


### PR DESCRIPTION
## Summary
Fixes shop/issues-develop#21438 - CLI crash caused by malformed JSON in package.json during Hydrogen monorepo detection.

## Problem
The CLI was crashing with error "Expected double-quoted property name in JSON" when the project's root `package.json` contained malformed JSON (trailing commas, missing quotes, etc.)

**Error Impact**: 
- 5 events, 2 affected users, 1 shop in last 7 days
- Complete CLI failure - no commands could run

## Cause
- We check for a custom `cli-hydrogen` package and prefer it to the included package
- This is only really useful in dev environments
- The code only validated file existence, not JSON validity

## Solution
- Only do this workaround in development environments