### PR TITLE
Do not crash on metrics errors

### DIFF
--- a/packages/cli-kit/src/public/node/vendor/otel-js/export/InstantaneousMetricReader.test.ts
+++ b/packages/cli-kit/src/public/node/vendor/otel-js/export/InstantaneousMetricReader.test.ts
@@ -1,0 +1,73 @@
+import {InstantaneousMetricReader} from './InstantaneousMetricReader.js'
+import {ExportResultCode} from '@opentelemetry/core'
+import type {PushMetricExporter, ResourceMetrics} from '@opentelemetry/sdk-metrics'
+import {MeterProvider} from '@opentelemetry/sdk-metrics'
+import {describe, expect, test, vi} from 'vitest'
+import {diag} from '@opentelemetry/api'
+
+vi.mock('@opentelemetry/api')
+
+function createMockExporter(resultCode: ExportResultCode, error?: Error): PushMetricExporter {
+  return {
+    export: vi.fn((_metrics: ResourceMetrics, callback: (result: {code: ExportResultCode; error?: Error}) => void) => {
+      callback({code: resultCode, error})
+    }),
+    forceFlush: vi.fn().mockResolvedValue(undefined),
+    shutdown: vi.fn().mockResolvedValue(undefined),
+  } as unknown as PushMetricExporter
+}
+
+function createReaderWithProvider(exporter: PushMetricExporter): {
+  reader: InstantaneousMetricReader
+  provider: MeterProvider
+} {
+  const reader = new InstantaneousMetricReader({exporter, throttleLimit: 0})
+  const provider = new MeterProvider()
+  provider.addMetricReader(reader)
+  return {reader, provider}
+}
+
+describe('InstantaneousMetricReader', () => {
+  test('logs errors when metrics collection fails', async () => {
+    const exporter = createMockExporter(ExportResultCode.SUCCESS)
+    const {reader, provider} = createReaderWithProvider(exporter)
+
+    const collectionError = new Error('Collection failed')
+    vi.spyOn(reader as any, 'collect').mockResolvedValue({
+      resourceMetrics: {resource: {}, scopeMetrics: []},
+      errors: [collectionError],
+    })
+
+    await expect(reader.forceFlush()).resolves.toBeUndefined()
+    expect(diag.error).toHaveBeenCalledWith('InstantaneousMetricReader: metrics collection errors', collectionError)
+    await provider.shutdown()
+  })
+
+  test('resolves on successful export', async () => {
+    const exporter = createMockExporter(ExportResultCode.SUCCESS)
+    const {reader, provider} = createReaderWithProvider(exporter)
+
+    await expect(reader.forceFlush()).resolves.toBeUndefined()
+    expect(diag.error).not.toHaveBeenCalled()
+    await provider.shutdown()
+  })
+
+  test('resolves without rejecting on export failure', async () => {
+    const err = new Error('Export failed with retryable status')
+    const exporter = createMockExporter(ExportResultCode.FAILED, err)
+    const {reader, provider} = createReaderWithProvider(exporter)
+
+    await expect(reader.forceFlush()).resolves.toBeUndefined()
+    expect(diag.error).toHaveBeenCalledWith('InstantaneousMetricReader: metrics export failed', err)
+    await provider.shutdown()
+  })
+
+  test('resolves without rejecting when export error is undefined', async () => {
+    const exporter = createMockExporter(ExportResultCode.FAILED)
+    const {reader, provider} = createReaderWithProvider(exporter)
+
+    await expect(reader.forceFlush()).resolves.toBeUndefined()
+    expect(diag.error).toHaveBeenCalledWith('InstantaneousMetricReader: metrics export failed', undefined)
+    await provider.shutdown()
+  })
+})

--- a/packages/cli-kit/src/public/node/vendor/otel-js/export/InstantaneousMetricReader.ts
+++ b/packages/cli-kit/src/public/node/vendor/otel-js/export/InstantaneousMetricReader.ts
@@ -38,16 +38,15 @@ export class InstantaneousMetricReader extends MetricReader {
     const {resourceMetrics, errors} = await this.collect({})
 
     if (errors.length > 0) {
-      diag.error('PeriodicExportingMetricReader: metrics collection errors', ...errors)
+      diag.error('InstantaneousMetricReader: metrics collection errors', ...errors)
     }
 
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve) => {
       this._exporter.export(resourceMetrics, (result) => {
-        if (result.code === ExportResultCode.SUCCESS) {
-          resolve()
-        } else {
-          reject(result.error ?? new Error(`InstantaneousMetricReader: metrics export failed (error ${result.error})`))
+        if (result.code !== ExportResultCode.SUCCESS) {
+          diag.error('InstantaneousMetricReader: metrics export failed', result.error)
         }
+        resolve()
       })
     })
   }


### PR DESCRIPTION
### WHY are these changes introduced?

Resolves incident #inv-18682 (February 2026 OTLP failures)

When the OTLP telemetry endpoint is unavailable or experiencing failures, the CLI currently crashes with unhandled errors, forcing users to run commands with `SHOPIFY_CLI_NO_ANALYTICS=1` as a workaround. This violates the principle that telemetry should be transparent to users - it should never impact CLI functionality.

**Related to:** PR #6851 (adds Bugsnag reporting for telemetry failures)

### WHAT is this pull request doing?

**Changes:**

**Always** **resolve** **the** **OTEL** **metrics** **emitter** - There is no need to halt execution/reject the emitting process if OTEL reporting fails. This is a non-critical process, and we should allow things to continue to function normally even if this fails



**HOW** is this fixing things?

- Commands exit with `EXIT_CODE=0` now as we are always resolving. Previously, they were exiting with `1`



```
1. CLI command finishes                                                                                                          
     ↓                                                                                                                             
  2. postrun hook (cli-kit/.../hooks/postrun.ts)                                                                                   
     → calls reportAnalyticsEvent()                                                                                                
     ↓                                                                                                                             
  3. reportAnalyticsEvent (analytics.ts:44)                                                                                        
     → Promise.all([doMonorail(), doOpenTelemetry()])                                                                              
     → has try/catch, BUT...                                                                                                       
     ↓                                                                                                                             
  4. doOpenTelemetry → recordMetrics (otel-metrics.ts:58)                                                                          
     → calls recorder.otel.record() on counters/histograms                                                                         
     ↓                                                                                                                             
  5. BaseOtelService.record() (BaseOtelService.ts:~140)                                                                            
     → instrument.record(value, labels)                                                                                            
     → void meterProvider.forceFlush({}).catch(() => {})   ← FIRE-AND-FORGET                                                       
     ↓                                                                                                                             
  6. MeterProvider.forceFlush()                                                                                                    
     ↓                                                                                                                             
  7. InstantaneousMetricReader.onForceFlush()  [throttled to 1000ms]                                                               
     → this.collect({})  — gathers accumulated metrics                                                                             
     → this._exporter.export(resourceMetrics, callback)                                                                            
     ↓                                                                                                                             
  8. OTLPMetricExporter sends HTTP request to OTEL collector                                                                       
     → callback fires with { code: SUCCESS | FAILED, error? } 
     → previously rejected any errors, now we log/report them, but always resolve
```