### PR TITLE
Support flexible templates for `app init`

### DIFF
--- a/.changeset/lemon-bees-post.md
+++ b/.changeset/lemon-bees-post.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Support flexible templates in `shopify app init`

--- a/packages/app/src/cli/models/app/app.ts
+++ b/packages/app/src/cli/models/app/app.ts
@@ -76,6 +76,37 @@ function fixSingleWildcards(value: string[] | undefined) {
 }
 
 /**
+ * Schema for loading template config during app init.
+ * Uses passthrough() to allow any extra keys from full-featured templates
+ * (e.g., metafields, metaobjects, webhooks) without strict validation.
+ */
+export const TemplateConfigSchema = zod
+  .object({
+    scopes: zod
+      .string()
+      .transform((scopes) => normalizeDelimitedString(scopes) ?? '')
+      .optional(),
+    access_scopes: zod
+      .object({
+        scopes: zod.string().transform((scopes) => normalizeDelimitedString(scopes) ?? ''),
+      })
+      .optional(),
+    web_directories: zod.array(zod.string()).optional(),
+  })
+  .passthrough()
+
+export type TemplateConfig = zod.infer<typeof TemplateConfigSchema>
+
+export function getTemplateScopesArray(config: TemplateConfig): string[] {
+  const scopesString = config.scopes ?? config.access_scopes?.scopes ?? ''
+  if (scopesString.length === 0) return []
+  return scopesString
+    .split(',')
+    .map((scope) => scope.trim())
+    .sort()
+}
+
+/**
  * Schema for a normal, linked app. Properties from modules are not validated.
  */
 export const AppSchema = zod.object({


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes an issue where app templates using certain module types cause `app init` to fail. The issue is due to the app template using module types that aren't defined within the CLI, but more generally due to `app init` validating/understanding app configuration.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Instead, we process app config during app instantiation as opaque blobs -- we don't rely on being able to validate them or a particular structure being in place.

In `app init` the app is loaded twice -- once as a template, and then again as the local copy of the app is linked to the remote version of it.

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?

Locally: `pnpm shopify app init --path="<where I keep my apps>" --template="https://github.com/Shopify/shopify-app-template-react-router#include-declarative-definition"`

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
