### PR TITLE
[Feature] Add "Open in Shopify POS" CTA for POS extensions

### DIFF
--- a/.changeset/pos-dev-console-open-in-pos.md
+++ b/.changeset/pos-dev-console-open-in-pos.md
@@ -1,0 +1,6 @@
+---
+'@shopify/ui-extensions-dev-console-app': patch
+---
+
+Add an "Open in Shopify POS" call-to-action in the mobile QR code modal for POS extensions.
+

--- a/packages/ui-extensions-dev-console/src/sections/Extensions/components/QRCodeModal/QRCodeModal.module.scss
+++ b/packages/ui-extensions-dev-console/src/sections/Extensions/components/QRCodeModal/QRCodeModal.module.scss
@@ -28,6 +28,7 @@
 
 .UrlCta {
    display: flex;
+   flex-wrap: wrap;
    gap: 0.8rem;
    align-items: center;
 }

--- a/packages/ui-extensions-dev-console/src/sections/Extensions/components/QRCodeModal/QRCodeModal.test.tsx
+++ b/packages/ui-extensions-dev-console/src/sections/Extensions/components/QRCodeModal/QRCodeModal.test.tsx
@@ -6,11 +6,16 @@ import {mockApp, mockExtension} from '@shopify/ui-extensions-server-kit/testing'
 import {render, withProviders} from '@shopify/ui-extensions-test-utils'
 import {mockI18n} from 'tests/mock-i18n'
 import {DefaultProviders} from 'tests/DefaultProviders'
+import {ExternalIcon} from '@shopify/polaris-icons'
 import {Modal} from '@/components/Modal'
+import {IconButton} from '@/components/IconButton'
 
 vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(null)
 
 vi.mock('@/components/Modal', () => ({Modal: (props: any) => props.children}))
+
+let isMobile = false
+vi.mock('@/utilities/device', () => ({isMobileDevice: () => isMobile}))
 
 mockI18n(en)
 
@@ -23,6 +28,10 @@ describe('QRCodeModal', () => {
       type: 'home' as const,
     },
   }
+
+  beforeEach(() => {
+    isMobile = false
+  })
 
   test('Renders <Modal/> closed if code is undefined', async () => {
     const app = mockApp()
@@ -62,6 +71,64 @@ describe('QRCodeModal', () => {
 
     expect(container).toContainReactComponent(QRCode, {
       value: `com.shopify.pos://pos-ui-extensions?url=${defaultProps.code.url}`,
+    })
+  })
+
+  test('renders Open in Shopify POS CTA for pos on mobile', async () => {
+    isMobile = true
+
+    const app = mockApp()
+    const store = 'example.com'
+    const extension = mockExtension()
+    const container = render(
+      <QRCodeModal {...defaultProps} code={{...defaultProps.code, type: 'point_of_sale'}} />,
+      withProviders(DefaultProviders),
+      {
+        state: {app, store, extensions: [extension]},
+      },
+    )
+
+    expect(container).toContainReactComponent(IconButton, {
+      source: ExternalIcon,
+      accessibilityLabel: en.qrcode.openPos,
+    })
+  })
+
+  test('does not render Open in Shopify POS CTA for pos on desktop', async () => {
+    isMobile = false
+
+    const app = mockApp()
+    const store = 'example.com'
+    const extension = mockExtension()
+    const container = render(
+      <QRCodeModal {...defaultProps} code={{...defaultProps.code, type: 'point_of_sale'}} />,
+      withProviders(DefaultProviders),
+      {
+        state: {app, store, extensions: [extension]},
+      },
+    )
+
+    expect(container).not.toContainReactComponent(IconButton, {
+      source: ExternalIcon,
+    })
+  })
+
+  test('does not render Open in Shopify POS CTA for non-pos types on mobile', async () => {
+    isMobile = true
+
+    const app = mockApp()
+    const store = 'example.com'
+    const extension = mockExtension()
+    const container = render(
+      <QRCodeModal {...defaultProps} code={{...defaultProps.code, type: 'checkout'}} />,
+      withProviders(DefaultProviders),
+      {
+        state: {app, store, extensions: [extension]},
+      },
+    )
+
+    expect(container).not.toContainReactComponent(IconButton, {
+      source: ExternalIcon,
     })
   })
 

--- a/packages/ui-extensions-dev-console/src/sections/Extensions/components/QRCodeModal/QRCodeModal.tsx
+++ b/packages/ui-extensions-dev-console/src/sections/Extensions/components/QRCodeModal/QRCodeModal.tsx
@@ -7,9 +7,10 @@ import copyToClipboard from 'copy-to-clipboard'
 import QRCode from 'qrcode.react'
 import {toast} from 'react-toastify'
 import {Surface} from '@shopify/ui-extensions-server-kit'
-import {ClipboardIcon} from '@shopify/polaris-icons'
+import {ClipboardIcon, ExternalIcon} from '@shopify/polaris-icons'
 import {Modal, ModalProps} from '@/components/Modal'
 import {IconButton} from '@/components/IconButton'
+import {isMobileDevice} from '@/utilities/device'
 
 interface Code {
   url: string
@@ -42,6 +43,8 @@ function QRCodeContent({url, type}: Code) {
 
   const {store, app} = useApp()
 
+  const shouldShowOpenInPOSCTA = type === 'point_of_sale' && isMobileDevice()
+
   const qrCodeURL = useMemo(() => {
     // The Websocket hasn't loaded data yet.
     // Shouldn't happen since you can't open modal without data,
@@ -64,10 +67,15 @@ function QRCodeContent({url, type}: Code) {
     return `https://${store}/admin/extensions-dev/mobile?url=${url}`
   }, [url, app, app?.mobileUrl])
 
-  const onButtonClick = useCallback(() => {
+  const onCopyClick = useCallback(() => {
     if (qrCodeURL && copyToClipboard(qrCodeURL)) {
       toast(i18n.translate('qrcode.copied'), {toastId: `copy-qrcode-${qrCodeURL}`})
     }
+  }, [qrCodeURL])
+
+  const onOpenInPOSClick = useCallback(() => {
+    if (!qrCodeURL) return
+    window.location.assign(qrCodeURL)
   }, [qrCodeURL])
 
   if (!qrCodeURL) {
@@ -84,14 +92,25 @@ function QRCodeContent({url, type}: Code) {
       <span className={styles.RightColumn}>
         {i18n.translate('right.one')}
         <span className={styles.UrlCta}>
-          {i18n.translate('right.two')}{' '}
+          {i18n.translate('right.two')}
           <IconButton
             type="button"
             source={ClipboardIcon}
             accessibilityLabel={i18n.translate('qrcode.copy')}
-            onClick={onButtonClick}
+            onClick={onCopyClick}
           />
         </span>
+        {shouldShowOpenInPOSCTA && (
+          <span className={styles.UrlCta}>
+            {i18n.translate('right.three')}
+            <IconButton
+              type="button"
+              source={ExternalIcon}
+              accessibilityLabel={i18n.translate('qrcode.openPos')}
+              onClick={onOpenInPOSClick}
+            />
+          </span>
+        )}
       </span>
     </div>
   )

--- a/packages/ui-extensions-dev-console/src/sections/Extensions/components/QRCodeModal/translations/en.json
+++ b/packages/ui-extensions-dev-console/src/sections/Extensions/components/QRCodeModal/translations/en.json
@@ -2,11 +2,13 @@
   "title": "View your work on mobile",
   "right": {
     "one": "Scan with your phone camera to see your work",
-    "two": "Or copy the URL to share:"
+    "two": "Or copy the URL to share:",
+    "three": "Or open it directly in Shopify POS:"
   },
   "qrcode": {
     "copy": "Copy link",
     "copied": "Link copied",
+    "openPos": "Open in Shopify POS",
     "content": "Scan to test {title} on mobile"
   }
 }

--- a/packages/ui-extensions-dev-console/src/utilities/device.ts
+++ b/packages/ui-extensions-dev-console/src/utilities/device.ts
@@ -1,0 +1,20 @@
+type NavigatorWithUserAgentData = Navigator & {
+  userAgentData?: {
+    mobile?: boolean
+  }
+}
+
+export function isMobileDevice(): boolean {
+  if (typeof navigator === 'undefined') return false
+
+  const navigatorWithUserAgentData = navigator as NavigatorWithUserAgentData
+  if (navigatorWithUserAgentData.userAgentData?.mobile) return true
+
+  const userAgent = navigator.userAgent ?? ''
+  if (/(Android|iPhone|iPad|iPod)/i.test(userAgent)) return true
+
+  // iPadOS 13+ uses a desktop-like UA but exposes touch points.
+  if (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1) return true
+
+  return false
+}


### PR DESCRIPTION
 ### WHY are these changes introduced?

  When developing POS UI extensions, the Dev Console “View mobile” flow requires scanning a QR code every time. On mobile devices, we can deep link directly into the Shopify POS app using the existing
  `com.shopify.pos://...` URL, reducing friction while keeping QR + copy as fallbacks.

### Demo

https://github.com/user-attachments/assets/2ca9dcf1-553c-4be7-8ac6-175d952683c3



  ### WHAT is this pull request doing?

  - Adds a third call-to-action in the QR code modal for POS extensions: “Or open it directly in Shopify POS:” with an `ExternalIcon`.
  - Shows the CTA only on mobile devices to avoid a misleading/invalid action on desktop browsers.
  - Adds an `isMobileDevice()` utility and unit tests for the new rendering conditions.
  - Uses `flex-wrap` on the CTA row to avoid the icon overflowing on narrow viewports.
  - Adds a changeset for `@shopify/ui-extensions-dev-console-app`.

  ### How to test your changes?

  1. In a project with a POS UI extension, run `shopify app dev` and open the Dev Console.
  2. In the Extensions list, click “View mobile” on a POS extension.
  3. On a mobile device (or mobile emulation with a mobile UA), verify the third line appears: “Or open it directly in Shopify POS:” and the External icon button.
  4. Tap the External icon; it should attempt to open Shopify POS via `com.shopify.pos://...`.
  5. Verify on desktop that the third CTA is not shown.
  6. Run tests: `pnpm -C packages/ui-extensions-dev-console vitest`

  ### Post-release steps

  None.

  ### Measuring impact

  - [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

  ### Checklist

  - [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
  - [x] I've considered possible documentation changes