### PR TITLE
Add new release version release notes file

### DIFF
--- a/RELEASE_NOTES/3.89.md
+++ b/RELEASE_NOTES/3.89.md
@@ -1,0 +1,12 @@
+## App
+
+- Add `shopify app import-custom-data-definitions` -- a command to automatically convert existing metafields and metaobjects to declarative TOML [#6658](https://github.com/Shopify/cli/pull/6658)
+- Add `--allow-updates` and `--allow-delete` flags to deploy and release [#6749](https://github.com/Shopify/cli/pull/6749)
+- Add support for an optional name field for webhook subscriptions in shopify.app.toml [#6576](https://github.com/Shopify/cli/pull/6576)
+- Support flexible templates in `shopify app init` [#6751](https://github.com/Shopify/cli/pull/6751)
+
+## Theme
+
+- Abort theme command when an invalid environment is passed in so it doesn't fall back to cached store data [#6698](https://github.com/Shopify/cli/pull/6698)
+- Fix issue where theme dev shortcuts keys would not work when using the 'theme-editor-sync' flag [#6752](https://github.com/Shopify/cli/pull/6752)
+- Create a slight delay when keypressing theme dev shortcut keys to stop accidental copy pasting and opening up a ton of tabs [#6711](https://github.com/Shopify/cli/pull/6711)


### PR DESCRIPTION
### WHY are these changes introduced?

This PR adds release notes for version 3.89, documenting new features and bug fixes for both App and Theme components.

### WHAT is this pull request doing?

Adding release notes for version 3.89 that include:

**App:**
- New command `shopify app import-custom-data-definitions` to convert existing metafields and metaobjects to declarative TOML
- Added `--allow-updates` and `--allow-delete` flags to deploy and release commands
- Added support for optional name field for webhook subscriptions in shopify.app.toml
- Added support for flexible templates in `shopify app init`

**Theme:**
- Fixed issue where theme commands would fall back to cached store data with invalid environments
- Fixed theme dev shortcuts not working with 'theme-editor-sync' flag
- Added delay when pressing theme dev shortcut keys to prevent accidental multiple tab openings

### How to test your changes?

Review the release notes to ensure they accurately reflect the changes made in version 3.89.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes