### PR TITLE
Use unified admin store domain for non-1P dev sessions

### DIFF
--- a/packages/app/src/cli/services/dev/processes/setup-dev-processes.test.ts
+++ b/packages/app/src/cli/services/dev/processes/setup-dev-processes.test.ts
@@ -36,6 +36,7 @@ import {getEnvironmentVariables} from '@shopify/cli-kit/node/environment'
 import {isStorefrontPasswordProtected} from '@shopify/theme'
 import {fetchTheme} from '@shopify/cli-kit/node/themes/api'
 import {firstPartyDev} from '@shopify/cli-kit/node/context/local'
+import {adminFqdn} from '@shopify/cli-kit/node/context/fqdn'
 
 vi.mock('../../context/identifiers.js')
 vi.mock('@shopify/cli-kit/node/session.js')
@@ -44,6 +45,13 @@ vi.mock('@shopify/cli-kit/node/environment')
 vi.mock('@shopify/theme')
 vi.mock('@shopify/cli-kit/node/themes/api')
 vi.mock('@shopify/cli-kit/node/context/local')
+vi.mock('@shopify/cli-kit/node/context/fqdn', async (importOriginal) => {
+  const original = await importOriginal<typeof import('@shopify/cli-kit/node/context/fqdn')>()
+  return {
+    ...original,
+    adminFqdn: vi.fn(),
+  }
+})
 
 beforeEach(() => {
   // mocked for draft extensions
@@ -71,6 +79,7 @@ beforeEach(() => {
   })
   // By default, firstPartyDev is false (local dev console only shown for 1P devs)
   vi.mocked(firstPartyDev).mockReturnValue(false)
+  vi.mocked(adminFqdn).mockResolvedValue('admin.shopify.com')
 })
 
 const appContextResult = {
@@ -167,7 +176,7 @@ describe('setup-dev-processes', () => {
     })
 
     // Dev console is NOT shown by default (only shown for 1P devs)
-    expect(res.previewUrl).toBe('https://store.myshopify.io/admin/oauth/redirect_from_cli?client_id=api-key')
+    expect(res.previewUrl).toBe('https://admin.shopify.com/store/store/apps/api-key')
     expect(res.processes[0]).toMatchObject({
       type: 'web',
       prefix: 'web-backend-frontend',
@@ -197,7 +206,7 @@ describe('setup-dev-processes', () => {
         apiKey: 'api-key',
         apiSecret: 'api-secret',
         port: expect.any(Number),
-        appUrl: 'https://store.myshopify.io/admin/oauth/redirect_from_cli?client_id=api-key',
+        appUrl: 'https://admin.shopify.com/store/store/apps/api-key',
         key: 'somekey',
         storeFqdn: 'store.myshopify.io',
       },

--- a/packages/app/src/cli/services/dev/processes/setup-dev-processes.ts
+++ b/packages/app/src/cli/services/dev/processes/setup-dev-processes.ts
@@ -15,7 +15,7 @@ import {AppLinkedInterface, getAppScopes, WebType} from '../../../models/app/app
 import {OrganizationApp} from '../../../models/organization.js'
 import {DevOptions} from '../../dev.js'
 import {LocalhostCert, getProxyingWebServer} from '../../../utilities/app/http-reverse-proxy.js'
-import {buildAppURLForWeb} from '../../../utilities/app/app-url.js'
+import {buildAppURLForAdmin, buildAppURLForWeb} from '../../../utilities/app/app-url.js'
 import {ApplicationURLs} from '../urls.js'
 import {DeveloperPlatformClient} from '../../../utilities/developer-platform-client.js'
 import {AppEventWatcher} from '../app-events/app-event-watcher.js'
@@ -25,6 +25,7 @@ import {isTruthy} from '@shopify/cli-kit/node/context/utilities'
 import {firstPartyDev} from '@shopify/cli-kit/node/context/local'
 import {getEnvironmentVariables} from '@shopify/cli-kit/node/environment'
 import {outputInfo} from '@shopify/cli-kit/node/output'
+import {adminFqdn} from '@shopify/cli-kit/node/context/fqdn'
 
 interface ProxyServerProcess
   extends BaseProcess<{
@@ -91,7 +92,6 @@ export async function setupDevProcesses({
 }> {
   const apiKey = remoteApp.apiKey
   const apiSecret = remoteApp.apiSecretKeys[0]?.secret ?? ''
-  const appPreviewUrl = buildAppURLForWeb(storeFqdn, apiKey)
   const env = getEnvironmentVariables()
   const shouldRenderGraphiQL = !isTruthy(env[environmentVariableNames.disableGraphiQLExplorer])
 
@@ -100,10 +100,24 @@ export async function setupDevProcesses({
   const appWatcher = new AppEventWatcher(reloadedApp, network.proxyUrl)
 
   // Decide on the appropriate preview URL for a session with these processes
-  // Use local dev console only for 1P developers (SHOPIFY_CLI_1P_DEV is enabled)
+  // - 1P developers with previewable extensions: use local dev console
+  // - 1P developers without previewable extensions: use legacy OAuth redirect URL
+  // - 3P developers: use unified admin URL
   const anyPreviewableExtensions = reloadedApp.allExtensions.some((ext) => ext.isPreviewable)
   const devConsoleURL = `${network.proxyUrl}/extensions/dev-console`
-  const useDevConsole = firstPartyDev() && anyPreviewableExtensions
+  const is1PDev = firstPartyDev()
+
+  // appPreviewUrl is the direct app URL (used by GraphiQL and dev session fallback)
+  // previewURL is what's shown to the user (may be dev console for 1P devs)
+  let appPreviewUrl: string
+  if (is1PDev) {
+    appPreviewUrl = buildAppURLForWeb(storeFqdn, apiKey)
+  } else {
+    const adminDomain = await adminFqdn()
+    appPreviewUrl = buildAppURLForAdmin(storeFqdn, apiKey, adminDomain)
+  }
+
+  const useDevConsole = is1PDev && anyPreviewableExtensions
   const previewURL = useDevConsole ? devConsoleURL : appPreviewUrl
 
   const graphiqlURL = shouldRenderGraphiQL

--- a/packages/app/src/cli/utilities/app/app-url.ts
+++ b/packages/app/src/cli/utilities/app/app-url.ts
@@ -6,6 +6,13 @@ export function buildAppURLForWeb(storeFqdn: string, apiKey: string) {
   return `https://${adminUrl}/admin/oauth/redirect_from_cli?client_id=${apiKey}`
 }
 
+export function buildAppURLForAdmin(storeFqdn: string, apiKey: string, adminDomain: string) {
+  const normalizedFQDN = normalizeStoreFqdn(storeFqdn)
+  const storeName = normalizedFQDN.split('.')[0]
+
+  return `https://${adminDomain}/store/${storeName}/apps/${apiKey}`
+}
+
 export function buildAppURLForMobile(storeFqdn: string, apiKey: string) {
   const normalizedFQDN = normalizeStoreFqdn(storeFqdn)
   const adminUrl = storeAdminUrl(normalizedFQDN)


### PR DESCRIPTION
### WHY are these changes introduced?

Updates the app preview URL shown to 3P developers during `shopify app dev` to use the unified admin URL format instead of the legacy OAuth redirect URL.

### WHAT is this pull request doing?

Changes the preview URL for 3P developers from the OAuth redirect URL to the unified admin URL format.

**Before (original):**

| Scenario | `appPreviewUrl` | `previewURL` (shown to user) |
|----------|-----------------|------------------------------|
| **1P dev + previewable extensions** | `https://{storeFqdn}/admin/oauth/redirect_from_cli?client_id={apiKey}` | `{proxyUrl}/extensions/dev-console` |
| **1P dev + no previewable extensions** | `https://{storeFqdn}/admin/oauth/redirect_from_cli?client_id={apiKey}` | Same as `appPreviewUrl` |
| **3P dev (any)** | `https://{storeFqdn}/admin/oauth/redirect_from_cli?client_id={apiKey}` | Same as `appPreviewUrl` |

**After (this PR):**

| Scenario | `appPreviewUrl` | `previewURL` (shown to user) |
|----------|-----------------|------------------------------|
| **1P dev + previewable extensions** | `https://{storeFqdn}/admin/oauth/redirect_from_cli?client_id={apiKey}` | `{proxyUrl}/extensions/dev-console` |
| **1P dev + no previewable extensions** | `https://{storeFqdn}/admin/oauth/redirect_from_cli?client_id={apiKey}` | Same as `appPreviewUrl` |
| **3P dev (any)** | `https://admin.shopify.com/store/{storeName}/apps/{apiKey}` | Same as `appPreviewUrl` |

**The only change:** 3P developers now get the unified admin URL instead of the OAuth redirect URL.

### How to test your changes?

1. Run `shopify app dev` as a 3P developer
2. Verify the preview URL shown uses the format `https://admin.shopify.com/store/{storeName}/apps/{apiKey}`
3. Run `shopify app dev` as a 1P developer (with `SHOPIFY_CLI_1P_DEV=1`)
4. Verify the preview URL still uses the legacy OAuth redirect format

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
