### PR TITLE
chore: use regular runner for workflow

### DIFF
--- a/.github/workflows/shopify-dev-preview-automation.yml
+++ b/.github/workflows/shopify-dev-preview-automation.yml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   dispatch-docs-sync:
     name: Dispatch docs sync to shop/world
-    runs-on: shopify-ubuntu-latest
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     if: github.repository_owner == 'Shopify'
     steps:


### PR DESCRIPTION
Must use the public ubuntu-latest runner for the shopify-dev-preview-automation workflow, since the premium one doesn't always work in public repos