### PR TITLE
Use the React Router template in acceptance tests

### DIFF
--- a/packages/features/features/app.feature
+++ b/packages/features/features/app.feature
@@ -5,8 +5,8 @@ Feature: Apps
 Background:
   Given I have a working directory
 
-Scenario: I scaffold ui, theme and function extensions in a remix app
-  And I create a remix app named MyExtendedApp with npm as package manager
+Scenario: I scaffold ui, theme and function extensions in a react-router app
+  And I create a react-router app named MyExtendedApp with npm as package manager
 #  When I create an extension named TestPurchaseExtensionReact of type post_purchase_ui and flavor react
 #  Then I have an extension named TestPurchaseExtensionReact of type checkout_post_purchase and flavor react
 #  When I create an extension named TestThemeExtension of type theme_app_extension

--- a/packages/features/steps/create-app.steps.ts
+++ b/packages/features/steps/create-app.steps.ts
@@ -50,13 +50,13 @@ When(
   /I create a (.+) app named (.+) with (.+) as package manager/,
   {timeout: 5 * 60 * 1000},
   async function (appType: string, appName: string, packageManager: string) {
-    let template
+    let templateArgs
     switch (appType) {
-      case 'remix':
-        template = 'https://github.com/Shopify/shopify-app-template-remix'
+      case 'react-router':
+        templateArgs = ['--template', 'reactRouter', '--flavor', 'javascript']
         break
       case 'extension-only':
-        template = 'https://github.com/Shopify/shopify-app-template-none'
+        templateArgs = ['--template', 'none']
         break
       default:
         throw new Error(`Unknown app type: ${appType}`)
@@ -73,8 +73,7 @@ When(
         '--package-manager',
         packageManager,
         '--local',
-        '--template',
-        template,
+        ...templateArgs,
       ],
       {env: {...process.env, ...this.temporaryEnv, NODE_OPTIONS: '', FORCE_COLOR: '0'}},
     )


### PR DESCRIPTION
### WHY are these changes introduced?

The Remix template is temporarily broken, causing the acceptance tests to fail

### WHAT is this pull request doing?

Switch to the React Router template, which is the default one now

### How to test your changes?

CI

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
