### PR TITLE
Add stdin support for `shopify app execute`

### DIFF
--- a/packages/app/src/cli/flags.ts
+++ b/packages/app/src/cli/flags.ts
@@ -38,9 +38,9 @@ export const appFlags = {
 export const bulkOperationFlags = {
   query: Flags.string({
     char: 'q',
-    description: 'The GraphQL query or mutation to run as a bulk operation.',
+    description: 'The GraphQL query or mutation to run as a bulk operation. If omitted, reads from standard input.',
     env: 'SHOPIFY_FLAG_QUERY',
-    required: true,
+    required: false,
   }),
   variables: Flags.string({
     char: 'v',

--- a/packages/cli-kit/src/public/node/system.test.ts
+++ b/packages/cli-kit/src/public/node/system.test.ts
@@ -2,9 +2,18 @@ import * as system from './system.js'
 import {execa} from 'execa'
 import {describe, expect, test, vi} from 'vitest'
 import which from 'which'
+import {Readable} from 'stream'
+import * as fs from 'fs'
 
 vi.mock('which')
 vi.mock('execa')
+vi.mock('fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof fs>()
+  return {
+    ...actual,
+    fstatSync: vi.fn(),
+  }
+})
 
 describe('captureOutput', () => {
   test('runs the command when it is not found in the current directory', async () => {
@@ -28,5 +37,79 @@ describe('captureOutput', () => {
 
     // Then
     await expect(got).rejects.toThrowError('Skipped run of unsecure binary command found in the current directory.')
+  })
+})
+
+describe('isStdinPiped', () => {
+  test('returns true when stdin is a FIFO (pipe)', () => {
+    // Given
+    vi.mocked(fs.fstatSync).mockReturnValue({isFIFO: () => true, isFile: () => false} as fs.Stats)
+
+    // When
+    const got = system.isStdinPiped()
+
+    // Then
+    expect(got).toBe(true)
+  })
+
+  test('returns true when stdin is a file redirect', () => {
+    // Given
+    vi.mocked(fs.fstatSync).mockReturnValue({isFIFO: () => false, isFile: () => true} as fs.Stats)
+
+    // When
+    const got = system.isStdinPiped()
+
+    // Then
+    expect(got).toBe(true)
+  })
+
+  test('returns false when stdin is a TTY (interactive)', () => {
+    // Given
+    vi.mocked(fs.fstatSync).mockReturnValue({isFIFO: () => false, isFile: () => false} as fs.Stats)
+
+    // When
+    const got = system.isStdinPiped()
+
+    // Then
+    expect(got).toBe(false)
+  })
+
+  test('returns false when fstatSync throws (e.g., CI with no stdin)', () => {
+    // Given
+    vi.mocked(fs.fstatSync).mockImplementation(() => {
+      throw new Error('EBADF')
+    })
+
+    // When
+    const got = system.isStdinPiped()
+
+    // Then
+    expect(got).toBe(false)
+  })
+})
+
+describe('readStdin', () => {
+  test('returns undefined when stdin is not piped', async () => {
+    // Given
+    vi.mocked(fs.fstatSync).mockReturnValue({isFIFO: () => false, isFile: () => false} as fs.Stats)
+
+    // When
+    const got = await system.readStdin()
+
+    // Then
+    expect(got).toBeUndefined()
+  })
+
+  test('returns trimmed content when stdin is piped', async () => {
+    // Given
+    vi.mocked(fs.fstatSync).mockReturnValue({isFIFO: () => true, isFile: () => false} as fs.Stats)
+    const mockStdin = Readable.from(['  hello world  '])
+    vi.spyOn(process, 'stdin', 'get').mockReturnValue(mockStdin as unknown as typeof process.stdin)
+
+    // When
+    const got = await system.readStdin()
+
+    // Then
+    expect(got).toBe('hello world')
   })
 })

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -961,12 +961,12 @@
         },
         "query": {
           "char": "q",
-          "description": "The GraphQL query or mutation to run as a bulk operation.",
+          "description": "The GraphQL query or mutation to run as a bulk operation. If omitted, reads from standard input.",
           "env": "SHOPIFY_FLAG_QUERY",
           "hasDynamicHelp": false,
           "multiple": false,
           "name": "query",
-          "required": true,
+          "required": false,
           "type": "option"
         },
         "reset": {


### PR DESCRIPTION
Resolves: https://github.com/orgs/shop/projects/208/views/34?pane=issue&itemId=139444955&issue=shop%7Cissues-api-foundations%7C1111

Inspired by: https://app.graphite.com/github/pr/Shopify/cli/6588/Initial-Setup-Bulk-Operations-Infrastructure-for-Shopify-CLI#comment-PRRC_kwDOHibhHs6WnBvj

### Summary
This PR enables users to pipe GraphQL queries into `shopify app execute` via stdin, improving the developer experience for bulk operations.

### Why This Change Matters
**Before**: Users had to pass queries inline via --query, which is cumbersome for complex multi-line GraphQL:
```
shopify app execute --query 'query { products(first: 100) { edges { node { id title variants(first: 10) { edges { node { id price } } } } } } }'
```
**After**: Users can pipe from files or other commands:
```
cat my-query.graphql | shopify app execute
```
This aligns with Unix conventions and how developers already work with GraphQL tooling.


### Design Decisions
1. Stdin utilities in `cli-kit/system.ts`
   - Placing `isStdinPiped()` and `readStdin()` in `system.ts` alongside other process utilities makes them discoverable and reusable for future commands.
2. Early return when TTY
    -  `readStdin()` returns undefined immediately when stdin is interactive. This prevents the command from hanging waiting for user input — a common pitfall in CLI tools.


### Thoughts for Future
- Consider adding to command help text — The flag description mentions stdin, but --help output could include an example.

