### PR TITLE
Fix snapshot script

### DIFF
--- a/packages/features/snapshots/regenerate.sh
+++ b/packages/features/snapshots/regenerate.sh
@@ -6,4 +6,4 @@ set -euo pipefail
 cd "$(dirname "$0")"
 
 # regenerate commands snapshot file
-../../cli/bin/dev.js commands --tree > commands.txt
+node ../../cli/bin/dev.js commands --tree > commands.txt


### PR DESCRIPTION
### WHY are these changes introduced?

`pnpm test:regenerate-snapshots` fails on some systems because `dev.js` is executed directly by bash, which interprets the ES module `import` statement as a shell command (ImageMagick's `import` on systems where it's installed).

### WHAT is this pull request doing?

Run `dev.js` with `node` explicitly instead of relying on direct execution.

### How to test your changes?

```bash
pnpm test:regenerate-snapshots
```

### Measuring impact

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes