### PR TITLE
Make `SHOPIFY_CLI_APP_TEMPLATES_JSON_PATH` work with `SHOPIFY_CLI_1P_DEV`

### DIFF
--- a/.changeset/fix-template-json-path-1p-dev.md
+++ b/.changeset/fix-template-json-path-1p-dev.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Fix `SHOPIFY_CLI_APP_TEMPLATES_JSON_PATH` env var not working when `SHOPIFY_CLI_1P_DEV` is enabled. The template override now works consistently regardless of which developer platform client is selected.


### PR DESCRIPTION
The template JSON override was only implemented in AppManagementClient, but when SHOPIFY_CLI_1P_DEV is enabled, PartnersClient is used instead. This adds the same override logic to PartnersClient so the env var works consistently regardless of which client is selected.

<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #0000 <!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
