### PR TITLE
Update theme and changeset CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,12 +2,12 @@
 * @shopify/app-inner-loop
 
 # Theme team and CLI owners should review theme changes
-packages/cli-kit/src/private/themes/* @shopify/developer-platforms @shopify/app-inner-loop
-packages/cli-kit/src/public/**/themes/* @shopify/developer-platforms @shopify/app-inner-loop
-packages/theme/** @shopify/developer-platforms @shopify/app-inner-loop
+packages/cli-kit/src/private/themes/* @shopify/developer-platforms
+packages/cli-kit/src/public/**/themes/* @shopify/developer-platforms
+packages/theme/** @shopify/developer-platforms
 
 # These are metafiles that can be reviewed by anyone
-.changeset/* @shopify/developer-platforms @shopify/app-inner-loop
+.changeset/*
 .github/CODEOWNERS @shopify/developer-platforms @shopify/app-inner-loop
 docs-shopify.dev/**  @shopify/developer-platforms @shopify/app-inner-loop
 packages/cli/oclif.manifest.json @shopify/developer-platforms @shopify/app-inner-loop


### PR DESCRIPTION
PRs like https://github.com/Shopify/cli/pull/6817 are unrelated to the @Shopify/app-inner-loop / Apps domain, but our `CODEOWNERS` setup keeps creating friction for both github teams by requesting reviews that don’t add much value.

We already have guardrails in place, like https://github.com/Shopify/cli/pull/6803 and the bot reminders around changeset updates, so it feels like we’ve got enough coverage to ensure changesets keep working as intended.

This PR updates the `CODEOWNERS` file to reduce unnecessary friction on review requests and make the code review process leaner for the Themes domain.