### PR TITLE
Use main-cli and javascript-cli branches for react-router template

### DIFF
--- a/packages/app/src/cli/prompts/init/init.test.ts
+++ b/packages/app/src/cli/prompts/init/init.test.ts
@@ -39,13 +39,13 @@ describe('init', () => {
 
   test('it renders branches for templates that have them', async () => {
     const answers = {
-      template: 'https://github.com/Shopify/shopify-app-template-react-router#javascript',
+      template: 'https://github.com/Shopify/shopify-app-template-react-router#javascript-cli',
     }
     const options: InitOptions = {}
 
     // Given
     vi.mocked(renderSelectPrompt).mockResolvedValueOnce('reactRouter')
-    vi.mocked(renderSelectPrompt).mockResolvedValueOnce('javascript')
+    vi.mocked(renderSelectPrompt).mockResolvedValueOnce('javascript-cli')
 
     // When
     const got = await init(options)
@@ -61,8 +61,8 @@ describe('init', () => {
     })
     expect(renderSelectPrompt).toHaveBeenCalledWith({
       choices: [
-        {label: 'JavaScript', value: 'javascript'},
-        {label: 'TypeScript', value: 'main'},
+        {label: 'JavaScript', value: 'javascript-cli'},
+        {label: 'TypeScript', value: 'main-cli'},
       ],
       message: 'For your React Router template, which language do you want?',
     })

--- a/packages/app/src/cli/prompts/init/init.ts
+++ b/packages/app/src/cli/prompts/init/init.ts
@@ -38,8 +38,8 @@ export const templates = {
     branches: {
       prompt: 'For your React Router template, which language do you want?',
       options: {
-        javascript: {branch: 'javascript', label: 'JavaScript'},
-        typescript: {branch: 'main', label: 'TypeScript'},
+        javascript: {branch: 'javascript-cli', label: 'JavaScript'},
+        typescript: {branch: 'main-cli', label: 'TypeScript'},
       },
     },
   } as Template,


### PR DESCRIPTION
> [!WARNING]
> Do not merge until the `shopify-app-template-react-router` repo has `main-cli` and `javascript-cli` branches created.

## Summary
- Updates the react-router template branch references from `main`/`javascript` to `main-cli`/`javascript-cli`

🤖 Generated with [Claude Code](https://claude.com/claude-code)