### PR TITLE
[Bulk Ops CLI] remove extra newline from bulk mutation variables

### DIFF
--- a/packages/app/src/cli/services/bulk-operations/stage-file.test.ts
+++ b/packages/app/src/cli/services/bulk-operations/stage-file.test.ts
@@ -69,7 +69,7 @@ describe('stageFile', () => {
     const uploadedBlob = fileAppendCall?.[1] as Blob
     const uploadedContent = await uploadedBlob?.text()
 
-    expect(uploadedContent).toBe('{"input":{"id":"gid://shopify/Product/123","tags":["test"]}}\n')
+    expect(uploadedContent).toBe('{"input":{"id":"gid://shopify/Product/123","tags":["test"]}}')
   })
 
   test('handles JSONL with multiple lines correctly', async () => {
@@ -94,7 +94,6 @@ describe('stageFile', () => {
       '{"input":{"id":"gid://shopify/Product/1","title":"New Shirt"}}',
       '{"input":{"id":"gid://shopify/Product/2","title":"Cool Pants"}}',
       '{"input":{"id":"gid://shopify/Product/3","title":"Nice Hat"}}',
-      '',
     ].join('\n')
 
     expect(uploadedContent).toBe(expectedContent)

--- a/packages/app/src/cli/services/bulk-operations/stage-file.ts
+++ b/packages/app/src/cli/services/bulk-operations/stage-file.ts
@@ -18,7 +18,7 @@ interface StageFileOptions {
 export async function stageFile(options: StageFileOptions): Promise<string> {
   const {adminSession, variablesJsonl} = options
 
-  const buffer = Buffer.from(variablesJsonl ? `${variablesJsonl}\n` : '', 'utf-8')
+  const buffer = Buffer.from(variablesJsonl ?? '', 'utf-8')
   const filename = 'bulk-variables.jsonl'
   const size = buffer.length
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/shop/issues-api-foundations/issues/1313.

### WHAT is this pull request doing?

Thanks to Rebecca's testing we discovered we're just... appending an extra newline, so if your input line already has one, we end up with an extra line? That's not right, so let's not do it.

I think this was being masked before because we were stripping whitespace, but since we've been changing whitespace handling on the back end, this is a real bug now.

### How to test your changes?

Create `products.jsonl` with a trailing newline:

```jsonl
{ "input": { "title": "Sweet new snowboard 1", "productType": "Snowboard", "vendor": "JadedPixel" } }
{ "input": { "title": "Sweet new snowboard 2", "productType": "Snowboard", "vendor": "JadedPixel" } }
{ "input": { "title": "Sweet new snowboard 3", "productType": "Snowboard", "vendor": "JadedPixel" } }
{ "input": { "title": "Sweet new snowboard 4", "productType": "Snowboard", "vendor": "JadedPixel" } }
{ "input": { "title": "Sweet new snowboard 5", "productType": "Snowboard", "vendor": "JadedPixel" } }
{ "input": { "title": "Sweet new snowboard 6", "productType": "Snowboard", "vendor": "JadedPixel" } }
{ "input": { "title": "Sweet new snowboard 7", "productType": "Snowboard", "vendor": "JadedPixel" } }
{ "input": { "title": "Sweet new snowboard 8", "productType": "Snowboard", "vendor": "JadedPixel" } }
{ "input": { "title": "Sweet new snowboard 9", "productType": "Snowboard", "vendor": "JadedPixel" } }
{ "input": { "title": "Sweet new snowboard 10", "productType": "Snowboard", "vendor": "JadedPixel" } }

```

Then run this command:

```bash
pnpm shopify app bulk execute --watch --variable-file products.jsonl --path=<path-to-your-app> --store=<your-store> --query \
  'mutation productCreate($input: ProductInput!) {
    productCreate(input: $input) {
      product {
        id
        title
        variants(first: 10) {
          edges {
            node {
              id
              title
              inventoryQuantity
            }
          }
        }
      }
      userErrors {
        message
        field
      }
    }
  }'
```

On main: user error on the last line.

<img width="1321" height="661" alt="image" src="https://github.com/user-attachments/assets/b0736a62-335d-4963-b825-58a11cb4127b" />

On this branch: no error on the last line!

<img width="1317" height="610" alt="image" src="https://github.com/user-attachments/assets/a0f0338d-4f97-4013-bef8-4cd03a7c4cb3" />

