### PR TITLE
suppress otel errors in console

### DIFF
--- a/.changeset/plenty-snails-return.md
+++ b/.changeset/plenty-snails-return.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': patch
+---
+
+[internal] suppress console errors when pushing metrics

--- a/packages/cli-kit/src/private/node/otel-metrics.ts
+++ b/packages/cli-kit/src/private/node/otel-metrics.ts
@@ -5,7 +5,7 @@ import {
   DefaultOtelServiceOptions,
 } from '../../public/node/vendor/otel-js/service/DefaultOtelService/DefaultOtelService.js'
 import {isUnitTest, opentelemetryDomain} from '../../public/node/context/local.js'
-import {ValueType} from '@opentelemetry/api'
+import {ValueType, diag} from '@opentelemetry/api'
 
 type MetricRecorder =
   | 'console'
@@ -150,6 +150,9 @@ function globalOtelService(options: CreateMetricRecorderOptions): OtelService {
       env: undefined,
       otelEndpoint: `${opentelemetryDomain()}/v1/metrics`,
     })
+    // Suppress OTEL diagnostic output — internal export errors (e.g. retryable failures)
+    // should never appear in user-facing CLI output.
+    diag.disable()
   }
   return _otelService
 }

--- a/packages/cli-kit/src/public/node/vendor/otel-js/utils/throttle.ts
+++ b/packages/cli-kit/src/public/node/vendor/otel-js/utils/throttle.ts
@@ -21,6 +21,12 @@ export function throttle<T extends (...args: any) => any>(
     timeout = null
     if (lastArgs) {
       result = func.apply(context, lastArgs)
+      // If the throttled function returns a promise, swallow rejections to
+      // prevent unhandled promise rejections (the caller already .catch()'d
+      // the leading-edge invocation and has no reference to trailing calls).
+      if (result && typeof (result as any).catch === 'function') {
+        (result as any).catch(() => {})
+      }
     }
     context = null
     lastArgs = null


### PR DESCRIPTION
### WHY are these changes introduced?

All CLI commands that send metrics are erroring out with the following error

```
OTLPExporterError: Export failed with retryable status
    at _promiseQueue.pushPromise._transport.send.then.resultCallback.code (/Users/alokswamy/src/github.com/Shopify/cli/node_modules/.pnpm/@opentelemetry+otlp-exporter-base@0.57.0_@opentelemetry+api@1.9.0/node_modules/@opentelemetry/otlp-exporter-base/build/src/otlp-export-delegate.js:78:28)
    at process.processTicksAndRejections (node:internal/process/task_queues:103:5)
```

This would suppress the errors in console, but doesn't solve the fact that the commands are still trying to HIT the server and failing

### WHAT is this pull request doing?

- disabling metric logs in console

### How to test your changes?



If OTEL server is still down, you should see this

![image.png](https://app.graphite.com/user-attachments/assets/2b29b397-ad9c-40ac-bfa2-22208065bbee.png)

- run this branch and run `SHOPIFY_CLI_ALWAYS_LOG_METRICS=1 npx shopify version` at the root level of the project
    - you should not see any metrics errors

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes