### PR TITLE
Fix snapit workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -59,7 +59,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@f47c8e6a9bd05ef3ee422fc8d8663be7fe4bdc61 # v3
+        uses: github/codeql-action/init@4bdb89f48054571735e3792627da6195c57459e2 # v3
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -87,6 +87,6 @@ jobs:
           exit 1
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@f47c8e6a9bd05ef3ee422fc8d8663be7fe4bdc61 # v3
+        uses: github/codeql-action/analyze@4bdb89f48054571735e3792627da6195c57459e2 # v3
         with:
           category: "/language:${{matrix.language}}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Force snapshot changeset
         run: "mv .changeset/force-snapshot-build.md.ignore .changeset/force-snapshot-build.md"
       - name: Create snapshot version
-        uses: Shopify/snapit@8dacdbe980a7628cf65d9b1d838ee7103450c6b8 # 8dacdbe980a7628cf65d9b1d838ee7103450c6b8
+        uses: Shopify/snapit@05253a195cc870a9eb6519f5e1f9a98ffd54431f # registry-and-package-manager
         with:
           global_install: 'true'
           github_comment_included_packages: '@shopify/cli'

--- a/.github/workflows/workflow-cleaner.yml
+++ b/.github/workflows/workflow-cleaner.yml
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Delete workflow runs
-        uses: Mattraks/delete-workflow-runs@5bf9a1dac5c4d041c029f0a8370ddf0c5cb5aeb7 # v2
+        uses: Mattraks/delete-workflow-runs@bd2822c9d98065c9766fb1f4bbc32325c47de4fb # v2
         with:
           token: ${{ github.token }}
           repository: ${{ github.repository }}


### PR DESCRIPTION
### WHY are these changes introduced?

Snapit was broken because NPM requires a new auth flow that wasn't supported yet. But it's [supported it now](https://github.com/Shopify/snapit/pull/52), and I've rebased the [branch that the CLI was using](https://github.com/Shopify/snapit/pull/41).

### WHAT is this pull request doing?

- Updates the snapit version to the latest registry-and-package-manager branch
- Updates the pinned versions (bin/pin-github-actions.js)

### How to test your changes?

Merge and `/snapit`

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
