### PR TITLE
Fix CLI loading on Node 25.2.0

### DIFF
--- a/packages/cli-kit/src/private/node/context/deprecations-store.ts
+++ b/packages/cli-kit/src/private/node/context/deprecations-store.ts
@@ -2,15 +2,8 @@ interface DeprecationsStore {
   nextDeprecationDate: Date | undefined
 }
 
-interface GlobalWithDeprecationsStore {
-  deprecationsStore: DeprecationsStore
-}
-
-const globalWithDeprecationsStore: GlobalWithDeprecationsStore = {
-  ...globalThis,
-  deprecationsStore: {
-    nextDeprecationDate: undefined,
-  },
+const deprecationsStore: DeprecationsStore = {
+  nextDeprecationDate: undefined,
 }
 
 /**
@@ -19,7 +12,7 @@ const globalWithDeprecationsStore: GlobalWithDeprecationsStore = {
  * @returns The next deprecation date.
  */
 export function getNextDeprecationDate(): Date | undefined {
-  return globalWithDeprecationsStore.deprecationsStore.nextDeprecationDate
+  return deprecationsStore.nextDeprecationDate
 }
 
 /**
@@ -35,7 +28,7 @@ export function setNextDeprecationDate(dates: Date[]): Date | undefined {
 
   const nextDeprecationDate = getNextDeprecationDate()
   if (!nextDeprecationDate || earliestFutureDateTime < nextDeprecationDate.getTime()) {
-    globalWithDeprecationsStore.deprecationsStore.nextDeprecationDate = new Date(earliestFutureDateTime)
+    deprecationsStore.nextDeprecationDate = new Date(earliestFutureDateTime)
   }
 }
 


### PR DESCRIPTION
### WHY are these changes introduced?

Node 25.2.0 was crashing in `dreprecations-store` due to spread of `globalThis`, which caused access of the `localStorage` property. [See this change in Node 25.2.0](https://github.com/nodejs/node/commit/4fbb1ab101).

```
node:internal/webstorage:28
          throw lazyDOMException(
                ^

DOMException [SecurityError]: Cannot initialize local storage without a `--localstorage-file` path
    at Object.get [as localStorage] (node:internal/webstorage:28:17)
    at get localStorage (node:internal/util:660:20)
    at file:///Users/nickwesselman/src/shopify-cli/packages/cli-kit/dist/private/node/context/deprecations-store.js:1:37
    at ModuleJob.run (node:internal/modules/esm/module_job:413:25)
    at async onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:654:26)
    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:101:5)
```


### WHAT is this pull request doing?

Removes use of `globalThis`. I don't see why it's needed here?

### How to test your changes?

Ideally we'd find an API that's adding the deprecation extension to its GraphQL results.

