### PR TITLE
return original zod schema after app module validation

### DIFF
--- a/packages/app/src/cli/utilities/json-schema.test.ts
+++ b/packages/app/src/cli/utilities/json-schema.test.ts
@@ -19,18 +19,15 @@ describe('unifiedConfigurationParserFactory', () => {
   }
 
   test('falls back to zod parser when no JSON schema is provided', async () => {
-    // Given
     const merged = {
       identifier: randomUUID(),
       parseConfigurationObject: mockParseConfigurationObject,
       validationSchema: undefined,
     }
 
-    // When
     const parser = await unifiedConfigurationParserFactory(merged as any)
     const result = parser({type: 'product_subscription'})
 
-    // Then
     expect(result).toEqual({
       state: 'ok',
       data: {type: 'product_subscription'},
@@ -39,7 +36,6 @@ describe('unifiedConfigurationParserFactory', () => {
   })
 
   test('falls back to zod parser when JSON schema is empty', async () => {
-    // Given
     const merged = {
       identifier: randomUUID(),
       parseConfigurationObject: mockParseConfigurationObject,
@@ -48,11 +44,9 @@ describe('unifiedConfigurationParserFactory', () => {
       },
     }
 
-    // When
     const parser = await unifiedConfigurationParserFactory(merged as any)
     const result = parser({type: 'product_subscription'})
 
-    // Then
     expect(result).toEqual({
       state: 'ok',
       data: {type: 'product_subscription'},
@@ -61,7 +55,6 @@ describe('unifiedConfigurationParserFactory', () => {
   })
 
   test('validates with both zod and JSON schema when both succeed', async () => {
-    // Given
     const merged = {
       identifier: randomUUID(),
       parseConfigurationObject: mockParseConfigurationObject,
@@ -70,11 +63,9 @@ describe('unifiedConfigurationParserFactory', () => {
       },
     }
 
-    // When
     const parser = await unifiedConfigurationParserFactory(merged as any)
     const result = parser({type: 'product_subscription'})
 
-    // Then
     expect(result).toEqual({
       state: 'ok',
       data: {type: 'product_subscription'},
@@ -83,7 +74,6 @@ describe('unifiedConfigurationParserFactory', () => {
   })
 
   test('returns errors when zod validation fails', async () => {
-    // Given
     const merged = {
       identifier: randomUUID(),
       parseConfigurationObject: mockParseConfigurationObject,
@@ -92,11 +82,9 @@ describe('unifiedConfigurationParserFactory', () => {
       },
     }
 
-    // When
     const parser = await unifiedConfigurationParserFactory(merged as any)
     const result = parser({type: 'invalid'})
 
-    // Then
     expect(result.state).toBe('error')
     expect(result.data).toBeUndefined()
     expect(result.errors).toHaveLength(1)
@@ -104,7 +92,6 @@ describe('unifiedConfigurationParserFactory', () => {
   })
 
   test('returns errors when JSON schema validation fails', async () => {
-    // Given
     const merged = {
       identifier: randomUUID(),
       parseConfigurationObject: mockParseConfigurationObject,
@@ -113,11 +100,9 @@ describe('unifiedConfigurationParserFactory', () => {
       },
     }
 
-    // When
     const parser = await unifiedConfigurationParserFactory(merged as any)
     const result = parser({type: 'product_subscription'})
 
-    // Then
     expect(result.state).toBe('error')
     expect(result.data).toBeUndefined()
     expect(result.errors).toBeDefined()
@@ -126,7 +111,6 @@ describe('unifiedConfigurationParserFactory', () => {
   })
 
   test('combines errors from both validations', async () => {
-    // Given
     const merged = {
       identifier: randomUUID(),
       parseConfigurationObject: mockParseConfigurationObject,
@@ -135,11 +119,9 @@ describe('unifiedConfigurationParserFactory', () => {
       },
     }
 
-    // When
     const parser = await unifiedConfigurationParserFactory(merged as any)
     const result = parser({type: 'invalid'})
 
-    // Then
     expect(result.state).toBe('error')
     expect(result.data).toBeUndefined()
     expect(result.errors).toBeDefined()
@@ -152,8 +134,107 @@ describe('unifiedConfigurationParserFactory', () => {
     expect(priceError).toBeDefined()
   })
 
+  test('transforms data to server format before contract validation', async () => {
+    // Given: Zod outputs TOML-shaped data, but the contract expects server-shaped data
+    const merged = {
+      identifier: randomUUID(),
+      parseConfigurationObject: (config: any) => ({
+        state: 'ok' as const,
+        data: {access_scopes: {scopes: config.access_scopes?.scopes}},
+        errors: undefined,
+      }),
+      transformLocalToRemote: (local: any) => ({
+        scopes: local.access_scopes?.scopes,
+      }),
+      validationSchema: {
+        jsonSchema: JSON.stringify({
+          type: 'object',
+          properties: {scopes: {type: 'string'}},
+          required: ['scopes'],
+        }),
+      },
+    }
+
+    const parser = await unifiedConfigurationParserFactory(merged as any)
+    const result = parser({access_scopes: {scopes: 'read_products'}})
+
+    expect(result.state).toBe('ok')
+  })
+
+  test('returns Zod-validated data, not contract-stripped data', async () => {
+    // Given: Zod outputs TOML-shaped data, transform converts to server-shaped for validation
+    const merged = {
+      identifier: randomUUID(),
+      parseConfigurationObject: (config: any) => ({
+        state: 'ok' as const,
+        data: {access_scopes: {scopes: config.access_scopes?.scopes}},
+        errors: undefined,
+      }),
+      transformLocalToRemote: (local: any) => ({
+        scopes: local.access_scopes?.scopes,
+      }),
+      validationSchema: {
+        jsonSchema: JSON.stringify({
+          type: 'object',
+          properties: {scopes: {type: 'string'}},
+        }),
+      },
+    }
+
+    const parser = await unifiedConfigurationParserFactory(merged as any)
+    const result = parser({access_scopes: {scopes: 'read_products'}})
+
+    expect(result.state).toBe('ok')
+    expect(result.data).toEqual({access_scopes: {scopes: 'read_products'}})
+  })
+
+  test('falls back to raw data when no transform is available', async () => {
+    // Given: no transformLocalToRemote, contract matches raw shape
+    const merged = {
+      identifier: randomUUID(),
+      parseConfigurationObject: mockParseConfigurationObject,
+      validationSchema: {
+        jsonSchema: JSON.stringify({
+          type: 'object',
+          properties: {type: {type: 'string'}},
+        }),
+      },
+    }
+
+    const parser = await unifiedConfigurationParserFactory(merged as any)
+    const result = parser({type: 'product_subscription'})
+
+    expect(result.state).toBe('ok')
+    expect(result.data).toEqual({type: 'product_subscription'})
+  })
+
+  test('contract cannot strip fields from returned data', async () => {
+    // Given: Zod output has extra_field, contract doesn't define it, strip mode is on
+    const merged = {
+      identifier: randomUUID(),
+      parseConfigurationObject: (config: any) => ({
+        state: 'ok' as const,
+        data: {...config, extra_field: 'preserved'},
+        errors: undefined,
+      }),
+      validationSchema: {
+        jsonSchema: JSON.stringify({
+          type: 'object',
+          properties: {type: {type: 'string'}},
+        }),
+      },
+    }
+
+    // When: strip mode (default)
+    const parser = await unifiedConfigurationParserFactory(merged as any)
+    const result = parser({type: 'product_subscription'})
+
+    // Then: extra_field survives because we return Zod data, not contract-processed data
+    expect(result.state).toBe('ok')
+    expect(result.data).toEqual({type: 'product_subscription', extra_field: 'preserved'})
+  })
+
   test('adds base properties to the JSON schema', async () => {
-    // Given
     const merged = {
       identifier: randomUUID(),
       parseConfigurationObject: mockParseConfigurationObject,
@@ -162,10 +243,8 @@ describe('unifiedConfigurationParserFactory', () => {
       },
     }
 
-    // When
     const parser = await unifiedConfigurationParserFactory(merged as any)
 
-    // Then - base properties should be accepted
     const result = parser({
       type: 'product_subscription',
       handle: 'test-handle',

--- a/packages/app/src/cli/utilities/json-schema.ts
+++ b/packages/app/src/cli/utilities/json-schema.ts
@@ -1,4 +1,5 @@
 import {FlattenedRemoteSpecification} from '../api/graphql/extension_specifications.js'
+import {AppConfigurationWithoutPath} from '../models/app/app.js'
 import {BaseConfigType} from '../models/extensions/schemas.js'
 import {RemoteAwareExtensionSpecification} from '../models/extensions/specification.js'
 import {ParseConfigurationResult} from '@shopify/cli-kit/node/schema'
@@ -49,7 +50,14 @@ export async function unifiedConfigurationParserFactory(
 
     // Then, even if this failed, we try to validate against the contract.
     const zodValidatedData = zodParse.state === 'ok' ? zodParse.data : undefined
-    const subjectForAjv = zodValidatedData ?? (config as JsonMapType)
+    let subjectForAjv: object
+    // If the zod validation succeeded and a transform function is provided, use the transform function to convert the data to the format expected by the contract.
+    // Otherwise, use the zod validated data as is.
+    if (zodValidatedData && merged.transformLocalToRemote) {
+      subjectForAjv = merged.transformLocalToRemote(zodValidatedData, {} as AppConfigurationWithoutPath)
+    } else {
+      subjectForAjv = zodValidatedData ?? (config as JsonMapType)
+    }
 
     const jsonSchemaParse = jsonSchemaValidate(
       subjectForAjv,
@@ -82,7 +90,7 @@ export async function unifiedConfigurationParserFactory(
 
     return {
       state: 'ok',
-      data: jsonSchemaParse.data as BaseConfigType,
+      data: zodValidatedData as BaseConfigType,
       errors: undefined,
     }
   }


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

See [incident notes](https://docs.google.com/document/d/1RqN-H6_6yhRvo0C20fXr9r1x3gYJ7mE3dxghpePLcqg/edit?tab=t.0). The current validation mutates data in-place twice: once for zod.transform and once during json schema validation. We can keep the json schema validation approach as-is with its stripping behavior (sohuld we long term? IMO no, but different discussion) so long as we return the zod object, which we don't strip. This is a least-we-can-do approach to gain some safety back by reducing the amount of mutation to data happening inside a validation loop. I've also added a check to run transforms on the data pre-json schema validation only if a transform function is provided. This allows us a migration path to get things on contracts.<!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes