### PR TITLE
Fix theme dev shortcut to editor tracking non page requests

### DIFF
--- a/.changeset/eighty-papers-hunt.md
+++ b/.changeset/eighty-papers-hunt.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Fix theme editor shortcut tracking fetch requests instead of page navigation

--- a/packages/theme/src/cli/utilities/theme-environment/html.test.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/html.test.ts
@@ -39,12 +39,12 @@ describe('getHtmlHandler', async () => {
     lastRequestedPath: '',
   } as unknown as DevServerContext
 
-  test('sets lastRequestedPath to the rendering URL', async () => {
+  test('sets lastRequestedPath when Sec-Fetch-Mode is navigate', async () => {
     const handler = getHtmlHandler(theme, ctx)
 
     expect(ctx.lastRequestedPath).toStrictEqual('')
 
-    const event = createH3Event('GET', '/search?q=foo&options%5Bprefix%5D=last')
+    const event = createH3Event('GET', '/search?q=foo&options%5Bprefix%5D=last', {'sec-fetch-mode': 'navigate'})
 
     vi.mocked(render).mockResolvedValueOnce(
       new Response('', {
@@ -58,6 +58,24 @@ describe('getHtmlHandler', async () => {
     await handler(event)
 
     expect(ctx.lastRequestedPath).toStrictEqual('/search?q=foo&options%5Bprefix%5D=last')
+  })
+
+  test('does not update lastRequestedPath when Sec-Fetch-Mode is not navigate', async () => {
+    const handler = getHtmlHandler(theme, ctx)
+    ctx.lastRequestedPath = '/previous-page'
+
+    const event = createH3Event('GET', '/search/suggest?q=foo&resources[type]=product', {'sec-fetch-mode': 'cors'})
+
+    vi.mocked(render).mockResolvedValueOnce(
+      new Response('', {
+        status: 200,
+        headers: {'x-request-id': 'test-request-id'},
+      }),
+    )
+
+    await handler(event)
+
+    expect(ctx.lastRequestedPath).toStrictEqual('/previous-page')
   })
 
   test('the development server session recovers when a theme id mismatch occurs', async () => {

--- a/packages/theme/src/cli/utilities/theme-environment/html.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/html.ts
@@ -24,7 +24,9 @@ export function getHtmlHandler(theme: Theme, ctx: DevServerContext): EventHandle
   return defineEventHandler((event) => {
     const [browserPathname = '/', browserSearch = ''] = event.path.split('?')
 
-    ctx.lastRequestedPath = event.path
+    if (isNavigationRequest(event)) {
+      ctx.lastRequestedPath = event.path
+    }
 
     const shouldRenderUploadErrorPage =
       ctx.options.errorOverlay !== 'silent' && ctx.localThemeFileSystem.uploadErrors.size > 0
@@ -158,6 +160,11 @@ function createErrorPageResponse(
 function isKnownRenderingRequest(event: H3Event) {
   const searchParams = new URLSearchParams(event.path.split('?')[1])
   return ['section_id', 'sections', 'app_block_id'].some((key) => searchParams.has(key))
+}
+
+/** Determines if a request is a user navigation type via sec-fetch-mode header. */
+function isNavigationRequest(event: H3Event): boolean {
+  return event.headers.get('sec-fetch-mode') === 'navigate'
 }
 
 async function tryProxyRequest(event: H3Event, ctx: DevServerContext, response: Response) {


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://community.shopify.dev/t/shopify-cli-theme-dev-editor-shortcut-loading-ajax-url/29157/5

When running `theme dev`, non-navigational requests like AJAX/fetch requests could be tracked as the `lastRequestedPath`. This caused the theme editor (E) shortcut to open the editor pointing to an AJAX endpoint (e.g., /cart/add.js or section URL instead of the actual page the user was viewing.

### WHAT is this pull request doing?
Use `Sec-Fetch-Mode` HTTP [header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Sec-Fetch-Mode) to update the `lastRequestedPath` only if it's a `navigation` type (like clicking links, typing a URL in the address bar)
<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?
You can replicate the issue by making a new file `/templates/product.ajax-test.liquid` and add this code

<details>

```
{%- layout none -%}
<div class="ajax-response">
  <h2>{{ product.title }}</h2>
  <p>{{ product.description | strip_html | truncate: 100 }}</p>
  <span class="price">{{ product.price | money }}</span>
</div>
```

Then edit your `layout/theme.liquid` by adding this code

```
<script>
      document.addEventListener('DOMContentLoaded', function() {
        if (window.location.pathname.startsWith('/products/')) {
          fetch(window.location.pathname + '?view=ajax-test')
            .then(response => response.text())
            .then(data => console.log('AJAX response loaded:', data.substring(0, 100) + '...'))
            .catch(err => console.error('AJAX fetch error:', err));
        }
      });
    </script>
```

</details>

Run theme dev, navigate to a product page and then try the shortcut key to the editor. You should get an error.
Afterwards, build and run this branch and try the same thing, you should see the product page as expected.

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
