### PR TITLE
Use native `FormData` for bulk mutation variable file uploads

### DIFF
--- a/packages/app/src/cli/services/bulk-operations/stage-file.ts
+++ b/packages/app/src/cli/services/bulk-operations/stage-file.ts
@@ -5,7 +5,7 @@ import {
 } from '../../api/graphql/bulk-operations/generated/staged-uploads-create.js'
 import {adminRequestDoc} from '@shopify/cli-kit/node/api/admin'
 import {AdminSession} from '@shopify/cli-kit/node/session'
-import {formData, fetch} from '@shopify/cli-kit/node/http'
+import {fetch} from '@shopify/cli-kit/node/http'
 import {AbortError} from '@shopify/cli-kit/node/error'
 import {outputContent} from '@shopify/cli-kit/node/output'
 import {renderSingleTask} from '@shopify/cli-kit/node/ui'
@@ -97,16 +97,13 @@ async function uploadFileToStagedUrl(
   parameters: {name: string; value: string}[],
   filename: string,
 ): Promise<void> {
-  const form = formData()
+  const form = new FormData()
 
   for (const param of parameters) {
     form.append(param.name, param.value)
   }
 
-  form.append('file', fileContents, {
-    filename,
-    contentType: 'text/jsonl',
-  })
+  form.append('file', new Blob([fileContents], {type: 'text/jsonl'}), filename)
 
   const uploadResponse = await renderSingleTask({
     title: outputContent`Uploading bulk operation variables`,


### PR DESCRIPTION
Small improvement related to https://github.com/shop/issues-api-foundations/issues/1047. Found it while testing the command looking for bugs (https://github.com/shop/issues-api-foundations/issues/1081).

## Summary

The `form-data` npm package triggers a deprecation warning when passed as a request body to node-fetch 3.x. This PR fixes it by switching bulk operation file uploads to use native `FormData` + `Blob` instead of the `form-data` package.

### Tophatting

On `main`, running a bulk mutation:

<img width="759" height="861" alt="image" src="https://github.com/user-attachments/assets/f1f23792-7c9b-47ce-884d-452724fb44f6" />

On this branch:

<img width="762" height="515" alt="image" src="https://github.com/user-attachments/assets/f9c5564b-310e-4be7-8fa9-398855dcaf44" />
