### PR TITLE
Fix flaky test on AutocompletePrompt.test.tsx

### DIFF
--- a/packages/cli-kit/src/private/node/testing/ui.ts
+++ b/packages/cli-kit/src/private/node/testing/ui.ts
@@ -177,6 +177,9 @@ export async function sendInputAndWaitForContent(
   ...inputs: string[]
 ) {
   await waitForContent(renderInstance, content, () => inputs.forEach((input) => renderInstance.stdin.write(input)))
+  // Yield so React 19's scheduler can flush effects (e.g. re-register useInput
+  // handlers with up-to-date closures) before subsequent input is sent.
+  await new Promise((resolve) => setImmediate(() => setTimeout(resolve, 0)))
 }
 
 /** Function that is useful when you want to check the last frame of a component that unmounted.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17187,7 +17187,7 @@ snapshots:
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
-      minimatch: 3.1.2
+      minimatch: 3.1.5
       object.fromentries: 2.0.8
       object.groupby: 1.0.3
       object.values: 1.2.1


### PR DESCRIPTION
### WHY are these changes introduced?

After [upgrading to React 19](https://github.com/Shopify/cli/pull/6831), some flaky tests raised that https://github.com/Shopify/cli/pull/6922 tried to fix.

But CI keeps failing https://github.com/Shopify/cli/actions/runs/22668051243/job/65704701620

### WHAT is this pull request doing?

Apparently it's a race condition. The flaky test sends ENTER right after detecting "No results found" in the frame, but React 19 hasn't yet re-registered the useInput handler with updated closures, so the stale handler still sees the old items and submits "first".

The fix adds a yield in `sendInputAndWaitForContent` (matching the existing pattern in `sendInputAndWaitForChange`) to let React 19 flush effects before subsequent input is sent.

### How to test your changes?

CI. I've re-run the tests here several times and that test didn't fail.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
