### PR TITLE
Add support for uploading instructions.md for ui extensions

### DIFF
--- a/packages/app/src/cli/models/extensions/schemas.ts
+++ b/packages/app/src/cli/models/extensions/schemas.ts
@@ -46,6 +46,7 @@ const NewExtensionPointSchema = zod.object({
   module: zod.string(),
   should_render: ShouldRenderSchema.optional(),
   tools: zod.string().optional(),
+  instructions: zod.string().optional(),
   metafields: zod.array(MetafieldSchema).optional(),
   default_placement: zod.string().optional(),
   urls: zod

--- a/packages/app/src/cli/models/extensions/specification.ts
+++ b/packages/app/src/cli/models/extensions/specification.ts
@@ -39,6 +39,7 @@ export enum AssetIdentifier {
   ShouldRender = 'should_render',
   Main = 'main',
   Tools = 'tools',
+  Instructions = 'instructions',
 }
 
 export interface Asset {


### PR DESCRIPTION
### WHY are these changes introduced?
Fix https://github.com/shop/issues-admin-extensibility/issues/2125

### WHAT is this pull request doing?

Adds support for an `instructions` field in UI extension configuration, similar to the existing `tools` field. This allows developers to specify a markdown file that contains instructions for using their extension.

The changes include:
- Adding `instructions` to the extension point schema
- Adding a new asset identifier for instructions
- Adding validation to ensure the instructions file exists
- Adding tests to verify the new functionality works correctly

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes