### PR TITLE
Renamed offline_mode to runs_offline

### DIFF
--- a/packages/app/src/cli/models/app/loader.test.ts
+++ b/packages/app/src/cli/models/app/loader.test.ts
@@ -3437,7 +3437,7 @@ describe('WebhooksSchema', () => {
     }
     const errorObj = {
       code: zod.ZodIssueCode.custom,
-      message: 'You can’t have multiple subscriptions with the same compliance topic',
+      message: 'You canâ€™t have multiple subscriptions with the same compliance topic',
       fatal: true,
       path: ['webhooks', 'subscriptions'],
     }

--- a/packages/app/src/cli/models/extensions/specifications/checkout_ui_extension.ts
+++ b/packages/app/src/cli/models/extensions/specifications/checkout_ui_extension.ts
@@ -23,15 +23,10 @@ const checkoutSpec = createExtensionSpecification({
   appModuleFeatures: (_) => ['ui_preview', 'cart_url', 'esbuild', 'single_js_entry_path', 'generates_source_maps'],
   buildConfig: {mode: 'ui'},
   deployConfig: async (config, directory) => {
-    const supportedFeatures =
-      config.supported_features?.runs_offline === undefined
-        ? undefined
-        : {offline_mode: config.supported_features.runs_offline}
-
     return {
       extension_points: config.extension_points,
       capabilities: config.capabilities,
-      supported_features: supportedFeatures,
+      supported_features: config.supported_features,
       metafields: config.metafields ?? [],
       name: config.name,
       settings: config.settings,

--- a/packages/app/src/cli/models/extensions/specifications/ui_extension.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/ui_extension.test.ts
@@ -996,7 +996,7 @@ Please check the configuration in ${joinPath(tmpDir, 'shopify.extension.toml')}`
       })
     })
 
-    test('returns supported_features with offline_mode true when runs_offline is configured', async () => {
+    test('returns supported_features with runs_offline true when configured', async () => {
       await inTemporaryDirectory(async (tmpDir) => {
         // Given
         vi.spyOn(loadLocales, 'loadLocalesConfig').mockResolvedValue({})
@@ -1030,12 +1030,12 @@ Please check the configuration in ${joinPath(tmpDir, 'shopify.extension.toml')}`
 
         // Then
         expect(deployConfig?.supported_features).toStrictEqual({
-          offline_mode: true,
+          runs_offline: true,
         })
       })
     })
 
-    test('returns supported_features with offline_mode false when runs_offline is configured', async () => {
+    test('returns supported_features with runs_offline false when configured', async () => {
       await inTemporaryDirectory(async (tmpDir) => {
         // Given
         vi.spyOn(loadLocales, 'loadLocalesConfig').mockResolvedValue({})
@@ -1069,7 +1069,7 @@ Please check the configuration in ${joinPath(tmpDir, 'shopify.extension.toml')}`
 
         // Then
         expect(deployConfig?.supported_features).toStrictEqual({
-          offline_mode: false,
+          runs_offline: false,
         })
       })
     })

--- a/packages/app/src/cli/models/extensions/specifications/ui_extension.ts
+++ b/packages/app/src/cli/models/extensions/specifications/ui_extension.ts
@@ -115,16 +115,12 @@ const uiExtensionSpec = createExtensionSpecification({
   },
   deployConfig: async (config, directory) => {
     const transformedExtensionPoints = config.extension_points?.map(addDistPathToAssets) ?? []
-    const supportedFeatures =
-      config.supported_features?.runs_offline === undefined
-        ? undefined
-        : {offline_mode: config.supported_features.runs_offline}
 
     return {
       api_version: config.api_version,
       extension_points: transformedExtensionPoints,
       capabilities: config.capabilities,
-      supported_features: supportedFeatures,
+      supported_features: config.supported_features,
       name: config.name,
       description: config.description,
       settings: config.settings,

--- a/packages/app/src/cli/services/dev/extension/payload.test.ts
+++ b/packages/app/src/cli/services/dev/extension/payload.test.ts
@@ -462,7 +462,7 @@ describe('getUIExtensionPayload', () => {
   })
 
   describe('supportedFeatures', () => {
-    test('returns supportedFeatures with offlineMode true when runs_offline is enabled', async () => {
+    test('returns supportedFeatures with runsOffline true when runs_offline is enabled', async () => {
       await inTemporaryDirectory(async (tmpDir) => {
         // Given
         const uiExtension = await testUIExtension({
@@ -488,12 +488,12 @@ describe('getUIExtensionPayload', () => {
 
         // Then
         expect(got.supportedFeatures).toStrictEqual({
-          offlineMode: true,
+          runsOffline: true,
         })
       })
     })
 
-    test('returns supportedFeatures with offlineMode false when runs_offline is disabled', async () => {
+    test('returns supportedFeatures with runsOffline false when runs_offline is disabled', async () => {
       await inTemporaryDirectory(async (tmpDir) => {
         // Given
         const uiExtension = await testUIExtension({
@@ -519,12 +519,12 @@ describe('getUIExtensionPayload', () => {
 
         // Then
         expect(got.supportedFeatures).toStrictEqual({
-          offlineMode: false,
+          runsOffline: false,
         })
       })
     })
 
-    test('returns supportedFeatures with offlineMode false when supported_features is not configured', async () => {
+    test('returns supportedFeatures with runsOffline false when supported_features is not configured', async () => {
       await inTemporaryDirectory(async (tmpDir) => {
         // Given
         const uiExtension = await testUIExtension({
@@ -547,7 +547,7 @@ describe('getUIExtensionPayload', () => {
 
         // Then
         expect(got.supportedFeatures).toStrictEqual({
-          offlineMode: false,
+          runsOffline: false,
         })
       })
     })

--- a/packages/app/src/cli/services/dev/extension/payload.ts
+++ b/packages/app/src/cli/services/dev/extension/payload.ts
@@ -54,7 +54,7 @@ export async function getUIExtensionPayload(
         },
       },
       supportedFeatures: {
-        offlineMode: extension.configuration.supported_features?.runs_offline ?? false,
+        runsOffline: extension.configuration.supported_features?.runs_offline ?? false,
       },
       capabilities: {
         blockProgress: extension.configuration.capabilities?.block_progress ?? false,

--- a/packages/app/src/cli/services/dev/extension/payload/models.ts
+++ b/packages/app/src/cli/services/dev/extension/payload/models.ts
@@ -46,7 +46,7 @@ export interface DevNewExtensionPointSchema extends NewExtensionPointSchemaType 
 }
 
 interface SupportedFeatures {
-  offlineMode: boolean
+  runsOffline: boolean
 }
 
 export interface UIExtensionPayload {

--- a/packages/ui-extensions-server-kit/src/types.ts
+++ b/packages/ui-extensions-server-kit/src/types.ts
@@ -160,7 +160,7 @@ export interface ExtensionPayload {
 }
 
 export interface ExtensionSupportedFeatures {
-  offlineMode: boolean
+  runsOffline: boolean
 }
 
 export enum Status {


### PR DESCRIPTION
### WHY are these changes introduced?
We are renaming offline_mode to runs_offline after some feedback from a GSD review. All of the internal API is left as offline_mode in order to ship this and reduce the amount of friction for now. We can migrate/refactor later if we decide it's worthwhile. 

### WHAT is this pull request doing?

Just a rename for the developer facing toml

### How to test your changes?

1. Create an extension with `supported_features.runs_offline` set to `true` or `false`
2. Run `pnpm shopify app dev --path {Path to extension}` to run this app locally and deploy the draft to your dev shop

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes