### PR TITLE
Migrate branding spec to deployConfig + transformRemoteToLocal

### DIFF
--- a/packages/app/src/cli/models/extensions/specifications/app_config_branding.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/app_config_branding.test.ts
@@ -1,25 +1,25 @@
 import spec from './app_config_branding.js'
-import {placeholderAppConfiguration} from '../../app/app.test-data.js'
 import {describe, expect, test} from 'vitest'
 
 describe('branding', () => {
   describe('transform', () => {
-    test('should return the transformed object', () => {
-      // Given
-      const object = {
+    test('transformLocalToRemote should be undefined', () => {
+      expect(spec.transformLocalToRemote).toBeUndefined()
+    })
+  })
+
+  describe('deployConfig', () => {
+    test('should preserve both name and handle in deploy payload', async () => {
+      const config = {
+        type: 'branding',
+        uid: 'branding',
+        path: '/test',
+        extensions: {},
         name: 'my-app',
         handle: 'my-app-handle',
       }
-      const appConfigSpec = spec
-
-      // When
-      const result = appConfigSpec.transformLocalToRemote!(object, placeholderAppConfiguration)
-
-      // Then
-      expect(result).toMatchObject({
-        name: 'my-app',
-        app_handle: 'my-app-handle',
-      })
+      const result = await spec.deployConfig!(config as any, '', '', undefined)
+      expect(result).toEqual({name: 'my-app', handle: 'my-app-handle'})
     })
   })
 

--- a/packages/app/src/cli/models/extensions/specifications/app_config_branding.ts
+++ b/packages/app/src/cli/models/extensions/specifications/app_config_branding.ts
@@ -1,4 +1,4 @@
-import {TransformationConfig, createConfigExtensionSpecification} from '../specification.js'
+import {configWithoutFirstClassFields, createConfigExtensionSpecification} from '../specification.js'
 import {BaseSchemaWithoutHandle} from '../schemas.js'
 import {zod} from '@shopify/cli-kit/node/schema'
 
@@ -13,17 +13,23 @@ const BrandingSchema = BaseSchemaWithoutHandle.extend({
     .optional(),
 })
 
-const BrandingTransformConfig: TransformationConfig = {
-  name: 'name',
-  app_handle: 'handle',
-}
-
 export const BrandingSpecIdentifier = 'branding'
 
 const appBrandingSpec = createConfigExtensionSpecification({
   identifier: BrandingSpecIdentifier,
   schema: BrandingSchema,
-  transformConfig: BrandingTransformConfig,
+  deployConfig: async (config) => {
+    // Use configWithoutFirstClassFields to strip type/handle/uid/path/extensions,
+    // then re-add handle since it's real branding data (not just a base field)
+    const stripped = configWithoutFirstClassFields(config)
+    const handle = (config as {handle?: string}).handle
+    if (handle === undefined) return stripped
+    return {...stripped, handle}
+  },
+  transformRemoteToLocal: (content: object) => ({
+    name: (content as {name?: string}).name,
+    handle: (content as {app_handle?: string}).app_handle,
+  }),
 })
 
 export default appBrandingSpec


### PR DESCRIPTION
## Summary
- Remove `transformConfig` from branding spec, set `deployConfig` and `transformRemoteToLocal` directly
- Reverse transform maps `app_handle` → `handle`, `name` → `name`
- `transformLocalToRemote` is now `undefined`
- Part of the [app module contracts migration](https://github.com/Shopify/cli/blob/02-27-rcb_contract-migration-1/plan.md)

## Test plan
- [x] Reverse transform test passes unchanged
- [x] New test verifies `transformLocalToRemote` is `undefined`

🤖 Generated with [Claude Code](https://claude.com/claude-code)