### PR TITLE
Move command from `shopify app execute` to `shopify app bulk execute`

### DIFF
--- a/packages/app/src/cli/commands/app/bulk/execute.ts
+++ b/packages/app/src/cli/commands/app/bulk/execute.ts
@@ -1,13 +1,13 @@
-import {appFlags, bulkOperationFlags} from '../../flags.js'
-import AppLinkedCommand, {AppLinkedCommandOutput} from '../../utilities/app-linked-command.js'
-import {linkedAppContext} from '../../services/app-context.js'
-import {storeContext} from '../../services/store-context.js'
-import {executeBulkOperation} from '../../services/bulk-operations/execute-bulk-operation.js'
+import {appFlags, bulkOperationFlags} from '../../../flags.js'
+import AppLinkedCommand, {AppLinkedCommandOutput} from '../../../utilities/app-linked-command.js'
+import {linkedAppContext} from '../../../services/app-context.js'
+import {storeContext} from '../../../services/store-context.js'
+import {executeBulkOperation} from '../../../services/bulk-operations/execute-bulk-operation.js'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
 import {readStdinString} from '@shopify/cli-kit/node/system'
 import {AbortError} from '@shopify/cli-kit/node/error'
 
-export default class Execute extends AppLinkedCommand {
+export default class BulkExecute extends AppLinkedCommand {
   static summary = 'Execute bulk operations.'
 
   static description = 'Execute bulk operations against the Shopify Admin API.'
@@ -21,13 +21,13 @@ export default class Execute extends AppLinkedCommand {
   }
 
   async run(): Promise<AppLinkedCommandOutput> {
-    const {flags} = await this.parse(Execute)
+    const {flags} = await this.parse(BulkExecute)
 
     const query = flags.query ?? (await readStdinString())
     if (!query) {
       throw new AbortError(
         'No query provided. Use the --query flag or pipe input via stdin.',
-        'Example: echo "query { ... }" | shopify app execute',
+        'Example: echo "query { ... }" | shopify app bulk execute',
       )
     }
 

--- a/packages/app/src/cli/index.ts
+++ b/packages/app/src/cli/index.ts
@@ -10,7 +10,7 @@ import Logs from './commands/app/logs.js'
 import Sources from './commands/app/app-logs/sources.js'
 import EnvPull from './commands/app/env/pull.js'
 import EnvShow from './commands/app/env/show.js'
-import Execute from './commands/app/execute.js'
+import Execute from './commands/app/bulk/execute.js'
 import FunctionBuild from './commands/app/function/build.js'
 import FunctionReplay from './commands/app/function/replay.js'
 import FunctionRun from './commands/app/function/run.js'
@@ -53,7 +53,7 @@ export const commands: {[key: string]: typeof AppLinkedCommand | typeof AppUnlin
   'app:config:pull': ConfigPull,
   'app:env:pull': EnvPull,
   'app:env:show': EnvShow,
-  'app:execute': Execute,
+  'app:bulk:execute': Execute,
   'app:generate:schema': GenerateSchema,
   'app:function:build': FunctionBuild,
   'app:function:replay': FunctionReplay,

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -86,6 +86,141 @@
       "strict": true,
       "summary": "Build the app, including extensions."
     },
+    "app:bulk:execute": {
+      "aliases": [
+      ],
+      "args": {
+      },
+      "customPluginName": "@shopify/app",
+      "description": "Execute bulk operations against the Shopify Admin API.",
+      "flags": {
+        "client-id": {
+          "description": "The Client ID of your app.",
+          "env": "SHOPIFY_FLAG_CLIENT_ID",
+          "exclusive": [
+            "config"
+          ],
+          "hasDynamicHelp": false,
+          "hidden": false,
+          "multiple": false,
+          "name": "client-id",
+          "type": "option"
+        },
+        "config": {
+          "char": "c",
+          "description": "The name of the app configuration.",
+          "env": "SHOPIFY_FLAG_APP_CONFIG",
+          "hasDynamicHelp": false,
+          "hidden": false,
+          "multiple": false,
+          "name": "config",
+          "type": "option"
+        },
+        "no-color": {
+          "allowNo": false,
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
+          "type": "boolean"
+        },
+        "output-file": {
+          "description": "The file path where results should be written. If not specified, results will be written to STDOUT.",
+          "env": "SHOPIFY_FLAG_OUTPUT_FILE",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "output-file",
+          "type": "option"
+        },
+        "path": {
+          "description": "The path to your app directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "path",
+          "noCacheDefault": true,
+          "type": "option"
+        },
+        "query": {
+          "char": "q",
+          "description": "The GraphQL query or mutation to run as a bulk operation. If omitted, reads from standard input.",
+          "env": "SHOPIFY_FLAG_QUERY",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "query",
+          "required": false,
+          "type": "option"
+        },
+        "reset": {
+          "allowNo": false,
+          "description": "Reset all your settings.",
+          "env": "SHOPIFY_FLAG_RESET",
+          "exclusive": [
+            "config"
+          ],
+          "hidden": false,
+          "name": "reset",
+          "type": "boolean"
+        },
+        "store": {
+          "char": "s",
+          "description": "The store domain. Must be an existing dev store.",
+          "env": "SHOPIFY_FLAG_STORE",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "store",
+          "type": "option"
+        },
+        "variable-file": {
+          "description": "Path to a file containing GraphQL variables in JSONL format (one JSON object per line). Can't be used with --variables.",
+          "env": "SHOPIFY_FLAG_VARIABLE_FILE",
+          "exclusive": [
+            "variables"
+          ],
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "variable-file",
+          "type": "option"
+        },
+        "variables": {
+          "char": "v",
+          "description": "The values for any GraphQL variables in your mutation, in JSON format. Can be specified multiple times.",
+          "env": "SHOPIFY_FLAG_VARIABLES",
+          "exclusive": [
+            "variable-file"
+          ],
+          "hasDynamicHelp": false,
+          "multiple": true,
+          "name": "variables",
+          "type": "option"
+        },
+        "verbose": {
+          "allowNo": false,
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "type": "boolean"
+        },
+        "watch": {
+          "allowNo": false,
+          "description": "Wait for bulk operation results before exiting.",
+          "env": "SHOPIFY_FLAG_WATCH",
+          "name": "watch",
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hidden": true,
+      "hiddenAliases": [
+      ],
+      "id": "app:bulk:execute",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "summary": "Execute bulk operations."
+    },
     "app:bulk:status": {
       "aliases": [
       ],
@@ -980,141 +1115,6 @@
       "pluginType": "core",
       "strict": true,
       "summary": "Display app and extensions environment variables."
-    },
-    "app:execute": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/app",
-      "description": "Execute bulk operations against the Shopify Admin API.",
-      "flags": {
-        "client-id": {
-          "description": "The Client ID of your app.",
-          "env": "SHOPIFY_FLAG_CLIENT_ID",
-          "exclusive": [
-            "config"
-          ],
-          "hasDynamicHelp": false,
-          "hidden": false,
-          "multiple": false,
-          "name": "client-id",
-          "type": "option"
-        },
-        "config": {
-          "char": "c",
-          "description": "The name of the app configuration.",
-          "env": "SHOPIFY_FLAG_APP_CONFIG",
-          "hasDynamicHelp": false,
-          "hidden": false,
-          "multiple": false,
-          "name": "config",
-          "type": "option"
-        },
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
-          "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
-        "output-file": {
-          "description": "The file path where results should be written. If not specified, results will be written to STDOUT.",
-          "env": "SHOPIFY_FLAG_OUTPUT_FILE",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "output-file",
-          "type": "option"
-        },
-        "path": {
-          "description": "The path to your app directory.",
-          "env": "SHOPIFY_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "path",
-          "noCacheDefault": true,
-          "type": "option"
-        },
-        "query": {
-          "char": "q",
-          "description": "The GraphQL query or mutation to run as a bulk operation. If omitted, reads from standard input.",
-          "env": "SHOPIFY_FLAG_QUERY",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "query",
-          "required": false,
-          "type": "option"
-        },
-        "reset": {
-          "allowNo": false,
-          "description": "Reset all your settings.",
-          "env": "SHOPIFY_FLAG_RESET",
-          "exclusive": [
-            "config"
-          ],
-          "hidden": false,
-          "name": "reset",
-          "type": "boolean"
-        },
-        "store": {
-          "char": "s",
-          "description": "The store domain. Must be an existing dev store.",
-          "env": "SHOPIFY_FLAG_STORE",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "store",
-          "type": "option"
-        },
-        "variable-file": {
-          "description": "Path to a file containing GraphQL variables in JSONL format (one JSON object per line). Can't be used with --variables.",
-          "env": "SHOPIFY_FLAG_VARIABLE_FILE",
-          "exclusive": [
-            "variables"
-          ],
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "variable-file",
-          "type": "option"
-        },
-        "variables": {
-          "char": "v",
-          "description": "The values for any GraphQL variables in your mutation, in JSON format. Can be specified multiple times.",
-          "env": "SHOPIFY_FLAG_VARIABLES",
-          "exclusive": [
-            "variable-file"
-          ],
-          "hasDynamicHelp": false,
-          "multiple": true,
-          "name": "variables",
-          "type": "option"
-        },
-        "verbose": {
-          "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
-          "type": "boolean"
-        },
-        "watch": {
-          "allowNo": false,
-          "description": "Wait for bulk operation results before exiting.",
-          "env": "SHOPIFY_FLAG_WATCH",
-          "name": "watch",
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hidden": true,
-      "hiddenAliases": [
-      ],
-      "id": "app:execute",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true,
-      "summary": "Execute bulk operations."
     },
     "app:function:build": {
       "aliases": [


### PR DESCRIPTION
Resolves: https://github.com/orgs/shop/projects/208/views/34?pane=issue&itemId=140363174&issue=shop%7Cissues-api-foundations%7C1127

Inspired by: https://github.com/Shopify/cli/pull/6596#discussion_r2543021287

### Background
There was a design decision made that determined that Bulk operations have enough differences in behavior and requirements to merit a separate command (`shopify app bulk execute`).

### Implementation
- Moved `packages/app/src/cli/commands/app/execute.ts` into `packages/app/src/cli/commands/app/bulk/execute.ts` and changed the imports.
- Changed the execute command index in the `packages/app/src/cli/index.ts` file.
- Regenerated the manifest.

### Tophatting
The new `shopify app bulk execute` command works!
![Screenshot 2025-12-02 at 12.44.42 PM.png](https://app.graphite.com/user-attachments/assets/ab8b7f40-b1df-4a37-9e5f-6df52cc548d9.png)

