### PR TITLE
BugError added for unexpected response from BulkOps API

### DIFF
--- a/packages/app/src/cli/commands/app/execute.ts
+++ b/packages/app/src/cli/commands/app/execute.ts
@@ -4,7 +4,7 @@ import {linkedAppContext} from '../../services/app-context.js'
 import {storeContext} from '../../services/store-context.js'
 import {executeBulkOperation} from '../../services/bulk-operations/execute-bulk-operation.js'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
-import {readStdin} from '@shopify/cli-kit/node/system'
+import {readStdinString} from '@shopify/cli-kit/node/system'
 import {AbortError} from '@shopify/cli-kit/node/error'
 
 export default class Execute extends AppLinkedCommand {
@@ -23,7 +23,7 @@ export default class Execute extends AppLinkedCommand {
   async run(): Promise<AppLinkedCommandOutput> {
     const {flags} = await this.parse(Execute)
 
-    const query = flags.query ?? (await readStdin())
+    const query = flags.query ?? (await readStdinString())
     if (!query) {
       throw new AbortError(
         'No query provided. Use the --query flag or pipe input via stdin.',

--- a/packages/app/src/cli/services/bulk-operations/execute-bulk-operation.test.ts
+++ b/packages/app/src/cli/services/bulk-operations/execute-bulk-operation.test.ts
@@ -459,4 +459,27 @@ describe('executeBulkOperation', () => {
       )
     },
   )
+  test('throws BugError and renders warning when bulk operation response returns null with no errors', async () => {
+    const query = '{ products { edges { node { id } } } }'
+    const mockResponse = {
+      bulkOperation: null,
+      userErrors: [],
+    }
+    vi.mocked(runBulkOperationQuery).mockResolvedValue(mockResponse)
+
+    await expect(
+      executeBulkOperation({
+        remoteApp: mockRemoteApp,
+        storeFqdn,
+        query,
+      }),
+    ).rejects.toThrow('Bulk operation response returned null with no error message.')
+
+    expect(renderWarning).toHaveBeenCalledWith({
+      headline: 'Bulk operation not created succesfully.',
+      body: 'This is an unexpected error. Please try again later.',
+    })
+
+    expect(renderSuccess).not.toHaveBeenCalled()
+  })
 })

--- a/packages/app/src/cli/services/bulk-operations/execute-bulk-operation.ts
+++ b/packages/app/src/cli/services/bulk-operations/execute-bulk-operation.ts
@@ -81,6 +81,12 @@ export async function executeBulkOperation(input: ExecuteBulkOperationInput): Pr
     } else {
       await renderBulkOperationResult(createdOperation, outputFile)
     }
+  } else {
+    renderWarning({
+      headline: 'Bulk operation not created succesfully.',
+      body: 'This is an unexpected error. Please try again later.',
+    })
+    throw new BugError('Bulk operation response returned null with no error message.')
   }
 }
 

--- a/packages/cli-kit/src/public/node/system.test.ts
+++ b/packages/cli-kit/src/public/node/system.test.ts
@@ -88,13 +88,13 @@ describe('isStdinPiped', () => {
   })
 })
 
-describe('readStdin', () => {
+describe('readStdinString', () => {
   test('returns undefined when stdin is not piped', async () => {
     // Given
     vi.mocked(fs.fstatSync).mockReturnValue({isFIFO: () => false, isFile: () => false} as fs.Stats)
 
     // When
-    const got = await system.readStdin()
+    const got = await system.readStdinString()
 
     // Then
     expect(got).toBeUndefined()
@@ -107,7 +107,7 @@ describe('readStdin', () => {
     vi.spyOn(process, 'stdin', 'get').mockReturnValue(mockStdin as unknown as typeof process.stdin)
 
     // When
-    const got = await system.readStdin()
+    const got = await system.readStdinString()
 
     // Then
     expect(got).toBe('hello world')

--- a/packages/cli-kit/src/public/node/system.ts
+++ b/packages/cli-kit/src/public/node/system.ts
@@ -229,7 +229,7 @@ export function isStdinPiped(): boolean {
  *
  * @returns A promise that resolves with the stdin content, or undefined if stdin is a TTY.
  */
-export async function readStdin(): Promise<string | undefined> {
+export async function readStdinString(): Promise<string | undefined> {
   if (!isStdinPiped()) {
     return undefined
   }


### PR DESCRIPTION
Resolves: https://github.com/orgs/shop/projects/208/views/34?pane=issue&itemId=139446745&issue=shop%7Cissues-api-foundations%7C1113

Inspiration from: https://app.graphite.com/github/pr/Shopify/cli/6588/Initial-Setup-Bulk-Operations-Infrastructure-for-Shopify-CLI#comment-PRRC_kwDOHibhHs6WnG-H

**Background**
When the CLI calls the BulkOps API, the API returns a `bulkOperationResponse` with two parts: `bulkOperation` and `userErrors`. When the code gets the `bulkOperationResponse` back, the code looks to see if `userErrors` exist before even looking at the `bulkOperation` part. 

I wanted to deal with the case where the `bulkOperation` value was `null`. However, if the `bulkOperation` value is `null`, there should be something in `userErrors`, and the code should have returned the error already (since it checks `userErrors` before `bulkOperation`). So, this case should never happen (this case being where `bulkOperation` is null and `userErrors` is empty).

I still wanted to write a case for this. So, I wrote `BugError` that alerts the team if this case ever happens. A `BugError` is something like Sentry in Core.

**Testing**
Added unit test to test this code path