### PR TITLE
Fix shopify version in snapshots

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,14 +66,14 @@ jobs:
           comment_suffix: "
             > [!CAUTION]
 
-            > After installing, validate the version by running just `shopify` in your terminal.
+            > After installing, validate the version by running `shopify version` in your terminal.
 
             > If the versions don't match, you might have multiple global instances installed.
 
             > Use `which shopify` to find out which one you are running and uninstall it."
           comment_package_manager: 'npm'
           comment_command_flags: '--@shopify:registry=https://registry.npmjs.org'
-          build_script: "pnpm nx run-many --target=bundle --all --skip-nx-cache --output-style=stream && pnpm refresh-manifests"
+          build_script: "node bin/update-cli-kit-version.js && pnpm nx run-many --target=bundle --all --skip-nx-cache --output-style=stream && pnpm refresh-manifests"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ''

--- a/bin/update-cli-kit-version.js
+++ b/bin/update-cli-kit-version.js
@@ -1,7 +1,15 @@
 #!/usr/bin/env node
-import {readFileSync, writeFile, writeFileSync} from 'fs';
+import {readFileSync, writeFileSync} from 'fs'
+import {dirname, join} from 'path'
+import {fileURLToPath} from 'url'
+
+// Always work from the repo root (where this script is located in bin/)
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const repoRoot = join(__dirname, '..')
 
 // Update the cli-kit version in version.ts
-const cliKitVersion = JSON.parse(readFileSync('packages/cli-kit/package.json')).version
+const packageJsonPath = join(repoRoot, 'packages/cli-kit/package.json')
+const cliKitVersion = JSON.parse(readFileSync(packageJsonPath, 'utf-8')).version
+const versionFilePath = join(repoRoot, 'packages/cli-kit/src/public/common/version.ts')
 const content = `export const CLI_KIT_VERSION = '${cliKitVersion}'\n`
-writeFileSync('packages/cli-kit/src/public/common/version.ts', content)
+writeFileSync(versionFilePath, content)

--- a/packages/cli-kit/project.json
+++ b/packages/cli-kit/project.json
@@ -22,9 +22,24 @@
       "inputs": [
         "{projectRoot}/src/**/*"
       ],
+      "dependsOn": [
+        "generate-version"
+      ],
       "options": {
         "command": "pnpm tsc -b ./tsconfig.build.json",
         "cwd": "packages/cli-kit"
+      }
+    },
+    "generate-version": {
+      "executor": "nx:run-commands",
+      "outputs": [
+        "{projectRoot}/src/public/common/version.ts"
+      ],
+      "inputs": [
+        "{projectRoot}/package.json"
+      ],
+      "options": {
+        "command": "node bin/update-cli-kit-version.js"
       }
     },
     "build-api-docs": {

--- a/packages/cli/project.json
+++ b/packages/cli/project.json
@@ -24,6 +24,11 @@
     },
     "bundle": {
       "executor": "nx:run-commands",
+      "dependsOn": [
+        "cli-kit:generate-version",
+        "app:build",
+        "theme:build"
+      ],
       "options": {
         "command": "node bin/bundle",
         "cwd": "packages/cli"


### PR DESCRIPTION
### WHY are these changes introduced?

The `shopify version` command was returning a wrong value (the current from the main branch, like `3.90.0`) for snapshot releases generated with `/snapit`

### WHAT is this pull request doing?

Ensure the script to update the CLI version constant in cli-kit is run as part of the bundle task

### How to test your changes?

- `npm i -g @shopify/cli@0.0.0-snapshot-20260217105009`
- `shopify version`

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
