### PR TITLE
fix(theme): remove browser user-agent from proxied requests

### DIFF
--- a/packages/theme/src/cli/utilities/theme-environment/proxy.test.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/proxy.test.ts
@@ -279,10 +279,10 @@ describe('dev proxy', () => {
       event.node.req.headers.connection = '...'
       event.node.req.headers['proxy-authenticate'] = '...'
       event.node.req.headers.host = 'abnb'
+      event.node.req.headers['user-agent'] = 'Mozilla/5.0 (browser UA)'
       // Kept:
       event.node.req.headers.accept = 'text/html'
       event.node.req.headers.cookie = 'oreo'
-      event.node.req.headers['user-agent'] = 'vitest'
       event.node.req.headers['x-custom'] = 'true'
 
       expect(getProxyStorefrontHeaders(event)).toMatchInlineSnapshot(`
@@ -290,10 +290,22 @@ describe('dev proxy', () => {
           "X-Forwarded-For": "42",
           "accept": "text/html",
           "cookie": "oreo",
-          "user-agent": "vitest",
           "x-custom": "true",
         }
       `)
+    })
+
+    test('removes browser user-agent so CLI user-agent is not overridden', () => {
+      // In HTTP/2, browsers send 'user-agent' in lowercase. Without explicit deletion,
+      // both 'user-agent' (browser) and 'User-Agent' (CLI, from defaultHeaders()) coexist
+      // as separate JS object keys, and Node's fetch normalizes them such that the browser
+      // UA wins. This matters for cart/checkout endpoints where the CLI UA identifies the
+      // request as coming from a dev tool, not a real user.
+      const event = createH3Event('POST', '/cart/add.js')
+      event.node.req.headers['user-agent'] = 'Mozilla/5.0 (Macintosh; Intel Mac OS X)'
+
+      const headers = getProxyStorefrontHeaders(event)
+      expect(headers['user-agent']).toBeUndefined()
     })
   })
 

--- a/packages/theme/src/cli/utilities/theme-environment/proxy.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/proxy.ts
@@ -303,6 +303,12 @@ export function getProxyStorefrontHeaders(event: H3Event) {
   // so we must also remove it from the response CSP.
   delete proxyRequestHeaders['upgrade-insecure-requests']
 
+  // Remove the browser's user-agent so that defaultHeaders() can reliably set the CLI
+  // user-agent. In HTTP/2, browsers send 'user-agent' in lowercase; without this deletion
+  // both 'user-agent' (browser) and 'User-Agent' (CLI) coexist as separate JS object keys
+  // and Node's fetch normalizes them such that the browser UA wins.
+  delete proxyRequestHeaders['user-agent']
+
   const ipAddress = getRequestIP(event)
   if (ipAddress) proxyRequestHeaders['X-Forwarded-For'] = ipAddress
 


### PR DESCRIPTION
## Summary

- Fixes 429 errors merchants were seeing on `POST /cart/add.js` during `shopify theme dev`
- In HTTP/2, browsers send headers lowercase (e.g. `user-agent`). The CLI sets `User-Agent` (title-case) via `defaultHeaders()`. Without explicit deletion, both coexist as separate JS object keys and Node's `fetch` normalizes them so the **browser UA wins**
- SFR then sees a real browser UA and applies bot-mitigation/rate-limiting rather than CLI allowances
- Fix: delete `proxyRequestHeaders['user-agent']` in `getProxyStorefrontHeaders()` before the merge with `defaultHeaders()`, so CLI always controls the outgoing `User-Agent`
- Cart/checkout/account endpoints are most affected since they intentionally omit Bearer token auth

Closes https://github.com/Shopify/theme-tools/issues/1142

## Test plan

- [ ] Updated existing `getProxyStorefrontHeaders` snapshot test — `user-agent` is now removed alongside other hop-by-hop/safari headers
- [ ] Added explicit test asserting `user-agent` is undefined after `getProxyStorefrontHeaders`
- [ ] Run `pnpm --filter @shopify/theme test` locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)