### PR TITLE
Add event logging on app dev

### DIFF
--- a/packages/app/src/cli/services/dev/processes/dev-session/dev-session-event-log.test.ts
+++ b/packages/app/src/cli/services/dev/processes/dev-session/dev-session-event-log.test.ts
@@ -1,0 +1,101 @@
+import {DevSessionEventLog} from './dev-session-event-log.js'
+import {inTemporaryDirectory, readFile, fileExists, rmdir} from '@shopify/cli-kit/node/fs'
+import {joinPath} from '@shopify/cli-kit/node/path'
+import {describe, test, expect} from 'vitest'
+
+describe('DevSessionEventLog', () => {
+  test('init creates the event log file', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      const eventLog = new DevSessionEventLog(tmpDir)
+      await eventLog.init()
+
+      const exists = await fileExists(joinPath(tmpDir, '.shopify', 'dev-session-events.jsonl'))
+      expect(exists).toBe(true)
+    })
+  })
+
+  test('init truncates existing file', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      const eventLog = new DevSessionEventLog(tmpDir)
+      await eventLog.init()
+      await eventLog.write({event: 'test-event'})
+
+      // Re-init should truncate
+      await eventLog.init()
+      const content = await readFile(eventLog.path)
+      expect(content).toBe('')
+    })
+  })
+
+  test('write appends JSONL lines', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      const eventLog = new DevSessionEventLog(tmpDir)
+      await eventLog.init()
+
+      await eventLog.write({event: 'first'})
+      await eventLog.write({event: 'second', extra: 'data'})
+
+      const content = await readFile(eventLog.path)
+      const lines = content.trim().split('\n')
+      expect(lines).toHaveLength(2)
+
+      const first = JSON.parse(lines[0]!)
+      expect(first.event).toBe('first')
+      expect(first.ts).toBeDefined()
+
+      const second = JSON.parse(lines[1]!)
+      expect(second.event).toBe('second')
+      expect(second.extra).toBe('data')
+    })
+  })
+
+  test('write is a no-op before init', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      const eventLog = new DevSessionEventLog(tmpDir)
+
+      // Should not throw
+      await eventLog.write({event: 'ignored'})
+
+      const exists = await fileExists(joinPath(tmpDir, '.shopify', 'dev-session-events.jsonl'))
+      expect(exists).toBe(false)
+    })
+  })
+
+  test('path returns the expected file path', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      const eventLog = new DevSessionEventLog(tmpDir)
+      expect(eventLog.path).toBe(joinPath(tmpDir, '.shopify', 'dev-session-events.jsonl'))
+    })
+  })
+
+  test('concurrent writes produce valid JSONL', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      const eventLog = new DevSessionEventLog(tmpDir)
+      await eventLog.init()
+
+      await Promise.all([
+        eventLog.write({event: 'event1', data: 'a'}),
+        eventLog.write({event: 'event2', data: 'b'}),
+        eventLog.write({event: 'event3', data: 'c'}),
+      ])
+
+      const content = await readFile(eventLog.path)
+      const lines = content.trim().split('\n')
+      expect(lines).toHaveLength(3)
+      for (const line of lines) {
+        expect(() => JSON.parse(line)).not.toThrow()
+      }
+    })
+  })
+
+  test('write rejects when file is deleted', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      const eventLog = new DevSessionEventLog(tmpDir)
+      await eventLog.init()
+
+      await rmdir(joinPath(tmpDir, '.shopify'), {force: true})
+
+      await expect(eventLog.write({event: 'test'})).rejects.toThrow()
+    })
+  })
+})

--- a/packages/app/src/cli/services/dev/processes/dev-session/dev-session-event-log.ts
+++ b/packages/app/src/cli/services/dev/processes/dev-session/dev-session-event-log.ts
@@ -1,0 +1,59 @@
+import {dirname, joinPath} from '@shopify/cli-kit/node/path'
+import {mkdir, writeFile, appendFile} from '@shopify/cli-kit/node/fs'
+import {addToGitIgnore} from '@shopify/cli-kit/node/git'
+
+export interface DevSessionEvent {
+  ts: string
+  event: string
+  [key: string]: unknown
+}
+
+/**
+ * Append-only JSONL event log for dev sessions.
+ * Enables external agents to observe dev session lifecycle by tailing
+ * `.shopify/dev-session-events.jsonl` in the app directory.
+ *
+ * Event types emitted:
+ * - `session-starting` — Dev session initialization (`store`, `app_id`, `extension_count`)
+ * - `session-created` — Session successfully created (`preview_url`, `graphiql_url`)
+ * - `session-updated` — Extensions updated (`extensions_updated`)
+ * - `session-start-failed` — Initial build errors prevented session creation (`reason`, `error_count`)
+ * - `change-detected` — File change detected (`extension_count`, `extensions[]` with `handle` and `type`)
+ * - `bundle-uploaded` — Extensions bundled and uploaded (`duration_ms`, `extensions`, `inherited_count`)
+ * - `status-loading`, `status-success`, `status-error` — Status transitions (`message`, `is_ready`, `preview_url`)
+ * - `remote-error`, `unknown-error` — Error events (`errors[]`)
+ *
+ * All events include a `ts` field with an ISO 8601 timestamp.
+ * The file is truncated on each `shopify app dev` start.
+ */
+export class DevSessionEventLog {
+  private readonly filePath: string
+  private readonly appDirectory: string
+  private initialized = false
+
+  constructor(appDirectory: string) {
+    this.appDirectory = appDirectory
+    this.filePath = joinPath(appDirectory, '.shopify', 'dev-session-events.jsonl')
+  }
+
+  async init(): Promise<void> {
+    await addToGitIgnore(this.appDirectory, '.shopify')
+    await mkdir(dirname(this.filePath))
+    await writeFile(this.filePath, '')
+    this.initialized = true
+  }
+
+  async write(event: Omit<DevSessionEvent, 'ts'>): Promise<void> {
+    if (!this.initialized) return
+    const line = JSON.stringify({ts: new Date().toISOString(), ...event})
+    await appendFile(this.filePath, `${line}\n`)
+  }
+
+  close(): void {
+    this.initialized = false
+  }
+
+  get path(): string {
+    return this.filePath
+  }
+}

--- a/packages/app/src/cli/services/dev/processes/dev-session/dev-session-process.test.ts
+++ b/packages/app/src/cli/services/dev/processes/dev-session/dev-session-process.test.ts
@@ -1,4 +1,5 @@
 import {setupDevSessionProcess, pushUpdatesForDevSession} from './dev-session-process.js'
+import {DevSessionEventLog} from './dev-session-event-log.js'
 import {DevSessionStatusManager} from './dev-session-status-manager.js'
 import {DeveloperPlatformClient} from '../../../../utilities/developer-platform-client.js'
 import {AppLinkedInterface} from '../../../../models/app/app.js'
@@ -671,6 +672,27 @@ describe('pushUpdatesForDevSession', () => {
     expect(stdout.write).toHaveBeenCalledWith(expect.stringContaining('Updated dev preview on test.myshopify.com'))
     expect(stdout.write).not.toHaveBeenCalledWith(expect.stringContaining('Another developer'))
     expect(stdout.write).not.toHaveBeenCalledWith(expect.stringContaining('taken ownership of this dev preview'))
+  })
+
+  test('writes lifecycle events to event log when provided', async () => {
+    // Given
+    const eventLog = {
+      write: vi.fn().mockResolvedValue(undefined),
+      close: vi.fn(),
+    } as unknown as DevSessionEventLog
+    options.eventLog = eventLog
+
+    // When
+    await pushUpdatesForDevSession({stderr, stdout, abortSignal: abortController.signal}, {...options, eventLog})
+    await appWatcher.start({stdout, stderr, signal: abortController.signal})
+    await flushPromises()
+
+    // Then - event log should have received lifecycle events during create
+    const writtenEvents = vi.mocked(eventLog.write).mock.calls.map((call) => call[0].event)
+    expect(writtenEvents).toContain('session-starting')
+    expect(writtenEvents).toContain('session-created')
+    // Status events from statusManager updates
+    expect(writtenEvents).toContain('status-success')
   })
 
   test('retries failed events along with newly received events', async () => {

--- a/packages/app/src/cli/services/dev/processes/dev-session/dev-session-process.ts
+++ b/packages/app/src/cli/services/dev/processes/dev-session/dev-session-process.ts
@@ -1,3 +1,4 @@
+import {DevSessionEventLog} from './dev-session-event-log.js'
 import {DevSessionStatusManager} from './dev-session-status-manager.js'
 import {DevSession} from './dev-session.js'
 import {BaseProcess, DevProcessFunction} from '../types.js'
@@ -17,6 +18,7 @@ export interface DevSessionProcessOptions {
   appPreviewURL: string
   appLocalProxyURL: string
   devSessionStatusManager: DevSessionStatusManager
+  eventLog?: DevSessionEventLog
 }
 
 export interface DevSessionProcess extends BaseProcess<DevSessionProcessOptions> {
@@ -42,6 +44,9 @@ export async function setupDevSessionProcess({
   }
 }
 
-export const pushUpdatesForDevSession: DevProcessFunction<DevSessionProcessOptions> = async ({stdout}, options) => {
-  await DevSession.start(options, stdout)
+export const pushUpdatesForDevSession: DevProcessFunction<DevSessionProcessOptions> = async (
+  {stdout, abortSignal},
+  options,
+) => {
+  await DevSession.start(options, stdout, abortSignal)
 }

--- a/packages/app/src/cli/services/dev/processes/dev-session/dev-session.ts
+++ b/packages/app/src/cli/services/dev/processes/dev-session/dev-session.ts
@@ -1,5 +1,6 @@
+import {DevSessionEvent, DevSessionEventLog} from './dev-session-event-log.js'
 import {DevSessionLogger} from './dev-session-logger.js'
-import {DevSessionStatusManager} from './dev-session-status-manager.js'
+import {DevSessionStatus, DevSessionStatusManager} from './dev-session-status-manager.js'
 import {DevSessionProcessOptions} from './dev-session-process.js'
 import {AppEvent, AppEventWatcher, ExtensionEvent} from '../../app-events/app-event-watcher.js'
 import {
@@ -15,6 +16,7 @@ import {getWebSocketUrl} from '../../extension.js'
 import {endHRTimeInMs, startHRTime} from '@shopify/cli-kit/node/hrtime'
 import {ClientError} from 'graphql-request'
 import {JsonMapType} from '@shopify/cli-kit/node/toml'
+import {AbortSignal} from '@shopify/cli-kit/node/abort'
 import {AbortError} from '@shopify/cli-kit/node/error'
 import {firstPartyDev, isUnitTest} from '@shopify/cli-kit/node/context/local'
 import {dirname, joinPath} from '@shopify/cli-kit/node/path'
@@ -41,38 +43,74 @@ type DevSessionResult =
   | {status: 'unknown-error'; error: Error}
 
 export class DevSession {
-  public static async start(options: DevSessionProcessOptions, stdout: Writable): Promise<DevSession> {
+  public static async start(
+    options: DevSessionProcessOptions,
+    stdout: Writable,
+    abortSignal?: AbortSignal,
+  ): Promise<DevSession> {
     const devSession = new DevSession(options, stdout)
-    await devSession.start()
+    await devSession.start(abortSignal)
     return devSession
   }
 
   private readonly statusManager: DevSessionStatusManager
   private readonly logger: DevSessionLogger
+  private readonly eventLog?: DevSessionEventLog
   private readonly options: DevSessionProcessOptions
   private readonly appWatcher: AppEventWatcher
   private readonly bundlePath: string
   private readonly appEventsProcessor: SerialBatchProcessor<AppEvent>
+  private readonly statusUpdateHandler: (status: DevSessionStatus) => void
   private failedEvents: AppEvent[] = []
   private currentSessionState: DevSessionState | null = null
 
   private constructor(processOptions: DevSessionProcessOptions, stdout: Writable) {
     this.statusManager = processOptions.devSessionStatusManager
     this.logger = new DevSessionLogger(stdout)
+    this.eventLog = processOptions.eventLog
     this.options = processOptions
     this.appWatcher = processOptions.appWatcher
     this.bundlePath = processOptions.appWatcher.buildOutputPath
     this.appEventsProcessor = new SerialBatchProcessor((events: AppEvent[]) => this.processEvents(events))
+    this.statusUpdateHandler = (status: DevSessionStatus) => {
+      const {type, message} = status.statusMessage ?? {}
+      // Only log updates with a status message; purely internal state changes (e.g. isReady toggling) are excluded
+      if (type && message) {
+        this.writeEvent({
+          event: `status-${type}`,
+          message,
+          is_ready: status.isReady,
+          preview_url: status.previewURL,
+        })
+      }
+    }
   }
 
-  private async start() {
+  private async start(abortSignal?: AbortSignal) {
     await this.logger.info(`Preparing dev preview on ${this.options.storeFqdn}`)
     this.statusManager.setMessage('LOADING')
+
+    this.statusManager.on('dev-session-update', this.statusUpdateHandler)
+    abortSignal?.addEventListener('abort', () => this.cleanup(), {once: true})
 
     this.appWatcher
       .onEvent(async (event) => this.onEvent(event))
       .onStart(async (event) => this.onStart(event))
       .onError(async (error) => this.handleDevSessionResult({status: 'unknown-error', error}))
+  }
+
+  private cleanup() {
+    this.statusManager.off('dev-session-update', this.statusUpdateHandler)
+    this.appWatcher.removeAllListeners()
+    this.eventLog?.close()
+  }
+
+  private writeEvent(event: Omit<DevSessionEvent, 'ts'>) {
+    this.eventLog?.write(event).catch((error) => {
+      const msg = `Event log write failed: ${error instanceof Error ? error.message : String(error)}`
+      // eslint-disable-next-line no-void
+      void this.logger.debug(msg)
+    })
   }
 
   /**
@@ -101,13 +139,22 @@ export class DevSession {
     this.failedEvents = []
     if (!event) return
 
+    this.writeEvent({
+      event: 'change-detected',
+      extension_count: event.extensionEvents.length,
+      extensions: event.extensionEvents.map((ext) => ({
+        handle: ext.extension.handle,
+        type: ext.type,
+      })),
+    })
+
     this.statusManager.setMessage('CHANGE_DETECTED')
     this.updatePreviewURL(event)
     await this.logger.logExtensionEvents(event)
 
     const networkStartTime = startHRTime()
     const result = await this.bundleExtensionsAndUpload(event)
-    await this.handleDevSessionResult(result, event)
+    await this.handleDevSessionResult(result, event, Number(endHRTimeInMs(networkStartTime)))
     await this.logger.debug(
       `✅ Event handled [Network: ${endHRTimeInMs(networkStartTime)}ms - Total: ${endHRTimeInMs(event.startTime)}ms]`,
     )
@@ -159,13 +206,27 @@ export class DevSession {
    * @param event - The app event
    */
   private async onStart(event: AppEvent) {
+    this.writeEvent({
+      event: 'session-starting',
+      store: this.options.storeFqdn,
+      app_id: this.options.appId,
+      extension_count: event.app.allExtensions.length,
+    })
+
+    const startTime = startHRTime()
     const errors = this.parseBuildErrors(event)
     if (errors.length) {
       await this.logger.logMultipleErrors(errors)
+      this.writeEvent({
+        event: 'session-start-failed',
+        reason: 'build-errors',
+        error_count: errors.length,
+        duration_ms: Number(endHRTimeInMs(startTime)),
+      })
       throw new AbortError('Dev preview aborted, build errors detected in extensions')
     }
     const result = await this.bundleExtensionsAndUpload(event)
-    await this.handleDevSessionResult(result, event)
+    await this.handleDevSessionResult(result, event, Number(endHRTimeInMs(startTime)))
   }
 
   /**
@@ -221,12 +282,23 @@ export class DevSession {
    * @param result - The result of the dev session
    * @param event - The app event
    */
-  private async handleDevSessionResult(result: DevSessionResult, event?: AppEvent) {
+  private async handleDevSessionResult(result: DevSessionResult, event?: AppEvent, durationMs?: number) {
     if (result.status === 'updated') {
+      this.writeEvent({
+        event: 'session-updated',
+        extensions_updated: event?.extensionEvents.map((ext) => ext.extension.handle) ?? [],
+        duration_ms: durationMs,
+      })
       await this.logger.success(`✅ Updated dev preview on ${this.options.storeFqdn}`)
       await this.logger.logExtensionUpdateMessages(event)
       await this.setUpdatedStatusMessage()
     } else if (result.status === 'created') {
+      this.writeEvent({
+        event: 'session-created',
+        preview_url: this.statusManager.status.previewURL,
+        graphiql_url: this.statusManager.status.graphiqlURL,
+        duration_ms: durationMs,
+      })
       this.statusManager.updateStatus({isReady: true})
       await this.logger.success(`✅ Ready, watching for changes in your app `)
       await this.logger.logExtensionUpdateMessages(event)
@@ -234,6 +306,14 @@ export class DevSession {
     } else if (result.status === 'aborted') {
       await this.logger.debug('❌ Dev preview update aborted (new change detected or error during update)')
     } else if (result.status === 'remote-error' || result.status === 'unknown-error') {
+      this.writeEvent({
+        event: result.status === 'remote-error' ? 'remote-error' : 'unknown-error',
+        duration_ms: durationMs,
+        errors:
+          result.status === 'remote-error'
+            ? result.error.map((err) => ({message: err.message, category: err.category}))
+            : [{message: result.error.message}],
+      })
       await this.logger.logUserErrors(result.error, event?.app.allExtensions ?? [])
       if (result.error instanceof Error && (result.error as Error & {cause?: string}).cause === 'validation-error') {
         this.statusManager.setMessage('VALIDATION_ERROR')
@@ -290,7 +370,17 @@ export class DevSession {
   private async bundleExtensionsAndUpload(appEvent: AppEvent): Promise<DevSessionResult> {
     try {
       const {manifest, inheritedModuleUids, assets} = await this.createManifest(appEvent)
+      const uploadStartTime = startHRTime()
       const signedURL = await this.uploadAssetsIfNeeded(assets, !this.statusManager.status.isReady)
+
+      if (signedURL) {
+        this.writeEvent({
+          event: 'bundle-uploaded',
+          duration_ms: Number(endHRTimeInMs(uploadStartTime)),
+          extensions: manifest.modules.map((mod) => mod.handle),
+          inherited_count: inheritedModuleUids.length,
+        })
+      }
 
       const websocketUrl = getWebSocketUrl(this.options.url)
       if (this.statusManager.status.isReady) {

--- a/packages/app/src/cli/services/dev/processes/setup-dev-processes.test.ts
+++ b/packages/app/src/cli/services/dev/processes/setup-dev-processes.test.ts
@@ -6,6 +6,7 @@ import {PreviewableExtensionProcess, launchPreviewableExtensionProcess} from './
 import {launchGraphiQLServer} from './graphiql.js'
 import {pushUpdatesForDraftableExtensions} from './draftable-extension.js'
 import {pushUpdatesForDevSession} from './dev-session/dev-session-process.js'
+import {DevSessionEventLog} from './dev-session/dev-session-event-log.js'
 import {runThemeAppExtensionsServer} from './theme-app-extension.js'
 import {launchAppWatcher} from './app-watcher-process.js'
 import {
@@ -37,7 +38,16 @@ import {isStorefrontPasswordProtected} from '@shopify/theme'
 import {fetchTheme} from '@shopify/cli-kit/node/themes/api'
 import {firstPartyDev} from '@shopify/cli-kit/node/context/local'
 import {adminFqdn} from '@shopify/cli-kit/node/context/fqdn'
+import {outputDebug} from '@shopify/cli-kit/node/output'
 
+vi.mock('./dev-session/dev-session-event-log.js')
+vi.mock('@shopify/cli-kit/node/output', async (importOriginal) => {
+  const original = await importOriginal<typeof import('@shopify/cli-kit/node/output')>()
+  return {
+    ...original,
+    outputDebug: vi.fn(),
+  }
+})
 vi.mock('../../context/identifiers.js')
 vi.mock('@shopify/cli-kit/node/session.js')
 vi.mock('../fetch.js')
@@ -80,6 +90,17 @@ beforeEach(() => {
   // By default, firstPartyDev is false (local dev console only shown for 1P devs)
   vi.mocked(firstPartyDev).mockReturnValue(false)
   vi.mocked(adminFqdn).mockResolvedValue('admin.shopify.com')
+
+  // DevSessionEventLog mock: init() succeeds by default
+  vi.mocked(DevSessionEventLog).mockImplementation(
+    () =>
+      ({
+        init: vi.fn().mockResolvedValue(undefined),
+        write: vi.fn().mockResolvedValue(undefined),
+        close: vi.fn(),
+        path: '/tmp/.shopify/dev-session-events.jsonl',
+      }) as unknown as DevSessionEventLog,
+  )
 })
 
 const appContextResult = {
@@ -378,6 +399,113 @@ describe('setup-dev-processes', () => {
         storeFqdn: 'store.myshopify.io',
       },
     })
+  })
+
+  test('dev-session process receives eventLog when init succeeds', async () => {
+    const developerPlatformClient: DeveloperPlatformClient = testDeveloperPlatformClient({supportsDevSessions: true})
+    const localApp = testAppWithConfig()
+    vi.spyOn(loader, 'reloadApp').mockResolvedValue(localApp)
+
+    const res = await setupDevProcesses({
+      localApp,
+      commandOptions: {
+        ...appContextResult,
+        directory: '',
+        update: false,
+        commandConfig: new Config({root: ''}),
+        skipDependenciesInstallation: false,
+        tunnel: {mode: 'auto'},
+      },
+      network: {
+        proxyUrl: 'https://example.com/proxy',
+        proxyPort: 444,
+        backendPort: 111,
+        frontendPort: 222,
+        currentUrls: {
+          applicationUrl: 'https://example.com/application',
+          redirectUrlWhitelist: ['https://example.com/redirect'],
+        },
+      },
+      remoteApp: {
+        apiKey: 'api-key',
+        apiSecretKeys: [{secret: 'api-secret'}],
+        id: '1234',
+        title: 'App',
+        organizationId: '5678',
+        grantedScopes: [],
+        flags: [],
+        developerPlatformClient,
+      },
+      remoteAppUpdated: true,
+      storeFqdn: 'store.myshopify.io',
+      storeId: '123456789',
+      developerPlatformClient,
+      partnerUrlsUpdated: true,
+      graphiqlPort: 1234,
+      graphiqlKey: 'somekey',
+    })
+
+    const devSessionProcess = res.processes.find((proc) => proc.type === 'dev-session')
+    expect(devSessionProcess?.options.eventLog).toBeDefined()
+  })
+
+  test('dev-session process receives no eventLog when init fails', async () => {
+    vi.mocked(DevSessionEventLog).mockImplementation(
+      () =>
+        ({
+          init: vi.fn().mockRejectedValue(new Error('permission denied')),
+          write: vi.fn().mockResolvedValue(undefined),
+          close: vi.fn(),
+          path: '/tmp/.shopify/dev-session-events.jsonl',
+        }) as unknown as DevSessionEventLog,
+    )
+
+    const developerPlatformClient: DeveloperPlatformClient = testDeveloperPlatformClient({supportsDevSessions: true})
+    const localApp = testAppWithConfig()
+    vi.spyOn(loader, 'reloadApp').mockResolvedValue(localApp)
+
+    const res = await setupDevProcesses({
+      localApp,
+      commandOptions: {
+        ...appContextResult,
+        directory: '',
+        update: false,
+        commandConfig: new Config({root: ''}),
+        skipDependenciesInstallation: false,
+        tunnel: {mode: 'auto'},
+      },
+      network: {
+        proxyUrl: 'https://example.com/proxy',
+        proxyPort: 444,
+        backendPort: 111,
+        frontendPort: 222,
+        currentUrls: {
+          applicationUrl: 'https://example.com/application',
+          redirectUrlWhitelist: ['https://example.com/redirect'],
+        },
+      },
+      remoteApp: {
+        apiKey: 'api-key',
+        apiSecretKeys: [{secret: 'api-secret'}],
+        id: '1234',
+        title: 'App',
+        organizationId: '5678',
+        grantedScopes: [],
+        flags: [],
+        developerPlatformClient,
+      },
+      remoteAppUpdated: true,
+      storeFqdn: 'store.myshopify.io',
+      storeId: '123456789',
+      developerPlatformClient,
+      partnerUrlsUpdated: true,
+      graphiqlPort: 1234,
+      graphiqlKey: 'somekey',
+    })
+
+    const devSessionProcess = res.processes.find((proc) => proc.type === 'dev-session')
+    expect(devSessionProcess?.options.eventLog).toBeUndefined()
+    expect(outputDebug).toHaveBeenCalledWith(expect.stringContaining('permission denied'))
   })
 
   test('process list includes app polling when envVar is enabled and functions are available', async () => {

--- a/packages/app/src/cli/services/dev/processes/setup-dev-processes.ts
+++ b/packages/app/src/cli/services/dev/processes/setup-dev-processes.ts
@@ -8,6 +8,7 @@ import {WebProcess, setupWebProcesses} from './web.js'
 import {DevSessionProcess, setupDevSessionProcess} from './dev-session/dev-session-process.js'
 import {AppLogsSubscribeProcess, setupAppLogsPollingProcess} from './app-logs-polling.js'
 import {AppWatcherProcess, setupAppWatcherProcess} from './app-watcher-process.js'
+import {DevSessionEventLog} from './dev-session/dev-session-event-log.js'
 import {DevSessionStatusManager} from './dev-session/dev-session-status-manager.js'
 import {environmentVariableNames} from '../../../constants.js'
 import {AppLinkedInterface, getAppScopes, WebType} from '../../../models/app/app.js'
@@ -24,7 +25,7 @@ import {getAvailableTCPPort} from '@shopify/cli-kit/node/tcp'
 import {isTruthy} from '@shopify/cli-kit/node/context/utilities'
 import {firstPartyDev} from '@shopify/cli-kit/node/context/local'
 import {getEnvironmentVariables} from '@shopify/cli-kit/node/environment'
-import {outputInfo} from '@shopify/cli-kit/node/output'
+import {outputDebug, outputInfo} from '@shopify/cli-kit/node/output'
 import {adminFqdn} from '@shopify/cli-kit/node/context/fqdn'
 
 interface ProxyServerProcess extends BaseProcess<{
@@ -123,6 +124,15 @@ export async function setupDevProcesses({
     ? `http://localhost:${graphiqlPort}/graphiql${graphiqlKey ? `?key=${graphiqlKey}` : ''}`
     : undefined
 
+  const eventLog = new DevSessionEventLog(reloadedApp.directory)
+  const eventLogReady = await eventLog
+    .init()
+    .then(() => true)
+    .catch((error) => {
+      outputDebug(`Dev session event logging unavailable: ${error instanceof Error ? error.message : String(error)}`)
+      return false
+    })
+
   const devSessionStatusManager = new DevSessionStatusManager({isReady: false, previewURL, graphiqlURL})
 
   const processes = [
@@ -174,6 +184,7 @@ export async function setupDevProcesses({
           appPreviewURL: appPreviewUrl,
           appLocalProxyURL: devConsoleURL,
           devSessionStatusManager,
+          eventLog: eventLogReady ? eventLog : undefined,
         })
       : await setupDraftableExtensionsProcess({
           localApp: reloadedApp,


### PR DESCRIPTION
## What

Add an append-only JSONL event log to `shopify app dev` that external tools can tail for real-time session observability.

## Why

AI coding agents and other external tools need a machine-readable way to observe the dev session lifecycle — knowing when a session starts, when extensions are uploaded, when errors occur, and when the preview is ready. Currently this information is only available in human-readable terminal output, which is fragile to parse and lossy.

See below for an example agent skill that would use this flow.

## How

- `DevSessionEventLog` — append-only JSONL writer at `.shopify/dev-session-events.jsonl`, gitignored, truncated on each `dev` start
- `DevSession` owns all event writes via a `writeEvent()` helper, subscribing to `DevSessionStatusManager` events for status transitions
- Event log initialization is non-critical: if `init()` fails (permissions, disk), dev continues without logging
- All writes are fire-and-forget with debug-level error logging
- Proper cleanup: abort signal tears down status listener, app watcher handlers, and closes the event log

## Testing

```bash
# In one terminal
shopify app dev

# In another terminal, tail the event log
tail -f .shopify/dev-session-events.jsonl | jq .
```

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes

---

<details>
<summary><b>📡 Agent Skill: dev-session-event-log</b></summary>

### Overview

`shopify app dev` writes a machine-readable event log to `.shopify/dev-session-events.jsonl` in the app root directory (where `shopify.app.toml` lives). The file is append-only JSONL (one JSON object per line), truncated on each `dev` start, and gitignored.

The log covers session lifecycle events only. It does not include build tool output (webpack/esbuild), network proxy activity, or individual compilation steps.

### Consuming the log

```bash
# Tail in real-time (human-readable)
tail -f .shopify/dev-session-events.jsonl | jq .

# Programmatic consumers should read complete lines before parsing,
# as tail -f may deliver partial lines during concurrent writes.
```

### Event reference

Every event has a `ts` (ISO 8601 timestamp) and `event` field. Additional fields vary by event type:

| Event | When | Key fields |
|-------|------|------------|
| `session-starting` | Dev session initialization begins | `store`, `app_id`, `extension_count` |
| `session-created` | Session successfully created | `preview_url`, `graphiql_url`, `duration_ms` |
| `session-updated` | Extensions updated after a file change | `extensions_updated` (string array of handles), `duration_ms` |
| `session-start-failed` | Build errors at startup (terminal — process exits) | `reason`, `error_count`, `duration_ms` |
| `change-detected` | File change detected | `extension_count`, `extensions[]` (each has `handle`, `type`) |
| `bundle-uploaded` | Extensions bundled and uploaded | `duration_ms`, `extensions[]` (handle strings), `inherited_count` |
| `status-loading` | Status transition to loading | `message`, `is_ready`, `preview_url` |
| `status-success` | Status transition to success | `message`, `is_ready`, `preview_url` |
| `status-error` | Status transition to error | `message`, `is_ready`, `preview_url` |
| `remote-error` | API/platform error | `errors[]` (each has `message`, `category`), `duration_ms` |
| `unknown-error` | Unexpected error | `errors[]` (each has `message` only), `duration_ms` |

**Notes:**
- `bundle-uploaded` is only emitted when assets need uploading. Config-only changes may skip it.
- `status-*` events are deduplicated — they only appear when the status message actually changes.

### Common patterns

**Wait for session ready:**
Watch for `session-created` — the `preview_url` field contains the URL to open.

**Detect and recover from errors:**
- `status-error` with message `"Build error..."` → fix source code, wait for next `status-success`
- `remote-error` → read `errors[].message` for the exact API validation error (e.g. invalid scopes)

**Typical successful startup:**
```
session-starting → bundle-uploaded → session-created → status-success
```

**Failed startup (terminal — process exits, must re-run `shopify app dev`):**
```
session-starting → session-start-failed
```

**Typical update cycle (file change):**
```
change-detected → status-loading → bundle-uploaded → session-updated → status-success
```

**Error and recovery:**
```
change-detected → status-error (build error)
  ... fix code ...
change-detected → bundle-uploaded → session-updated → status-success
```

**Silent abort:** If a new file change arrives while an update is in-flight, the in-progress update may be silently aborted. You'll see a new `change-detected` without a preceding `session-updated` for the prior change.

### Example events

```jsonl
{"ts":"2026-03-04T19:13:41.502Z","event":"session-starting","store":"example.myshopify.com","app_id":"gid://shopify/App/123","extension_count":4}
{"ts":"2026-03-04T19:13:42.246Z","event":"bundle-uploaded","duration_ms":741.31,"extensions":["app_access","webhooks","app_home","branding"],"inherited_count":0}
{"ts":"2026-03-04T19:13:43.970Z","event":"session-created","preview_url":"https://admin.shopify.com/store/example/apps/abc123","graphiql_url":"http://localhost:3457/graphiql","duration_ms":2467.12}
{"ts":"2026-03-04T19:13:43.978Z","event":"status-success","message":"Ready, watching for changes in your app","is_ready":true,"preview_url":"https://admin.shopify.com/store/example/apps/abc123"}
{"ts":"2026-03-04T19:16:35.816Z","event":"change-detected","extension_count":1,"extensions":[{"handle":"admin-action","type":"created"}]}
{"ts":"2026-03-04T19:35:38.123Z","event":"remote-error","errors":[{"message":"These scopes are invalid - [read_fake_scope]","category":"invalid"}]}
```

</details>
