### PR TITLE
Run the publish command in a separate step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,13 +99,19 @@ jobs:
         with:
           node-version: 24.12.0
       - name: Create Release Pull Request
+        id: changesets
         uses: changesets/action@e0145edc7d9d8679003495b11f87bd8ef63c0cba # v1
         with:
           version: pnpm changeset-manifests
           title: Version Packages - ${{ github.ref_name }}
-          publish: pnpm release latest
+          createGithubReleases: false
         env:
-          NODE_AUTH_TOKEN: ''
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish packages
+        if: steps.changesets.outputs.hasChangesets == 'false'
+        run: pnpm release latest
+        env:
           NPM_TOKEN: ''
           NPM_CONFIG_PROVENANCE: true
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -134,6 +140,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ''
-          NODE_AUTH_TOKEN: ''
           NPM_CONFIG_PROVENANCE: true
           SHOPIFY_CLI_BUILD_REPO: ${{ github.repository }}


### PR DESCRIPTION
### WHY are these changes introduced?

Continuation of https://github.com/Shopify/cli/pull/6713

The `changeset-release` GitHub Action job [keeps failing](https://github.com/Shopify/cli/actions/runs/20171101422/job/58060042374) with `Access token expired or revoked` when trying to publish packages, while the `manual-cron-release` job works correctly.

The only difference was the command to publish, so maybe the `changesets/action` is not properly passing through the OIDC authentication environment when executing the publish command internally.

### WHAT is this pull request doing?

Splits the changesets action responsibilities:
- The `changesets/action` now only handles creating/updating version PRs
- Package publishing is done in a separate step using `pnpm release latest` directly (matching the working `manual-cron-release` job)


### How to test your changes?

Merge and retry

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
