### PR TITLE
Fix Promise.withResolvers TypeScript signature conflict

### DIFF
--- a/packages/theme/src/cli/polyfills/promiseWithResolvers.ts
+++ b/packages/theme/src/cli/polyfills/promiseWithResolvers.ts
@@ -6,7 +6,7 @@ interface PromiseWithResolvers<T> {
 
 declare global {
   interface PromiseConstructor {
-    withResolvers?<T>(): PromiseWithResolvers<T>
+    withResolvers<T>(): PromiseWithResolvers<T>
   }
 }
 


### PR DESCRIPTION
## Summary

#6740 introduced a global declaration for `Promise.withResolvers` ([this line](https://github.com/Shopify/cli/pull/6740/changes#diff-0ce173cf5766df7690ae612e050b1a974672ff3f6a350e319426a2cd3b208da8R9)) but incorrectly marked it as optional with `?`. this conflicts with node 24's native type definition which marks it as required, causing typescript to error:

<img width="1220" height="813" alt="image" src="https://github.com/user-attachments/assets/f5ef20a1-1921-4970-80c1-dfafbbd6528c" />

this PR fixes it by removing that optional modifier in the global `PromiseConstructor` interface declaration.

## Test plan

- [x] `pnpm nx run theme:type-check` passes
- [x] `pnpm refresh-manifests` completes successfully