### PR TITLE
Extract extension_directories transforms from Zod schema

### DIFF
--- a/packages/app/src/cli/models/app/app.test.ts
+++ b/packages/app/src/cli/models/app/app.test.ts
@@ -4,6 +4,7 @@ import {
   getAppScopes,
   getAppScopesArray,
   getUIExtensionRendererVersion,
+  normalizeExtensionDirectories,
   validateExtensionsHandlesInCollection,
   validateFunctionExtensionsWithUiHandle,
 } from './app.js'
@@ -58,31 +59,36 @@ const CORRECT_CURRENT_APP_SCHEMA: CurrentAppConfiguration = {
 }
 
 describe('app schema validation', () => {
-  test('extension_directories should be transformed to double asterisks', () => {
+  test('extension_directories preserves raw values without transformation', () => {
     const config = {
       ...CORRECT_CURRENT_APP_SCHEMA,
       extension_directories: ['extensions/*'],
     }
     const parsed = AppSchema.parse(config)
-    expect(parsed.extension_directories).toEqual(['extensions/**'])
+    expect(parsed.extension_directories).toEqual(['extensions/*'])
+  })
+})
+
+describe('normalizeExtensionDirectories', () => {
+  test('converts single trailing wildcard to double asterisks', () => {
+    expect(normalizeExtensionDirectories(['extensions/*'])).toEqual(['extensions/**'])
   })
 
-  test('extension_directories is not transformed if it ends with double asterisks', () => {
-    const config = {
-      ...CORRECT_CURRENT_APP_SCHEMA,
-      extension_directories: ['extensions/**'],
-    }
-    const parsed = AppSchema.parse(config)
-    expect(parsed.extension_directories).toEqual(['extensions/**'])
+  test('preserves double asterisks', () => {
+    expect(normalizeExtensionDirectories(['extensions/**'])).toEqual(['extensions/**'])
   })
 
-  test('extension_directories is not transformed if it doesnt end with a wildcard', () => {
-    const config = {
-      ...CORRECT_CURRENT_APP_SCHEMA,
-      extension_directories: ['extensions'],
-    }
-    const parsed = AppSchema.parse(config)
-    expect(parsed.extension_directories).toEqual(['extensions'])
+  test('does not transform paths without wildcards', () => {
+    expect(normalizeExtensionDirectories(['extensions'])).toEqual(['extensions'])
+  })
+
+  test('strips trailing path separators before fixing wildcards', () => {
+    expect(normalizeExtensionDirectories(['extensions/'])).toEqual(['extensions'])
+    expect(normalizeExtensionDirectories(['extensions\\'])).toEqual(['extensions'])
+  })
+
+  test('returns undefined for undefined input', () => {
+    expect(normalizeExtensionDirectories(undefined)).toBeUndefined()
   })
 })
 

--- a/packages/app/src/cli/models/app/app.ts
+++ b/packages/app/src/cli/models/app/app.ts
@@ -32,11 +32,7 @@ import {deepMergeObjects} from '@shopify/cli-kit/common/object'
 
 // Schemas for loading app configuration
 
-const ExtensionDirectoriesSchema = zod
-  .array(zod.string())
-  .optional()
-  .transform(removeTrailingPathSeparator)
-  .transform(fixSingleWildcards)
+const ExtensionDirectoriesSchema = zod.array(zod.string()).optional()
 
 function removeTrailingPathSeparator(value: string[] | undefined) {
   // eslint-disable-next-line no-useless-escape
@@ -48,6 +44,14 @@ function removeTrailingPathSeparator(value: string[] | undefined) {
 function fixSingleWildcards(value: string[] | undefined) {
   // eslint-disable-next-line no-useless-escape
   return value?.map((dir) => dir.replace(/([^\*])\*$/, '$1**'))
+}
+
+/**
+ * Normalize extension directories for glob/chokidar consumption:
+ * strips trailing path separators, then converts single trailing `*` to `**`.
+ */
+export function normalizeExtensionDirectories(dirs: string[] | undefined): string[] | undefined {
+  return fixSingleWildcards(removeTrailingPathSeparator(dirs))
 }
 
 /**

--- a/packages/app/src/cli/models/app/loader.ts
+++ b/packages/app/src/cli/models/app/loader.ts
@@ -14,6 +14,7 @@ import {
   SchemaForConfig,
   AppLinkedInterface,
   AppHiddenConfig,
+  normalizeExtensionDirectories,
 } from './app.js'
 import {parseHumanReadableError} from './error-parsing.js'
 import {configurationFileNames, dotEnvFileNames} from '../../constants.js'
@@ -621,7 +622,8 @@ class AppLoader<TConfig extends CurrentAppConfiguration, TModuleSpec extends Ext
   }
 
   private async createExtensionInstances(appDirectory: string, extensionDirectories?: string[]) {
-    const extensionConfigPaths = [...(extensionDirectories ?? [defaultExtensionDirectory])].map((extensionPath) => {
+    const normalizedDirs = normalizeExtensionDirectories(extensionDirectories)
+    const extensionConfigPaths = [...(normalizedDirs ?? [defaultExtensionDirectory])].map((extensionPath) => {
       return joinPath(appDirectory, extensionPath, '*.extension.toml')
     })
     extensionConfigPaths.push(`!${joinPath(appDirectory, '**/node_modules/**')}`)

--- a/packages/app/src/cli/services/dev/app-events/file-watcher.ts
+++ b/packages/app/src/cli/services/dev/app-events/file-watcher.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-case-declarations */
-import {AppLinkedInterface} from '../../../models/app/app.js'
+import {AppLinkedInterface, normalizeExtensionDirectories} from '../../../models/app/app.js'
 import {configurationFileNames} from '../../../constants.js'
 import {dirname, joinPath, normalizePath, relativePath} from '@shopify/cli-kit/node/path'
 import {FSWatcher} from 'chokidar'
@@ -85,7 +85,9 @@ export class FileWatcher {
    * This ensures the watcher picks up any changes in what files need to be watched.
    */
   async start(): Promise<void> {
-    const extensionDirectories = [...(this.app.configuration.extension_directories ?? ['extensions'])]
+    const extensionDirectories = [
+      ...(normalizeExtensionDirectories(this.app.configuration.extension_directories) ?? ['extensions']),
+    ]
     const fullExtensionDirectories = extensionDirectories.map((directory) => joinPath(this.app.directory, directory))
     const watchPaths = [this.app.configPath, ...fullExtensionDirectories]
 


### PR DESCRIPTION
### WHY are these changes introduced?

`ExtensionDirectoriesSchema` chains two Zod `.transform()` calls that silently reshape the parsed value:

- `removeTrailingPathSeparator` — strips trailing `/` or `\` (e.g. `extensions/` → `extensions`)
- `fixSingleWildcards` — converts a single trailing `*` to `**` for glob compatibility (e.g. `extensions/*` → `extensions/**`)

After parsing, `config.extension_directories` no longer matches what the user wrote in their TOML. This means writing the config back to disk would persist the transformed values instead of the originals — a data corruption risk during config link/pull. It also violates the contract established earlier in this stack: `AppConfiguration` should describe what's in the file, nothing more.

### WHAT is this pull request doing?

Removes both transforms from the Zod schema so the parsed config preserves the raw TOML value. Adds an explicit `normalizeExtensionDirectories()` helper that consumers call at point of use:

- **`loader.ts`** — `createExtensionInstances()` normalizes before globbing for extension TOMLs
- **`file-watcher.ts`** — `start()` normalizes before passing directories to chokidar

These are the only two consumers that need normalized paths. All other readers (deploy, config write-back, display) should see the raw user-authored value.

The snapshot tests from #6947 confirm no change in end-to-end TOML output.

### How to test your changes?

```
npx vitest run packages/app/src/cli/models/app/app.test.ts
npx vitest run packages/app/src/cli/services/app/config-pipeline-snapshot.test.ts
```

### Measuring impact

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes