### PR TITLE
DevServer: Increase check port timeout to 1s

### DIFF
--- a/packages/cli-kit/src/public/node/vendor/dev_server/network/index.ts
+++ b/packages/cli-kit/src/public/node/vendor/dev_server/network/index.ts
@@ -11,7 +11,7 @@ export interface ConnectionArguments {
 }
 
 // eslint-disable-next-line prettier/prettier
-const DEFAULT_CONNECT_TIMEOUT = 100
+const DEFAULT_CONNECT_TIMEOUT = 1000
 // Skip initialization on module load to prevent Spin trying to load a macOS dylib
 // (port checks should never run on Spin anyway)
 let checkPort: ReturnType<typeof getCheckPortHelper>


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

The default timeout we're using for port checks is too agressive, and does not match the timeout we're using for the command in `spawnSync`.

With the current configuration, we're running the following command: 

`nc -z -w 1 <IP> <PORT>`

`-w 1` sets one second as the command timeout, but we're passing 100ms to `spawnSync`, which is killing the process before the command finishes. As a consequence, the CLI returns this error too many times when working with the local environment:

<img width="748" height="388" alt="Captura de pantalla 2025-11-26 a las 16 32 48" src="https://github.com/user-attachments/assets/5f471f05-5ef3-4df5-96d5-2decdc1cef96" />

### WHAT is this pull request doing?

This PR brings consistent timeouts for `spawnSync` and the `nc` command. The tests I've made always succeeded. I also checked that the IP used for `identity` was the correct one according to the `/ect/hosts` file in my machine, so the timeout issue was the only thing I could spot

### How to test your changes?

Run command that need the identity service with the local environment flag:

`SHOPIFY_SERVICE_ENV=local p shopify app init --template remix `

### Post-release steps

n/a

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
