### PR TITLE
Store local sessions separately

### DIFF
--- a/packages/cli-kit/src/private/node/conf-store.test.ts
+++ b/packages/cli-kit/src/private/node/conf-store.test.ts
@@ -14,10 +14,17 @@ import {
   setCachedPartnerAccountStatus,
   runWithRateLimit,
 } from './conf-store.js'
+import {isLocalEnvironment} from './context/service.js'
 import {LocalStorage} from '../../public/node/local-storage.js'
 import {inTemporaryDirectory} from '../../public/node/fs.js'
 
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
+
+vi.mock('./context/service.js')
+
+beforeEach(() => {
+  vi.mocked(isLocalEnvironment).mockReturnValue(false)
+})
 
 describe('getSession', () => {
   test('returns the content of the SessionStore key', async () => {
@@ -68,7 +75,7 @@ describe('removeSession', () => {
 })
 
 describe('getCurrentSessionId', () => {
-  test('returns the content of the currentSessionId key', async () => {
+  test('returns the content of the currentSessionId key in production', async () => {
     await inTemporaryDirectory(async (cwd) => {
       // Given
       const config = new LocalStorage<ConfSchema>({cwd})
@@ -79,6 +86,21 @@ describe('getCurrentSessionId', () => {
 
       // Then
       expect(got).toEqual('user-123')
+    })
+  })
+
+  test('returns the content of the currentDevSessionId key in dev', async () => {
+    await inTemporaryDirectory(async (cwd) => {
+      // Given
+      vi.mocked(isLocalEnvironment).mockReturnValue(true)
+      const config = new LocalStorage<ConfSchema>({cwd})
+      config.set('currentDevSessionId', 'dev-user-456')
+
+      // When
+      const got = getCurrentSessionId(config)
+
+      // Then
+      expect(got).toEqual('dev-user-456')
     })
   })
 
@@ -94,10 +116,24 @@ describe('getCurrentSessionId', () => {
       expect(got).toBeUndefined()
     })
   })
+
+  test('does not return dev session when in production', async () => {
+    await inTemporaryDirectory(async (cwd) => {
+      // Given
+      const config = new LocalStorage<ConfSchema>({cwd})
+      config.set('currentDevSessionId', 'dev-user')
+
+      // When
+      const got = getCurrentSessionId(config)
+
+      // Then
+      expect(got).toBeUndefined()
+    })
+  })
 })
 
 describe('setCurrentSessionId', () => {
-  test('saves the desired content in the currentSessionId key', async () => {
+  test('saves to currentSessionId in production', async () => {
     await inTemporaryDirectory(async (cwd) => {
       // Given
       const config = new LocalStorage<ConfSchema>({cwd})
@@ -107,12 +143,28 @@ describe('setCurrentSessionId', () => {
 
       // Then
       expect(config.get('currentSessionId')).toEqual('user-456')
+      expect(config.get('currentDevSessionId')).toBeUndefined()
+    })
+  })
+
+  test('saves to currentDevSessionId in dev', async () => {
+    await inTemporaryDirectory(async (cwd) => {
+      // Given
+      vi.mocked(isLocalEnvironment).mockReturnValue(true)
+      const config = new LocalStorage<ConfSchema>({cwd})
+
+      // When
+      setCurrentSessionId('dev-user-789', config)
+
+      // Then
+      expect(config.get('currentDevSessionId')).toEqual('dev-user-789')
+      expect(config.get('currentSessionId')).toBeUndefined()
     })
   })
 })
 
 describe('removeCurrentSessionId', () => {
-  test('removes the currentSessionId key', async () => {
+  test('removes the currentSessionId key in production', async () => {
     await inTemporaryDirectory(async (cwd) => {
       // Given
       const config = new LocalStorage<ConfSchema>({cwd})
@@ -123,6 +175,87 @@ describe('removeCurrentSessionId', () => {
 
       // Then
       expect(config.get('currentSessionId')).toBeUndefined()
+    })
+  })
+
+  test('removes the currentDevSessionId key in dev', async () => {
+    await inTemporaryDirectory(async (cwd) => {
+      // Given
+      vi.mocked(isLocalEnvironment).mockReturnValue(true)
+      const config = new LocalStorage<ConfSchema>({cwd})
+      config.set('currentDevSessionId', 'dev-user')
+
+      // When
+      removeCurrentSessionId(config)
+
+      // Then
+      expect(config.get('currentDevSessionId')).toBeUndefined()
+    })
+  })
+})
+
+describe('session environment isolation', () => {
+  test('getSessions returns production sessions in production', async () => {
+    await inTemporaryDirectory(async (cwd) => {
+      // Given
+      const config = new LocalStorage<ConfSchema>({cwd})
+      config.set('sessionStore', 'prod-sessions')
+      config.set('devSessionStore', 'dev-sessions')
+
+      // When
+      const got = getSessions(config)
+
+      // Then
+      expect(got).toEqual('prod-sessions')
+    })
+  })
+
+  test('getSessions returns dev sessions in dev', async () => {
+    await inTemporaryDirectory(async (cwd) => {
+      // Given
+      vi.mocked(isLocalEnvironment).mockReturnValue(true)
+      const config = new LocalStorage<ConfSchema>({cwd})
+      config.set('sessionStore', 'prod-sessions')
+      config.set('devSessionStore', 'dev-sessions')
+
+      // When
+      const got = getSessions(config)
+
+      // Then
+      expect(got).toEqual('dev-sessions')
+    })
+  })
+
+  test('setSessions writes to devSessionStore in dev without affecting production', async () => {
+    await inTemporaryDirectory(async (cwd) => {
+      // Given
+      const config = new LocalStorage<ConfSchema>({cwd})
+      setSessions('prod-sessions', config)
+
+      // When
+      vi.mocked(isLocalEnvironment).mockReturnValue(true)
+      setSessions('dev-sessions', config)
+
+      // Then
+      expect(config.get('sessionStore')).toEqual('prod-sessions')
+      expect(config.get('devSessionStore')).toEqual('dev-sessions')
+    })
+  })
+
+  test('removeSessions only removes sessions for the current environment', async () => {
+    await inTemporaryDirectory(async (cwd) => {
+      // Given
+      const config = new LocalStorage<ConfSchema>({cwd})
+      config.set('sessionStore', 'prod-sessions')
+      config.set('devSessionStore', 'dev-sessions')
+
+      // When
+      vi.mocked(isLocalEnvironment).mockReturnValue(true)
+      removeSessions(config)
+
+      // Then
+      expect(config.get('devSessionStore')).toBeUndefined()
+      expect(config.get('sessionStore')).toEqual('prod-sessions')
     })
   })
 })

--- a/packages/cli-kit/src/private/node/conf-store.ts
+++ b/packages/cli-kit/src/private/node/conf-store.ts
@@ -1,3 +1,4 @@
+import {isLocalEnvironment} from './context/service.js'
 import {isUnitTest} from '../../public/node/context/local.js'
 import {LocalStorage} from '../../public/node/local-storage.js'
 import {outputContent, outputDebug} from '../../public/node/output.js'
@@ -28,6 +29,8 @@ interface Cache {
 export interface ConfSchema {
   sessionStore: string
   currentSessionId?: string
+  devSessionStore?: string
+  currentDevSessionId?: string
   cache?: Cache
 }
 
@@ -45,6 +48,14 @@ function cliKitStore() {
   return _instance
 }
 
+function sessionStoreKey(): 'devSessionStore' | 'sessionStore' {
+  return isLocalEnvironment() ? 'devSessionStore' : 'sessionStore'
+}
+
+function currentSessionIdKey(): 'currentDevSessionId' | 'currentSessionId' {
+  return isLocalEnvironment() ? 'currentDevSessionId' : 'currentSessionId'
+}
+
 /**
  * Get session.
  *
@@ -52,7 +63,7 @@ function cliKitStore() {
  */
 export function getSessions(config: LocalStorage<ConfSchema> = cliKitStore()): string | undefined {
   outputDebug(outputContent`Getting session store...`)
-  return config.get('sessionStore')
+  return config.get(sessionStoreKey())
 }
 
 /**
@@ -62,7 +73,7 @@ export function getSessions(config: LocalStorage<ConfSchema> = cliKitStore()): s
  */
 export function setSessions(session: string, config: LocalStorage<ConfSchema> = cliKitStore()): void {
   outputDebug(outputContent`Setting session store...`)
-  config.set('sessionStore', session)
+  config.set(sessionStoreKey(), session)
 }
 
 /**
@@ -70,7 +81,7 @@ export function setSessions(session: string, config: LocalStorage<ConfSchema> = 
  */
 export function removeSessions(config: LocalStorage<ConfSchema> = cliKitStore()): void {
   outputDebug(outputContent`Removing session store...`)
-  config.delete('sessionStore')
+  config.delete(sessionStoreKey())
 }
 
 /**
@@ -80,7 +91,7 @@ export function removeSessions(config: LocalStorage<ConfSchema> = cliKitStore())
  */
 export function getCurrentSessionId(config: LocalStorage<ConfSchema> = cliKitStore()): string | undefined {
   outputDebug(outputContent`Getting current session ID...`)
-  return config.get('currentSessionId')
+  return config.get(currentSessionIdKey())
 }
 
 /**
@@ -90,7 +101,7 @@ export function getCurrentSessionId(config: LocalStorage<ConfSchema> = cliKitSto
  */
 export function setCurrentSessionId(sessionId: string, config: LocalStorage<ConfSchema> = cliKitStore()): void {
   outputDebug(outputContent`Setting current session ID...`)
-  config.set('currentSessionId', sessionId)
+  config.set(currentSessionIdKey(), sessionId)
 }
 
 /**
@@ -98,7 +109,7 @@ export function setCurrentSessionId(sessionId: string, config: LocalStorage<Conf
  */
 export function removeCurrentSessionId(config: LocalStorage<ConfSchema> = cliKitStore()): void {
   outputDebug(outputContent`Removing current session ID...`)
-  config.delete('currentSessionId')
+  config.delete(currentSessionIdKey())
 }
 
 type CacheValueForKey<TKey extends keyof Cache> = NonNullable<Cache[TKey]>['value']


### PR DESCRIPTION
### WHY are these changes introduced?

In https://github.com/Shopify/cli/pull/5914 we added support for multiple sessions, but if you switch between environments (production/development), the sessions get overwritten, so you have to log in again.

### WHAT is this pull request doing?

When running the CLI against the local environment, save the sessions in different store fields.

### How to test your changes?

- `npm i -g --@shopify:registry=https://registry.npmjs.org @shopify/cli@0.0.0-snapshot-20260304092735`
- `shopify auth logout`
- `shopify app versions list`
- `SHOPIFY_SERVICE_ENV=local shopify app versions list`
- `shopify app versions list`
- `SHOPIFY_SERVICE_ENV=local shopify app versions list`

It should only start the login flow once per environment.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
