### PR TITLE
POC of adding header support to `app execute`

### DIFF
--- a/packages/app/src/cli/commands/app/execute.ts
+++ b/packages/app/src/cli/commands/app/execute.ts
@@ -28,6 +28,7 @@ export default class Execute extends AppLinkedCommand {
       variables: flags.variables,
       outputFile: flags['output-file'],
       ...(flags.version && {version: flags.version}),
+      ...(flags.header && {headers: flags.header}),
     })
 
     return {app: appContextResult.app}

--- a/packages/app/src/cli/flags.ts
+++ b/packages/app/src/cli/flags.ts
@@ -106,4 +106,9 @@ export const operationFlags = {
     description: 'The file name where results should be written, instead of STDOUT.',
     env: 'SHOPIFY_FLAG_OUTPUT_FILE',
   }),
+  header: Flags.string({
+    description: 'Custom HTTP header to include with the request, in "Key: Value" format. Can be specified multiple times.',
+    env: 'SHOPIFY_FLAG_HEADER',
+    multiple: true,
+  }),
 }

--- a/packages/cli-kit/src/public/node/api/admin.ts
+++ b/packages/cli-kit/src/public/node/api/admin.ts
@@ -62,6 +62,8 @@ export interface AdminRequestOptions<TResult, TVariables extends Variables> {
   responseOptions?: GraphQLResponseOptions<TResult>
   /** Custom request behaviour for retries and timeouts. */
   preferredBehaviour?: RequestModeInput
+  /** Custom HTTP headers to include with the request. */
+  addedHeaders?: {[header: string]: string}
 }
 
 /**
@@ -73,14 +75,14 @@ export interface AdminRequestOptions<TResult, TVariables extends Variables> {
 export async function adminRequestDoc<TResult, TVariables extends Variables>(
   options: AdminRequestOptions<TResult, TVariables>,
 ): Promise<TResult> {
-  const {query, session, variables, version, responseOptions, preferredBehaviour} = options
+  const {query, session, variables, version, responseOptions, preferredBehaviour, addedHeaders: customHeaders} = options
 
   let apiVersion = version ?? LatestApiVersionByFQDN.get(session.storeFqdn)
   if (!apiVersion) {
     apiVersion = await fetchLatestSupportedApiVersion(session, preferredBehaviour)
   }
   let storeDomain = session.storeFqdn
-  const addedHeaders = themeAccessHeaders(session)
+  const addedHeaders = {...themeAccessHeaders(session), ...customHeaders}
 
   if (serviceEnvironment() === 'local') {
     addedHeaders['x-forwarded-host'] = storeDomain


### PR DESCRIPTION
# Add custom HTTP header support to GraphQL operations

### WHY are these changes introduced?

This PR adds the ability to include custom HTTP headers when executing GraphQL operations via the CLI, which enables more advanced API usage scenarios.

### WHAT is this pull request doing?

- Adds a new `--header` flag to the `app execute` command that accepts custom HTTP headers in "Key: Value" format
- Allows specifying multiple headers with repeated flag usage
- Properly parses and validates header format, trimming whitespace and handling empty values
- Includes GraphQL response extensions (like query cost) in the output when present
- Updates the admin API request function to accept and apply custom headers

### How to test your changes?

1. Run a GraphQL query with a custom header:
   ```
   shopify app execute --header "X-Custom-Header: value" "query { shop { name } }"
   ```

2. Use multiple headers:
   ```
   shopify app execute --header "X-Header-1: value1" --header "X-Header-2: value2" "query { shop { name } }"
   ```

3. Verify that response extensions appear in the output when present.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes