### PR TITLE
Introduce `--output-file` flag, write bulk operation results to STDOUT or a file

### DIFF
--- a/packages/app/src/cli/commands/app/execute.ts
+++ b/packages/app/src/cli/commands/app/execute.ts
@@ -41,6 +41,7 @@ export default class Execute extends AppLinkedCommand {
       variables: flags.variables,
       variableFile: flags['variable-file'],
       watch: flags.watch,
+      outputFile: flags['output-file'],
     })
 
     return {app: appContextResult.app}

--- a/packages/app/src/cli/flags.ts
+++ b/packages/app/src/cli/flags.ts
@@ -68,4 +68,8 @@ export const bulkOperationFlags = {
     env: 'SHOPIFY_FLAG_WATCH',
     default: false,
   }),
+  'output-file': Flags.string({
+    description: 'The file path where results should be written. If not specified, results will be written to STDOUT.',
+    env: 'SHOPIFY_FLAG_OUTPUT_FILE',
+  }),
 }

--- a/packages/app/src/cli/services/bulk-operations/download-bulk-operation-results.test.ts
+++ b/packages/app/src/cli/services/bulk-operations/download-bulk-operation-results.test.ts
@@ -1,0 +1,35 @@
+import {downloadBulkOperationResults} from './download-bulk-operation-results.js'
+import {fetch} from '@shopify/cli-kit/node/http'
+import {describe, test, expect, vi} from 'vitest'
+
+vi.mock('@shopify/cli-kit/node/http')
+
+describe('downloadBulkOperationResults', () => {
+  test('returns text content when fetch is successful', async () => {
+    const mockUrl = 'https://example.com/results.jsonl'
+    const mockContent = '{"id":"gid://shopify/Product/123"}\n{"id":"gid://shopify/Product/456"}'
+
+    vi.mocked(fetch).mockResolvedValue({
+      ok: true,
+      text: async () => mockContent,
+    } as Awaited<ReturnType<typeof fetch>>)
+
+    const result = await downloadBulkOperationResults(mockUrl)
+
+    expect(fetch).toHaveBeenCalledWith(mockUrl)
+    expect(result).toBe(mockContent)
+  })
+
+  test('throws error when fetch fails', async () => {
+    const mockUrl = 'https://example.com/results.jsonl'
+
+    vi.mocked(fetch).mockResolvedValue({
+      ok: false,
+      statusText: 'Not Found',
+    } as Awaited<ReturnType<typeof fetch>>)
+
+    await expect(downloadBulkOperationResults(mockUrl)).rejects.toThrow(
+      'Failed to download bulk operation results: Not Found',
+    )
+  })
+})

--- a/packages/app/src/cli/services/bulk-operations/download-bulk-operation-results.ts
+++ b/packages/app/src/cli/services/bulk-operations/download-bulk-operation-results.ts
@@ -1,0 +1,12 @@
+import {fetch} from '@shopify/cli-kit/node/http'
+import {AbortError} from '@shopify/cli-kit/node/error'
+
+export async function downloadBulkOperationResults(url: string): Promise<string> {
+  const response = await fetch(url)
+
+  if (!response.ok) {
+    throw new AbortError(`Failed to download bulk operation results: ${response.statusText}`)
+  }
+
+  return response.text()
+}

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -846,6 +846,14 @@
           "name": "no-color",
           "type": "boolean"
         },
+        "output-file": {
+          "description": "The file path where results should be written. If not specified, results will be written to STDOUT.",
+          "env": "SHOPIFY_FLAG_OUTPUT_FILE",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "output-file",
+          "type": "option"
+        },
         "path": {
           "description": "The path to your app directory.",
           "env": "SHOPIFY_FLAG_PATH",


### PR DESCRIPTION
### WHY are these changes introduced?

https://github.com/shop/issues-api-foundations/issues/1096

### WHAT is this pull request doing?

Adds behaviour to `shopify app execute` to match the designs:

- if `--watch` and `--output-file` are both provided, write results to that file after completion
- if `--watch` is provided but `--output-file` is not, write results to STDOUT after completion
- if `--watch` is not provided, no change to behaviour

### How to test your changes?

Try running `shopify app execute` with `--watch` and `--output-file` and verify it writes to the correct file:

```
pnpm shopify app execute --path=<PATH_TO_YOUR_APP> --query="{ products { edges { node { id } } } }" --watch --output-file=my-results.jsonl
```

<img width="754" height="277" alt="image" src="https://github.com/user-attachments/assets/c4144b26-ea59-4326-ac1f-6862560fbaea" />

<img width="615" height="320" alt="image" src="https://github.com/user-attachments/assets/cdc82513-3adc-4f58-bb29-2a684625963f" />

Then try doing the same thing without `--output-file`, and verify it prints to STDOUT:

```
pnpm shopify app execute --path=<PATH_TO_YOUR_APP> --query="{ products { edges { node { id } } } }" --watch
```

<img width="902" height="812" alt="image" src="https://github.com/user-attachments/assets/ce8492a7-3e3c-40d5-81f9-aceeaafd9fc3" />
