### PR TITLE
Create a slight delay in on shortcut keys so you can't spam theme in theme dev

### DIFF
--- a/.changeset/ninety-shirts-guess.md
+++ b/.changeset/ninety-shirts-guess.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Create a slight delay when keypressing theme dev shortcut keys to stop accidental copy pasting and opening up a ton of tabs

--- a/packages/theme/src/cli/services/dev.test.ts
+++ b/packages/theme/src/cli/services/dev.test.ts
@@ -1,5 +1,5 @@
-import {openURLSafely, renderLinks} from './dev.js'
-import {describe, expect, test, vi} from 'vitest'
+import {openURLSafely, renderLinks, createKeypressHandler} from './dev.js'
+import {describe, expect, test, vi, beforeEach, afterEach} from 'vitest'
 import {buildTheme} from '@shopify/cli-kit/node/themes/factories'
 import {DEVELOPMENT_THEME_ROLE} from '@shopify/cli-kit/node/themes/utils'
 import {renderSuccess, renderWarning} from '@shopify/cli-kit/node/ui'
@@ -100,5 +100,136 @@ describe('openURLSafely', () => {
         body: error.stack ?? error.message,
       })
     })
+  })
+})
+
+describe('createKeypressHandler', () => {
+  const urls = {
+    local: 'http://127.0.0.1:9292',
+    giftCard: 'http://127.0.0.1:9292/gift_cards/[store_id]/preview',
+    themeEditor: 'https://my-store.myshopify.com/admin/themes/123/editor?hr=9292',
+    preview: 'https://my-store.myshopify.com/?preview_theme_id=123',
+  }
+
+  const ctx = {lastRequestedPath: '/'}
+
+  beforeEach(() => {
+    vi.mocked(openURL).mockResolvedValue(true)
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  test('opens localhost when "t" is pressed', () => {
+    // Given
+    const handler = createKeypressHandler(urls, ctx)
+
+    // When
+    handler('t', {name: 't'})
+
+    // Then
+    expect(openURL).toHaveBeenCalledWith(urls.local)
+  })
+
+  test('opens theme preview when "p" is pressed', () => {
+    // Given
+    const handler = createKeypressHandler(urls, ctx)
+
+    // When
+    handler('p', {name: 'p'})
+
+    // Then
+    expect(openURL).toHaveBeenCalledWith(urls.preview)
+  })
+
+  test('opens theme editor when "e" is pressed', () => {
+    // Given
+    const handler = createKeypressHandler(urls, ctx)
+
+    // When
+    handler('e', {name: 'e'})
+
+    // Then
+    expect(openURL).toHaveBeenCalledWith(urls.themeEditor)
+  })
+
+  test('opens gift card preview when "g" is pressed', () => {
+    // Given
+    const handler = createKeypressHandler(urls, ctx)
+
+    // When
+    handler('g', {name: 'g'})
+
+    // Then
+    expect(openURL).toHaveBeenCalledWith(urls.giftCard)
+  })
+
+  test('appends preview path to theme editor URL when lastRequestedPath is not "/"', () => {
+    // Given
+    const ctxWithPath = {lastRequestedPath: '/products/test-product'}
+    const handler = createKeypressHandler(urls, ctxWithPath)
+
+    // When
+    handler('e', {name: 'e'})
+
+    // Then
+    expect(openURL).toHaveBeenCalledWith(
+      `${urls.themeEditor}&previewPath=${encodeURIComponent('/products/test-product')}`,
+    )
+  })
+
+  test('debounces rapid keypresses - only opens URL once during debounce window', () => {
+    // Given
+    const handler = createKeypressHandler(urls, ctx)
+
+    // When
+    handler('t', {name: 't'})
+    handler('t', {name: 't'})
+    handler('t', {name: 't'})
+    handler('t', {name: 't'})
+
+    // Then
+    expect(openURL).toHaveBeenCalledTimes(1)
+    expect(openURL).toHaveBeenCalledWith(urls.local)
+  })
+
+  test('allows keypresses after debounce period expires', () => {
+    // Given
+    const handler = createKeypressHandler(urls, ctx)
+
+    // When
+    handler('t', {name: 't'})
+    expect(openURL).toHaveBeenCalledTimes(1)
+
+    handler('t', {name: 't'})
+    handler('t', {name: 't'})
+    expect(openURL).toHaveBeenCalledTimes(1)
+
+    // Advance time to exceed debounce period
+    vi.advanceTimersByTime(100)
+
+    handler('p', {name: 'p'})
+
+    // Then
+    expect(openURL).toHaveBeenCalledTimes(2)
+    expect(openURL).toHaveBeenNthCalledWith(1, urls.local)
+    expect(openURL).toHaveBeenNthCalledWith(2, urls.preview)
+  })
+
+  test('debounces different keys during the same debounce window', () => {
+    // Given
+    const handler = createKeypressHandler(urls, ctx)
+
+    // When
+    handler('t', {name: 't'})
+    handler('p', {name: 'p'})
+    handler('e', {name: 'e'})
+    handler('g', {name: 'g'})
+
+    // Then
+    expect(openURL).toHaveBeenCalledTimes(1)
+    expect(openURL).toHaveBeenCalledWith(urls.local)
   })
 })


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/developer-tools-team/issues/918

If you copy and paste in the terminal when running `theme dev` you can end up with a ton of tabs opening.
Since we are watching for certain keys like `t` to open localhost, if you were to copy and paste text that had multiple `t|p|e|g`<-- shortcut keys, you can end up opening a lot of tabs.

### WHAT is this pull request doing?

When a key is pressed we create a short lived lock, and any other keys pressed during that time will be ignored. The delay is set to 100ms so we shouldn't see any problems with someone quickly doing something like opening localhost and then the editor for themselves.

I also added some extra keypress tests that we didn't originally have.

### How to test your changes?
This is a fun one to test.
- On a current shopify version, run `theme dev` and in the console, paste `tteeppggtt`. This should open 10 tabs.
- Build this branch and do the same. Only the first key should register (`t`) and open localhost once.
- You can also test if it feels snappy enough by manually pressing a couple keys like opening localhost, then the editor, then the preview pane to see how it feels.

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
