### PR TITLE
run e2e tests across supported os and node versions

### DIFF
--- a/.github/workflows/tests-pr.yml
+++ b/.github/workflows/tests-pr.yml
@@ -221,11 +221,16 @@ jobs:
           base-branch-name: '${{ github.base_ref }}'
 
   e2e-tests:
-    name: 'E2E tests'
+    name: 'E2E tests (${{ matrix.os }}, node ${{ matrix.node }})'
     if: github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 15
     continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ['ubuntu-latest', 'windows-latest', 'macos-latest']
+        node: ['20.14.0', '22.2.0', '24.1.0']
     steps:
       - uses: actions/checkout@v3
         with:
@@ -235,7 +240,7 @@ jobs:
       - name: Setup deps
         uses: ./.github/actions/setup-cli-deps
         with:
-          node-version: ${{ env.DEFAULT_NODE_VERSION }}
+          node-version: ${{ matrix.node }}
       - name: Build
         run: pnpm nx run-many --all --skip-nx-cache --target=build --output-style=stream
       - name: Install Playwright Chromium
@@ -256,14 +261,14 @@ jobs:
         uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}
         with:
-          name: playwright-report
+          name: playwright-report-${{ matrix.os }}-node${{ matrix.node }}
           path: packages/e2e/playwright-report/
           retention-days: 14
       - name: Upload test results
         uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}
         with:
-          name: playwright-results
+          name: playwright-results-${{ matrix.os }}-node${{ matrix.node }}
           path: packages/e2e/test-results/
           retention-days: 14
 


### PR DESCRIPTION
### WHY are these changes introduced?

The E2E tests were only running on Ubuntu with a single Node.js version, which doesn't provide adequate coverage for cross-platform compatibility and Node.js version support.

### WHAT is this pull request doing?

Expands E2E test coverage by introducing a matrix strategy that runs tests across multiple operating systems (Ubuntu, Windows, macOS) and Node.js versions (20.14.0, 22.2.0, 24.1.0). The job name now includes the OS and Node version for better identification, and artifact names are made unique per matrix combination to prevent conflicts.

### How to test your changes?

Create a pull request and observe that the E2E tests now run across all matrix combinations in the GitHub Actions workflow.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes