### PR TITLE
Update Docs to reflect upgrade of minimal node version supported

### DIFF
--- a/docs-shopify.dev/generated/generated_static_pages.json
+++ b/docs-shopify.dev/generated/generated_static_pages.json
@@ -10,7 +10,7 @@
         "type": "Generic",
         "anchorLink": "requirements",
         "title": "Requirements",
-        "sectionContent": "\n- [Node.js](https://nodejs.org/en/download/): 20.10 or higher\n- A Node.js package manager: [npm](https://www.npmjs.com/get-npm), [Yarn 1.x](https://classic.yarnpkg.com/lang/en/docs/install), or [pnpm](https://pnpm.io/installation).\n- [Git](https://git-scm.com/downloads): 2.28.0 or higher\n"
+        "sectionContent": "\n- [Node.js](https://nodejs.org/en/download/): 20.17 or higher\n- A Node.js package manager: [npm](https://www.npmjs.com/get-npm), [Yarn 1.x](https://classic.yarnpkg.com/lang/en/docs/install), or [pnpm](https://pnpm.io/installation).\n- [Git](https://git-scm.com/downloads): 2.28.0 or higher\n"
       },
       {
         "type": "Generic",

--- a/docs-shopify.dev/static/cli.doc.ts
+++ b/docs-shopify.dev/static/cli.doc.ts
@@ -13,7 +13,7 @@ const data: LandingTemplateSchema = {
       anchorLink: 'requirements',
       title: 'Requirements',
       sectionContent: `
-- [Node.js](https://nodejs.org/en/download/): 20.10 or higher
+- [Node.js](https://nodejs.org/en/download/): 20.17 or higher
 - A Node.js package manager: [npm](https://www.npmjs.com/get-npm), [Yarn 1.x](https://classic.yarnpkg.com/lang/en/docs/install), or [pnpm](https://pnpm.io/installation).
 - [Git](https://git-scm.com/downloads): 2.28.0 or higher
 `,

--- a/docs/cli/get-started.md
+++ b/docs/cli/get-started.md
@@ -7,7 +7,7 @@ This wiki contains documentation that's useful for contributors of the project.
 
 If you'd like to contribute to this project, the following system dependencies need to be present in the environment.
 
-- [Node](https://nodejs.org/en/) (v20.10 or higher)
+- [Node](https://nodejs.org/en/) (v20.17 or higher)
 - [PNPM](https://pnpm.io/) (v10)
 
 ### Set up


### PR DESCRIPTION
### WHY are these changes introduced?

Updates the minimum required Node.js version for Shopify CLI.

### WHAT is this pull request doing?

Updates the Node.js version requirement from 20.10 to 20.17 in both the public documentation and the contributor documentation.

### cgHow to test your changes?

1. Verify that the Node.js version requirement is correctly updated to 20.17 in both files
2. Ensure the links to Node.js installation pages are still working correctly

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes