### PR TITLE
Resolve OTLP export failures instead of rejecting

### DIFF
--- a/packages/cli-kit/src/public/node/vendor/otel-js/export/InstantaneousMetricReader.test.ts
+++ b/packages/cli-kit/src/public/node/vendor/otel-js/export/InstantaneousMetricReader.test.ts
@@ -1,0 +1,48 @@
+import {InstantaneousMetricReader} from './InstantaneousMetricReader.js'
+import {ExportResultCode} from '@opentelemetry/core'
+import type {PushMetricExporter, ResourceMetrics} from '@opentelemetry/sdk-metrics'
+import {MeterProvider} from '@opentelemetry/sdk-metrics'
+import {describe, expect, test, vi} from 'vitest'
+
+function createMockExporter(resultCode: ExportResultCode, error?: Error): PushMetricExporter {
+  return {
+    export: vi.fn((_metrics: ResourceMetrics, callback: (result: {code: ExportResultCode; error?: Error}) => void) => {
+      callback({code: resultCode, error})
+    }),
+    forceFlush: vi.fn().mockResolvedValue(undefined),
+    shutdown: vi.fn().mockResolvedValue(undefined),
+  } as unknown as PushMetricExporter
+}
+
+function createReaderWithProvider(exporter: PushMetricExporter): {reader: InstantaneousMetricReader; provider: MeterProvider} {
+  const reader = new InstantaneousMetricReader({exporter, throttleLimit: 0})
+  const provider = new MeterProvider()
+  provider.addMetricReader(reader)
+  return {reader, provider}
+}
+
+describe('InstantaneousMetricReader', () => {
+  test('resolves on successful export', async () => {
+    const exporter = createMockExporter(ExportResultCode.SUCCESS)
+    const {reader, provider} = createReaderWithProvider(exporter)
+
+    await expect(reader.forceFlush()).resolves.toBeUndefined()
+    await provider.shutdown()
+  })
+
+  test('resolves without rejecting on export failure', async () => {
+    const exporter = createMockExporter(ExportResultCode.FAILED, new Error('Export failed with retryable status'))
+    const {reader, provider} = createReaderWithProvider(exporter)
+
+    await expect(reader.forceFlush()).resolves.toBeUndefined()
+    await provider.shutdown()
+  })
+
+  test('resolves without rejecting when export error is undefined', async () => {
+    const exporter = createMockExporter(ExportResultCode.FAILED)
+    const {reader, provider} = createReaderWithProvider(exporter)
+
+    await expect(reader.forceFlush()).resolves.toBeUndefined()
+    await provider.shutdown()
+  })
+})

--- a/packages/cli-kit/src/public/node/vendor/otel-js/export/InstantaneousMetricReader.ts
+++ b/packages/cli-kit/src/public/node/vendor/otel-js/export/InstantaneousMetricReader.ts
@@ -41,13 +41,12 @@ export class InstantaneousMetricReader extends MetricReader {
       diag.error('PeriodicExportingMetricReader: metrics collection errors', ...errors)
     }
 
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve) => {
       this._exporter.export(resourceMetrics, (result) => {
-        if (result.code === ExportResultCode.SUCCESS) {
-          resolve()
-        } else {
-          reject(result.error ?? new Error(`InstantaneousMetricReader: metrics export failed (error ${result.error})`))
+        if (result.code !== ExportResultCode.SUCCESS) {
+          diag.error('InstantaneousMetricReader: metrics export failed', result.error)
         }
+        resolve()
       })
     })
   }

--- a/packages/cli-kit/src/public/node/vendor/otel-js/service/BaseOtelService/BaseOtelService.ts
+++ b/packages/cli-kit/src/public/node/vendor/otel-js/service/BaseOtelService/BaseOtelService.ts
@@ -136,8 +136,7 @@ export class BaseOtelService implements OtelService {
           instrument.add(finalValue, finalLabels)
         }
         // We flush metrics after every record - we do not await as we fire & forget.
-        // Catch any export errors to prevent unhandled rejections from crashing the CLI
-        void this.meterProvider.forceFlush({}).catch(() => {})
+        void this.meterProvider.forceFlush({})
       }
       record(firstValue, firstLabels)
       this.metrics.set(metricName, record)


### PR DESCRIPTION
### WHY are these changes introduced?

Related to incident #inv-18682 (February 2026 OTLP failures). Stacks on #6851.

When the OTLP endpoint is unreachable, the `OTLPMetricExporter`'s internal HTTP retry mechanism produces an `OTLPExporterError: Export failed with retryable status` as an **unhandled promise rejection**. This bypasses all existing try/catch layers (`analytics.ts`, `FailSafeOtelService`) because:

1. `BaseOtelService.record()` is synchronous — the export happens asynchronously via a detached `forceFlush()` call
2. The OTLP transport's retry logic rejects independently of the `export()` callback pattern
3. Node.js (v15+) treats unhandled promise rejections as uncaught exceptions, terminating the process

The existing `.catch(() => {})` on `forceFlush()` only catches the `InstantaneousMetricReader.onForceFlush()` rejection, not the transport-level rejections from the HTTP exporter internals.

### WHAT is this pull request doing?

Fixes the problem at the single chokepoint — `InstantaneousMetricReader.onForceFlush()`:

1. **Resolves instead of rejecting** on export failure — metrics export is never fatal
2. **Logs failures** via `diag.error()` at the layer where the failure actually occurs
3. **Removes the redundant `.catch(() => {})`** from `BaseOtelService` since `forceFlush()` can no longer reject
4. **Adds tests** for the `InstantaneousMetricReader` verifying it resolves on both success and failure

This makes all paths safe (`forceFlush()`, `shutdown()`, and any future callers) without needing scattered `.catch()` handlers.

### How to test your changes?

```bash
npx vitest run packages/cli-kit/src/public/node/vendor/otel-js/export/InstantaneousMetricReader.test.ts
npx vitest run packages/cli-kit/src/private/node/otel-metrics.test.ts
npx vitest run packages/cli-kit/src/public/node/analytics.test.ts
```

### Measuring impact

- [x] n/a - bug fix for OTLP endpoint outage resilience

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)