### PR TITLE
[Bugfix] Remove blocks on calls to partners api

### DIFF
--- a/packages/app/src/cli/utilities/developer-platform-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client.ts
@@ -58,7 +58,6 @@ import {
 } from '../api/graphql/app-management/generated/app-logs-subscribe.js'
 import {Session} from '@shopify/cli-kit/node/session'
 import {TokenItem} from '@shopify/cli-kit/node/ui'
-import {blockPartnersAccess} from '@shopify/cli-kit/node/environment'
 import {UnauthorizedHandler} from '@shopify/cli-kit/node/api/graphql'
 import {JsonMapType} from '@shopify/cli-kit/node/toml'
 
@@ -85,9 +84,7 @@ export function allDeveloperPlatformClients(): DeveloperPlatformClient[] {
 
   clients.push(AppManagementClient.getInstance())
 
-  if (!blockPartnersAccess()) {
-    clients.push(PartnersClient.getInstance())
-  }
+  clients.push(PartnersClient.getInstance())
 
   return clients
 }
@@ -105,8 +102,6 @@ function selectDeveloperPlatformClientByOrg(organization: Organization): Develop
 }
 
 function defaultDeveloperPlatformClient(): DeveloperPlatformClient {
-  if (blockPartnersAccess()) return AppManagementClient.getInstance()
-
   return PartnersClient.getInstance()
 }
 

--- a/packages/cli-kit/src/private/node/constants.ts
+++ b/packages/cli-kit/src/private/node/constants.ts
@@ -42,8 +42,6 @@ export const environmentVariables = {
   otelURL: 'SHOPIFY_CLI_OTEL_EXPORTER_OTLP_ENDPOINT',
   themeKitAccessDomain: 'SHOPIFY_CLI_THEME_KIT_ACCESS_DOMAIN',
   json: 'SHOPIFY_FLAG_JSON',
-  neverUsePartnersApi: 'SHOPIFY_CLI_NEVER_USE_PARTNERS_API',
-  usePartnersApi: 'SHOPIFY_CLI_USE_PARTNERS_API',
   skipNetworkLevelRetry: 'SHOPIFY_CLI_SKIP_NETWORK_LEVEL_RETRY',
   maxRequestTimeForNetworkCalls: 'SHOPIFY_CLI_MAX_REQUEST_TIME_FOR_NETWORK_CALLS',
 }

--- a/packages/cli-kit/src/public/node/context/fqdn.test.ts
+++ b/packages/cli-kit/src/public/node/context/fqdn.test.ts
@@ -8,11 +8,9 @@ import {
   adminFqdn,
 } from './fqdn.js'
 import {Environment, serviceEnvironment} from '../../../private/node/context/service.js'
-import {blockPartnersAccess} from '../environment.js'
 import {expect, describe, test, vi} from 'vitest'
 
 vi.mock('../../../private/node/context/service.js')
-vi.mock('../environment.js')
 
 vi.mock('../vendor/dev_server/index.js', () => {
   return {
@@ -34,7 +32,6 @@ describe('partners', () => {
   test('returns the local fqdn when the environment is local', async () => {
     // Given
     vi.mocked(serviceEnvironment).mockReturnValue(Environment.Local)
-    vi.mocked(blockPartnersAccess).mockReturnValue(false)
 
     // When
     const got = await partnersFqdn()
@@ -46,7 +43,6 @@ describe('partners', () => {
   test('returns the production fqdn when the environment is production', async () => {
     // Given
     vi.mocked(serviceEnvironment).mockReturnValue(Environment.Production)
-    vi.mocked(blockPartnersAccess).mockReturnValue(false)
 
     // When
     const got = await partnersFqdn()

--- a/packages/cli-kit/src/public/node/context/fqdn.ts
+++ b/packages/cli-kit/src/public/node/context/fqdn.ts
@@ -1,7 +1,6 @@
-import {AbortError, BugError} from '../error.js'
+import {AbortError} from '../error.js'
 import {serviceEnvironment} from '../../../private/node/context/service.js'
 import {DevServer, DevServerCore} from '../vendor/dev_server/index.js'
-import {blockPartnersAccess} from '../environment.js'
 
 export const NotProvidedStoreFQDNError = new AbortError(
   "Couldn't obtain the Shopify FQDN because the store FQDN was not provided.",
@@ -13,9 +12,6 @@ export const NotProvidedStoreFQDNError = new AbortError(
  * @returns Fully-qualified domain of the partners service we should interact with.
  */
 export async function partnersFqdn(): Promise<string> {
-  if (blockPartnersAccess()) {
-    throw new BugError('Partners API is is no longer available.')
-  }
   const environment = serviceEnvironment()
   const productionFqdn = 'partners.shopify.com'
   switch (environment) {

--- a/packages/cli-kit/src/public/node/environment.ts
+++ b/packages/cli-kit/src/public/node/environment.ts
@@ -84,26 +84,6 @@ export function jsonOutputEnabled(environment = getEnvironmentVariables()): bool
 }
 
 /**
- * If true, the CLI should not use the Partners API.
- *
- * @returns True when the CLI should not use the Partners API.
- */
-export function blockPartnersAccess(): boolean {
-  // Block if explicitly set to never use Partners API
-  if (isTruthy(getEnvironmentVariables()[environmentVariables.neverUsePartnersApi])) {
-    return true
-  }
-
-  // If explicitly forcing to use Partners API, do not block
-  if (isTruthy(getEnvironmentVariables()[environmentVariables.usePartnersApi])) {
-    return false
-  }
-
-  // Block for 3P devs
-  return !isTruthy(getEnvironmentVariables()[environmentVariables.firstPartyDev])
-}
-
-/**
  * If true, the CLI should not use the network level retry.
  *
  * If there is an error when calling a network API that looks like a DNS or connectivity issue, the CLI will by default


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes [issues-develop/issues/21679](https://github.com/shop/issues/issues/1503)

### WHAT is this pull request doing?

Reverting changes we shipped that block the Partners API, as we still need to use it for dashboard extension migration.

### How to test your changes?

Run `shopify app deploy` on any app with a dashboard managed extension that needs to be migrated to the new platform.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
  - I'll have to look for references for these env vars
