### PR TITLE
Stringify query parsing in GraphiQL

### DIFF
--- a/packages/app/src/cli/services/dev/graphiql/server.ts
+++ b/packages/app/src/cli/services/dev/graphiql/server.ts
@@ -168,8 +168,8 @@ export function setupGraphiQLServer({
         {
           url,
           defaultQueries: [{query: defaultQuery}],
-          query,
-          variables,
+          query: query ? JSON.stringify(query) : undefined,
+          variables: variables ? JSON.stringify(variables) : undefined,
         },
       ),
     )

--- a/packages/app/src/cli/services/dev/graphiql/templates/graphiql.tsx
+++ b/packages/app/src/cli/services/dev/graphiql/templates/graphiql.tsx
@@ -252,10 +252,10 @@ export function graphiqlTemplate({
             }),
             defaultEditorToolsVisibility: true,
             {% if query %}
-            query: '{{query}}',
+            query: {{query}},
             {% endif %}
             {% if variables %}
-            variables: '{{variables}}',
+            variables: {{variables}},
             {% endif %}
             defaultTabs: [
               {query: "${graphiqlIntroMessage


### PR DESCRIPTION
### WHY are these changes introduced?

The GraphiQL dev server reflects URL query parameters (`query`, `variables`) into an inline `<script>` block via Liquid `{{ }}` interpolation without JavaScript-string escaping. Since `liquidjs` does not HTML-escape by default and the values sit inside a `<script>` context, this is a reflected XSS sink. An attacker can craft a URL that breaks out of the JS string literal and executes arbitrary code in the GraphiQL origin, which has same-origin access to the Admin API proxy endpoint.

### WHAT is this pull request doing?

`JSON.stringify` the `query` and `variables` values before passing them to the Liquid template, and remove the manual single-quote wrapping in the template. `JSON.stringify` properly escapes quotes, backslashes, `</script>`, and all other JS metacharacters, producing a safe string literal for inline script injection.

### How to test your changes?

1. Run `shopify app dev` and open GraphiQL
2. Verify normal `?query=...` prefill still works (e.g. `?query={shop{name}}`)
3. Verify a payload like `?query='+alert(1)+'` renders as an inert string value in the editor rather than executing

![image.png](https://app.graphite.com/user-attachments/assets/e80dfdf3-d514-46fe-b274-d7d149ab2af3.png)

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes