### PR TITLE
Gracefully catch unexpected html (non json) response from external services

### DIFF
--- a/packages/cli-kit/src/private/node/session/exchange.ts
+++ b/packages/cli-kit/src/private/node/session/exchange.ts
@@ -229,12 +229,22 @@ async function tokenRequest(params: {
   url.search = new URLSearchParams(Object.entries(params)).toString()
 
   const res = await shopifyFetch(url.href, {method: 'POST'})
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const payload: any = await res.json()
+  try {
+    const responseText = await res.text()
 
-  if (res.ok) return ok(payload)
+    const payload = JSON.parse(responseText)
+    if (res.ok) return ok(payload)
 
-  return err({error: payload.error, store: params.store})
+    return err({error: payload.error, store: params.store})
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      throw new AbortError(
+        `Received invalid response from authentication service (HTTP ${res.status}).`,
+        'The response could not be parsed as JSON. The service may be temporarily unavailable. Please try again.',
+      )
+    }
+    throw error
+  }
 }
 
 function buildIdentityToken(

--- a/packages/cli-kit/src/public/node/github.ts
+++ b/packages/cli-kit/src/public/node/github.ts
@@ -47,14 +47,24 @@ export async function getLatestGitHubRelease(
   outputDebug(outputContent`Getting the latest release of GitHub repository ${owner}/${repo}...`)
   const url = `https://api.github.com/repos/${owner}/${repo}/releases`
   const fetchResult = await fetch(url)
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const jsonBody: any = await fetchResult.json()
+  try {
+    const responseText = await fetchResult.text()
+    const jsonBody = JSON.parse(responseText)
 
-  if (fetchResult.status !== 200) {
-    throw new GitHubClientError(url, fetchResult.status, jsonBody)
+    if (fetchResult.status !== 200) {
+      throw new GitHubClientError(url, fetchResult.status, jsonBody)
+    }
+
+    return jsonBody.find(options.filter)
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      throw new AbortError(
+        `Received invalid response from GitHub API (HTTP ${fetchResult.status}).`,
+        'The response could not be parsed as JSON. The service may be temporarily unavailable. Please try again.',
+      )
+    }
+    throw error
   }
-
-  return jsonBody.find(options.filter)
 }
 
 interface ParseRepositoryURLOutput {

--- a/packages/cli-kit/src/public/node/session.test.ts
+++ b/packages/cli-kit/src/public/node/session.test.ts
@@ -280,7 +280,7 @@ describe('ensureAuthenticatedAdminAsApp', () => {
     // Given
     vi.mocked(shopifyFetch).mockResolvedValueOnce({
       status: 200,
-      json: async () => ({access_token: 'app_access_token'}),
+      text: async () => JSON.stringify({access_token: 'app_access_token'}),
     } as any)
 
     // When

--- a/packages/cli-kit/src/public/node/session.ts
+++ b/packages/cli-kit/src/public/node/session.ts
@@ -315,8 +315,9 @@ export async function ensureAuthenticatedAdminAsApp(
     'slow-request',
   )
 
+  const body = await tokenResponse.text()
+
   if (tokenResponse.status === 400) {
-    const body = await tokenResponse.text()
     if (body.includes('app_not_installed')) {
       throw new AbortError(
         outputContent`App is not installed on ${outputToken.green(
@@ -328,7 +329,16 @@ export async function ensureAuthenticatedAdminAsApp(
       `Failed to get access token for app ${clientId} on store ${storeFqdn}: ${tokenResponse.statusText}`,
     )
   }
-
-  const tokenJson = (await tokenResponse.json()) as {access_token: string}
-  return {token: tokenJson.access_token, storeFqdn}
+  try {
+    const tokenJson = JSON.parse(body) as {access_token: string}
+    return {token: tokenJson.access_token, storeFqdn}
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      throw new AbortError(
+        `Received invalid response from admin authentication service (HTTP ${tokenResponse.status}).`,
+        'The response could not be parsed as JSON. The service may be temporarily unavailable. Please try again.',
+      )
+    }
+    throw error
+  }
 }


### PR DESCRIPTION
### WHY are these changes introduced?

[Issue #1325](https://github.com/shop/issues/issues/1325)

[Vault error](https://vault.shopify.io/teams/16949-Dev-Experience/issues/1312-error-unexpected-token-html-h-is-not-valid-json)

[Observe error](https://observe.shopify.io/a/observe/errors/11062327764500656069)

JSON parsing errors in HTTP responses were causing unhandled exceptions and poor error messages when external services return malformed responses or are temporarily unavailable.

### WHAT is this pull request doing?

Add proper error handling for JSON parsing failures in HTTP response processing across three modules:

- **Token exchange service**: Wrap JSON parsing in try-catch and throw descriptive `AbortError` when identity service returns invalid JSON
- **GitHub API client**: Handle JSON parsing errors when fetching release information and provide clear error messaging
- **Admin authentication**: Add error handling for malformed responses from the admin authentication service

All error messages inform users that the service may be temporarily unavailable and suggest retrying.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes