### PR TITLE
Fix permission and NPM version in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,11 +52,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Install pnpm
-        uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # pin@v4.0.0
+      - name: Setup deps
+        uses: ./.github/actions/setup-cli-deps
         with:
-          version: ${{ env.PNPM_VERSION }}
-          run_install: false
+          node-version: 24.12.0
       - name: Force snapshot changeset
         run: "mv .changeset/force-snapshot-build.md.ignore .changeset/force-snapshot-build.md"
       - name: Create snapshot version
@@ -87,7 +86,7 @@ jobs:
     if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.tag == '') }}
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       pull-requests: write
       id-token: write
     steps:
@@ -98,7 +97,7 @@ jobs:
       - name: Setup deps
         uses: ./.github/actions/setup-cli-deps
         with:
-          node-version: 24.1.0
+          node-version: 24.12.0
       - name: Create Release Pull Request
         uses: changesets/action@e9cc34b540dd3ad1b030c57fd97269e8f6ad905a #  pin@v1
         with:
@@ -128,7 +127,7 @@ jobs:
       - name: Setup deps
         uses: ./.github/actions/setup-cli-deps
         with:
-          node-version: 24.1.0
+          node-version: 24.12.0
       - name: Release
         run: pnpm release ${{ github.event.inputs.tag || 'nightly' }}
         env:


### PR DESCRIPTION
### WHY are these changes introduced?

Continuation of https://github.com/Shopify/cli/pull/6709

The release is still failing: https://github.com/Shopify/cli/actions/runs/20146132860/job/57826928555

In https://github.com/Shopify/cli/pull/6707 I changed the contents permission from `write` to `read`, but the changesets action needs it to push a branch `changeset-release/main`.

### WHAT is this pull request doing?

- Adds back the `write` permission to `contents`
- Updates the Node version to 24.12 that comes bundled with NPM 11.6.2 (OIDC authentication requires NPM 11.5.1 or higher)

### How to test your changes?

Merge and try again

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
