### PR TITLE
Fix shadowenv trust error in new git worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -150,7 +150,9 @@ packages/*/docs/
 .build
 
 packaging/dist
-!./.shadowenv.d/yarn.lisp
+
+# Shadowenv generates user-specific files that shouldn't be committed
+.shadowenv.d/
 
 cloudflared*
 function-runner*

--- a/.shadowenv.d/.gitignore
+++ b/.shadowenv.d/.gitignore
@@ -1,2 +1,0 @@
-*
-!yarn.lisp

--- a/.shadowenv.d/yarn.lisp
+++ b/.shadowenv.d/yarn.lisp
@@ -1,1 +1,0 @@
-(env/prepend-to-pathlist "PATH" (expand-path "./bin/shadowenv/"))

--- a/bin/shadowenv/p
+++ b/bin/shadowenv/p
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-set -e
-
-printf "\033[0;32mNote that p is an alias for pnpm activated by shadowenv in the CLI repository\n\033[0m"
-pnpm $@

--- a/bin/shadowenv/yarn
+++ b/bin/shadowenv/yarn
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-
-printf "\033[1;32myarn \033[0;32mhas been superseded by \033[1;32mpnpm \033[0;32mso please use that instead.\n\033[0m"
-printf "\033[0;30mCheck out https://github.com/Shopify/cli/pull/870 to understand the rationale behind the move.\n"
-
-"$(brew --prefix)/bin/yarn" "$@"
-


### PR DESCRIPTION
### WHY are these changes introduced?

When developers create new git worktrees in this repo, they see:

```
░shadowenv failure: directory: '.../.shadowenv.d' contains untrusted shadowenv program
```

This doesn't happen in other Shopify repos. The root cause: `.shadowenv.d/yarn.lisp` was committed to git (added in 2022 for acceptance tests), but shadowenv trust files are user-specific and **not** committed. New worktrees get the lisp file but no trust → error.

### WHAT is this pull request doing?

Removes the committed shadowenv files and adds `.shadowenv.d/` to `.gitignore` as a safeguard.

| File | Action | Reason |
|------|--------|--------|
| `.shadowenv.d/yarn.lisp` | Delete | Root cause of trust error |
| `.shadowenv.d/.gitignore` | Delete | Was keeping yarn.lisp tracked |
| `bin/shadowenv/yarn` | Delete | Yarn deprecation warning (pnpm migration done in 2022) |
| `bin/shadowenv/p` | Delete | pnpm alias (just type `pnpm` directly) |
| `.gitignore` | Edit | Add `.shadowenv.d/` to prevent reintroduction |

Going forward, `dev up` will generate shadowenv files as needed and handle trust automatically.

### How to test your changes?

1. Create a new worktree: `git worktree add ../test-worktree main`
2. `cd ../test-worktree`
3. Confirm **no** shadowenv trust error appears
4. Run `dev up` - should work normally
5. Clean up: `git worktree remove ../test-worktree`

### Measuring impact

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes