### PR TITLE
Fix the default environments infrastructure so it doesn’t fail when running commands that don’t require authentication

### DIFF
--- a/.changeset/crisp-loops-start.md
+++ b/.changeset/crisp-loops-start.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Fix the default environments infrastructure so it doesn’t fail when running commands that don't require authentication

--- a/packages/theme/src/cli/utilities/theme-command.ts
+++ b/packages/theme/src/cli/utilities/theme-command.ts
@@ -77,13 +77,19 @@ export default abstract class ThemeCommand extends Command {
 
     const environments = (Array.isArray(flags.environment) ? flags.environment : [flags.environment]).filter(Boolean)
 
+    // Check if store flag is required by the command
+    const storeIsRequired =
+      requiredFlags !== null &&
+      requiredFlags.some((flag) => (Array.isArray(flag) ? flag.includes('store') : flag === 'store'))
+
     // Single environment or no environment
     if (environments.length <= 1) {
-      if (environments[0] && !flags.store) {
+      if (environments[0] && !flags.store && storeIsRequired) {
         throw new AbortError(`Please provide a valid environment.`)
       }
 
-      const session = commandRequiresAuth ? await this.createSession(flags) : undefined
+      const shouldCreateSession = commandRequiresAuth && (storeIsRequired || flags.store)
+      const session = shouldCreateSession ? await this.createSession(flags) : undefined
       const commandName = this.constructor.name.toLowerCase()
 
       recordEvent(`theme-command:${commandName}:single-env:authenticated`)


### PR DESCRIPTION
### WHY are these changes introduced?

`shopify theme check` currently fails when the default environment is set in `shopify.theme.toml`.

### WHAT is this pull request doing?

This PR updates the multi-env infrastructure so it doesn’t fail when `--store` isn’t included in the list of required flags.

### How to test your changes?

- Go to an empty directory
- Create a `shopify.theme.toml` file
  ```toml
  [environments.default]
  store = "xyz.myshopify.com"
  ```
- Run `shopify theme check`
- Notice it no longer fails

### Post-release steps

N/A

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
