### PR TITLE
Remove hardcoded version from theme duplicate API call

### DIFF
--- a/.changeset/fluffy-signs-peel.md
+++ b/.changeset/fluffy-signs-peel.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': minor
+---
+
+Remove hardcoded theme duplicate mutation API version

--- a/packages/cli-kit/src/public/node/themes/api.test.ts
+++ b/packages/cli-kit/src/public/node/themes/api.test.ts
@@ -470,7 +470,6 @@ describe('themeDuplicate', () => {
         session,
         variables: {id: `gid://shopify/OnlineStoreTheme/${id}`, name},
         preferredBehaviour: expectedApiOptions,
-        version: '2025-10',
         responseOptions: {
           onResponse: expect.any(Function),
         },

--- a/packages/cli-kit/src/public/node/themes/api.ts
+++ b/packages/cli-kit/src/public/node/themes/api.ts
@@ -486,7 +486,6 @@ export async function themeDuplicate(
     session,
     variables: {id: composeThemeGid(id), name},
     preferredBehaviour: THEME_API_NETWORK_BEHAVIOUR,
-    version: '2025-10',
     responseOptions: {
       onResponse: (response) => {
         requestId = response.headers.get('x-request-id') ?? undefined


### PR DESCRIPTION
- follow up on https://github.com/Shopify/cli/pull/6050

### WHY are these changes introduced?

To create the [`theme duplicate`](https://shopify.dev/docs/api/shopify-cli/theme/theme-duplicate) CLI command we needed to add a new public [mutation](https://shopify.dev/docs/api/admin-graphql/latest/mutations/themeDuplicate) to the admin graphql API. The mutation was added to the `2025-10` version of the API and since that version was not yet supported we needed to point to it specifically in order to use it as part of the command

Now that `2025-10` is the latest API version we no longer need to hardcode it

### WHAT is this pull request doing?

This PR removes the hardcoded `version: 2025-10` from the theme duplicate API call

### How to test your changes?

- Pull down the branch `gh pr checkout 6737` (somethings up with snapit 🤔 )
- Ensure `pnpm shopify theme duplicate` still works as expected

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] Existing analytics will cater for this addition

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
