### PR TITLE
3.87 Patch: Fix images not loading in theme app extensions

### DIFF
--- a/.changeset/frank-oranges-juggle.md
+++ b/.changeset/frank-oranges-juggle.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': patch
+---
+
+Fix zip and brotliCompress functions to handle binary files

--- a/packages/cli-kit/src/public/node/archiver.ts
+++ b/packages/cli-kit/src/public/node/archiver.ts
@@ -1,8 +1,9 @@
 import {relativePath, joinPath, dirname} from './path.js'
-import {glob, removeFile, readFile} from './fs.js'
+import {glob, removeFile} from './fs.js'
 import {outputDebug, outputContent, outputToken} from '../../public/node/output.js'
 import archiver from 'archiver'
 import {createWriteStream, readFileSync, writeFileSync} from 'fs'
+import {readFile} from 'fs/promises'
 import {tmpdir} from 'os'
 import {randomUUID} from 'crypto'
 


### PR DESCRIPTION
Patch for v3.87 of https://github.com/Shopify/cli/pull/6614