### PR TITLE
Introduce `AGENTS.md` file support in `shopify theme init`

### DIFF
--- a/.changeset/forty-steaks-decide.md
+++ b/.changeset/forty-steaks-decide.md
@@ -1,0 +1,6 @@
+---
+'@shopify/cli-kit': minor
+'@shopify/theme': minor
+---
+
+Introduce `AGENTS.md` file support in `shopify theme init`

--- a/packages/cli-kit/src/public/node/fs.ts
+++ b/packages/cli-kit/src/public/node/fs.ts
@@ -48,6 +48,7 @@ import {
   rename as fsRename,
   unlink as fsUnlink,
   readdir as fsReaddir,
+  symlink as fsSymlink,
 } from 'fs/promises'
 import {pathToFileURL as pathToFile} from 'url'
 import * as os from 'os'
@@ -262,6 +263,31 @@ export async function removeFile(path: string): Promise<void> {
 export async function renameFile(from: string, to: string): Promise<void> {
   outputDebug(outputContent`Renaming file from ${outputToken.path(from)} to ${outputToken.path(to)}...`)
   await fsRename(from, to)
+}
+
+/**
+ * Creates a symbolic link.
+ *
+ * @param target - Path that the symlink points to.
+ * @param path - Path where the symlink will be created.
+ */
+export async function symlink(target: string, path: string): Promise<void> {
+  outputDebug(outputContent`Creating symbolic link from ${outputToken.path(path)} to ${outputToken.path(target)}...`)
+
+  // On Windows, we need to specify the type of symlink (file or dir)
+  let type: 'file' | 'dir' | 'junction' = 'file'
+
+  try {
+    const stats = await fsLstat(target)
+    if (stats.isDirectory()) {
+      type = 'junction'
+    }
+    // eslint-disable-next-line no-catch-all/no-catch-all
+  } catch {
+    // If we can't stat the target, assume it's a file
+  }
+
+  await fsSymlink(target, path, type)
 }
 
 /**

--- a/packages/theme/src/cli/services/init.ts
+++ b/packages/theme/src/cli/services/init.ts
@@ -87,7 +87,7 @@ export async function createAIInstructions(themeRoot: string, aiInstruction: AII
 
           const instructions = (
             aiInstruction === 'all'
-              ? (Object.keys(SUPPORTED_AI_INSTRUCTIONS).filter((key) => key !== 'all') as AIInstruction[])
+              ? Object.keys(SUPPORTED_AI_INSTRUCTIONS).filter((key) => key !== 'all')
               : [aiInstruction]
           ) as Exclude<AIInstruction, 'all'>[]
 
@@ -130,7 +130,7 @@ export async function createAIInstructions(themeRoot: string, aiInstruction: AII
 export async function createAIInstructionFiles(
   themeRoot: string,
   agentsPath: string,
-  instruction: AIInstruction,
+  instruction: Exclude<AIInstruction, 'all'>,
 ): Promise<{copiedFile?: string}> {
   if (instruction === 'cursor') {
     // Cursor natively supports AGENTS.md, so no symlink needed
@@ -140,9 +140,9 @@ export async function createAIInstructionFiles(
   const symlinkMap = {
     github: 'copilot-instructions.md',
     claude: 'CLAUDE.md',
-  } as const
+  }
 
-  const symlinkName = symlinkMap[instruction as Exclude<AIInstruction, 'all' | 'cursor'>]
+  const symlinkName = symlinkMap[instruction]
   const symlinkPath = joinPath(themeRoot, symlinkName)
 
   try {

--- a/packages/theme/src/cli/services/init.ts
+++ b/packages/theme/src/cli/services/init.ts
@@ -85,10 +85,11 @@ export async function createAIInstructions(themeRoot: string, aiInstruction: AII
             shallow: true,
           })
 
-          const instructions =
+          const instructions = (
             aiInstruction === 'all'
               ? (Object.keys(SUPPORTED_AI_INSTRUCTIONS).filter((key) => key !== 'all') as AIInstruction[])
               : [aiInstruction]
+          ) as Exclude<AIInstruction, 'all'>[]
 
           try {
             const sourcePath = joinPath(tempDir, 'ai', 'github', 'copilot-instructions.md')

--- a/packages/theme/src/cli/services/init.ts
+++ b/packages/theme/src/cli/services/init.ts
@@ -136,10 +136,10 @@ export async function createAIInstructionFiles(
     return {}
   }
 
-  const symlinkMap: {[key in Exclude<AIInstruction, 'all' | 'cursor'>]: string} = {
+  const symlinkMap = {
     github: 'copilot-instructions.md',
     claude: 'CLAUDE.md',
-  }
+  } as const
 
   const symlinkName = symlinkMap[instruction as Exclude<AIInstruction, 'all' | 'cursor'>]
   const symlinkPath = joinPath(themeRoot, symlinkName)

--- a/packages/theme/src/cli/services/init.ts
+++ b/packages/theme/src/cli/services/init.ts
@@ -1,13 +1,14 @@
-import {renderSelectPrompt, renderTasks} from '@shopify/cli-kit/node/ui'
+import {renderSelectPrompt, renderWarning, renderTasks} from '@shopify/cli-kit/node/ui'
 import {downloadGitRepository, removeGitRemote} from '@shopify/cli-kit/node/git'
 import {joinPath} from '@shopify/cli-kit/node/path'
-import {rmdir, fileExists, inTemporaryDirectory, copyDirectoryContents} from '@shopify/cli-kit/node/fs'
+import {rmdir, fileExists, inTemporaryDirectory, readFile, writeFile, symlink} from '@shopify/cli-kit/node/fs'
 import {AbortError} from '@shopify/cli-kit/node/error'
 
 export const SKELETON_THEME_URL = 'https://github.com/Shopify/skeleton-theme.git'
 const AI_INSTRUCTIONS_REPO_URL = 'https://github.com/Shopify/theme-liquid-docs.git'
 
 const SUPPORTED_AI_INSTRUCTIONS = {
+  all: 'All',
   github: 'VS Code (GitHub Copilot)',
   cursor: 'Cursor',
   claude: 'Claude',
@@ -57,7 +58,7 @@ async function removeDirectory(path: string) {
 
 export async function promptAIInstruction() {
   const aiChoice = (await renderSelectPrompt({
-    message: 'Include LLM instructions in the theme?',
+    message: 'Which LLM instruction file would you like to include in your theme?',
     choices: [
       ...Object.entries(SUPPORTED_AI_INSTRUCTIONS).map(([key, value]) => ({
         label: value,
@@ -71,6 +72,8 @@ export async function promptAIInstruction() {
 }
 
 export async function createAIInstructions(themeRoot: string, aiInstruction: AIInstruction) {
+  const createdFiles: string[] = []
+
   await renderTasks([
     {
       title: `Adding AI instructions into ${themeRoot}`,
@@ -81,16 +84,30 @@ export async function createAIInstructions(themeRoot: string, aiInstruction: AII
             destination: tempDir,
             shallow: true,
           })
-          const aiSrcDir = joinPath(tempDir, 'ai', aiInstruction)
 
-          let aiDestDir = themeRoot
-
-          if (aiInstruction !== 'claude') {
-            aiDestDir = joinPath(themeRoot, `.${aiInstruction}`)
-          }
+          const instructions =
+            aiInstruction === 'all'
+              ? (Object.keys(SUPPORTED_AI_INSTRUCTIONS).filter((key) => key !== 'all') as AIInstruction[])
+              : [aiInstruction]
 
           try {
-            await copyDirectoryContents(aiSrcDir, aiDestDir)
+            const sourcePath = joinPath(tempDir, 'ai', 'github', 'copilot-instructions.md')
+            const sourceContent = await readFile(sourcePath)
+
+            const agentsPath = joinPath(themeRoot, 'AGENTS.md')
+            const agentsContent = `# AGENTS.md\n\n${sourceContent}`
+            await writeFile(agentsPath, agentsContent)
+
+            const results = await Promise.all(
+              instructions.map((instruction) => createAIInstructionFiles(themeRoot, agentsPath, instruction)),
+            )
+
+            // Collect files that were copied instead of symlinked
+            results.forEach((result) => {
+              if (result.copiedFile) {
+                createdFiles.push(result.copiedFile)
+              }
+            })
           } catch (error) {
             throw new AbortError('Failed to create AI instructions')
           }
@@ -98,4 +115,47 @@ export async function createAIInstructions(themeRoot: string, aiInstruction: AII
       },
     },
   ])
+
+  if (createdFiles.length > 0) {
+    renderWarning({
+      headline: 'Files created instead of symlinks.',
+      body: `Shopify CLI attempted to create symbolic links between AGENTS.md and ${createdFiles.join(
+        ', ',
+      )}, but your system doesn't have Developer Mode enabled or symlinks are disabled. Separate files were created instead.`,
+    })
+  }
+}
+
+export async function createAIInstructionFiles(
+  themeRoot: string,
+  agentsPath: string,
+  instruction: AIInstruction,
+): Promise<{copiedFile?: string}> {
+  if (instruction === 'cursor') {
+    // Cursor natively supports AGENTS.md, so no symlink needed
+    return {}
+  }
+
+  const symlinkMap: {[key in Exclude<AIInstruction, 'all' | 'cursor'>]: string} = {
+    github: 'copilot-instructions.md',
+    claude: 'CLAUDE.md',
+  }
+
+  const symlinkName = symlinkMap[instruction as Exclude<AIInstruction, 'all' | 'cursor'>]
+  const symlinkPath = joinPath(themeRoot, symlinkName)
+
+  try {
+    await symlink(agentsPath, symlinkPath)
+    return {}
+  } catch (error) {
+    // On Windows, symlinks may require admin privileges or Developer Mode
+    // Fall back to copying the file if symlink creation fails
+    if (error instanceof Error) {
+      const agentsContent = await readFile(agentsPath)
+      await writeFile(symlinkPath, agentsContent)
+      return {copiedFile: symlinkName}
+    } else {
+      throw error
+    }
+  }
 }


### PR DESCRIPTION
### WHY are these changes introduced?

This pull request updates the `shopify theme init` to consistently use `AGENTS.md` files. For consistency and compatibility, we are keeping symlinks with each editor standard.

<img width="70%" alt="image" src="https://github.com/user-attachments/assets/74dcbab8-9029-46b7-849f-0a85be8aa708" />

Additionally, this pull request introduces a new "All" option to create symlinks for all editors:

<img width="80%" alt="image" src="https://github.com/user-attachments/assets/b0792d23-ca98-4fd2-9da7-c2f75bee97cd" />

### WHAT is this pull request doing?

This pull request:
- Updates the `init` theme service to handle the feature mentioned above
- Updates `cli-kit` to expose the symlink creation API

### How to test your changes?

- Run `shopify theme init`

### Post-release steps

None

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g., a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows).
- [x] I've considered possible [documentation](https://shopify.dev) changes.