### PR TITLE
Fix create-doc-pr script

### DIFF
--- a/bin/create-doc-pr.js
+++ b/bin/create-doc-pr.js
@@ -22,11 +22,11 @@ async function createPR() {
     files[`areas/platforms/shopify-dev/db/data/docs/templated_apis/shopify_cli/${fileName}`] = (await readFile(path.join(generatedDirectory, fileName))).toString()
   }
 
-  await withOctokit("shopify", async (octokit) => {
+  await withOctokit("shop", async (octokit) => {
     const response = await octokit
       .createPullRequest({
-        owner: "shopify",
-        repo: "shopify-dev",
+        owner: "shop",
+        repo: "world",
         title: `[CLI] Update docs for version: ${version}`,
         body: `We are updating the CLI documentation with the contents of the recently released version of the Shopify CLI [${version}](https://www.npmjs.com/package/@shopify/cli/v/${version})`,
         head: `shopify-cli-${version}`,
@@ -43,7 +43,7 @@ async function createPR() {
       })
 
     if (response) {
-      console.log(`PR URL: https://github.com/shopify/shopify-dev/pull/${response.data.number}`)
+      console.log(`PR URL: https://github.com/shop/world/pull/${response.data.number}`)
     } else {
       console.log("No changes detected, PR not created.")
     }


### PR DESCRIPTION
### WHY are these changes introduced?

`shopify-dev` is now in world, so the post-release script to create a PR updating the documentation was failing

### WHAT is this pull request doing?

Updates the script to create the PR in world

### How to test your changes?

`./bin/create-doc-pr.js`

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
