### PR TITLE
Ignore the API collect endpoint in the `shopify theme dev` and `shopify app dev` commands

### DIFF
--- a/.changeset/quiet-toys-admire.md
+++ b/.changeset/quiet-toys-admire.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Ignore API collect endpoint in `shopify theme dev` and `shopify app dev` commands

--- a/packages/theme/src/cli/utilities/theme-environment/proxy.test.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/proxy.test.ts
@@ -126,6 +126,50 @@ describe('dev proxy', () => {
         `"<https://cdn.shopify.com>; rel=\\"preconnect\\", <https://cdn.shopify.com>; rel=\\"preconnect\\"; crossorigin,</cdn/shop/t/10/assets/component-localization-form.css?v=120620094879297847921723560016>; as=\\"style\\"; rel=\\"preload\\""`,
       )
     })
+
+    test('proxies beacon endpoint URLs to local server', () => {
+      const content = html`<html>
+        <head></head>
+        <body>
+          <div data-shs-beacon-endpoint="https://my-store.myshopify.com/api/collect"></div>
+        </body>
+      </html>`
+
+      expect(injectCdnProxy(content, ctx)).toMatchInlineSnapshot(`
+        "<html>
+                <head></head>
+                <body>
+                  <div data-shs-beacon-endpoint=\\"/api/collect\\"></div>
+                </body>
+              </html>"
+      `)
+    })
+
+    test('proxies beacon endpoint URLs with single quotes', () => {
+      const content = `<div data-shs-beacon-endpoint='https://my-store.myshopify.com/api/collect'></div>`
+
+      expect(injectCdnProxy(content, ctx)).toMatchInlineSnapshot(
+        `"<div data-shs-beacon-endpoint='/api/collect'></div>"`,
+      )
+    })
+
+    test('proxies multiple beacon endpoint URLs in the same content', () => {
+      const content = html`<html>
+        <body>
+          <div data-shs-beacon-endpoint="https://my-store.myshopify.com/api/collect"></div>
+          <span data-shs-beacon-endpoint="https://my-store.myshopify.com/api/collect"></span>
+        </body>
+      </html>`
+
+      expect(injectCdnProxy(content, ctx)).toMatchInlineSnapshot(`
+        "<html>
+                <body>
+                  <div data-shs-beacon-endpoint=\\"/api/collect\\"></div>
+                  <span data-shs-beacon-endpoint=\\"/api/collect\\"></span>
+                </body>
+              </html>"
+      `)
+    })
   })
 
   describe('patchRenderingResponse', () => {


### PR DESCRIPTION
Re-apply https://github.com/Shopify/cli/pull/6779 that was oddly closed 👻 

### WHY are these changes introduced?

This PR updates the theme development server (for both themes and theme app extensions) to ignore the `/api/collect` endpoint when running `shopify theme dev` and `shopify app dev`, since that endpoint can’t be proxied.

### WHAT is this pull request doing?

Updates the proxy patching logic to handle the beacon endpoint data attribute.

### How to test your changes?

- Run `shopify theme dev` and `shopify app dev`
- Notice that `/api/collect` requests no longer fail

Before:
<img width="60%" alt="image" src="https://github.com/user-attachments/assets/f67c6cbb-59d3-4e56-83ab-c1a0914d01ac" />

After:
<img width="60%" alt="image" src="https://github.com/user-attachments/assets/cf98f8a7-8e9d-4a80-80e7-518bd4ee1bf9" />


### Post-release steps

N/A

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
