### PR TITLE
add extensions/*/tests directory to workspace

### DIFF
--- a/packages/app/src/cli/services/init/init.ts
+++ b/packages/app/src/cli/services/init/init.ts
@@ -108,7 +108,9 @@ async function init(options: InitOptions) {
           packageJSON.name = hyphenizedName
           packageJSON.author = (await username()) ?? ''
           packageJSON.private = true
-          const workspacesFolders = ['extensions/*'].concat(detectAdditionalWorkspacesFolders(templateScaffoldDir))
+          const workspacesFolders = ['extensions/*', 'extensions/*/tests'].concat(
+            detectAdditionalWorkspacesFolders(templateScaffoldDir),
+          )
 
           switch (packageManager) {
             case 'npm':


### PR DESCRIPTION
### WHY are these changes introduced?

Part of https://github.com/shop/issues-shopifyvm/issues/552

### WHAT is this pull request doing?

Adds the new function `extension/*/tests` path to the workspace during `app init`.
This allows the dependencies to be properly discovered during `pnpm install`, and makes it possible to run the tests right after generating.

### How to test your changes?

- install the snapshot
```
npm i -g --@shopify:registry=https://registry.npmjs.org @shopify/cli@0.0.0-snapshot-20251105181940
```
- Init a new app extension-only app. Use pnpm to get workspaces.
```
shopify app init --template=none --package-manager=pnpm
```
- cd into the app
- generate a new extension that has the new structure
```
shopify app generate extension -u https://github.com/Shopify/extensions-templates.git\#lopert.add-wasm-tests --template=discount --flavor=vanilla-js --name alex-discount
```
- run the tests from the app root folder. The generate should have properly installed the required deps, and this should execute the default.test under `extensions/alex-discount/tests`
```
pnpm vitest run
```
### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
