### PR TITLE
Ignore the identifier attribute for event subscriptions when fetching configs from the remote server

### DIFF
--- a/packages/app/src/cli/models/app/loader.test.ts
+++ b/packages/app/src/cli/models/app/loader.test.ts
@@ -2090,7 +2090,7 @@ redirect_urls = [ "https://example.com/api/auth" ]
     const app = await loadTestingApp()
 
     // Then
-    expect(app.allExtensions).toHaveLength(5)
+    expect(app.allExtensions).toHaveLength(6)
     const extensionsConfig = app.allExtensions.map((ext) => ext.configuration)
     expect(extensionsConfig).toEqual([
       expect.objectContaining({
@@ -2105,6 +2105,9 @@ redirect_urls = [ "https://example.com/api/auth" ]
         webhooks: {
           api_version: '2023-07',
         },
+      }),
+      expect.objectContaining({
+        name: 'for-testing',
       }),
       expect.objectContaining({
         pos: {
@@ -2145,7 +2148,7 @@ redirect_urls = [ "https://example.com/api/auth" ]
     const app = await loadTestingApp({remoteFlags: []})
 
     // Then
-    expect(app.allExtensions).toHaveLength(6)
+    expect(app.allExtensions).toHaveLength(7)
     const extensionsConfig = app.allExtensions.map((ext) => ext.configuration)
     expect(extensionsConfig).toEqual([
       {
@@ -2166,6 +2169,9 @@ redirect_urls = [ "https://example.com/api/auth" ]
             {topics: ['orders/delete'], uri: 'https://example.com'},
           ],
         },
+        name: 'for-testing-webhooks',
+      },
+      {
         name: 'for-testing-webhooks',
       },
       {

--- a/packages/app/src/cli/models/extensions/extension-instance.ts
+++ b/packages/app/src/cli/models/extensions/extension-instance.ts
@@ -12,6 +12,7 @@ import {PosSpecIdentifier} from './specifications/app_config_point_of_sale.js'
 import {PrivacyComplianceWebhooksSpecIdentifier} from './specifications/app_config_privacy_compliance_webhooks.js'
 import {WebhooksSpecIdentifier} from './specifications/app_config_webhook.js'
 import {WebhookSubscriptionSpecIdentifier} from './specifications/app_config_webhook_subscription.js'
+import {EventsSpecIdentifier} from './specifications/app_config_events.js'
 import {
   ExtensionBuildOptions,
   buildFunctionExtension,
@@ -44,6 +45,7 @@ export const CONFIG_EXTENSION_IDS: string[] = [
   PrivacyComplianceWebhooksSpecIdentifier,
   WebhookSubscriptionSpecIdentifier,
   WebhooksSpecIdentifier,
+  EventsSpecIdentifier,
 ]
 
 /**

--- a/packages/app/src/cli/models/extensions/load-specifications.ts
+++ b/packages/app/src/cli/models/extensions/load-specifications.ts
@@ -6,6 +6,7 @@ import appWebhooksSpec, {WebhooksSpecIdentifier} from './specifications/app_conf
 import appWebhookSubscriptionSpec, {
   WebhookSubscriptionSpecIdentifier,
 } from './specifications/app_config_webhook_subscription.js'
+import appEventsSpec, {EventsSpecIdentifier} from './specifications/app_config_events.js'
 import appBrandingSpec, {BrandingSpecIdentifier} from './specifications/app_config_branding.js'
 import appAccessSpec, {AppAccessSpecIdentifier} from './specifications/app_config_app_access.js'
 import appPrivacyComplienceSpec, {
@@ -32,6 +33,7 @@ const SORTED_CONFIGURATION_SPEC_IDENTIFIERS = [
   AppAccessSpecIdentifier,
   WebhooksSpecIdentifier,
   WebhookSubscriptionSpecIdentifier,
+  EventsSpecIdentifier,
   PrivacyComplianceWebhooksSpecIdentifier,
   AppProxySpecIdentifier,
   PosSpecIdentifier,
@@ -58,6 +60,7 @@ function loadSpecifications() {
     appPrivacyComplienceSpec,
     appWebhooksSpec,
     appWebhookSubscriptionSpec,
+    appEventsSpec,
   ]
   const moduleSpecs = [
     checkoutPostPurchaseSpec,

--- a/packages/app/src/cli/models/extensions/specifications/app_config_events.ts
+++ b/packages/app/src/cli/models/extensions/specifications/app_config_events.ts
@@ -1,0 +1,23 @@
+import {transformToEventsConfig, transformFromEventsConfig} from './transform/app_config_events.js'
+import {CustomTransformationConfig, createConfigExtensionSpecification} from '../specification.js'
+import {BaseSchemaWithoutHandle} from '../schemas.js'
+import {zod} from '@shopify/cli-kit/node/schema'
+
+export const EventsSpecIdentifier = 'events'
+
+const EventsTransformConfig: CustomTransformationConfig = {
+  forward: transformFromEventsConfig,
+  reverse: (content: object) => transformToEventsConfig(content),
+}
+
+const EventsSchema = BaseSchemaWithoutHandle.extend({
+  events: zod.any().optional(),
+})
+
+const appEventsSpec = createConfigExtensionSpecification({
+  identifier: EventsSpecIdentifier,
+  schema: EventsSchema,
+  transformConfig: EventsTransformConfig,
+})
+
+export default appEventsSpec

--- a/packages/app/src/cli/models/extensions/specifications/transform/app_config_events.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/transform/app_config_events.test.ts
@@ -1,0 +1,86 @@
+import {transformToEventsConfig, transformFromEventsConfig} from './app_config_events.js'
+import {describe, expect, test} from 'vitest'
+
+describe('transformFromEventsConfig', () => {
+  test('returns content as-is without transformation', () => {
+    const content = {
+      events: {
+        api_version: '2024-01',
+        subscription: [{topic: 'orders/create', uri: 'https://example.com', actions: ['create']}],
+      },
+    }
+
+    const result = transformFromEventsConfig(content)
+
+    expect(result).toEqual(content)
+  })
+})
+
+describe('transformToEventsConfig', () => {
+  test('strips server-managed identifier field from subscriptions while preserving all other fields', () => {
+    const remoteContent = {
+      events: {
+        api_version: '2024-01',
+        subscription: [
+          {
+            topic: 'orders/create',
+            uri: 'https://example.com/webhook',
+            actions: ['create'],
+            identifier: 'id-1',
+          },
+          {
+            topic: 'products/update',
+            uri: 'https://example.com/webhook',
+            actions: ['update'],
+            handle: 'my-subscription',
+            triggers: ['product_updated'],
+            query: 'query { id }',
+            query_filter: 'status:active',
+            identifier: 'id-2',
+          },
+        ],
+      },
+    }
+
+    const result = transformToEventsConfig(remoteContent)
+
+    expect(result).toEqual({
+      events: {
+        api_version: '2024-01',
+        subscription: [
+          {
+            topic: 'orders/create',
+            uri: 'https://example.com/webhook',
+            actions: ['create'],
+          },
+          {
+            topic: 'products/update',
+            uri: 'https://example.com/webhook',
+            actions: ['update'],
+            handle: 'my-subscription',
+            triggers: ['product_updated'],
+            query: 'query { id }',
+            query_filter: 'status:active',
+          },
+        ],
+      },
+    })
+  })
+
+  test('handles missing subscription field', () => {
+    const remoteContent = {
+      events: {
+        api_version: '2024-01',
+      },
+    }
+
+    const result = transformToEventsConfig(remoteContent)
+
+    expect(result).toEqual({
+      events: {
+        api_version: '2024-01',
+        subscription: undefined,
+      },
+    })
+  })
+})

--- a/packages/app/src/cli/models/extensions/specifications/transform/app_config_events.ts
+++ b/packages/app/src/cli/models/extensions/specifications/transform/app_config_events.ts
@@ -1,0 +1,30 @@
+import {getPathValue} from '@shopify/cli-kit/common/object'
+
+/**
+ * Transforms the events config from local to remote format.
+ * No transformation needed - local config is already in the correct format for the server.
+ * The 'identifier' field is server-managed and should not exist in local configs.
+ */
+export function transformFromEventsConfig(content: object) {
+  return content
+}
+
+/**
+ * Transforms the events config from remote to local format.
+ * Strips the server-managed 'identifier' field from subscriptions.
+ */
+export function transformToEventsConfig(content: object) {
+  const eventsConfig = getPathValue(content, 'events') as {api_version: string; subscription: object[]}
+  const apiVersion = getPathValue(eventsConfig, 'api_version')
+  const subscription = getPathValue(eventsConfig, 'subscription') as {identifier: string}[]
+
+  // Server always includes identifier - strip it for local TOML
+  const cleanedSubscriptions = subscription?.map((sub) => {
+    const {identifier, ...rest} = sub
+    return rest
+  })
+
+  const events = apiVersion || cleanedSubscriptions ? {api_version: apiVersion, subscription: cleanedSubscriptions} : {}
+
+  return {events}
+}


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

This PR fixes the issue where the identifier attribute added on the server side was causing the same events config to be marked as `updated`. More details can be found in the linked issue.

Fixes https://github.com/shop/issues-event-foundations/issues/763

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

When redeploying the same events config, there was a bug causing it to show `updated`. It should show `no changes`. 
To fix this, I added a specification for the events module in the CLI and added a transformation config, where the remote->local transformation would remove the `identifier` attribute and the local->remote transformation is a no-op.

![Screenshot 2026-02-02 at 4.36.29 PM.png](https://app.graphite.com/user-attachments/assets/c9996f8e-d0b6-4f90-a84f-bb0efd744f38.png)

![Screenshot 2026-02-02 at 4.36.02 PM.png](https://app.graphite.com/user-attachments/assets/82c8d6ef-b5a0-4570-b682-475c283b1851.png)

### How to test your changes?

See https://github.com/shop/issues-event-foundations/issues/763#issuecomment-3837542155

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes