### PR TITLE
Rewrite dev store APIs in local dev for app preview

### DIFF
--- a/packages/app/src/cli/utilities/app/app-url.ts
+++ b/packages/app/src/cli/utilities/app/app-url.ts
@@ -1,13 +1,15 @@
-import {normalizeStoreFqdn} from '@shopify/cli-kit/node/context/fqdn'
+import {normalizeStoreFqdn, storeAdminUrl} from '@shopify/cli-kit/node/context/fqdn'
 
 export function buildAppURLForWeb(storeFqdn: string, apiKey: string) {
   const normalizedFQDN = normalizeStoreFqdn(storeFqdn)
-  return `https://${normalizedFQDN}/admin/oauth/redirect_from_cli?client_id=${apiKey}`
+  const adminUrl = storeAdminUrl(normalizedFQDN)
+  return `https://${adminUrl}/admin/oauth/redirect_from_cli?client_id=${apiKey}`
 }
 
 export function buildAppURLForMobile(storeFqdn: string, apiKey: string) {
   const normalizedFQDN = normalizeStoreFqdn(storeFqdn)
-  const hostUrl = `${normalizedFQDN}/admin/apps/${apiKey}`
+  const adminUrl = storeAdminUrl(normalizedFQDN)
+  const hostUrl = `${adminUrl}/admin/apps/${apiKey}`
   const hostParam = Buffer.from(hostUrl).toString('base64').replace(/[=]/g, '')
   return `https://${hostUrl}?shop=${normalizedFQDN}&host=${hostParam}`
 }

--- a/packages/cli-kit/src/public/node/context/fqdn.ts
+++ b/packages/cli-kit/src/public/node/context/fqdn.ts
@@ -141,3 +141,18 @@ export function normalizeStoreFqdn(store: string): string {
     storeFqdn.endsWith('.myshopify.com') || storeFqdn.endsWith('shopify.io') || storeFqdn.endsWith('.shop.dev')
   return containDomain(storeFqdn) ? storeFqdn : addDomain(storeFqdn)
 }
+
+/**
+ * Convert a store FQDN to the admin URL pattern for local development.
+ * In local mode, transforms \{store\}.my.shop.dev to admin.shop.dev/store/\{store\}.
+ *
+ * @param storeFqdn - Normalized store FQDN.
+ * @returns Store admin URL base (without protocol or path).
+ */
+export function storeAdminUrl(storeFqdn: string): string {
+  if (serviceEnvironment() === 'local' && storeFqdn.endsWith('.my.shop.dev')) {
+    const storeName = storeFqdn.replace('.my.shop.dev', '')
+    return `admin.shop.dev/store/${storeName}`
+  }
+  return storeFqdn
+}


### PR DESCRIPTION
### WHY are these changes introduced?

Recent changes to normalize store FQDNs in local development mode (commits ce04cc67ba and 86748acbb9 from https://github.com/Shopify/cli/pull/6735) introduced a transformation that replaces `.my.shop.dev` with `.dev-api.shop.dev`. This breaks `shopify app dev` in local environments because:

1. The BusinessPlatform API cannot find stores with the `.dev-api.shop.dev` domain
2. Preview URLs are generated with the wrong domain pattern for local dev stores

### WHAT is this pull request doing?

This PR makes two changes to fix local development:

**1. Reverts the `.dev-api.shop.dev` transformation** (`fqdn.ts`)
- Removes the automatic replacement of `.my.shop.dev` → `.dev-api.shop.dev`
- This allows the CLI to query for stores using their actual registered domain
- Store lookups in BusinessPlatform API now succeed for local dev stores

**2. Transforms preview URLs for local dev** (`app-url.ts`)
- In local mode, transforms app preview URLs from `{store}.my.shop.dev/admin/...` to `admin.shop.dev/store/{store}/admin/...`
- This matches the URL pattern used by local development servers
- Applied to both web and mobile app URLs

### How to test your changes?

**Prerequisites:**
- Local dev environment with `SHOPIFY_SERVICE_ENV=local`
- A dev store accessible in your organization (e.g., `dev-store.my.shop.dev`)

**Testing:**
```bash
SHOPIFY_SERVICE_ENV=local \
shopify app dev --path=<your-app-path>
```

**Expected behavior:**
- ✅ CLI successfully finds your dev store (no "Could not find store for domain" error)
- ✅ Preview URLs use the `admin.shop.dev/store/{store-name}/admin/...` pattern
- ✅ Dev server starts successfully

**Before these changes:**
- ❌ Error: "Could not find store for domain dev-store.dev-api.shop.dev"
- ❌ Store lookup fails because BusinessPlatform doesn't recognize `.dev-api.shop.dev`

### Measuring impact

- [x] n/a - this is a bug-fix for local development environment

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows) - changes only affect local dev with `SHOPIFY_SERVICE_ENV=local`
- [x] I've considered possible documentation changes - no user-facing docs needed (internal local dev)
