### PR TITLE
added trim to the name field

### DIFF
--- a/packages/app/src/cli/models/extensions/specifications/app_config_webhook_subscription.ts
+++ b/packages/app/src/cli/models/extensions/specifications/app_config_webhook_subscription.ts
@@ -29,7 +29,7 @@ export const SingleWebhookSubscriptionSchema = zod.object({
   include_fields: zod.array(zod.string({invalid_type_error: 'Value must be a string'})).optional(),
   filter: zod.string({invalid_type_error: 'Value must be a string'}).optional(),
   payload_query: zod.string({invalid_type_error: 'Value must be a string'}).trim().min(1).optional(),
-  name: zod.string({invalid_type_error: 'Value must be a string'}).min(1).max(50).optional(),
+  name: zod.string({invalid_type_error: 'Value must be a string'}).trim().min(1).max(50).optional(),
 })
 
 /* this transforms webhooks remotely to be accepted by the TOML


### PR DESCRIPTION
Add `.trim()` to the webhook subscription `name` field validation for consistency with other string fields.

In the [previous PR adding name validation](https://github.com/Shopify/cli/pull/6576), I missed adding `.trim()` to line 32 in `app_config_webhook_subscription.ts` (see [this comment](https://github.com/Shopify/cli/pull/6576#discussion_r2498183805)).

This adds it to match the pattern used for `payload_query` and other string fields.
