### PR TITLE
Fix: normalize cached store URL before comparison in storeContext

### DIFF
--- a/packages/app/src/cli/services/store-context.test.ts
+++ b/packages/app/src/cli/services/store-context.test.ts
@@ -203,6 +203,91 @@ describe('storeContext', () => {
     })
   })
 
+  test('does not update hidden config when cached URL differs only by format', async () => {
+    await inTemporaryDirectory(async (dir) => {
+      // The TOML has an un-normalized URL (with https:// prefix)
+      const appWithUnnormalizedUrl = testAppLinked({
+        configuration: {
+          client_id: 'client_id',
+          name: 'app-config-name',
+          build: {
+            dev_store_url: 'https://test-store.myshopify.com',
+          },
+        } as any,
+        hiddenConfig: {
+          dev_store_url: 'test-store.myshopify.com',
+        },
+      })
+      const updatedAppContextResult = {...appContextResult, app: appWithUnnormalizedUrl}
+      const storeMatchingNormalized = testOrganizationStore({
+        shopId: 'store1',
+        shopDomain: 'test-store.myshopify.com',
+      })
+
+      await prepareAppFolder(appWithUnnormalizedUrl, dir)
+      vi.mocked(fetchStore).mockResolvedValue(storeMatchingNormalized)
+
+      await storeContext({appContextResult: updatedAppContextResult, forceReselectStore: false})
+
+      // The hidden config should NOT be updated since the normalized URLs match
+      // and the hidden config already has a value
+      const hiddenConfig = await readFile(appHiddenConfigPath(dir))
+      // The file was initialized empty, so if updateHiddenConfig was NOT called,
+      // it should still be empty
+      expect(hiddenConfig).toEqual('')
+    })
+  })
+
+  test('does not update hidden config when cached URL is a short store name', async () => {
+    await inTemporaryDirectory(async (dir) => {
+      // The TOML has just the store name without .myshopify.com
+      const appWithShortUrl = testAppLinked({
+        configuration: {
+          client_id: 'client_id',
+          name: 'app-config-name',
+          build: {
+            dev_store_url: 'test-store',
+          },
+        } as any,
+        hiddenConfig: {
+          dev_store_url: 'test-store.myshopify.com',
+        },
+      })
+      const updatedAppContextResult = {...appContextResult, app: appWithShortUrl}
+      const storeMatchingNormalized = testOrganizationStore({
+        shopId: 'store1',
+        shopDomain: 'test-store.myshopify.com',
+      })
+
+      await prepareAppFolder(appWithShortUrl, dir)
+      vi.mocked(fetchStore).mockResolvedValue(storeMatchingNormalized)
+
+      await storeContext({appContextResult: updatedAppContextResult, forceReselectStore: false})
+
+      // The hidden config should NOT be updated since normalized URLs match
+      const hiddenConfig = await readFile(appHiddenConfigPath(dir))
+      expect(hiddenConfig).toEqual('')
+    })
+  })
+
+  test('updates hidden config when store actually changes', async () => {
+    await inTemporaryDirectory(async (dir) => {
+      await prepareAppFolder(mockApp, dir)
+      const differentStore = testOrganizationStore({
+        shopId: 'store2',
+        shopDomain: 'different-store.myshopify.com',
+      })
+      vi.mocked(fetchStore).mockResolvedValue(differentStore)
+
+      await storeContext({appContextResult, forceReselectStore: false})
+
+      const hiddenConfig = await readFile(appHiddenConfigPath(dir))
+      expect(hiddenConfig).toEqual(
+        '{\n  "client_id": {\n    "dev_store_url": "different-store.myshopify.com"\n  }\n}',
+      )
+    })
+  })
+
   test('ensures user access to store', async () => {
     await inTemporaryDirectory(async (dir) => {
       await prepareAppFolder(mockApp, dir)

--- a/packages/app/src/cli/services/store-context.ts
+++ b/packages/app/src/cli/services/store-context.ts
@@ -67,8 +67,12 @@ export async function storeContext({
   await logMetadata(selectedStore, forceReselectStore)
   selectedStore.shopDomain = normalizeStoreFqdn(selectedStore.shopDomain)
 
-  // Save the selected store in the hidden config file
-  if (selectedStore.shopDomain !== cachedStoreURL || !devStoreUrlFromHiddenConfig) {
+  // Save the selected store in the hidden config file.
+  // Normalize the cached URL before comparing so that format differences
+  // (e.g. "https://store.myshopify.com" vs "store.myshopify.com") don't
+  // cause unnecessary writes.
+  const normalizedCachedURL = cachedStoreURL ? normalizeStoreFqdn(cachedStoreURL) : undefined
+  if (selectedStore.shopDomain !== normalizedCachedURL || !devStoreUrlFromHiddenConfig) {
     await app.updateHiddenConfig({dev_store_url: selectedStore.shopDomain})
   }
 


### PR DESCRIPTION
The cached dev_store_url from app.toml or hidden config was compared against the already-normalized selectedStore.shopDomain without first normalizing it. This meant format differences (e.g. 'https://store.myshopify.com' vs 'store.myshopify.com', or 'store' vs 'store.myshopify.com') would cause a false mismatch and trigger unnecessary writes to .shopify/project.json on every `dev` run.

Now we normalize cachedStoreURL before comparing, so the hidden config is only updated when the store actually changes.

<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #0000 <!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
