### PR TITLE
Add warning and confirmation before running theme doctor

### DIFF
--- a/packages/cli/src/cli/commands/doctor-release/theme/index.test.ts
+++ b/packages/cli/src/cli/commands/doctor-release/theme/index.test.ts
@@ -1,0 +1,47 @@
+import DoctorReleaseTheme from './index.js'
+import {runThemeDoctor} from '../../../services/doctor-release/theme/runner.js'
+import {renderConfirmationPrompt} from '@shopify/cli-kit/node/ui'
+import {afterEach, expect, test, vi} from 'vitest'
+
+vi.mock('@shopify/cli-kit/node/ui')
+vi.mock('../../../services/doctor-release/theme/runner.js')
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
+
+test('does not run theme doctor when user cancels', async () => {
+  // Given
+  vi.stubEnv('SHOPIFY_CLI_DOCTOR', '1')
+  vi.mocked(renderConfirmationPrompt).mockResolvedValue(false)
+
+  // When
+  await DoctorReleaseTheme.run(['--environment', 'test'])
+
+  // Then
+  expect(runThemeDoctor).not.toHaveBeenCalled()
+})
+
+test('runs theme doctor when user confirms', async () => {
+  // Given
+  vi.stubEnv('SHOPIFY_CLI_DOCTOR', '1')
+  vi.mocked(renderConfirmationPrompt).mockResolvedValue(true)
+  vi.mocked(runThemeDoctor).mockResolvedValue([])
+
+  // When
+  await DoctorReleaseTheme.run(['--environment', 'test'])
+
+  // Then
+  expect(runThemeDoctor).toHaveBeenCalled()
+})
+
+test('does not run theme doctor when environment variable is not set', async () => {
+  // Given - no SHOPIFY_CLI_DOCTOR env var set
+
+  // When
+  await DoctorReleaseTheme.run(['--environment', 'test'])
+
+  // Then - neither prompt nor doctor should be called
+  expect(renderConfirmationPrompt).not.toHaveBeenCalled()
+  expect(runThemeDoctor).not.toHaveBeenCalled()
+})

--- a/packages/cli/src/cli/commands/doctor-release/theme/index.ts
+++ b/packages/cli/src/cli/commands/doctor-release/theme/index.ts
@@ -4,6 +4,7 @@ import {globalFlags} from '@shopify/cli-kit/node/cli'
 import {Flags} from '@oclif/core'
 import {resolvePath, cwd} from '@shopify/cli-kit/node/path'
 import {canRunDoctorRelease} from '@shopify/cli-kit/node/context/local'
+import {renderConfirmationPrompt, RenderConfirmationPromptOptions} from '@shopify/cli-kit/node/ui'
 
 export default class DoctorReleaseTheme extends Command {
   static description = 'Run all theme command doctor-release tests'
@@ -39,7 +40,16 @@ export default class DoctorReleaseTheme extends Command {
     if (!canRunDoctorRelease()) {
       return
     }
+    const promptOptions: RenderConfirmationPromptOptions = {
+      message: `This will run automated theme commands against your shop. It will modify remote themes. Please confirm before running.`,
+      confirmationMessage: 'Yes I understand',
+      cancellationMessage: 'No, cancel the command',
+    }
+    const confirmed = await renderConfirmationPrompt(promptOptions)
 
+    if (!confirmed) {
+      return
+    }
     const {flags} = await this.parse(DoctorReleaseTheme)
 
     const results = await runThemeDoctor({


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes [#1016](https://github.com/Shopify/developer-tools-team/issues/1016)

Building off the architecture for a new `theme doctor` command in [this PR](https://github.com/Shopify/cli/pull/6798), I introduce a warning and confirm with the user before executing the `theme doctor` test suite, as the tests will interact with user's remote shop. 

### WHAT is this pull request doing?

- add the `renderConfirmationPrompt` function to the `doctor/theme/index.ts` file
- add a new unittest file and 2 unittests to verify that behavior for `User Confirms` and `User Cancels` are correct

looks like this when User Confirms(test suite executes):
<img width="693" height="620" alt="Screenshot 2026-02-06 at 11 53 14 AM" src="https://github.com/user-attachments/assets/c73b3f69-8d93-472f-be85-b554f01af4e2" />

and when User Cancels (exit the command):
<img width="699" height="98" alt="Screenshot 2026-02-06 at 11 53 28 AM" src="https://github.com/user-attachments/assets/4287a182-06f6-49b5-8fa5-c01746433c0c" />

UPDATE: working with the addition of the required environment variable, I verified the variable requirement executes first and then the prompt and confirmation.
If the correct env variable is present:
<img width="580" height="165" alt="Screenshot 2026-02-10 at 7 12 54 PM" src="https://github.com/user-attachments/assets/18fc3eb9-a68f-4c18-a693-c3a69fb93a1c" />

If the incorrect variable is present: 
<img width="563" height="80" alt="Screenshot 2026-02-10 at 7 12 16 PM" src="https://github.com/user-attachments/assets/f57c9643-db32-4708-ad6b-30fcddf324c1" />

I also wrote a new unittest to confirm this behavior.

### How to test your changes?
pull my branch down locally
`p build`
run `shopify-dev doctor theme -e <local-env-name>` in external terminal 
see the warning and prompt and the expected behaviors between Yes/No



