### PR TITLE
Block Partners API for 3P devs

### DIFF
--- a/packages/app/src/cli/services/app-logs/dev/poll-app-logs.test.ts
+++ b/packages/app/src/cli/services/app-logs/dev/poll-app-logs.test.ts
@@ -2,20 +2,19 @@ import {pollAppLogs} from './poll-app-logs.js'
 import {writeAppLogsToFile} from './write-app-logs.js'
 import {FunctionRunLog} from '../types.js'
 import {testDeveloperPlatformClient} from '../../../models/app/app.test-data.js'
-import {partnersFqdn} from '@shopify/cli-kit/node/context/fqdn'
 import {describe, expect, test, vi, beforeEach, afterEach} from 'vitest'
 import * as components from '@shopify/cli-kit/node/ui/components'
 import * as output from '@shopify/cli-kit/node/output'
 import camelcaseKeys from 'camelcase-keys'
+import {appManagementFqdn} from '@shopify/cli-kit/node/context/fqdn'
 
 const JWT_TOKEN = 'jwtToken'
-const API_KEY = 'apiKey'
 const TEST_LOGS_DIR = '/test/logs/dir'
 
 vi.mock('./write-app-logs.js')
 vi.mock('@shopify/cli-kit/node/http')
 
-const FQDN = await partnersFqdn()
+const FQDN = await appManagementFqdn()
 const LOGS = '1\\n2\\n3\\n4\\n'
 const FUNCTION_ERROR = 'function_error'
 const FUNCTION_RUN = 'function_run'

--- a/packages/app/src/cli/utilities/developer-platform-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client.ts
@@ -96,11 +96,17 @@ export function selectDeveloperPlatformClient({
   organization,
 }: SelectDeveloperPlatformClientOptions = {}): DeveloperPlatformClient {
   if (organization) return selectDeveloperPlatformClientByOrg(organization)
-  return PartnersClient.getInstance()
+  return defaultDeveloperPlatformClient()
 }
 
 function selectDeveloperPlatformClientByOrg(organization: Organization): DeveloperPlatformClient {
   if (organization.source === OrganizationSource.BusinessPlatform) return AppManagementClient.getInstance()
+  return PartnersClient.getInstance()
+}
+
+function defaultDeveloperPlatformClient(): DeveloperPlatformClient {
+  if (blockPartnersAccess()) return AppManagementClient.getInstance()
+
   return PartnersClient.getInstance()
 }
 

--- a/packages/cli-kit/src/public/node/context/fqdn.test.ts
+++ b/packages/cli-kit/src/public/node/context/fqdn.test.ts
@@ -8,9 +8,11 @@ import {
   adminFqdn,
 } from './fqdn.js'
 import {Environment, serviceEnvironment} from '../../../private/node/context/service.js'
+import {blockPartnersAccess} from '../environment.js'
 import {expect, describe, test, vi} from 'vitest'
 
 vi.mock('../../../private/node/context/service.js')
+vi.mock('../environment.js')
 
 vi.mock('../vendor/dev_server/index.js', () => {
   return {
@@ -32,6 +34,7 @@ describe('partners', () => {
   test('returns the local fqdn when the environment is local', async () => {
     // Given
     vi.mocked(serviceEnvironment).mockReturnValue(Environment.Local)
+    vi.mocked(blockPartnersAccess).mockReturnValue(false)
 
     // When
     const got = await partnersFqdn()
@@ -43,6 +46,7 @@ describe('partners', () => {
   test('returns the production fqdn when the environment is production', async () => {
     // Given
     vi.mocked(serviceEnvironment).mockReturnValue(Environment.Production)
+    vi.mocked(blockPartnersAccess).mockReturnValue(false)
 
     // When
     const got = await partnersFqdn()

--- a/packages/cli-kit/src/public/node/context/fqdn.ts
+++ b/packages/cli-kit/src/public/node/context/fqdn.ts
@@ -14,7 +14,7 @@ export const NotProvidedStoreFQDNError = new AbortError(
  */
 export async function partnersFqdn(): Promise<string> {
   if (blockPartnersAccess()) {
-    throw new BugError('Partners API is blocked by the SHOPIFY_CLI_NEVER_USE_PARTNERS_API environment variable.')
+    throw new BugError('Partners API is is no longer available.')
   }
   const environment = serviceEnvironment()
   const productionFqdn = 'partners.shopify.com'

--- a/packages/cli-kit/src/public/node/environment.ts
+++ b/packages/cli-kit/src/public/node/environment.ts
@@ -86,10 +86,13 @@ export function jsonOutputEnabled(environment = getEnvironmentVariables()): bool
 /**
  * If true, the CLI should not use the Partners API.
  *
- * @returns True if the SHOPIFY_CLI_NEVER_USE_PARTNERS_API environment variable is set.
+ * @returns True when SHOPIFY_CLI_NEVER_USE_PARTNERS_API is set or SHOPIFY_CLI_1P_DEV is not set.
  */
 export function blockPartnersAccess(): boolean {
-  return isTruthy(getEnvironmentVariables()[environmentVariables.neverUsePartnersApi])
+  return (
+    isTruthy(getEnvironmentVariables()[environmentVariables.neverUsePartnersApi]) ||
+    !isTruthy(getEnvironmentVariables()[environmentVariables.firstPartyDev])
+  )
 }
 
 /**


### PR DESCRIPTION
### WHY are these changes introduced?

Only 1P devs still need Partners API, so we can avoid additional API calls for the rest

### WHAT is this pull request doing?

- Blocks Partners API when `SHOPIFY_CLI_NEVER_USE_PARTNERS_API` is set or `SHOPIFY_CLI_1P_DEV` is not set
- Makes App Management API the default API

### How to test your changes?

- `p shopify app init --template none --verbose` => No Partners
- `SHOPIFY_CLI_1P_DEV=1 p shopify app init --template none --verbose` => uses Partners
- `SHOPIFY_CLI_NEVER_USE_PARTNERS_API=1 SHOPIFY_CLI_1P_DEV=1 p shopify app init --template none --verbose` => No Partners


### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
