### PR TITLE
Fix issue with admin-link extensions

### DIFF
--- a/packages/app/src/cli/models/extensions/specification.ts
+++ b/packages/app/src/cli/models/extensions/specification.ts
@@ -261,7 +261,7 @@ export function createContractBasedModuleSpecification<TConfiguration extends Ba
     identifier: spec.identifier,
     schema: zod.any({}) as unknown as ZodSchemaType<TConfiguration>,
     appModuleFeatures: spec.appModuleFeatures,
-    buildConfig: spec.buildConfig,
+    buildConfig: spec.buildConfig ?? {mode: 'none'},
     deployConfig: async (config, directory) => {
       let parsedConfig = configWithoutFirstClassFields(config)
       if (spec.appModuleFeatures().includes('localization')) {


### PR DESCRIPTION
### WHY are these changes introduced?

This change ensures that the `buildConfig` property always has a default value when creating a contract-based module specification.

### WHAT is this pull request doing?

Adds a default value of `{mode: 'none'}` to the `buildConfig` property when it's not provided in the specification. This prevents potential undefined errors when accessing this property.

### How to test your changes?

1. Add an admin-link extension to your project, `app build`​ (or dev, or deploy) should work fine.   
Without this change, that same command would crash.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes