### PR TITLE
Fix --alias to also match by userId for UUID-aliased sessions

### DIFF
--- a/packages/cli-kit/src/private/node/session/store.test.ts
+++ b/packages/cli-kit/src/private/node/session/store.test.ts
@@ -178,6 +178,17 @@ describe('session store', () => {
       expect(result).toBeUndefined()
     })
 
+    test('returns userId when alias matches userId directly', async () => {
+      // Given
+      vi.mocked(getSessions).mockReturnValue(JSON.stringify(mockSessions))
+
+      // When
+      const result = await findSessionByAlias('user1')
+
+      // Then
+      expect(result).toBe('user1')
+    })
+
     test('returns first matching userId when multiple sessions have same alias', async () => {
       // Given
       const sessionsWithDuplicateAlias = {

--- a/packages/cli-kit/src/private/node/session/store.ts
+++ b/packages/cli-kit/src/private/node/session/store.ts
@@ -71,7 +71,7 @@ export async function findSessionByAlias(alias: string): Promise<string | undefi
   if (!fqdnSessions) return undefined
 
   for (const [userId, session] of Object.entries(fqdnSessions)) {
-    if (session.identity.alias === alias) {
+    if (session.identity.alias === alias || userId === alias) {
       return userId
     }
   }


### PR DESCRIPTION
## WHY are these changes introduced?

When a session's email alias fails to resolve during login, the `alias` field ends up as `undefined`. The session list display falls back to showing `userId` (UUID) via `session.identity.alias ?? userId`. But `findSessionByAlias` only matches against `session.identity.alias`, so `--alias <UUID>` doesn't find anything and falls through to the interactive prompt.

(The personal context is that I have a few different staff/partner accounts I work through so in every separate theme folder on my machine I automatically run `shopify auth login --alias` with the appropriate account - around 15 times a day).

## WHAT is this pull request doing?

`findSessionByAlias` now also matches on the session's `userId` key as a fallback, so `--alias <UUID>` works for sessions where the alias was never set.

One-line change in `store.ts`, one new test in `store.test.ts`.

Note: this does not fix the display issue — sessions with undefined aliases will still show as UUIDs in the session picker. That would require re-fetching the email at some point (e.g. during token refresh).

## How to test your changes?

- `pnpm -F @shopify/cli-kit test -- src/private/node/session/store.test.ts`
- Manual: on the live build, `shopify auth login --alias "<UUID>"` falls through to the interactive prompt instead of selecting the session. On the patched build, it selects the session correctly. 
<img width="1900" height="878" alt="image" src="https://github.com/user-attachments/assets/4200f084-d62d-4267-85f9-a3f484599df0" />


## Measuring impact

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

## Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
