### PR TITLE
Add message when store not found.

### DIFF
--- a/packages/app/src/cli/services/dev/fetch.test.ts
+++ b/packages/app/src/cli/services/dev/fetch.test.ts
@@ -11,7 +11,6 @@ import {AppManagementClient} from '../../utilities/developer-platform-client/app
 import {afterEach, describe, expect, test, vi} from 'vitest'
 import {renderFatalError} from '@shopify/cli-kit/node/ui'
 import {mockAndCaptureOutput} from '@shopify/cli-kit/node/testing/output'
-import {AbortError} from '@shopify/cli-kit/node/error'
 
 const ORG1: Organization = {
   id: '1',
@@ -121,7 +120,7 @@ describe('fetchStore', () => {
     const got = fetchStore(ORG1, 'domain1', developerPlatformClient)
 
     // Then
-    await expect(got).rejects.toThrow(new AbortError(`Could not find Store for domain domain1 in Organization org1.`))
+    await expect(got).rejects.toThrow(`Your current account (org1) doesn't have access to store domain1.`)
   })
 })
 

--- a/packages/app/src/cli/services/dev/fetch.ts
+++ b/packages/app/src/cli/services/dev/fetch.ts
@@ -125,7 +125,16 @@ export async function fetchStore(
 ): Promise<OrganizationStore> {
   const store = await developerPlatformClient.storeByDomain(org.id, storeFqdn)
 
-  if (!store) throw new AbortError(`Could not find Store for domain ${storeFqdn} in Organization ${org.businessName}.`)
+  if (!store) {
+    throw new AbortError(
+      `Your current account (${org.businessName}) doesn't have access to store ${storeFqdn}.`,
+      undefined,
+      [
+        ['Select a different store with', {command: '--store'}, 'or', {command: '--reset'}],
+        ['Use', {command: 'shopify auth login'}, 'to log in with a different account that has access to this store'],
+      ],
+    )
+  }
 
   return store
 }

--- a/packages/cli-kit/src/private/node/session/exchange.ts
+++ b/packages/cli-kit/src/private/node/session/exchange.ts
@@ -212,6 +212,8 @@ function tokenRequestErrorHandler({error, store}: {error: string; store?: string
   }
   if (error === 'invalid_target') {
     return new InvalidTargetError(invalidTargetErrorMessage, '', [
+      ['Select a different store with', {command: '--store'}],
+      ['Use', {command: 'shopify auth login'}, 'to log in with a different account that has access to this store'],
       'Ensure you have logged in to the store using the Shopify admin at least once.',
       'Ensure you are the store owner, or have a staff account if you are attempting to log in to a dev store.',
       'Ensure you are using the permanent store domain, not a vanity domain.',

--- a/packages/cli-kit/src/public/node/api/admin.test.ts
+++ b/packages/cli-kit/src/public/node/api/admin.test.ts
@@ -5,6 +5,7 @@ import {buildHeaders} from '../../../private/node/api/headers.js'
 import * as http from '../../../public/node/http.js'
 import {defaultThemeKitAccessDomain} from '../../../private/node/constants.js'
 import {test, vi, expect, describe} from 'vitest'
+import {ClientError} from 'graphql-request'
 
 vi.mock('./graphql.js')
 vi.mock('../../../private/node/api/headers.js')
@@ -89,6 +90,19 @@ describe('admin-graphql-api', () => {
       token: themeAccessToken,
       variables: {variables: 'variables'},
     })
+  })
+
+  test('throws helpful error when admin API returns 403', async () => {
+    // Given
+    const errorResponse = {
+      status: 403,
+      errors: [],
+      headers: new Headers(),
+    }
+    vi.mocked(graphqlRequestDoc).mockRejectedValue(new ClientError(errorResponse, {query: ''}))
+
+    // When/Then
+    await expect(admin.supportedApiVersions(Session)).rejects.toThrow(/don't have access to this store/)
   })
 })
 

--- a/packages/cli-kit/src/public/node/api/admin.ts
+++ b/packages/cli-kit/src/public/node/api/admin.ts
@@ -170,13 +170,17 @@ async function fetchApiVersions(session: AdminSession, preferredBehaviour?: Requ
     return response.publicApiVersions
   } catch (error) {
     if (error instanceof ClientError && error.response.status === 403) {
-      const storeName = session.storeFqdn.replace('.myshopify.com', '')
       throw new AbortError(
-        outputContent`Looks like you don't have access this dev store: (${outputToken.link(
-          storeName,
+        outputContent`Looks like you don't have access to this store: ${outputToken.link(
+          session.storeFqdn,
           `https://${session.storeFqdn}`,
-        )})`,
-        outputContent`If you're not the owner, create a dev store staff account for yourself`,
+        )}`,
+        undefined,
+        [
+          ['Select a different store with', {command: '--store'}],
+          ['Use', {command: 'shopify auth login'}, 'to log in with a different account that has access to this store'],
+          "If you're not the owner, create a dev store staff account for yourself",
+        ],
       )
     }
     if (error instanceof ClientError && (error.response.status === 401 || error.response.status === 404)) {


### PR DESCRIPTION
### WHY are these changes introduced?

Addresses feedback from internal Slack discussion: https://shopify.slack.com/archives/C05E3BDFDRB/p1764604207635019

Also fixes community forum issue: https://community.shopify.dev/t/cli-cant-access-another-stores-account/26483

**Problem:** When users log out and log in with a different account, the CLI tries to use the cached store from the previous account. This results in confusing error messages that don't explain:
1. The user is logged into a different account/organization
2. They can use `--store` to select a different store
3. They can use `shopify auth login` to switch back to the account with access

### WHAT is this pull request doing?

Improves error messages in three locations where store access errors occur:

#### 1. App Dev - Store Not Found in Organization
**File:** `packages/app/src/cli/services/dev/fetch.ts`

When a cached store doesn't exist in the current organization (lines 128-137).

**Before:**
```
Could not find Store for domain example.myshopify.com in Organization Acme Corp.
```

**After:**
```
Your current account (Acme Corp) doesn't have access to store example.myshopify.com.

Next steps:
• Select a different store with --store or --reset
• Use shopify auth login to log in with a different account that has access to this store
```

#### 2. Theme/App Dev - Invalid Target Authentication Error
**File:** `packages/cli-kit/src/private/node/session/exchange.ts`

When token exchange fails with `invalid_target` (lines 213-220).

**Before:**
```
You are not authorized to use the CLI to develop in the provided store: example.myshopify.com.

Next steps:
• Ensure you have logged in to the store using the Shopify admin at least once.
• Ensure you are the store owner, or have a staff account...
• Ensure you are using the permanent store domain, not a vanity domain.
```

**After:** (Added two new suggestions at the top)
```
You are not authorized to use the CLI to develop in the provided store: example.myshopify.com.

Next steps:
• Select a different store with --store
• Use shopify auth login to log in with a different account that has access to this store
• Ensure you have logged in to the store using the Shopify admin at least once.
• Ensure you are the store owner, or have a staff account...
• Ensure you are using the permanent store domain, not a vanity domain.
```

#### 3. Theme Dev - 403 Admin API Access Error
**File:** `packages/cli-kit/src/public/node/api/admin.ts`

When accessing the Admin API returns 403 (lines 172-185). This is the exact error from the community forum post.

**Before:**
```
Looks like you don't have access this dev store: (store-name).
If you're not the owner, create a dev store staff account for yourself
```

**After:**
```
Looks like you don't have access to this store: store.myshopify.com

Next steps:
• Select a different store with --store
• Use shopify auth login to log in with a different account that has access to this store
• If you're not the owner, create a dev store staff account for yourself
```

### Tests Added/Updated

- Updated `fetch.test.ts`: Existing test updated to match new error message ✅
- Added `admin.test.ts`: New test for 403 admin API error case ✅
- No changes needed to `exchange.test.ts`: Tests still pass ✅

All 29 tests passing across modified files.

### How to test your changes?

**Scenario 1: App dev with wrong account**
1. Create an app project linked to account A
2. Run `shopify auth logout` then `shopify auth login` with account B
3. Run `shopify app dev`
4. Verify error message suggests `--store` and `shopify auth login`

**Scenario 2: Theme dev with wrong account**
1. Run `shopify theme dev` with store from account A
2. Run `shopify auth logout` then `shopify auth login` with account B  
3. Run `shopify theme dev`
4. Verify error message suggests `--store` and `shopify auth login`

**Scenario 3: Using --store flag**
1. After seeing the error, run `shopify app dev --store other-store.myshopify.com`
2. Verify command works with explicitly specified store

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
