### PR TITLE
Abort theme command when an invalid environment is provided

### DIFF
--- a/.changeset/fifty-plants-ask.md
+++ b/.changeset/fifty-plants-ask.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Abort theme command when an invalid environment is passed in so it doesn't fall back to cached store data

--- a/packages/theme/src/cli/utilities/theme-command.test.ts
+++ b/packages/theme/src/cli/utilities/theme-command.test.ts
@@ -191,6 +191,18 @@ describe('ThemeCommand', () => {
       })
     })
 
+    test('single environment provided but not found in TOML - throws AbortError', async () => {
+      // Given
+      vi.mocked(loadEnvironment).mockResolvedValue(undefined)
+
+      await CommandConfig.load()
+      const command = new TestThemeCommand(['--environment', 'notreal'], CommandConfig)
+
+      // When/Then
+      await expect(command.run()).rejects.toThrow(AbortError)
+      await expect(command.run()).rejects.toThrow('Please provide a valid environment.')
+    })
+
     test('multiple environments provided - uses renderConcurrent for parallel execution', async () => {
       // Given
       vi.mocked(loadEnvironment)

--- a/packages/theme/src/cli/utilities/theme-command.ts
+++ b/packages/theme/src/cli/utilities/theme-command.ts
@@ -79,6 +79,10 @@ export default abstract class ThemeCommand extends Command {
 
     // Single environment or no environment
     if (environments.length <= 1) {
+      if (environments[0] && !flags.store) {
+        throw new AbortError(`Please provide a valid environment.`)
+      }
+
       const session = commandRequiresAuth ? await this.createSession(flags) : undefined
       const commandName = this.constructor.name.toLowerCase()
 


### PR DESCRIPTION
### WHY are these changes introduced?

When running theme commands with an environment that doesn't exist, we fall back to using the cached store data instead (which can be a different store entirely). 

See below pictures.
Legitimate Environment
<img width="859" height="576" alt="Screenshot 2025-12-09 at 1 37 04 PM" src="https://github.com/user-attachments/assets/1bb6f858-7b3a-44ee-8d01-6cccfd279004" />
We get a warning that the environment isn't found but still use the prior store
<img width="855" height="514" alt="Screenshot 2025-12-09 at 1 37 23 PM" src="https://github.com/user-attachments/assets/23d2f543-33d0-4bce-89e7-134516afab0f" />

### WHAT is this pull request doing?
When running a theme command, we will check if the environment has the store flag which is needed, if it doesn't exist, stop the command and return a warning. 

I chose this way as we already run `loadEnvironment` in the base command and it only renders a warning that the environment doesn't exist. 
<img width="844" height="225" alt="image" src="https://github.com/user-attachments/assets/218184b5-5b43-47a9-842d-1d0abe2e580b" />


### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
