### PR TITLE
fix SSRF vulnerability in proxy.ts

### DIFF
--- a/.changeset/rich-swans-draw.md
+++ b/.changeset/rich-swans-draw.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Protect SSRF vulnerability in proxy requests when hosts don't match

--- a/packages/theme/src/cli/utilities/theme-environment/proxy.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/proxy.ts
@@ -293,6 +293,13 @@ export function proxyStorefrontRequest(event: H3Event, ctx: DevServerContext): P
   const host = event.path.startsWith(EXTENSION_CDN_PREFIX) ? 'cdn.shopify.com' : ctx.session.storeFqdn
   const url = new URL(path, `https://${host}`)
 
+  // Check that we aren't redirecting to external hosts
+  if (url.hostname !== host) {
+    return Promise.reject(
+      new Error(`Request failed: Hostname mismatch. Expected host: ${host}. Resulting URL hostname: ${url.hostname}`),
+    )
+  }
+
   // When a .css.liquid or .js.liquid file is requested but it doesn't exist in SFR,
   // it will be rendered with a query string like `assets/file.css?1234`.
   // For some reason, after refreshing, this rendered URL keeps the wrong `?1234`


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes [#947](https://github.com/Shopify/developer-tools-team/issues/947#issuecomment-3772789077) 

### WHAT is this pull request doing?

Fixes the vulnerability when proxying by introducing a check where if the two host names don't match, the request is not executed and a 502 error is surfaced to the user. 
I could have identified hosts preceded by `// `and then performed the matching logic or even tried to correct the incorrect host but we (I and Josh) chose to throw an error because it's simpler to do, and the alternate method of rewriting the `//` path would involve regexes, and we don't want to try loading these requests. This change ensures we block the request. We also chose to throw an error instead of outputWarn as this is a rare but real vulnerability and if it happens, we want the surfaced error message to be loud

Baseline behavior:

Malicious request in logs and browser:
<img width="1011" height="830" alt="Screenshot 2026-01-22 at 3 45 10 PM" src="https://github.com/user-attachments/assets/0382380d-6bf6-4d7e-bdd5-4f75bb8c39e2" />
<img width="695" height="439" alt="Screenshot 2026-01-22 at 3 45 42 PM" src="https://github.com/user-attachments/assets/a9fad9f9-aae3-435b-8257-4a08c592c946" />

### How to test your changes?

`p build` (in editor terminal) on main branch
Start the dev server in an external terminal 

When the server is running, use the `t `shortcut to trigger a legitimate request and see the healthy logs output
To trigger the SSRF detection,  visit the malicious URL directly in your browser:
`http://127.0.0.1:9292//pokeapi.co/api/v2/pokemon/gengar`
and see the browser behavior change

Then switch to my branch to see the fix in action:
before testing the new build, kill the server in the external terminal `ctrl-c`
Then `p build`
Then restart the server again

Then run the malicious request again and see the new browser and log behavior: 
<img width="966" height="405" alt="Screenshot 2026-01-22 at 6 47 33 PM" src="https://github.com/user-attachments/assets/760bac74-69ce-40d1-b096-2095862dd39e" />
<img width="671" height="405" alt="Screenshot 2026-01-22 at 9 00 46 PM" src="https://github.com/user-attachments/assets/b65d1e64-f26c-42ae-8957-7e3480683739" />
<img width="976" height="407" alt="Screenshot 2026-01-22 at 9 05 32 PM" src="https://github.com/user-attachments/assets/ec8e2a17-f5f2-4b83-bac8-d16a6f4eb7bf" />
<img width="684" height="503" alt="Screenshot 2026-01-22 at 9 06 07 PM" src="https://github.com/user-attachments/assets/9a0cb721-5c70-4e40-aa18-fefb257f78fc" />

wrote a new unittest to verify the behavior and all proxy tests pass and all storefront-renderer tests pass

###Update
During this PR lifecycle, Chrome released a browser update which changed the behavior of the `//` . the vulnerability of a replacement of primary host by a secondary host following the `// `no longer exists in the most recent version of Chrome (as far as we can tell, the patch was released 1.27.26). This also affects the browser behavior for our fix.  On newer versions of Chrome, users will no longer see the 502 gateway or the terminal output, they will see: 
<img width="984" height="322" alt="Screenshot 2026-01-29 at 12 02 23 PM" src="https://github.com/user-attachments/assets/1c971289-dc33-4f28-b475-a150aedf3577" />
<img width="567" height="402" alt="Screenshot 2026-01-29 at 2 24 01 PM" src="https://github.com/user-attachments/assets/faedc33f-ce51-46d9-856e-ed8c48bff992" />

The fix still protects against a malicious attack, but the browser response looks different.