### PR TITLE
On app selection keep retrying when failing but avoid capturing unrelated errors

### DIFF
--- a/packages/app/src/cli/commands/app/init.ts
+++ b/packages/app/src/cli/commands/app/init.ts
@@ -167,6 +167,7 @@ async function selectAppOrNewAppName(
     return {result: 'new', name, org}
   } else {
     const app = await selectAppPrompt(searchForAppsByNameFactory(developerPlatformClient, org.id), apps, hasMorePages)
+    if (!app) throw new AbortError('Unable to select an app: the selection prompt was interrupted.')
 
     const fullSelectedApp = await developerPlatformClient.appFromIdentifiers(app.apiKey)
     if (!fullSelectedApp) throw new AbortError(`App with id ${app.id} not found`)

--- a/packages/app/src/cli/prompts/dev.ts
+++ b/packages/app/src/cli/prompts/dev.ts
@@ -32,7 +32,7 @@ export async function selectAppPrompt(
   options?: {
     directory?: string
   },
-): Promise<MinimalAppIdentifiers> {
+): Promise<MinimalAppIdentifiers | undefined> {
   const tomls = await getTomls(options?.directory)
 
   if (tomls) setCachedCommandTomlMap(tomls)
@@ -64,15 +64,7 @@ export async function selectAppPrompt(
     },
   })
 
-  const appChoice = currentAppChoices.find((app) => app.apiKey === apiKey)!
-
-  if (!appChoice) {
-    throw new Error(
-      `Unable to select an app: the selection prompt was interrupted multiple times./n
-      Api key ${apiKey} was selected but not found in ${currentAppChoices.map((app) => app.apiKey).join(', ')}`,
-    )
-  }
-  return appChoice
+  return currentAppChoices.find((app) => app.apiKey === apiKey)
 }
 
 interface SelectStorePromptOptions {

--- a/packages/app/src/cli/services/dev/select-app.test.ts
+++ b/packages/app/src/cli/services/dev/select-app.test.ts
@@ -3,9 +3,11 @@ import {AppInterface, WebType} from '../../models/app/app.js'
 import {Organization, OrganizationSource} from '../../models/organization.js'
 import {appNamePrompt, createAsNewAppPrompt, selectAppPrompt} from '../../prompts/dev.js'
 import {testApp, testOrganizationApp, testDeveloperPlatformClient} from '../../models/app/app.test-data.js'
+import {BugError} from '@shopify/cli-kit/node/error'
 import {describe, expect, vi, test} from 'vitest'
 
 vi.mock('../../prompts/dev')
+vi.mock('@shopify/cli-kit/node/output')
 
 const LOCAL_APP: AppInterface = testApp({
   directory: '',
@@ -81,5 +83,49 @@ describe('selectOrCreateApp', () => {
     expect(got).toEqual({...APP1, newApp: true})
     expect(appNamePrompt).toHaveBeenCalledWith(LOCAL_APP.name)
     expect(developerPlatformClient.createApp).toHaveBeenCalledWith(ORG1, {name: 'app-name'})
+  })
+
+  test('retries when selectAppPrompt returns undefined and succeeds on next attempt', async () => {
+    // Given
+    vi.mocked(selectAppPrompt).mockResolvedValueOnce(undefined).mockResolvedValueOnce(APPS[0])
+    vi.mocked(createAsNewAppPrompt).mockResolvedValue(false)
+
+    // When
+    const {developerPlatformClient} = mockDeveloperPlatformClient()
+    const got = await selectOrCreateApp(APPS, false, ORG1, developerPlatformClient, {name: LOCAL_APP.name})
+
+    // Then
+    expect(got).toEqual(APP1)
+    expect(selectAppPrompt).toHaveBeenCalledTimes(2)
+  })
+
+  test('throws BugError when selectAppPrompt returns undefined for all attempts', async () => {
+    // Given
+    vi.mocked(selectAppPrompt).mockResolvedValue(undefined)
+    vi.mocked(createAsNewAppPrompt).mockResolvedValue(false)
+
+    // When/Then
+    const {developerPlatformClient} = mockDeveloperPlatformClient()
+    await expect(selectOrCreateApp(APPS, false, ORG1, developerPlatformClient, {name: LOCAL_APP.name})).rejects.toThrow(
+      BugError,
+    )
+    expect(selectAppPrompt).toHaveBeenCalledTimes(2)
+  })
+
+  test('throws BugError when appFromIdentifiers returns undefined for all attempts', async () => {
+    // Given
+    vi.mocked(selectAppPrompt).mockResolvedValue(APPS[0])
+    vi.mocked(createAsNewAppPrompt).mockResolvedValue(false)
+    const developerPlatformClient = testDeveloperPlatformClient({
+      async appFromIdentifiers(_apiKey) {
+        return undefined
+      },
+    })
+
+    // When/Then
+    await expect(selectOrCreateApp(APPS, false, ORG1, developerPlatformClient, {name: LOCAL_APP.name})).rejects.toThrow(
+      BugError,
+    )
+    expect(selectAppPrompt).toHaveBeenCalledTimes(2)
   })
 })

--- a/packages/app/src/cli/services/dev/select-app.ts
+++ b/packages/app/src/cli/services/dev/select-app.ts
@@ -5,7 +5,7 @@ import {getCachedCommandInfo, setCachedCommandTomlPreference} from '../local-sto
 import {CreateAppOptions, DeveloperPlatformClient} from '../../utilities/developer-platform-client.js'
 import {AppConfigurationFileName} from '../../models/app/loader.js'
 import {BugError} from '@shopify/cli-kit/node/error'
-import {outputInfo, outputDebug} from '@shopify/cli-kit/node/output'
+import {outputInfo} from '@shopify/cli-kit/node/output'
 
 const MAX_PROMPT_RETRIES = 2
 
@@ -51,52 +51,33 @@ export async function selectOrCreateApp(
     const tomls = (cachedData?.tomls as {[key: string]: AppConfigurationFileName}) ?? {}
 
     for (let attempt = 0; attempt < MAX_PROMPT_RETRIES; attempt++) {
-      try {
-        // eslint-disable-next-line no-await-in-loop
-        const app = await selectAppPrompt(
-          searchForAppsByNameFactory(developerPlatformClient, org.id),
-          apps,
-          hasMorePages,
-          {directory: options.directory},
-        )
+      // eslint-disable-next-line no-await-in-loop
+      const app = await selectAppPrompt(
+        searchForAppsByNameFactory(developerPlatformClient, org.id),
+        apps,
+        hasMorePages,
+        {directory: options.directory},
+      )
 
+      if (!app) {
+        if (attempt < MAX_PROMPT_RETRIES - 1) outputInfo('App selection failed. Retrying...')
+        continue
+      } else {
         const selectedToml = tomls[app.apiKey]
         if (selectedToml) setCachedCommandTomlPreference(selectedToml)
 
         // eslint-disable-next-line no-await-in-loop
         const fullSelectedApp = await developerPlatformClient.appFromIdentifiers(app.apiKey)
 
-        if (!fullSelectedApp) {
-          throw new BugError(
-            `Unable to fetch app ${app.apiKey} from Shopify`,
-            'Try running `shopify app config link` to connect to an app you have access to.',
-          )
-        }
-
-        return fullSelectedApp
-      } catch (error) {
-        // Don't retry BugError - those indicate actual bugs, not transient issues
-        if (error instanceof BugError) {
-          throw error
-        }
-
-        const errorObj = error as Error
-
-        // Log each attempt for observability
-        outputDebug(`App selection attempt ${attempt + 1}/${MAX_PROMPT_RETRIES} failed: ${errorObj.message}`)
-
-        // If we have retries left, inform user and retry
-        if (attempt < MAX_PROMPT_RETRIES - 1) {
-          outputInfo('App selection failed. Retrying...')
-        } else {
-          throw new BugError(errorObj.message, TRY_MESSAGE)
+        if (fullSelectedApp) {
+          return fullSelectedApp
         }
       }
     }
 
     // User-facing error message with key diagnostic info
     const errorMessage = [
-      'Unable to select an app: the selection prompt was interrupted multiple times.',
+      'Unable to select an app: the selection prompt failed multiple times.',
       '',
       `Available apps: ${apps.length}`,
     ].join('\n')


### PR DESCRIPTION
### WHY are these changes introduced?

[Vault Error](https://vault.shopify.io/teams/16949-Dev-Experience/issues/15250-error-unable-to-select-an-app-the-selection-prompt-was-interrupted-multiple-times-n-api-key-b63658c9ac9ed829afa377cd4b20e574-was-selected-but-not-found-in)

GH [Issue #15725](https://github.com/shop/issues/issues/15725)

[Observe link](https://observe.shopify.io/a/observe/errors/690203412664924336?r=%7B%22from%22%3A%22now-3d%22%2C%22to%22%3A%22now%22%7D&tz=browser&f=%7B%7D)

The app selection logic contained redundant error handling and retry mechanisms that were making the code unnecessarily complex and potentially masking actual issues during the selection process.

### WHAT is this pull request doing?

- Removes redundant error checking in `selectAppPrompt` function that was checking for null after using the non-null assertion operator
- Simplifies the retry logic in `selectOrCreateApp` by removing try-catch blocks and letting natural control flow handle retries
- Updates error message from "interrupted" to "failed" to better reflect the actual failure condition
- Streamlines the app selection flow while maintaining the same retry behavior

### How to test your changes?

1. Run `shopify app dev` in a project directory
2. Go through the app selection prompt
3. Verify that app selection works normally
4. Test edge cases where app selection might fail to ensure retry logic still functions
5. Confirm error messages are clear and helpful when selection ultimately fails

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes