### PR TITLE
Fix flaky AutocompletePrompt tests under React 19 on CI

### DIFF
--- a/packages/cli-kit/src/private/node/testing/ui.ts
+++ b/packages/cli-kit/src/private/node/testing/ui.ts
@@ -23,6 +23,17 @@ export class Stdin extends EventEmitter {
   constructor(options: {isTTY?: boolean} = {}) {
     super()
     this.isTTY = options.isTTY ?? true
+
+    // When a 'readable' listener is added and there's pending data,
+    // re-emit 'readable' so the new listener can read it. This mirrors
+    // real Node streams where buffered data is available to new readers,
+    // and prevents dropped input when data is written before Ink's
+    // useInput effect registers its listener.
+    this.on('newListener', (event: string) => {
+      if (event === 'readable' && this.data !== null) {
+        setImmediate(() => this.emit('readable'))
+      }
+    })
   }
 
   write = (data: string) => {

--- a/packages/cli-kit/src/private/node/ui/components/AutocompletePrompt.test.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/AutocompletePrompt.test.tsx
@@ -1,7 +1,6 @@
 import {AutocompletePrompt, SearchResults} from './AutocompletePrompt.js'
 import {
   getLastFrameAfterUnmount,
-  sendInputAndWait,
   sendInputAndWaitForChange,
   sendInputAndWaitForContent,
   waitForInputsToBeReady,
@@ -286,8 +285,9 @@ describe('AutocompletePrompt', async () => {
     await waitForInputsToBeReady()
 
     await sendInputAndWaitForContent(renderInstance, 'No results found', 'a')
-    // prompt doesn't change when enter is pressed
-    await sendInputAndWait(renderInstance, 100, ENTER)
+    // prompt doesn't change when enter is pressed — yield to let React
+    // 19's scheduler process any batched updates from the keypress
+    await sendInputAndWaitForContent(renderInstance, 'No results found', ENTER)
 
     expect(renderInstance.lastFrame()).toMatchInlineSnapshot(`
       "?  Associate your project with the org Castile Ventures?   [36ma[46m█[49m[39m
@@ -328,12 +328,11 @@ describe('AutocompletePrompt', async () => {
   test('has a loading state', async () => {
     const onEnter = vi.fn()
 
+    // Use a promise that never resolves so the loading state persists
+    // for the entire test, eliminating timing races with React 19's
+    // batched rendering on slow CI runners.
     const search = () => {
-      return new Promise<SearchResults<string>>((resolve) => {
-        setTimeout(() => {
-          resolve({data: [{label: 'a', value: 'b'}]})
-        }, 2000)
-      })
+      return new Promise<SearchResults<string>>(() => {})
     }
 
     const renderInstance = render(
@@ -347,9 +346,9 @@ describe('AutocompletePrompt', async () => {
 
     await waitForInputsToBeReady()
     await sendInputAndWaitForContent(renderInstance, 'Loading...', 'a')
-    // prompt doesn't change when enter is pressed
-    await new Promise((resolve) => setTimeout(resolve, 100))
-    await sendInputAndWait(renderInstance, 100, ENTER)
+    // prompt doesn't change when enter is pressed — yield to let React
+    // 19's scheduler process any batched updates from the keypress
+    await sendInputAndWaitForContent(renderInstance, 'Loading...', ENTER)
 
     expect(renderInstance.lastFrame()).toMatchInlineSnapshot(`
       "?  Associate your project with the org Castile Ventures?   [36ma[46m█[49m[39m


### PR DESCRIPTION
## Summary
- Fix the `Stdin` mock to re-emit `'readable'` when a listener is added and there's pending data. This mirrors real Node stream behavior and prevents dropped input when data is written before Ink's `useInput` effect registers its listener — the root cause of the "allows searching with pagination" timeout on slow CI runners.
- Replace `sendInputAndWait` fixed delays in the "doesn't submit if there are no choices" and "has a loading state" tests with `sendInputAndWaitForContent`, which deterministically waits for React to confirm the frame still shows expected content after the keypress
- Use a never-resolving search promise in the "has a loading state" test so the loading state persists for the entire test, eliminating races where React 19's batched rendering could resolve the search and transition back to Idle before the ENTER keypress is processed

## Test plan
- [x] `pnpm --filter @shopify/cli-kit vitest run src/private/node/ui/components/AutocompletePrompt.test.tsx` passes locally
- [x] `pnpm --filter @shopify/app vitest run src/cli/services/dev/ui/components/Dev.test.tsx src/cli/services/dev/ui/components/DevSessionUI.test.tsx` passes locally
- [ ] CI passes without flaky failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)