### PR TITLE
Never return finished results when running `app bulk execute` without `--watch`

### DIFF
--- a/packages/app/src/cli/services/bulk-operations/execute-bulk-operation.ts
+++ b/packages/app/src/cli/services/bulk-operations/execute-bulk-operation.ts
@@ -121,7 +121,16 @@ export async function executeBulkOperation(input: ExecuteBulkOperationInput): Pr
       }
     } else {
       const operation = await shortBulkOperationPoll(adminSession, createdOperation.id)
-      await renderBulkOperationResult(operation, outputFile)
+      const errorStatuses = ['FAILED', 'CANCELED', 'EXPIRED']
+      if (errorStatuses.includes(operation.status)) {
+        await renderBulkOperationResult(operation, outputFile)
+      } else {
+        renderSuccess({
+          headline: 'Bulk operation is running.',
+          body: statusCommandHelpMessage(operation.id),
+          customSections: [{body: [{list: {items: [outputContent`ID: ${outputToken.cyan(operation.id)}`.value]}}]}],
+        })
+      }
     }
   } else {
     renderWarning({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14384,15 +14384,6 @@ snapshots:
       msw: 2.8.7(@types/node@24.7.0)(typescript@5.8.3)
       vite: 6.4.1(@types/node@18.19.70)(jiti@2.4.2)(sass@1.89.1)(yaml@2.8.1)
 
-  '@vitest/mocker@3.2.1(msw@2.8.7(@types/node@24.7.0)(typescript@5.8.3))(vite@6.4.1(@types/node@24.7.0)(jiti@2.4.2)(sass@1.89.1)(yaml@2.8.1))':
-    dependencies:
-      '@vitest/spy': 3.2.1
-      estree-walker: 3.0.3
-      magic-string: 0.30.17
-    optionalDependencies:
-      msw: 2.8.7(@types/node@24.7.0)(typescript@5.8.3)
-      vite: 6.4.1(@types/node@24.7.0)(jiti@2.4.2)(sass@1.89.1)(yaml@2.8.1)
-
   '@vitest/pretty-format@3.2.1':
     dependencies:
       tinyrainbow: 2.0.0
@@ -19992,7 +19983,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.1
-      '@vitest/mocker': 3.2.1(msw@2.8.7(@types/node@24.7.0)(typescript@5.8.3))(vite@6.4.1(@types/node@24.7.0)(jiti@2.4.2)(sass@1.89.1)(yaml@2.8.1))
+      '@vitest/mocker': 3.2.1(msw@2.8.7(@types/node@24.7.0)(typescript@5.8.3))(vite@6.4.1(@types/node@18.19.70)(jiti@2.4.2)(sass@1.89.1)(yaml@2.8.1))
       '@vitest/pretty-format': 3.2.1
       '@vitest/runner': 3.2.1
       '@vitest/snapshot': 3.2.1


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/shop/issues-api-foundations/issues/1295.

Currently, when we do our initial couple polls to make sure the bulk op is running as expected, if it finishes within that window (which would be super fast), we just immediately print the output.

### WHAT is this pull request doing?

If a small bulk operation completes during the short poll window, we now say "bulk operation running" instead of "bulk operation complete", even though it is complete. This is a bit odd, but we have decided it is desirable behavior because it guarantees consistency -- whether the job is small or large, the output will be the same, which is helpful for scripting.

### How to test your changes?

Try running a very small mutation, like for example this one:

```bash
pnpm shopify app bulk execute --path=<PATH_TO_TEST_APP> --query="{ products { edges { node { id handle } } } }" --store=<DEV_STORE_DOMAIN>
```

You should see "Bulk operation is running" now, instead of "Bulk operation succeeded".

<img width="758" height="226" alt="image" src="https://github.com/user-attachments/assets/cc9a8fd5-426b-41e0-abb9-cdf30163f4e9" />
