### PR TITLE
Avoid sending 'unknown' to Observe as the user ID

### DIFF
--- a/packages/cli-kit/src/public/node/error-handler.test.ts
+++ b/packages/cli-kit/src/public/node/error-handler.test.ts
@@ -263,7 +263,7 @@ describe('sends errors to Bugsnag', () => {
     expect(capturedEventHandler).toHaveBeenCalled()
 
     const mockEvent = capturedEventHandler.mock.calls[0]![0]
-    expect(mockEvent.setUser).toHaveBeenCalledWith('unknown')
+    expect(mockEvent.setUser).toHaveBeenCalledWith(undefined)
   })
 
   test('attaches custom metadata with allowed slice_name when startCommand is present', async () => {

--- a/packages/cli-kit/src/public/node/error-handler.ts
+++ b/packages/cli-kit/src/public/node/error-handler.ts
@@ -126,7 +126,11 @@ export async function sendErrorToBugsnag(
 
     if (report) {
       initializeBugsnag()
-      const userId = await getLastSeenUserIdAfterAuth()
+      let userId: string | undefined = await getLastSeenUserIdAfterAuth()
+      if (userId === 'unknown') {
+        // Observe will use the IP when undefined
+        userId = undefined
+      }
       await new Promise((resolve, reject) => {
         outputDebug(`Reporting ${unhandled ? 'unhandled' : 'handled'} error to Bugsnag: ${reportableError.message}`)
         const eventHandler = (event: Event) => {


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/cli/pull/6458#discussion_r2392401808

When the user id is not found, we are sending `unknown` to Observe.

### WHAT is this pull request doing?

Sends `undefined` when not found, so that Observe uses the IP

### How to test your changes?

- `npm i -g --@shopify:registry=https://registry.npmjs.org @shopify/cli@0.0.0-snapshot-20260202095504`
- `shopify auth logout`
- `shopify app info --path wronggg`
- Look for the error in Observe and check that the `__observe_session_stability_user` contains an IP. [Example](https://observe.shopify.io/goto/RBF8sJNDR?orgId=1).


### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
