### PR TITLE
Add channel_config hash to allow extension-level fields

### DIFF
--- a/packages/app/src/cli/models/extensions/specifications/channel.ts
+++ b/packages/app/src/cli/models/extensions/specifications/channel.ts
@@ -7,6 +7,7 @@ const ChannelSpecificationSchema = BaseSchemaWithHandle.extend({
   type: zod.literal('channel_config'),
   name: zod.string().optional(),
   description: zod.string().optional(),
+  channel_config: zod.record(zod.any()).optional(),
 })
 
 const SUBDIRECTORY_NAME = 'specifications'
@@ -25,6 +26,7 @@ const channelSpecificationSpec = createExtensionSpecification({
       handle: config.handle,
       name: config.name,
       description: config.description,
+      channel_config: config.channel_config,
     }
   },
 })


### PR DESCRIPTION
### WHY are these changes introduced?

To support extension-level configuration related to channels lifecycle.
The extension is under a flag, so this is a non-breaking change

### WHAT is this pull request doing?

Adds an optional `channel_config` field to the `ChannelSpecificationSchema` and includes it in the returned configuration object. This allows channel-specific configuration to be stored in extension specifications.

### How to test your changes?

1. Create a channel extension specification with a `channel_config` property
2. Verify that the configuration is properly parsed and returned
3. Ensure existing channel specifications without this field continue to work

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes