### PR TITLE
Migrate app_home spec to deployConfig + transformRemoteToLocal

### DIFF
--- a/packages/app/src/cli/models/app/app.test.ts
+++ b/packages/app/src/cli/models/app/app.test.ts
@@ -884,7 +884,7 @@ describe('manifest', () => {
           assets: appHome.uid,
           target: appHome.contextValue,
           config: expect.objectContaining({
-            app_url: 'https://new-url.io',
+            application_url: 'https://new-url.io',
           }),
         },
         {
@@ -942,8 +942,9 @@ describe('manifest', () => {
           assets: appHome.uid,
           target: appHome.contextValue,
           config: {
-            app_url: 'https://example.com',
+            application_url: 'https://example.com',
             embedded: true,
+            metafields: [],
           },
         },
       ],

--- a/packages/app/src/cli/models/extensions/specifications/app_config_app_home.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/app_config_app_home.test.ts
@@ -1,30 +1,11 @@
 import spec from './app_config_app_home.js'
-import {placeholderAppConfiguration} from '../../app/app.test-data.js'
 import {describe, expect, test} from 'vitest'
 
 describe('app_home', () => {
   describe('transform', () => {
-    test('should return the transformed object', () => {
-      // Given
-      const object = {
-        application_url: 'https://my-app-url.dev',
-        embedded: true,
-        app_preferences: {
-          url: 'https://my-preferences-url.dev',
-        },
-      }
-
+    test('transformLocalToRemote should be undefined', () => {
       const appConfigSpec = spec
-
-      // When
-      const result = appConfigSpec.transformLocalToRemote!(object, placeholderAppConfiguration)
-
-      // Then
-      expect(result).toMatchObject({
-        app_url: 'https://my-app-url.dev',
-        embedded: true,
-        preferences_url: 'https://my-preferences-url.dev',
-      })
+      expect(appConfigSpec.transformLocalToRemote).toBeUndefined()
     })
   })
 

--- a/packages/app/src/cli/models/extensions/specifications/app_config_app_home.ts
+++ b/packages/app/src/cli/models/extensions/specifications/app_config_app_home.ts
@@ -1,6 +1,7 @@
 import {validateUrl} from '../../app/validation/common.js'
 import {BaseSchemaWithoutHandle} from '../schemas.js'
-import {TransformationConfig, createConfigExtensionSpecification} from '../specification.js'
+import {configWithoutFirstClassFields, createConfigExtensionSpecification} from '../specification.js'
+import {getPathValue, setPathValue} from '@shopify/cli-kit/common/object'
 import {zod} from '@shopify/cli-kit/node/schema'
 
 const AppHomeSchema = BaseSchemaWithoutHandle.extend({
@@ -13,18 +14,25 @@ const AppHomeSchema = BaseSchemaWithoutHandle.extend({
     .optional(),
 })
 
-const AppHomeTransformConfig: TransformationConfig = {
-  app_url: 'application_url',
-  embedded: 'embedded',
-  preferences_url: 'app_preferences.url',
-}
-
 export const AppHomeSpecIdentifier = 'app_home'
 
 const appHomeSpec = createConfigExtensionSpecification({
   identifier: AppHomeSpecIdentifier,
   schema: AppHomeSchema,
-  transformConfig: AppHomeTransformConfig,
+  deployConfig: async (config) => {
+    const {name, ...rest} = configWithoutFirstClassFields(config)
+    return rest
+  },
+  transformRemoteToLocal: (remoteContent: object) => {
+    const result: {[key: string]: unknown} = {}
+    const appUrl = getPathValue(remoteContent, 'app_url')
+    if (appUrl !== undefined) result.application_url = appUrl
+    const embedded = getPathValue(remoteContent, 'embedded')
+    if (embedded !== undefined) result.embedded = embedded
+    const preferencesUrl = getPathValue(remoteContent, 'preferences_url')
+    if (preferencesUrl !== undefined) setPathValue(result, 'app_preferences.url', preferencesUrl)
+    return result
+  },
   patchWithAppDevURLs: (config, urls) => {
     config.application_url = urls.applicationUrl
   },


### PR DESCRIPTION
## Summary
- Remove `transformConfig` from app_home spec, set `deployConfig` and `transformRemoteToLocal` directly
- Reverse transform maps `app_url` → `application_url`, `preferences_url` → `app_preferences.url`
- `transformLocalToRemote` is now `undefined`
- Part of the [app module contracts migration](https://github.com/Shopify/cli/blob/02-27-rcb_contract-migration-1/plan.md)

## Test plan
- [x] Reverse transform test passes unchanged
- [x] New test verifies `transformLocalToRemote` is `undefined`

🤖 Generated with [Claude Code](https://claude.com/claude-code)