### PR TITLE
Automatic rate limit restoration w/ admin API calls

### DIFF
--- a/packages/app/src/cli/api/admin-as-app.ts
+++ b/packages/app/src/cli/api/admin-as-app.ts
@@ -13,6 +13,7 @@ interface AdminAsAppRequestOptions<TResult, TVariables extends Variables> {
   query: TypedDocumentNode<TResult, TVariables>
   session: AdminSession
   variables?: TVariables
+  autoRateLimitRestore?: boolean
 }
 
 /**
@@ -33,6 +34,10 @@ async function setupAdminAsAppRequest(session: AdminSession) {
 /**
  * Executes a GraphQL query against the Shopify Admin API, on behalf of the app. Uses typed documents.
  *
+ * If `autoRateLimitRestore` is true, the function will wait for a period of time such that the rate limit consumed by
+ * the query is restored back to its original value. This means this function is suitable for use in loops with
+ * multiple queries performed.
+ *
  * @param options - The options for the request.
  * @returns The response of the query of generic type <T>.
  */
@@ -43,5 +48,6 @@ export async function adminAsAppRequestDoc<TResult, TVariables extends Variables
     query: options.query,
     ...(await setupAdminAsAppRequest(options.session)),
     variables: options.variables,
+    autoRateLimitRestore: options.autoRateLimitRestore,
   })
 }

--- a/packages/cli-kit/src/public/node/http.ts
+++ b/packages/cli-kit/src/public/node/http.ts
@@ -38,7 +38,7 @@ type AutomaticCancellationBehaviour =
       useAbortSignal: AbortSignal | (() => AbortSignal)
     }
 
-type RequestBehaviour = NetworkRetryBehaviour & AutomaticCancellationBehaviour
+export type RequestBehaviour = NetworkRetryBehaviour & AutomaticCancellationBehaviour
 
 export type RequestModeInput = PresetFetchBehaviour | RequestBehaviour
 


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Add optional support for automatic recovery of rate limit consumed in Admin API calls. If a call consumes 10 units (from `extensions.cost.actualQueryCost`), and the recovery rate per second is 1000 units (from `extensions.cost.restoreRate`), then we should wait 0.01s after making our API call to ensure the same amount of tokens we've consumed have had the chance to recover. 

This means we can have code that hits the Admin API in succession -- such as Metafield import, where there are many queries to make -- without being a bad citizen or hitting a rate limit. 

From a callers perspective its as if the API call took very very slightly longer.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

After making a GraphQL call, if the relevant option is enabled, inspect the `extensions.cost` part of the raw GraphQL response, check for unit usage/recovery rate, and sleep the requisite amount of time. The time is dependent on query complexity, but it's often no more than double digit milliseconds.

Sleep information is included in the debug output. Time spent sleeping is counted under network usage time for analytics purposes.

### How to test your changes?

There's good test coverage, and an upstack PR makes direct use of this in a CLI command

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
