### PR TITLE
Add `--variable-file` flag for bulk operation mutations

### DIFF
--- a/packages/app/src/cli/commands/app/execute.ts
+++ b/packages/app/src/cli/commands/app/execute.ts
@@ -39,6 +39,7 @@ export default class Execute extends AppLinkedCommand {
       storeFqdn: store.shopDomain,
       query: flags.query,
       variables: flags.variables,
+      variableFile: flags['variable-file'],
     })
 
     return {app: appContextResult.app}

--- a/packages/app/src/cli/flags.ts
+++ b/packages/app/src/cli/flags.ts
@@ -48,6 +48,14 @@ export const bulkOperationFlags = {
       'The values for any GraphQL variables in your mutation, in JSON format. Can be specified multiple times.',
     env: 'SHOPIFY_FLAG_VARIABLES',
     multiple: true,
+    exclusive: ['variable-file'],
+  }),
+  'variable-file': Flags.string({
+    description:
+      "Path to a file containing GraphQL variables in JSONL format (one JSON object per line). Can't be used with --variables.",
+    env: 'SHOPIFY_FLAG_VARIABLE_FILE',
+    parse: async (input) => resolvePath(input),
+    exclusive: ['variables'],
   }),
   store: Flags.string({
     char: 's',

--- a/packages/app/src/cli/services/bulk-operations/run-mutation.test.ts
+++ b/packages/app/src/cli/services/bulk-operations/run-mutation.test.ts
@@ -34,7 +34,7 @@ describe('runBulkOperationMutation', () => {
     const bulkOperationResult = await runBulkOperationMutation({
       adminSession: mockSession,
       query: 'mutation productUpdate($input: ProductInput!) { productUpdate(input: $input) { product { id } } }',
-      variables: ['{"input":{"id":"gid://shopify/Product/123","tags":["test"]}}'],
+      variablesJsonl: '{"input":{"id":"gid://shopify/Product/123","tags":["test"]}}',
     })
 
     expect(bulkOperationResult?.bulkOperation).toEqual(successfulBulkOperation)

--- a/packages/app/src/cli/services/bulk-operations/run-mutation.ts
+++ b/packages/app/src/cli/services/bulk-operations/run-mutation.ts
@@ -10,17 +10,17 @@ import {AdminSession} from '@shopify/cli-kit/node/session'
 interface BulkOperationRunMutationOptions {
   adminSession: AdminSession
   query: string
-  variables?: string[]
+  variablesJsonl?: string
 }
 
 export async function runBulkOperationMutation(
   options: BulkOperationRunMutationOptions,
 ): Promise<BulkOperationRunMutationMutation['bulkOperationRunMutation']> {
-  const {adminSession, query: mutation, variables} = options
+  const {adminSession, query: mutation, variablesJsonl} = options
 
   const stagedUploadPath = await stageFile({
     adminSession,
-    jsonVariables: variables,
+    variablesJsonl,
   })
 
   const response = await adminRequestDoc<BulkOperationRunMutationMutation, BulkOperationRunMutationMutationVariables>({

--- a/packages/app/src/cli/services/bulk-operations/stage-file.ts
+++ b/packages/app/src/cli/services/bulk-operations/stage-file.ts
@@ -10,13 +10,13 @@ import {AbortError} from '@shopify/cli-kit/node/error'
 
 interface StageFileOptions {
   adminSession: AdminSession
-  jsonVariables?: string[]
+  variablesJsonl?: string
 }
 
 export async function stageFile(options: StageFileOptions): Promise<string> {
-  const {adminSession, jsonVariables = []} = options
+  const {adminSession, variablesJsonl} = options
 
-  const buffer = convertJsonToJsonlBuffer(jsonVariables)
+  const buffer = Buffer.from(variablesJsonl ? `${variablesJsonl}\n` : '', 'utf-8')
   const filename = 'bulk-variables.jsonl'
   const size = buffer.length
 
@@ -26,11 +26,6 @@ export async function stageFile(options: StageFileOptions): Promise<string> {
   await uploadFileToStagedUrl(buffer, target.url, target.parameters, filename)
 
   return target.stagedUploadKey
-}
-
-function convertJsonToJsonlBuffer(jsonVariables: string[]): Buffer {
-  const jsonlContent = `${jsonVariables.join('\n')}\n`
-  return Buffer.from(jsonlContent, 'utf-8')
 }
 
 async function requestStagedUpload(

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -885,10 +885,24 @@
           "name": "store",
           "type": "option"
         },
+        "variable-file": {
+          "description": "Path to a file containing GraphQL variables in JSONL format (one JSON object per line). Can't be used with --variables.",
+          "env": "SHOPIFY_FLAG_VARIABLE_FILE",
+          "exclusive": [
+            "variables"
+          ],
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "variable-file",
+          "type": "option"
+        },
         "variables": {
           "char": "v",
           "description": "The values for any GraphQL variables in your mutation, in JSON format. Can be specified multiple times.",
           "env": "SHOPIFY_FLAG_VARIABLES",
+          "exclusive": [
+            "variable-file"
+          ],
           "hasDynamicHelp": false,
           "multiple": true,
           "name": "variables",


### PR DESCRIPTION
Resolves https://github.com/shop/issues-api-foundations/issues/1110.

### Summary
Adds a new `--variable-file` flag to shopify app execute that allows users to provide mutation variables from a JSONL file instead of passing them inline via `--variables`. This makes it easier to execute bulk operations with many variables.

### Implementation Details
- New function: `parseVariablesToJsonl()` 
  - Validates mutual exclusivity of `--variables` and `--variable-file`
  - Reads and validates file existence
  - Returns variables in JSONL format
- Restructured data flow to use JSONL strings throughout:
  - File content is passed through as JSONL
  - Reduces unnecessary conversions (no split/rejoin for files)
- Simplified `stageFile()`:
  - Now accepts variablesJsonl string parameter
  - Converts directly to Buffer for upload

### Testing
Create a file called `variables.jsonl`. This should be in the file:
```
{"input":{"id":"gid://shopify/Product/123","tags":["test"]}}
{"input":{"id":"gid://shopify/Product/456","tags":["test2"]}}
```

Run this command:
```
pnpm shopify app execute \
  --path <PATH_TO_APP> \
  -q 'mutation productUpdate($input: ProductInput!) { ... }' \
  --variable-file ./variables.jsonl
```