### PR TITLE
Guide users to use `bulk status` when an operation is still running in the background

### DIFF
--- a/packages/cli-kit/src/public/node/ui.tsx
+++ b/packages/cli-kit/src/public/node/ui.tsx
@@ -490,6 +490,7 @@ export async function renderTasks<TContext>(
 export interface RenderSingleTaskOptions<T> {
   title: TokenizedString
   task: (updateStatus: (status: TokenizedString) => void) => Promise<T>
+  onAbort?: () => void
   renderOptions?: RenderOptions
 }
 
@@ -504,10 +505,15 @@ export interface RenderSingleTaskOptions<T> {
  * ▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
  * Loading app ...
  */
-export async function renderSingleTask<T>({title, task, renderOptions}: RenderSingleTaskOptions<T>): Promise<T> {
+export async function renderSingleTask<T>({
+  title,
+  task,
+  onAbort,
+  renderOptions,
+}: RenderSingleTaskOptions<T>): Promise<T> {
   // eslint-disable-next-line max-params
   return new Promise<T>((resolve, reject) => {
-    render(<SingleTask title={title} task={task} onComplete={resolve} />, {
+    render(<SingleTask title={title} task={task} onComplete={resolve} onAbort={onAbort} />, {
       ...renderOptions,
       exitOnCtrlC: false,
     }).catch(reject)


### PR DESCRIPTION
### WHY are these changes introduced?

https://github.com/shop/issues-api-foundations/issues/1095

We want to make sure it's clear to users when things are still running in the background.

### WHAT is this pull request doing?

Let's helpfully print a nice message telling users when they can use the `bulk status` command, even if they CTRL+C out of an operation midway!

We did this by:

- implementing a new optional `onAbort` callback to `renderSingleTask`, which you can use to configure custom behaviour when the user quits mid-way through a single task
- teaching `executeBulkOperation` and `watchBulkOperation` to use that new `onAbort` callback to display a nice message when the user quits while watching a bulk operation

### How to test your changes?

Without `--watch`, you get a nice help message:

<img width="895" height="493" alt="image" src="https://github.com/user-attachments/assets/02746512-e002-4123-9634-61778a40face" />

With `--watch`, if you abort using CTRL+C before it's done, you get a nice help message:

https://github.com/user-attachments/assets/457a47d3-e375-43d7-8e65-3ce9f5433869

With `--watch`, without aborting, same behaviour as before this PR:

<img width="934" height="279" alt="image" src="https://github.com/user-attachments/assets/d178be82-2ea4-4582-a32e-ac8b43101812" />


