### PR TITLE
feat(graphiql): add shared types, constants, and validation

### DIFF
--- a/packages/graphiql-console/src/types/config.ts
+++ b/packages/graphiql-console/src/types/config.ts
@@ -1,0 +1,33 @@
+export interface GraphiQLConfig {
+  // Initial server data
+  apiVersion: string
+  apiVersions: string[]
+  appName: string
+  appUrl: string
+  storeFqdn: string
+  // Optional auth key
+  key?: string
+
+  // API endpoints
+  baseUrl: string
+
+  // Optional initial query state
+  query?: string
+  variables?: string
+
+  // Default queries for tabs
+  defaultQueries?: {
+    query: string
+    variables?: string
+    preface?: string
+  }[]
+}
+
+// Global config interface
+declare global {
+  interface Window {
+    __GRAPHIQL_CONFIG__?: GraphiQLConfig
+  }
+}
+
+export {}

--- a/packages/graphiql-console/src/utils/configValidation.test.ts
+++ b/packages/graphiql-console/src/utils/configValidation.test.ts
@@ -1,0 +1,313 @@
+import {validateConfig} from './configValidation.ts'
+import {describe, test, expect, vi} from 'vitest'
+import type {GraphiQLConfig} from '@/types/config.ts'
+
+describe('validateConfig', () => {
+  const fallbackConfig: GraphiQLConfig = {
+    baseUrl: 'http://localhost:3457',
+    apiVersion: '2024-10',
+    apiVersions: ['2024-01', '2024-04', '2024-07', '2024-10'],
+    appName: 'Test App',
+    appUrl: 'http://localhost:3000',
+    storeFqdn: 'test-store.myshopify.com',
+  }
+
+  describe('URL validation', () => {
+    test('accepts valid localhost URLs', () => {
+      const config = {
+        ...fallbackConfig,
+        baseUrl: 'http://localhost:3457',
+        appUrl: 'http://127.0.0.1:3000',
+      }
+      const result = validateConfig(config, fallbackConfig)
+      expect(result.baseUrl).toBe('http://localhost:3457')
+      expect(result.appUrl).toBe('http://127.0.0.1:3000')
+    })
+
+    test('accepts valid Shopify domain URLs', () => {
+      const config = {
+        ...fallbackConfig,
+        baseUrl: 'https://my-store.myshopify.com',
+        appUrl: 'https://test-app.myshopify.com',
+      }
+      const result = validateConfig(config, fallbackConfig)
+      expect(result.baseUrl).toBe('https://my-store.myshopify.com')
+      expect(result.appUrl).toBe('https://test-app.myshopify.com')
+    })
+
+    test('rejects javascript: protocol URLs', () => {
+      const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      const config = {
+        ...fallbackConfig,
+        baseUrl: 'javascript:alert("XSS")',
+        appUrl: 'javascript:void(0)',
+      }
+      const result = validateConfig(config, fallbackConfig)
+      expect(result.baseUrl).toBe(fallbackConfig.baseUrl)
+      expect(result.appUrl).toBe(fallbackConfig.appUrl)
+      expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining('[Security] Unsafe URL rejected'))
+
+      consoleWarnSpy.mockRestore()
+    })
+
+    test('rejects data: protocol URLs', () => {
+      const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      const config = {
+        ...fallbackConfig,
+        baseUrl: 'data:text/html,<script>alert("XSS")</script>',
+      }
+      const result = validateConfig(config, fallbackConfig)
+      expect(result.baseUrl).toBe(fallbackConfig.baseUrl)
+
+      consoleWarnSpy.mockRestore()
+    })
+
+    test('rejects URLs with embedded script tags', () => {
+      const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      const config = {
+        ...fallbackConfig,
+        baseUrl: 'http://localhost:3457/<script>alert("XSS")</script>',
+      }
+      const result = validateConfig(config, fallbackConfig)
+      expect(result.baseUrl).toBe(fallbackConfig.baseUrl)
+
+      consoleWarnSpy.mockRestore()
+    })
+
+    test('rejects URLs with event handlers', () => {
+      const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      const config = {
+        ...fallbackConfig,
+        appUrl: 'http://localhost" onerror="alert(1)',
+      }
+      const result = validateConfig(config, fallbackConfig)
+      expect(result.appUrl).toBe(fallbackConfig.appUrl)
+
+      consoleWarnSpy.mockRestore()
+    })
+
+    test('rejects URLs not in allowlist', () => {
+      const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      const config = {
+        ...fallbackConfig,
+        baseUrl: 'https://evil.com',
+        appUrl: 'http://malicious.site',
+      }
+      const result = validateConfig(config, fallbackConfig)
+      expect(result.baseUrl).toBe(fallbackConfig.baseUrl)
+      expect(result.appUrl).toBe(fallbackConfig.appUrl)
+      expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining('[Security] URL not in allowlist'))
+
+      consoleWarnSpy.mockRestore()
+    })
+  })
+
+  describe('string sanitization', () => {
+    test('accepts valid string values', () => {
+      const config = {
+        ...fallbackConfig,
+        apiVersion: '2024-10',
+        appName: 'My Test App',
+        storeFqdn: 'my-store.myshopify.com',
+      }
+      const result = validateConfig(config, fallbackConfig)
+      expect(result.apiVersion).toBe('2024-10')
+      expect(result.appName).toBe('My Test App')
+      expect(result.storeFqdn).toBe('my-store.myshopify.com')
+    })
+
+    test('sanitizes strings with script tags', () => {
+      const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      const config = {
+        ...fallbackConfig,
+        appName: '<script>alert("XSS")</script>Malicious App',
+      }
+      const result = validateConfig(config, fallbackConfig)
+      expect(result.appName).toBe(fallbackConfig.appName)
+
+      consoleWarnSpy.mockRestore()
+    })
+
+    test('sanitizes strings with event handlers', () => {
+      const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      const config = {
+        ...fallbackConfig,
+        storeFqdn: 'test" onerror="alert(1)',
+      }
+      const result = validateConfig(config, fallbackConfig)
+      expect(result.storeFqdn).toBe(fallbackConfig.storeFqdn)
+
+      consoleWarnSpy.mockRestore()
+    })
+
+    test('sanitizes strings with javascript: protocol', () => {
+      const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      const config = {
+        ...fallbackConfig,
+        appName: 'javascript:alert("XSS")',
+      }
+      const result = validateConfig(config, fallbackConfig)
+      expect(result.appName).toBe(fallbackConfig.appName)
+
+      consoleWarnSpy.mockRestore()
+    })
+  })
+
+  describe('array validation', () => {
+    test('filters and sanitizes apiVersions array', () => {
+      const config = {
+        ...fallbackConfig,
+        apiVersions: ['2024-10', '<script>alert("XSS")</script>', '2024-07', 123 as any],
+      }
+      const result = validateConfig(config, fallbackConfig)
+      expect(result.apiVersions).toHaveLength(2)
+      expect(result.apiVersions).toContain('2024-10')
+      expect(result.apiVersions).toContain('2024-07')
+      expect(result.apiVersions).not.toContain('<script>alert("XSS")</script>')
+    })
+
+    test('uses fallback for invalid apiVersions', () => {
+      const config = {
+        ...fallbackConfig,
+        apiVersions: 'not-an-array' as any,
+      }
+      const result = validateConfig(config, fallbackConfig)
+      expect(result.apiVersions).toEqual(fallbackConfig.apiVersions)
+    })
+  })
+
+  describe('optional fields', () => {
+    test('preserves valid optional fields', () => {
+      const config = {
+        ...fallbackConfig,
+        key: 'safe-key-123',
+        query: '{ shop { name } }',
+        variables: '{}',
+      }
+      const result = validateConfig(config, fallbackConfig)
+      expect(result.key).toBe('safe-key-123')
+      expect(result.query).toBe('{ shop { name } }')
+      expect(result.variables).toBe('{}')
+    })
+
+    test('sanitizes optional fields with dangerous content', () => {
+      const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      const config = {
+        ...fallbackConfig,
+        query: '<script>alert("XSS")</script>{ shop { name } }',
+      }
+      const result = validateConfig(config, fallbackConfig)
+      expect(result.query).toBe('')
+
+      consoleWarnSpy.mockRestore()
+    })
+
+    test('omits optional fields when undefined', () => {
+      const config = {
+        ...fallbackConfig,
+      }
+      const result = validateConfig(config, fallbackConfig)
+      expect(result.key).toBeUndefined()
+      expect(result.query).toBeUndefined()
+      expect(result.variables).toBeUndefined()
+    })
+  })
+
+  describe('defaultQueries validation', () => {
+    test('validates and sanitizes defaultQueries array', () => {
+      const config = {
+        ...fallbackConfig,
+        defaultQueries: [
+          {
+            query: '{ shop { name } }',
+            variables: '{}',
+            preface: 'Get shop info',
+          },
+          {
+            query: '<script>alert("XSS")</script>',
+            variables: '{}',
+          },
+        ],
+      }
+      const result = validateConfig(config, fallbackConfig)
+      expect(result.defaultQueries).toHaveLength(2)
+      expect(result.defaultQueries?.[0]?.query).toBe('{ shop { name } }')
+      expect(result.defaultQueries?.[1]?.query).toBe('')
+    })
+
+    test('uses fallback for invalid defaultQueries', () => {
+      const config = {
+        ...fallbackConfig,
+        defaultQueries: 'not-an-array' as any,
+      }
+      const result = validateConfig(config, fallbackConfig)
+      expect(result.defaultQueries).toBe(fallbackConfig.defaultQueries)
+    })
+  })
+
+  describe('invalid input handling', () => {
+    test('returns fallback for undefined config', () => {
+      const result = validateConfig(undefined, fallbackConfig)
+      expect(result).toEqual(fallbackConfig)
+    })
+
+    test('returns fallback for null config', () => {
+      const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      const result = validateConfig(null as any, fallbackConfig)
+      expect(result).toEqual(fallbackConfig)
+
+      consoleWarnSpy.mockRestore()
+    })
+
+    test('returns fallback for non-object config', () => {
+      const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      const result = validateConfig('not an object' as any, fallbackConfig)
+      expect(result).toEqual(fallbackConfig)
+
+      consoleWarnSpy.mockRestore()
+    })
+  })
+
+  describe('complex XSS scenarios', () => {
+    test('blocks polyglot XSS attempts', () => {
+      const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      const config = {
+        ...fallbackConfig,
+        appName:
+          'jaVasCript:/*-/*`/*\\`/*\'/*"/**/(/* */oNcliCk=alert() )//%0D%0A%0d%0a//</stYle/</titLe/</teXtarEa/</scRipt/--!>\\x3csVg/<sVg/oNloAd=alert()//>\\x3e',
+      }
+      const result = validateConfig(config, fallbackConfig)
+      expect(result.appName).toBe(fallbackConfig.appName)
+
+      consoleWarnSpy.mockRestore()
+    })
+
+    test('allows localhost URL with query parameters', () => {
+      const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      const config = {
+        ...fallbackConfig,
+        appUrl: 'http://localhost:3000?query=%3Cscript%3Ealert(1)%3C/script%3E',
+      }
+      const result = validateConfig(config, fallbackConfig)
+      // Localhost URLs are allowed, query params are preserved by URL constructor
+      // The protection is at the protocol/domain level, not query string
+      expect(result.appUrl).toBe('http://localhost:3000?query=%3Cscript%3Ealert(1)%3C/script%3E')
+      expect(consoleWarnSpy).not.toHaveBeenCalled()
+
+      consoleWarnSpy.mockRestore()
+    })
+  })
+})

--- a/packages/graphiql-console/src/utils/configValidation.ts
+++ b/packages/graphiql-console/src/utils/configValidation.ts
@@ -1,0 +1,153 @@
+import type {GraphiQLConfig} from '@/types/config.ts'
+
+/**
+ * Security: URL validation to prevent XSS and injection attacks
+ *
+ * This module validates and sanitizes URLs from window.__GRAPHIQL_CONFIG__
+ * to prevent malicious scripts or data from being injected through config.
+ */
+
+const SAFE_URL_PROTOCOLS = ['http:', 'https:']
+const ALLOWED_LOCALHOST_PATTERNS = [
+  /^https?:\/\/localhost(:\d+)?(\/.*)?(\?.*)?$/,
+  /^https?:\/\/127\.0\.0\.1(:\d+)?(\/.*)?(\?.*)?$/,
+  /^https?:\/\/\[::1\](:\d+)?(\/.*)?(\?.*)?$/,
+]
+const ALLOWED_SHOPIFY_PATTERN = /^https:\/\/[a-zA-Z0-9-]+\.myshopify\.(com|io)(:\d+)?(\/.*)?(\?.*)?$/
+
+/**
+ * Validates that a URL is safe to use (no javascript:, data:, or other dangerous protocols)
+ */
+function isUrlSafe(url: string): boolean {
+  try {
+    // eslint-disable-next-line node/no-unsupported-features/node-builtins
+    const parsed = new URL(url)
+
+    // Only allow http/https protocols
+    if (!SAFE_URL_PROTOCOLS.includes(parsed.protocol)) {
+      return false
+    }
+
+    // Check for suspicious patterns that could indicate XSS attempts
+    const suspiciousPatterns = [/javascript:/i, /data:/i, /vbscript:/i, /<script/i, /onerror=/i, /onload=/i]
+
+    if (suspiciousPatterns.some((pattern) => pattern.test(url))) {
+      return false
+    }
+
+    return true
+    // eslint-disable-next-line no-catch-all/no-catch-all
+  } catch {
+    // Invalid URL format - not rethrowing as this is expected for invalid URLs
+    return false
+  }
+}
+
+/**
+ * Validates that a URL matches expected patterns (localhost or Shopify domains)
+ */
+function isUrlAllowed(url: string): boolean {
+  try {
+    // Check localhost patterns
+    if (ALLOWED_LOCALHOST_PATTERNS.some((pattern) => pattern.test(url))) {
+      return true
+    }
+
+    // Check Shopify domain pattern
+    if (ALLOWED_SHOPIFY_PATTERN.test(url)) {
+      return true
+    }
+
+    return false
+    // eslint-disable-next-line no-catch-all/no-catch-all
+  } catch {
+    // Pattern matching error - not rethrowing as this is expected for malformed URLs
+    return false
+  }
+}
+
+/**
+ * Validates and sanitizes a URL, returning the safe URL or a fallback
+ */
+function validateUrl(url: string | undefined, fallback: string): string {
+  if (!url) {
+    return fallback
+  }
+
+  if (!isUrlSafe(url)) {
+    // eslint-disable-next-line no-console
+    console.warn(`[Security] Unsafe URL rejected: ${url}. Using fallback: ${fallback}`)
+    return fallback
+  }
+
+  if (!isUrlAllowed(url)) {
+    // eslint-disable-next-line no-console
+    console.warn(`[Security] URL not in allowlist: ${url}. Using fallback: ${fallback}`)
+    return fallback
+  }
+
+  return url
+}
+
+/**
+ * Sanitizes a string to prevent XSS by removing potentially dangerous content
+ */
+function sanitizeString(value: string | undefined, fallback: string): string {
+  if (!value) {
+    return fallback
+  }
+
+  // Check for script tags or event handlers
+  const dangerousPatterns = [/<script/i, /<\/script/i, /javascript:/i, /onerror=/i, /onload=/i, /onclick=/i]
+
+  if (dangerousPatterns.some((pattern) => pattern.test(value))) {
+    // eslint-disable-next-line no-console
+    console.warn(`[Security] Dangerous content detected in string. Using fallback.`)
+    return fallback
+  }
+
+  return value
+}
+
+/**
+ * Validates the entire GraphiQL config object
+ * Returns a sanitized config with dangerous values replaced by safe fallbacks
+ */
+export function validateConfig(config: Partial<GraphiQLConfig> | undefined, fallback: GraphiQLConfig): GraphiQLConfig {
+  if (!config || typeof config !== 'object') {
+    // eslint-disable-next-line no-console
+    console.warn('[Security] Invalid config object. Using fallback.')
+    return fallback
+  }
+
+  return {
+    // Validate URLs with strict checks
+    baseUrl: validateUrl(config.baseUrl, fallback.baseUrl),
+    appUrl: validateUrl(config.appUrl, fallback.appUrl),
+
+    // Sanitize string fields
+    apiVersion: sanitizeString(config.apiVersion, fallback.apiVersion),
+    apiVersions: Array.isArray(config.apiVersions)
+      ? config.apiVersions
+          .filter((version) => typeof version === 'string')
+          .map((version) => sanitizeString(version, ''))
+          .filter((version) => version !== '')
+      : fallback.apiVersions,
+    appName: sanitizeString(config.appName, fallback.appName),
+    storeFqdn: sanitizeString(config.storeFqdn, fallback.storeFqdn),
+
+    // Optional fields with validation
+    key: config.key ? sanitizeString(config.key, '') : undefined,
+    query: config.query ? sanitizeString(config.query, '') : undefined,
+    variables: config.variables ? sanitizeString(config.variables, '') : undefined,
+
+    // Complex nested structure validation
+    defaultQueries: Array.isArray(config.defaultQueries)
+      ? config.defaultQueries.map((queryItem) => ({
+          query: sanitizeString(queryItem?.query, ''),
+          variables: queryItem?.variables ? sanitizeString(queryItem.variables, '') : undefined,
+          preface: queryItem?.preface ? sanitizeString(queryItem.preface, '') : undefined,
+        }))
+      : fallback.defaultQueries,
+  }
+}


### PR DESCRIPTION
### WHY are these changes introduced?

This PR builds on the foundation from PR #6578 by establishing the core type system, configuration validation, and default content for the GraphiQL console. This is the second PR in the 8-PR migration stack.

**Context:** The GraphiQL console will receive configuration from the Rails server via `window.__GRAPHIQL_CONFIG__`. This configuration includes URLs, API endpoints, and user data. We need:
- Strong TypeScript types for configuration data
- Security validation to prevent XSS attacks through config injection
- Default content for the welcome screen and initial queries

### WHAT is this pull request doing?

This PR adds the type definitions, security validation layer, and default content that will be used throughout the GraphiQL application.

**Key Changes:**

**1. Type Definitions** (`src/types/config.ts`):
- `GraphiQLConfig` interface defining all configuration fields
- Server data: `apiVersion`, `apiVersions`, `appName`, `appUrl`, `storeFqdn`
- API endpoints: `baseUrl`
- Optional initial state: `query`, `variables`, `defaultQueries`
- Global window interface extension for `window.__GRAPHIQL_CONFIG__`

**2. Security Validation** (`src/utils/configValidation.ts`):
- **XSS Prevention**: Validates all URLs to only allow http/https protocols
- **URL Allowlist**: Restricts URLs to localhost and `*.myshopify.com` domains
- **String Sanitization**: Detects and blocks script tags, event handlers, and javascript: URLs
- **Safe Fallbacks**: Returns sanitized config with dangerous values replaced by safe defaults
- Comprehensive 313-line test suite covering all attack vectors

**Security Patterns Blocked:**
```javascript
// All of these would be rejected:
javascript:alert('xss')
data:text/html,<script>alert('xss')</script>
http://evil.com/steal-tokens
<script>alert('xss')</script>
<img onerror="alert('xss')" src=x>
```

**3. Default Content** (`src/constants/defaultContent.ts`):
- Welcome message explaining GraphiQL features and keyboard shortcuts
- Platform-aware control key display (⌘ for Mac, Ctrl for Windows/Linux)
- Default shop query to fetch basic store information

**Files Added:**
- `src/types/config.ts` - TypeScript interfaces
- `src/constants/defaultContent.ts` - Welcome message and default query
- `src/utils/configValidation.ts` - Security validation (153 lines)
- `src/utils/configValidation.test.ts` - Security tests (313 lines)

### Dependencies

**Builds on:** PR #6578 (package foundation)

### How to test your changes?

```bash
# Run the comprehensive security validation tests
pnpm --filter @shopify/graphiql-console test src/utils/configValidation.test.ts

# Type check the new interfaces
pnpm --filter @shopify/graphiql-console tsc --noEmit

# All 313 test cases should pass, covering:
# - URL protocol validation
# - XSS attack prevention
# - Shopify domain allowlist
# - String sanitization
# - Safe fallback behavior
```

### Measuring impact

- [x] n/a - this is foundational security infrastructure

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible documentation changes