### PR TITLE
Gate tools and instructions behind Remote DOM api_version check

### DIFF
--- a/.changeset/smart-teams-win.md
+++ b/.changeset/smart-teams-win.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Exclude unsupported assets from the build manifest for Remote UI extensions

--- a/packages/app/src/cli/models/extensions/specifications/ui_extension.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/ui_extension.test.ts
@@ -79,7 +79,7 @@ describe('ui_extension', async () => {
 
   async function setupToolsExtension(
     tmpDir: string,
-    options: {tools?: string; instructions?: string; createFiles?: boolean} = {},
+    options: {tools?: string; instructions?: string; createFiles?: boolean; apiVersion?: string} = {},
   ) {
     await mkdir(joinPath(tmpDir, 'src'))
     await touchFile(joinPath(tmpDir, 'src', 'ExtensionPointA.js'))
@@ -106,7 +106,7 @@ describe('ui_extension', async () => {
 
     const configuration = {
       targeting: [targetConfig],
-      api_version: '2023-01' as const,
+      api_version: options.apiVersion ?? '2025-10',
       name: 'UI Extension',
       description: 'This is an ordinary test extension',
       type: 'ui_extension',
@@ -557,7 +557,7 @@ describe('ui_extension', async () => {
       ])
     })
 
-    test('build_manifest includes tools asset when tools is present', async () => {
+    test('build_manifest includes tools asset when tools is present and api_version supports Remote DOM', async () => {
       const allSpecs = await loadLocalExtensionsSpecifications()
       const specification = allSpecs.find((spec) => spec.identifier === 'ui_extension')!
       const configuration = {
@@ -568,7 +568,7 @@ describe('ui_extension', async () => {
             tools: './tools.json',
           },
         ],
-        api_version: '2023-01' as const,
+        api_version: '2025-10' as const,
         name: 'UI Extension',
         description: 'This is an ordinary test extension',
         type: 'ui_extension',
@@ -625,7 +625,70 @@ describe('ui_extension', async () => {
       ])
     })
 
-    test('build_manifest includes instructions asset when instructions is present', async () => {
+    test('build_manifest excludes tools asset when api_version does not support Remote DOM', async () => {
+      const allSpecs = await loadLocalExtensionsSpecifications()
+      const specification = allSpecs.find((spec) => spec.identifier === 'ui_extension')!
+      const configuration = {
+        targeting: [
+          {
+            target: 'EXTENSION::POINT::A',
+            module: './src/ExtensionPointA.js',
+            tools: './tools.json',
+          },
+        ],
+        api_version: '2023-01' as const,
+        name: 'UI Extension',
+        description: 'This is an ordinary test extension',
+        type: 'ui_extension',
+        handle: 'test-ui-extension',
+        capabilities: {
+          block_progress: false,
+          network_access: false,
+          api_access: false,
+          collect_buyer_consent: {
+            customer_privacy: true,
+            sms_marketing: false,
+          },
+          iframe: {
+            sources: [],
+          },
+        },
+        settings: {},
+      }
+
+      // When
+      const parsed = specification.parseConfigurationObject(configuration)
+      if (parsed.state !== 'ok') {
+        throw new Error("Couldn't parse configuration")
+      }
+
+      const got = parsed.data
+
+      // Then
+      expect(got.extension_points).toStrictEqual([
+        {
+          target: 'EXTENSION::POINT::A',
+          module: './src/ExtensionPointA.js',
+          tools: undefined,
+          instructions: undefined,
+          metafields: [],
+          default_placement_reference: undefined,
+          capabilities: undefined,
+          preloads: {},
+          build_manifest: {
+            assets: {
+              main: {
+                filepath: 'test-ui-extension.js',
+                module: './src/ExtensionPointA.js',
+              },
+            },
+          },
+          urls: {},
+        },
+      ])
+    })
+
+    test('build_manifest includes instructions asset when instructions is present and api_version supports Remote DOM', async () => {
       const allSpecs = await loadLocalExtensionsSpecifications()
       const specification = allSpecs.find((spec) => spec.identifier === 'ui_extension')!
       const configuration = {
@@ -636,7 +699,7 @@ describe('ui_extension', async () => {
             instructions: './instructions.md',
           },
         ],
-        api_version: '2023-01' as const,
+        api_version: '2025-10' as const,
         name: 'UI Extension',
         description: 'This is an ordinary test extension',
         type: 'ui_extension',
@@ -685,6 +748,69 @@ describe('ui_extension', async () => {
                 filepath: 'test-ui-extension-instructions-instructions.md',
                 module: './instructions.md',
                 static: true,
+              },
+            },
+          },
+          urls: {},
+        },
+      ])
+    })
+
+    test('build_manifest excludes instructions asset when api_version does not support Remote DOM', async () => {
+      const allSpecs = await loadLocalExtensionsSpecifications()
+      const specification = allSpecs.find((spec) => spec.identifier === 'ui_extension')!
+      const configuration = {
+        targeting: [
+          {
+            target: 'EXTENSION::POINT::A',
+            module: './src/ExtensionPointA.js',
+            instructions: './instructions.md',
+          },
+        ],
+        api_version: '2023-01' as const,
+        name: 'UI Extension',
+        description: 'This is an ordinary test extension',
+        type: 'ui_extension',
+        handle: 'test-ui-extension',
+        capabilities: {
+          block_progress: false,
+          network_access: false,
+          api_access: false,
+          collect_buyer_consent: {
+            customer_privacy: true,
+            sms_marketing: false,
+          },
+          iframe: {
+            sources: [],
+          },
+        },
+        settings: {},
+      }
+
+      // When
+      const parsed = specification.parseConfigurationObject(configuration)
+      if (parsed.state !== 'ok') {
+        throw new Error("Couldn't parse configuration")
+      }
+
+      const got = parsed.data
+
+      // Then
+      expect(got.extension_points).toStrictEqual([
+        {
+          target: 'EXTENSION::POINT::A',
+          module: './src/ExtensionPointA.js',
+          tools: undefined,
+          instructions: undefined,
+          metafields: [],
+          default_placement_reference: undefined,
+          capabilities: undefined,
+          preloads: {},
+          build_manifest: {
+            assets: {
+              main: {
+                filepath: 'test-ui-extension.js',
+                module: './src/ExtensionPointA.js',
               },
             },
           },
@@ -852,7 +978,7 @@ Please check the configuration in ${joinPath(tmpDir, 'shopify.extension.toml')}`
       })
     })
 
-    test('build_manifest includes both tools and instructions when both are present', async () => {
+    test('build_manifest includes both tools and instructions when both are present and api_version supports Remote DOM', async () => {
       const allSpecs = await loadLocalExtensionsSpecifications()
       const specification = allSpecs.find((spec) => spec.identifier === 'ui_extension')!
       const configuration = {
@@ -864,7 +990,7 @@ Please check the configuration in ${joinPath(tmpDir, 'shopify.extension.toml')}`
             instructions: './instructions.md',
           },
         ],
-        api_version: '2023-01' as const,
+        api_version: '2025-10' as const,
         name: 'UI Extension',
         description: 'This is an ordinary test extension',
         type: 'ui_extension',

--- a/packages/app/src/cli/models/extensions/specifications/ui_extension.ts
+++ b/packages/app/src/cli/models/extensions/specifications/ui_extension.ts
@@ -45,6 +45,10 @@ export const UIExtensionSchema = BaseSchema.extend({
 })
   .refine((config) => validatePoints(config), missingExtensionPointsMessage)
   .transform((config) => {
+    const apiVersion = config.api_version
+    const {year, month} = parseApiVersion(apiVersion ?? '') ?? {year: 0, month: 0}
+    const remoteDom = year > 2025 || (year === 2025 && month >= 10)
+
     const extensionPoints = (config.targeting ?? config.extension_points ?? []).map((targeting) => {
       const buildManifest: BuildManifest = {
         assets: {
@@ -60,7 +64,7 @@ export const UIExtensionSchema = BaseSchema.extend({
                 },
               }
             : null),
-          ...(targeting.tools
+          ...(remoteDom && targeting.tools
             ? {
                 [AssetIdentifier.Tools]: {
                   filepath: `${config.handle}-${AssetIdentifier.Tools}-${basename(targeting.tools)}`,
@@ -69,7 +73,7 @@ export const UIExtensionSchema = BaseSchema.extend({
                 },
               }
             : null),
-          ...(targeting.instructions
+          ...(remoteDom && targeting.instructions
             ? {
                 [AssetIdentifier.Instructions]: {
                   filepath: `${config.handle}-${AssetIdentifier.Instructions}-${basename(targeting.instructions)}`,
@@ -90,8 +94,8 @@ export const UIExtensionSchema = BaseSchema.extend({
         capabilities: targeting.capabilities,
         preloads: targeting.preloads ?? {},
         build_manifest: buildManifest,
-        tools: targeting.tools,
-        instructions: targeting.instructions,
+        tools: remoteDom ? targeting.tools : undefined,
+        instructions: remoteDom ? targeting.instructions : undefined,
       }
     })
     return {...config, extension_points: extensionPoints}
@@ -424,7 +428,7 @@ async function validateUIExtensionPointConfig(
 
 function isRemoteDomExtension(
   config: ExtensionInstance['configuration'],
-): config is ExtensionInstance<{api_version: string}>['configuration'] {
+): config is ExtensionInstance['configuration'] & {api_version: string} {
   const apiVersion = config.api_version
   if (!apiVersion) {
     return false


### PR DESCRIPTION
### What:
Only add tools and instructions to the build_manifest for ui_extension when isRemoteDomExtension is true (`api_version >= 2025-10`). Previously these were unconditionally included regardless of api_version even though they are not supported.

Also fixes the isRemoteDomExtension type guard return type from `ExtensionInstance<{api_version: string}>['configuration']` (which lost all other config properties) to `ExtensionInstance['configuration'] & {api_version: string}` (which preserves them while narrowing api_version).

### Changes:

ui_extension.ts:
- In the UIExtensionSchema transform, compute whether the config qualifies as Remote DOM and only spread tools/instructions into build_manifest assets when true
- tools and instructions on the extension point object are set to undefined for non-Remote-DOM versions
- Fixed isRemoteDomExtension type guard return type

ui_extension.test.ts:
- Updated existing tools/instructions build_manifest tests to use api_version: '2025-10'
- Added 2 new negative tests confirming tools/instructions are excluded for non-Remote-DOM api versions
- Updated setupToolsExtension helper to default to '2025-10' with an apiVersion option
- Renamed test descriptions to clarify Remote DOM version dependency

### Testing
All unit tests should pass