### PR TITLE
fix issue for undefined sessions in theme commands

### DIFF
--- a/.changeset/goofy-colts-sink.md
+++ b/.changeset/goofy-colts-sink.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Fix issue where certain theme commands were failing to have sessions created

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -6326,6 +6326,7 @@
       "hiddenAliases": [
       ],
       "id": "theme:init",
+      "multiEnvironmentsFlags": null,
       "pluginAlias": "@shopify/cli",
       "pluginName": "@shopify/cli",
       "pluginType": "core",
@@ -6363,6 +6364,7 @@
       "hiddenAliases": [
       ],
       "id": "theme:language-server",
+      "multiEnvironmentsFlags": null,
       "pluginAlias": "@shopify/cli",
       "pluginName": "@shopify/cli",
       "pluginType": "core",
@@ -6705,6 +6707,7 @@
       "hiddenAliases": [
       ],
       "id": "theme:package",
+      "multiEnvironmentsFlags": null,
       "pluginAlias": "@shopify/cli",
       "pluginName": "@shopify/cli",
       "pluginType": "core",

--- a/packages/theme/src/cli/commands/theme/init.ts
+++ b/packages/theme/src/cli/commands/theme/init.ts
@@ -1,5 +1,5 @@
 import {themeFlags} from '../../flags.js'
-import ThemeCommand from '../../utilities/theme-command.js'
+import ThemeCommand, {RequiredFlags} from '../../utilities/theme-command.js'
 import {
   cloneRepoAndCheckoutLatestTag,
   cloneRepo,
@@ -56,6 +56,8 @@ export default class Init extends ThemeCommand {
       env: 'SHOPIFY_FLAG_LATEST',
     }),
   }
+
+  static multiEnvironmentsFlags: RequiredFlags = null
 
   async command(flags: InitFlags, _adminSession: AdminSession, _multiEnvironment: boolean, args: InitArgs) {
     const name = args.name || (await this.promptName(flags.path))

--- a/packages/theme/src/cli/commands/theme/language-server.ts
+++ b/packages/theme/src/cli/commands/theme/language-server.ts
@@ -1,4 +1,4 @@
-import ThemeCommand from '../../utilities/theme-command.js'
+import ThemeCommand, {RequiredFlags} from '../../utilities/theme-command.js'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
 import {startServer} from '@shopify/theme-language-server-node'
 
@@ -12,6 +12,8 @@ export default class LanguageServer extends ThemeCommand {
   static flags = {
     ...globalFlags,
   }
+
+  static multiEnvironmentsFlags: RequiredFlags = null
 
   async command() {
     startServer()

--- a/packages/theme/src/cli/commands/theme/package.ts
+++ b/packages/theme/src/cli/commands/theme/package.ts
@@ -1,5 +1,5 @@
 import {themeFlags} from '../../flags.js'
-import ThemeCommand from '../../utilities/theme-command.js'
+import ThemeCommand, {RequiredFlags} from '../../utilities/theme-command.js'
 import {packageTheme} from '../../services/package.js'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
 import {InferredFlags} from '@oclif/core/interfaces'
@@ -22,6 +22,8 @@ export default class Package extends ThemeCommand {
     ...globalFlags,
     path: themeFlags.path,
   }
+
+  static multiEnvironmentsFlags: RequiredFlags = null
 
   async command(flags: PackageFlags) {
     await packageTheme(flags.path)

--- a/packages/theme/src/cli/utilities/theme-command.test.ts
+++ b/packages/theme/src/cli/utilities/theme-command.test.ts
@@ -137,9 +137,6 @@ class TestThemeCommandWithoutStoreRequired extends ThemeCommand {
       env: 'SHOPIFY_FLAG_PATH',
       default: 'current/working/directory',
     }),
-    password: Flags.string({
-      env: 'SHOPIFY_FLAG_PASSWORD',
-    }),
     store: Flags.string({
       env: 'SHOPIFY_FLAG_STORE',
     }),
@@ -267,7 +264,7 @@ describe('ThemeCommand', () => {
       expect(ensureAuthenticatedThemes).not.toHaveBeenCalled()
     })
 
-    test('single environment provided with store - creates session when store is provided even if not required', async () => {
+    test('single environment provided with store - does not create session when command does not require auth', async () => {
       // Given
       const environmentConfig = {path: '/some/path', store: 'store.myshopify.com'}
       vi.mocked(loadEnvironment).mockResolvedValue(environmentConfig)
@@ -279,9 +276,9 @@ describe('ThemeCommand', () => {
       await command.run()
 
       // Then
-      expect(ensureAuthenticatedThemes).toHaveBeenCalledOnce()
+      expect(ensureAuthenticatedThemes).not.toHaveBeenCalled()
       expect(command.commandCalls).toHaveLength(1)
-      expect(command.commandCalls[0]?.session).toEqual(mockSession)
+      expect(command.commandCalls[0]?.session).toBeUndefined()
     })
 
     test('multiple environments provided - uses renderConcurrent for parallel execution', async () => {

--- a/packages/theme/src/cli/utilities/theme-command.ts
+++ b/packages/theme/src/cli/utilities/theme-command.ts
@@ -88,8 +88,7 @@ export default abstract class ThemeCommand extends Command {
         throw new AbortError(`Please provide a valid environment.`)
       }
 
-      const shouldCreateSession = commandRequiresAuth && (storeIsRequired || flags.store)
-      const session = shouldCreateSession ? await this.createSession(flags) : undefined
+      const session = commandRequiresAuth ? await this.createSession(flags) : undefined
       const commandName = this.constructor.name.toLowerCase()
 
       recordEvent(`theme-command:${commandName}:single-env:authenticated`)


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/developer-tools-team/issues/1024?reload=1
Follow up from the [PR](https://github.com/Shopify/cli/pull/6795) to fix default environments

CLI main is failing on commands that don't need a store flag to run such as `theme profile`. A few other commands are failing with an error `Cannot read properties of undefined` such as `theme init`

### WHAT is this pull request doing?

Two parter:
1. I have reverted some of the logic from the other PR back to checking if a command needs authorization and not checking against store flags
2. The commands failing with error were missing `static multiEnvironmentsFlags: RequiredFlags = null` which is our way of telling whether these commands support multi env or not. I have added them where needed.

### How to test your changes?
Unfortunately we need to test this in a few configurations to make sure we caught every instance.

Run the commands using regular auth (email / password) login
- `shopify theme dev` Should pass
- `shopify theme list` Should pass
- `shopify theme package` Should pass
- `shopify theme check` Should pass
- `shopify theme profile` Should pass

Run the commands using a default environment (`[environments.default]`) in your `shopify.theme.toml` **Note**: Using the default environment means you do not need to explicitly pass it as an environment.
- `shopify theme dev` Should pass
- `shopify theme list` Should pass
- `shopify theme package` Should pass
- `shopify theme check` Should pass
- `shopify theme profile` Should fail (can only run using regular auth)

Run the commands using an environment variable (-e my_store) from your `shopify.theme.toml`
- `shopify theme dev` Should pass
- `shopify theme list` Should pass
- `shopify theme package` Should fail (`package` doesn't have an environment flag)
- `shopify theme check` Should pass
- `shopify theme profile` Should fail (can only run using regular auth)

Run the commands using two environment variables (-e my_store, -e my_other_store ) from your `shopify.theme.toml`
- `shopify theme dev` Should fail (can't run in multi env mode)
- `shopify theme list` Should pass
I shortened this one since only a few commands run in multi env mode


### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
