### PR TITLE
Refactor identity client code execution

### DIFF
--- a/packages/cli-kit/src/private/node/clients/identity/identity-client.ts
+++ b/packages/cli-kit/src/private/node/clients/identity/identity-client.ts
@@ -1,18 +1,31 @@
-import {IdentityToken} from '../../session/schema.js'
-import {TokenRequestResult} from '../../session/exchange.js'
 import {API} from '../../api.js'
 import {Environment, serviceEnvironment} from '../../context/service.js'
 import {BugError} from '../../../../public/node/error.js'
 import {Result} from '../../../../public/node/result.js'
 
-export abstract class IdentityClient {
-  abstract requestAccessToken(scopes: string[]): Promise<IdentityToken>
+export interface TokenRequestResult {
+  access_token: string
+  expires_in: number
+  refresh_token: string
+  scope: string
+  id_token?: string
+}
 
+export interface DeviceAuthorizationResponse {
+  deviceCode: string
+  userCode: string
+  verificationUri: string
+  expiresIn: number
+  verificationUriComplete?: string
+  interval?: number
+}
+
+export abstract class IdentityClient {
   abstract tokenRequest(params: {
     [key: string]: string
   }): Promise<Result<TokenRequestResult, {error: string; store?: string}>>
 
-  abstract refreshAccessToken(currentToken: IdentityToken): Promise<IdentityToken>
+  abstract requestDeviceAuthorization(scopes: string[]): Promise<DeviceAuthorizationResponse>
 
   abstract clientId(): string
 

--- a/packages/cli-kit/src/private/node/session.ts
+++ b/packages/cli-kit/src/private/node/session.ts
@@ -3,6 +3,8 @@ import {allDefaultScopes, apiScopes} from './session/scopes.js'
 import {
   exchangeAccessForApplicationTokens,
   exchangeCustomPartnerToken,
+  requestAccessToken,
+  refreshAccessToken,
   ExchangeScopes,
   InvalidGrantError,
   InvalidRequestError,
@@ -288,7 +290,6 @@ The CLI is currently unable to prompt for reauthentication.`,
  * Execute the full authentication flow.
  *
  * @param applications - An object containing the applications we need to be authenticated with.
- * @param alias - Optional alias to use for the session.
  */
 async function executeCompleteFlow(applications: OAuthApplications): Promise<Session> {
   const scopes = getFlattenScopes(applications)
@@ -305,7 +306,7 @@ async function executeCompleteFlow(applications: OAuthApplications): Promise<Ses
   if (identityTokenInformation) {
     identityToken = buildIdentityTokenFromEnv(scopes, identityTokenInformation)
   } else {
-    identityToken = await identityClient.requestAccessToken(scopes)
+    identityToken = await requestAccessToken(scopes)
   }
 
   // Exchange identity token for application tokens
@@ -336,7 +337,7 @@ async function executeCompleteFlow(applications: OAuthApplications): Promise<Ses
  */
 async function refreshTokens(session: Session, applications: OAuthApplications): Promise<Session> {
   // Refresh Identity Token
-  const identityToken = await getIdentityClient().refreshAccessToken(session.identity)
+  const identityToken = await refreshAccessToken(session.identity)
   // Exchange new identity token for application tokens
   const exchangeScopes = getExchangeScopes(applications)
   const applicationTokens = await exchangeAccessForApplicationTokens(

--- a/packages/cli-kit/src/private/node/session/device-authorization.ts
+++ b/packages/cli-kit/src/private/node/session/device-authorization.ts
@@ -1,14 +1,5 @@
 import {Response} from 'node-fetch'
 
-export interface DeviceAuthorizationResponse {
-  deviceCode: string
-  userCode: string
-  verificationUri: string
-  expiresIn: number
-  verificationUriComplete?: string
-  interval?: number
-}
-
 export function convertRequestToParams(queryParams: {client_id: string; scope: string}): string {
   return Object.entries(queryParams)
     .map(([key, value]) => value && `${key}=${value}`)

--- a/packages/cli-kit/src/private/node/session/token-utils.ts
+++ b/packages/cli-kit/src/private/node/session/token-utils.ts
@@ -1,0 +1,87 @@
+import {ApplicationToken, IdentityToken} from './schema.js'
+import {TokenRequestResult} from '../clients/identity/identity-client.js'
+import {AbortError, BugError, ExtendableError} from '../../../public/node/error.js'
+import * as jose from 'jose'
+
+export class InvalidGrantError extends ExtendableError {}
+export class InvalidRequestError extends ExtendableError {}
+class InvalidTargetError extends AbortError {}
+
+/**
+ * Handles errors returned from token requests to the identity service.
+ * Maps specific error codes to appropriate error types for proper error handling.
+ *
+ * @param error - The error code returned from the identity service
+ * @param store - Optional store name for contextual error messages
+ * @returns An appropriate error instance based on the error code
+ */
+export function tokenRequestErrorHandler({error, store}: {error: string; store?: string}) {
+  const invalidTargetErrorMessage = `You are not authorized to use the CLI to develop in the provided store${
+    store ? `: ${store}` : '.'
+  }`
+
+  if (error === 'invalid_grant') {
+    // There's a scenario when Identity returns "invalid_grant" when trying to refresh the token
+    // using a valid refresh token. When that happens, we take the user through the authentication flow.
+    return new InvalidGrantError()
+  }
+  if (error === 'invalid_request') {
+    // There's a scenario when Identity returns "invalid_request" when exchanging an identity token.
+    // This means the token is invalid. We clear the session and throw an error to let the caller know.
+    return new InvalidRequestError()
+  }
+  if (error === 'invalid_target') {
+    return new InvalidTargetError(invalidTargetErrorMessage, '', [
+      'Ensure you have logged in to the store using the Shopify admin at least once.',
+      'Ensure you are the store owner, or have a staff account if you are attempting to log in to a dev store.',
+      'Ensure you are using the permanent store domain, not a vanity domain.',
+    ])
+  }
+  // eslint-disable-next-line @shopify/cli/no-error-factory-functions
+  return new AbortError(error)
+}
+
+/**
+ * Builds an IdentityToken from a token request result.
+ * Extracts the user ID from the id_token JWT if not provided.
+ *
+ * @param result - The token request result from the identity service
+ * @param existingUserId - Optional existing user ID to preserve
+ * @param existingAlias - Optional existing alias to preserve
+ * @returns A complete IdentityToken with all required fields
+ */
+export function buildIdentityToken(
+  result: TokenRequestResult,
+  existingUserId?: string,
+  existingAlias?: string,
+): IdentityToken {
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  const userId = existingUserId ?? (result.id_token ? jose.decodeJwt(result.id_token).sub! : undefined)
+
+  if (!userId) {
+    throw new BugError('Error setting userId for session. No id_token or pre-existing user ID provided.')
+  }
+
+  return {
+    accessToken: result.access_token,
+    refreshToken: result.refresh_token,
+    expiresAt: new Date(Date.now() + result.expires_in * 1000),
+    scopes: result.scope.split(' '),
+    userId,
+    alias: existingAlias,
+  }
+}
+
+/**
+ * Builds an ApplicationToken from a token request result.
+ *
+ * @param result - The token request result from the identity service
+ * @returns An ApplicationToken with access token, expiration, and scopes
+ */
+export function buildApplicationToken(result: TokenRequestResult): ApplicationToken {
+  return {
+    accessToken: result.access_token,
+    expiresAt: new Date(Date.now() + result.expires_in * 1000),
+    scopes: result.scope.split(' '),
+  }
+}


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Part of: shop/issues-develop#21594

- Refactor the auth/identity flows slightly to make the client lightweight
- This also removes circular dependencies between existing auth modules and our new client

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

- pull shared util code into separate module
- only house identity network flows within the client

### How to test your changes?

- Have core running always
- Supported env configurations:
1. BP Online ✅  + Identity Online ✅ 
2. BP Online ✅  + Identity Offline ❌ 
3. Prod auth flows with local CLI ✅ 

- I'm running a simple `pnpm shopify auth logout && SHOPIFY_CLI_NEVER_USE_PARTNERS_API=1 SHOPIFY_SERVICE_ENV=local pnpm shopify app info`
- Then the same command without `pnpm shopify auth logout` to test without the entire flow
- Do this for all environment combinations

We are still blocked on BP + Management API auth checks, so these patches are required to allow the CLI to authenticate correctly in all non-prod scenarios

<details>
<summary>BP Patch</summary>

In `db/data/access/api_clients.yml` add

```yml
- name: shopify-cli-development
  client_id: shopify-cli-development # key change
  scopes:
  - # <existing scopes as other development client>
  environments:
  - development
  - test
```
</details>

<details>
<summary>Core Patch</summary>

In `components/apps/app/controllers/concerns/organization_authorization_concern.rb#organization_user`

```ruby
if DevelopmentSupport::HostDetection.running?(service_name: "business-platform") &&
        DevelopmentSupport::HostDetection.running?(service_name: "identity")
      @organization_user ||= 
        AccessAndAuth::FetchOrganizationUser.perform(
          # ...
        )
      )
    else
      @organization_user ||= AccessAndAuth::OrganizationUser.new( # key change to mock out user
        id: "gid://Shopify/OrganizationUser/1",
        status: "good",
        organization_permissions: [:develop_apps],
        owner: true,
        organization: AccessAndAuth::Organization.new(organization_id: 1),
        full_name: 'Dev User',
        email: "dev@shopify.com",
        administrative_permissions: []
      )
    end
```
</details>