### PR TITLE
Add env var to allow using Partners API

### DIFF
--- a/packages/cli-kit/src/private/node/constants.ts
+++ b/packages/cli-kit/src/private/node/constants.ts
@@ -43,6 +43,7 @@ export const environmentVariables = {
   themeKitAccessDomain: 'SHOPIFY_CLI_THEME_KIT_ACCESS_DOMAIN',
   json: 'SHOPIFY_FLAG_JSON',
   neverUsePartnersApi: 'SHOPIFY_CLI_NEVER_USE_PARTNERS_API',
+  usePartnersApi: 'SHOPIFY_CLI_USE_PARTNERS_API',
   skipNetworkLevelRetry: 'SHOPIFY_CLI_SKIP_NETWORK_LEVEL_RETRY',
   maxRequestTimeForNetworkCalls: 'SHOPIFY_CLI_MAX_REQUEST_TIME_FOR_NETWORK_CALLS',
 }

--- a/packages/cli-kit/src/public/node/environment.ts
+++ b/packages/cli-kit/src/public/node/environment.ts
@@ -86,13 +86,21 @@ export function jsonOutputEnabled(environment = getEnvironmentVariables()): bool
 /**
  * If true, the CLI should not use the Partners API.
  *
- * @returns True when SHOPIFY_CLI_NEVER_USE_PARTNERS_API is set or SHOPIFY_CLI_1P_DEV is not set.
+ * @returns True when the CLI should not use the Partners API.
  */
 export function blockPartnersAccess(): boolean {
-  return (
-    isTruthy(getEnvironmentVariables()[environmentVariables.neverUsePartnersApi]) ||
-    !isTruthy(getEnvironmentVariables()[environmentVariables.firstPartyDev])
-  )
+  // Block if explicitly set to never use Partners API
+  if (isTruthy(getEnvironmentVariables()[environmentVariables.neverUsePartnersApi])) {
+    return true
+  }
+
+  // If explicitly forcing to use Partners API, do not block
+  if (isTruthy(getEnvironmentVariables()[environmentVariables.usePartnersApi])) {
+    return false
+  }
+
+  // Block for 3P devs
+  return !isTruthy(getEnvironmentVariables()[environmentVariables.firstPartyDev])
 }
 
 /**


### PR DESCRIPTION
### WHY are these changes introduced?

Continuation of https://github.com/Shopify/cli/pull/6645

Some internal tests are still using Partners apps that can't be migrated yet ([related thread](https://shopify.slack.com/archives/C07UJ7UNMTK/p1764080948277779)), so we need a way to allow 3P apps to use Partners API

### WHAT is this pull request doing?

Adds a new `SHOPIFY_CLI_USE_PARTNERS_API` to unblock it

### How to test your changes?

- `p shopify app init --template none --verbose` => No Partners
- `SHOPIFY_CLI_USE_PARTNERS_API=1 p shopify app init --template none --verbose` => uses Partners
- `SHOPIFY_CLI_1P_DEV=1 p shopify app init --template none --verbose` => uses Partners
- `SHOPIFY_CLI_NEVER_USE_PARTNERS_API=1 SHOPIFY_CLI_1P_DEV=1 p shopify app init --template none --verbose` => No Partners

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
