### PR TITLE
fix(cli-kit): batch large output chunks to prevent event loop blocking

### DIFF
--- a/packages/cli-kit/src/private/node/ui/components/ConcurrentOutput.test.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/ConcurrentOutput.test.tsx
@@ -262,6 +262,41 @@ describe('ConcurrentOutput', () => {
     expect(logColumns[1]?.length).toBe(25 + 2)
   })
 
+  test('renders large chunks split into batches without dropping lines', async () => {
+    // Given - simulate a large stack trace (>100 lines) arriving as a single write
+    const processSync = new Synchronizer()
+    const lineCount = 250
+    const largeOutput = Array.from({length: lineCount}, (_, i) => `line ${i + 1}`).join('\n')
+
+    const processes = [
+      {
+        prefix: 'pos-ext',
+        action: async (stdout: Writable, _stderr: Writable, _signal: AbortSignal) => {
+          stdout.write(largeOutput)
+          processSync.resolve()
+        },
+      },
+    ]
+
+    // When - keepRunningAfterProcessesResolve prevents the component from unmounting
+    // before all setImmediate-batched state updates have been applied
+    const renderInstance = render(
+      <ConcurrentOutput
+        processes={processes}
+        abortSignal={new AbortController().signal}
+        keepRunningAfterProcessesResolve
+      />,
+    )
+    await processSync.promise
+    await waitForContent(renderInstance, `line ${lineCount}`)
+
+    // Then - all lines should be rendered
+    const frame = unstyled(renderInstance.lastFrame()!)
+    for (let i = 1; i <= lineCount; i++) {
+      expect(frame).toContain(`line ${i}`)
+    }
+  })
+
   test('rejects with the error thrown inside one of the processes', async () => {
     // Given
     const backendProcess = {

--- a/packages/cli-kit/src/private/node/ui/components/ConcurrentOutput.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/ConcurrentOutput.tsx
@@ -8,7 +8,7 @@ import stripAnsi from 'strip-ansi'
 import {Writable} from 'stream'
 import {AsyncLocalStorage} from 'node:async_hooks'
 
-const MAX_LINES_PER_BATCH = 100
+const MAX_LINES_PER_BATCH = 20
 
 export interface ConcurrentOutputProps {
   processes: OutputProcess[]

--- a/packages/cli-kit/src/private/node/ui/components/ConcurrentOutput.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/ConcurrentOutput.tsx
@@ -5,7 +5,7 @@ import {Box, Static, Text, TextProps, useApp} from 'ink'
 import figures from 'figures'
 import stripAnsi from 'strip-ansi'
 
-import {Writable} from 'stream'
+import {Transform, Writable} from 'stream'
 import {AsyncLocalStorage} from 'node:async_hooks'
 
 const MAX_LINES_PER_BATCH = 20
@@ -134,49 +134,57 @@ const ConcurrentOutput: FunctionComponent<ConcurrentOutputProps> = ({
 
   const writableStream = useCallback(
     (process: OutputProcess, prefixes: string[]) => {
-      return new Writable({
-        write(chunk, _encoding, next) {
+      // Transform: splits incoming chunks into MAX_LINES_PER_BATCH-line pieces.
+      // Runs synchronously inside the writer's async context, so outputContextStore
+      // (prefix, stripAnsi overrides set by useConcurrentOutputContext) is available here.
+      const splitter = new Transform({
+        readableObjectMode: true,
+        transform(chunk, _encoding, callback) {
           const context = outputContextStore.getStore()
           const prefix = context?.outputPrefix ?? process.prefix
           const shouldStripAnsi = context?.stripAnsi ?? true
           const log = chunk.toString('utf8').replace(/(\n)$/, '')
-
-          const index = addPrefix(prefix, prefixes)
-
           const allLines = shouldStripAnsi ? stripAnsi(log).split(/\n/) : log.split(/\n/)
-
-          if (allLines.length <= MAX_LINES_PER_BATCH) {
-            setProcessOutput((previousProcessOutput) => [
-              ...previousProcessOutput,
-              {color: lineColor(index), prefix, lines: allLines},
-            ])
-            next()
-            return
-          }
-
-          // For large chunks (e.g. big stack traces), split into batches and yield
-          // between each via setImmediate so the event loop can process keyboard
-          // events (q, p, etc.) between renders instead of blocking.
-          const batches: string[][] = []
+          // Flag batches that came from a large chunk so the sink knows to yield
+          // between them. Single-batch writes keep synchronous next() to preserve
+          // existing behaviour for normal (small) output.
+          const isLargeChunk = allLines.length > MAX_LINES_PER_BATCH
           for (let i = 0; i < allLines.length; i += MAX_LINES_PER_BATCH) {
-            batches.push(allLines.slice(i, i + MAX_LINES_PER_BATCH))
+            this.push({prefix, lines: allLines.slice(i, i + MAX_LINES_PER_BATCH), isLargeChunk})
           }
-
-          const scheduleBatch = (batchIndex: number) => {
-            if (batchIndex >= batches.length) {
-              next()
-              return
-            }
-            setProcessOutput((previousProcessOutput) => [
-              ...previousProcessOutput,
-              {color: lineColor(index), prefix, lines: batches[batchIndex]!},
-            ])
-            setImmediate(() => scheduleBatch(batchIndex + 1))
-          }
-
-          scheduleBatch(0)
+          callback()
         },
       })
+
+      // Writable: renders each batch into React state.
+      // For large-chunk batches, setImmediate(next) yields the event loop so keyboard
+      // shortcuts (q, p) can fire between renders, and creates real Node.js backpressure:
+      // when next() is pending the pipe pauses the splitter, preventing unbounded
+      // memory growth from fast producers.
+      // For normal output (single-batch writes) next() is called synchronously to
+      // preserve the existing rendering behaviour.
+      const sink = new Writable({
+        objectMode: true,
+        write(
+          {prefix, lines, isLargeChunk}: {prefix: string; lines: string[]; isLargeChunk: boolean},
+          _encoding,
+          next,
+        ) {
+          const index = addPrefix(prefix, prefixes)
+          setProcessOutput((previousProcessOutput) => [
+            ...previousProcessOutput,
+            {color: lineColor(index), prefix, lines},
+          ])
+          if (isLargeChunk) {
+            setImmediate(next)
+          } else {
+            next()
+          }
+        },
+      })
+
+      splitter.pipe(sink)
+      return splitter
     },
     [lineColor],
   )

--- a/packages/cli-kit/src/private/node/ui/components/ConcurrentOutput.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/ConcurrentOutput.tsx
@@ -8,6 +8,8 @@ import stripAnsi from 'strip-ansi'
 import {Writable} from 'stream'
 import {AsyncLocalStorage} from 'node:async_hooks'
 
+const MAX_LINES_PER_BATCH = 100
+
 export interface ConcurrentOutputProps {
   processes: OutputProcess[]
   prefixColumnSize?: number
@@ -141,16 +143,38 @@ const ConcurrentOutput: FunctionComponent<ConcurrentOutputProps> = ({
 
           const index = addPrefix(prefix, prefixes)
 
-          const lines = shouldStripAnsi ? stripAnsi(log).split(/\n/) : log.split(/\n/)
-          setProcessOutput((previousProcessOutput) => [
-            ...previousProcessOutput,
-            {
-              color: lineColor(index),
-              prefix,
-              lines,
-            },
-          ])
-          next()
+          const allLines = shouldStripAnsi ? stripAnsi(log).split(/\n/) : log.split(/\n/)
+
+          if (allLines.length <= MAX_LINES_PER_BATCH) {
+            setProcessOutput((previousProcessOutput) => [
+              ...previousProcessOutput,
+              {color: lineColor(index), prefix, lines: allLines},
+            ])
+            next()
+            return
+          }
+
+          // For large chunks (e.g. big stack traces), split into batches and yield
+          // between each via setImmediate so the event loop can process keyboard
+          // events (q, p, etc.) between renders instead of blocking.
+          const batches: string[][] = []
+          for (let i = 0; i < allLines.length; i += MAX_LINES_PER_BATCH) {
+            batches.push(allLines.slice(i, i + MAX_LINES_PER_BATCH))
+          }
+
+          const scheduleBatch = (batchIndex: number) => {
+            if (batchIndex >= batches.length) {
+              next()
+              return
+            }
+            setProcessOutput((previousProcessOutput) => [
+              ...previousProcessOutput,
+              {color: lineColor(index), prefix, lines: batches[batchIndex]!},
+            ])
+            setImmediate(() => scheduleBatch(batchIndex + 1))
+          }
+
+          scheduleBatch(0)
         },
       })
     },


### PR DESCRIPTION
## Problem

When a POS UI extension throws a large stack trace, the entire output arrives as a single `write()` call to `ConcurrentOutput`'s `Writable` stream. The synchronous processing of large chunks — `stripAnsi()`, `split(/\n/)`, and `setProcessOutput` with a spread of the full accumulated array — causes a render cycle expensive enough to block the Node.js event loop. During that time, Ink's `useInput` hook cannot process keypresses, so `q` (quit) and `p` (preview) become unresponsive.

## Fix

The `writableStream` write handler now uses a two-stage pipeline: a `Transform` stream that splits large chunks into batches of `MAX_LINES_PER_BATCH` (20) lines, followed by a `Writable` sink that renders each batch. For batches from large chunks, `setImmediate(next)` yields to the event loop between renders so Ink's input handling can run.

- Chunks ≤ 20 lines: unchanged behavior, `next()` called synchronously
- Chunks > 20 lines: split into 20-line batches with `setImmediate` scheduling between each batch

The Transform stream preserves the existing `outputContextStore` context (prefix and stripAnsi overrides) and maintains proper Node.js backpressure by deferring `next()` until each batch is processed.

## Test

Added a test that writes 250 lines as a single chunk and verifies all lines appear in the rendered output without being dropped during batch processing.