### PR TITLE
Fix doc generation script

### DIFF
--- a/bin/create-doc-pr.js
+++ b/bin/create-doc-pr.js
@@ -19,7 +19,7 @@ async function createPR() {
 
   const files = {}
   for (const fileName of fileNames) {
-    files[`db/data/docs/templated_apis/shopify_cli/${fileName}`] = (await readFile(path.join(generatedDirectory, fileName))).toString()
+    files[`areas/platforms/shopify-dev/db/data/docs/templated_apis/shopify_cli/${fileName}`] = (await readFile(path.join(generatedDirectory, fileName))).toString()
   }
 
   await withOctokit("shopify", async (octokit) => {


### PR DESCRIPTION
### WHY are these changes introduced?

In https://github.com/Shopify/shopify-dev/pull/67845 the path structure for shopify-dev changed, so our script to update the docs there stopped working.

### WHAT is this pull request doing?

Updates our script to update the shopify-dev docs to work with the new structure

### How to test your changes?

Update any doc and run `./bin/create-doc-pr.js`

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
