### PR TITLE
Fix theme editor sync not reloading on schema changes

### DIFF
--- a/.changeset/fix-theme-editor-sync-schema-reload.md
+++ b/.changeset/fix-theme-editor-sync-schema-reload.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Fix theme editor sync not reloading customizer on schema changes

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -50,7 +50,7 @@
     "yaml": "2.7.0"
   },
   "devDependencies": {
-    "@shopify/theme-hot-reload": "^0.0.18",
+    "@shopify/theme-hot-reload": "^0.0.22",
     "@vitest/coverage-istanbul": "^3.1.4",
     "node-stream-zip": "^1.15.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -717,8 +717,8 @@ importers:
         version: 2.7.0
     devDependencies:
       '@shopify/theme-hot-reload':
-        specifier: ^0.0.18
-        version: 0.0.18
+        specifier: ^0.0.22
+        version: 0.0.22
       '@vitest/coverage-istanbul':
         specifier: ^3.1.4
         version: 3.2.1(vitest@3.2.1(@types/node@24.7.0)(jiti@2.4.2)(jsdom@20.0.3)(msw@2.8.7(@types/node@24.7.0)(typescript@5.8.3))(sass@1.89.1)(yaml@2.7.0))
@@ -3768,8 +3768,8 @@ packages:
     resolution: {integrity: sha512-S1DFAb71NqVzOr89Jh3OjVrT7tP/e0gbJHKp1gRG1/dGW7T0xCvZZGkhgNU04x5qJGY7umAkzI4oCvQWpv1ogg==}
     hasBin: true
 
-  '@shopify/theme-hot-reload@0.0.18':
-    resolution: {integrity: sha512-l+IBuk+rG5T+5PKYyPrwgh7PDCxmEMpBFJeen6PM+h6RI4CDhAGRaiwUo5eN1o1JX51HdHHCts3rTEW+KUgq+Q==}
+  '@shopify/theme-hot-reload@0.0.22':
+    resolution: {integrity: sha512-RiaLPqhW3iAJKlO3KRvU4sQJ0cJIwhZ5Zx77wYw+3+oFXHC+vNrB+mjIarxoqCbUdm+E1eUwAs0aGU74YjFWkA==}
 
   '@shopify/theme-language-server-common@2.20.0':
     resolution: {integrity: sha512-NgkFR+UnvvJ2rtB1buYyEs4ed0sZuEe4g7Fu92UamKrJxAh3iWXnFtcLkPulIEgilNRN6PPp38f6mnVA/cBZrA==}
@@ -14032,7 +14032,7 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@shopify/theme-hot-reload@0.0.18': {}
+  '@shopify/theme-hot-reload@0.0.22': {}
 
   '@shopify/theme-language-server-common@2.20.0':
     dependencies:


### PR DESCRIPTION
### WHY are these changes introduced?

Closes https://github.com/Shopify/developer-tools-team/issues/1033.

When using `shopify theme dev --theme-editor-sync`, making schema changes to section files (e.g., adding/modifying settings in `{% schema %}` blocks) did not trigger the theme customizer to reload. Users had to manually refresh the customizer to see schema updates.

This is a regression since version 3.88.1.

### WHAT is this pull request doing?

Bumps `@shopify/theme-hot-reload` from `^0.0.18` to `^0.0.22`.

**Root cause:** The hot-reload client was only checking `javascriptTag` changes to trigger full page reloads, but ignored `schemaTag` changes that the server was already sending.

The fix existed upstream in v0.0.20+ (commit 4785747 in the theme-hot-reload package), which adds:
```javascript
if (event.payload?.updatedFileParts?.javascriptTag ||
    event.payload?.updatedFileParts?.schemaTag) {
    return fullPageReload(event.key);
}
```

### How to test your changes?

_Note: I'm currently having 1Password issues so I'm locked out of the admin and haven't been able to manually test these myself_

1. Run `shopify theme dev --theme-editor-sync` in a theme directory
2. Open the theme customizer in your browser
3. Edit a section's `{% schema %}` block (e.g., add a new setting)
4. Save the file
5. **Expected:** The customizer reloads automatically and shows the new schema setting
6. **Before fix:** No reload occurred; manual refresh was required

### Measuring impact

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes