### PR TITLE
Throw descriptive AbortErrors during expected authorization errors

### DIFF
--- a/.changeset/tame-tips-play.md
+++ b/.changeset/tame-tips-play.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': patch
+---
+
+Throw descriptive AbortErrors during expected authorization errors

--- a/packages/cli-kit/src/private/node/session/device-authorization.ts
+++ b/packages/cli-kit/src/private/node/session/device-authorization.ts
@@ -142,7 +142,11 @@ export async function pollForDeviceAuthorization(code: string, interval = 5): Pr
           startPolling()
           return
         case 'access_denied':
+          reject(new AbortError(`Device authorization failed: Access denied.`))
+          return
         case 'expired_token':
+          reject(new AbortError(`Device authorization failed: Token expired. Please try again.`))
+          return
         case 'unknown_failure': {
           reject(new Error(`Device authorization failed: ${error}`))
         }


### PR DESCRIPTION
### WHY are these changes introduced?

Currently, `access_denied` and `expired_token` errors raise are reported as unexpected errors. This should not be the case: barring bad server changes, both are caused by user actions. 

### WHAT is this pull request doing?

Throws `AbortError` instead of `Error`. This treats them as expected. 

### How to test your changes?

1. `pnpm shopify app init`
2. When prompted to login, do not press anything. Wait for ten minutes.
3. Open the link and login.
4. Confirm that the error message matches.

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
