### PR TITLE
add shebang back to script and disable lint rule

### DIFF
--- a/bin/create-doc-pr.js
+++ b/bin/create-doc-pr.js
@@ -1,3 +1,5 @@
+// eslint-disable-next-line n/shebang
+#!/usr/bin/env node
 
 import {fileURLToPath} from "node:url"
 import {createRequire} from 'node:module'


### PR DESCRIPTION
The `pnpm post-release` was missing the she bang as a lint rule caught and deleted it. I've added it back and disabled the lint rule for the file.