### PR TITLE
Simplify tests to avoid o3 warnings

### DIFF
--- a/packages/cli-kit/src/public/node/ui.tsx
+++ b/packages/cli-kit/src/public/node/ui.tsx
@@ -100,7 +100,10 @@ export type RenderAlertOptions = Omit<AlertOptions, 'type'>
  * │                                                          │
  * ╰──────────────────────────────────────────────────────────╯
  * [1] https://shopify.dev
- * [2] https://www.google.com
+ * [2] https://www.google.com/search?q=jh56t9l34kpo35tw8s28hn7s
+ * 9s2xvzla01d8cn6j7yq&rlz=1C1GCEU_enUS832US832&oq=jh56t9l34kpo
+ * 35tw8s28hn7s9s2xvzla01d8cn6j7yq&aqs=chrome.0.35i39l2j0l4j46j
+ * 69i60.2711j0j7&sourceid=chrome&ie=UTF-8
  * [3] https://shopify.com
  *
  */


### PR DESCRIPTION
### WHY are these changes introduced?

There's a [new warning](https://github.com/Shopify/cli/pull/6823#issuecomment-3920130093) about code using `o3` (openai), and we have some files that contain that string, causing false positives.

### WHAT is this pull request doing?

Simplifies some test URLs to remove the `o3` part and avoid the warning.

### How to test your changes?

CI

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
