### PR TITLE
Fix images not loading in theme app extensions

### DIFF
--- a/.changeset/frank-oranges-juggle.md
+++ b/.changeset/frank-oranges-juggle.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': patch
+---
+
+Fix zip and brotliCompress functions to handle binary files

--- a/packages/cli-kit/src/public/node/archiver.ts
+++ b/packages/cli-kit/src/public/node/archiver.ts
@@ -1,8 +1,9 @@
 import {relativePath, joinPath, dirname} from './path.js'
-import {glob, removeFile, readFile} from './fs.js'
+import {glob, removeFile} from './fs.js'
 import {outputDebug, outputContent, outputToken} from '../../public/node/output.js'
 import archiver from 'archiver'
 import {createWriteStream, readFileSync, writeFileSync} from 'fs'
+import {readFile} from 'fs/promises'
 import {tmpdir} from 'os'
 import {randomUUID} from 'crypto'
 


### PR DESCRIPTION
### WHY are these changes introduced?

Re: https://community.shopify.dev/t/images-in-theme-app-extension-break-after-upgrading-to-shopify-cli-v3-87-0/25200

Images are failing to load in theme app extensions.

### WHAT is this pull request doing?

Our wrapper around fs's `readFile` sets a default of `{encoding: 'utf8'}` to the options. This will cause any binary files (like images or fonts) to not be read properly.

There isn't a way to disable the encoding based on how the function is currently typed so I'm switching to fs's version of `readFile` which will handle all file types correctly automatically.

### How to test your changes?

1. Install the snapped version `npm i -g --@shopify:registry=https://registry.npmjs.org @shopify/cli@0.0.0-snapshot-20251112222441`
2. Navigate to an app that contains a theme app extension
3. Ensure the theme app extension contains an image and the image is being rendered somewhere in the code
4. Run `shopify app dev`
5. Navigate to the admin of your dev store and got to Online Store
6. Customize a theme and add your theme app extension to it
7. Ensure the image loads properly
8. Bonus: to know for sure that this PR is fixing the issue you can reinstall the latest version of the Shopify CLI, go through the same steps, and ensure that the image doesn't load correctly

| v3.87.2 | v0.0.0-snapshot-20251112222441 |
|--------|--------|
| <img width="475" height="340" alt="image" src="https://github.com/user-attachments/assets/1e6aba85-b74f-4b90-ae1e-3e8e9703c321" /> | <img width="441" height="344" alt="image" src="https://github.com/user-attachments/assets/19851319-5228-4921-bc59-cec46d810784" /> | 

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
