### PR TITLE
Suggest `auth login` to change the account

### DIFF
--- a/packages/app/src/cli/services/context.test.ts
+++ b/packages/app/src/cli/services/context.test.ts
@@ -716,7 +716,7 @@ const renderTryMessage = (isOrg: boolean, identifier: string) => [
         'Check that your account has permission to develop apps for this organization or contact the owner of the organization to grant you permission',
         [
           'Run',
-          {command: 'shopify auth logout'},
+          {command: 'shopify auth login'},
           'to log into a different',
           isOrg ? 'organization' : 'account',
           'than',

--- a/packages/app/src/cli/services/context.ts
+++ b/packages/app/src/cli/services/context.ts
@@ -53,7 +53,7 @@ const appNotFoundHelpMessage = (accountIdentifier: string, isOrg = false) => [
         'Check that your account has permission to develop apps for this organization or contact the owner of the organization to grant you permission',
         [
           'Run',
-          {command: 'shopify auth logout'},
+          {command: 'shopify auth login'},
           'to log into a different',
           isOrg ? 'organization' : 'account',
           'than',

--- a/packages/app/src/cli/services/dev/fetch.test.ts
+++ b/packages/app/src/cli/services/dev/fetch.test.ts
@@ -143,7 +143,7 @@ describe('NoOrgError', () => {
       │  Next steps                                                                  │
       │    • Your current active session is associated with the partner@shopify.com  │
       │      user account. To start a new session with a different account, run      │
-      │      \`shopify auth logout\`                                                   │
+      │      \`shopify auth login\`                                                    │
       │    • Have you created a Shopify Partners organization [1]?                   │
       │    • Does your account include Manage app permissions?, please contact the   │
       │      owner of the organization to grant you access.                          │
@@ -177,7 +177,7 @@ describe('NoOrgError', () => {
       │  Next steps                                                                  │
       │    • Your current active session is associated with the organization         │
       │      organization account. To start a new session with a different account,  │
-      │      run \`shopify auth logout\`                                               │
+      │      run \`shopify auth login\`                                                │
       │    • Have you created a Shopify Partners organization [1]?                   │
       │    • Does your account include Manage app permissions?, please contact the   │
       │      owner of the organization to grant you access.                          │
@@ -210,8 +210,7 @@ describe('NoOrgError', () => {
       │                                                                              │
       │  Next steps                                                                  │
       │    • Your current active session is associated with an unknown account. To   │
-      │      start a new session with a different account, run \`shopify auth         │
-      │      logout\`                                                                 │
+      │      start a new session with a different account, run \`shopify auth login\`  │
       │    • Have you created a Shopify Partners organization [1]?                   │
       │    • Does your account include Manage app permissions?, please contact the   │
       │      owner of the organization to grant you access.                          │

--- a/packages/app/src/cli/services/dev/fetch.ts
+++ b/packages/app/src/cli/services/dev/fetch.ts
@@ -29,7 +29,7 @@ export class NoOrgError extends AbortError {
         `Your current active session is associated with ${identifierMessage(
           formattedIdentifier,
         )} account. To start a new session with a different account, run`,
-        {command: 'shopify auth logout'},
+        {command: 'shopify auth login'},
       ],
       [
         'Have you',


### PR DESCRIPTION
### WHY are these changes introduced?

We still suggest running `shopify auth logout` to test with a different account, but `shopify auth login` is more appropriate.

### WHAT is this pull request doing?

Replaces the suggested command everywhere

| Before | After |
|--------|--------|
| <img width="1276" height="176" alt="before" src="https://github.com/user-attachments/assets/8e9b226b-ba59-4661-b91d-3a9b8e375691" /> | <img width="1270" height="180" alt="after" src="https://github.com/user-attachments/assets/8e2ad1d8-b4ca-4af1-a492-7c9246e1caff" /> | 

### How to test your changes?

- `shopify app info` with a wrong account

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
