### PR TITLE
add admin section to the hosted app specification

### DIFF
--- a/packages/app/src/cli/models/extensions/specifications/app_config_hosted_app_home.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/app_config_hosted_app_home.test.ts
@@ -7,20 +7,20 @@ vi.mock('@shopify/cli-kit/node/fs')
 
 describe('hosted_app_home', () => {
   describe('transform', () => {
-    test('should return the transformed object with static_root', () => {
+    test('should return the transformed object preserving admin nesting', () => {
       const object = {
-        static_root: 'public',
+        admin: {static_root: 'public'},
       }
       const appConfigSpec = spec
 
       const result = appConfigSpec.transformLocalToRemote!(object, placeholderAppConfiguration)
 
       expect(result).toMatchObject({
-        static_root: 'public',
+        admin: {static_root: 'public'},
       })
     })
 
-    test('should return empty object when static_root is not provided', () => {
+    test('should return empty object when admin.static_root is not provided', () => {
       const object = {}
       const appConfigSpec = spec
 
@@ -31,16 +31,16 @@ describe('hosted_app_home', () => {
   })
 
   describe('reverseTransform', () => {
-    test('should return the reversed transformed object with static_root', () => {
+    test('should return the reversed transformed object preserving admin nesting', () => {
       const object = {
-        static_root: 'public',
+        admin: {static_root: 'public'},
       }
       const appConfigSpec = spec
 
       const result = appConfigSpec.transformRemoteToLocal!(object)
 
       expect(result).toMatchObject({
-        static_root: 'public',
+        admin: {static_root: 'public'},
       })
     })
 
@@ -57,7 +57,7 @@ describe('hosted_app_home', () => {
   describe('copyStaticAssets', () => {
     test('should copy static assets from source to output directory', async () => {
       vi.mocked(copyDirectoryContents).mockResolvedValue(undefined)
-      const config = {static_root: 'public'}
+      const config = {admin: {static_root: 'public'}}
       const directory = '/app/root'
       const outputPath = '/output/dist/bundle.js'
 
@@ -66,7 +66,7 @@ describe('hosted_app_home', () => {
       expect(copyDirectoryContents).toHaveBeenCalledWith('/app/root/public', '/output/dist')
     })
 
-    test('should not copy assets when static_root is not provided', async () => {
+    test('should not copy assets when admin.static_root is not provided', async () => {
       const config = {}
       const directory = '/app/root'
       const outputPath = '/output/dist/bundle.js'
@@ -78,7 +78,7 @@ describe('hosted_app_home', () => {
 
     test('should throw error when copy fails', async () => {
       vi.mocked(copyDirectoryContents).mockRejectedValue(new Error('Permission denied'))
-      const config = {static_root: 'public'}
+      const config = {admin: {static_root: 'public'}}
       const directory = '/app/root'
       const outputPath = '/output/dist/bundle.js'
 
@@ -96,7 +96,7 @@ describe('hosted_app_home', () => {
 
   describe('identifier', () => {
     test('should have correct identifier', () => {
-      expect(spec.identifier).toBe('hosted_app_home')
+      expect(spec.identifier).toBe('admin')
     })
   })
 })

--- a/packages/app/src/cli/models/extensions/specifications/app_config_hosted_app_home.ts
+++ b/packages/app/src/cli/models/extensions/specifications/app_config_hosted_app_home.ts
@@ -5,14 +5,18 @@ import {dirname, joinPath} from '@shopify/cli-kit/node/path'
 import {zod} from '@shopify/cli-kit/node/schema'
 
 const HostedAppHomeSchema = BaseSchemaWithoutHandle.extend({
-  static_root: zod.string().optional(),
+  admin: zod
+    .object({
+      static_root: zod.string().optional(),
+    })
+    .optional(),
 })
 
 const HostedAppHomeTransformConfig: TransformationConfig = {
-  static_root: 'static_root',
+  admin: 'admin',
 }
 
-export const HostedAppHomeSpecIdentifier = 'hosted_app_home'
+export const HostedAppHomeSpecIdentifier = 'admin'
 
 const hostedAppHomeSpec = createConfigExtensionSpecification({
   identifier: HostedAppHomeSpecIdentifier,
@@ -20,8 +24,9 @@ const hostedAppHomeSpec = createConfigExtensionSpecification({
   schema: HostedAppHomeSchema,
   transformConfig: HostedAppHomeTransformConfig,
   copyStaticAssets: async (config, directory, outputPath) => {
-    if (!config.static_root) return
-    const sourceDir = joinPath(directory, config.static_root)
+    const staticRoot = config.admin?.static_root
+    if (!staticRoot) return
+    const sourceDir = joinPath(directory, staticRoot)
     const outputDir = dirname(outputPath)
 
     return copyDirectoryContents(sourceDir, outputDir).catch((error) => {


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

<!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Updates CLI for name change from hosted app -> admin

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?

[See core PR](https://app.graphite.com/github/pr/shop/world/444381/Rename-HostedApp-module-to-Admin-module) for :tophat:

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes