### PR TITLE
Update dev-session queries with new schema

### DIFF
--- a/packages/app/src/cli/api/graphql/app-dev/generated/dev-session-create.ts
+++ b/packages/app/src/cli/api/graphql/app-dev/generated/dev-session-create.ts
@@ -14,7 +14,7 @@ export type DevSessionCreateMutation = {
   devSessionCreate?: {
     devSession?: {
       websocketUrl?: string | null
-      updatedAt: string
+      updatedAt: unknown
       user?: {id: string; email?: string | null} | null
       app: {id: string; key: string}
     } | null

--- a/packages/app/src/cli/api/graphql/app-dev/generated/dev-session-update.ts
+++ b/packages/app/src/cli/api/graphql/app-dev/generated/dev-session-update.ts
@@ -15,7 +15,7 @@ export type DevSessionUpdateMutation = {
   devSessionUpdate?: {
     devSession?: {
       websocketUrl?: string | null
-      updatedAt: string
+      updatedAt: unknown
       user?: {id: string; email?: string | null} | null
       app: {id: string; key: string}
     } | null


### PR DESCRIPTION
### WHY are these changes introduced?

The `updatedAt` field in the GraphQL generated types was incorrectly typed as `string`, which may not accurately represent the actual data type returned by the API.

### WHAT is this pull request doing?

Changes the `updatedAt` field type from `string` to `unknown` in the `DevSessionCreateMutation` and `DevSessionUpdateMutation` GraphQL generated types. This provides more flexibility in handling the timestamp data without making assumptions about its format.

### How to test your changes?

1. Run the development session creation flow
2. Verify that TypeScript compilation passes without type errors
3. Test the development session update functionality
4. Ensure that the `updatedAt` field can be properly handled in consuming code

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes