### PR TITLE
Add failsafe and improve logging on unexpected select app error

### DIFF
--- a/packages/app/src/cli/prompts/dev.ts
+++ b/packages/app/src/cli/prompts/dev.ts
@@ -64,7 +64,16 @@ export async function selectAppPrompt(
       }
     },
   })
-  return currentAppChoices.find((app) => app.apiKey === apiKey)!
+
+  const appChoice = currentAppChoices.find((app) => app.apiKey === apiKey)!
+
+  if (!appChoice) {
+    throw new Error(
+      `Unable to select an app: the selection prompt was interrupted multiple times./n
+      Api key ${apiKey} was selected but not found in ${currentAppChoices.map((app) => app.apiKey).join(', ')}`,
+    )
+  }
+  return appChoice
 }
 
 interface SelectStorePromptOptions {

--- a/packages/app/src/cli/services/dev/select-app.ts
+++ b/packages/app/src/cli/services/dev/select-app.ts
@@ -5,6 +5,22 @@ import {getCachedCommandInfo, setCachedCommandTomlPreference} from '../local-sto
 import {CreateAppOptions, DeveloperPlatformClient} from '../../utilities/developer-platform-client.js'
 import {AppConfigurationFileName} from '../../models/app/loader.js'
 import {BugError} from '@shopify/cli-kit/node/error'
+import {outputInfo, outputDebug} from '@shopify/cli-kit/node/output'
+
+const MAX_PROMPT_RETRIES = 2
+
+const TRY_MESSAGE = [
+  'This may happen if:',
+  '  • Running in an unstable environment (container restart, resource limits)',
+  '  • Network interruption during app fetching',
+  '',
+  'Try running the command again. If the issue persists:',
+  '  • Check system resources and stability',
+  '  • Try running outside of containers/WSL if applicable',
+  '  • Report this issue with the error details and a verbose log',
+]
+  .filter(Boolean)
+  .join('\n')
 
 /**
  * Select an app from env, list or create a new one:
@@ -30,25 +46,61 @@ export async function selectOrCreateApp(
     const name = await appNamePrompt(options.name)
     return developerPlatformClient.createApp(org, {...options, name})
   } else {
-    const app = await selectAppPrompt(searchForAppsByNameFactory(developerPlatformClient, org.id), apps, hasMorePages, {
-      directory: options.directory,
-    })
+    // Capture app selection context
+    const cachedData = getCachedCommandInfo()
+    const tomls = (cachedData?.tomls as {[key: string]: AppConfigurationFileName}) ?? {}
 
-    const data = getCachedCommandInfo()
-    const tomls = (data?.tomls as {[key: string]: AppConfigurationFileName}) ?? {}
-    const selectedToml = tomls[app.apiKey]
+    for (let attempt = 0; attempt < MAX_PROMPT_RETRIES; attempt++) {
+      try {
+        // eslint-disable-next-line no-await-in-loop
+        const app = await selectAppPrompt(
+          searchForAppsByNameFactory(developerPlatformClient, org.id),
+          apps,
+          hasMorePages,
+          {directory: options.directory},
+        )
 
-    if (selectedToml) setCachedCommandTomlPreference(selectedToml)
+        const selectedToml = tomls[app.apiKey]
+        if (selectedToml) setCachedCommandTomlPreference(selectedToml)
 
-    const fullSelectedApp = await developerPlatformClient.appFromIdentifiers(app.apiKey)
+        // eslint-disable-next-line no-await-in-loop
+        const fullSelectedApp = await developerPlatformClient.appFromIdentifiers(app.apiKey)
 
-    if (!fullSelectedApp) {
-      // This is unlikely, and a bug. But we still want a nice user facing message plus appropriate context logged.
-      throw new BugError(
-        `Unable to fetch app ${app.apiKey} from Shopify`,
-        'Try running `shopify app config link` to connect to an app you have access to.',
-      )
+        if (!fullSelectedApp) {
+          throw new BugError(
+            `Unable to fetch app ${app.apiKey} from Shopify`,
+            'Try running `shopify app config link` to connect to an app you have access to.',
+          )
+        }
+
+        return fullSelectedApp
+      } catch (error) {
+        // Don't retry BugError - those indicate actual bugs, not transient issues
+        if (error instanceof BugError) {
+          throw error
+        }
+
+        const errorObj = error as Error
+
+        // Log each attempt for observability
+        outputDebug(`App selection attempt ${attempt + 1}/${MAX_PROMPT_RETRIES} failed: ${errorObj.message}`)
+
+        // If we have retries left, inform user and retry
+        if (attempt < MAX_PROMPT_RETRIES - 1) {
+          outputInfo('App selection failed. Retrying...')
+        } else {
+          throw new BugError(errorObj.message, TRY_MESSAGE)
+        }
+      }
     }
-    return fullSelectedApp
+
+    // User-facing error message with key diagnostic info
+    const errorMessage = [
+      'Unable to select an app: the selection prompt was interrupted multiple times.',
+      '',
+      `Available apps: ${apps.length}`,
+    ].join('\n')
+
+    throw new BugError(errorMessage, TRY_MESSAGE)
   }
 }

--- a/packages/cli-kit/src/public/node/ui.tsx
+++ b/packages/cli-kit/src/public/node/ui.tsx
@@ -426,7 +426,7 @@ export async function renderAutocompletePrompt<T>(
   }
 
   return runWithTimer('cmd_all_timing_prompts_ms')(async () => {
-    let selectedValue: T
+    let selectedValue: T | undefined
     await render(
       <AutocompletePrompt
         {...newProps}
@@ -439,7 +439,14 @@ export async function renderAutocompletePrompt<T>(
         exitOnCtrlC: false,
       },
     )
-    return selectedValue!
+
+    if (selectedValue === undefined) {
+      throw new Error(
+        'Prompt was interrupted before a selection was made. This can happen if the process received a signal, was terminated, or the prompt was aborted.',
+      )
+    }
+
+    return selectedValue
   })
 }
 


### PR DESCRIPTION
### WHY are these changes introduced?

[Issue #771](https://github.com/shop/issues/issues/771)

[vault error ](https://vault.shopify.io/teams/16949/issues/761)

Fixes an issue where app selection prompts could fail silently without proper error handling or diagnostics, leading to a poor developer experience when the prompt is interrupted.

### WHAT is this pull request doing?

Adds robust error handling and retry logic to the app selection process:

- Implements a retry mechanism (up to 2 attempts) when app selection is interrupted
- Captures comprehensive diagnostics about the environment and failure context
- Provides detailed error messages with troubleshooting suggestions
- Adds specific handling for different environments (Docker, WSL)
- Improves the autocomplete prompt to throw meaningful errors when interrupted

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes