### PR TITLE
Fix local store domain

### DIFF
--- a/packages/cli-kit/src/public/node/context/fqdn.ts
+++ b/packages/cli-kit/src/public/node/context/fqdn.ts
@@ -139,5 +139,8 @@ export function normalizeStoreFqdn(store: string): string {
   }
   const containDomain = (storeFqdn: string) =>
     storeFqdn.endsWith('.myshopify.com') || storeFqdn.endsWith('shopify.io') || storeFqdn.endsWith('.shop.dev')
-  return containDomain(storeFqdn) ? storeFqdn : addDomain(storeFqdn)
+  const normalizedFqdn = containDomain(storeFqdn) ? storeFqdn : addDomain(storeFqdn)
+  // Use dev-api domain for OAuth redirects in local environment
+  // See: https://github.com/Shopify/dev_server?tab=readme-ov-file#shop-redirects
+  return normalizedFqdn.replace('.my.shop.dev', '.dev-api.shop.dev')
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Related to https://github.com/shop/issues-bundles-and-combined-listings/issues/1250

When running `app dev` against local, the App Home link points to `https://dev-store-local.my.shop.dev/admin/oauth/redirect_from_cli?client_id=xxx`, which throws a 404:

<img width="1406" height="1110" alt="image" src="https://github.com/user-attachments/assets/c1365735-262e-4004-a507-410a55723727" />

Related discussion: https://shopify.slack.com/archives/C08GKEEKXGE/p1765883873388589

### WHAT is this pull request doing?

Replaces `.my.shop.dev` with `.dev-api.shop.dev`, which is apparently required for the OAuth flow: https://github.com/Shopify/dev_server?tab=readme-ov-file#shop-redirects

### How to test your changes?

`SHOPIFY_CLI_NEVER_USE_PARTNERS_API=1 SHOPIFY_SERVICE_ENV=local pnpm shopify app dev`

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
