### PR TITLE
Add dev-console=show to app dev preview url

### DIFF
--- a/packages/app/src/cli/services/dev/processes/setup-dev-processes.test.ts
+++ b/packages/app/src/cli/services/dev/processes/setup-dev-processes.test.ts
@@ -176,7 +176,7 @@ describe('setup-dev-processes', () => {
     })
 
     // Dev console is NOT shown by default (only shown for 1P devs)
-    expect(res.previewUrl).toBe('https://admin.shopify.com/store/store/apps/api-key')
+    expect(res.previewUrl).toBe('https://admin.shopify.com/store/store/apps/api-key?dev-console=show')
     expect(res.processes[0]).toMatchObject({
       type: 'web',
       prefix: 'web-backend-frontend',
@@ -206,7 +206,7 @@ describe('setup-dev-processes', () => {
         apiKey: 'api-key',
         apiSecret: 'api-secret',
         port: expect.any(Number),
-        appUrl: 'https://admin.shopify.com/store/store/apps/api-key',
+        appUrl: 'https://admin.shopify.com/store/store/apps/api-key?dev-console=show',
         key: 'somekey',
         storeFqdn: 'store.myshopify.io',
       },

--- a/packages/app/src/cli/utilities/app/app-url.ts
+++ b/packages/app/src/cli/utilities/app/app-url.ts
@@ -10,7 +10,7 @@ export function buildAppURLForAdmin(storeFqdn: string, apiKey: string, adminDoma
   const normalizedFQDN = normalizeStoreFqdn(storeFqdn)
   const storeName = normalizedFQDN.split('.')[0]
 
-  return `https://${adminDomain}/store/${storeName}/apps/${apiKey}`
+  return `https://${adminDomain}/store/${storeName}/apps/${apiKey}?dev-console=show`
 }
 
 export function buildAppURLForMobile(storeFqdn: string, apiKey: string) {


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes the issue where the dev console is not automatically shown for developers when accessing the app URL.

When combined with the `admin-web` changes from https://app.graphite.com/github/pr/shop/world/392400/redirect_from_cli-maximizes-dev-console , this will close https://github.com/shop/issues-develop/issues/21960

### WHAT is this pull request doing?

Adds the `dev-console=show` query parameter to the app URL generated for admin, ensuring that the dev console is maximized by default when opening `app dev` preview links.

### How to test your changes?

1. https://app.graphite.com/github/pr/shop/world/392400/redirect_from_cli-maximizes-dev-console#discussion-IC_kwDONO8Wts7leWER will allow you to test against production
2. Run `dev` command for an app
3. Click on the provided app URL
4. Verify that the dev console is automatically shown without needing to manually add the query parameter

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes