### PR TITLE
Refactor createConfigExtensionSpecification to support direct deployConfig and transform params

### DIFF
--- a/packages/app/src/cli/models/extensions/specification.integration.test.ts
+++ b/packages/app/src/cli/models/extensions/specification.integration.test.ts
@@ -1,7 +1,13 @@
 import {loadLocalExtensionsSpecifications} from './load-specifications.js'
-import {configWithoutFirstClassFields, createContractBasedModuleSpecification} from './specification.js'
+import {
+  configWithoutFirstClassFields,
+  createConfigExtensionSpecification,
+  createContractBasedModuleSpecification,
+} from './specification.js'
+import {BaseSchemaWithoutHandle} from './schemas.js'
 import {AppSchema} from '../app/app.js'
 import {describe, test, expect, beforeAll} from 'vitest'
+import {zod} from '@shopify/cli-kit/node/schema'
 
 // If the AppSchema is not instanced, the dynamic loading of loadLocalExtensionsSpecifications is not working
 beforeAll(() => {
@@ -45,6 +51,70 @@ describe('createContractBasedModuleSpecification', () => {
       }),
     )
     expect(got.appModuleFeatures()).toEqual(['localization'])
+  })
+})
+
+describe('createConfigExtensionSpecification', () => {
+  const TestSchema = BaseSchemaWithoutHandle.extend({
+    name: zod.string().optional(),
+    handle: zod.string().optional(),
+  })
+
+  test('derives transforms from transformConfig when direct params are not provided', () => {
+    const spec = createConfigExtensionSpecification({
+      identifier: 'test-module',
+      schema: TestSchema,
+      transformConfig: {server_name: 'name'},
+    })
+
+    // Forward transform maps TOML field names to server field names
+    const transformed = spec.transformLocalToRemote!({name: 'My App'}, {} as any)
+    expect(transformed).toEqual({server_name: 'My App'})
+
+    // Reverse transform maps server field names back to TOML
+    const reversed = spec.transformRemoteToLocal!({server_name: 'My App'})
+    expect(reversed).toEqual({name: 'My App'})
+
+    expect(spec.experience).toBe('configuration')
+    expect(spec.uidStrategy).toBe('single')
+  })
+
+  test('uses deployConfig and transformRemoteToLocal directly when provided without transformConfig', () => {
+    const spec = createConfigExtensionSpecification({
+      identifier: 'test-module',
+      schema: TestSchema,
+      deployConfig: async (config) => ({name: (config as any).name}),
+      transformRemoteToLocal: (content: object) => ({
+        name: (content as any).server_name,
+      }),
+    })
+
+    // No forward transform — deployConfig handles the deploy path instead
+    expect(spec.transformLocalToRemote).toBeUndefined()
+
+    // Reverse transform is the directly provided function
+    const reversed = spec.transformRemoteToLocal!({server_name: 'My App'})
+    expect(reversed).toEqual({name: 'My App'})
+
+    // deployConfig is set
+    expect(spec.deployConfig).toBeDefined()
+  })
+
+  test('direct params take precedence over transformConfig-derived values', () => {
+    const directForward = (obj: object) => ({overridden: true})
+    const directReverse = (obj: object) => ({overridden: true})
+
+    const spec = createConfigExtensionSpecification({
+      identifier: 'test-module',
+      schema: TestSchema,
+      transformConfig: {server_name: 'name'},
+      transformLocalToRemote: directForward,
+      transformRemoteToLocal: directReverse,
+    })
+
+    // Direct params win over transformConfig-derived values
+    expect(spec.transformLocalToRemote!({name: 'test'}, {} as any)).toEqual({overridden: true})
+    expect(spec.transformRemoteToLocal!({server_name: 'test'})).toEqual({overridden: true})
   })
 })
 

--- a/packages/app/src/cli/models/extensions/specification.ts
+++ b/packages/app/src/cli/models/extensions/specification.ts
@@ -246,20 +246,30 @@ export function createConfigExtensionSpecification<TConfiguration extends BaseCo
   identifier: string
   schema: ZodSchemaType<TConfiguration>
   appModuleFeatures?: (config?: TConfiguration) => ExtensionFeature[]
-  transformConfig: TransformationConfig | CustomTransformationConfig
+  transformConfig?: TransformationConfig | CustomTransformationConfig
+  deployConfig?: ExtensionSpecification<TConfiguration>['deployConfig']
+  transformLocalToRemote?: ExtensionSpecification<TConfiguration>['transformLocalToRemote']
+  transformRemoteToLocal?: ExtensionSpecification<TConfiguration>['transformRemoteToLocal']
   uidStrategy?: UidStrategy
   getDevSessionUpdateMessages?: (config: TConfiguration) => Promise<string[]>
   patchWithAppDevURLs?: (config: TConfiguration, urls: ApplicationURLs) => void
 }): ExtensionSpecification<TConfiguration> {
   const appModuleFeatures = spec.appModuleFeatures ?? (() => [])
+
+  const transformLocalToRemote =
+    spec.transformLocalToRemote ?? (spec.transformConfig ? resolveAppConfigTransform(spec.transformConfig) : undefined)
+  const transformRemoteToLocal =
+    spec.transformRemoteToLocal ?? resolveReverseAppConfigTransform(spec.schema, spec.transformConfig)
+
   return createExtensionSpecification({
     identifier: spec.identifier,
     // This casting is required because `name` and `type` are mandatory for the existing extension spec configurations,
     // however, app config extensions config content is parsed from the `shopify.app.toml`
     schema: spec.schema,
     appModuleFeatures,
-    transformLocalToRemote: resolveAppConfigTransform(spec.transformConfig),
-    transformRemoteToLocal: resolveReverseAppConfigTransform(spec.schema, spec.transformConfig),
+    deployConfig: spec.deployConfig,
+    transformLocalToRemote,
+    transformRemoteToLocal,
     experience: 'configuration',
     uidStrategy: spec.uidStrategy ?? 'single',
     getDevSessionUpdateMessages: spec.getDevSessionUpdateMessages,


### PR DESCRIPTION
## Summary

Refactors `createConfigExtensionSpecification` to accept optional `deployConfig`, `transformLocalToRemote`, and `transformRemoteToLocal` parameters directly, alongside the existing `transformConfig`. This is a **prerequisite** for the [app module contracts migration](https://github.com/Shopify/extensions/discussions/3277) — it unblocks all per-module PRs (#6909–#6915).

## Why this is necessary

Today, `createConfigExtensionSpecification` derives both forward (`transformLocalToRemote`) and reverse (`transformRemoteToLocal`) transforms from a single `transformConfig` parameter. There is **no way to express "no forward transform"** — `resolveAppConfigTransform` always returns a function.

The contract migration requires exactly this: each core app config module needs to stop sending CLI-transformed payloads and instead send TOML-shaped data directly via `deployConfig`, while **preserving** the reverse transform (since the server still returns Layer 2 field names and `app config link/pull` depends on `transformRemoteToLocal`).

Without this change, per-module migrations would have to either:
1. Hack `transformConfig` with dummy forward functions that are never called
2. Switch to `createContractBasedModuleSpecification`, which removes the reverse transform entirely and **breaks `app config link` and `app config pull`**

### What changes

`createConfigExtensionSpecification` now accepts three new optional parameters:

- **`deployConfig`** — passed through to the extension spec. When set, the deploy path uses this instead of `transformLocalToRemote` (the existing fallback chain in `extension-instance.ts:211` is `deployConfig ?? transformLocalToRemote ?? undefined`).
- **`transformLocalToRemote`** — overrides the forward transform derived from `transformConfig`. Can be left `undefined` to express "no forward transform."
- **`transformRemoteToLocal`** — overrides the reverse transform derived from `transformConfig`.

Resolution logic:
```
transformLocalToRemote = direct param ?? (derive from transformConfig if present) ?? undefined
transformRemoteToLocal = direct param ?? derive from transformConfig/schema
```

### Backward compatibility

- `transformConfig` is now optional but fully supported — all existing specs using it are unchanged
- When only `transformConfig` is provided, behavior is identical to before
- Direct params take precedence over `transformConfig`-derived values when both are provided
- No existing spec files are modified in this PR

### How per-module PRs (#6909–#6915) use this

Each module migrates from:
```ts
createConfigExtensionSpecification({
  identifier: 'branding',
  schema: BrandingSchema,
  transformConfig: {name: 'name', app_handle: 'handle'},
})
```

To:
```ts
createConfigExtensionSpecification({
  identifier: 'branding',
  schema: BrandingSchema,
  deployConfig: async (config) => configWithoutFirstClassFields(config),
  transformRemoteToLocal: (content: object) => ({
    name: (content as {name: string}).name,
    handle: (content as {app_handle: string}).app_handle,
  }),
})
```

This sends TOML-shaped data directly (via `deployConfig`), with no forward transform. The server's write adapter normalizes to Layer 2 for storage. The reverse transform is preserved for `app config link/pull`.

## Test plan

- [x] Existing `transformConfig` usage still derives both transforms correctly
- [x] `deployConfig` + `transformRemoteToLocal` work without `transformConfig` (forward transform is `undefined`)
- [x] Direct params take precedence over `transformConfig`-derived values
- [x] All 47 existing specification integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>