### PR TITLE
return an error when using Theme Access password with theme profile

### DIFF
--- a/.changeset/short-items-see.md
+++ b/.changeset/short-items-see.md
@@ -2,4 +2,4 @@
 '@shopify/theme': patch
 ---
 
-Return error when running theme profile using a themekit access password
+Return error when running `theme profile` using a Theme Access password

--- a/packages/theme/src/cli/services/profile.test.ts
+++ b/packages/theme/src/cli/services/profile.test.ts
@@ -82,17 +82,6 @@ describe('profile', () => {
     expect(htmlContent).toContain('speedscope')
   })
 
-  test('uses provided passwords for authentication', async () => {
-    // When
-    await profile(mockAdminSession, themeId, urlPath, true, 'themeAccessPassword', 'storePassword')
-
-    // Then
-    expect(ensureAuthenticatedStorefront).toHaveBeenCalledWith([], 'themeAccessPassword', {
-      forceRefresh: false,
-      noPrompt: true,
-    })
-  })
-
   test('throws error when fetch fails', async () => {
     // Given
     vi.mocked(render).mockRejectedValue(new Error('Network error'))
@@ -120,7 +109,7 @@ describe('profile', () => {
     await expect(result).rejects.toThrow('Bad response: 404: {"error":"Some error message"}')
   })
 
-  test('throws error when an Admin API token is used', async () => {
+  test('throws error when a password is used', async () => {
     // When
     const result = profile(mockAdminSession, themeId, urlPath, true, 'shpat_hello', undefined)
 
@@ -128,7 +117,7 @@ describe('profile', () => {
     await expect(result).rejects.toThrow(
       new AbortError(
         'Unable to use Admin API or Theme Access tokens with the profile command',
-        'You can authenticate normally by not passing the --password flag.',
+        'You must authenticate manually by not passing the --password flag.',
       ),
     )
   })

--- a/packages/theme/src/cli/services/profile.ts
+++ b/packages/theme/src/cli/services/profile.ts
@@ -22,12 +22,10 @@ export async function profile(
     ? await ensureValidPassword(storefrontPassword, adminSession.storeFqdn)
     : undefined
 
-  const isUnsupportedToken = ['shpat_', 'shptka_'].some((prefix) => themeAccessPassword?.startsWith(prefix))
-
-  if (isUnsupportedToken) {
+  if (themeAccessPassword) {
     throw new AbortError(
       'Unable to use Admin API or Theme Access tokens with the profile command',
-      'You can authenticate normally by not passing the --password flag.',
+      'You must authenticate manually by not passing the --password flag.',
     )
   }
 


### PR DESCRIPTION
### WHY are these changes introduced?
References : https://github.com/Shopify/cli/issues/6168

When running `theme profile` and authenticating with a Theme Access app token, it will return a `500` status code.

### WHAT is this pull request doing?

We dot not currently allow theme profiling when using a theme access token. We can revisit this in the future but for now we will return an error saying the command does not work with Theme Access passwords.

Before:
<img width="656" height="525" alt="image" src="https://github.com/user-attachments/assets/2440b262-2311-4191-8a93-668dc54fadfc" />

After:
<img width="656" height="367" alt="image" src="https://github.com/user-attachments/assets/f60eca53-2bfb-49bf-9ab0-a077932acbb5" />


### How to test your changes?
- Setup an environment that uses a themekit token (tokens start with `shptka_`)
- run `theme profile -e <your_env>

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
