### PR TITLE
Fixed bug for relative URIs in app dev

### DIFF
--- a/packages/app/src/cli/models/extensions/specifications/transform/app_config_events.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/transform/app_config_events.test.ts
@@ -2,15 +2,124 @@ import {transformToEventsConfig, transformFromEventsConfig} from './app_config_e
 import {describe, expect, test} from 'vitest'
 
 describe('transformFromEventsConfig', () => {
-  test('returns content as-is without transformation', () => {
+  test('returns content as-is when all URIs are absolute', () => {
     const content = {
       events: {
         api_version: '2024-01',
         subscription: [{topic: 'orders/create', uri: 'https://example.com', actions: ['create']}],
       },
     }
+    const appConfiguration = {application_url: 'https://tunnel.example.com'}
+
+    const result = transformFromEventsConfig(content, appConfiguration)
+
+    expect(result).toEqual(content)
+  })
+
+  test('prepends application_url to relative URIs in subscriptions', () => {
+    const content = {
+      events: {
+        api_version: '2024-01',
+        subscription: [
+          {topic: 'orders/create', uri: '/webhooks/orders', actions: ['create']},
+          {topic: 'products/update', uri: 'https://absolute.example.com/webhook', actions: ['update']},
+        ],
+      },
+    }
+    const appConfiguration = {application_url: 'https://tunnel.example.com'}
+
+    const result = transformFromEventsConfig(content, appConfiguration)
+
+    expect(result).toEqual({
+      events: {
+        api_version: '2024-01',
+        subscription: [
+          {topic: 'orders/create', uri: 'https://tunnel.example.com/webhooks/orders', actions: ['create']},
+          {topic: 'products/update', uri: 'https://absolute.example.com/webhook', actions: ['update']},
+        ],
+      },
+    })
+  })
+
+  test('returns content as-is when no application_url in config', () => {
+    const content = {
+      events: {
+        api_version: '2024-01',
+        subscription: [{topic: 'orders/create', uri: '/webhooks/orders', actions: ['create']}],
+      },
+    }
+
+    const result = transformFromEventsConfig(content, {})
+
+    expect(result).toEqual(content)
+  })
+
+  test('returns content as-is when no appConfiguration provided', () => {
+    const content = {
+      events: {
+        api_version: '2024-01',
+        subscription: [{topic: 'orders/create', uri: '/webhooks/orders', actions: ['create']}],
+      },
+    }
 
     const result = transformFromEventsConfig(content)
+
+    expect(result).toEqual(content)
+  })
+
+  test('handles application_url with trailing slash', () => {
+    const content = {
+      events: {
+        api_version: '2024-01',
+        subscription: [{topic: 'orders/create', uri: '/webhooks/orders', actions: ['create']}],
+      },
+    }
+    const appConfiguration = {application_url: 'https://tunnel.example.com/'}
+
+    const result = transformFromEventsConfig(content, appConfiguration)
+
+    expect(result).toEqual({
+      events: {
+        api_version: '2024-01',
+        subscription: [
+          {topic: 'orders/create', uri: 'https://tunnel.example.com/webhooks/orders', actions: ['create']},
+        ],
+      },
+    })
+  })
+
+  test('returns content as-is when subscription array is empty', () => {
+    const content = {
+      events: {
+        api_version: '2024-01',
+        subscription: [],
+      },
+    }
+    const appConfiguration = {application_url: 'https://tunnel.example.com'}
+
+    const result = transformFromEventsConfig(content, appConfiguration)
+
+    expect(result).toEqual(content)
+  })
+
+  test('returns content as-is when no subscriptions', () => {
+    const content = {
+      events: {
+        api_version: '2024-01',
+      },
+    }
+    const appConfiguration = {application_url: 'https://tunnel.example.com'}
+
+    const result = transformFromEventsConfig(content, appConfiguration)
+
+    expect(result).toEqual(content)
+  })
+
+  test('returns content as-is when events is undefined', () => {
+    const content = {}
+    const appConfiguration = {application_url: 'https://tunnel.example.com'}
+
+    const result = transformFromEventsConfig(content, appConfiguration)
 
     expect(result).toEqual(content)
   })

--- a/packages/app/src/cli/models/extensions/specifications/transform/app_config_events.ts
+++ b/packages/app/src/cli/models/extensions/specifications/transform/app_config_events.ts
@@ -1,12 +1,42 @@
+import {prependApplicationUrl} from '../validation/url_prepender.js'
+import {CurrentAppConfiguration} from '../../../app/app.js'
 import {getPathValue} from '@shopify/cli-kit/common/object'
+
+interface EventsConfig {
+  events?: {
+    api_version?: string
+    subscription?: {uri: string; [key: string]: unknown}[]
+  }
+}
 
 /**
  * Transforms the events config from local to remote format.
- * No transformation needed - local config is already in the correct format for the server.
- * The 'identifier' field is server-managed and should not exist in local configs.
+ * Resolves relative URIs (starting with /) by prepending the application_url.
+ * During dev, application_url is set to the tunnel URL, ensuring events
+ * are delivered to the correct endpoint.
  */
-export function transformFromEventsConfig(content: object) {
-  return content
+export function transformFromEventsConfig(content: object, appConfiguration?: object) {
+  const eventsConfig = content as EventsConfig
+
+  if (!eventsConfig.events?.subscription) {
+    return content
+  }
+
+  let appUrl: string | undefined
+  if (appConfiguration && 'application_url' in appConfiguration) {
+    appUrl = (appConfiguration as CurrentAppConfiguration)?.application_url
+  }
+
+  return {
+    ...eventsConfig,
+    events: {
+      ...eventsConfig.events,
+      subscription: eventsConfig.events.subscription.map((sub) => ({
+        ...sub,
+        uri: prependApplicationUrl(sub.uri, appUrl),
+      })),
+    },
+  }
 }
 
 /**
@@ -24,7 +54,8 @@ export function transformToEventsConfig(content: object) {
     return rest
   })
 
-  const events = apiVersion || cleanedSubscriptions ? {api_version: apiVersion, subscription: cleanedSubscriptions} : {}
+  const events =
+    (apiVersion ?? cleanedSubscriptions) ? {api_version: apiVersion, subscription: cleanedSubscriptions} : {}
 
   return {events}
 }


### PR DESCRIPTION
closes: https://github.com/shop/issues-event-foundations/issues/793
### WHY are these changes introduced?

During development, webhook events need to be delivered to the local development server through a tunnel URL. Previously, relative URIs in event subscriptions were not being resolved, causing webhook delivery failures.

### WHAT is this pull request doing?

Implements URI resolution for event subscriptions by modifying `transformFromEventsConfig` to prepend the `application_url` to relative URIs (those starting with `/`). Absolute URIs remain unchanged. The transformation handles edge cases including missing configuration, trailing slashes in application URLs, and empty subscription arrays.

### How to test your changes?

1. Create an app with event subscriptions using relative URIs (e.g., `/webhooks/orders`)
2. Start the development server with a tunnel
3. Verify that the event subscriptions are registered with the full tunnel URL
4. Test with absolute URIs to ensure they remain unchanged
5. Run the test suite to verify all edge cases are handled