### PR TITLE
Fix CLI loader

### DIFF
--- a/packages/cli-kit/src/public/node/custom-oclif-loader.ts
+++ b/packages/cli-kit/src/public/node/custom-oclif-loader.ts
@@ -26,8 +26,11 @@ export class ShopifyConfig extends Config {
           path,
         }
       }
-      super(options)
+    }
 
+    super(options)
+
+    if (isDevelopment()) {
       // @ts-expect-error: This is a private method that we are overriding. OCLIF doesn't provide a way to extend it.
       // eslint-disable-next-line @typescript-eslint/unbound-method
       this.determinePriority = this.customPriority


### PR DESCRIPTION
### WHY are these changes introduced?

After [this change](https://github.com/Shopify/cli/pull/6574), all CLI commands are broken in production.

### WHAT is this pull request doing?

Ensures the `ShopifyConfig` constructor always calls `super()`, no matter the environment

### How to test your changes?

- `SHOPIFY_CLI_ENV=production p shopify version`
- `p shopify version`

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
