### PR TITLE
Migrate point_of_sale spec to deployConfig + transformRemoteToLocal

### DIFF
--- a/packages/app/src/cli/models/extensions/extension-instance.test.ts
+++ b/packages/app/src/cli/models/extensions/extension-instance.test.ts
@@ -246,7 +246,7 @@ describe('deployConfig', async () => {
       appConfiguration: placeholderAppConfiguration,
     })
 
-    expect(got).toMatchObject({embedded: true})
+    expect(got).toMatchObject({pos: {embedded: true}})
   })
 
   test('returns undefined when the transformed config is empty', async () => {

--- a/packages/app/src/cli/models/extensions/specifications/app_config_point_of_sale.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/app_config_point_of_sale.test.ts
@@ -1,25 +1,10 @@
 import spec from './app_config_point_of_sale.js'
-import {placeholderAppConfiguration} from '../../app/app.test-data.js'
 import {describe, expect, test} from 'vitest'
 
 describe('app_cofig_point_of_sale', () => {
-  describe('transform', () => {
-    test('should return the transformed object', () => {
-      // Given
-      const object = {
-        pos: {
-          embedded: true,
-        },
-      }
-      const appConfigSpec = spec
-
-      // When
-      const result = appConfigSpec.transformLocalToRemote!(object, placeholderAppConfiguration)
-
-      // Then
-      expect(result).toMatchObject({
-        embedded: true,
-      })
+  describe('transformLocalToRemote', () => {
+    test('should be undefined since deployConfig is used instead', () => {
+      expect(spec.transformLocalToRemote).toBeUndefined()
     })
   })
 

--- a/packages/app/src/cli/models/extensions/specifications/app_config_point_of_sale.ts
+++ b/packages/app/src/cli/models/extensions/specifications/app_config_point_of_sale.ts
@@ -1,4 +1,4 @@
-import {createConfigExtensionSpecification, TransformationConfig} from '../specification.js'
+import {createConfigExtensionSpecification, configWithoutFirstClassFields} from '../specification.js'
 import {BaseSchemaWithoutHandle} from '../schemas.js'
 import {zod} from '@shopify/cli-kit/node/schema'
 
@@ -12,14 +12,14 @@ const PosConfigurationSchema = BaseSchemaWithoutHandle.extend({
 
 export const PosSpecIdentifier = 'point_of_sale'
 
-const PosTransformConfig: TransformationConfig = {
-  embedded: 'pos.embedded',
-}
-
 const appPOSSpec = createConfigExtensionSpecification({
   identifier: PosSpecIdentifier,
   schema: PosConfigurationSchema,
-  transformConfig: PosTransformConfig,
+  deployConfig: async (config) => {
+    const {name, ...rest} = configWithoutFirstClassFields(config)
+    return rest
+  },
+  transformRemoteToLocal: (content: object) => ({pos: {embedded: (content as {embedded: boolean}).embedded}}),
 })
 
 export default appPOSSpec

--- a/packages/app/src/cli/services/deploy.test.ts
+++ b/packages/app/src/cli/services/deploy.test.ts
@@ -453,7 +453,7 @@ describe('deploy', () => {
       appModules: [
         {
           uuid: extensionNonUuidManaged.localIdentifier,
-          config: JSON.stringify({embedded: true}),
+          config: JSON.stringify({pos: {embedded: true}}),
           context: '',
           handle: extensionNonUuidManaged.handle,
           specificationIdentifier: undefined,


### PR DESCRIPTION
## Summary
- Remove `transformConfig` from point_of_sale spec, set `deployConfig` (pass-through with `configWithoutFirstClassFields`) and `transformRemoteToLocal` directly
- `transformLocalToRemote` is now `undefined` — TOML shape sent directly to server
- Part of the [app module contracts migration](https://github.com/Shopify/cli/blob/02-27-rcb_contract-migration-1/plan.md)

## Test plan
- [x] Existing reverse transform test passes unchanged
- [x] New test verifies `transformLocalToRemote` is `undefined`

🤖 Generated with [Claude Code](https://claude.com/claude-code)