### PR TITLE
Migrate app_proxy spec to deployConfig + transformRemoteToLocal

### DIFF
--- a/packages/app/src/cli/models/app/app.test.ts
+++ b/packages/app/src/cli/models/app/app.test.ts
@@ -877,38 +877,34 @@ describe('manifest', () => {
       name: 'my-app',
       handle: '',
       modules: [
-        {
+        expect.objectContaining({
           type: 'app_home_external',
           handle: 'app_home',
           uid: appHome.uid,
-          assets: appHome.uid,
-          target: appHome.contextValue,
           config: expect.objectContaining({
             application_url: 'https://new-url.io',
           }),
-        },
-        {
+        }),
+        expect.objectContaining({
           type: 'app_proxy_external',
           handle: 'app_proxy',
           uid: appProxy.uid,
-          assets: appProxy.uid,
-          target: appProxy.contextValue,
           config: expect.objectContaining({
-            url: 'https://new-proxy-url.io',
-            subpath: '/updated-path',
-            prefix: 'updated-prefix',
+            app_proxy: expect.objectContaining({
+              url: 'https://new-proxy-url.io',
+              subpath: '/updated-path',
+              prefix: 'updated-prefix',
+            }),
           }),
-        },
-        {
+        }),
+        expect.objectContaining({
           type: 'app_access_external',
           handle: 'app_access',
           uid: appAccess.uid,
-          assets: appAccess.uid,
-          target: appAccess.contextValue,
           config: expect.objectContaining({
             auth: {redirect_urls: ['https://new-url.io/auth/callback']},
           }),
-        },
+        }),
       ],
     })
   })

--- a/packages/app/src/cli/models/extensions/specifications/app_config_app_proxy.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/app_config_app_proxy.test.ts
@@ -1,67 +1,9 @@
 import spec, {type AppProxyConfigType} from './app_config_app_proxy.js'
-import {placeholderAppConfiguration} from '../../app/app.test-data.js'
-import {AppConfigurationWithoutPath} from '../../app/app.js'
 import {describe, expect, test} from 'vitest'
 
 describe('app_config_app_proxy', () => {
-  describe('transform', () => {
-    test('should return the transformed object', () => {
-      // Given
-      const object = {
-        app_proxy: {
-          url: 'https://my-proxy-new.dev',
-          subpath: 'subpath-whatever',
-          prefix: 'apps',
-        },
-      }
-      const appConfigSpec = spec
-
-      // When
-      const result = appConfigSpec.transformLocalToRemote!(object, placeholderAppConfiguration)
-
-      // Then
-      expect(result).toMatchObject({
-        url: 'https://my-proxy-new.dev',
-        subpath: 'subpath-whatever',
-        prefix: 'apps',
-      })
-    })
-
-    test('when a relative URL is used, it inherits the application_url', () => {
-      // Given
-      const object = {
-        app_proxy: {
-          url: '/api/proxy',
-          subpath: 'tools',
-          prefix: 'apps',
-        },
-      }
-      const appConfigSpec = spec
-
-      // When
-      const result = appConfigSpec.transformLocalToRemote!(object, {
-        application_url: 'https://my-app-url.com/',
-      } as unknown as AppConfigurationWithoutPath)
-
-      // Then
-      expect(result).toMatchObject({
-        url: 'https://my-app-url.com/api/proxy',
-        subpath: 'tools',
-        prefix: 'apps',
-      })
-    })
-
-    test('returns empty object when app_proxy is not configured', () => {
-      // Given
-      const object = {}
-      const appConfigSpec = spec
-
-      // When
-      const result = appConfigSpec.transformLocalToRemote!(object, placeholderAppConfiguration)
-
-      // Then
-      expect(result).toEqual({})
-    })
+  test('transformLocalToRemote is not defined', () => {
+    expect(spec.transformLocalToRemote).toBeUndefined()
   })
 
   describe('reverseTransform', () => {

--- a/packages/app/src/cli/models/extensions/specifications/app_config_app_proxy.ts
+++ b/packages/app/src/cli/models/extensions/specifications/app_config_app_proxy.ts
@@ -1,13 +1,11 @@
-import {prependApplicationUrl} from './validation/url_prepender.js'
 import {removeTrailingSlash} from './validation/common.js'
 import {validateRelativeUrl} from '../../app/validation/common.js'
 import {
   ExtensionSpecification,
-  CustomTransformationConfig,
   createConfigExtensionSpecification,
+  configWithoutFirstClassFields,
 } from '../specification.js'
 import {BaseSchemaWithoutHandle} from '../schemas.js'
-import {CurrentAppConfiguration} from '../../app/app.js'
 import {zod} from '@shopify/cli-kit/node/schema'
 
 const AppProxySchema = BaseSchemaWithoutHandle.extend({
@@ -27,25 +25,14 @@ export type AppProxyConfigType = zod.infer<typeof AppProxySchema>
 
 export const AppProxySpecIdentifier = 'app_proxy'
 
-const AppProxyTransformConfig: CustomTransformationConfig = {
-  forward: (content, appConfiguration) => {
-    const appProxyConfig = content as {app_proxy?: {url: string; subpath: string; prefix: string}}
-
-    if (!appProxyConfig.app_proxy) {
-      return {}
-    }
-
-    let appUrl: string | undefined
-    if ('application_url' in appConfiguration) {
-      appUrl = (appConfiguration as CurrentAppConfiguration)?.application_url
-    }
-    return {
-      url: prependApplicationUrl(appProxyConfig.app_proxy.url, appUrl),
-      subpath: appProxyConfig.app_proxy.subpath,
-      prefix: appProxyConfig.app_proxy.prefix,
-    }
+const appProxySpec: ExtensionSpecification = createConfigExtensionSpecification({
+  identifier: AppProxySpecIdentifier,
+  schema: AppProxySchema,
+  deployConfig: async (config) => {
+    const {name, ...rest} = configWithoutFirstClassFields(config)
+    return rest
   },
-  reverse: (content) => {
+  transformRemoteToLocal: (content) => {
     const proxyConfig = content as {url: string; subpath: string; prefix: string}
     return {
       app_proxy: {
@@ -55,12 +42,6 @@ const AppProxyTransformConfig: CustomTransformationConfig = {
       },
     }
   },
-}
-
-const appProxySpec: ExtensionSpecification = createConfigExtensionSpecification({
-  identifier: AppProxySpecIdentifier,
-  schema: AppProxySchema,
-  transformConfig: AppProxyTransformConfig,
   getDevSessionUpdateMessages: async (config) => {
     if (!config.app_proxy) {
       return []


### PR DESCRIPTION
## Summary
- Remove `transformConfig` from app_proxy spec, including `prependApplicationUrl` forward logic
- Set `deployConfig` and `transformRemoteToLocal` directly (flat `url`/`prefix`/`subpath` → nested `app_proxy`)
- `transformLocalToRemote` is now `undefined` — server handles URL resolution
- Part of the [app module contracts migration](https://github.com/Shopify/cli/blob/02-27-rcb_contract-migration-1/plan.md)

## Test plan
- [x] Reverse transform test passes unchanged
- [x] Forward transform tests removed (transformLocalToRemote is undefined)
- [x] `getDevSessionUpdateMessages` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)