### PR TITLE
Fix hot-reloading for the {% javascript %} tag when serving compiled assets scripts with multibyte characters

### DIFF
--- a/.changeset/lovely-terms-tell.md
+++ b/.changeset/lovely-terms-tell.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Fix hot-reloading for the {% javascript %} tag when serving compiled assets scripts with multibyte characters

--- a/packages/theme/src/cli/utilities/theme-environment/local-assets.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/local-assets.ts
@@ -130,7 +130,7 @@ function handleStylesCss(ctx: DevServerContext, event: H3Event) {
 
   return serveStatic(event, {
     getContents: () => stylesheet,
-    getMeta: () => ({type: 'text/css', size: stylesheet.length, mtime: new Date()}),
+    getMeta: () => ({type: 'text/css', size: Buffer.byteLength(stylesheet), mtime: new Date()}),
   })
 }
 
@@ -190,7 +190,7 @@ function handleBlockScriptsJs(ctx: DevServerContext, event: H3Event, kind: 'bloc
 
   return serveStatic(event, {
     getContents: () => javascript,
-    getMeta: () => ({type: 'text/javascript', size: javascript.length, mtime: new Date()}),
+    getMeta: () => ({type: 'text/javascript', size: Buffer.byteLength(javascript), mtime: new Date()}),
   })
 }
 


### PR DESCRIPTION
### WHY are these changes introduced?

When hot-reloading compiled JS generated from `{% javascript %}` blocks, the response `Content-Length` header could be computed using the string character count rather than the UTF‑8 byte length. This becomes incorrect as soon as the output contains multi-byte characters (e.g., an em dash `—`).

### WHAT is this pull request doing?

This PR updates the compiled_assets script response path to set `content-length` based on the UTF‑8 byte length.

### How to test your changes?

- Run `shopify theme dev` with a snippet like this:
```
Hey
{% javascript %}
console.log("Hey, hey")
// ...not full cart — derive count from response

console.log("Hey, hey, heeeey!")
{% endjavascript %}
```

### Post-release steps

n/a

### Measuring impact

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes