### PR TITLE
Add user display during short poll

### DIFF
--- a/packages/app/src/cli/services/bulk-operations/watch-bulk-operation.test.ts
+++ b/packages/app/src/cli/services/bulk-operations/watch-bulk-operation.test.ts
@@ -171,7 +171,7 @@ describe('watchBulkOperation', () => {
   })
 })
 
-describe('quickWatchBulkOperation', () => {
+describe('shortBulkOperationPoll', () => {
   const mockAdminSession = {token: 'test-token', storeFqdn: 'test.myshopify.com'}
   const operationId = 'gid://shopify/BulkOperation/123'
 
@@ -206,6 +206,9 @@ describe('quickWatchBulkOperation', () => {
 
   beforeEach(() => {
     vi.mocked(sleep).mockResolvedValue()
+    vi.mocked(renderSingleTask).mockImplementation(async ({task}) => {
+      return task(() => {})
+    })
   })
 
   test('returns immediately when operation is already completed', async () => {


### PR DESCRIPTION
Resolves: https://github.com/orgs/shop/projects/208/views/34?pane=issue&itemId=143907836&issue=shop%7Cissues-api-foundations%7C1160

### WHY are these changes introduced?

Improve the user experience when polling for bulk operations by showing a task indicator.

### WHAT is this pull request doing?
- Enhances `shortBulkOperationPoll` to display a task indicator while checking the bulk operation status
- Update unit tests correspondingly

### How to test your changes?

1. Run a command that uses bulk operations
2. Verify that a "Checking bulk operation status..." indicator appears in the console
3. Confirm that the operation completes successfully with the indicator show

![Screenshot 2025-12-09 at 4.53.52 PM.png](https://app.graphite.com/user-attachments/assets/c528b8ce-ccdc-4a50-b1c6-351d91bdc20c.png)

ing progress

