### PR TITLE
fix: wire --poll flag through to chokidar in theme dev

### DIFF
--- a/packages/cli-kit/src/public/node/themes/types.ts
+++ b/packages/cli-kit/src/public/node/themes/types.ts
@@ -30,6 +30,7 @@ export interface ThemeFileSystemOptions {
   listing?: string
   noDelete?: boolean
   notify?: string
+  poll?: boolean
 }
 
 /**

--- a/packages/theme/src/cli/commands/theme/dev.ts
+++ b/packages/theme/src/cli/commands/theme/dev.ts
@@ -69,8 +69,8 @@ You can run this command only in a directory that matches the [default Shopify t
       env: 'SHOPIFY_FLAG_ERROR_OVERLAY',
     }),
     poll: Flags.boolean({
-      hidden: true,
-      description: 'Force polling to detect file changes.',
+      description:
+        'Use polling to detect file changes. Use this when file system events are unreliable, such as with build tools that preserve timestamps, Docker volumes, or network filesystems.',
       env: 'SHOPIFY_FLAG_POLL',
     }),
     'theme-editor-sync': Flags.boolean({
@@ -183,6 +183,7 @@ You can run this command only in a directory that matches the [default Shopify t
       ignore,
       only,
       notify: flags.notify,
+      poll: flags.poll,
     })
 
     await metafieldsPull({

--- a/packages/theme/src/cli/services/dev.ts
+++ b/packages/theme/src/cli/services/dev.ts
@@ -40,6 +40,7 @@ interface DevOptions {
   only: string[]
   notify?: string
   listing?: string
+  poll?: boolean
 }
 
 export async function dev(options: DevOptions) {
@@ -83,6 +84,7 @@ export async function dev(options: DevOptions) {
     listing: options.listing,
     noDelete: options.noDelete,
     notify: options.notify,
+    poll: options.poll,
   })
 
   const host = options.host ?? DEFAULT_HOST

--- a/packages/theme/src/cli/utilities/theme-fs.test.ts
+++ b/packages/theme/src/cli/utilities/theme-fs.test.ts
@@ -135,6 +135,42 @@ describe('theme-fs', () => {
       )
     })
 
+    test('passes usePolling and useFsEvents options to chokidar when poll is true', async () => {
+      // Given
+      const root = joinPath(locationOfThisFile, 'fixtures/theme')
+      const watchSpy = vi.spyOn(chokidar, 'watch')
+
+      // When
+      const themeFileSystem = mountThemeFileSystem(root, {poll: true})
+      await themeFileSystem.ready()
+      await themeFileSystem.startWatcher('123', {token: 'token'} as any)
+
+      // Then
+      expect(watchSpy).toHaveBeenCalledWith(expect.any(Array), {
+        ignored: expect.any(Array),
+        persistent: expect.any(Boolean),
+        ignoreInitial: true,
+        usePolling: true,
+        useFsEvents: false,
+      })
+    })
+
+    test('does not include usePolling or useFsEvents in chokidar options when poll is not set', async () => {
+      // Given
+      const root = joinPath(locationOfThisFile, 'fixtures/theme')
+      const watchSpy = vi.spyOn(chokidar, 'watch')
+
+      // When
+      const themeFileSystem = mountThemeFileSystem(root)
+      await themeFileSystem.ready()
+      await themeFileSystem.startWatcher('123', {token: 'token'} as any)
+
+      // Then
+      const chokidarOptions = watchSpy.mock.calls[0]?.[1] as Record<string, unknown>
+      expect(chokidarOptions).not.toHaveProperty('usePolling')
+      expect(chokidarOptions).not.toHaveProperty('useFsEvents')
+    })
+
     test('does not include listing directory when no listing is specified', async () => {
       // Given
       const root = joinPath(locationOfThisFile, 'fixtures/theme')

--- a/packages/theme/src/cli/utilities/theme-fs.ts
+++ b/packages/theme/src/cli/utilities/theme-fs.ts
@@ -319,6 +319,7 @@ export function mountThemeFileSystem(root: string, options?: ThemeFileSystemOpti
         ignored: DEFAULT_IGNORE_PATTERNS,
         persistent: !process.env.SHOPIFY_UNIT_TEST,
         ignoreInitial: true,
+        ...(options?.poll ? {usePolling: true, useFsEvents: false} : {}),
       })
 
       watcher


### PR DESCRIPTION
## Summary

- The `--poll` flag was defined on `theme dev` but never wired through to chokidar's `usePolling` option, making it a no-op
- On Linux/Windows, chokidar's `fs.watch` backend compares `mtimeMs` and suppresses change events when the timestamp hasn't changed. Build tools (like Gulp + Sass) that preserve the original source file's timestamp on compiled output cause file change events to be silently dropped
- This wires `poll` through the full chain: command → service → `mountThemeFileSystem` → `chokidar.watch`. When `--poll` is set, both `usePolling: true` and `useFsEvents: false` are passed to chokidar (`useFsEvents: false` is required because on macOS chokidar prefers FSEvents over polling even when `usePolling: true` is set)
- Also unhides the `--poll` flag and improves its description to tell users when to use it

Related: https://community.shopify.dev/t/theme-dev-sometimes-misses-file-updates/29269/4

## Test plan

- [x] New tests verify `usePolling: true` + `useFsEvents: false` are passed to chokidar when `poll: true`
- [x] New tests verify `usePolling` and `useFsEvents` are absent from chokidar options when `poll` is not set
- [x] All 44 existing tests in `theme-fs.test.ts` continue to pass
- [ ] Manual: `shopify theme dev --poll` enables chokidar polling mode
- [ ] Manual: `shopify theme dev --help` shows the `--poll` flag with improved description

🤖 Generated with [Claude Code](https://claude.com/claude-code)