### PR TITLE
Update `app bulk execute` to fail if given a mutation document but no variables

### DIFF
--- a/packages/app/src/cli/services/bulk-operations/execute-bulk-operation.test.ts
+++ b/packages/app/src/cli/services/bulk-operations/execute-bulk-operation.test.ts
@@ -134,6 +134,7 @@ describe('executeBulkOperation', () => {
 
   test('runs mutation operation when GraphQL document starts with mutation', async () => {
     const mutation = 'mutation productUpdate($input: ProductInput!) { productUpdate(input: $input) { product { id } } }'
+    const variables = ['{"input":{"id":"gid://shopify/Product/123"}}']
     const mockResponse: BulkOperationRunMutationMutation['bulkOperationRunMutation'] = {
       bulkOperation: createdBulkOperation,
       userErrors: [],
@@ -145,12 +146,13 @@ describe('executeBulkOperation', () => {
       remoteApp: mockRemoteApp,
       store: mockStore,
       query: mutation,
+      variables,
     })
 
     expect(runBulkOperationMutation).toHaveBeenCalledWith({
       adminSession: mockAdminSession,
       query: mutation,
-      variablesJsonl: undefined,
+      variablesJsonl: '{"input":{"id":"gid://shopify/Product/123"}}',
       version: BULK_OPERATIONS_MIN_API_VERSION,
     })
     expect(runBulkOperationQuery).not.toHaveBeenCalled()
@@ -324,6 +326,22 @@ describe('executeBulkOperation', () => {
       expect(runBulkOperationQuery).not.toHaveBeenCalled()
       expect(runBulkOperationMutation).not.toHaveBeenCalled()
     })
+  })
+
+  test('throws error when mutation is provided without variables', async () => {
+    const mutation = 'mutation productUpdate($input: ProductInput!) { productUpdate(input: $input) { product { id } } }'
+
+    await expect(
+      executeBulkOperation({
+        organization: mockOrganization,
+        remoteApp: mockRemoteApp,
+        store: mockStore,
+        query: mutation,
+      }),
+    ).rejects.toThrow('Bulk mutations require variables')
+
+    expect(runBulkOperationQuery).not.toHaveBeenCalled()
+    expect(runBulkOperationMutation).not.toHaveBeenCalled()
   })
 
   test('uses watchBulkOperation (not quickWatchBulkOperation) when watch flag is true', async () => {

--- a/packages/app/src/cli/services/bulk-operations/execute-bulk-operation.ts
+++ b/packages/app/src/cli/services/bulk-operations/execute-bulk-operation.ts
@@ -207,10 +207,15 @@ function resultsContainUserErrors(results: string): boolean {
   })
 }
 
-/**
- * Validates bulk operation-specific constraints for variables.
- */
 function validateBulkOperationVariables(graphqlOperation: string, variablesJsonl?: string): void {
+  if (isMutation(graphqlOperation) && !variablesJsonl) {
+    throw new AbortError(
+      outputContent`Bulk mutations require variables. Provide a JSONL file with ${outputToken.yellow(
+        '--variable-file',
+      )} or individual JSON objects with ${outputToken.yellow('--variables')}.`,
+    )
+  }
+
   if (!isMutation(graphqlOperation) && variablesJsonl) {
     throw new AbortError(
       outputContent`The ${outputToken.yellow('--variables')} and ${outputToken.yellow(


### PR DESCRIPTION
Small bugfix related to https://github.com/shop/issues-api-foundations/issues/1047. Found it while testing the command looking for bugs (https://github.com/shop/issues-api-foundations/issues/1081).

## Summary
Without variables, bulk mutations have no input data to operate on. So, this PR adds validation that bulk mutations must include variables (via `--variables` or `--variable-file`). If not, the user now gets a clear error message instead of a cryptic XML error from the staged upload API

## Tophatting

On `main`, running `app bulk execute` against a dev store with a mutation but no variables:

<img width="615" height="219" alt="image" src="https://github.com/user-attachments/assets/3dde8975-0386-4909-a5d3-a2d5d5788e19" />

On this branch, doing the same:

<img width="644" height="140" alt="image" src="https://github.com/user-attachments/assets/d3d418a7-179b-4dae-b8d0-13158720478f" />

