### PR TITLE
Fix confusing error message when query is empty

### DIFF
--- a/packages/app/src/cli/api/graphql/admin/generated/types.d.ts
+++ b/packages/app/src/cli/api/graphql/admin/generated/types.d.ts
@@ -89,8 +89,6 @@ export type Scalars = {
   JSON: {input: JsonMapType | string; output: JsonMapType}
   /** A monetary value string without a currency symbol or code. Example value: `"100.57"`. */
   Money: {input: any; output: any}
-  /** A scalar value. */
-  Scalar: {input: any; output: any}
   /**
    * Represents a unique identifier in the Storefront API. A `StorefrontID` value can
    * be used wherever an ID is expected in the Storefront API.

--- a/packages/app/src/cli/api/graphql/bulk-operations/generated/types.d.ts
+++ b/packages/app/src/cli/api/graphql/bulk-operations/generated/types.d.ts
@@ -89,8 +89,6 @@ export type Scalars = {
   JSON: {input: JsonMapType | string; output: JsonMapType}
   /** A monetary value string without a currency symbol or code. Example value: `"100.57"`. */
   Money: {input: any; output: any}
-  /** A scalar value. */
-  Scalar: {input: any; output: any}
   /**
    * Represents a unique identifier in the Storefront API. A `StorefrontID` value can
    * be used wherever an ID is expected in the Storefront API.

--- a/packages/app/src/cli/utilities/execute-command-helpers.test.ts
+++ b/packages/app/src/cli/utilities/execute-command-helpers.test.ts
@@ -130,6 +130,18 @@ describe('prepareExecuteContext', () => {
     await expect(prepareExecuteContext(flagsWithoutQuery)).rejects.toThrow('exactlyOne constraint')
   })
 
+  test('throws AbortError when query flag is empty string', async () => {
+    const flagsWithEmptyQuery = {...mockFlags, query: ''}
+
+    await expect(prepareExecuteContext(flagsWithEmptyQuery)).rejects.toThrow('--query flag value is empty')
+  })
+
+  test('throws AbortError when query flag contains only whitespace', async () => {
+    const flagsWithWhitespaceQuery = {...mockFlags, query: '   \n\t  '}
+
+    await expect(prepareExecuteContext(flagsWithWhitespaceQuery)).rejects.toThrow('--query flag value is empty')
+  })
+
   test('returns query, app context, and store', async () => {
     const result = await prepareExecuteContext(mockFlags)
 
@@ -167,6 +179,24 @@ describe('prepareExecuteContext', () => {
 
     await expect(prepareExecuteContext(flagsWithQueryFile)).rejects.toThrow('Query file not found')
     expect(readFile).not.toHaveBeenCalled()
+  })
+
+  test('throws AbortError when query file is empty', async () => {
+    vi.mocked(fileExists).mockResolvedValue(true)
+    vi.mocked(readFile).mockResolvedValue('' as any)
+
+    const flagsWithQueryFile = {...mockFlags, query: undefined, 'query-file': '/path/to/empty.graphql'}
+
+    await expect(prepareExecuteContext(flagsWithQueryFile)).rejects.toThrow('is empty')
+  })
+
+  test('throws AbortError when query file contains only whitespace', async () => {
+    vi.mocked(fileExists).mockResolvedValue(true)
+    vi.mocked(readFile).mockResolvedValue('   \n\t  ' as any)
+
+    const flagsWithQueryFile = {...mockFlags, query: undefined, 'query-file': '/path/to/whitespace.graphql'}
+
+    await expect(prepareExecuteContext(flagsWithQueryFile)).rejects.toThrow('is empty')
   })
 
   test('validates GraphQL query using validateSingleOperation', async () => {

--- a/packages/app/src/cli/utilities/execute-command-helpers.ts
+++ b/packages/app/src/cli/utilities/execute-command-helpers.ts
@@ -63,7 +63,10 @@ export async function prepareAppStoreContext(flags: AppStoreContextFlags): Promi
 export async function prepareExecuteContext(flags: ExecuteCommandFlags): Promise<ExecuteContext> {
   let query: string | undefined
 
-  if (flags.query) {
+  if (flags.query !== undefined) {
+    if (!flags.query.trim()) {
+      throw new AbortError('The --query flag value is empty. Please provide a valid GraphQL query or mutation.')
+    }
     query = flags.query
   } else if (flags['query-file']) {
     const queryFile = flags['query-file']
@@ -73,6 +76,13 @@ export async function prepareExecuteContext(flags: ExecuteCommandFlags): Promise
       )
     }
     query = await readFile(queryFile, {encoding: 'utf8'})
+    if (!query.trim()) {
+      throw new AbortError(
+        outputContent`Query file at ${outputToken.path(
+          queryFile,
+        )} is empty. Please provide a valid GraphQL query or mutation.`,
+      )
+    }
   }
 
   if (!query) {

--- a/packages/cli-kit/src/cli/api/graphql/admin/generated/types.d.ts
+++ b/packages/cli-kit/src/cli/api/graphql/admin/generated/types.d.ts
@@ -89,8 +89,6 @@ export type Scalars = {
   JSON: {input: JsonMapType | string; output: JsonMapType}
   /** A monetary value string without a currency symbol or code. Example value: `"100.57"`. */
   Money: {input: any; output: any}
-  /** A scalar value. */
-  Scalar: {input: any; output: any}
   /**
    * Represents a unique identifier in the Storefront API. A `StorefrontID` value can
    * be used wherever an ID is expected in the Storefront API.


### PR DESCRIPTION
Resolves: https://github.com/orgs/shop/projects/208/views/34?pane=issue&itemId=3840291657&issue=shop%7Cissues-api-foundations%7C1312

### Problem
The code would reach this [`BugError`](https://github.com/Shopify/cli/blob/52e54ff15c7fe4c5eb564ceae7196131ee17c22e/packages/app/src/cli/utilities/execute-command-helpers.ts#L88-L92), which it should never reach. This was because when a query or query file was blank, it was considered "provided" by oclif (satisfying the exactlyOne constraint) but empty by the code.                                         

### Solution
Added validation that checks if the query or query file content is blank, and throws a user-friendly error message instead of falling through to the `BugError`.



  ### Test plan                                                                                                                                                                                                                                                                          
  - Added unit test for empty `--query` flag                                                                                                              
  - Added unit test for `--query` flag with only whitespace                                                                                               
  - Added unit test for empty query file                                                                                                                
  - Added unit test for query file containing only whitespace                                                                                           
  - All existing tests pass (15 total) 

### Before and After
**Before:**
- For empty `--query` or empty `--query-file`:
![Screenshot 2026-01-21 at 3.21.48 PM.png](https://app.graphite.com/user-attachments/assets/46a499ad-9e7a-473c-9edc-a02210285038.png)

**After:**

- For empty `--query`:
![Screenshot 2026-01-21 at 3.07.24 PM.png](https://app.graphite.com/user-attachments/assets/eba05b7d-1c16-4119-9bc8-a9bbeb540a8a.png)

- For empty `--query-file`:
![Screenshot 2026-01-21 at 3.06.55 PM.png](https://app.graphite.com/user-attachments/assets/89727303-b0c0-4ad3-8973-19ea792a5767.png)

