### PR TITLE
Better handling of slow networks for bulk variable upload

### DIFF
--- a/packages/app/src/cli/services/bulk-operations/stage-file.ts
+++ b/packages/app/src/cli/services/bulk-operations/stage-file.ts
@@ -7,6 +7,8 @@ import {adminRequestDoc} from '@shopify/cli-kit/node/api/admin'
 import {AdminSession} from '@shopify/cli-kit/node/session'
 import {formData, fetch} from '@shopify/cli-kit/node/http'
 import {AbortError} from '@shopify/cli-kit/node/error'
+import {outputContent} from '@shopify/cli-kit/node/output'
+import {renderSingleTask} from '@shopify/cli-kit/node/ui'
 
 interface StageFileOptions {
   adminSession: AdminSession
@@ -106,9 +108,18 @@ async function uploadFileToStagedUrl(
     contentType: 'text/jsonl',
   })
 
-  const uploadResponse = await fetch(uploadUrl, {
-    method: 'POST',
-    body: form,
+  const uploadResponse = await renderSingleTask({
+    title: outputContent`Uploading bulk operation variables`,
+    task: async () => {
+      return fetch(
+        uploadUrl,
+        {
+          method: 'POST',
+          body: form,
+        },
+        'slow-request',
+      )
+    },
   })
 
   if (!uploadResponse.ok) {


### PR DESCRIPTION
### WHY are these changes introduced?

To improve user experience by providing visual feedback during bulk operation file uploads, and disabling timeouts.

### WHAT is this pull request doing?

Adds a progress indicator when uploading bulk operation variables. This change wraps the file upload process in a `renderSingleTask` UI component to show a loading indicator during the potentially slow upload process.

It also enables the `slow-request` fetch behavior, which disables timeouts and retries.

### How to test your changes?

1. Use a tool like [Network Link Conditioner](https://nshipster.com/network-link-conditioner/) to simulate a slow connection.
1. Run a bulk operation with a large variable file
1. Verify that a loading indicator appears during the upload process
1. Confirm the upload completes successfully

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes