### PR TITLE
Include websocket URL in dev session create API call

### DIFF
--- a/packages/app/src/cli/api/graphql/app-dev/generated/dev-session-create.ts
+++ b/packages/app/src/cli/api/graphql/app-dev/generated/dev-session-create.ts
@@ -16,7 +16,7 @@ export type DevSessionCreateMutation = {
   } | null
 }
 
-export const DevSessionCreateDocument = {
+export const DevSessionCreate = {
   kind: 'Document',
   definitions: [
     {

--- a/packages/app/src/cli/api/graphql/app-dev/generated/dev-session-delete.ts
+++ b/packages/app/src/cli/api/graphql/app-dev/generated/dev-session-delete.ts
@@ -9,7 +9,7 @@ export type DevSessionDeleteMutationVariables = Types.Exact<{
 
 export type DevSessionDeleteMutation = {devSessionDelete?: {userErrors: {message: string}[]} | null}
 
-export const DevSessionDeleteDocument = {
+export const DevSessionDelete = {
   kind: 'Document',
   definitions: [
     {

--- a/packages/app/src/cli/api/graphql/app-dev/generated/dev-session-update.ts
+++ b/packages/app/src/cli/api/graphql/app-dev/generated/dev-session-update.ts
@@ -7,7 +7,6 @@ import {TypedDocumentNode as DocumentNode} from '@graphql-typed-document-node/co
 export type DevSessionUpdateMutationVariables = Types.Exact<{
   appId: Types.Scalars['String']['input']
   assetsUrl?: Types.InputMaybe<Types.Scalars['String']['input']>
-  websocketUrl?: Types.InputMaybe<Types.Scalars['String']['input']>
   manifest?: Types.InputMaybe<Types.Scalars['JSON']['input']>
   inheritedModuleUids: Types.Scalars['String']['input'][] | Types.Scalars['String']['input']
 }>
@@ -18,7 +17,7 @@ export type DevSessionUpdateMutation = {
   } | null
 }
 
-export const DevSessionUpdateDocument = {
+export const DevSessionUpdate = {
   kind: 'Document',
   definitions: [
     {
@@ -34,11 +33,6 @@ export const DevSessionUpdateDocument = {
         {
           kind: 'VariableDefinition',
           variable: {kind: 'Variable', name: {kind: 'Name', value: 'assetsUrl'}},
-          type: {kind: 'NamedType', name: {kind: 'Name', value: 'String'}},
-        },
-        {
-          kind: 'VariableDefinition',
-          variable: {kind: 'Variable', name: {kind: 'Name', value: 'websocketUrl'}},
           type: {kind: 'NamedType', name: {kind: 'Name', value: 'String'}},
         },
         {
@@ -74,11 +68,6 @@ export const DevSessionUpdateDocument = {
                 kind: 'Argument',
                 name: {kind: 'Name', value: 'assetsUrl'},
                 value: {kind: 'Variable', name: {kind: 'Name', value: 'assetsUrl'}},
-              },
-              {
-                kind: 'Argument',
-                name: {kind: 'Name', value: 'websocketUrl'},
-                value: {kind: 'Variable', name: {kind: 'Name', value: 'websocketUrl'}},
               },
               {
                 kind: 'Argument',

--- a/packages/app/src/cli/api/graphql/app-dev/queries/dev-session-update.graphql
+++ b/packages/app/src/cli/api/graphql/app-dev/queries/dev-session-update.graphql
@@ -1,5 +1,5 @@
-mutation DevSessionUpdate($appId: String!, $assetsUrl: String, $websocketUrl: String, $manifest: JSON, $inheritedModuleUids: [String!]!) {
-  devSessionUpdate(appId: $appId, assetsUrl: $assetsUrl, websocketUrl: $websocketUrl, manifest: $manifest, inheritedModuleUids: $inheritedModuleUids) {
+mutation DevSessionUpdate($appId: String!, $assetsUrl: String, $manifest: JSON, $inheritedModuleUids: [String!]!) {
+  devSessionUpdate(appId: $appId, assetsUrl: $assetsUrl, manifest: $manifest, inheritedModuleUids: $inheritedModuleUids) {
     userErrors {
       message
       on

--- a/packages/app/src/cli/api/graphql/business-platform-organizations/generated/types.d.ts
+++ b/packages/app/src/cli/api/graphql/business-platform-organizations/generated/types.d.ts
@@ -1,4 +1,6 @@
 /* eslint-disable @typescript-eslint/consistent-type-definitions, @typescript-eslint/naming-convention, @typescript-eslint/no-explicit-any  */
+import {JsonMapType} from '@shopify/cli-kit/node/toml'
+
 export type Maybe<T> = T | null
 export type InputMaybe<T> = Maybe<T>
 export type Exact<T extends {[key: string]: unknown}> = {[K in keyof T]: T[K]}
@@ -40,6 +42,8 @@ export type Scalars = {
   ISO8601Date: {input: any; output: any}
   /** An ISO 8601-encoded datetime */
   ISO8601DateTime: {input: any; output: any}
+  /** Represents untyped JSON */
+  JSON: {input: JsonMapType | string; output: JsonMapType}
   /** The ID for a LegalEntity. */
   LegalEntityID: {input: any; output: any}
   /** The ID for a OrganizationDomain. */

--- a/packages/app/src/cli/services/dev/processes/dev-session/dev-session-process.test.ts
+++ b/packages/app/src/cli/services/dev/processes/dev-session/dev-session-process.test.ts
@@ -407,13 +407,13 @@ describe('pushUpdatesForDevSession', () => {
       appId: 'app123',
       // Assets URL is empty because the affected extension has no assets
       assetsUrl: undefined,
-      websocketUrl: 'wss://test.dev/extensions',
       manifest: {
         name: 'App',
         handle: '',
         modules: [
           {
             uid: 'test-ui-extension-uid',
+            uuid: undefined,
             assets: 'test-ui-extension-uid',
             handle: updatedExtension.handle,
             type: updatedExtension.externalType,
@@ -453,7 +453,6 @@ describe('pushUpdatesForDevSession', () => {
       shopFqdn: 'test.myshopify.com',
       appId: 'app123',
       assetsUrl: 'https://gcs.url',
-      websocketUrl: 'wss://test.dev/extensions',
       manifest: expect.any(Object),
       inheritedModuleUids: [],
     })

--- a/packages/app/src/cli/services/dev/processes/dev-session/dev-session.ts
+++ b/packages/app/src/cli/services/dev/processes/dev-session/dev-session.ts
@@ -285,7 +285,6 @@ export class DevSession {
           assetsUrl: signedURL,
           manifest,
           inheritedModuleUids,
-          websocketUrl,
         }
         return this.devSessionUpdateWithRetry(payload)
       } else {

--- a/packages/app/src/cli/utilities/developer-platform-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client.ts
@@ -174,7 +174,6 @@ export interface DevSessionUpdateOptions extends DevSessionSharedOptions {
   assetsUrl?: string
   manifest: AppManifest
   inheritedModuleUids: string[]
-  websocketUrl?: string
 }
 
 export type DevSessionDeleteOptions = DevSessionSharedOptions

--- a/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
@@ -79,19 +79,13 @@ import {AppHomeSpecIdentifier} from '../../models/extensions/specifications/app_
 import {BrandingSpecIdentifier} from '../../models/extensions/specifications/app_config_branding.js'
 import {AppAccessSpecIdentifier} from '../../models/extensions/specifications/app_config_app_access.js'
 import {CONFIG_EXTENSION_IDS} from '../../models/extensions/extension-instance.js'
+import {DevSessionCreate, DevSessionCreateMutation} from '../../api/graphql/app-dev/generated/dev-session-create.js'
 import {
-  DevSessionCreateDocument as DevSessionCreate,
-  DevSessionCreateMutation,
-} from '../../api/graphql/app-dev/generated/dev-session-create.js'
-import {
-  DevSessionUpdateDocument as DevSessionUpdate,
+  DevSessionUpdate,
   DevSessionUpdateMutation,
   DevSessionUpdateMutationVariables,
 } from '../../api/graphql/app-dev/generated/dev-session-update.js'
-import {
-  DevSessionDeleteDocument as DevSessionDelete,
-  DevSessionDeleteMutation,
-} from '../../api/graphql/app-dev/generated/dev-session-delete.js'
+import {DevSessionDelete, DevSessionDeleteMutation} from '../../api/graphql/app-dev/generated/dev-session-delete.js'
 import {
   FetchStoreByDomain,
   FetchStoreByDomainQueryVariables,
@@ -1044,7 +1038,6 @@ export class AppManagementClient implements DeveloperPlatformClient {
     shopFqdn,
     manifest,
     inheritedModuleUids,
-    websocketUrl,
   }: DevSessionUpdateOptions): Promise<DevSessionUpdateMutation> {
     const appIdNumber = String(numberFromGid(appId))
     const variables: DevSessionUpdateMutationVariables = {
@@ -1052,7 +1045,6 @@ export class AppManagementClient implements DeveloperPlatformClient {
       assetsUrl,
       manifest: JSON.stringify(manifest),
       inheritedModuleUids,
-      websocketUrl,
     }
     return this.appDevRequest({query: DevSessionUpdate, shopFqdn, variables})
   }


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/shop/issues-develop/issues/21519

### WHAT is this pull request doing?

- Extracts a `getWebSocketUrl` utility to re-use it in several places
- Adds `websocketUrl` parameter to `DevSessionCreate`
- Removes the `manifest` parameter from `DevSessionCreate`, that was being ignored (only used to update)

### How to test your changes?

`SHOPIFY_CLI_NEVER_USE_PARTNERS_API=1 SHOPIFY_SERVICE_ENV=local p shopify app dev` with https://github.com/shop/world/pull/358315

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
