### PR TITLE
add option to bypass running service check if configured

### DIFF
--- a/packages/cli-kit/src/public/node/context/fqdn.ts
+++ b/packages/cli-kit/src/public/node/context/fqdn.ts
@@ -115,7 +115,7 @@ export async function identityFqdn(): Promise<string> {
   const productionFqdn = 'accounts.shopify.com'
   switch (environment) {
     case 'local':
-      return new DevServer('identity').host()
+      return new DevServer('identity').host({useMockIfNotRunning: true})
     default:
       return productionFqdn
   }

--- a/packages/cli-kit/src/public/node/vendor/dev_server/dev-server-2024.test.ts
+++ b/packages/cli-kit/src/public/node/vendor/dev_server/dev-server-2024.test.ts
@@ -1,0 +1,24 @@
+import {createServer} from './dev-server-2024.js'
+import {beforeEach, describe, expect, test} from 'vitest'
+import {assertCompatibleEnvironment} from './env.js'
+import {vi} from 'vitest'
+
+vi.mock('./env.js')
+
+beforeEach(() => {
+  vi.mocked(assertCompatibleEnvironment).mockImplementation(() => true)
+})
+
+describe('createServer', () => {
+  describe('host', () => {
+    test('throws when dev server is not running and useMockIfNotRunning is not set', () => {
+      const server = createServer('test-project')
+      expect(() => server.host()).toThrow()
+    })
+
+    test('does not throw when useMockIfNotRunning is true', () => {
+      const server = createServer('test-project')
+      expect(() => server.host({useMockIfNotRunning: true})).not.toThrow()
+    })
+  })
+})

--- a/packages/cli-kit/src/public/node/vendor/dev_server/dev-server-2024.ts
+++ b/packages/cli-kit/src/public/node/vendor/dev_server/dev-server-2024.ts
@@ -16,9 +16,12 @@ export function createServer(projectName: string) {
   }
 }
 
-function host(projectName: string, options: HostOptions = {}): string {
+function host(projectName: string, options: HostOptions = {useMockIfNotRunning: false}): string {
   assertCompatibleEnvironment()
-  ;(assertRunningOverride || assertRunning2024)(projectName)
+
+  if (!options.useMockIfNotRunning) {
+    assertRunning2024(projectName)
+  }
 
   const prefix = (options.nonstandardHostPrefix || projectName).replace(/_/g, '-')
 
@@ -79,11 +82,4 @@ function resolveBackendHost(name: string): string {
   } catch {
     return host
   }
-}
-
-// Allow overrides for more concise test setup. Meh.
-let assertRunningOverride: typeof assertRunning2024 | undefined
-
-export function setAssertRunning(override: typeof assertRunningOverride) {
-  assertRunningOverride = override
 }

--- a/packages/cli-kit/src/public/node/vendor/dev_server/types.ts
+++ b/packages/cli-kit/src/public/node/vendor/dev_server/types.ts
@@ -10,4 +10,5 @@ export interface DevServer {
 
 export interface HostOptions {
   nonstandardHostPrefix?: string
+  useMockIfNotRunning?: boolean
 }


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Part of: shop/issues-develop#21594

- Allow the CLI to not throw in local development when a service is not running if configured
- This will allow certain services to be mocked out

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

- add a configuration option `useMockIfNotRunning` passed to the dev server that omits the DevServer running check if `true`

### How to test your changes?

- added a test file for the 2024 dev server
