### PR TITLE
Extract scopes transforms from Zod schemas into accessor functions

### DIFF
--- a/packages/app/src/cli/models/app/app.test.ts
+++ b/packages/app/src/cli/models/app/app.test.ts
@@ -175,16 +175,16 @@ describe('getUIExtensionRendererVersion', () => {
 })
 
 describe('getAppScopes', () => {
-  test('returns the access_scopes.scopes key', () => {
+  test('returns the access_scopes.scopes key with normalization', () => {
     const config = {...DEFAULT_CONFIG, access_scopes: {scopes: 'read_themes,read_themes'}}
-    expect(getAppScopes(config)).toEqual('read_themes,read_themes')
+    expect(getAppScopes(config)).toEqual('read_themes')
   })
 })
 
 describe('getAppScopesArray', () => {
-  test('returns the access_scopes.scopes key', () => {
+  test('returns the access_scopes.scopes key as array with normalization', () => {
     const config = {...DEFAULT_CONFIG, access_scopes: {scopes: 'read_themes, read_order ,write_products'}}
-    expect(getAppScopesArray(config)).toEqual(['read_themes', 'read_order', 'write_products'])
+    expect(getAppScopesArray(config)).toEqual(['read_order', 'read_themes', 'write_products'])
   })
 })
 

--- a/packages/app/src/cli/models/app/app.ts
+++ b/packages/app/src/cli/models/app/app.ts
@@ -13,6 +13,7 @@ import {configurationFileNames} from '../../constants.js'
 import {ApplicationURLs} from '../../services/dev/urls.js'
 import {patchAppHiddenConfigFile} from '../../services/app/patch-app-configuration-file.js'
 import {WebhookSubscription} from '../extensions/specifications/types/app_config_webhook.js'
+import {normalizeDelimitedString} from '@shopify/cli-kit/common/string'
 import {joinPath} from '@shopify/cli-kit/node/path'
 import {ZodObjectOf, zod} from '@shopify/cli-kit/node/schema'
 import {DotEnvFile} from '@shopify/cli-kit/node/dot-env'
@@ -73,6 +74,31 @@ export const AppSchema = zod
   .passthrough()
 
 /**
+ * Schema for loading template config during app init.
+ * Uses passthrough() to allow any extra keys from full-featured templates
+ * (e.g., metafields, metaobjects, webhooks) without strict validation.
+ */
+export const TemplateConfigSchema = zod
+  .object({
+    scopes: zod.string().optional(),
+    access_scopes: zod
+      .object({
+        scopes: zod.string(),
+      })
+      .optional(),
+    web_directories: zod.array(zod.string()).optional(),
+  })
+  .passthrough()
+
+export type TemplateConfig = zod.infer<typeof TemplateConfigSchema>
+
+export function getTemplateScopesArray(config: TemplateConfig): string[] {
+  const scopesString = normalizeDelimitedString(config.scopes ?? config.access_scopes?.scopes)
+  if (!scopesString || scopesString.length === 0) return []
+  return scopesString.split(',').map((scope) => scope.trim())
+}
+
+/**
  * Hidden configuration for an app. Stored inside ./shopify/project.json
  * This is a set of values that are needed by the CLI that are not part of the app configuration.
  * These are not meant to be git tracked and the user doesn't need to know about their existence.
@@ -127,7 +153,7 @@ export function getAppVersionedSchema(
  * @param config - a configuration file
  */
 export function getAppScopes(config: CurrentAppConfiguration): string {
-  return config.access_scopes?.scopes ?? ''
+  return normalizeDelimitedString(config.access_scopes?.scopes) ?? ''
 }
 
 /**

--- a/packages/app/src/cli/models/app/loader.test.ts
+++ b/packages/app/src/cli/models/app/loader.test.ts
@@ -3487,6 +3487,19 @@ describe('WebhooksSchema', () => {
 describe('getAppConfigurationState', () => {
   test.each([
     [
+      `scopes = "  write_xyz,     write_abc    "`,
+      {
+        state: 'template-only',
+        configSource: 'cached',
+        configurationFileName: 'shopify.app.toml',
+        appDirectory: expect.any(String),
+        configurationPath: expect.stringMatching(/shopify.app.toml$/),
+        startingOptions: {
+          scopes: '  write_xyz,     write_abc    ',
+        },
+      },
+    ],
+    [
       `client_id="abcdef"`,
       {
         basicConfiguration: {

--- a/packages/app/src/cli/models/extensions/specifications/app_config_app_access.ts
+++ b/packages/app/src/cli/models/extensions/specifications/app_config_app_access.ts
@@ -1,7 +1,6 @@
 import {validateUrl} from '../../app/validation/common.js'
 import {TransformationConfig, createConfigExtensionSpecification} from '../specification.js'
 import {BaseSchemaWithoutHandle} from '../schemas.js'
-import {normalizeDelimitedString} from '@shopify/cli-kit/common/string'
 import {zod} from '@shopify/cli-kit/node/schema'
 
 const AppAccessSchema = BaseSchemaWithoutHandle.extend({
@@ -17,10 +16,7 @@ const AppAccessSchema = BaseSchemaWithoutHandle.extend({
     .optional(),
   access_scopes: zod
     .object({
-      scopes: zod
-        .string()
-        .transform((scopes) => normalizeDelimitedString(scopes) ?? '')
-        .optional(),
+      scopes: zod.string().optional(),
       required_scopes: zod.array(zod.string()).optional(),
       optional_scopes: zod.array(zod.string()).optional(),
       use_legacy_install_flow: zod.boolean().optional(),


### PR DESCRIPTION
### WHY are these changes introduced?

Phase 2b of config model cleanup. The `normalizeDelimitedString` transform on scopes (sort, deduplicate, trim) is applied at parse time in 3 Zod schemas across 2 files. This means `config.access_scopes.scopes` doesn't match what the user wrote in their TOML — `"write_products,read_products"` silently becomes `"read_products,write_products"`. Config objects should preserve the source value; normalization belongs in the accessor layer.

### WHAT is this pull request doing?

**Removes parse-time transforms from 3 schemas:**
- `LegacyAppSchema.scopes` in `app.ts`
- `TemplateConfigSchema.scopes` and `.access_scopes.scopes` in `app.ts`
- `AppAccessSchema.access_scopes.scopes` in `app_config_app_access.ts`

**Moves normalization into accessor functions:**
- `getAppScopes()` — now calls `normalizeDelimitedString()` before returning
- `getTemplateScopesArray()` — now calls `normalizeDelimitedString()` instead of manual `.sort()`

`getAppScopesArray()` delegates to `getAppScopes()` so it gets normalization for free.

**Why this is safe:**
- All CLI consumers read scopes through `getAppScopes()`/`getAppScopesArray()`/`getTemplateScopesArray()`
- Deploy path (`transformLocalToRemote`) is pure path remapping — platform normalizes server-side
- `warnIfScopesDifferBeforeDev` in `dev.ts` does its own `rationaliseScopes()` normalization before comparing
- Re-normalizing already-normalized scopes is a no-op

### How to test your changes?

```
npx vitest run packages/app/src/cli/models/app/app.test.ts
npx vitest run packages/app/src/cli/models/extensions/specifications/app_config_app_access.test.ts
npx vitest run packages/app/src/cli/services/app/config-pipeline-snapshot.test.ts
```

### Measuring impact

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes