### PR TITLE
Auto-upgrade

### DIFF
--- a/docs-shopify.dev/commands/upgrade.doc.ts
+++ b/docs-shopify.dev/commands/upgrade.doc.ts
@@ -3,8 +3,8 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs'
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'upgrade',
-  description: `Shows details on how to upgrade Shopify CLI.`,
-  overviewPreviewDescription: `Shows details on how to upgrade Shopify CLI.`,
+  description: `Upgrades Shopify CLI using your package manager.`,
+  overviewPreviewDescription: `Upgrades Shopify CLI.`,
   type: 'command',
   isVisualComponent: false,
   defaultExample: {

--- a/docs-shopify.dev/generated/generated_docs_data.json
+++ b/docs-shopify.dev/generated/generated_docs_data.json
@@ -7815,8 +7815,8 @@
   },
   {
     "name": "upgrade",
-    "description": "Shows details on how to upgrade Shopify CLI.",
-    "overviewPreviewDescription": "Shows details on how to upgrade Shopify CLI.",
+    "description": "Upgrades Shopify CLI using your package manager.",
+    "overviewPreviewDescription": "Upgrades Shopify CLI.",
     "type": "command",
     "isVisualComponent": false,
     "defaultExample": {

--- a/packages/app/src/cli/services/app/config/link.test.ts
+++ b/packages/app/src/cli/services/app/config/link.test.ts
@@ -37,6 +37,9 @@ vi.mock('@shopify/cli-kit/node/ui')
 vi.mock('../../context/partner-account-info.js')
 vi.mock('../../context.js')
 vi.mock('../select-app.js')
+vi.mock('@shopify/cli-kit/node/is-global', () => ({
+  currentProcessIsGlobal: () => false,
+}))
 
 const DEFAULT_REMOTE_CONFIGURATION = {
   name: 'app1',

--- a/packages/app/src/cli/services/app/config/use.test.ts
+++ b/packages/app/src/cli/services/app/config/use.test.ts
@@ -19,6 +19,9 @@ vi.mock('../../local-storage.js')
 vi.mock('../../../models/app/loader.js')
 vi.mock('@shopify/cli-kit/node/ui')
 vi.mock('../../context.js')
+vi.mock('@shopify/cli-kit/node/is-global', () => ({
+  currentProcessIsGlobal: () => false,
+}))
 
 describe('use', () => {
   test('clears currentConfiguration when reset is true', async () => {
@@ -31,6 +34,7 @@ describe('use', () => {
         developerPlatformClient: testDeveloperPlatformClient(),
       }
       writeFileSync(joinPath(tmp, 'package.json'), '{}')
+      writeFileSync(joinPath(tmp, 'shopify.app.toml'), '')
 
       // When
       await use(options)

--- a/packages/app/src/cli/services/generate.test.ts
+++ b/packages/app/src/cli/services/generate.test.ts
@@ -38,6 +38,9 @@ vi.mock('../prompts/generate/extension.js')
 vi.mock('../services/generate/extension.js')
 vi.mock('../services/context.js')
 vi.mock('./local-storage.js')
+vi.mock('@shopify/cli-kit/node/is-global', () => ({
+  currentProcessIsGlobal: () => false,
+}))
 
 afterEach(() => {
   mockAndCaptureOutput().clear()

--- a/packages/app/src/cli/services/init/init.ts
+++ b/packages/app/src/cli/services/init/init.ts
@@ -124,6 +124,7 @@ async function init(options: InitOptions) {
               await appendFile(joinPath(templateScaffoldDir, '.npmrc'), `auto-install-peers=true\n`)
               break
             }
+            case 'homebrew':
             case 'unknown':
               throw new UnknownPackageManagerError()
           }

--- a/packages/cli-kit/src/private/node/conf-store.ts
+++ b/packages/cli-kit/src/private/node/conf-store.ts
@@ -29,6 +29,7 @@ export interface ConfSchema {
   sessionStore: string
   currentSessionId?: string
   cache?: Cache
+  autoUpgradeEnabled?: boolean
 }
 
 let _instance: LocalStorage<ConfSchema> | undefined
@@ -254,6 +255,24 @@ export async function runWithRateLimit(options: RunWithRateLimitOptions, config 
   config.set('cache', cache)
 
   return true
+}
+
+/**
+ * Get auto-upgrade preference.
+ *
+ * @returns Whether auto-upgrade is enabled, or undefined if never set.
+ */
+export function getAutoUpgradeEnabled(config: LocalStorage<ConfSchema> = cliKitStore()): boolean | undefined {
+  return config.get('autoUpgradeEnabled')
+}
+
+/**
+ * Set auto-upgrade preference.
+ *
+ * @param enabled - Whether auto-upgrade should be enabled.
+ */
+export function setAutoUpgradeEnabled(enabled: boolean, config: LocalStorage<ConfSchema> = cliKitStore()): void {
+  config.set('autoUpgradeEnabled', enabled)
 }
 
 export function getConfigStoreForPartnerStatus() {

--- a/packages/cli-kit/src/public/node/fs.ts
+++ b/packages/cli-kit/src/public/node/fs.ts
@@ -15,7 +15,7 @@ import {
 
 import {temporaryDirectory, temporaryDirectoryTask} from 'tempy'
 import {sep, join} from 'pathe'
-import {findUp as internalFindUp} from 'find-up'
+import {findUp as internalFindUp, findUpSync as internalFindUpSync} from 'find-up'
 import {minimatch} from 'minimatch'
 import fastGlobLib from 'fast-glob'
 import {
@@ -647,6 +647,23 @@ export async function findPathUp(
   // findUp has odd typing
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const got = await internalFindUp(matcher as any, options)
+  return got ? normalizePath(got) : undefined
+}
+
+/**
+ * Find a file by walking parent directories.
+ *
+ * @param matcher - A pattern or an array of patterns to match a file name.
+ * @param options - Options for the search.
+ * @returns The first path found that matches or `undefined` if none could be found.
+ */
+export function findPathUpSync(
+  matcher: OverloadParameters<typeof internalFindUp>[0],
+  options: OverloadParameters<typeof internalFindUp>[1],
+): ReturnType<typeof internalFindUpSync> {
+  // findUp has odd typing
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const got = internalFindUpSync(matcher as any, options)
   return got ? normalizePath(got) : undefined
 }
 

--- a/packages/cli-kit/src/public/node/hooks/postrun.test.ts
+++ b/packages/cli-kit/src/public/node/hooks/postrun.test.ts
@@ -1,0 +1,83 @@
+import {autoUpgradeIfNeeded} from './postrun.js'
+import {mockAndCaptureOutput} from '../testing/output.js'
+import {getOutputUpdateCLIReminder, runCLIUpgrade, versionToAutoUpgrade} from '../upgrade.js'
+import {isMajorVersionChange} from '../version.js'
+import {describe, expect, test, vi, afterEach} from 'vitest'
+
+vi.mock('../upgrade.js', async (importOriginal) => {
+  const actual: any = await importOriginal()
+  return {
+    ...actual,
+    runCLIUpgrade: vi.fn(),
+    getOutputUpdateCLIReminder: vi.fn(),
+    versionToAutoUpgrade: vi.fn(),
+  }
+})
+
+vi.mock('../version.js', async (importOriginal) => {
+  const actual: any = await importOriginal()
+  return {
+    ...actual,
+    isMajorVersionChange: vi.fn(),
+  }
+})
+
+afterEach(() => {
+  mockAndCaptureOutput().clear()
+})
+
+describe('autoUpgradeIfNeeded', () => {
+  test('runs the upgrade when versionToAutoUpgrade returns a version', async () => {
+    // Given
+    vi.mocked(versionToAutoUpgrade).mockReturnValue('3.91.0')
+    vi.mocked(runCLIUpgrade).mockResolvedValue()
+
+    // When
+    await autoUpgradeIfNeeded()
+
+    // Then
+    expect(runCLIUpgrade).toHaveBeenCalled()
+  })
+
+  test('falls back to warning when the upgrade fails', async () => {
+    // Given
+    const outputMock = mockAndCaptureOutput()
+    vi.mocked(versionToAutoUpgrade).mockReturnValue('3.91.0')
+    vi.mocked(runCLIUpgrade).mockRejectedValue(new Error('upgrade failed'))
+    const installReminder = '💡 Version 3.91.0 available! Run `npm install @shopify/cli@latest`'
+    vi.mocked(getOutputUpdateCLIReminder).mockReturnValue(installReminder)
+
+    // When
+    await autoUpgradeIfNeeded()
+
+    // Then
+    expect(outputMock.warn()).toMatch(installReminder)
+  })
+
+  test('does nothing when versionToAutoUpgrade returns undefined', async () => {
+    // Given
+    vi.mocked(versionToAutoUpgrade).mockReturnValue(undefined)
+
+    // When
+    await autoUpgradeIfNeeded()
+
+    // Then
+    expect(runCLIUpgrade).not.toHaveBeenCalled()
+  })
+
+  test('shows warning instead of upgrading for a major version change', async () => {
+    // Given
+    const outputMock = mockAndCaptureOutput()
+    vi.mocked(versionToAutoUpgrade).mockReturnValue('4.0.0')
+    vi.mocked(isMajorVersionChange).mockReturnValue(true)
+    const installReminder = '💡 Version 4.0.0 available! Run `npm install @shopify/cli@latest`'
+    vi.mocked(getOutputUpdateCLIReminder).mockReturnValue(installReminder)
+
+    // When
+    await autoUpgradeIfNeeded()
+
+    // Then
+    expect(runCLIUpgrade).not.toHaveBeenCalled()
+    expect(outputMock.warn()).toMatch(installReminder)
+  })
+})

--- a/packages/cli-kit/src/public/node/hooks/postrun.ts
+++ b/packages/cli-kit/src/public/node/hooks/postrun.ts
@@ -1,8 +1,11 @@
 import {postrun as deprecationsHook} from './deprecations.js'
 import {reportAnalyticsEvent} from '../analytics.js'
-import {outputDebug} from '../../../public/node/output.js'
+import {outputDebug, outputWarn} from '../../../public/node/output.js'
+import {getOutputUpdateCLIReminder, runCLIUpgrade, versionToAutoUpgrade} from '../../../public/node/upgrade.js'
 import BaseCommand from '../base-command.js'
 import * as metadata from '../../../public/node/metadata.js'
+import {CLI_KIT_VERSION} from '../../common/version.js'
+import {isMajorVersionChange} from '../version.js'
 import {Command, Hook} from '@oclif/core'
 
 let postRunHookCompleted = false
@@ -25,6 +28,33 @@ export const hook: Hook.Postrun = async ({config, Command}) => {
   const command = Command.id.replace(/:/g, ' ')
   outputDebug(`Completed command ${command}`)
   postRunHookCompleted = true
+
+  if (!command.includes('notifications') && !command.includes('upgrade')) await autoUpgradeIfNeeded()
+}
+
+/**
+ * Auto-upgrades the CLI after a command completes, if a newer version is available.
+ *
+ * @returns Resolves when the upgrade attempt (or fallback warning) is complete.
+ */
+export async function autoUpgradeIfNeeded(): Promise<void> {
+  const newerVersion = versionToAutoUpgrade()
+  if (!newerVersion) return
+  if (isMajorVersionChange(CLI_KIT_VERSION, newerVersion)) {
+    return outputWarn(getOutputUpdateCLIReminder(newerVersion))
+  }
+
+  try {
+    await runCLIUpgrade()
+    // eslint-disable-next-line no-catch-all/no-catch-all
+  } catch (error) {
+    const errorMessage = `Auto-upgrade failed: ${error}`
+    outputDebug(errorMessage)
+    outputWarn(getOutputUpdateCLIReminder(newerVersion))
+    // Report to Observe as a handled error without showing anything extra to the user
+    const {sendErrorToBugsnag} = await import('../../../public/node/error-handler.js')
+    await sendErrorToBugsnag(new Error(errorMessage), 'expected_error')
+  }
 }
 
 /**

--- a/packages/cli-kit/src/public/node/hooks/prerun.test.ts
+++ b/packages/cli-kit/src/public/node/hooks/prerun.test.ts
@@ -1,47 +1,5 @@
-import {parseCommandContent, warnOnAvailableUpgrade} from './prerun.js'
-import {checkForCachedNewVersion, packageManagerFromUserAgent} from '../node-package-manager.js'
-import {cacheClear} from '../../../private/node/conf-store.js'
-import {mockAndCaptureOutput} from '../testing/output.js'
-import {describe, expect, test, vi, afterEach, beforeEach} from 'vitest'
-
-vi.mock('../node-package-manager')
-
-beforeEach(() => {
-  cacheClear()
-})
-
-afterEach(() => {
-  mockAndCaptureOutput().clear()
-  cacheClear()
-})
-
-describe('warnOnAvailableUpgrade', () => {
-  test('displays latest version and an install command when a newer exists', async () => {
-    // Given
-    const outputMock = mockAndCaptureOutput()
-    vi.mocked(checkForCachedNewVersion).mockReturnValue('3.0.10')
-    vi.mocked(packageManagerFromUserAgent).mockReturnValue('npm')
-    const installReminder = '💡 Version 3.0.10 available! Run `npm install @shopify/cli@latest`'
-
-    // When
-    await warnOnAvailableUpgrade()
-
-    // Then
-    expect(outputMock.warn()).toMatch(installReminder)
-  })
-
-  test('displays nothing when no newer version exists', async () => {
-    // Given
-    const outputMock = mockAndCaptureOutput()
-    vi.mocked(checkForCachedNewVersion).mockReturnValue(undefined)
-
-    // When
-    await warnOnAvailableUpgrade()
-
-    // Then
-    expect(outputMock.warn()).toEqual('')
-  })
-})
+import {parseCommandContent} from './prerun.js'
+import {describe, expect, test} from 'vitest'
 
 describe('parseCommandContent', () => {
   test('when a create command is used should return the correct command content', async () => {

--- a/packages/cli-kit/src/public/node/is-global.test.ts
+++ b/packages/cli-kit/src/public/node/is-global.test.ts
@@ -1,24 +1,62 @@
 import {currentProcessIsGlobal, inferPackageManagerForGlobalCLI, installGlobalCLIPrompt} from './is-global.js'
+import {findPathUpSync} from './fs.js'
+import {cwd} from './path.js'
 import {terminalSupportsPrompting} from './system.js'
 import {renderSelectPrompt} from './ui.js'
 import {globalCLIVersion} from './version.js'
-import * as execa from 'execa'
 import {beforeEach, describe, expect, test, vi} from 'vitest'
+import {realpathSync} from 'fs'
 
 vi.mock('./system.js')
 vi.mock('./ui.js')
-vi.mock('execa')
 vi.mock('which')
 vi.mock('./version.js')
+
+// Mock fs.js to make findPathUpSync controllable for getProjectDir.
+// find-up v6 runs returned paths through locatePathSync which checks file existence,
+// so we need to mock findPathUpSync directly rather than globSync.
+vi.mock('./fs.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./fs.js')>()
+  return {
+    ...actual,
+    findPathUpSync: vi.fn((...args: Parameters<typeof actual.findPathUpSync>) => actual.findPathUpSync(...args)),
+  }
+})
+
+// Mock fs.realpathSync at the module level
+// By default, call through to the real implementation for real paths,
+// but return the path as-is for fake test paths that don't exist
+vi.mock('fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs')>()
+  const realRealpathSync = actual.realpathSync
+  const {existsSync} = actual
+  return {
+    ...actual,
+    realpathSync: vi.fn((path, options) => {
+      // For real paths, use the actual implementation
+      // For fake test paths, just return the path as-is
+      if (existsSync(String(path))) {
+        return realRealpathSync(path, options)
+      }
+      return String(path)
+    }),
+  }
+})
 
 const globalNPMPath = '/path/to/global/npm'
 const globalYarnPath = '/path/to/global/yarn'
 const globalPNPMPath = '/path/to/global/pnpm'
+const globalHomebrewIntel = '/usr/local/Cellar/shopify-cli/3.89.0/bin/shopify'
+const globalHomebrewAppleSilicon = '/opt/homebrew/Cellar/shopify-cli/3.89.0/bin/shopify'
+const globalHomebrewLinux = '/home/linuxbrew/.linuxbrew/Cellar/shopify-cli/3.89.0/bin/shopify'
 const unknownGlobalPath = '/path/to/global/unknown'
-const localProjectPath = '/path/local'
+// Must be within the actual workspace so currentProcessIsGlobal recognizes it as local
+const localProjectPath = `${cwd()}/node_modules/.bin/shopify`
 
 beforeEach(() => {
-  ;(vi.mocked(execa.execaSync) as any).mockReturnValue({stdout: localProjectPath})
+  // Mock findPathUpSync so getProjectDir returns a shopify.app.toml at the cwd.
+  // This lets currentProcessIsGlobal compare binary paths against the project root.
+  vi.mocked(findPathUpSync).mockReturnValue(`${cwd()}/shopify.app.toml`)
 })
 
 describe('currentProcessIsGlobal', () => {
@@ -46,6 +84,11 @@ describe('currentProcessIsGlobal', () => {
 })
 
 describe('inferPackageManagerForGlobalCLI', () => {
+  beforeEach(() => {
+    // Reset mock to default behavior (calls through to real implementation)
+    vi.mocked(realpathSync).mockClear()
+  })
+
   test('returns yarn if yarn is in path', async () => {
     // Given
     const argv = ['node', globalYarnPath, 'shopify']
@@ -88,6 +131,115 @@ describe('inferPackageManagerForGlobalCLI', () => {
 
     // Then
     expect(got).toBe('unknown')
+  })
+
+  test('returns homebrew if SHOPIFY_HOMEBREW_FORMULA is set', async () => {
+    // Given
+    const argv = ['node', globalHomebrewAppleSilicon, 'shopify']
+    const env = {SHOPIFY_HOMEBREW_FORMULA: 'shopify-cli'}
+
+    // When
+    const got = inferPackageManagerForGlobalCLI(argv, env)
+
+    // Then
+    expect(got).toBe('homebrew')
+  })
+
+  test('returns homebrew for Intel Mac Cellar path', async () => {
+    // Given
+    const argv = ['node', globalHomebrewIntel, 'shopify']
+
+    // When
+    const got = inferPackageManagerForGlobalCLI(argv)
+
+    // Then
+    expect(got).toBe('homebrew')
+  })
+
+  test('returns homebrew for Apple Silicon Cellar path', async () => {
+    // Given
+    const argv = ['node', globalHomebrewAppleSilicon, 'shopify']
+
+    // When
+    const got = inferPackageManagerForGlobalCLI(argv)
+
+    // Then
+    expect(got).toBe('homebrew')
+  })
+
+  test('returns homebrew for Linux Homebrew path', async () => {
+    // Given
+    const argv = ['node', globalHomebrewLinux, 'shopify']
+
+    // When
+    const got = inferPackageManagerForGlobalCLI(argv)
+
+    // Then
+    expect(got).toBe('homebrew')
+  })
+
+  test('returns homebrew when HOMEBREW_PREFIX matches path', async () => {
+    // Given
+    const argv = ['node', '/opt/homebrew/bin/shopify', 'shopify']
+    const env = {HOMEBREW_PREFIX: '/opt/homebrew'}
+
+    // When
+    const got = inferPackageManagerForGlobalCLI(argv, env)
+
+    // Then
+    expect(got).toBe('homebrew')
+  })
+
+  test('resolves symlinks to detect actual package manager (yarn)', async () => {
+    // Given: A symlink in /opt/homebrew/bin pointing to yarn global
+    const symlinkPath = '/opt/homebrew/bin/shopify'
+    const realYarnPath = '/Users/user/.config/yarn/global/node_modules/.bin/shopify'
+    const argv = ['node', symlinkPath, 'shopify']
+    const env = {HOMEBREW_PREFIX: '/opt/homebrew'}
+
+    // Mock realpathSync for this specific test to resolve the symlink
+    vi.mocked(realpathSync).mockImplementationOnce(() => realYarnPath)
+
+    // When
+    const got = inferPackageManagerForGlobalCLI(argv, env)
+
+    // Then: Should detect yarn (from real path), not homebrew (from symlink)
+    expect(got).toBe('yarn')
+    expect(vi.mocked(realpathSync)).toHaveBeenCalledWith(symlinkPath)
+  })
+
+  test('resolves symlinks to detect real homebrew installation', async () => {
+    // Given: A symlink in /opt/homebrew/bin pointing to a Cellar path (real Homebrew)
+    const symlinkPath = '/opt/homebrew/bin/shopify'
+    const realHomebrewPath = '/opt/homebrew/Cellar/shopify-cli/3.89.0/bin/shopify'
+    const argv = ['node', symlinkPath, 'shopify']
+
+    // Mock realpathSync for this specific test to resolve the symlink
+    vi.mocked(realpathSync).mockImplementationOnce(() => realHomebrewPath)
+
+    // When
+    const got = inferPackageManagerForGlobalCLI(argv)
+
+    // Then: Should still detect homebrew from the real Cellar path
+    expect(got).toBe('homebrew')
+  })
+
+  test('falls back to original path if realpath fails', async () => {
+    // Given: A path that realpathSync cannot resolve
+    const nonExistentPath = '/opt/homebrew/bin/shopify'
+    const argv = ['node', nonExistentPath, 'shopify']
+    const env = {HOMEBREW_PREFIX: '/opt/homebrew'}
+
+    // Mock realpathSync for this specific test to throw an error
+    vi.mocked(realpathSync).mockImplementationOnce(() => {
+      throw new Error('ENOENT: no such file or directory')
+    })
+
+    // When
+    const got = inferPackageManagerForGlobalCLI(argv, env)
+
+    // Then: Should fall back to checking the original path
+    expect(got).toBe('homebrew')
   })
 })
 

--- a/packages/cli-kit/src/public/node/node-package-manager.ts
+++ b/packages/cli-kit/src/public/node/node-package-manager.ts
@@ -35,6 +35,7 @@ export const lockfilesByManager: {[key in PackageManager]: Lockfile | undefined}
   npm: npmLockfile,
   pnpm: pnpmLockfile,
   bun: bunLockfile,
+  homebrew: undefined,
   unknown: undefined,
 }
 export type Lockfile = 'yarn.lock' | 'package-lock.json' | 'pnpm-lock.yaml' | 'bun.lockb'
@@ -50,7 +51,7 @@ export type DependencyType = 'dev' | 'prod' | 'peer'
 /**
  * A union that represents the package managers available.
  */
-export const packageManager = ['yarn', 'npm', 'pnpm', 'bun', 'unknown'] as const
+export const packageManager = ['yarn', 'npm', 'pnpm', 'bun', 'homebrew', 'unknown'] as const
 export type PackageManager = (typeof packageManager)[number]
 
 /**
@@ -526,6 +527,8 @@ export async function addNPMDependencies(
       await installDependencies(options, argumentsToAddDependenciesWithBun(dependenciesWithVersion, options.type))
       await installDependencies(options, ['install'])
       break
+    case 'homebrew':
+      throw new AbortError("Homebrew can't be used to install project dependencies. Use npm, yarn, pnpm, or bun.")
     case 'unknown':
       throw new UnknownPackageManagerError()
   }

--- a/packages/cli-kit/src/public/node/output.ts
+++ b/packages/cli-kit/src/public/node/output.ts
@@ -124,6 +124,7 @@ export function formatPackageManagerCommand(
       }
       return pieces.join(' ')
     }
+    case 'homebrew':
     case 'unknown': {
       const pieces = [scriptName, ...scriptArgs]
       return pieces.join(' ')

--- a/packages/cli-kit/src/public/node/upgrade.test.ts
+++ b/packages/cli-kit/src/public/node/upgrade.test.ts
@@ -1,17 +1,35 @@
+import {isDevelopment} from './context/local.js'
 import {currentProcessIsGlobal, inferPackageManagerForGlobalCLI} from './is-global.js'
-import {packageManagerFromUserAgent} from './node-package-manager.js'
-import {cliInstallCommand} from './upgrade.js'
-import {vi, describe, test, expect} from 'vitest'
+import {checkForCachedNewVersion, packageManagerFromUserAgent, PackageManager} from './node-package-manager.js'
+import {exec, isCI} from './system.js'
+import {cliInstallCommand, runCLIUpgrade, versionToAutoUpgrade} from './upgrade.js'
+import {isPreReleaseVersion} from './version.js'
+import {getAutoUpgradeEnabled} from '../../private/node/conf-store.js'
+import {vi, describe, test, expect, beforeEach} from 'vitest'
 
+vi.mock('./context/local.js')
 vi.mock('./is-global.js')
 vi.mock('./node-package-manager.js')
+vi.mock('./system.js')
+vi.mock('../../private/node/conf-store.js')
+vi.mock('./version.js', async (importOriginal) => {
+  const actual: any = await importOriginal()
+  return {
+    ...actual,
+    isPreReleaseVersion: vi.fn(() => false),
+  }
+})
 
 describe('cliInstallCommand', () => {
+  beforeEach(() => {
+    // Mock isDevelopment to return false by default (not in CLI development mode)
+    vi.mocked(isDevelopment).mockReturnValue(false)
+  })
+
   test('says to install globally via npm if the current process is globally installed and no package manager is provided', () => {
     // Given
     vi.mocked(currentProcessIsGlobal).mockReturnValue(true)
-    vi.mocked(packageManagerFromUserAgent).mockReturnValue('unknown')
-    vi.mocked(inferPackageManagerForGlobalCLI).mockReturnValue('unknown')
+    vi.mocked(inferPackageManagerForGlobalCLI).mockReturnValue('npm')
 
     // When
     const got = cliInstallCommand()
@@ -67,63 +85,139 @@ describe('cliInstallCommand', () => {
     `)
   })
 
-  test('says to install locally via npm if the current process is locally installed and no package manager is provided', () => {
+  test('returns undefined if the current process is locally installed', () => {
     // Given
     vi.mocked(currentProcessIsGlobal).mockReturnValue(false)
-    vi.mocked(packageManagerFromUserAgent).mockReturnValue('unknown')
-    vi.mocked(inferPackageManagerForGlobalCLI).mockReturnValue('unknown')
 
     // When
     const got = cliInstallCommand()
 
     // Then
-    expect(got).toMatchInlineSnapshot(`
-      "npm install @shopify/cli@latest"
-    `)
+    expect(got).toBeUndefined()
+  })
+})
+describe('runCLIUpgrade', () => {
+  beforeEach(() => {
+    // Mock isDevelopment to return false by default (not in CLI development mode)
+    vi.mocked(isDevelopment).mockReturnValue(false)
   })
 
-  test('says to install locally via yarn if the current process is locally installed and yarn is the global package manager', () => {
+  test('runs the install command via exec for a global npm install', async () => {
     // Given
-    vi.mocked(currentProcessIsGlobal).mockReturnValue(false)
-    vi.mocked(packageManagerFromUserAgent).mockReturnValue('unknown')
-    vi.mocked(inferPackageManagerForGlobalCLI).mockReturnValue('yarn')
-
-    // When
-    const got = cliInstallCommand()
-
-    // Then
-    expect(got).toMatchInlineSnapshot(`
-      "yarn add @shopify/cli@latest"
-    `)
-  })
-
-  test('says to install locally via npm if the current process is locally installed and npm is the global package manager', () => {
-    // Given
-    vi.mocked(currentProcessIsGlobal).mockReturnValue(false)
-    vi.mocked(packageManagerFromUserAgent).mockReturnValue('unknown')
+    vi.mocked(currentProcessIsGlobal).mockReturnValue(true)
     vi.mocked(inferPackageManagerForGlobalCLI).mockReturnValue('npm')
+    vi.mocked(exec).mockResolvedValue()
 
     // When
-    const got = cliInstallCommand()
+    await runCLIUpgrade()
 
     // Then
-    expect(got).toMatchInlineSnapshot(`
-      "npm install @shopify/cli@latest"
-    `)
+    expect(exec).toHaveBeenCalledWith('npm', ['install', '-g', '@shopify/cli@latest'], {stdio: 'inherit'})
   })
 
-  test('says to install locally via pnpm if the current process is locally installed and pnpm is the global package manager', () => {
+  test('runs the install command via exec for a global yarn install', async () => {
     // Given
-    vi.mocked(currentProcessIsGlobal).mockReturnValue(false)
-    vi.mocked(packageManagerFromUserAgent).mockReturnValue('unknown')
-    vi.mocked(inferPackageManagerForGlobalCLI).mockReturnValue('pnpm')
+    vi.mocked(currentProcessIsGlobal).mockReturnValue(true)
+    vi.mocked(inferPackageManagerForGlobalCLI).mockReturnValue('yarn')
+    vi.mocked(exec).mockResolvedValue()
 
     // When
-    const got = cliInstallCommand()
+    await runCLIUpgrade()
 
     // Then
-    expect(got).toMatchInlineSnapshot(`
-      "pnpm add @shopify/cli@latest"
-    `)
+    expect(exec).toHaveBeenCalledWith('yarn', ['global', 'add', '@shopify/cli@latest'], {stdio: 'inherit'})
+  })
+
+  test('runs the install command via exec for a global homebrew install', async () => {
+    // Given
+    vi.mocked(currentProcessIsGlobal).mockReturnValue(true)
+    vi.mocked(inferPackageManagerForGlobalCLI).mockReturnValue('homebrew')
+    vi.mocked(exec).mockResolvedValue()
+
+    // When
+    await runCLIUpgrade()
+
+    // Then
+    expect(exec).toHaveBeenCalledWith('brew', ['upgrade', 'shopify-cli'], {stdio: 'inherit'})
+  })
+
+  test('throws an error when cliInstallCommand returns undefined', async () => {
+    // Given
+    vi.mocked(currentProcessIsGlobal).mockReturnValue(true)
+    // Force a falsy return so cliInstallCommand() returns undefined
+    vi.mocked(inferPackageManagerForGlobalCLI).mockReturnValue('' as unknown as PackageManager)
+
+    // When/Then
+    await expect(runCLIUpgrade()).rejects.toThrow('Could not determine the package manager')
+  })
+
+  test('does nothing when running in development mode for local install (SHOPIFY_ENV=development)', async () => {
+    // Given
+    vi.mocked(currentProcessIsGlobal).mockReturnValue(false)
+    vi.mocked(isDevelopment).mockReturnValue(true)
+
+    // When
+    await runCLIUpgrade()
+
+    // Then
+    expect(exec).not.toHaveBeenCalled()
+  })
+})
+
+describe('versionToAutoUpgrade', () => {
+  test('returns the newer version for a minor bump when auto-upgrade is enabled', () => {
+    vi.mocked(checkForCachedNewVersion).mockReturnValue('3.91.0')
+    vi.mocked(isCI).mockReturnValue(false)
+    vi.mocked(getAutoUpgradeEnabled).mockReturnValue(true)
+    expect(versionToAutoUpgrade()).toBe('3.91.0')
+  })
+
+  test('returns the newer version for a patch bump when auto-upgrade is enabled', () => {
+    vi.mocked(checkForCachedNewVersion).mockReturnValue('3.90.1')
+    vi.mocked(isCI).mockReturnValue(false)
+    vi.mocked(getAutoUpgradeEnabled).mockReturnValue(true)
+    expect(versionToAutoUpgrade()).toBe('3.90.1')
+  })
+
+  test('returns undefined when no cached newer version exists', () => {
+    vi.mocked(checkForCachedNewVersion).mockReturnValue(undefined)
+    expect(versionToAutoUpgrade()).toBeUndefined()
+  })
+
+  test('returns undefined when running in CI', () => {
+    vi.mocked(checkForCachedNewVersion).mockReturnValue('3.91.0')
+    vi.mocked(isCI).mockReturnValue(true)
+    vi.mocked(getAutoUpgradeEnabled).mockReturnValue(true)
+    expect(versionToAutoUpgrade()).toBeUndefined()
+  })
+
+  test('returns undefined when auto-upgrade is not enabled', () => {
+    vi.mocked(checkForCachedNewVersion).mockReturnValue('3.91.0')
+    vi.mocked(isCI).mockReturnValue(false)
+    vi.mocked(getAutoUpgradeEnabled).mockReturnValue(false)
+    expect(versionToAutoUpgrade()).toBeUndefined()
+  })
+
+  test('returns undefined when auto-upgrade preference has never been set', () => {
+    vi.mocked(checkForCachedNewVersion).mockReturnValue('3.91.0')
+    vi.mocked(isCI).mockReturnValue(false)
+    vi.mocked(getAutoUpgradeEnabled).mockReturnValue(undefined)
+    expect(versionToAutoUpgrade()).toBeUndefined()
+  })
+
+  test('returns the newer version for a major version change when auto-upgrade is enabled', () => {
+    vi.mocked(checkForCachedNewVersion).mockReturnValue('4.0.0')
+    vi.mocked(isCI).mockReturnValue(false)
+    vi.mocked(getAutoUpgradeEnabled).mockReturnValue(true)
+    expect(versionToAutoUpgrade()).toEqual('4.0.0')
+  })
+
+  test('returns undefined for a pre-release (nightly/snapshot) version', () => {
+    vi.mocked(checkForCachedNewVersion).mockReturnValue('3.91.0')
+    vi.mocked(isCI).mockReturnValue(false)
+    vi.mocked(getAutoUpgradeEnabled).mockReturnValue(true)
+    vi.mocked(isPreReleaseVersion).mockReturnValue(true)
+    expect(versionToAutoUpgrade()).toBeUndefined()
+    vi.mocked(isPreReleaseVersion).mockReturnValue(false)
   })
 })

--- a/packages/cli-kit/src/public/node/upgrade.ts
+++ b/packages/cli-kit/src/public/node/upgrade.ts
@@ -1,6 +1,22 @@
-import {currentProcessIsGlobal, inferPackageManagerForGlobalCLI} from './is-global.js'
-import {packageManagerFromUserAgent} from './node-package-manager.js'
-import {outputContent, outputToken} from './output.js'
+import {isDevelopment} from './context/local.js'
+import {currentProcessIsGlobal, inferPackageManagerForGlobalCLI, getProjectDir} from './is-global.js'
+import {
+  checkForCachedNewVersion,
+  findUpAndReadPackageJson,
+  PackageJson,
+  checkForNewVersion,
+  DependencyType,
+  usesWorkspaces,
+  addNPMDependencies,
+  getPackageManager,
+} from './node-package-manager.js'
+import {outputContent, outputDebug, outputInfo, outputToken} from './output.js'
+import {cwd, moduleDirectory, sniffForPath} from './path.js'
+import {exec, isCI} from './system.js'
+import {renderConfirmationPrompt} from './ui.js'
+import {isPreReleaseVersion} from './version.js'
+import {getAutoUpgradeEnabled, setAutoUpgradeEnabled} from '../../private/node/conf-store.js'
+import {CLI_KIT_VERSION} from '../common/version.js'
 
 /**
  * Utility function for generating an install command for the user to run
@@ -8,22 +24,91 @@ import {outputContent, outputToken} from './output.js'
  *
  * @returns A string with the command to run.
  */
-export function cliInstallCommand(): string {
-  const isGlobal = currentProcessIsGlobal()
-  let packageManager = packageManagerFromUserAgent()
-  // packageManagerFromUserAgent() will return 'unknown' if it can't determine the package manager
-  if (packageManager === 'unknown') {
-    packageManager = inferPackageManagerForGlobalCLI()
-  }
-  // inferPackageManagerForGlobalCLI() will also return 'unknown' if it can't determine the package manager
-  if (packageManager === 'unknown') packageManager = 'npm'
+export function cliInstallCommand(): string | undefined {
+  const packageManager = inferPackageManagerForGlobalCLI()
+  if (!packageManager) return undefined
 
-  if (packageManager === 'yarn') {
-    return `${packageManager} ${isGlobal ? 'global ' : ''}add @shopify/cli@latest`
+  if (packageManager === 'homebrew') {
+    return 'brew upgrade shopify-cli'
+  } else if (packageManager === 'yarn') {
+    return `${packageManager} global add @shopify/cli@latest`
   } else {
     const verb = packageManager === 'pnpm' ? 'add' : 'install'
-    return `${packageManager} ${verb} ${isGlobal ? '-g ' : ''}@shopify/cli@latest`
+    return `${packageManager} ${verb} -g @shopify/cli@latest`
   }
+}
+
+/**
+ * Runs the CLI upgrade using the appropriate package manager.
+ * Determines the install command and executes it.
+ *
+ * @throws AbortError if the package manager or command cannot be determined.
+ */
+export async function runCLIUpgrade(): Promise<void> {
+  // Path where the current project is (app/hydrogen)
+  const path = sniffForPath() ?? cwd()
+  const projectDir = getProjectDir(path)
+
+  // Check if we are running in a global context if not, return
+  const isGlobal = currentProcessIsGlobal()
+
+  // Don't auto-upgrade for development mode
+  if (!isGlobal && isDevelopment()) {
+    outputDebug('Auto-upgrade: Skipping auto-upgrade in development mode.')
+    return
+  }
+
+  // Generate the install command for the global CLI and execute it
+  if (isGlobal) {
+    const installCommand = cliInstallCommand()
+    if (!installCommand) {
+      throw new Error('Could not determine the package manager')
+    }
+    const [command, ...args] = installCommand.split(' ')
+    if (!command) {
+      throw new Error('Could not determine the command to run')
+    }
+    outputInfo(outputContent`Upgrading Shopify CLI by running: ${outputToken.genericShellCommand(installCommand)}...`)
+    await exec(command, args, {stdio: 'inherit'})
+  } else if (projectDir) {
+    await upgradeLocalShopify(projectDir, CLI_KIT_VERSION)
+  } else {
+    throw new Error('Could not determine the local project directory')
+  }
+}
+
+/**
+ * Returns the version to auto-upgrade to, or undefined if auto-upgrade should be skipped.
+ * Auto-upgrade is disabled by default and must be enabled via `shopify upgrade`.
+ * Also skips for CI, pre-release versions, or when no newer version is available.
+ *
+ * @returns The version string to upgrade to, or undefined if no upgrade should happen.
+ */
+export function versionToAutoUpgrade(): string | undefined {
+  const currentVersion = CLI_KIT_VERSION
+  const newerVersion = checkForCachedNewVersion('@shopify/cli', currentVersion)
+  if (!newerVersion) {
+    outputDebug('Auto-upgrade: No newer version available.')
+    return undefined
+  }
+  if (!getAutoUpgradeEnabled()) {
+    outputDebug('Auto-upgrade: Skipping because auto-upgrade is not enabled.')
+    return undefined
+  }
+  if (process.env.SHOPIFY_CLI_FORCE_AUTO_UPGRADE === '1') {
+    outputDebug('Auto-upgrade: Forcing auto-upgrade because of SHOPIFY_CLI_FORCE_AUTO_UPGRADE.')
+    return newerVersion
+  }
+  if (isCI()) {
+    outputDebug('Auto-upgrade: Skipping auto-upgrade in CI.')
+    return undefined
+  }
+  if (isPreReleaseVersion(currentVersion)) {
+    outputDebug('Auto-upgrade: Skipping auto-upgrade for pre-release version.')
+    return undefined
+  }
+
+  return newerVersion
 }
 
 /**
@@ -33,6 +118,103 @@ export function cliInstallCommand(): string {
  * @returns The message to remind the user to update the CLI.
  */
 export function getOutputUpdateCLIReminder(version: string): string {
-  return outputContent`💡 Version ${version} available! Run ${outputToken.genericShellCommand(cliInstallCommand())}`
-    .value
+  const installCommand = cliInstallCommand()
+  if (installCommand) {
+    return outputContent`💡 Version ${version} available! Run ${outputToken.genericShellCommand(installCommand)}`.value
+  }
+  return outputContent`💡 Version ${version} available!`.value
+}
+
+/**
+ * Prompts the user to enable or disable automatic upgrades, then persists their choice.
+ *
+ * @returns Whether the user chose to enable auto-upgrade.
+ */
+export async function promptAutoUpgrade(): Promise<boolean> {
+  const enabled = await renderConfirmationPrompt({
+    message: 'Enable automatic updates for Shopify CLI?',
+    confirmationMessage: 'Yes, automatically update',
+    cancellationMessage: "No, I'll update manually",
+  })
+  setAutoUpgradeEnabled(enabled)
+  return enabled
+}
+
+async function upgradeLocalShopify(projectDir: string, currentVersion: string) {
+  const packageJson = (await findUpAndReadPackageJson(projectDir)).content
+  const packageJsonDependencies = packageJson.dependencies ?? {}
+  const packageJsonDevDependencies = packageJson.devDependencies ?? {}
+  const allDependencies = {...packageJsonDependencies, ...packageJsonDevDependencies}
+
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  let resolvedCLIVersion = allDependencies[await cliDependency()]!
+
+  if (resolvedCLIVersion.slice(0, 1).match(/[\^~]/)) resolvedCLIVersion = currentVersion
+  const newestCLIVersion = await checkForNewVersion(await cliDependency(), resolvedCLIVersion)
+
+  if (newestCLIVersion) {
+    outputUpgradeMessage(resolvedCLIVersion, newestCLIVersion)
+  } else {
+    outputWontInstallMessage(resolvedCLIVersion)
+  }
+
+  await installJsonDependencies('prod', packageJsonDependencies, projectDir)
+  await installJsonDependencies('dev', packageJsonDevDependencies, projectDir)
+}
+
+async function installJsonDependencies(
+  depsEnv: DependencyType,
+  deps: {[key: string]: string},
+  directory: string,
+): Promise<void> {
+  const packagesToUpdate = [await cliDependency(), ...(await oclifPlugins())]
+    .filter((pkg: string): boolean => {
+      const pkgRequirement: string | undefined = deps[pkg]
+      return Boolean(pkgRequirement)
+    })
+    .map((pkg) => {
+      return {name: pkg, version: 'latest'}
+    })
+
+  const appUsesWorkspaces = await usesWorkspaces(directory)
+
+  if (packagesToUpdate.length > 0) {
+    await addNPMDependencies(packagesToUpdate, {
+      packageManager: await getPackageManager(directory),
+      type: depsEnv,
+      directory,
+      stdout: process.stdout,
+      stderr: process.stderr,
+      addToRootDirectory: appUsesWorkspaces,
+    })
+  }
+}
+
+async function cliDependency(): Promise<string> {
+  return (await packageJsonContents()).name
+}
+
+async function oclifPlugins(): Promise<string[]> {
+  return (await packageJsonContents())?.oclif?.plugins || []
+}
+
+type PackageJsonWithName = Omit<PackageJson, 'name'> & {name: string}
+let _packageJsonContents: PackageJsonWithName | undefined
+
+async function packageJsonContents(): Promise<PackageJsonWithName> {
+  if (!_packageJsonContents) {
+    const packageJson = await findUpAndReadPackageJson(moduleDirectory(import.meta.url))
+    _packageJsonContents = _packageJsonContents ?? (packageJson.content as PackageJsonWithName)
+  }
+  return _packageJsonContents
+}
+
+function outputWontInstallMessage(currentVersion: string): void {
+  outputInfo(outputContent`You're on the latest version, ${outputToken.yellow(currentVersion)}, no need to upgrade!`)
+}
+
+function outputUpgradeMessage(currentVersion: string, newestVersion: string): void {
+  outputInfo(
+    outputContent`Upgrading CLI from ${outputToken.yellow(currentVersion)} to ${outputToken.yellow(newestVersion)}...`,
+  )
 }

--- a/packages/cli-kit/src/public/node/version.ts
+++ b/packages/cli-kit/src/public/node/version.ts
@@ -1,6 +1,6 @@
 import {captureOutput} from '../node/system.js'
 import which from 'which'
-import {satisfies} from 'semver'
+import {satisfies, SemVer} from 'semver'
 /**
  * Returns the version of the local dependency of the CLI if it's installed in the provided directory.
  *
@@ -52,4 +52,19 @@ export async function globalCLIVersion(): Promise<string | undefined> {
  */
 export function isPreReleaseVersion(version: string): boolean {
   return version.startsWith('0.0.0')
+}
+
+/**
+ * Checks if there is a major version change between two versions.
+ * Pre-release versions (0.0.0-*) are treated as not having a major version change.
+ *
+ * @param currentVersion - The current version.
+ * @param newerVersion - The newer version to compare against.
+ * @returns True if there is a major version change.
+ */
+export function isMajorVersionChange(currentVersion: string, newerVersion: string): boolean {
+  if (isPreReleaseVersion(currentVersion) || isPreReleaseVersion(newerVersion)) return false
+  const currentSemVer = new SemVer(currentVersion)
+  const newerSemVer = new SemVer(newerVersion)
+  return currentSemVer.major !== newerSemVer.major
 }

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -2742,16 +2742,16 @@ DESCRIPTION
 
 ## `shopify upgrade`
 
-Shows details on how to upgrade Shopify CLI.
+Upgrades Shopify CLI.
 
 ```
 USAGE
   $ shopify upgrade
 
 DESCRIPTION
-  Shows details on how to upgrade Shopify CLI.
+  Upgrades Shopify CLI.
 
-  Shows details on how to upgrade Shopify CLI.
+  Upgrades Shopify CLI using your package manager.
 ```
 
 ## `shopify version`

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -7770,8 +7770,8 @@
       ],
       "args": {
       },
-      "description": "Shows details on how to upgrade Shopify CLI.",
-      "descriptionWithMarkdown": "Shows details on how to upgrade Shopify CLI.",
+      "description": "Upgrades Shopify CLI using your package manager.",
+      "descriptionWithMarkdown": "Upgrades Shopify CLI using your package manager.",
       "enableJsonFlag": false,
       "flags": {
       },
@@ -7783,7 +7783,7 @@
       "pluginName": "@shopify/cli",
       "pluginType": "core",
       "strict": true,
-      "summary": "Shows details on how to upgrade Shopify CLI."
+      "summary": "Upgrades Shopify CLI."
     },
     "version": {
       "aliases": [

--- a/packages/cli/src/cli/commands/upgrade.test.ts
+++ b/packages/cli/src/cli/commands/upgrade.test.ts
@@ -1,6 +1,6 @@
 import {describe, test, vi, expect} from 'vitest'
 
-vi.mock('../services/upgrade.js')
+vi.mock('@shopify/cli-kit/node/upgrade')
 
 describe('upgrade command', () => {
   test('launches service with path', async () => {

--- a/packages/cli/src/cli/commands/upgrade.ts
+++ b/packages/cli/src/cli/commands/upgrade.ts
@@ -1,17 +1,15 @@
-import {cliInstallCommand} from '@shopify/cli-kit/node/upgrade'
 import Command from '@shopify/cli-kit/node/base-command'
-import {renderInfo} from '@shopify/cli-kit/node/ui'
+import {promptAutoUpgrade, runCLIUpgrade} from '@shopify/cli-kit/node/upgrade'
 
 export default class Upgrade extends Command {
-  static summary = 'Shows details on how to upgrade Shopify CLI.'
+  static summary = 'Upgrades Shopify CLI.'
 
-  static descriptionWithMarkdown = 'Shows details on how to upgrade Shopify CLI.'
+  static descriptionWithMarkdown = 'Upgrades Shopify CLI using your package manager.'
 
   static description = this.descriptionWithoutMarkdown()
 
   async run(): Promise<void> {
-    renderInfo({
-      body: [`To upgrade Shopify CLI use your package manager.\n`, `Example:`, {command: cliInstallCommand()}],
-    })
+    await promptAutoUpgrade()
+    await runCLIUpgrade()
   }
 }


### PR DESCRIPTION
HackDays project: https://vault.shopify.io/hackdays/153/projects/22255

### WHY are these changes introduced?

We want our devs to always use the latest CLI version and avoid fragmentation

### WHAT is this pull request doing?

Adds a prompt in `shopify upgrade` to ask about enabling auto-update:

<img width="518" height="141" alt="24-34-eshor-470hq" src="https://github.com/user-attachments/assets/1ba7e194-6112-4d46-b1b6-14d691fa889d" />

Then, it checks once per day if there is a new CLI version available and automatically upgrades unless:
- Disabled
- Local CLI installation
- CI
- Snapshot or nightly version
- Major version change
- Development environment

The way to upgrade is to simply run the appropriated package manager command for the user (like `npm i -g @shopify/cli@latest` for NPM).

### How to test your changes?

Install the snapsot with different package managers and operating systems:
- `npm i -g --@shopify:registry=https://registry.npmjs.org @shopify/cli@0.0.0-snapshot-20260224152342`
- `shopify cache clear` => removes cached version check
- `shopify version` => does nothing because it skips auto-update in snapshots
- `SHOPIFY_CLI_FORCE_AUTO_UPGRADE=1 shopify version` => does nothing because auto-update is disabled
- `shopify upgrade` => enable auto-upgrade
- `npm i -g --@shopify:registry=https://registry.npmjs.org @shopify/cli@0.0.0-snapshot-20260224152342` => install the snapshot again because the previous command installed the latest version
- `shopify version` => does nothing because it skips auto-update in snapshots
- `SHOPIFY_CLI_FORCE_AUTO_UPGRADE=1 shopify version` => auto-updates

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [x] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
