### PR TITLE
Fix app config file watching on Windows

### DIFF
--- a/packages/app/src/cli/services/dev/app-events/file-watcher.ts
+++ b/packages/app/src/cli/services/dev/app-events/file-watcher.ts
@@ -230,13 +230,13 @@ export class FileWatcher {
   private readonly handleFileEvent = (event: string, path: string) => {
     const startTime = startHRTime()
     const normalizedPath = normalizePath(path)
-    const isConfigAppPath = path === this.app.configuration.path
+    const isConfigAppPath = normalizedPath === normalizePath(this.app.configuration.path)
     const isExtensionToml = path.endsWith('.extension.toml')
 
     outputDebug(`🌀: ${event} ${path.replace(this.app.directory, '')}\n`)
 
     if (isConfigAppPath) {
-      this.handleEventForExtension(event, path, this.app.directory, startTime, false)
+      this.handleEventForExtension(event, path, this.app.directory, startTime, false, isExtensionToml, isConfigAppPath)
     } else {
       const affectedExtensions = this.extensionWatchedFiles.get(normalizedPath)
       const isUnknownExtension = affectedExtensions === undefined || affectedExtensions.size === 0
@@ -249,10 +249,10 @@ export class FileWatcher {
       }
 
       for (const extensionPath of affectedExtensions ?? []) {
-        this.handleEventForExtension(event, path, extensionPath, startTime, false)
+        this.handleEventForExtension(event, path, extensionPath, startTime, false, isExtensionToml, isConfigAppPath)
       }
       if (isUnknownExtension) {
-        this.handleEventForExtension(event, path, this.app.directory, startTime, true)
+        this.handleEventForExtension(event, path, this.app.directory, startTime, true, isExtensionToml, isConfigAppPath)
       }
     }
     this.debouncedEmit()
@@ -264,9 +264,9 @@ export class FileWatcher {
     extensionPath: string,
     startTime: StartTime,
     isUnknownExtension: boolean,
+    isExtensionToml: boolean,
+    isConfigAppPath: boolean,
   ) {
-    const isExtensionToml = path.endsWith('.extension.toml')
-    const isConfigAppPath = path === this.app.configuration.path
 
     switch (event) {
       case 'change':


### PR DESCRIPTION
## Summary
- `shopify app dev` was not detecting changes to `shopify.app.toml` on Windows
- Chokidar delivers paths with backslashes on Windows (`C:\project\shopify.app.toml`) but the app configuration stores paths with forward slashes (`C:/project/shopify.app.toml`)
- The raw string comparison (`path === this.app.configuration.path`) silently failed on Windows
- Fixed by using `normalizePath()` on both sides of the comparison in `handleFileEvent` and `handleEventForExtension`

## Test plan
- [x] Added test simulating Windows backslash paths from chokidar
- [x] Existing tests still pass
- [ ] Snap release and verify on Windows that `shopify.app.toml` changes are picked up during `shopify app dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)