### PR TITLE
fix theme dev shortcut keys not working with theme-editor-sync

### DIFF
--- a/.changeset/fuzzy-lies-agree.md
+++ b/.changeset/fuzzy-lies-agree.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Fix issue where theme dev shortcuts keys would not work when using the 'theme-editor-sync' flag

--- a/packages/theme/src/cli/services/dev.ts
+++ b/packages/theme/src/cli/services/dev.ts
@@ -123,9 +123,6 @@ export async function dev(options: DevOptions) {
   const {serverStart, renderDevSetupProgress, backgroundJobPromise} = setupDevServer(options.theme, ctx)
 
   readline.emitKeypressEvents(process.stdin)
-  if (process.stdin.isTTY) {
-    process.stdin.setRawMode(true)
-  }
 
   const keypressHandler = createKeypressHandler(urls, ctx)
   process.stdin.on('keypress', keypressHandler)
@@ -135,6 +132,9 @@ export async function dev(options: DevOptions) {
     renderDevSetupProgress()
       .then(serverStart)
       .then(() => {
+        if (process.stdin.isTTY) {
+          process.stdin.setRawMode(true)
+        }
         renderLinks(urls)
         if (options.open) {
           openURLSafely(urls.local, 'development server')


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://community.shopify.dev/t/shopify-cli-theme-dev-key-shortcuts-not-working-anymore/28028

When running `theme dev --theme-editor-sync`, the shortcut keys to open links from the terminal would not work, and instead print the shortcut key to the terminal.
<img width="764" height="313" alt="image" src="https://github.com/user-attachments/assets/3751a67d-e511-4891-a946-f13c6643bc0b" />


### WHAT is this pull request doing?

When we run `theme dev` we put the terminal into raw mode to look for keypresses. This works as expected.
When we run `theme dev theme-editor-sync` runs the file synchronization which uses ink. Ink changes the terminal mode and stops the listener from working. 

The fix involves setting raw mode after the the dev setup process has finished.

### How to test your changes?
Run the latest version of the CLI
Run `theme dev --theme-editor-sync`
Try pushing a shortcut key like `t` (It **shouldn't** work)

Pull down the branch
Build the branch
Run `theme dev --theme-editor-sync`
Try pushing a shortcut key like `t` (It **should** work)

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
