### PR TITLE
Remove unused field selections from `BulkOperation` GraphQL documents

### DIFF
--- a/packages/app/src/cli/api/graphql/bulk-operations/generated/bulk-operation-run-mutation.ts
+++ b/packages/app/src/cli/api/graphql/bulk-operations/generated/bulk-operation-run-mutation.ts
@@ -15,14 +15,10 @@ export type BulkOperationRunMutationMutation = {
       completedAt?: unknown | null
       createdAt: unknown
       errorCode?: Types.BulkOperationErrorCode | null
-      fileSize?: unknown | null
       id: string
       objectCount: unknown
       partialDataUrl?: string | null
-      query: string
-      rootObjectCount: unknown
       status: Types.BulkOperationStatus
-      type: Types.BulkOperationType
       url?: string | null
     } | null
     userErrors: {code?: Types.BulkMutationErrorCode | null; field?: string[] | null; message: string}[]
@@ -88,14 +84,10 @@ export const BulkOperationRunMutation = {
                       {kind: 'Field', name: {kind: 'Name', value: 'completedAt'}},
                       {kind: 'Field', name: {kind: 'Name', value: 'createdAt'}},
                       {kind: 'Field', name: {kind: 'Name', value: 'errorCode'}},
-                      {kind: 'Field', name: {kind: 'Name', value: 'fileSize'}},
                       {kind: 'Field', name: {kind: 'Name', value: 'id'}},
                       {kind: 'Field', name: {kind: 'Name', value: 'objectCount'}},
                       {kind: 'Field', name: {kind: 'Name', value: 'partialDataUrl'}},
-                      {kind: 'Field', name: {kind: 'Name', value: 'query'}},
-                      {kind: 'Field', name: {kind: 'Name', value: 'rootObjectCount'}},
                       {kind: 'Field', name: {kind: 'Name', value: 'status'}},
-                      {kind: 'Field', name: {kind: 'Name', value: 'type'}},
                       {kind: 'Field', name: {kind: 'Name', value: 'url'}},
                       {kind: 'Field', name: {kind: 'Name', value: '__typename'}},
                     ],

--- a/packages/app/src/cli/api/graphql/bulk-operations/generated/bulk-operation-run-query.ts
+++ b/packages/app/src/cli/api/graphql/bulk-operations/generated/bulk-operation-run-query.ts
@@ -13,14 +13,10 @@ export type BulkOperationRunQueryMutation = {
       completedAt?: unknown | null
       createdAt: unknown
       errorCode?: Types.BulkOperationErrorCode | null
-      fileSize?: unknown | null
       id: string
       objectCount: unknown
       partialDataUrl?: string | null
-      query: string
-      rootObjectCount: unknown
       status: Types.BulkOperationStatus
-      type: Types.BulkOperationType
       url?: string | null
     } | null
     userErrors: {code?: Types.BulkOperationUserErrorCode | null; field?: string[] | null; message: string}[]
@@ -71,14 +67,10 @@ export const BulkOperationRunQuery = {
                       {kind: 'Field', name: {kind: 'Name', value: 'completedAt'}},
                       {kind: 'Field', name: {kind: 'Name', value: 'createdAt'}},
                       {kind: 'Field', name: {kind: 'Name', value: 'errorCode'}},
-                      {kind: 'Field', name: {kind: 'Name', value: 'fileSize'}},
                       {kind: 'Field', name: {kind: 'Name', value: 'id'}},
                       {kind: 'Field', name: {kind: 'Name', value: 'objectCount'}},
                       {kind: 'Field', name: {kind: 'Name', value: 'partialDataUrl'}},
-                      {kind: 'Field', name: {kind: 'Name', value: 'query'}},
-                      {kind: 'Field', name: {kind: 'Name', value: 'rootObjectCount'}},
                       {kind: 'Field', name: {kind: 'Name', value: 'status'}},
-                      {kind: 'Field', name: {kind: 'Name', value: 'type'}},
                       {kind: 'Field', name: {kind: 'Name', value: 'url'}},
                       {kind: 'Field', name: {kind: 'Name', value: '__typename'}},
                     ],

--- a/packages/app/src/cli/api/graphql/bulk-operations/generated/types.d.ts
+++ b/packages/app/src/cli/api/graphql/bulk-operations/generated/types.d.ts
@@ -188,13 +188,6 @@ export type BulkOperationStatus =
   /** The bulk operation is runnning. */
   | 'RUNNING'
 
-/** The valid values for the bulk operation's type. */
-export type BulkOperationType =
-  /** The bulk operation is a mutation. */
-  | 'MUTATION'
-  /** The bulk operation is a query. */
-  | 'QUERY'
-
 /** Possible error codes that can be returned by `BulkOperationUserError`. */
 export type BulkOperationUserErrorCode =
   /** The input value is invalid. */

--- a/packages/app/src/cli/api/graphql/bulk-operations/mutations/bulk-operation-run-mutation.graphql
+++ b/packages/app/src/cli/api/graphql/bulk-operations/mutations/bulk-operation-run-mutation.graphql
@@ -12,14 +12,10 @@ mutation BulkOperationRunMutation(
       completedAt
       createdAt
       errorCode
-      fileSize
       id
       objectCount
       partialDataUrl
-      query
-      rootObjectCount
       status
-      type
       url
     }
     userErrors {

--- a/packages/app/src/cli/api/graphql/bulk-operations/mutations/bulk-operation-run-query.graphql
+++ b/packages/app/src/cli/api/graphql/bulk-operations/mutations/bulk-operation-run-query.graphql
@@ -8,14 +8,10 @@ mutation BulkOperationRunQuery($query: String!) {
       completedAt
       createdAt
       errorCode
-      fileSize
       id
       objectCount
       partialDataUrl
-      query
-      rootObjectCount
       status
-      type
       url
     }
     userErrors {

--- a/packages/app/src/cli/services/bulk-operations/execute-bulk-operation.test.ts
+++ b/packages/app/src/cli/services/bulk-operations/execute-bulk-operation.test.ts
@@ -32,13 +32,9 @@ describe('executeBulkOperation', () => {
     status: 'CREATED',
     errorCode: null,
     createdAt: '2024-01-01T00:00:00Z',
-    objectCount: '0',
-    fileSize: '0',
-    url: null,
-    query: '{ products { edges { node { id } } } }',
-    rootObjectCount: '0',
-    type: 'QUERY',
     completedAt: null,
+    objectCount: '0',
+    url: null,
     partialDataUrl: null,
   }
 


### PR DESCRIPTION
Adjacent to https://github.com/shop/issues-api-foundations/issues/1093, but not directly related.

### WHY are these changes introduced?

I noticed while working on https://github.com/Shopify/cli/pull/6595 that we are asking for fields that we don't use in some of our GraphQL mutations. I want us to follow GraphQL best practices so I'm cleaning that up :)

### WHAT is this pull request doing?

Clean up the field selections of `bulkOperationRunMutation` and `bulkOperationRunQuery`, so that we don't ask for any fields that we won't actually use.

### How to test your changes?

All tests pass and all tophat steps from https://github.com/Shopify/cli/pull/6595 still work.