### PR TITLE
hydrogen/Bump cli-hydrogen to 11.1.8 (main)

### DIFF
--- a/.changeset/update-hydrogen-cli-11.1.8.md
+++ b/.changeset/update-hydrogen-cli-11.1.8.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli': patch
+---
+
+Update cli-hydrogen 11.1.8

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -64,7 +64,7 @@
     "@shopify/plugin-cloudflare": "3.91.0",
     "@shopify/plugin-did-you-mean": "3.91.0",
     "@shopify/theme": "3.91.0",
-    "@shopify/cli-hydrogen": "11.1.5",
+    "@shopify/cli-hydrogen": "11.1.8",
     "@types/global-agent": "3.0.0",
     "@vitest/coverage-istanbul": "^3.1.4",
     "esbuild-plugin-copy": "^2.1.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -265,7 +265,7 @@ importers:
         version: 8.18.1
       '@vitest/coverage-istanbul':
         specifier: ^3.1.4
-        version: 3.2.4(vitest@3.2.4(@types/node@22.19.11)(jiti@2.6.1)(jsdom@20.0.3)(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(sass@1.97.3)(yaml@2.7.0))
+        version: 3.2.4(vitest@3.2.4(@types/node@24.7.0)(jiti@2.6.1)(jsdom@20.0.3)(msw@2.12.10(@types/node@24.7.0)(typescript@5.9.3))(sass@1.97.3)(yaml@2.7.0))
 
   packages/cli:
     dependencies:
@@ -292,8 +292,8 @@ importers:
         specifier: 3.91.0
         version: link:../app
       '@shopify/cli-hydrogen':
-        specifier: 11.1.5
-        version: 11.1.5(@graphql-codegen/cli@6.0.1(@parcel/watcher@2.5.6)(@types/node@18.19.70)(crossws@0.3.5)(graphql@16.10.0)(typescript@5.9.3))(graphql-config@5.1.5(@types/node@22.19.11)(crossws@0.3.5)(graphql@16.10.0)(typescript@5.9.3))(graphql@16.10.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(sass@1.97.3)(yaml@2.7.0))
+        specifier: 11.1.8
+        version: 11.1.8(@graphql-codegen/cli@6.0.1(@parcel/watcher@2.5.6)(@types/node@18.19.70)(crossws@0.3.5)(graphql@16.10.0)(typescript@5.9.3))(graphql-config@5.1.5(@types/node@24.7.0)(crossws@0.3.5)(graphql@16.10.0)(typescript@5.9.3))(graphql@16.10.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@6.4.1(@types/node@24.7.0)(jiti@2.6.1)(sass@1.97.3)(yaml@2.7.0))
       '@shopify/cli-kit':
         specifier: 3.91.0
         version: link:../cli-kit
@@ -311,7 +311,7 @@ importers:
         version: 3.0.0
       '@vitest/coverage-istanbul':
         specifier: ^3.1.4
-        version: 3.2.4(vitest@3.2.4(@types/node@22.19.11)(jiti@2.6.1)(jsdom@20.0.3)(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(sass@1.97.3)(yaml@2.7.0))
+        version: 3.2.4(vitest@3.2.4(@types/node@24.7.0)(jiti@2.6.1)(jsdom@20.0.3)(msw@2.12.10(@types/node@24.7.0)(typescript@5.9.3))(sass@1.97.3)(yaml@2.7.0))
       esbuild-plugin-copy:
         specifier: ^2.1.1
         version: 2.1.1(esbuild@0.27.2)
@@ -540,10 +540,10 @@ importers:
         version: 3.0.4
       '@vitest/coverage-istanbul':
         specifier: ^3.1.4
-        version: 3.2.4(vitest@3.2.4(@types/node@22.19.11)(jiti@2.6.1)(jsdom@20.0.3)(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(sass@1.97.3)(yaml@2.7.0))
+        version: 3.2.4(vitest@3.2.4(@types/node@24.7.0)(jiti@2.6.1)(jsdom@20.0.3)(msw@2.12.10(@types/node@24.7.0)(typescript@5.9.3))(sass@1.97.3)(yaml@2.7.0))
       msw:
         specifier: ^2.7.1
-        version: 2.12.10(@types/node@22.19.11)(typescript@5.9.3)
+        version: 2.12.10(@types/node@24.7.0)(typescript@5.9.3)
       node-stream-zip:
         specifier: ^1.15.0
         version: 1.15.0
@@ -568,7 +568,7 @@ importers:
         version: link:../cli-kit
       '@vitest/coverage-istanbul':
         specifier: ^3.1.4
-        version: 3.2.4(vitest@3.2.4(@types/node@22.19.11)(jiti@2.6.1)(jsdom@20.0.3)(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(sass@1.97.3)(yaml@2.7.0))
+        version: 3.2.4(vitest@3.2.4(@types/node@24.7.0)(jiti@2.6.1)(jsdom@20.0.3)(msw@2.12.10(@types/node@24.7.0)(typescript@5.9.3))(sass@1.97.3)(yaml@2.7.0))
       esbuild-plugin-copy:
         specifier: ^2.1.1
         version: 2.1.1(esbuild@0.27.2)
@@ -589,7 +589,7 @@ importers:
         version: 8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)
       '@vitest/eslint-plugin':
         specifier: 1.1.44
-        version: 1.1.44(@typescript-eslint/utils@8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)(vitest@3.2.4(@types/node@22.19.11)(jiti@2.6.1)(jsdom@20.0.3)(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(sass@1.97.3)(yaml@2.7.0))
+        version: 1.1.44(@typescript-eslint/utils@8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)(vitest@3.2.4(@types/node@24.7.0)(jiti@2.6.1)(jsdom@20.0.3)(msw@2.12.10(@types/node@24.7.0)(typescript@5.9.3))(sass@1.97.3)(yaml@2.7.0))
       debug:
         specifier: 4.4.0
         version: 4.4.0(supports-color@8.1.1)
@@ -669,7 +669,7 @@ importers:
     devDependencies:
       '@vitest/coverage-istanbul':
         specifier: ^3.1.4
-        version: 3.2.4(vitest@3.2.4(@types/node@22.19.11)(jiti@2.6.1)(jsdom@20.0.3)(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(sass@1.97.3)(yaml@2.7.0))
+        version: 3.2.4(vitest@3.2.4(@types/node@24.7.0)(jiti@2.6.1)(jsdom@20.0.3)(msw@2.12.10(@types/node@24.7.0)(typescript@5.9.3))(sass@1.97.3)(yaml@2.7.0))
 
   packages/plugin-did-you-mean:
     dependencies:
@@ -685,7 +685,7 @@ importers:
     devDependencies:
       '@vitest/coverage-istanbul':
         specifier: ^3.1.4
-        version: 3.2.4(vitest@3.2.4(@types/node@22.19.11)(jiti@2.6.1)(jsdom@20.0.3)(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(sass@1.97.3)(yaml@2.7.0))
+        version: 3.2.4(vitest@3.2.4(@types/node@24.7.0)(jiti@2.6.1)(jsdom@20.0.3)(msw@2.12.10(@types/node@24.7.0)(typescript@5.9.3))(sass@1.97.3)(yaml@2.7.0))
 
   packages/theme:
     dependencies:
@@ -716,7 +716,7 @@ importers:
         version: 0.0.18
       '@vitest/coverage-istanbul':
         specifier: ^3.1.4
-        version: 3.2.4(vitest@3.2.4(@types/node@22.19.11)(jiti@2.6.1)(jsdom@20.0.3)(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(sass@1.97.3)(yaml@2.7.0))
+        version: 3.2.4(vitest@3.2.4(@types/node@24.7.0)(jiti@2.6.1)(jsdom@20.0.3)(msw@2.12.10(@types/node@24.7.0)(typescript@5.9.3))(sass@1.97.3)(yaml@2.7.0))
       node-stream-zip:
         specifier: ^1.15.0
         version: 1.15.0
@@ -780,7 +780,7 @@ importers:
         version: 1.97.3
       vite:
         specifier: 6.4.1
-        version: 6.4.1(@types/node@22.19.11)(jiti@2.6.1)(sass@1.97.3)(yaml@2.7.0)
+        version: 6.4.1(@types/node@24.7.0)(jiti@2.6.1)(sass@1.97.3)(yaml@2.7.0)
 
   packages/ui-extensions-server-kit:
     devDependencies:
@@ -807,7 +807,7 @@ importers:
         version: 0.8.0
       vite:
         specifier: 6.4.1
-        version: 6.4.1(@types/node@22.19.11)(jiti@2.6.1)(sass@1.97.3)(yaml@2.7.0)
+        version: 6.4.1(@types/node@24.7.0)(jiti@2.6.1)(sass@1.97.3)(yaml@2.7.0)
 
   packages/ui-extensions-test-utils:
     devDependencies:
@@ -3583,13 +3583,13 @@ packages:
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
 
-  '@shopify/cli-hydrogen@11.1.5':
-    resolution: {integrity: sha512-KnyKdJ2EZI44YzRK8mWifP7g0ndm3Q9daPdq2da84EnXpZ+a7AHSruud95b1fANawVBoK7i6RIeDrgcwmri0NA==}
+  '@shopify/cli-hydrogen@11.1.8':
+    resolution: {integrity: sha512-D/wrNhmToV69pHiR3aGHttrKm0CHNgm8d1ISDbLJg2Z4THhmHJK0Pj08/RZcgGPINJq35komG0FhCq0Xr7kUbA==}
     engines: {node: '>=18.0.0'}
     hasBin: true
     peerDependencies:
       '@graphql-codegen/cli': ^5.0.2
-      '@react-router/dev': 7.9.2
+      '@react-router/dev': 7.12.0
       '@shopify/hydrogen-codegen': ^0.3.3
       '@shopify/mini-oxygen': ^4.0.0
       graphql-config: ^5.0.3
@@ -4100,6 +4100,9 @@ packages:
 
   '@types/node@22.19.11':
     resolution: {integrity: sha512-BH7YwL6rA93ReqeQS1c4bsPpcfOmJasG+Fkr6Y59q83f9M1WcBRHR2vM+P9eOisYRcN3ujQoiZY8uk5W+1WL8w==}
+
+  '@types/node@24.7.0':
+    resolution: {integrity: sha512-IbKooQVqUBrlzWTi79E8Fw78l8k1RNtlDDNWsFZs7XonuQSJ8oNYfEeclhprUldXISRMLzBpILuKgPlIxm+/Yw==}
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
@@ -9094,6 +9097,9 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
+  undici-types@7.14.0:
+    resolution: {integrity: sha512-QQiYxHuyZ9gQUIrmPo3IA+hUl4KYk8uSA7cHrcKd/l3p1OTpZcM0Tbp9x7FAtXdAYhlasd60ncPpgu6ihG6TOA==}
+
   undici@5.29.0:
     resolution: {integrity: sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==}
     engines: {node: '>=14.0'}
@@ -10204,7 +10210,7 @@ snapshots:
       '@babel/traverse': 7.29.0
       '@babel/types': 7.29.0
       convert-source-map: 2.0.0
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -10950,7 +10956,7 @@ snapshots:
       '@babel/parser': 7.29.0
       '@babel/template': 7.28.6
       '@babel/types': 7.29.0
-      debug: 4.4.0(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -11903,7 +11909,7 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
-  '@graphql-tools/executor-http@1.3.3(@types/node@22.19.11)(graphql@16.10.0)':
+  '@graphql-tools/executor-http@1.3.3(@types/node@24.7.0)(graphql@16.10.0)':
     dependencies:
       '@graphql-hive/signal': 1.0.0
       '@graphql-tools/executor-common': 0.0.4(graphql@16.10.0)
@@ -11913,7 +11919,7 @@ snapshots:
       '@whatwg-node/fetch': 0.10.13
       '@whatwg-node/promise-helpers': 1.3.2
       graphql: 16.10.0
-      meros: 1.3.2(@types/node@22.19.11)
+      meros: 1.3.2(@types/node@24.7.0)
       tslib: 2.8.1
     transitivePeerDependencies:
       - '@types/node'
@@ -12031,7 +12037,7 @@ snapshots:
   '@graphql-tools/optimize@2.0.0(graphql@16.10.0)':
     dependencies:
       graphql: 16.10.0
-      tslib: 2.6.3
+      tslib: 2.8.1
 
   '@graphql-tools/relay-operation-optimizer@6.5.18(graphql@16.10.0)':
     dependencies:
@@ -12048,7 +12054,7 @@ snapshots:
       '@ardatan/relay-compiler': 12.0.3(graphql@16.10.0)
       '@graphql-tools/utils': 10.7.2(graphql@16.10.0)
       graphql: 16.10.0
-      tslib: 2.6.3
+      tslib: 2.8.1
     transitivePeerDependencies:
       - encoding
 
@@ -12081,10 +12087,10 @@ snapshots:
       - crossws
       - utf-8-validate
 
-  '@graphql-tools/url-loader@8.0.33(@types/node@22.19.11)(crossws@0.3.5)(graphql@16.10.0)':
+  '@graphql-tools/url-loader@8.0.33(@types/node@24.7.0)(crossws@0.3.5)(graphql@16.10.0)':
     dependencies:
       '@graphql-tools/executor-graphql-ws': 2.0.7(crossws@0.3.5)(graphql@16.10.0)
-      '@graphql-tools/executor-http': 1.3.3(@types/node@22.19.11)(graphql@16.10.0)
+      '@graphql-tools/executor-http': 1.3.3(@types/node@24.7.0)(graphql@16.10.0)
       '@graphql-tools/executor-legacy-ws': 1.1.25(graphql@16.10.0)
       '@graphql-tools/utils': 10.7.2(graphql@16.10.0)
       '@graphql-tools/wrap': 10.1.4(graphql@16.10.0)
@@ -12162,12 +12168,12 @@ snapshots:
     optionalDependencies:
       '@types/node': 18.19.70
 
-  '@inquirer/confirm@5.1.21(@types/node@22.19.11)':
+  '@inquirer/confirm@5.1.21(@types/node@24.7.0)':
     dependencies:
-      '@inquirer/core': 10.3.2(@types/node@22.19.11)
-      '@inquirer/type': 3.0.10(@types/node@22.19.11)
+      '@inquirer/core': 10.3.2(@types/node@24.7.0)
+      '@inquirer/type': 3.0.10(@types/node@24.7.0)
     optionalDependencies:
-      '@types/node': 22.19.11
+      '@types/node': 24.7.0
 
   '@inquirer/core@10.3.2(@types/node@18.19.70)':
     dependencies:
@@ -12182,18 +12188,18 @@ snapshots:
     optionalDependencies:
       '@types/node': 18.19.70
 
-  '@inquirer/core@10.3.2(@types/node@22.19.11)':
+  '@inquirer/core@10.3.2(@types/node@24.7.0)':
     dependencies:
       '@inquirer/ansi': 1.0.2
       '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@22.19.11)
+      '@inquirer/type': 3.0.10(@types/node@24.7.0)
       cli-width: 4.1.0
       mute-stream: 2.0.0
       signal-exit: 4.1.0
       wrap-ansi: 6.2.0
       yoctocolors-cjs: 2.1.3
     optionalDependencies:
-      '@types/node': 22.19.11
+      '@types/node': 24.7.0
 
   '@inquirer/core@9.2.1':
     dependencies:
@@ -12324,9 +12330,9 @@ snapshots:
     optionalDependencies:
       '@types/node': 18.19.70
 
-  '@inquirer/type@3.0.10(@types/node@22.19.11)':
+  '@inquirer/type@3.0.10(@types/node@24.7.0)':
     optionalDependencies:
-      '@types/node': 22.19.11
+      '@types/node': 24.7.0
 
   '@isaacs/balanced-match@4.0.1': {}
 
@@ -13218,7 +13224,7 @@ snapshots:
 
   '@shikijs/vscode-textmate@10.0.2': {}
 
-  '@shopify/cli-hydrogen@11.1.5(@graphql-codegen/cli@6.0.1(@parcel/watcher@2.5.6)(@types/node@18.19.70)(crossws@0.3.5)(graphql@16.10.0)(typescript@5.9.3))(graphql-config@5.1.5(@types/node@22.19.11)(crossws@0.3.5)(graphql@16.10.0)(typescript@5.9.3))(graphql@16.10.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(sass@1.97.3)(yaml@2.7.0))':
+  '@shopify/cli-hydrogen@11.1.8(@graphql-codegen/cli@6.0.1(@parcel/watcher@2.5.6)(@types/node@18.19.70)(crossws@0.3.5)(graphql@16.10.0)(typescript@5.9.3))(graphql-config@5.1.5(@types/node@24.7.0)(crossws@0.3.5)(graphql@16.10.0)(typescript@5.9.3))(graphql@16.10.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@6.4.1(@types/node@24.7.0)(jiti@2.6.1)(sass@1.97.3)(yaml@2.7.0))':
     dependencies:
       '@ast-grep/napi': 0.34.1
       '@oclif/core': 3.26.5
@@ -13242,8 +13248,8 @@ snapshots:
       use-resize-observer: 9.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     optionalDependencies:
       '@graphql-codegen/cli': 6.0.1(@parcel/watcher@2.5.6)(@types/node@18.19.70)(crossws@0.3.5)(graphql@16.10.0)(typescript@5.9.3)
-      graphql-config: 5.1.5(@types/node@22.19.11)(crossws@0.3.5)(graphql@16.10.0)(typescript@5.9.3)
-      vite: 6.4.1(@types/node@22.19.11)(jiti@2.6.1)(sass@1.97.3)(yaml@2.7.0)
+      graphql-config: 5.1.5(@types/node@24.7.0)(crossws@0.3.5)(graphql@16.10.0)(typescript@5.9.3)
+      vite: 6.4.1(@types/node@24.7.0)(jiti@2.6.1)(sass@1.97.3)(yaml@2.7.0)
     transitivePeerDependencies:
       - graphql
       - react
@@ -14044,6 +14050,10 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  '@types/node@24.7.0':
+    dependencies:
+      undici-types: 7.14.0
+
   '@types/normalize-package-data@2.4.4': {}
 
   '@types/parse-json@4.0.2': {}
@@ -14123,7 +14133,7 @@ snapshots:
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 18.19.70
+      '@types/node': 24.7.0
 
   '@types/yargs-parser@21.0.3': {}
 
@@ -14307,7 +14317,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-istanbul@3.2.4(vitest@3.2.4(@types/node@22.19.11)(jiti@2.6.1)(jsdom@20.0.3)(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(sass@1.97.3)(yaml@2.7.0))':
+  '@vitest/coverage-istanbul@3.2.4(vitest@3.2.4(@types/node@24.7.0)(jiti@2.6.1)(jsdom@20.0.3)(msw@2.12.10(@types/node@24.7.0)(typescript@5.9.3))(sass@1.97.3)(yaml@2.7.0))':
     dependencies:
       '@istanbuljs/schema': 0.1.3
       debug: 4.4.3(supports-color@8.1.1)
@@ -14319,7 +14329,7 @@ snapshots:
       magicast: 0.3.5
       test-exclude: 7.0.2
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/node@22.19.11)(jiti@2.6.1)(jsdom@20.0.3)(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(sass@1.97.3)(yaml@2.7.0)
+      vitest: 3.2.4(@types/node@24.7.0)(jiti@2.6.1)(jsdom@20.0.3)(msw@2.12.10(@types/node@24.7.0)(typescript@5.9.3))(sass@1.97.3)(yaml@2.7.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -14331,13 +14341,13 @@ snapshots:
       typescript: 5.9.3
       vitest: 3.2.4(@types/node@18.19.70)(jiti@2.6.1)(jsdom@20.0.3)(msw@2.12.10(@types/node@18.19.70)(typescript@5.9.3))(sass@1.97.3)(yaml@2.7.0)
 
-  '@vitest/eslint-plugin@1.1.44(@typescript-eslint/utils@8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)(vitest@3.2.4(@types/node@22.19.11)(jiti@2.6.1)(jsdom@20.0.3)(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(sass@1.97.3)(yaml@2.7.0))':
+  '@vitest/eslint-plugin@1.1.44(@typescript-eslint/utils@8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)(vitest@3.2.4(@types/node@24.7.0)(jiti@2.6.1)(jsdom@20.0.3)(msw@2.12.10(@types/node@24.7.0)(typescript@5.9.3))(sass@1.97.3)(yaml@2.7.0))':
     dependencies:
       '@typescript-eslint/utils': 8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.3(jiti@2.6.1)
     optionalDependencies:
       typescript: 5.9.3
-      vitest: 3.2.4(@types/node@22.19.11)(jiti@2.6.1)(jsdom@20.0.3)(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(sass@1.97.3)(yaml@2.7.0)
+      vitest: 3.2.4(@types/node@24.7.0)(jiti@2.6.1)(jsdom@20.0.3)(msw@2.12.10(@types/node@24.7.0)(typescript@5.9.3))(sass@1.97.3)(yaml@2.7.0)
 
   '@vitest/expect@3.2.4':
     dependencies:
@@ -14356,13 +14366,13 @@ snapshots:
       msw: 2.12.10(@types/node@18.19.70)(typescript@5.9.3)
       vite: 6.4.1(@types/node@18.19.70)(jiti@2.6.1)(sass@1.97.3)(yaml@2.7.0)
 
-  '@vitest/mocker@3.2.4(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@6.4.1(@types/node@18.19.70)(jiti@2.6.1)(sass@1.97.3)(yaml@2.7.0))':
+  '@vitest/mocker@3.2.4(msw@2.12.10(@types/node@24.7.0)(typescript@5.9.3))(vite@6.4.1(@types/node@18.19.70)(jiti@2.6.1)(sass@1.97.3)(yaml@2.7.0))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      msw: 2.12.10(@types/node@22.19.11)(typescript@5.9.3)
+      msw: 2.12.10(@types/node@24.7.0)(typescript@5.9.3)
       vite: 6.4.1(@types/node@18.19.70)(jiti@2.6.1)(sass@1.97.3)(yaml@2.7.0)
 
   '@vitest/pretty-format@3.2.4':
@@ -16627,13 +16637,13 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  graphql-config@5.1.5(@types/node@22.19.11)(crossws@0.3.5)(graphql@16.10.0)(typescript@5.9.3):
+  graphql-config@5.1.5(@types/node@24.7.0)(crossws@0.3.5)(graphql@16.10.0)(typescript@5.9.3):
     dependencies:
       '@graphql-tools/graphql-file-loader': 8.1.9(graphql@16.10.0)
       '@graphql-tools/json-file-loader': 8.0.26(graphql@16.10.0)
       '@graphql-tools/load': 8.1.8(graphql@16.10.0)
       '@graphql-tools/merge': 9.1.7(graphql@16.10.0)
-      '@graphql-tools/url-loader': 8.0.33(@types/node@22.19.11)(crossws@0.3.5)(graphql@16.10.0)
+      '@graphql-tools/url-loader': 8.0.33(@types/node@24.7.0)(crossws@0.3.5)(graphql@16.10.0)
       '@graphql-tools/utils': 10.7.2(graphql@16.10.0)
       cosmiconfig: 8.3.6(typescript@5.9.3)
       graphql: 16.10.0
@@ -17063,7 +17073,7 @@ snapshots:
 
   is-lower-case@2.0.2:
     dependencies:
-      tslib: 2.6.3
+      tslib: 2.8.1
 
   is-map@2.0.3: {}
 
@@ -17140,7 +17150,7 @@ snapshots:
 
   is-upper-case@2.0.2:
     dependencies:
-      tslib: 2.6.3
+      tslib: 2.8.1
 
   is-weakmap@2.0.2: {}
 
@@ -17521,7 +17531,7 @@ snapshots:
 
   lower-case-first@2.0.2:
     dependencies:
-      tslib: 2.6.3
+      tslib: 2.8.1
 
   lower-case@2.0.2:
     dependencies:
@@ -17614,9 +17624,9 @@ snapshots:
     optionalDependencies:
       '@types/node': 18.19.70
 
-  meros@1.3.2(@types/node@22.19.11):
+  meros@1.3.2(@types/node@24.7.0):
     optionalDependencies:
-      '@types/node': 22.19.11
+      '@types/node': 24.7.0
     optional: true
 
   methods@1.1.2: {}
@@ -17732,9 +17742,9 @@ snapshots:
       - '@types/node'
     optional: true
 
-  msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3):
+  msw@2.12.10(@types/node@24.7.0)(typescript@5.9.3):
     dependencies:
-      '@inquirer/confirm': 5.1.21(@types/node@22.19.11)
+      '@inquirer/confirm': 5.1.21(@types/node@24.7.0)
       '@mswjs/interceptors': 0.41.3
       '@open-draft/deferred-promise': 2.2.0
       '@types/statuses': 2.0.6
@@ -19122,7 +19132,7 @@ snapshots:
 
   sponge-case@1.0.1:
     dependencies:
-      tslib: 2.6.3
+      tslib: 2.8.1
 
   sprintf-js@1.0.3: {}
 
@@ -19186,7 +19196,7 @@ snapshots:
     dependencies:
       emoji-regex: 10.6.0
       get-east-asian-width: 1.5.0
-      strip-ansi: 7.1.0
+      strip-ansi: 7.1.2
 
   string-width@8.2.0:
     dependencies:
@@ -19310,7 +19320,7 @@ snapshots:
 
   swap-case@2.0.2:
     dependencies:
-      tslib: 2.6.3
+      tslib: 2.8.1
 
   symbol-tree@3.2.4: {}
 
@@ -19440,7 +19450,7 @@ snapshots:
 
   title-case@3.0.3:
     dependencies:
-      tslib: 2.6.3
+      tslib: 2.8.1
 
   tldts-core@7.0.23: {}
 
@@ -19653,6 +19663,8 @@ snapshots:
 
   undici-types@6.21.0: {}
 
+  undici-types@7.14.0: {}
+
   undici@5.29.0:
     dependencies:
       '@fastify/busboy': 2.1.1
@@ -19800,13 +19812,13 @@ snapshots:
       - tsx
       - yaml
 
-  vite-node@3.2.4(@types/node@22.19.11)(jiti@2.6.1)(sass@1.97.3)(yaml@2.7.0):
+  vite-node@3.2.4(@types/node@24.7.0)(jiti@2.6.1)(sass@1.97.3)(yaml@2.7.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3(supports-color@8.1.1)
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 6.4.1(@types/node@22.19.11)(jiti@2.6.1)(sass@1.97.3)(yaml@2.7.0)
+      vite: 6.4.1(@types/node@24.7.0)(jiti@2.6.1)(sass@1.97.3)(yaml@2.7.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -19836,7 +19848,7 @@ snapshots:
       sass: 1.97.3
       yaml: 2.7.0
 
-  vite@6.4.1(@types/node@22.19.11)(jiti@2.6.1)(sass@1.97.3)(yaml@2.7.0):
+  vite@6.4.1(@types/node@24.7.0)(jiti@2.6.1)(sass@1.97.3)(yaml@2.7.0):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.3)
@@ -19845,7 +19857,7 @@ snapshots:
       rollup: 4.59.0
       tinyglobby: 0.2.15
     optionalDependencies:
-      '@types/node': 22.19.11
+      '@types/node': 24.7.0
       fsevents: 2.3.3
       jiti: 2.6.1
       sass: 1.97.3
@@ -19893,11 +19905,11 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@3.2.4(@types/node@22.19.11)(jiti@2.6.1)(jsdom@20.0.3)(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(sass@1.97.3)(yaml@2.7.0):
+  vitest@3.2.4(@types/node@24.7.0)(jiti@2.6.1)(jsdom@20.0.3)(msw@2.12.10(@types/node@24.7.0)(typescript@5.9.3))(sass@1.97.3)(yaml@2.7.0):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(vite@6.4.1(@types/node@18.19.70)(jiti@2.6.1)(sass@1.97.3)(yaml@2.7.0))
+      '@vitest/mocker': 3.2.4(msw@2.12.10(@types/node@24.7.0)(typescript@5.9.3))(vite@6.4.1(@types/node@18.19.70)(jiti@2.6.1)(sass@1.97.3)(yaml@2.7.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -19915,11 +19927,11 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 6.4.1(@types/node@22.19.11)(jiti@2.6.1)(sass@1.97.3)(yaml@2.7.0)
-      vite-node: 3.2.4(@types/node@22.19.11)(jiti@2.6.1)(sass@1.97.3)(yaml@2.7.0)
+      vite: 6.4.1(@types/node@24.7.0)(jiti@2.6.1)(sass@1.97.3)(yaml@2.7.0)
+      vite-node: 3.2.4(@types/node@24.7.0)(jiti@2.6.1)(sass@1.97.3)(yaml@2.7.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 22.19.11
+      '@types/node': 24.7.0
       jsdom: 20.0.3
     transitivePeerDependencies:
       - jiti


### PR DESCRIPTION
Update @shopify/cli-hydrogen to version 11.1.8

## Release Notes

### Patch Changes

- Update Storefront API and Customer Account API to version 2025-10 ([#3430](https://github.com/Shopify/hydrogen/pull/3430))

- Add support for Bun's text-based lockfile (`bun.lock`) introduced in Bun 1.2, and npm's shrinkwrap lockfile (`npm-shrinkwrap.json`), as alternatives to their respective primary lockfiles (`bun.lockb` and `package-lock.json`). ([#3430](https://github.com/Shopify/hydrogen/pull/3430))

- Add `cartGiftCardCodesAdd` mutation ([#3430](https://github.com/Shopify/hydrogen/pull/3430))

  **New Feature: cartGiftCardCodesAdd**

  The skeleton template has been updated to use the new `cartGiftCardCodesAdd` mutation:

  - Removed `UpdateGiftCardForm` component from `CartSummary.tsx`
  - Added `AddGiftCardForm` component using `CartForm.ACTIONS.GiftCardCodesAdd`

  If you customized the gift card form in your project, you may want to migrate to the new `Add` action for simpler code.

- Add support for nested cart line items (warranties, gift wrapping, etc.) ([#3430](https://github.com/Shopify/hydrogen/pull/3430))

  Storefront API 2025-10 introduces `parentRelationship` on cart line items, enabling parent-child relationships for add-ons. This update displays nested line items in the cart.

  **Changes:**
  - Updates GraphQL fragments to include `parentRelationship` and `lineComponents` fields
  - Updates `CartMain` and `CartLineItem` to render child line items with visual hierarchy

---

**Full release:** https://github.com/Shopify/hydrogen/releases/tag/%40shopify%2Fcli-hydrogen%4011.1.8