### PR TITLE
Forward headers for proxy calls

### DIFF
--- a/packages/theme/src/cli/utilities/theme-environment/storefront-renderer.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/storefront-renderer.ts
@@ -1,5 +1,5 @@
 import {parseCookies, serializeCookies} from './cookies.js'
-import {defaultHeaders, storefrontReplaceTemplatesParams} from './storefront-utils.js'
+import {cleanHeader, defaultHeaders, storefrontReplaceTemplatesParams} from './storefront-utils.js'
 import {DevServerSession, DevServerRenderContext} from './types.js'
 import {createFetchError} from '../errors.js'
 import {outputDebug} from '@shopify/cli-kit/node/output'
@@ -153,11 +153,4 @@ function themeAccessHeaders(session: DevServerSession) {
     'X-Shopify-Shop': session.storeFqdn,
     'X-Shopify-Access-Token': session.token,
   }
-}
-
-function cleanHeader(headers: {[key: string]: string}): {[key: string]: string} {
-  // Force the use of the 'Cookie' key if consumers also provide the 'cookie' key
-  delete headers.cookie
-  delete headers.authorization
-  return headers
 }

--- a/packages/theme/src/cli/utilities/theme-environment/storefront-utils.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/storefront-utils.ts
@@ -26,3 +26,10 @@ export function defaultHeaders() {
     'User-Agent': `Shopify CLI; v=${CLI_KIT_VERSION}`,
   }
 }
+
+export function cleanHeader(headers: {[key: string]: string}): {[key: string]: string} {
+  // Force the use of the 'Cookie' key if consumers also provide the 'cookie' key
+  delete headers.cookie
+  delete headers.authorization
+  return headers
+}

--- a/packages/theme/src/cli/utilities/theme-environment/theme-environment.test.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/theme-environment.test.ts
@@ -82,10 +82,10 @@ describe('setupDevServer', () => {
   const localThemeExtensionFileSystem = emptyThemeExtFileSystem()
   const defaultServerContext: DevServerContext = {
     session: {
-      storefrontToken: '',
+      storefrontToken: 'shptka_test_token_123',
       token: '',
       storeFqdn: 'my-store.myshopify.com',
-      sessionCookies: {},
+      sessionCookies: {_shopify_essential: 'test-cookie-value'},
     },
     lastRequestedPath: '',
     localThemeFileSystem,
@@ -703,7 +703,11 @@ describe('setupDevServer', () => {
         expect.objectContaining({
           method: 'GET',
           redirect: 'manual',
-          headers: {referer},
+          headers: expect.objectContaining({
+            referer,
+            'User-Agent': expect.stringContaining('Shopify CLI'),
+            Authorization: expect.stringContaining('Bearer'),
+          }),
         }),
       )
 
@@ -724,7 +728,11 @@ describe('setupDevServer', () => {
         expect.objectContaining({
           method: 'GET',
           redirect: 'manual',
-          headers: {referer},
+          headers: expect.objectContaining({
+            referer,
+            'User-Agent': expect.stringContaining('Shopify CLI'),
+            Authorization: expect.stringContaining('Bearer'),
+          }),
         }),
       )
     })
@@ -784,7 +792,11 @@ describe('setupDevServer', () => {
         expect.objectContaining({
           method: 'GET',
           redirect: 'manual',
-          headers: {referer},
+          headers: expect.objectContaining({
+            referer,
+            'User-Agent': expect.stringContaining('Shopify CLI'),
+            Authorization: expect.stringContaining('Bearer'),
+          }),
         }),
       )
 
@@ -807,7 +819,11 @@ describe('setupDevServer', () => {
         expect.objectContaining({
           method: 'GET',
           redirect: 'manual',
-          headers: {referer},
+          headers: expect.objectContaining({
+            referer,
+            'User-Agent': expect.stringContaining('Shopify CLI'),
+            Authorization: expect.stringContaining('Bearer'),
+          }),
         }),
       )
 
@@ -853,7 +869,11 @@ describe('setupDevServer', () => {
         expect.objectContaining({
           method: 'GET',
           redirect: 'manual',
-          headers: {referer},
+          headers: expect.objectContaining({
+            referer,
+            'User-Agent': expect.stringContaining('Shopify CLI'),
+            Authorization: expect.stringContaining('Bearer'),
+          }),
         }),
       )
 


### PR DESCRIPTION
### WHAT is this pull request doing?

Matching storefront logic by sending the same headers in proxy calls
I also moved the `cleanHeaders` function into a util folder so it can be reused in the proxy logic.

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
