### PR TITLE
Add admin-as-app authentication

### DIFF
--- a/packages/app/src/cli/api/admin-as-app.test.ts
+++ b/packages/app/src/cli/api/admin-as-app.test.ts
@@ -1,0 +1,69 @@
+import {adminAsAppRequestDoc} from './admin-as-app.js'
+import {graphqlRequestDoc} from '@shopify/cli-kit/node/api/graphql'
+import {AdminSession} from '@shopify/cli-kit/node/session'
+import {describe, test, expect, vi, beforeEach} from 'vitest'
+import {TypedDocumentNode} from '@graphql-typed-document-node/core'
+
+vi.mock('@shopify/cli-kit/node/api/graphql')
+
+describe('adminAsAppRequestDoc', () => {
+  const mockSession: AdminSession = {
+    token: 'test-app-token',
+    storeFqdn: 'test-store.myshopify.com',
+  }
+
+  const mockQuery: TypedDocumentNode<{shop: {name: string}}, {id: string}> = {} as any
+  const mockVariables = {id: 'gid://shopify/Shop/123'}
+  const mockResponse = {shop: {name: 'Test Shop'}}
+
+  beforeEach(() => {
+    vi.mocked(graphqlRequestDoc).mockResolvedValue(mockResponse)
+  })
+
+  test('calls graphqlRequestDoc with correct parameters', async () => {
+    // When
+    await adminAsAppRequestDoc({
+      query: mockQuery,
+      session: mockSession,
+      variables: mockVariables,
+    })
+
+    // Then
+    expect(graphqlRequestDoc).toHaveBeenCalledWith({
+      query: mockQuery,
+      token: 'test-app-token',
+      api: 'Admin',
+      url: 'https://test-store.myshopify.com/admin/api/unstable/graphql.json',
+      variables: mockVariables,
+    })
+  })
+
+  test('returns the response from graphqlRequestDoc', async () => {
+    // When
+    const result = await adminAsAppRequestDoc({
+      query: mockQuery,
+      session: mockSession,
+      variables: mockVariables,
+    })
+
+    // Then
+    expect(result).toEqual(mockResponse)
+  })
+
+  test('works without variables', async () => {
+    // When
+    await adminAsAppRequestDoc({
+      query: mockQuery,
+      session: mockSession,
+    })
+
+    // Then
+    expect(graphqlRequestDoc).toHaveBeenCalledWith({
+      query: mockQuery,
+      token: 'test-app-token',
+      api: 'Admin',
+      url: 'https://test-store.myshopify.com/admin/api/unstable/graphql.json',
+      variables: undefined,
+    })
+  })
+})

--- a/packages/app/src/cli/api/admin-as-app.ts
+++ b/packages/app/src/cli/api/admin-as-app.ts
@@ -1,0 +1,47 @@
+import {graphqlRequestDoc} from '@shopify/cli-kit/node/api/graphql'
+import {adminUrl} from '@shopify/cli-kit/node/api/admin'
+import {AdminSession} from '@shopify/cli-kit/node/session'
+import {Variables} from 'graphql-request'
+import {TypedDocumentNode} from '@graphql-typed-document-node/core'
+
+/**
+ * @param query - GraphQL query to execute.
+ * @param session - Admin session.
+ * @param variables - GraphQL variables to pass to the query.
+ */
+interface AdminAsAppRequestOptions<TResult, TVariables extends Variables> {
+  query: TypedDocumentNode<TResult, TVariables>
+  session: AdminSession
+  variables?: TVariables
+}
+
+/**
+ * Sets up the request to the Shopify Admin API, on behalf of the app.
+ *
+ * @param session - Admin session.
+ */
+async function setupAdminAsAppRequest(session: AdminSession) {
+  const api = 'Admin'
+  const url = adminUrl(session.storeFqdn, 'unstable')
+  return {
+    token: session.token,
+    api,
+    url,
+  }
+}
+
+/**
+ * Executes a GraphQL query against the Shopify Admin API, on behalf of the app. Uses typed documents.
+ *
+ * @param options - The options for the request.
+ * @returns The response of the query of generic type <T>.
+ */
+export async function adminAsAppRequestDoc<TResult, TVariables extends Variables>(
+  options: AdminAsAppRequestOptions<TResult, TVariables>,
+): Promise<TResult> {
+  return graphqlRequestDoc<TResult, TVariables>({
+    query: options.query,
+    ...(await setupAdminAsAppRequest(options.session)),
+    variables: options.variables,
+  })
+}


### PR DESCRIPTION
### WHY are these changes introduced?

To enable the CLI to make authenticated requests to the Admin API on behalf of the app, rather than on behalf of the logged in user. This is useful for tasks where its important that the app's access and identity is used.

### WHAT is this pull request doing?

- Adds `adminAsAppRequestDoc` function to execute GraphQL queries against the Admin API on behalf of an app
- Implements `ensureAuthenticatedAdminAsApp` to obtain app-based authentication tokens
- Adds comprehensive test coverage for both new functions
