### PR TITLE
Read client steps from remote config

### DIFF
--- a/packages/app/src/cli/api/graphql/app-management/generated/specifications.ts
+++ b/packages/app/src/cli/api/graphql/app-management/generated/specifications.ts
@@ -13,6 +13,7 @@ export type FetchSpecificationsQuery = {
     identifier: string
     externalIdentifier: string
     features: string[]
+    clientSteps?: string | null
     uidStrategy:
       | {appModuleLimit: number; isClientProvided: boolean}
       | {appModuleLimit: number; isClientProvided: boolean}
@@ -55,6 +56,7 @@ export const FetchSpecifications = {
                 {kind: 'Field', name: {kind: 'Name', value: 'identifier'}},
                 {kind: 'Field', name: {kind: 'Name', value: 'externalIdentifier'}},
                 {kind: 'Field', name: {kind: 'Name', value: 'features'}},
+                {kind: 'Field', name: {kind: 'Name', value: 'clientSteps'}},
                 {
                   kind: 'Field',
                   name: {kind: 'Name', value: 'uidStrategy'},

--- a/packages/app/src/cli/api/graphql/app-management/queries/specifications.graphql
+++ b/packages/app/src/cli/api/graphql/app-management/queries/specifications.graphql
@@ -4,6 +4,7 @@ query fetchSpecifications($organizationId: ID!) {
     identifier
     externalIdentifier
     features
+    clientSteps
     uidStrategy {
       appModuleLimit
       isClientProvided

--- a/packages/app/src/cli/api/graphql/extension_specifications.ts
+++ b/packages/app/src/cli/api/graphql/extension_specifications.ts
@@ -1,3 +1,4 @@
+import {ClientSteps} from '../../services/build/client-steps.js'
 import {gql} from 'graphql-request'
 
 export const ExtensionSpecificationsQuery = gql`
@@ -36,6 +37,7 @@ export interface RemoteSpecification {
   gated: boolean
   externalIdentifier: string
   experience: 'extension' | 'configuration' | 'deprecated'
+  clientSteps?: ClientSteps
   options: {
     managementExperience: 'cli' | 'custom' | 'dashboard'
     registrationLimit: number

--- a/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
@@ -141,6 +141,7 @@ import {
   AppLogsSubscribeMutationVariables,
 } from '../../api/graphql/app-management/generated/app-logs-subscribe.js'
 import {SourceExtension} from '../../api/graphql/app-management/generated/types.js'
+import {ClientSteps} from '../../services/build/client-steps.js'
 import {getPartnersToken} from '@shopify/cli-kit/node/environment'
 import {ensureAuthenticatedAppManagementAndBusinessPlatform, Session} from '@shopify/cli-kit/node/session'
 import {isUnitTest} from '@shopify/cli-kit/node/context/local'
@@ -454,6 +455,7 @@ export class AppManagementClient implements DeveloperPlatformClient {
         identifier: spec.identifier,
         externalIdentifier: spec.externalIdentifier,
         gated: false,
+        clientSteps: parseClientSteps(spec.clientSteps),
         options: {
           managementExperience: 'cli',
           registrationLimit: spec.uidStrategy.appModuleLimit,
@@ -1430,4 +1432,8 @@ function toUserError(err: CreateAppVersionMutation['appVersionCreate']['userErro
 
 function isStoreProvisionable(permissions: string[]) {
   return permissions.includes('ondemand_access_to_stores')
+}
+function parseClientSteps(clientSteps: string | null | undefined): ClientSteps | undefined {
+  if (!clientSteps) return undefined
+  return JSON.parse(clientSteps)
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Extension specifications need to include client steps information to support build processes that require step-by-step client-side operations.

### WHAT is this pull request doing?

- Adds `clientSteps` field to the GraphQL query for fetching extension specifications
- Updates the `RemoteSpecification` interface to include a `clientSteps` property of type `ClientSteps`
- Implements parsing logic in `AppManagementClient` to convert the string-based `clientSteps` field from the API response into a structured `ClientSteps` array
- Imports the `ClientSteps` type from the build services module

### How to test your changes?

1. Run the application and trigger a fetch of extension specifications
2. Verify that the `clientSteps` field is properly retrieved from the GraphQL API
3. Confirm that the client steps are correctly parsed and available in the specification objects

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes