### PR TITLE
Improve deploy errors on CI

### DIFF
--- a/packages/app/src/cli/prompts/deploy-release.ts
+++ b/packages/app/src/cli/prompts/deploy-release.ts
@@ -76,12 +76,12 @@ function shouldSkipConfirmationPrompt({
 
   // If we're in non-TTY mode and there are changes that require confirmation, throw an error
   if (!isTTY() && (hasDeletes || hasUpdates)) {
-    let suggestedFlag = '--force'
-    if (hasUpdates && !hasDeletes) suggestedFlag = '--allow-updates'
-    if (hasDeletes && !hasUpdates) suggestedFlag = '--allow-deletes'
+    const suggestedFlags: string[] = []
+    if (hasUpdates) suggestedFlags.push('--allow-updates')
+    if (hasDeletes) suggestedFlags.push('--allow-deletes')
     throw new AbortError('This deployment includes changes that require confirmation.', [
       'Run the command with',
-      {command: suggestedFlag},
+      {command: suggestedFlags.join(' ')},
       'to deploy without confirmation.',
     ])
   }


### PR DESCRIPTION
### WHY are these changes introduced?

Related to https://github.com/Shopify/cli/pull/6749

Discussion: https://shopify.slack.com/archives/C05E3BDFDRB/p1768512316204469

### WHAT is this pull request doing?

When deploying on CI a version including both updates and deletes without the required flags, we added a new message suggesting to use `--force`, but we prefer to suggest the equivalent `--allow-updates --allow-deletes`, which it's clearer on the intent.

### How to test your changes?

`CI=1 pnpm shopify app deploy` with added and removed extensions

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
