### PR TITLE
Add erroring for when variables are given for a BulkOps query

### DIFF
--- a/packages/app/src/cli/services/bulk-operations/run-query.ts
+++ b/packages/app/src/cli/services/bulk-operations/run-query.ts
@@ -14,6 +14,7 @@ export async function runBulkOperationQuery(
   options: BulkOperationRunQueryOptions,
 ): Promise<BulkOperationRunQueryMutation['bulkOperationRunQuery']> {
   const {adminSession, query} = options
+
   const response = await adminRequestDoc<BulkOperationRunQueryMutation, {query: string}>({
     query: BulkOperationRunQuery,
     session: adminSession,


### PR DESCRIPTION
**Resolves:** https://github.com/shop/issues-api-foundations/issues/1047?issue=shop%7Cissues-api-foundations%7C1097

### Background
Variables are only supported for [bulkOperationRunMutation](https://shopify.dev/docs/api/admin-graphql/latest/mutations/bulkoperationrunmutation), not [bulkOperationRunQuery](https://shopify.dev/docs/api/admin-graphql/latest/mutations/bulkOperationRunQuery). 


The workflow of the CLI command is shown [here](https://draw.shopify.io/embed/owaw6botp0rxvppc2z34ldsb?d=v-220.-79.2651.1443.bLH_tfkrBrIpLZ1T7vtKp). This PR is represented by the leftmost side of this diagram.

### Testing

Try running
```
pnpm shopify:run app execute \
  --path ./<TEST APP> \
  -q '{ products(first: 10) { edges { node { id title } } } }'\
  -v '[{"input": {"id": "gid://shopify/Product/<PRODUCT ID>", "tags": ["bulk-test"]}}]'
```
This should error because queries do not support variables.

![Screenshot 2025-11-13 at 11.35.40 PM.png](https://app.graphite.com/user-attachments/assets/30064ec0-c956-4079-9c02-2726e2c870a8.png)

While, 
```
pnpm shopify:run app execute \
  --path ./coffee-and-more \
  -q '{ products(first: 10) { edges { node { id title } } } }'\
```
should return a successful BulkOps Query.

![Screenshot 2025-11-13 at 11.39.01 PM.png](https://app.graphite.com/user-attachments/assets/34aaf2e3-06a0-4ac4-9678-ca1279f0ed3a.png)

