### PR TITLE
Add retries + consolidate downloads in get-graphql-schemas

### DIFF
--- a/bin/get-graphql-schemas.js
+++ b/bin/get-graphql-schemas.js
@@ -29,7 +29,7 @@ function sleep(ms) {
  * @property {string} owner
  * @property {string} repo
  * @property {string} pathToFile
- * @property {string} localPath
+ * @property {string[]} localPaths
  * @property {string | undefined} [branch]
  * @property {boolean} [usesLfs]
  */
@@ -42,64 +42,54 @@ const schemas = [
     owner: 'Shopify',
     repo: 'partners',
     pathToFile: 'db/graphql/cli_schema.graphql',
-    localPath: './packages/app/src/cli/api/graphql/partners/cli_schema.graphql',
+    localPaths: ['./packages/app/src/cli/api/graphql/partners/cli_schema.graphql'],
   },
   {
     owner: 'shop',
     repo: 'world',
     pathToFile: 'areas/platforms/organizations/db/graphql/destinations_schema.graphql',
-    localPath: './packages/app/src/cli/api/graphql/business-platform-destinations/destinations_schema.graphql',
+    localPaths: ['./packages/app/src/cli/api/graphql/business-platform-destinations/destinations_schema.graphql'],
   },
   {
     owner: 'shop',
     repo: 'world',
     pathToFile: 'areas/platforms/organizations/db/graphql/organizations_schema.graphql',
-    localPath: './packages/app/src/cli/api/graphql/business-platform-organizations/organizations_schema.graphql',
+    localPaths: ['./packages/app/src/cli/api/graphql/business-platform-organizations/organizations_schema.graphql'],
   },
   {
     owner: 'shop',
     repo: 'world',
     pathToFile: 'areas/core/shopify/db/graphql/app_dev_schema_unstable_public.graphql',
-    localPath: './packages/app/src/cli/api/graphql/app-dev/app_dev_schema.graphql',
+    localPaths: ['./packages/app/src/cli/api/graphql/app-dev/app_dev_schema.graphql'],
   },
   {
     owner: 'shop',
     repo: 'world',
     pathToFile: 'areas/core/shopify/db/graphql/app_management_schema_unstable_public.graphql',
-    localPath: './packages/app/src/cli/api/graphql/app-management/app_management_schema.graphql',
+    localPaths: ['./packages/app/src/cli/api/graphql/app-management/app_management_schema.graphql'],
   },
   {
     owner: 'shop',
     repo: 'world',
     pathToFile: 'areas/core/shopify/db/graphql/admin_schema_unstable_public.graphql',
-    localPath: './packages/cli-kit/src/cli/api/graphql/admin/admin_schema.graphql',
+    localPaths: [
+      './packages/cli-kit/src/cli/api/graphql/admin/admin_schema.graphql',
+      './packages/app/src/cli/api/graphql/bulk-operations/admin_schema.graphql',
+      './packages/app/src/cli/api/graphql/admin/admin_schema.graphql',
+    ],
     usesLfs: true,
   },
   {
     owner: 'shop',
     repo: 'world',
     pathToFile: 'areas/core/shopify/db/graphql/webhooks_schema_unstable_public.graphql',
-    localPath: './packages/app/src/cli/api/graphql/webhooks/webhooks_schema.graphql',
+    localPaths: ['./packages/app/src/cli/api/graphql/webhooks/webhooks_schema.graphql'],
   },
   {
     owner: 'shop',
     repo: 'world',
     pathToFile: 'areas/core/shopify/db/graphql/functions_cli_api_schema_unstable_public.graphql',
-    localPath: './packages/app/src/cli/api/graphql/functions/functions_cli_schema.graphql',
-  },
-  {
-    owner: 'shop',
-    repo: 'world',
-    pathToFile: 'areas/core/shopify/db/graphql/admin_schema_unstable_public.graphql',
-    localPath: './packages/app/src/cli/api/graphql/bulk-operations/admin_schema.graphql',
-    usesLfs: true,
-  },
-  {
-    owner: 'shop',
-    repo: 'world',
-    pathToFile: 'areas/core/shopify/db/graphql/admin_schema_unstable_public.graphql',
-    localPath: './packages/app/src/cli/api/graphql/admin/admin_schema.graphql',
-    usesLfs: true,
+    localPaths: ['./packages/app/src/cli/api/graphql/functions/functions_cli_schema.graphql'],
   },
 ]
 
@@ -152,16 +142,13 @@ async function fetchFileForSchema(schema, octokit) {
         content = Buffer.from(data).toString('utf-8')
       }
 
-      // Define the local path where the file will be saved
-      const localFilePath = schema.localPath
-
-      const dir = path.dirname(localFilePath)
-      fs.mkdirSync(dir, {recursive: true})
-
-      // Write the content to a local file
-      fs.writeFileSync(localFilePath, content)
-
-      console.log(`File downloaded successfully to ${localFilePath}`)
+      // Write the content to all local paths
+      for (const localFilePath of schema.localPaths) {
+        const dir = path.dirname(localFilePath)
+        fs.mkdirSync(dir, {recursive: true})
+        fs.writeFileSync(localFilePath, content)
+        console.log(`File saved to ${localFilePath}`)
+      }
       return true
     } catch (error) {
       const isRateLimited = error.status === 429
@@ -218,8 +205,10 @@ async function fetchFilesFromLocal() {
     const localDir = schema.repo === 'world' ? '//' : schema.repo
     const localRepoDirectory = execSync(`/opt/dev/bin/dev cd --no-chdir ${localDir}`).toString().split('/areas')[0].trim()
     const sourcePath = path.join(localRepoDirectory, schema.pathToFile)
-    console.log('Copying', sourcePath, 'to', schema.localPath)
-    fs.copyFileSync(sourcePath, schema.localPath)
+    for (const localPath of schema.localPaths) {
+      console.log('Copying', sourcePath, 'to', localPath)
+      fs.copyFileSync(sourcePath, localPath)
+    }
   }
   console.log('Done!')
 }

--- a/bin/get-graphql-schemas.js
+++ b/bin/get-graphql-schemas.js
@@ -8,6 +8,22 @@ import {execSync} from "node:child_process";
 
 const BRANCH = 'main'
 
+// Retry config for GitHub API rate limiting (gitmon).
+// Uses longer delays than cli-kit's DEFAULT_RETRY_DELAY_MS (1s) because gitmon
+// blocks by subnet/network pattern, requiring more patience than typical API throttling.
+// Exponential backoff: 5s → 10s → 20s (35s total) is acceptable for CI scripts.
+const MAX_RETRIES = 3
+const INITIAL_RETRY_DELAY_MS = 5000
+
+/**
+ * Sleep for the specified number of milliseconds
+ * @param {number} ms
+ * @returns {Promise<void>}
+ */
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
 /**
  * @typedef {Object} Schema
  * @property {string} owner
@@ -94,52 +110,86 @@ const schemas = [
  * @returns {Promise<boolean>}
  */
 async function fetchFileForSchema(schema, octokit) {
-  try {
-    // Fetch the file content from the repository
-    const branch = schema.branch ?? BRANCH
-    const owner = schema.owner
-    const repoName = schema.repo
+  const branch = schema.branch ?? BRANCH
+  const owner = schema.owner
+  const repoName = schema.repo
+  const fileDescription = schema.usesLfs
+    ? `LFS file ${owner}/${repoName}#${branch}: ${schema.pathToFile}`
+    : `${owner}/${repoName}#${branch}: ${schema.pathToFile}`
 
-    let content = ''
-    if (schema.usesLfs) {
-      console.log(`\nFetching LFS file ${owner}/${repoName}#${branch}: ${schema.pathToFile} ...`)
-      const {data: {download_url}} = await octokit.repos.getContent({
-        mediaType: { format: "json" },
-        owner: owner,
-        repo: repoName,
-        path: schema.pathToFile,
-        ref: branch,
-      })
-      console.log(`LFS download via ${download_url}...`)
-      content = await fetch(download_url).then(res => res.text())
-    } else {
-      console.log(`\nFetching ${owner}/${repoName}#${branch}: ${schema.pathToFile} ...`)
-      const {data} = await octokit.repos.getContent({
-        mediaType: { format: "raw" },
-        owner: owner,
-        repo: repoName,
-        path: schema.pathToFile,
-        ref: branch,
-      })
+  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    try {
+      let content = ''
+      if (schema.usesLfs) {
+        console.log(`\nFetching ${fileDescription} ...`)
+        const {data: {download_url}} = await octokit.repos.getContent({
+          mediaType: { format: "json" },
+          owner: owner,
+          repo: repoName,
+          path: schema.pathToFile,
+          ref: branch,
+        })
+        console.log(`LFS download via ${download_url}...`)
+        content = await fetch(download_url).then(res => {
+          if (!res.ok) {
+            const error = new Error(`HTTP ${res.status}: ${res.statusText}`)
+            error.status = res.status
+            error.response = {headers: res.headers}
+            throw error
+          }
+          return res.text()
+        })
+      } else {
+        console.log(`\nFetching ${fileDescription} ...`)
+        const {data} = await octokit.repos.getContent({
+          mediaType: { format: "raw" },
+          owner: owner,
+          repo: repoName,
+          path: schema.pathToFile,
+          ref: branch,
+        })
 
-      content = Buffer.from(data).toString('utf-8')
+        content = Buffer.from(data).toString('utf-8')
+      }
+
+      // Define the local path where the file will be saved
+      const localFilePath = schema.localPath
+
+      const dir = path.dirname(localFilePath)
+      fs.mkdirSync(dir, {recursive: true})
+
+      // Write the content to a local file
+      fs.writeFileSync(localFilePath, content)
+
+      console.log(`File downloaded successfully to ${localFilePath}`)
+      return true
+    } catch (error) {
+      const isRateLimited = error.status === 429
+      const isTransientNetworkError = ['ECONNRESET', 'ETIMEDOUT', 'ENOTFOUND', 'ECONNREFUSED', 'EAI_AGAIN']
+        .includes(error.code)
+      const isRetryable = isRateLimited || isTransientNetworkError
+      const hasRetriesLeft = attempt < MAX_RETRIES
+
+      if (isRetryable && hasRetriesLeft) {
+        const retryAfterHeader = error.response?.headers?.['retry-after']
+        const parsedRetryAfter = parseInt(retryAfterHeader, 10)
+        const retryAfterSeconds = (!isNaN(parsedRetryAfter) && parsedRetryAfter > 0) ? Math.min(parsedRetryAfter, 120) : null
+        const delayMs = retryAfterSeconds ? retryAfterSeconds * 1000 : INITIAL_RETRY_DELAY_MS * Math.pow(2, attempt)
+        const delaySeconds = Math.round(delayMs / 1000)
+
+        const reason = isRateLimited ? 'Rate limited' : `Network error (${error.code})`
+        console.warn(`${reason} fetching ${fileDescription}. Retrying in ${delaySeconds}s (retry ${attempt + 1} of ${MAX_RETRIES}). Error: ${error.message}`)
+        await sleep(delayMs)
+        continue
+      }
+
+      console.error(`Error fetching ${fileDescription}: ${error.message}`)
+      return false
     }
-
-    // Define the local path where the file will be saved
-    const localFilePath = schema.localPath
-
-    const dir = path.dirname(localFilePath)
-    fs.mkdirSync(dir, {recursive: true})
-
-    // Write the content to a local file
-    fs.writeFileSync(localFilePath, content)
-
-    console.log(`File downloaded successfully to ${localFilePath}`)
-    return true
-  } catch (error) {
-    console.error(`Error fetching file: ${error.message}`)
-    return false
   }
+
+  // All retries exhausted without success
+  return false
 }
 
 /**


### PR DESCRIPTION
### WHY are these changes introduced?

The `pnpm graphql-codegen:get-graphql-schemas` script fails intermittently in CI due to GitHub's internal rate limiter (gitmon) returning HTTP 429 errors, and occasionally due to transient network issues. This causes flaky CI runs that require manual re-triggering.

### WHAT is this pull request doing?

**Deduplicate schema fetches:**
- Changed `localPath` to `localPaths` array to support multiple destinations per source file
- The admin schema (fetched via LFS) was being downloaded 3 times for different local paths - now fetched once and copied to all destinations
- Reduces API calls from 10 to 8, eliminating redundant LFS fetches that triggered rate limiting

**Add retry logic with exponential backoff:**
- Retry up to 3 times on HTTP 429 responses and transient network errors (ECONNRESET, ETIMEDOUT, etc.)
- Use exponential backoff: 5s → 10s → 20s
- Respect `retry-after` header if present (capped at 120s, validated for positive integers)
- Handle LFS file download errors properly (native `fetch()` doesn't throw on HTTP errors)
- Log retry attempts with file context and error details for debugging

Note: The standard `@octokit/plugin-throttling` package doesn't help here because gitmon's 429 responses lack the `retry-after` header that the plugin requires to trigger its callbacks.

### How to test your changes?

Run the schema fetch script:

```bash
pnpm graphql-codegen:get-graphql-schemas
```

You should see the admin schema fetched once and saved to 3 locations:
```
Fetching LFS file shop/world#main: areas/core/shopify/db/graphql/admin_schema_unstable_public.graphql ...
File saved to ./packages/cli-kit/src/cli/api/graphql/admin/admin_schema.graphql
File saved to ./packages/app/src/cli/api/graphql/bulk-operations/admin_schema.graphql
File saved to ./packages/app/src/cli/api/graphql/admin/admin_schema.graphql
```

If rate limited, you'll see retry messages:
```
Rate limited fetching LFS file shop/world#main: ... Retrying in 5s (retry 1 of 3). Error: HTTP 429: Too Many Requests
```

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes