### PR TITLE
change hardcoded links in theme pull to use methods to surface urls instead

### DIFF
--- a/.changeset/tender-wolves-doubt.md
+++ b/.changeset/tender-wolves-doubt.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli': patch
+---
+
+change hardcoded links in theme pull to use methods to surface urls instead

--- a/packages/theme/src/cli/services/pull.ts
+++ b/packages/theme/src/cli/services/pull.ts
@@ -14,6 +14,7 @@ import {glob} from '@shopify/cli-kit/node/fs'
 import {cwd} from '@shopify/cli-kit/node/path'
 import {insideGitDirectory, isClean} from '@shopify/cli-kit/node/git'
 import {recordTiming} from '@shopify/cli-kit/node/analytics'
+import {themeEditorUrl, themePreviewUrl} from '@shopify/cli-kit/node/themes/urls'
 import {Writable} from 'stream'
 
 interface PullOptions {
@@ -165,9 +166,6 @@ async function executePull(
   const themeChecksums = rejectGeneratedStaticAssets(remoteChecksums)
   recordTiming('theme-service:pull:file-system')
 
-  const store = session.storeFqdn
-  const themeId = theme.id
-
   await downloadTheme(theme, session, themeChecksums, themeFileSystem, options, context)
 
   const header = options.environment ? `Environment: ${options.environment}` : ''
@@ -179,7 +177,7 @@ async function executePull(
         {
           link: {
             label: 'View your theme',
-            url: `https://${store}/?preview_theme_id=${themeId}`,
+            url: themePreviewUrl(theme, session),
           },
         },
       ],
@@ -187,7 +185,7 @@ async function executePull(
         {
           link: {
             label: 'Customize your theme at the theme editor',
-            url: `https://${store}/admin/themes/${themeId}/editor`,
+            url: themeEditorUrl(theme, session),
           },
         },
       ],


### PR DESCRIPTION
### WHY are these changes introduced?
The `theme pull` command had hardcoded links for previewing your theme, and launching the theme editor. 

Fixes [#1063 ](https://github.com/Shopify/developer-tools-team/issues/1063)

### WHAT is this pull request doing?
The hardcoded links were replaced by `themePreviewUrl` and `themeEditorUrl` methods.

The `themePreviewURL` function builds the url following two paths and one path can lead to the url looking slightly different than the original string behavior (it truncates the url if `theme.role === live`, but I tested both urls in my browser and they went to the same place. 
This is the Before + After:
Before: 
```
[1] https://f9e81e-af.myshopify.com/?preview_theme_id=145364484332
[2] https://f9e81e-af.myshopify.com/admin/themes/145364484332/editor
```
After:
```
[1] https://f9e81e-af.myshopify.com
[2] https://f9e81e-af.myshopify.com/admin/themes/145364484332/editor
```

The After is cleaner for this edge case and doesn't add the unnecessary preview part, as the theme is live and the url can point to the live view.

I noticed there were no unittests testing `renderSuccess` but that other sibling tests do test that and the message surfaced to user, so I added that test

### How to test your changes?

- while on main, run `p build`, then `shopify-dev theme pull  -e <local-env-name> `in external terminal
- choose a live theme to pull to see the edge case
- note the older, longer url surfaced to the user after the `renderSuccess` message
- pull my branch down locally: `fix-hardcoded-links-in-theme-pull`
- `p build`
- run `shopify-dev theme pull  -e <local-env-name>` in external terminal
- note the newer url without the unnecessary preview appended (if you chose a live theme). 
- If you choose an unpublished theme to pull the urls remain exactly the same


### Measuring impact

How do we know this change was effective? Please choose one:
- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix



