### PR TITLE
remove `reverse: true` in `listBulkOperations`

### DIFF
--- a/packages/app/src/cli/api/graphql/bulk-operations/generated/list-bulk-operations.ts
+++ b/packages/app/src/cli/api/graphql/bulk-operations/generated/list-bulk-operations.ts
@@ -7,7 +7,6 @@ export type ListBulkOperationsQueryVariables = Types.Exact<{
   query?: Types.InputMaybe<Types.Scalars['String']['input']>
   first: Types.Scalars['Int']['input']
   sortKey: Types.BulkOperationsSortKeys
-  reverse: Types.Scalars['Boolean']['input']
 }>
 
 export type ListBulkOperationsQuery = {
@@ -48,11 +47,6 @@ export const ListBulkOperations = {
           variable: {kind: 'Variable', name: {kind: 'Name', value: 'sortKey'}},
           type: {kind: 'NonNullType', type: {kind: 'NamedType', name: {kind: 'Name', value: 'BulkOperationsSortKeys'}}},
         },
-        {
-          kind: 'VariableDefinition',
-          variable: {kind: 'Variable', name: {kind: 'Name', value: 'reverse'}},
-          type: {kind: 'NonNullType', type: {kind: 'NamedType', name: {kind: 'Name', value: 'Boolean'}}},
-        },
       ],
       selectionSet: {
         kind: 'SelectionSet',
@@ -75,11 +69,6 @@ export const ListBulkOperations = {
                 kind: 'Argument',
                 name: {kind: 'Name', value: 'sortKey'},
                 value: {kind: 'Variable', name: {kind: 'Name', value: 'sortKey'}},
-              },
-              {
-                kind: 'Argument',
-                name: {kind: 'Name', value: 'reverse'},
-                value: {kind: 'Variable', name: {kind: 'Name', value: 'reverse'}},
               },
             ],
             selectionSet: {

--- a/packages/app/src/cli/api/graphql/bulk-operations/queries/list-bulk-operations.graphql
+++ b/packages/app/src/cli/api/graphql/bulk-operations/queries/list-bulk-operations.graphql
@@ -1,5 +1,5 @@
-query ListBulkOperations($query: String, $first: Int!, $sortKey: BulkOperationsSortKeys!, $reverse: Boolean!) {
-  bulkOperations(first: $first, query: $query, sortKey: $sortKey, reverse: $reverse) {
+query ListBulkOperations($query: String, $first: Int!, $sortKey: BulkOperationsSortKeys!) {
+  bulkOperations(first: $first, query: $query, sortKey: $sortKey) {
     nodes {
       id
       status

--- a/packages/app/src/cli/services/bulk-operations/bulk-operation-status.ts
+++ b/packages/app/src/cli/services/bulk-operations/bulk-operation-status.ts
@@ -121,7 +121,6 @@ export async function listBulkOperations(options: ListBulkOperationsOptions): Pr
       query: `created_at:>=${sevenDaysAgo}`,
       first: 100,
       sortKey: 'CREATED_AT',
-      reverse: true,
     },
     version: await resolveApiVersion({
       adminSession,


### PR DESCRIPTION
### WHY are these changes introduced?

This was actually the intended sort order all along. See the [brief], where we show newest-first sorting: (https://docs.google.com/document/d/157CvTbzxv5RDkAJCCeZMcWEPrsGLEdkFc8Hd48fUSM8/edit?usp=sharing):

<img width="983" height="293" alt="image" src="https://github.com/user-attachments/assets/20c5c897-74f1-49a2-aa44-14f95061d7ec" />

I messed this up when initially implementing -- I'd assumed the default sort would be oldest first, so we'd need to reverse it. Turns out [the default sort is newest first](https://github.com/shop/world/blob/main/areas/core/shopify/components/platform/bulk_operations/app/models/pagination/bulk_operations_query.rb#L10), so we don't! (We didn't realize the issue before because without the auth fixes, operations would stop being visible to this command fairly quickly.)

### WHAT is this pull request doing?

Let's just... not reverse the sort anymore!

### How to test your changes?

Run `app bulk status` now and verify that newest are at the top:

<img width="963" height="271" alt="image" src="https://github.com/user-attachments/assets/4f6d57d0-b576-4d62-b2d6-076fba928b15" />