### PR TITLE
Dont throw error for unused keys in toml while in local mode

### DIFF
--- a/packages/app/src/cli/models/app/loader.test.ts
+++ b/packages/app/src/cli/models/app/loader.test.ts
@@ -2723,6 +2723,36 @@ redirect_urls = [ "https://example.com/api/auth" ]
       'Unsupported section(s) in app configuration: and_another, something_else',
     )
   })
+
+  test('does not throw unsupported config property error when mode is local', async () => {
+    const linkedAppConfigurationWithExtraConfig = `
+    name = "for-testing"
+    client_id = "1234567890"
+    application_url = "https://example.com/lala"
+    embedded = true
+
+    [build]
+    include_config_on_deploy = true
+
+    [webhooks]
+    api_version = "2023-07"
+
+    [auth]
+    redirect_urls = [ "https://example.com/api/auth" ]
+
+    [something_else]
+    not_valid = true
+
+    [and_another]
+    bad = true
+    `
+    await writeConfig(linkedAppConfigurationWithExtraConfig)
+
+    const app = await loadTestingApp({mode: 'local'})
+
+    expect(app).toBeDefined()
+    expect(app.name).toBe('for-testing')
+  })
 })
 
 describe('getAppConfigurationFileName', () => {

--- a/packages/app/src/cli/models/app/loader.ts
+++ b/packages/app/src/cli/models/app/loader.ts
@@ -682,7 +682,7 @@ class AppLoader<TConfig extends AppConfiguration, TModuleSpec extends ExtensionS
         return !configKeysThatAreNeverModules.includes(key)
       })
 
-    if (unusedKeys.length > 0) {
+    if (unusedKeys.length > 0 && this.mode !== 'local') {
       this.abortOrReport(
         outputContent`Unsupported section(s) in app configuration: ${unusedKeys.sort().join(', ')}`,
         undefined,


### PR DESCRIPTION
### WHY are these changes introduced?

This change prevents the app loader from reporting unsupported configuration sections when running in local mode.

### WHAT is this pull request doing?

Modifies the app loader to only report unsupported configuration sections when not in local mode. This allows for more flexibility in local development environments without triggering unnecessary warnings.

### How to test your changes?

1. Create an app with metafields/metaobjects
2. Run `shopify app build`
3. See that it builds without errors.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes