### PR TITLE
add SHOPIFY_CLI_ENV=development for test commands

### DIFF
--- a/.github/workflows/tests-manual.yml
+++ b/.github/workflows/tests-manual.yml
@@ -59,7 +59,7 @@ jobs:
         with:
           node-version: ${{ inputs.node-version }}
       - name: Unit tests
-        run: pnpm test:unit --output-style=stream
+        run: pnpm test --output-style=stream
       - name: Setup tmate session
         if: ${{ failure() && inputs.debug-enabled }}
         uses: mxschmitt/action-tmate@c0afd6f790e3a5564914980036ebf83216678101 # v3

--- a/dev.yml
+++ b/dev.yml
@@ -45,7 +45,7 @@ commands:
     run: pnpm run clean
   test:
     desc: 'Runs the tests'
-    run: pnpm run test:unit
+    run: pnpm run test
   build:
     desc: 'Build the project'
     run: pnpm run build:affected

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "shopify": "nx build cli && node packages/cli/bin/dev.js",
     "test:e2e": "nx run-many --target=build --projects=cli,create-app --skip-nx-cache && pnpm --filter e2e exec playwright test",
     "test:regenerate-snapshots": "packages/e2e/scripts/regenerate-snapshots.sh",
-    "test:unit": "pnpm vitest run",
     "test": "pnpm vitest run",
     "type-check:affected": "nx affected --target=type-check",
     "type-check": "nx run-many --target=type-check --all --skip-nx-cache",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,6 +2,9 @@ import {defineConfig} from 'vitest/config'
 
 export default defineConfig({
   test: {
+    env: {
+      SHOPIFY_CLI_ENV: 'development',
+    },
     coverage: {
       provider: 'istanbul',
     },


### PR DESCRIPTION
### WHY are these changes introduced?
Some unit tests fail when `SHOPIFY_CLI_ENV=development` is not set. Specifically, four tests in the `removeDuplicatedPlugins` suite in `base-command.test.ts` depend on `BaseCommand.init()` skipping `registerCleanBugsnagErrorsFromWithinPlugins` (which only runs when not in development mode). Without this skip, that function runs against mock plugins that have no `root` property, throws before `removeDuplicatedPlugins` can execute, and the assertions fail.

Relevant discussion: https://shopify.slack.com/archives/C05E3BDFDRB/p1773343132505319

### Context

There are three ways to run unit tests locally:

1. **`dev test`**
   - Defined in [dev.yml](https://github.com/Shopify/cli/blob/75c7f9f1cdc19a85a1a783fbe37370d693a44dd9/dev.yml#L46-L48). 
   - For internal Shopify engineers. 
   - `SHOPIFY_CLI_ENV=development` is already set in [dev.yml](https://github.com/Shopify/cli/blob/66e2910cd6fc281bb21880b11619c28ee238b564/dev.yml#L26), so tests pass after `dev up`.
2. **`pnpm test`** 
   - Defined in [package.json](https://github.com/Shopify/cli/blob/9374634338e924f1ec890f69a3357c82d5422a70/package.json#L32-L33). 
   - For both external contributors and internal engineers. 
   - Previously did **not** set `SHOPIFY_CLI_ENV=development`, so four tests failed unless the caller exported the variable manually.
3. **Direct invocation** — `pnpm vitest run`
   - Same issue as above; requires manually setting `SHOPIFY_CLI_ENV=development`.

### WHAT is this pull request doing?

- Sets `SHOPIFY_CLI_ENV: 'development'` in `vite.config.ts` under `test.env`, so the variable is applied to **all** vitest invocations (`pnpm test`, `pnpm vitest run`, and CI) on all platforms — without requiring a shell prefix or additional dependencies like `cross-env`.
- Removes the now-redundant `test:unit` script. After [cucumber tests were removed](https://github.com/Shopify/cli/pull/6996), `test` and `test:unit` became identical (`pnpm vitest run`). Keeping both caused confusion with no benefit.
- Updates `.github/workflows/tests-manual.yml` to reference `pnpm test` instead of the removed `pnpm test:unit`.

### How to test your changes?
Run the commands below on different branches:
```bash
dev up
unset SHOPIFY_CLI_ENV
pnpm test # or dev test
# Output
```

**On `main` - reproduce the failure:**
Output: 4 tests fail in `base-command.test.ts > removeDuplicatedPlugins`

**On this branch - verify the fix:**
Output: all tests pass

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes