### PR TITLE
Fix orgAndApps crash when organization is not found

### DIFF
--- a/.changeset/fix-org-not-found-error.md
+++ b/.changeset/fix-org-not-found-error.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Fix crash when organization is not found in app-management-client by throwing NoOrgError instead of accessing properties on undefined

--- a/packages/app/src/cli/utilities/developer-platform-client/app-management-client.test.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/app-management-client.test.ts
@@ -1772,6 +1772,28 @@ describe('organizations', () => {
   })
 })
 
+describe('orgAndApps', () => {
+  test('throws NoOrgError if organization is not found', async () => {
+    // Given
+    const client = AppManagementClient.getInstance()
+    client.businessPlatformToken = () => Promise.resolve('business-platform-token')
+    client.session = () => Promise.resolve({token: '', accountInfo: {type: 'UnknownAccount'}}) as any
+
+    vi.mocked(businessPlatformRequestDoc).mockResolvedValue({
+      currentUserAccount: {organization: null},
+    })
+    vi.mocked(appManagementRequestDoc).mockResolvedValue({
+      appsConnection: {edges: [], pageInfo: {hasNextPage: false}},
+    })
+
+    // When
+    const got = () => client.orgAndApps('1')
+
+    // Then
+    await expect(got).rejects.toThrow('No Organization found')
+  })
+})
+
 describe('singleton pattern', () => {
   test('getInstance returns the same instance', () => {
     // Given/When

--- a/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
@@ -7,6 +7,7 @@ import {
   OrganizationExpFlagsQueryVariables,
   OrganizationExpFlags,
 } from '../../api/graphql/business-platform-organizations/generated/organization_exp_flags.js'
+import {NoOrgError} from '../../services/dev/fetch.js'
 import {environmentVariableNames} from '../../constants.js'
 import {RemoteSpecification} from '../../api/graphql/extension_specifications.js'
 import {
@@ -411,7 +412,11 @@ export class AppManagementClient implements DeveloperPlatformClient {
       this.orgFromId(organizationId),
       this.appsForOrg(organizationId),
     ])
-    return {organization: organization!, apps, hasMorePages}
+    if (!organization) {
+      const {accountInfo} = await this.session()
+      throw new NoOrgError(accountInfo, organizationId)
+    }
+    return {organization, apps, hasMorePages}
   }
 
   async appsForOrg(organizationId: string, term = ''): Promise<Paginateable<{apps: MinimalOrganizationApp[]}>> {


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes [shop/issues#20081](https://github.com/shop/issues/issues/20081) — 13 error events from 3 users on CLI v3.92.0.

`app-management-client.ts:orgAndApps()` uses a non-null assertion (`organization!`) on the result of `orgFromId()`, which can return `undefined`. The `undefined` org propagates to `selectOrCreateApp()` where `org.id` crashes with `Cannot read properties of undefined (reading 'id')`.

### WHAT is this pull request doing?

Replaces the `organization!` non-null assertion with an explicit check that throws `NoOrgError` when the organization is not found — matching the existing `partners-client` behavior (line 689-691).

- Import `NoOrgError` from `../../services/dev/fetch.js`
- Check if `organization` is undefined after `orgFromId()` resolves
- Throw `NoOrgError` with the session's `accountInfo` and `organizationId`
- Add test verifying the new error behavior

### How to test your changes?

```
npx vitest packages/app/src/cli/utilities/developer-platform-client/app-management-client.test.ts
```

### Measuring impact

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes