### PR TITLE
Fix unsupported `IN` operator for `store_type` filter in `FetchStoreByDomain`

### DIFF
--- a/packages/app/src/cli/api/graphql/business-platform-organizations/generated/fetch_store_by_domain.ts
+++ b/packages/app/src/cli/api/graphql/business-platform-organizations/generated/fetch_store_by_domain.ts
@@ -5,7 +5,7 @@ import {TypedDocumentNode as DocumentNode} from '@graphql-typed-document-node/co
 
 export type FetchStoreByDomainQueryVariables = Types.Exact<{
   domain?: Types.InputMaybe<Types.Scalars['String']['input']>
-  storeTypes: Types.Scalars['String']['input']
+  filters?: Types.InputMaybe<Types.ShopFilterInput[] | Types.ShopFilterInput>
 }>
 
 export type FetchStoreByDomainQuery = {
@@ -44,8 +44,11 @@ export const FetchStoreByDomain = {
         },
         {
           kind: 'VariableDefinition',
-          variable: {kind: 'Variable', name: {kind: 'Name', value: 'storeTypes'}},
-          type: {kind: 'NonNullType', type: {kind: 'NamedType', name: {kind: 'Name', value: 'String'}}},
+          variable: {kind: 'Variable', name: {kind: 'Name', value: 'filters'}},
+          type: {
+            kind: 'ListType',
+            type: {kind: 'NonNullType', type: {kind: 'NamedType', name: {kind: 'Name', value: 'ShopFilterInput'}}},
+          },
         },
       ],
       selectionSet: {
@@ -66,26 +69,7 @@ export const FetchStoreByDomain = {
                     {
                       kind: 'Argument',
                       name: {kind: 'Name', value: 'filters'},
-                      value: {
-                        kind: 'ObjectValue',
-                        fields: [
-                          {
-                            kind: 'ObjectField',
-                            name: {kind: 'Name', value: 'field'},
-                            value: {kind: 'EnumValue', value: 'STORE_TYPE'},
-                          },
-                          {
-                            kind: 'ObjectField',
-                            name: {kind: 'Name', value: 'operator'},
-                            value: {kind: 'EnumValue', value: 'IN'},
-                          },
-                          {
-                            kind: 'ObjectField',
-                            name: {kind: 'Name', value: 'value'},
-                            value: {kind: 'Variable', name: {kind: 'Name', value: 'storeTypes'}},
-                          },
-                        ],
-                      },
+                      value: {kind: 'Variable', name: {kind: 'Name', value: 'filters'}},
                     },
                     {
                       kind: 'Argument',

--- a/packages/app/src/cli/api/graphql/business-platform-organizations/generated/types.d.ts
+++ b/packages/app/src/cli/api/graphql/business-platform-organizations/generated/types.d.ts
@@ -80,9 +80,54 @@ export type Scalars = {
   URL: { input: string; output: string; }
 };
 
+/** Operators for user filter queries. */
+export type Operator =
+  /** Between operator. */
+  | 'BETWEEN'
+  /** Equals operator. */
+  | 'EQUALS'
+  /** In operator. */
+  | 'IN';
+
 export type OrganizationUserProvisionShopAccessInput = {
   /** The shop to provision the requester on. */
   shopifyShopId: Scalars['PropertyPublicID']['input'];
+};
+
+/** Field options for filtering shop queries. */
+export type ShopFilterField =
+  /**
+   * The phase of the client transfer process. Requires
+   * `store_type=client_transfer`. Values: `in_development`, `pending`, `completed`.
+   */
+  | 'CLIENT_TRANSFER_PHASE'
+  /**
+   * The status of the collaborator relationship. Requires
+   * `store_type=collaborator`. Values: `active`, `access_pending`, `expired`.
+   */
+  | 'COLLABORATOR_RELATIONSHIP_STATUS'
+  /** The GID of the counterpart organization. Requires `store_type=client_transfer` or `store_type=collaborator`. */
+  | 'COUNTERPART_ORGANIZATION_ID'
+  /**
+   * The plan of the shop. Values: `basic`, `grow`, `plus`, `frozen`, `advanced`,
+   * `inactive`, `cancelled`, `client_transfer`, `plus_client_transfer`,
+   * `development_legacy`, `custom`, `fraudulent`, `staff`, `trial`,
+   * `plus_development`, `retail`, `shop_pay_commerce_components`, `non_profit`.
+   */
+  | 'SHOP_PLAN'
+  /** The active/inactive status of the shop. Values: `active`, `inactive`. */
+  | 'STORE_STATUS'
+  /**
+   * The type of the shop. Values: `development`, `production`, `app_development`,
+   * `development_superset`, `client_transfer`, `collaborator`.
+   */
+  | 'STORE_TYPE';
+
+/** Represents a single filter option for shop queries. */
+export type ShopFilterInput = {
+  field: ShopFilterField;
+  operator: Operator;
+  value: Scalars['String']['input'];
 };
 
 export type Store =

--- a/packages/app/src/cli/api/graphql/business-platform-organizations/queries/fetch_store_by_domain.graphql
+++ b/packages/app/src/cli/api/graphql/business-platform-organizations/queries/fetch_store_by_domain.graphql
@@ -1,8 +1,8 @@
-query FetchStoreByDomain($domain: String, $storeTypes: String!) {
+query FetchStoreByDomain($domain: String, $filters: [ShopFilterInput!]) {
   organization {
     id
     name
-    accessibleShops(filters: {field: STORE_TYPE, operator: IN, value: $storeTypes}, search: $domain) {
+    accessibleShops(filters: $filters, search: $domain) {
       edges {
         node {
           id

--- a/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
@@ -90,10 +90,7 @@ import {
   DevSessionUpdateMutationVariables,
 } from '../../api/graphql/app-dev/generated/dev-session-update.js'
 import {DevSessionDelete, DevSessionDeleteMutation} from '../../api/graphql/app-dev/generated/dev-session-delete.js'
-import {
-  FetchStoreByDomain,
-  FetchStoreByDomainQueryVariables,
-} from '../../api/graphql/business-platform-organizations/generated/fetch_store_by_domain.js'
+import {FetchStoreByDomain} from '../../api/graphql/business-platform-organizations/generated/fetch_store_by_domain.js'
 import {
   ListAppDevStores,
   ListAppDevStoresQuery,
@@ -841,26 +838,30 @@ export class AppManagementClient implements DeveloperPlatformClient {
   }
 
   async storeByDomain(orgId: string, shopDomain: string, storeTypes: Store[]): Promise<OrganizationStore | undefined> {
-    const queryVariables: FetchStoreByDomainQueryVariables = {
-      domain: shopDomain,
-      storeTypes: storeTypes.map((t) => t.toLowerCase()).join(','),
-    }
-    const storesResult = await this.businessPlatformOrganizationsRequest({
-      query: FetchStoreByDomain,
-      organizationId: String(numberFromGid(orgId)),
-      variables: queryVariables,
-    })
+    const results = await Promise.all(
+      storeTypes.map((storeType) =>
+        this.businessPlatformOrganizationsRequest({
+          query: FetchStoreByDomain,
+          organizationId: String(numberFromGid(orgId)),
+          variables: {
+            domain: shopDomain,
+            filters: [{field: 'STORE_TYPE' as const, operator: 'EQUALS' as const, value: storeType.toLowerCase()}],
+          },
+        }),
+      ),
+    )
 
-    const organization = storesResult.organization
-
-    if (!organization) {
+    const organizations = results.map((result) => result.organization).filter((org) => org != null)
+    if (organizations.length === 0) {
       throw new AbortError(`No organization found`)
     }
 
-    const bpStoresArray = organization.accessibleShops?.edges.map((value) => value.node) ?? []
-    const provisionable = isStoreProvisionable(organization.currentUser?.organizationPermissions ?? [])
-    const storesArray = mapBusinessPlatformStoresToOrganizationStores(bpStoresArray, provisionable)
-    return storesArray[0]
+    const stores = organizations.flatMap((org) => {
+      const nodes = org.accessibleShops?.edges.map((edge) => edge.node) ?? []
+      const provisionable = isStoreProvisionable(org.currentUser?.organizationPermissions ?? [])
+      return mapBusinessPlatformStoresToOrganizationStores(nodes, provisionable)
+    })
+    return stores[0]
   }
 
   async ensureUserAccessToStore(orgId: string, store: OrganizationStore): Promise<void> {


### PR DESCRIPTION
Resolves: https://github.com/shop/issues-api-foundations/issues/1372

**Summary**

- Fix `FetchStoreByDomain` using the unsupported `IN` operator for `store_type `filters on `accessibleShops`. The backend silently ignores unrecognized operators, so the filter was never applied and all stores were returned.
- Switch to `EQUALS` operator via structured `ShopFilterInput` filters. Since the backend `AND`s multiple filters, we fan out one request per store type and merge results.
- Change `storeByDomain` return type from `OrganizationStore | undefined` to `OrganizationStore[]` so callers receive all matches across store types.

**Implmentation Details**

- The `IN` operator is unsupported for `STORE_TYPE` filters in the business-platform-organizations API, and multiple filters are combined with `AND `logic. Since a store can't match multiple types simultaneously, we work around this by making one request per store type in parallel using `EQUALS`. Most call sites pass a single type (`APP_DEVELOPMENT`), so this is a no-op for the common path. The 4-type case (app logs, webhook trigger) makes 4 parallel requests instead of 1.

**Test plan**

- Existing `fetchStore` tests updated and passing
- Verify `storeByDomain` correctly filters by store type (previously all stores were returned regardless of type)
- Regenerate GraphQL types from updated `.graphql` query

Tophat instructions:

1. `shopify app dev --path <your-app>` : confirm dev store resolves normally
2. `shopify app dev --path <your-app> --store <non-dev-store-domain>` : should fail with "store not found", confirming the store type filter is now applied (previously all stores were returned regardless of type)