### PR TITLE
Asset pipeline flow for hosted static app

### DIFF
--- a/packages/app/src/cli/models/extensions/extension-instance.ts
+++ b/packages/app/src/cli/models/extensions/extension-instance.ts
@@ -373,7 +373,7 @@ export class ExtensionInstance<TConfiguration extends BaseConfigType = BaseConfi
           this.specification.buildConfig.filePatterns,
           this.specification.buildConfig.ignoredFilePatterns,
         )
-      case 'static_app':
+      case 'hosted_app_home':
         await this.copyStaticAssets()
         break
       case 'none':

--- a/packages/app/src/cli/models/extensions/extension-instance.ts
+++ b/packages/app/src/cli/models/extensions/extension-instance.ts
@@ -2,29 +2,51 @@ import {BaseConfigType, MAX_EXTENSION_HANDLE_LENGTH, MAX_UID_LENGTH} from './sch
 import {FunctionConfigType} from './specifications/function.js'
 import {ExtensionFeature, ExtensionSpecification} from './specification.js'
 import {SingleWebhookSubscriptionType} from './specifications/app_config_webhook_schemas/webhooks_schema.js'
-import {ExtensionBuildOptions, bundleFunctionExtension} from '../../services/build/extension.js'
-import {bundleThemeExtension} from '../../services/extensions/bundle.js'
+import {AppHomeSpecIdentifier} from './specifications/app_config_app_home.js'
+import {AppAccessSpecIdentifier} from './specifications/app_config_app_access.js'
+import {AppProxySpecIdentifier} from './specifications/app_config_app_proxy.js'
+import {BrandingSpecIdentifier} from './specifications/app_config_branding.js'
+import {PosSpecIdentifier} from './specifications/app_config_point_of_sale.js'
+import {PrivacyComplianceWebhooksSpecIdentifier} from './specifications/app_config_privacy_compliance_webhooks.js'
+import {WebhooksSpecIdentifier} from './specifications/app_config_webhook.js'
+import {WebhookSubscriptionSpecIdentifier} from './specifications/app_config_webhook_subscription.js'
+import {EventsSpecIdentifier} from './specifications/app_config_events.js'
+import {HostedAppHomeSpecIdentifier} from './specifications/app_config_hosted_app_home.js'
+import {
+  ExtensionBuildOptions,
+  buildFunctionExtension,
+  buildThemeExtension,
+  buildUIExtension,
+  bundleFunctionExtension,
+} from '../../services/build/extension.js'
+import {bundleThemeExtension, copyFilesForExtension} from '../../services/extensions/bundle.js'
 import {Identifiers} from '../app/identifiers.js'
 import {DeveloperPlatformClient} from '../../utilities/developer-platform-client.js'
-import {AppConfiguration} from '../app/app.js'
+import {AppConfigurationWithoutPath} from '../app/app.js'
 import {ApplicationURLs} from '../../services/dev/urls.js'
-import {executeStep, BuildContext} from '../../services/build/client-steps.js'
 import {ok} from '@shopify/cli-kit/node/result'
 import {constantize, slugify} from '@shopify/cli-kit/common/string'
 import {hashString, nonRandomUUID} from '@shopify/cli-kit/node/crypto'
 import {partnersFqdn} from '@shopify/cli-kit/node/context/fqdn'
-import {joinPath, normalizePath, resolvePath, relativePath, basename} from '@shopify/cli-kit/node/path'
-import {fileExists, moveFile, glob, copyFile, globSync} from '@shopify/cli-kit/node/fs'
+import {joinPath, basename, normalizePath, resolvePath} from '@shopify/cli-kit/node/path'
+import {fileExists, touchFile, moveFile, writeFile, glob, copyFile, globSync} from '@shopify/cli-kit/node/fs'
 import {getPathValue} from '@shopify/cli-kit/common/object'
 import {outputDebug} from '@shopify/cli-kit/node/output'
-import {
-  extractJSImports,
-  extractImportPathsRecursively,
-  clearImportPathsCache,
-  getImportScanningCacheStats,
-} from '@shopify/cli-kit/node/import-extractor'
-import {isTruthy} from '@shopify/cli-kit/node/context/utilities'
+import {extractJSImports, extractImportPathsRecursively} from '@shopify/cli-kit/node/import-extractor'
 import {uniq} from '@shopify/cli-kit/common/array'
+
+export const CONFIG_EXTENSION_IDS: string[] = [
+  AppAccessSpecIdentifier,
+  AppHomeSpecIdentifier,
+  AppProxySpecIdentifier,
+  BrandingSpecIdentifier,
+  HostedAppHomeSpecIdentifier,
+  PosSpecIdentifier,
+  PrivacyComplianceWebhooksSpecIdentifier,
+  WebhookSubscriptionSpecIdentifier,
+  WebhooksSpecIdentifier,
+  EventsSpecIdentifier,
+]
 
 /**
  * Class that represents an instance of a local extension
@@ -101,7 +123,7 @@ export class ExtensionInstance<TConfiguration extends BaseConfigType = BaseConfi
   }
 
   get isAppConfigExtension() {
-    return this.specification.experience === 'configuration'
+    return ['single', 'dynamic'].includes(this.specification.uidStrategy)
   }
 
   get isFlow() {
@@ -117,11 +139,14 @@ export class ExtensionInstance<TConfiguration extends BaseConfigType = BaseConfi
   }
 
   get outputFileName() {
-    return basename(this.outputRelativePath)
-  }
-
-  get outputRelativePath() {
-    return this.specification.getOutputRelativePath?.(this) ?? ''
+    const mode = this.specification.buildConfig.mode
+    if (mode === 'copy_files' || mode === 'theme') {
+      return ''
+    } else if (mode === 'function') {
+      return 'index.wasm'
+    } else {
+      return `${this.handle}.js`
+    }
   }
 
   constructor(options: {
@@ -139,9 +164,19 @@ export class ExtensionInstance<TConfiguration extends BaseConfigType = BaseConfi
     this.handle = this.buildHandle()
     this.localIdentifier = this.handle
     this.idEnvironmentVariableName = `SHOPIFY_${constantize(this.localIdentifier)}_ID`
-    this.outputPath = joinPath(this.directory, this.outputRelativePath)
+    this.outputPath = this.directory
     this.uid = this.buildUIDFromStrategy()
     this.devUUID = `dev-${this.uid}`
+
+    if (this.features.includes('esbuild') || this.type === 'tax_calculation') {
+      this.outputPath = joinPath(this.directory, 'dist', this.outputFileName)
+    }
+
+    if (this.isFunctionExtension) {
+      const config = this.configuration as unknown as FunctionConfigType
+      const defaultPath = joinPath('dist', 'index.wasm')
+      this.outputPath = joinPath(this.directory, config.build?.path ?? defaultPath)
+    }
   }
 
   get draftMessages() {
@@ -214,7 +249,7 @@ export class ExtensionInstance<TConfiguration extends BaseConfigType = BaseConfi
     const pathToMove = pathsToMove[0]
     if (pathToMove === undefined) return Promise.resolve()
 
-    const outputPath = joinPath(this.directory, relativePath(inputPath, pathToMove))
+    const outputPath = joinPath(this.directory, 'dist', basename(pathToMove))
     await moveFile(pathToMove, outputPath, {overwrite: true})
     outputDebug(`Source map for ${this.localIdentifier} created: ${outputPath}`)
   }
@@ -315,29 +350,40 @@ export class ExtensionInstance<TConfiguration extends BaseConfigType = BaseConfi
   }
 
   async build(options: ExtensionBuildOptions): Promise<void> {
-    const {clientSteps = []} = this.specification
+    const mode = this.specification.buildConfig.mode
 
-    const context: BuildContext = {
-      extension: this,
-      options,
-      stepResults: new Map(),
-    }
-
-    const steps = clientSteps.find((lifecycle) => lifecycle.lifecycle === 'deploy')?.steps ?? []
-
-    for (const step of steps) {
-      // eslint-disable-next-line no-await-in-loop
-      const result = await executeStep(step, context)
-      context.stepResults.set(step.id, result)
-
-      if (!result.success && !step.continueOnError) {
-        throw new Error(`Build step "${step.name}" failed: ${result.error?.message}`)
-      }
+    switch (mode) {
+      case 'theme':
+        await buildThemeExtension(this, options)
+        return bundleThemeExtension(this, options)
+      case 'function':
+        return buildFunctionExtension(this, options)
+      case 'ui':
+        await buildUIExtension(this, options)
+        // Copy static assets after build completes
+        return this.copyStaticAssets()
+      case 'tax_calculation':
+        await touchFile(this.outputPath)
+        await writeFile(this.outputPath, '(()=>{})();')
+        break
+      case 'copy_files':
+        return copyFilesForExtension(
+          this,
+          options,
+          this.specification.buildConfig.filePatterns,
+          this.specification.buildConfig.ignoredFilePatterns,
+        )
+      case 'static_app':
+        await this.copyStaticAssets()
+        break
+      case 'none':
+        break
     }
   }
 
   async buildForBundle(options: ExtensionBuildOptions, bundleDirectory: string, outputId?: string) {
     this.outputPath = this.getOutputPathForDirectory(bundleDirectory, outputId)
+
     await this.build(options)
 
     const bundleInputPath = joinPath(bundleDirectory, this.getOutputFolderId(outputId))
@@ -367,7 +413,8 @@ export class ExtensionInstance<TConfiguration extends BaseConfigType = BaseConfi
 
   getOutputPathForDirectory(directory: string, outputId?: string) {
     const id = this.getOutputFolderId(outputId)
-    return joinPath(directory, id, this.outputRelativePath)
+    const outputFile = this.outputFileName === '' ? '' : joinPath('dist', this.outputFileName)
+    return joinPath(directory, id, outputFile)
   }
 
   get singleTarget() {
@@ -474,7 +521,6 @@ export class ExtensionInstance<TConfiguration extends BaseConfigType = BaseConfi
   async rescanImports(): Promise<boolean> {
     const oldImportPaths = this.cachedImportPaths
     this.cachedImportPaths = undefined
-    clearImportPathsCache()
     this.scanImports()
     return oldImportPaths !== this.cachedImportPaths
   }
@@ -489,26 +535,13 @@ export class ExtensionInstance<TConfiguration extends BaseConfigType = BaseConfi
       return this.cachedImportPaths
     }
 
-    if (isTruthy(process.env.SHOPIFY_CLI_DISABLE_IMPORT_SCANNING)) {
-      this.cachedImportPaths = []
-      return this.cachedImportPaths
-    }
-
     try {
-      const startTime = performance.now()
-      const entryFiles = this.devSessionDefaultWatchPaths()
-
-      const imports = entryFiles.flatMap((entryFile) => {
+      const imports = this.devSessionDefaultWatchPaths().flatMap((entryFile) => {
         return extractImportPathsRecursively(entryFile).map((importPath) => normalizePath(resolvePath(importPath)))
       })
-
+      // Cache and return unique paths
       this.cachedImportPaths = uniq(imports) ?? []
-      const elapsed = Math.round(performance.now() - startTime)
-      const cacheStats = getImportScanningCacheStats()
-      const cacheInfo = cacheStats ? ` (cache: ${cacheStats.directImports} parsed, ${cacheStats.fileExists} stats)` : ''
-      outputDebug(
-        `Import scan for "${this.handle}": ${entryFiles.length} entries, ${this.cachedImportPaths.length} files, ${elapsed}ms${cacheInfo}`,
-      )
+      outputDebug(`Found ${this.cachedImportPaths.length} external imports (recursively) for extension ${this.handle}`)
       return this.cachedImportPaths
       // eslint-disable-next-line no-catch-all/no-catch-all
     } catch (error) {
@@ -533,8 +566,6 @@ export class ExtensionInstance<TConfiguration extends BaseConfigType = BaseConfi
         } else {
           return nonRandomUUID(JSON.stringify(this.configuration))
         }
-      default:
-        return this.specification.identifier
     }
   }
 
@@ -564,14 +595,14 @@ export class ExtensionInstance<TConfiguration extends BaseConfigType = BaseConfi
 
 interface ExtensionDeployConfigOptions {
   apiKey: string
-  appConfiguration: AppConfiguration
+  appConfiguration: AppConfigurationWithoutPath
 }
 
 interface ExtensionBundleConfigOptions {
   identifiers: Identifiers
   developerPlatformClient: DeveloperPlatformClient
   apiKey: string
-  appConfiguration: AppConfiguration
+  appConfiguration: AppConfigurationWithoutPath
 }
 
 interface BundleConfig {

--- a/packages/app/src/cli/models/extensions/load-specifications.ts
+++ b/packages/app/src/cli/models/extensions/load-specifications.ts
@@ -27,7 +27,7 @@ import uiExtensionSpec from './specifications/ui_extension.js'
 import webPixelSpec from './specifications/web_pixel_extension.js'
 import editorExtensionCollectionSpecification from './specifications/editor_extension_collection.js'
 import channelSpecificationSpec from './specifications/channel.js'
-import adminSpecificationSpec from './specifications/admin.js'
+import hostedAppHomeSpec, {HostedAppHomeSpecIdentifier} from './specifications/app_config_hosted_app_home.js'
 
 const SORTED_CONFIGURATION_SPEC_IDENTIFIERS = [
   BrandingSpecIdentifier,
@@ -39,6 +39,7 @@ const SORTED_CONFIGURATION_SPEC_IDENTIFIERS = [
   AppProxySpecIdentifier,
   PosSpecIdentifier,
   AppHomeSpecIdentifier,
+  HostedAppHomeSpecIdentifier,
 ]
 
 /**
@@ -62,7 +63,7 @@ function loadSpecifications() {
     appWebhooksSpec,
     appWebhookSubscriptionSpec,
     appEventsSpec,
-    adminSpecificationSpec,
+    hostedAppHomeSpec,
   ]
   const moduleSpecs = [
     checkoutPostPurchaseSpec,

--- a/packages/app/src/cli/models/extensions/specification.ts
+++ b/packages/app/src/cli/models/extensions/specification.ts
@@ -1,10 +1,9 @@
 import {ZodSchemaType, BaseConfigType, BaseSchema} from './schemas.js'
 import {ExtensionInstance} from './extension-instance.js'
 import {blocks} from '../../constants.js'
-import {ClientSteps} from '../../services/build/client-steps.js'
 
 import {Flag} from '../../utilities/developer-platform-client.js'
-import {AppConfiguration} from '../app/app.js'
+import {AppConfigurationWithoutPath} from '../app/app.js'
 import {loadLocalesConfig} from '../../utilities/extensions/locales-configuration.js'
 import {ApplicationURLs} from '../../services/dev/urls.js'
 import {Result} from '@shopify/cli-kit/node/result'
@@ -23,18 +22,16 @@ export type ExtensionFeature =
   | 'localization'
   | 'generates_source_maps'
 
-export type TransformationConfig = Record<string, string>
+export interface TransformationConfig {
+  [key: string]: string
+}
 
 export interface CustomTransformationConfig {
-  forward?: (obj: object, appConfiguration: AppConfiguration, options?: {flags?: Flag[]}) => object
+  forward?: (obj: object, appConfiguration: AppConfigurationWithoutPath, options?: {flags?: Flag[]}) => object
   reverse?: (obj: object, options?: {flags?: Flag[]}) => object
 }
 
 type ExtensionExperience = 'extension' | 'configuration'
-
-export function isAppConfigSpecification(spec: {experience: string}): boolean {
-  return spec.experience === 'configuration'
-}
 type UidStrategy = 'single' | 'dynamic' | 'uuid'
 
 export enum AssetIdentifier {
@@ -57,9 +54,8 @@ export interface BuildAsset {
 }
 
 type BuildConfig =
-  | {mode: 'ui' | 'theme' | 'function' | 'tax_calculation' | 'none' | 'hosted_app_home'}
+  | {mode: 'ui' | 'theme' | 'function' | 'tax_calculation' | 'none' | 'static_app'}
   | {mode: 'copy_files'; filePatterns: string[]; ignoredFilePatterns?: string[]}
-
 /**
  * Extension specification with all the needed properties and methods to load an extension.
  */
@@ -73,18 +69,16 @@ export interface ExtensionSpecification<TConfiguration extends BaseConfigType = 
   surface: string
   registrationLimit: number
   experience: ExtensionExperience
-  clientSteps?: ClientSteps
   buildConfig: BuildConfig
   dependency?: string
   graphQLType?: string
-  getOutputRelativePath?: (extension: ExtensionInstance<TConfiguration>) => string
   getBundleExtensionStdinContent?: (config: TConfiguration) => {main: string; assets?: Asset[]}
   deployConfig?: (
     config: TConfiguration,
     directory: string,
     apiKey: string,
     moduleId?: string,
-  ) => Promise<Record<string, unknown> | undefined>
+  ) => Promise<{[key: string]: unknown} | undefined>
   validate?: (config: TConfiguration, configPath: string, directory: string) => Promise<Result<unknown, string>>
   preDeployValidation?: (extension: ExtensionInstance<TConfiguration>) => Promise<void>
   buildValidation?: (extension: ExtensionInstance<TConfiguration>) => Promise<void>
@@ -99,7 +93,7 @@ export interface ExtensionSpecification<TConfiguration extends BaseConfigType = 
    * @param localContent - Content taken from the local filesystem
    * @returns Transformed configuration to send to the platform in place of the locally provided content
    */
-  transformLocalToRemote?: (localContent: object, appConfiguration: AppConfiguration) => object
+  transformLocalToRemote?: (localContent: object, appConfiguration: AppConfigurationWithoutPath) => object
 
   /**
    * If required, convert configuration from the platform to the format used locally in the filesystem.
@@ -209,7 +203,6 @@ export function createExtensionSpecification<TConfiguration extends BaseConfigTy
     experience: spec.experience ?? 'extension',
     uidStrategy: spec.uidStrategy ?? (spec.experience === 'configuration' ? 'single' : 'uuid'),
     getDevSessionUpdateMessages: spec.getDevSessionUpdateMessages,
-    clientSteps: spec.clientSteps,
     buildConfig: spec.buildConfig ?? {mode: 'none'},
   }
   const merged = {...defaults, ...spec}
@@ -217,13 +210,7 @@ export function createExtensionSpecification<TConfiguration extends BaseConfigTy
   return {
     ...merged,
     contributeToAppConfigurationSchema: (appConfigSchema: ZodSchemaType<unknown>) => {
-      const isConfig = isAppConfigSpecification(merged)
-      const hasSchema = merged.schema._def.shape !== undefined
-      // This filters out webhook subscription specifications from contributing to the app configuration schema
-      const hasSingleUidStrategy = merged.uidStrategy === 'single'
-
-      const canContribute = isConfig && hasSchema && hasSingleUidStrategy
-      if (!canContribute) {
+      if (merged.uidStrategy !== 'single') {
         // no change
         return appConfigSchema
       }
@@ -258,13 +245,13 @@ export function createExtensionSpecification<TConfiguration extends BaseConfigTy
 export function createConfigExtensionSpecification<TConfiguration extends BaseConfigType = BaseConfigType>(spec: {
   identifier: string
   schema: ZodSchemaType<TConfiguration>
-  clientSteps?: ClientSteps
   buildConfig?: BuildConfig
   appModuleFeatures?: (config?: TConfiguration) => ExtensionFeature[]
   transformConfig: TransformationConfig | CustomTransformationConfig
   uidStrategy?: UidStrategy
   getDevSessionUpdateMessages?: (config: TConfiguration) => Promise<string[]>
   patchWithAppDevURLs?: (config: TConfiguration, urls: ApplicationURLs) => void
+  copyStaticAssets?: (config: TConfiguration, directory: string, outputPath: string) => Promise<void>
 }): ExtensionSpecification<TConfiguration> {
   const appModuleFeatures = spec.appModuleFeatures ?? (() => [])
   return createExtensionSpecification({
@@ -277,34 +264,21 @@ export function createConfigExtensionSpecification<TConfiguration extends BaseCo
     transformRemoteToLocal: resolveReverseAppConfigTransform(spec.schema, spec.transformConfig),
     experience: 'configuration',
     uidStrategy: spec.uidStrategy ?? 'single',
-    clientSteps: spec.clientSteps,
     buildConfig: spec.buildConfig ?? {mode: 'none'},
     getDevSessionUpdateMessages: spec.getDevSessionUpdateMessages,
     patchWithAppDevURLs: spec.patchWithAppDevURLs,
+    copyStaticAssets: spec.copyStaticAssets,
   })
 }
 
 export function createContractBasedModuleSpecification<TConfiguration extends BaseConfigType = BaseConfigType>(
-  spec: Pick<
-    CreateExtensionSpecType<TConfiguration>,
-    | 'identifier'
-    | 'appModuleFeatures'
-    | 'buildConfig'
-    | 'uidStrategy'
-    | 'clientSteps'
-    | 'experience'
-    | 'transformRemoteToLocal'
-  >,
+  spec: Pick<CreateExtensionSpecType<TConfiguration>, 'identifier' | 'appModuleFeatures' | 'buildConfig'>,
 ) {
   return createExtensionSpecification({
     identifier: spec.identifier,
     schema: zod.any({}) as unknown as ZodSchemaType<TConfiguration>,
     appModuleFeatures: spec.appModuleFeatures,
-    experience: spec.experience,
     buildConfig: spec.buildConfig ?? {mode: 'none'},
-    clientSteps: spec.clientSteps,
-    uidStrategy: spec.uidStrategy,
-    transformRemoteToLocal: spec.transformRemoteToLocal,
     deployConfig: async (config, directory) => {
       let parsedConfig = configWithoutFirstClassFields(config)
       if (spec.appModuleFeatures().includes('localization')) {
@@ -330,7 +304,7 @@ function resolveReverseAppConfigTransform<T>(
   transformConfig?: TransformationConfig | CustomTransformationConfig,
 ) {
   if (!transformConfig)
-    return (content: object) => defaultAppConfigReverseTransform(schema, content as Record<string, unknown>)
+    return (content: object) => defaultAppConfigReverseTransform(schema, content as {[key: string]: unknown})
 
   if (Object.keys(transformConfig).includes('reverse')) {
     return (transformConfig as CustomTransformationConfig).reverse!
@@ -398,8 +372,8 @@ function appConfigTransform(
  * @returns The nested object
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-function defaultAppConfigReverseTransform<T>(schema: zod.ZodType<T, any, any>, content: Record<string, unknown>) {
-  return Object.keys(schema._def.shape()).reduce((result: Record<string, unknown>, key: string) => {
+function defaultAppConfigReverseTransform<T>(schema: zod.ZodType<T, any, any>, content: {[key: string]: unknown}) {
+  return Object.keys(schema._def.shape()).reduce((result: {[key: string]: unknown}, key: string) => {
     let innerSchema = schema._def.shape()[key]
     if (innerSchema instanceof zod.ZodOptional) {
       innerSchema = innerSchema._def.innerType

--- a/packages/app/src/cli/models/extensions/specification.ts
+++ b/packages/app/src/cli/models/extensions/specification.ts
@@ -54,7 +54,7 @@ export interface BuildAsset {
 }
 
 type BuildConfig =
-  | {mode: 'ui' | 'theme' | 'function' | 'tax_calculation' | 'none' | 'static_app'}
+  | {mode: 'ui' | 'theme' | 'function' | 'tax_calculation' | 'none' | 'hosted_app_home'}
   | {mode: 'copy_files'; filePatterns: string[]; ignoredFilePatterns?: string[]}
 /**
  * Extension specification with all the needed properties and methods to load an extension.

--- a/packages/app/src/cli/models/extensions/specifications/app_config_hosted_app_home.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/app_config_hosted_app_home.test.ts
@@ -89,14 +89,14 @@ describe('hosted_app_home', () => {
   })
 
   describe('buildConfig', () => {
-    test('should have static_app build mode', () => {
-      expect(spec.buildConfig).toEqual({mode: 'static_app'})
+    test('should have hosted_app_home build mode', () => {
+      expect(spec.buildConfig).toEqual({mode: 'hosted_app_home'})
     })
   })
 
   describe('identifier', () => {
     test('should have correct identifier', () => {
-      expect(spec.identifier).toBe('hosted_app')
+      expect(spec.identifier).toBe('hosted_app_home')
     })
   })
 })

--- a/packages/app/src/cli/models/extensions/specifications/app_config_hosted_app_home.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/app_config_hosted_app_home.test.ts
@@ -1,0 +1,102 @@
+import spec from './app_config_hosted_app_home.js'
+import {placeholderAppConfiguration} from '../../app/app.test-data.js'
+import {copyDirectoryContents} from '@shopify/cli-kit/node/fs'
+import {describe, expect, test, vi} from 'vitest'
+
+vi.mock('@shopify/cli-kit/node/fs')
+
+describe('hosted_app_home', () => {
+  describe('transform', () => {
+    test('should return the transformed object with static_root', () => {
+      const object = {
+        static_root: 'public',
+      }
+      const appConfigSpec = spec
+
+      const result = appConfigSpec.transformLocalToRemote!(object, placeholderAppConfiguration)
+
+      expect(result).toMatchObject({
+        static_root: 'public',
+      })
+    })
+
+    test('should return empty object when static_root is not provided', () => {
+      const object = {}
+      const appConfigSpec = spec
+
+      const result = appConfigSpec.transformLocalToRemote!(object, placeholderAppConfiguration)
+
+      expect(result).toMatchObject({})
+    })
+  })
+
+  describe('reverseTransform', () => {
+    test('should return the reversed transformed object with static_root', () => {
+      const object = {
+        static_root: 'public',
+      }
+      const appConfigSpec = spec
+
+      const result = appConfigSpec.transformRemoteToLocal!(object)
+
+      expect(result).toMatchObject({
+        static_root: 'public',
+      })
+    })
+
+    test('should return empty object when static_root is not provided', () => {
+      const object = {}
+      const appConfigSpec = spec
+
+      const result = appConfigSpec.transformRemoteToLocal!(object)
+
+      expect(result).toMatchObject({})
+    })
+  })
+
+  describe('copyStaticAssets', () => {
+    test('should copy static assets from source to output directory', async () => {
+      vi.mocked(copyDirectoryContents).mockResolvedValue(undefined)
+      const config = {static_root: 'public'}
+      const directory = '/app/root'
+      const outputPath = '/output/dist/bundle.js'
+
+      await spec.copyStaticAssets!(config, directory, outputPath)
+
+      expect(copyDirectoryContents).toHaveBeenCalledWith('/app/root/public', '/output/dist')
+    })
+
+    test('should not copy assets when static_root is not provided', async () => {
+      const config = {}
+      const directory = '/app/root'
+      const outputPath = '/output/dist/bundle.js'
+
+      await spec.copyStaticAssets!(config, directory, outputPath)
+
+      expect(copyDirectoryContents).not.toHaveBeenCalled()
+    })
+
+    test('should throw error when copy fails', async () => {
+      vi.mocked(copyDirectoryContents).mockRejectedValue(new Error('Permission denied'))
+      const config = {static_root: 'public'}
+      const directory = '/app/root'
+      const outputPath = '/output/dist/bundle.js'
+
+      await expect(spec.copyStaticAssets!(config, directory, outputPath)).rejects.toThrow(
+        'Failed to copy static assets from /app/root/public to /output/dist: Permission denied',
+      )
+    })
+  })
+
+  describe('buildConfig', () => {
+    test('should have static_app build mode', () => {
+      expect(spec.buildConfig).toEqual({mode: 'static_app'})
+    })
+  })
+
+  describe('identifier', () => {
+    test('should have correct identifier', () => {
+      expect(spec.identifier).toBe('hosted_app')
+    })
+  })
+})

--- a/packages/app/src/cli/models/extensions/specifications/app_config_hosted_app_home.ts
+++ b/packages/app/src/cli/models/extensions/specifications/app_config_hosted_app_home.ts
@@ -1,0 +1,33 @@
+import {BaseSchemaWithoutHandle} from '../schemas.js'
+import {TransformationConfig, createConfigExtensionSpecification} from '../specification.js'
+import {copyDirectoryContents} from '@shopify/cli-kit/node/fs'
+import {dirname, joinPath} from '@shopify/cli-kit/node/path'
+import {zod} from '@shopify/cli-kit/node/schema'
+
+const HostedAppHomeSchema = BaseSchemaWithoutHandle.extend({
+  static_root: zod.string().optional(),
+})
+
+const HostedAppHomeTransformConfig: TransformationConfig = {
+  static_root: 'static_root',
+}
+
+export const HostedAppHomeSpecIdentifier = 'hosted_app'
+
+const hostedAppHomeSpec = createConfigExtensionSpecification({
+  identifier: HostedAppHomeSpecIdentifier,
+  buildConfig: {mode: 'static_app'} as const,
+  schema: HostedAppHomeSchema,
+  transformConfig: HostedAppHomeTransformConfig,
+  copyStaticAssets: async (config, directory, outputPath) => {
+    if (!config.static_root) return
+    const sourceDir = joinPath(directory, config.static_root)
+    const outputDir = dirname(outputPath)
+
+    return copyDirectoryContents(sourceDir, outputDir).catch((error) => {
+      throw new Error(`Failed to copy static assets from ${sourceDir} to ${outputDir}: ${error.message}`)
+    })
+  },
+})
+
+export default hostedAppHomeSpec

--- a/packages/app/src/cli/models/extensions/specifications/app_config_hosted_app_home.ts
+++ b/packages/app/src/cli/models/extensions/specifications/app_config_hosted_app_home.ts
@@ -12,11 +12,11 @@ const HostedAppHomeTransformConfig: TransformationConfig = {
   static_root: 'static_root',
 }
 
-export const HostedAppHomeSpecIdentifier = 'hosted_app'
+export const HostedAppHomeSpecIdentifier = 'hosted_app_home'
 
 const hostedAppHomeSpec = createConfigExtensionSpecification({
   identifier: HostedAppHomeSpecIdentifier,
-  buildConfig: {mode: 'static_app'} as const,
+  buildConfig: {mode: 'hosted_app_home'} as const,
   schema: HostedAppHomeSchema,
   transformConfig: HostedAppHomeTransformConfig,
   copyStaticAssets: async (config, directory, outputPath) => {

--- a/packages/app/src/cli/services/generate/fetch-extension-specifications.ts
+++ b/packages/app/src/cli/services/generate/fetch-extension-specifications.ts
@@ -78,6 +78,7 @@ async function mergeLocalAndRemoteSpecs(
 
     const merged = {...localSpec, ...remoteSpec, loadedRemoteSpecs: true} as RemoteAwareExtensionSpecification &
       FlattenedRemoteSpecification
+
     // If configuration is inside an app.toml -- i.e. single UID mode -- we must be able to parse a partial slice.
     let handleInvalidAdditionalProperties: HandleInvalidAdditionalProperties
     switch (merged.uidStrategy) {

--- a/packages/app/src/cli/services/generate/fetch-extension-specifications.ts
+++ b/packages/app/src/cli/services/generate/fetch-extension-specifications.ts
@@ -1,5 +1,5 @@
 import {loadLocalExtensionsSpecifications} from '../../models/extensions/load-specifications.js'
-import {RemoteSpecification} from '../../api/graphql/extension_specifications.js'
+import {FlattenedRemoteSpecification, RemoteSpecification} from '../../api/graphql/extension_specifications.js'
 import {
   createContractBasedModuleSpecification,
   ExtensionSpecification,
@@ -10,7 +10,7 @@ import {MinimalAppIdentifiers} from '../../models/organization.js'
 import {unifiedConfigurationParserFactory} from '../../utilities/json-schema.js'
 import {getArrayRejectingUndefined} from '@shopify/cli-kit/common/array'
 import {outputDebug} from '@shopify/cli-kit/node/output'
-import {normaliseJsonSchema} from '@shopify/cli-kit/node/json-schema'
+import {HandleInvalidAdditionalProperties, normaliseJsonSchema} from '@shopify/cli-kit/node/json-schema'
 
 interface FetchSpecificationsOptions {
   developerPlatformClient: DeveloperPlatformClient
@@ -35,24 +35,21 @@ export async function fetchSpecifications({
 }: FetchSpecificationsOptions): Promise<RemoteAwareExtensionSpecification[]> {
   const result: RemoteSpecification[] = await developerPlatformClient.specifications(app)
 
-  const extensionSpecifications: RemoteSpecification[] = result
+  const extensionSpecifications: FlattenedRemoteSpecification[] = result
     .filter((specification) => ['extension', 'configuration'].includes(specification.experience))
     .map((spec) => {
+      const newSpec = spec as FlattenedRemoteSpecification
       // WORKAROUND: The identifiers in the API are different for these extensions to the ones the CLI
       // has been using so far. This is a workaround to keep the CLI working until the API is updated.
       if (spec.identifier === 'theme_app_extension') spec.identifier = 'theme'
       if (spec.identifier === 'subscription_management') spec.identifier = 'product_subscription'
+      newSpec.registrationLimit = spec.options.registrationLimit
+      newSpec.surface = spec.features?.argo?.surface
 
       // Hardcoded value for the post purchase extension because the value is wrong in the API
-      if (spec.identifier === 'checkout_post_purchase') spec.surface = 'post_purchase'
+      if (spec.identifier === 'checkout_post_purchase') newSpec.surface = 'post_purchase'
 
-      // Hardcoded values for the webhook_subscription extension because the values are wrong in the API
-      if (spec.identifier === 'webhook_subscription') {
-        spec.experience = 'configuration'
-        spec.uidStrategy = 'dynamic'
-      }
-
-      return spec
+      return newSpec
     })
 
   const local = await loadLocalExtensionsSpecifications()
@@ -62,26 +59,45 @@ export async function fetchSpecifications({
 
 async function mergeLocalAndRemoteSpecs(
   local: ExtensionSpecification[],
-  remote: RemoteSpecification[],
+  remote: FlattenedRemoteSpecification[],
 ): Promise<RemoteAwareExtensionSpecification[]> {
   // Iterate over the remote specs and merge them with the local ones
   // If the local spec is missing, and the remote one has a validation schema, create a new local spec using contracts
   const updated = remote.map(async (remoteSpec) => {
     let localSpec = local.find((local) => local.identifier === remoteSpec.identifier)
     if (!localSpec && remoteSpec.validationSchema?.jsonSchema) {
-      localSpec = await createRemoteOnlySpecification(remoteSpec, remoteSpec.validationSchema)
+      const normalisedSchema = await normaliseJsonSchema(remoteSpec.validationSchema.jsonSchema)
+      const hasLocalization = normalisedSchema.properties?.localization !== undefined
+      localSpec = createContractBasedModuleSpecification({
+        identifier: remoteSpec.identifier,
+        appModuleFeatures: () => (hasLocalization ? ['localization'] : []),
+      })
+      localSpec.uidStrategy = remoteSpec.options.uidIsClientProvided ? 'uuid' : 'single'
     }
     if (!localSpec) return undefined
 
-    const merged = mergeLocalAndRemoteSpec(localSpec, remoteSpec)
+    const merged = {...localSpec, ...remoteSpec, loadedRemoteSpecs: true} as RemoteAwareExtensionSpecification &
+      FlattenedRemoteSpecification
+    // If configuration is inside an app.toml -- i.e. single UID mode -- we must be able to parse a partial slice.
+    let handleInvalidAdditionalProperties: HandleInvalidAdditionalProperties
+    switch (merged.uidStrategy) {
+      case 'uuid':
+        handleInvalidAdditionalProperties = 'fail'
+        break
+      case 'single':
+        handleInvalidAdditionalProperties = 'strip'
+        break
+      case 'dynamic':
+        handleInvalidAdditionalProperties = 'fail'
+        break
+    }
 
-    const parseConfigurationObject = await unifiedConfigurationParserFactory(
-      merged,
-      remoteSpec.validationSchema,
-      merged.experience === 'extension' ? 'fail' : 'strip',
-    )
+    const parseConfigurationObject = await unifiedConfigurationParserFactory(merged, handleInvalidAdditionalProperties)
 
-    return {...merged, parseConfigurationObject}
+    return {
+      ...merged,
+      parseConfigurationObject,
+    }
   })
 
   const result = getArrayRejectingUndefined<RemoteAwareExtensionSpecification>(await Promise.all(updated))
@@ -114,37 +130,4 @@ async function mergeLocalAndRemoteSpecs(
   }
 
   return result
-}
-
-function mergeLocalAndRemoteSpec(
-  localSpec: ExtensionSpecification,
-  remoteSpec: RemoteSpecification,
-): RemoteAwareExtensionSpecification {
-  const merged: RemoteAwareExtensionSpecification = {
-    ...localSpec,
-    loadedRemoteSpecs: true,
-    // Remote values have priority over local ones.
-    externalName: remoteSpec.externalName,
-    externalIdentifier: remoteSpec.externalIdentifier,
-    experience: remoteSpec.experience as 'extension' | 'configuration',
-    registrationLimit: remoteSpec.registrationLimit,
-    uidStrategy: remoteSpec.uidStrategy,
-    surface: remoteSpec.surface ?? localSpec.surface,
-  }
-  return merged
-}
-
-async function createRemoteOnlySpecification(
-  remoteSpec: RemoteSpecification,
-  validationSchema: {jsonSchema: string},
-): Promise<RemoteAwareExtensionSpecification> {
-  const normalisedSchema = await normaliseJsonSchema(validationSchema.jsonSchema)
-  const hasLocalization = normalisedSchema.properties?.localization !== undefined
-  const localSpec = createContractBasedModuleSpecification({
-    identifier: remoteSpec.identifier,
-    uidStrategy: remoteSpec.uidStrategy,
-    experience: remoteSpec.experience as 'extension' | 'configuration',
-    appModuleFeatures: () => (hasLocalization ? ['localization'] : []),
-  })
-  return {...localSpec, loadedRemoteSpecs: true}
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Related to [Hosted app project](https://vault.shopify.io/gsd/projects/48450-App-Extensions-Provide-app-developers-the-ability-to-build-a-simple-app-home-without-needing-a-backend).

Related to https://github.com/shop/world/pull/382743

Closes https://github.com/shop/issues-admin-extensibility/issues/2186

### WHAT is this pull request doing?

This PR introduces the asset pipeline flow for hosted static apps, enabling static asset copying during the build process.                     
                                                                                                                                                                                                                                                                                  
- New hosted_app specification (`app_config_hosted_app_home.ts`): Adds a configuration extension specification for hosted apps with a `static_root` field                                                                                                                                         
- New `static_app` build mode: Extends the build config modes to include `static_app`, which triggers static asset copying                         
- Enhanced config extension specifications:                                                                                                    
  - Added optional buildConfig and copyStaticAssets parameters to createConfigExtensionSpecification()                                         
  - Config extensions can now define custom build behavior                                                                                     
                                                                                                                                                 
### How it works                                                                                                                                   
                                                                                                                                                 
When a hosted app defines a static_root in its configuration:                                                                                  

1. The `hosted_app` specification is loaded with build mode `static_app`                                                                           
1. During build, `copyStaticAssets()` is invoked                                                                                                 
1. Contents from the configured `static_root` directory are copied to the output directory                                                       
                                                                                                                                             
### How to test your changes?

- Configure a hosted app with `static_root` pointing to a static assets directory                                                                
- Run `shopify app deploy` and verify assets are copied to the output directory - `.shopify/deploy-bundle`                                                                            
- Verify deploy works when static_root is not specified                                                                 
- TODO: Verify appropriate error handling when source directory doesn't exist  

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
