### PR TITLE
Call generateExtensionTypes after building extensions when filters are updated

### DIFF
--- a/.changeset/twelve-memes-knock.md
+++ b/.changeset/twelve-memes-knock.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Enable types to be re-generated when extensions are rebuilt during dev

--- a/packages/app/src/cli/services/dev/app-events/app-event-watcher.ts
+++ b/packages/app/src/cli/services/dev/app-events/app-event-watcher.ts
@@ -163,6 +163,12 @@ export class AppEventWatcher extends EventEmitter {
           // Build the created/updated extensions and update the extension events with the build result
           await this.buildExtensions(buildableEvents)
 
+          // Generate the extension types after building the extensions so new imports are included
+          // Skip if the app was reloaded, as generateExtensionTypes was already called during reload
+          if (!appEvent.appWasReloaded) {
+            await this.app.generateExtensionTypes()
+          }
+
           // Find deleted extensions and delete their previous build output
           await this.deleteExtensionsBuildOutput(appEvent)
           this.emit('all', appEvent)


### PR DESCRIPTION
### WHY are these changes introduced?

Fix https://github.com/Shopify/admin-extensibility/issues/2295

Currently TypeScript types are only generated for UI extensions when the extension toml is updated. This means newly imported files would have missing types.

[Screen Recording 2025-11-27 at 9.47.03 AM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/11ef0c10-c58b-4eb3-bc04-8655fc639dcf.mov" />](https://app.graphite.com/user-attachments/video/11ef0c10-c58b-4eb3-bc04-8655fc639dcf.mov)

### WHAT is this pull request doing?

This PR enables automatic regeneration of TypeScript types when extensions are rebuilt during development. Specifically:

- Adds logic to regenerate extension types after extensions are rebuilt due to file changes
- Ensures types are regenerated when extensions are deleted to clean up type definitions
- Avoids duplicate type generation when the app is reloaded (as types are already generated during reload)
- Adds comprehensive tests to verify the type generation behavior in different scenarios

### How to test your changes?

1. Create am app with a ui extension and run dev.
2. Create a new `test.ts` file with the following content:
```ts
export function test() {
    console.log('shopify', shopify);
}
``` 
3. Add `import {test} from './test.ts'` in the extension's module and save the file
4. Verify that when hovering over `shopify` in test.ts you see the types

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes