### PR TITLE
Hook DCDD import into import-extensions command

### DIFF
--- a/packages/app/src/cli/commands/app/deploy.ts
+++ b/packages/app/src/cli/commands/app/deploy.ts
@@ -87,7 +87,7 @@ export default class Deploy extends AppLinkedCommand {
     }
     this.failMissingNonTTYFlags(flags, requiredNonTTYFlags)
 
-    const {app, remoteApp, developerPlatformClient, organization} = await linkedAppContext({
+    const {app, remoteApp, developerPlatformClient, organization, specifications} = await linkedAppContext({
       directory: flags.path,
       clientId,
       forceRelink: flags.reset,
@@ -106,6 +106,7 @@ export default class Deploy extends AppLinkedCommand {
       version: flags.version,
       commitReference: flags['source-control-url'],
       skipBuild: flags['no-build'],
+      specifications,
     })
 
     return {app: result.app}

--- a/packages/app/src/cli/services/generate/shop-import/declarative-definitions.ts
+++ b/packages/app/src/cli/services/generate/shop-import/declarative-definitions.ts
@@ -200,7 +200,7 @@ export function processDeclarativeDefinitionNodes(
   }
 }
 
-async function _importDeclarativeDefinitions(options: ImportDeclarativeDefinitionsOptions) {
+export async function importDeclarativeDefinitions(options: ImportDeclarativeDefinitionsOptions) {
   const adminSession = await renderSingleTask({
     title: outputContent`Connecting to shop`,
     task: async () => {


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

This hooks the import of declarative definitions into the `import-extensions` command. It requires a selection of changes: unlike other extensions, these are never automatically imported.
