### PR TITLE
Detect dev session takeover

### DIFF
--- a/packages/app/src/cli/api/graphql/app-dev/generated/dev-session-create.ts
+++ b/packages/app/src/cli/api/graphql/app-dev/generated/dev-session-create.ts
@@ -12,6 +12,13 @@ export type DevSessionCreateMutationVariables = Types.Exact<{
 
 export type DevSessionCreateMutation = {
   devSessionCreate?: {
+    devSession?: {
+      websocketUrl?: string | null
+      updatedAt: string
+      user?: {id: string; email?: string | null} | null
+      app: {id: string; key: string}
+    } | null
+    warnings?: {message: string; code: Types.DevSessionWarningCode}[] | null
     userErrors: {message: string; on: JsonMapType; field?: string[] | null; category: string}[]
   } | null
 }
@@ -66,6 +73,54 @@ export const DevSessionCreate = {
             selectionSet: {
               kind: 'SelectionSet',
               selections: [
+                {
+                  kind: 'Field',
+                  name: {kind: 'Name', value: 'devSession'},
+                  selectionSet: {
+                    kind: 'SelectionSet',
+                    selections: [
+                      {kind: 'Field', name: {kind: 'Name', value: 'websocketUrl'}},
+                      {kind: 'Field', name: {kind: 'Name', value: 'updatedAt'}},
+                      {
+                        kind: 'Field',
+                        name: {kind: 'Name', value: 'user'},
+                        selectionSet: {
+                          kind: 'SelectionSet',
+                          selections: [
+                            {kind: 'Field', name: {kind: 'Name', value: 'id'}},
+                            {kind: 'Field', name: {kind: 'Name', value: 'email'}},
+                            {kind: 'Field', name: {kind: 'Name', value: '__typename'}},
+                          ],
+                        },
+                      },
+                      {
+                        kind: 'Field',
+                        name: {kind: 'Name', value: 'app'},
+                        selectionSet: {
+                          kind: 'SelectionSet',
+                          selections: [
+                            {kind: 'Field', name: {kind: 'Name', value: 'id'}},
+                            {kind: 'Field', name: {kind: 'Name', value: 'key'}},
+                            {kind: 'Field', name: {kind: 'Name', value: '__typename'}},
+                          ],
+                        },
+                      },
+                      {kind: 'Field', name: {kind: 'Name', value: '__typename'}},
+                    ],
+                  },
+                },
+                {
+                  kind: 'Field',
+                  name: {kind: 'Name', value: 'warnings'},
+                  selectionSet: {
+                    kind: 'SelectionSet',
+                    selections: [
+                      {kind: 'Field', name: {kind: 'Name', value: 'message'}},
+                      {kind: 'Field', name: {kind: 'Name', value: 'code'}},
+                      {kind: 'Field', name: {kind: 'Name', value: '__typename'}},
+                    ],
+                  },
+                },
                 {
                   kind: 'Field',
                   name: {kind: 'Name', value: 'userErrors'},

--- a/packages/app/src/cli/api/graphql/app-dev/generated/dev-session-update.ts
+++ b/packages/app/src/cli/api/graphql/app-dev/generated/dev-session-update.ts
@@ -13,6 +13,12 @@ export type DevSessionUpdateMutationVariables = Types.Exact<{
 
 export type DevSessionUpdateMutation = {
   devSessionUpdate?: {
+    devSession?: {
+      websocketUrl?: string | null
+      updatedAt: string
+      user?: {id: string; email?: string | null} | null
+      app: {id: string; key: string}
+    } | null
     userErrors: {message: string; on: JsonMapType; field?: string[] | null; category: string}[]
   } | null
 }
@@ -83,6 +89,42 @@ export const DevSessionUpdate = {
             selectionSet: {
               kind: 'SelectionSet',
               selections: [
+                {
+                  kind: 'Field',
+                  name: {kind: 'Name', value: 'devSession'},
+                  selectionSet: {
+                    kind: 'SelectionSet',
+                    selections: [
+                      {kind: 'Field', name: {kind: 'Name', value: 'websocketUrl'}},
+                      {kind: 'Field', name: {kind: 'Name', value: 'updatedAt'}},
+                      {
+                        kind: 'Field',
+                        name: {kind: 'Name', value: 'user'},
+                        selectionSet: {
+                          kind: 'SelectionSet',
+                          selections: [
+                            {kind: 'Field', name: {kind: 'Name', value: 'id'}},
+                            {kind: 'Field', name: {kind: 'Name', value: 'email'}},
+                            {kind: 'Field', name: {kind: 'Name', value: '__typename'}},
+                          ],
+                        },
+                      },
+                      {
+                        kind: 'Field',
+                        name: {kind: 'Name', value: 'app'},
+                        selectionSet: {
+                          kind: 'SelectionSet',
+                          selections: [
+                            {kind: 'Field', name: {kind: 'Name', value: 'id'}},
+                            {kind: 'Field', name: {kind: 'Name', value: 'key'}},
+                            {kind: 'Field', name: {kind: 'Name', value: '__typename'}},
+                          ],
+                        },
+                      },
+                      {kind: 'Field', name: {kind: 'Name', value: '__typename'}},
+                    ],
+                  },
+                },
                 {
                   kind: 'Field',
                   name: {kind: 'Name', value: 'userErrors'},

--- a/packages/app/src/cli/api/graphql/app-dev/generated/types.d.ts
+++ b/packages/app/src/cli/api/graphql/app-dev/generated/types.d.ts
@@ -46,3 +46,8 @@ export type Scalars = {
    */
   URL: {input: string; output: string}
 }
+
+/** The code for a dev session warning. */
+export type DevSessionWarningCode =
+  /** Another user's dev session was overwritten. */
+  'SESSION_TAKEOVER'

--- a/packages/app/src/cli/api/graphql/app-dev/queries/dev-session-create.graphql
+++ b/packages/app/src/cli/api/graphql/app-dev/queries/dev-session-create.graphql
@@ -1,5 +1,21 @@
 mutation DevSessionCreate($appId: String!, $assetsUrl: String!, $websocketUrl: String) {
   devSessionCreate(appId: $appId, assetsUrl: $assetsUrl, websocketUrl: $websocketUrl) {
+    devSession {
+      websocketUrl
+      updatedAt
+      user {
+        id
+        email
+      }
+      app {
+        id
+        key
+      }
+    }
+    warnings {
+      message
+      code
+    }
     userErrors {
       message
       on

--- a/packages/app/src/cli/api/graphql/app-dev/queries/dev-session-update.graphql
+++ b/packages/app/src/cli/api/graphql/app-dev/queries/dev-session-update.graphql
@@ -1,5 +1,17 @@
 mutation DevSessionUpdate($appId: String!, $assetsUrl: String, $manifest: JSON, $inheritedModuleUids: [String!]!) {
   devSessionUpdate(appId: $appId, assetsUrl: $assetsUrl, manifest: $manifest, inheritedModuleUids: $inheritedModuleUids) {
+    devSession {
+      websocketUrl
+      updatedAt
+      user {
+        id
+        email
+      }
+      app {
+        id
+        key
+      }
+    }
     userErrors {
       message
       on


### PR DESCRIPTION
## Summary

Implements client-side detection and handling for multi-user dev session conflicts, building on backend changes in https://github.com/shop/world/pull/383392.

When multiple developers run `shopify app dev` on the same app/shop combination, the CLI now provides clear feedback to both users about the session takeover and gracefully handles the conflict.

## Changes

### GraphQL Query Updates
- **dev-session-create.graphql**: Now requests `devSession`, `warnings`, and `userErrors` fields
- **dev-session-update.graphql**: Now requests `devSession` with user and websocket information

### Schema Updates
Updated local schema file (`app_dev_schema.graphql`) to match backend changes:
- Added `devSession` field to `DevSessionCreatePayload`
- Added `warnings` array to `DevSessionCreatePayload`
- Added `devSession` field to `DevSessionUpdatePayload`
- Added new types: `DevSessionWarning` and `DevSessionWarningCode` enum

### Implementation (dev-session.ts)

**Session State Tracking:**
- Added `DevSessionState` interface to track websocket URL and user information
- Added `currentSessionState` instance variable to maintain session metadata

**Create-Time Warning Display:**
- Stores initial session state when dev session is created
- Displays warnings from backend (e.g., `SESSION_TAKEOVER`)
- Warnings are non-blocking - session creation succeeds even with warnings

**Update-Time Takeover Detection:**
- Compares returned `websocketUrl` against expected local websocket URL on every update
- If mismatch detected → another developer has taken over the session
- Displays clear error message including the new user's email
- Throws `AbortError` to gracefully terminate the dev session with actionable next steps

## User Experience

### Scenario: User B Takes Over User A's Session

**User A starts dev:**
```
$ shopify app dev
✅ Ready, watching for changes in your app
```

**User B starts dev (same app/shop):**
```
$ shopify app dev
⚠️  Another user is already running a dev preview for this app on example.myshopify.com.
✅ Ready, watching for changes in your app
```

**User A makes a code change:**
```
[app-extension] Extension updated

❌ Error
└  
⚠️  Another developer (user-b@shopify.com) has taken over this dev session.
Your preview is no longer active. Terminating dev session...

Dev session has been taken over by another user.
You can restart by running \`shopify app dev\` again.
```

## Benefits

- ✅ **Immediate feedback for aggressor**: User B knows they displaced someone
- ✅ **Quick discovery for victim**: User A learns about takeover on next code change (typically seconds)
- ✅ **Clean separation**: Warnings (non-blocking) vs errors (blocking)
- ✅ **Graceful termination**: Clear messaging with actionable next steps
- ✅ **No false positives**: Only checks during actual mutations, not on normal disconnects
- ✅ **Future-proof**: Uses structured warning codes for extensibility

## Dependencies

This PR depends on backend changes:
- https://github.com/shop/world/pull/383392 - Adds session takeover warning on create

## Testing Plan

Once the backend PR is merged:
1. Test session takeover warning appears when User B starts dev
2. Test User A's session terminates gracefully on next update after takeover
3. Verify error messages are clear and actionable
4. Test edge cases:
   - Same user, multiple machines
   - Same user, same machine (should show no warning)
   - Rapid takeover scenarios

Addresses https://github.com/shop/issues-develop/issues/21606

### Measuring impact

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes