### PR TITLE
wire up identity client to current identity callsites

### DIFF
--- a/packages/cli-kit/src/private/node/session/device-authorization.test.ts
+++ b/packages/cli-kit/src/private/node/session/device-authorization.test.ts
@@ -3,7 +3,6 @@ import {
   pollForDeviceAuthorization,
   requestDeviceAuthorization,
 } from './device-authorization.js'
-import {clientId} from './identity.js'
 import {IdentityToken} from './schema.js'
 import {exchangeDeviceCodeForAccessToken} from './exchange.js'
 import {identityFqdn} from '../../../public/node/context/fqdn.js'
@@ -50,7 +49,6 @@ describe('requestDeviceAuthorization', () => {
     const response = new Response(JSON.stringify(data))
     vi.mocked(shopifyFetch).mockResolvedValue(response)
     vi.mocked(identityFqdn).mockResolvedValue('fqdn.com')
-    vi.mocked(clientId).mockReturnValue('clientId')
 
     // When
     const got = await requestDeviceAuthorization(['scope1', 'scope2'])
@@ -59,7 +57,7 @@ describe('requestDeviceAuthorization', () => {
     expect(shopifyFetch).toBeCalledWith('https://fqdn.com/oauth/device_authorization', {
       method: 'POST',
       headers: {'Content-type': 'application/x-www-form-urlencoded'},
-      body: 'client_id=clientId&scope=scope1 scope2',
+      body: 'client_id=fbdb2649-e327-4907-8f67-908d24cfd7e3&scope=scope1 scope2',
     })
     expect(got).toEqual(dataExpected)
   })
@@ -71,7 +69,6 @@ describe('requestDeviceAuthorization', () => {
     Object.defineProperty(response, 'statusText', {value: 'OK'})
     vi.mocked(shopifyFetch).mockResolvedValue(response)
     vi.mocked(identityFqdn).mockResolvedValue('fqdn.com')
-    vi.mocked(clientId).mockReturnValue('clientId')
 
     // When/Then
     await expect(requestDeviceAuthorization(['scope1', 'scope2'])).rejects.toThrowError(
@@ -86,7 +83,6 @@ describe('requestDeviceAuthorization', () => {
     Object.defineProperty(response, 'statusText', {value: 'OK'})
     vi.mocked(shopifyFetch).mockResolvedValue(response)
     vi.mocked(identityFqdn).mockResolvedValue('fqdn.com')
-    vi.mocked(clientId).mockReturnValue('clientId')
 
     // When/Then
     await expect(requestDeviceAuthorization(['scope1', 'scope2'])).rejects.toThrowError(
@@ -102,7 +98,6 @@ describe('requestDeviceAuthorization', () => {
     Object.defineProperty(response, 'statusText', {value: 'Not Found'})
     vi.mocked(shopifyFetch).mockResolvedValue(response)
     vi.mocked(identityFqdn).mockResolvedValue('fqdn.com')
-    vi.mocked(clientId).mockReturnValue('clientId')
 
     // When/Then
     await expect(requestDeviceAuthorization(['scope1', 'scope2'])).rejects.toThrowError(
@@ -117,7 +112,6 @@ describe('requestDeviceAuthorization', () => {
     Object.defineProperty(response, 'statusText', {value: 'Internal Server Error'})
     vi.mocked(shopifyFetch).mockResolvedValue(response)
     vi.mocked(identityFqdn).mockResolvedValue('fqdn.com')
-    vi.mocked(clientId).mockReturnValue('clientId')
 
     // When/Then
     await expect(requestDeviceAuthorization(['scope1', 'scope2'])).rejects.toThrowError(
@@ -134,7 +128,6 @@ describe('requestDeviceAuthorization', () => {
     response.text = vi.fn().mockRejectedValue(new Error('Network error'))
     vi.mocked(shopifyFetch).mockResolvedValue(response)
     vi.mocked(identityFqdn).mockResolvedValue('fqdn.com')
-    vi.mocked(clientId).mockReturnValue('clientId')
 
     // When/Then
     await expect(requestDeviceAuthorization(['scope1', 'scope2'])).rejects.toThrowError(

--- a/packages/cli-kit/src/private/node/session/device-authorization.ts
+++ b/packages/cli-kit/src/private/node/session/device-authorization.ts
@@ -1,4 +1,3 @@
-import {clientId} from './identity.js'
 import {exchangeDeviceCodeForAccessToken} from './exchange.js'
 import {IdentityToken} from './schema.js'
 import {identityFqdn} from '../../../public/node/context/fqdn.js'
@@ -8,6 +7,7 @@ import {AbortError, BugError} from '../../../public/node/error.js'
 import {isCloudEnvironment} from '../../../public/node/context/local.js'
 import {isCI, openURL} from '../../../public/node/system.js'
 import {isTTY, keypress} from '../../../public/node/ui.js'
+import {getIdentityClient} from '../clients/identity/instance.js'
 import {Response} from 'node-fetch'
 
 export interface DeviceAuthorizationResponse {
@@ -31,7 +31,7 @@ export interface DeviceAuthorizationResponse {
  */
 export async function requestDeviceAuthorization(scopes: string[]): Promise<DeviceAuthorizationResponse> {
   const fqdn = await identityFqdn()
-  const identityClientId = clientId()
+  const identityClientId = getIdentityClient().clientId()
   const queryParams = {client_id: identityClientId, scope: scopes.join(' ')}
   const url = `https://${fqdn}/oauth/device_authorization`
 

--- a/packages/cli-kit/src/private/node/session/exchange.test.ts
+++ b/packages/cli-kit/src/private/node/session/exchange.test.ts
@@ -8,7 +8,7 @@ import {
   refreshAccessToken,
   requestAppToken,
 } from './exchange.js'
-import {applicationId, clientId} from './identity.js'
+import {applicationId} from './identity.js'
 import {IdentityToken} from './schema.js'
 import {shopifyFetch} from '../../../public/node/http.js'
 import {identityFqdn} from '../../../public/node/context/fqdn.js'
@@ -43,7 +43,6 @@ vi.mock('../../../public/node/context/fqdn.js')
 vi.mock('./identity')
 
 beforeEach(() => {
-  vi.mocked(clientId).mockReturnValue('clientId')
   vi.setSystemTime(currentDate)
   vi.mocked(applicationId).mockImplementation((api) => api)
   vi.mocked(identityFqdn).mockResolvedValue('fqdn.com')
@@ -301,7 +300,7 @@ describe.each(tokenExchangeMethods)(
       expect(params.get('grant_type')).toBe(grantType)
       expect(params.get('requested_token_type')).toBe(accessTokenType)
       expect(params.get('subject_token_type')).toBe(accessTokenType)
-      expect(params.get('client_id')).toBe('clientId')
+      expect(params.get('client_id')).toBe('fbdb2649-e327-4907-8f67-908d24cfd7e3')
       expect(params.get('audience')).toBe(expectedApi)
       expect(params.get('scope')).toBe(expectedScopes.join(' '))
       expect(params.get('subject_token')).toBe(cliToken)

--- a/packages/cli-kit/src/private/node/session/identity.ts
+++ b/packages/cli-kit/src/private/node/session/identity.ts
@@ -2,7 +2,7 @@ import {API} from '../api.js'
 import {BugError} from '../../../public/node/error.js'
 import {Environment, serviceEnvironment} from '../context/service.js'
 
-export function clientId(): string {
+function _clientId(): string {
   const environment = serviceEnvironment()
   if (environment === Environment.Local) {
     return 'e5380e02-312a-7408-5718-e07017e9cf52'


### PR DESCRIPTION
### WHY are these changes introduced?

Part of: https://github.com/shop/issues-develop/issues/21594

- We're swapping the current codepaths that call bespoke identity modules to instead use the client
- This allows for easy environment configuration

### WHAT is this pull request doing?

- Simply replace the callsites