### PR TITLE
Allow to create contract-based specifications with some local overrides

### DIFF
--- a/packages/app/src/cli/models/extensions/specification.integration.test.ts
+++ b/packages/app/src/cli/models/extensions/specification.integration.test.ts
@@ -31,7 +31,10 @@ describe('allLocalSpecs', () => {
 describe('createContractBasedModuleSpecification', () => {
   test('creates a specification with the given identifier', () => {
     // When
-    const got = createContractBasedModuleSpecification('test', ['localization'])
+    const got = createContractBasedModuleSpecification({
+      identifier: 'test',
+      appModuleFeatures: () => ['localization'],
+    })
 
     // Then
     expect(got).toMatchObject(

--- a/packages/app/src/cli/models/extensions/specification.ts
+++ b/packages/app/src/cli/models/extensions/specification.ts
@@ -255,17 +255,17 @@ export function createConfigExtensionSpecification<TConfiguration extends BaseCo
 }
 
 export function createContractBasedModuleSpecification<TConfiguration extends BaseConfigType = BaseConfigType>(
-  identifier: string,
-  appModuleFeatures?: ExtensionFeature[],
+  spec: Pick<CreateExtensionSpecType<TConfiguration>, 'identifier' | 'appModuleFeatures' | 'buildConfig'>,
 ) {
   return createExtensionSpecification({
-    identifier,
+    identifier: spec.identifier,
     schema: zod.any({}) as unknown as ZodSchemaType<TConfiguration>,
-    appModuleFeatures: () => appModuleFeatures ?? [],
+    appModuleFeatures: spec.appModuleFeatures,
+    buildConfig: spec.buildConfig,
     deployConfig: async (config, directory) => {
       let parsedConfig = configWithoutFirstClassFields(config)
-      if (appModuleFeatures?.includes('localization')) {
-        const localization = await loadLocalesConfig(directory, identifier)
+      if (spec.appModuleFeatures().includes('localization')) {
+        const localization = await loadLocalesConfig(directory, spec.identifier)
         parsedConfig = {...parsedConfig, localization}
       }
       return parsedConfig

--- a/packages/app/src/cli/models/extensions/specifications/channel.ts
+++ b/packages/app/src/cli/models/extensions/specifications/channel.ts
@@ -1,32 +1,16 @@
-import {createExtensionSpecification} from '../specification.js'
-import {BaseSchemaWithHandle} from '../schemas.js'
-import {zod} from '@shopify/cli-kit/node/schema'
+import {createContractBasedModuleSpecification} from '../specification.js'
 import {joinPath} from '@shopify/cli-kit/node/path'
-
-const ChannelSpecificationSchema = BaseSchemaWithHandle.extend({
-  type: zod.literal('channel_config'),
-  name: zod.string().optional(),
-  description: zod.string().optional(),
-})
 
 const SUBDIRECTORY_NAME = 'specifications'
 const FILE_EXTENSIONS = ['json', 'toml', 'yaml', 'yml', 'svg']
 
-// Generate glob patterns for all supported file types
-const getGlobPatterns = () => FILE_EXTENSIONS.map((ext) => joinPath(SUBDIRECTORY_NAME, '**', `*.${ext}`))
-
-const channelSpecificationSpec = createExtensionSpecification({
+const channelSpecificationSpec = createContractBasedModuleSpecification({
   identifier: 'channel_config',
-  schema: ChannelSpecificationSchema,
-  buildConfig: {mode: 'copy_files', filePatterns: getGlobPatterns()},
-  appModuleFeatures: () => [],
-  deployConfig: async (config, _directory) => {
-    return {
-      handle: config.handle,
-      name: config.name,
-      description: config.description,
-    }
+  buildConfig: {
+    mode: 'copy_files',
+    filePatterns: FILE_EXTENSIONS.map((ext) => joinPath(SUBDIRECTORY_NAME, '**', `*.${ext}`)),
   },
+  appModuleFeatures: () => [],
 })
 
 export default channelSpecificationSpec

--- a/packages/app/src/cli/services/generate/fetch-extension-specifications.ts
+++ b/packages/app/src/cli/services/generate/fetch-extension-specifications.ts
@@ -68,7 +68,10 @@ async function mergeLocalAndRemoteSpecs(
     if (!localSpec && remoteSpec.validationSchema?.jsonSchema) {
       const normalisedSchema = await normaliseJsonSchema(remoteSpec.validationSchema.jsonSchema)
       const hasLocalization = normalisedSchema.properties?.localization !== undefined
-      localSpec = createContractBasedModuleSpecification(remoteSpec.identifier, hasLocalization ? ['localization'] : [])
+      localSpec = createContractBasedModuleSpecification({
+        identifier: remoteSpec.identifier,
+        appModuleFeatures: () => (hasLocalization ? ['localization'] : []),
+      })
       localSpec.uidStrategy = remoteSpec.options.uidIsClientProvided ? 'uuid' : 'single'
     }
     if (!localSpec) return undefined


### PR DESCRIPTION
### WHY are these changes introduced?

Refactors the `createContractBasedModuleSpecification` function to accept a single object parameter instead of multiple arguments, making the API more flexible and consistent.

### WHAT is this pull request doing?

- Modifies `createContractBasedModuleSpecification` to accept a configuration object with `identifier`, `appModuleFeatures`, and `buildConfig` properties
- Updates all calls to this function throughout the codebase
- Simplifies the channel specification implementation by leveraging the contract-based module specification

### How to test your changes?

1. Run the extension specification tests to ensure they pass
2. Create a new channel extension to verify the specification works correctly
3. Verify that existing extensions using contract-based module specifications continue to function properly

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes