### PR TITLE
Skip CLA check for Cursor

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -11,11 +11,14 @@ jobs:
     name: "[PR] CLA"
     runs-on: ubuntu-latest
     if: |
-      (github.event.issue.pull_request
-        && !github.event.issue.pull_request.merged_at
-        && contains(github.event.comment.body, 'signed')
+      github.actor != 'cursoragent'
+      && (
+        (github.event.issue.pull_request
+          && !github.event.issue.pull_request.merged_at
+          && contains(github.event.comment.body, 'signed')
+        )
+        || (github.event.pull_request && !github.event.pull_request.merged)
       )
-      || (github.event.pull_request && !github.event.pull_request.merged)
     steps:
       - uses: Shopify/shopify-cla-action@9938f4b43524d1cfa7471ce9a803edf226697284 # v1
         with:


### PR DESCRIPTION
### WHY are these changes introduced?

When Cursor is the author of a commit, the [CLA check is failing](https://github.com/Shopify/cli/actions/runs/23195354857):

```
Error: In order to merge this pull request, all contributors must sign [Shopify’s CLA](https://cla.shopify.com/).

- @cursoragent: [Sign the CLA](https://cla.shopify.com/) and comment "I have signed the CLA!" to re-run the checks and have your PR reviewed.
CLA: 509e7c51ece228447c2475180442c3b0b856734a Done
```

### WHAT is this pull request doing?

Skips the check for Cursor

### How to test your changes?

Merge and try again

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
