### PR TITLE
make new package for app execute

### DIFF
--- a/packages/app/src/cli/commands/app/execute.ts
+++ b/packages/app/src/cli/commands/app/execute.ts
@@ -1,0 +1,29 @@
+import {appFlags} from '../../flags.js'
+import AppUnlinkedCommand, {AppUnlinkedCommandOutput} from '../../utilities/app-unlinked-command.js'
+import {AppInterface} from '../../models/app/app.js'
+import {globalFlags} from '@shopify/cli-kit/node/cli'
+import {renderSuccess} from '@shopify/cli-kit/node/ui'
+
+export default class Execute extends AppUnlinkedCommand {
+  static summary = 'Execute app operations.'
+
+  static description = 'Execute app operations.'
+
+  static hidden = true
+
+  static flags = {
+    ...globalFlags,
+    ...appFlags,
+  }
+
+  async run(): Promise<AppUnlinkedCommandOutput> {
+    await this.parse(Execute)
+
+    renderSuccess({
+      headline: 'Execute command ran successfully!',
+      body: 'Placeholder command. Add execution logic here.',
+    })
+
+    return {app: undefined as unknown as AppInterface}
+  }
+}

--- a/packages/app/src/cli/index.ts
+++ b/packages/app/src/cli/index.ts
@@ -8,6 +8,7 @@ import Logs from './commands/app/logs.js'
 import Sources from './commands/app/app-logs/sources.js'
 import EnvPull from './commands/app/env/pull.js'
 import EnvShow from './commands/app/env/show.js'
+import Execute from './commands/app/execute.js'
 import FunctionBuild from './commands/app/function/build.js'
 import FunctionReplay from './commands/app/function/replay.js'
 import FunctionRun from './commands/app/function/run.js'
@@ -48,6 +49,7 @@ export const commands: {[key: string]: typeof AppLinkedCommand | typeof AppUnlin
   'app:config:use': ConfigUse,
   'app:env:pull': EnvPull,
   'app:env:show': EnvShow,
+  'app:execute': Execute,
   'app:generate:schema': GenerateSchema,
   'app:function:build': FunctionBuild,
   'app:function:replay': FunctionReplay,

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -808,6 +808,84 @@
       "strict": true,
       "summary": "Display app and extensions environment variables."
     },
+    "app:execute": {
+      "aliases": [
+      ],
+      "args": {
+      },
+      "customPluginName": "@shopify/app",
+      "description": "Execute app operations.",
+      "flags": {
+        "client-id": {
+          "description": "The Client ID of your app.",
+          "env": "SHOPIFY_FLAG_CLIENT_ID",
+          "exclusive": [
+            "config"
+          ],
+          "hasDynamicHelp": false,
+          "hidden": false,
+          "multiple": false,
+          "name": "client-id",
+          "type": "option"
+        },
+        "config": {
+          "char": "c",
+          "description": "The name of the app configuration.",
+          "env": "SHOPIFY_FLAG_APP_CONFIG",
+          "hasDynamicHelp": false,
+          "hidden": false,
+          "multiple": false,
+          "name": "config",
+          "type": "option"
+        },
+        "no-color": {
+          "allowNo": false,
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path to your app directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "path",
+          "noCacheDefault": true,
+          "type": "option"
+        },
+        "reset": {
+          "allowNo": false,
+          "description": "Reset all your settings.",
+          "env": "SHOPIFY_FLAG_RESET",
+          "exclusive": [
+            "config"
+          ],
+          "hidden": false,
+          "name": "reset",
+          "type": "boolean"
+        },
+        "verbose": {
+          "allowNo": false,
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hidden": true,
+      "hiddenAliases": [
+      ],
+      "id": "app:execute",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "summary": "Execute app operations."
+    },
     "app:function:build": {
       "aliases": [
       ],


### PR DESCRIPTION
Resolves: https://github.com/shop/issues-api-foundations/issues/1064

**Background**

Creating the new `shopify app execute` CLI command.  
This is just the bare bones outline of the CLI command that is basically empty. We will be implementing the command logic into this.


**To Test**
Use `pnpm shopify app execute` to test commands during development. This builds and runs the CLI from source without needing to install it globally.


**Why regenerate the manifest:**

I had to run the `pnpm refresh-manifests` command to regenerate the manifest. This is because:
- The oclif manifest and README must be updated when adding new commands. 
- They contain command metadata for discovery, help documentation, and public docs.

What it added:
- Registered app:execute in oclif.manifest.json with flags and descriptions
- Updated README.md with command documentation
- Without this, the command exists in code but isn't discoverable by the CLI.



