### PR TITLE
create allowlist for localhost variants and validate host on requests

### DIFF
--- a/.changeset/few-maps-melt.md
+++ b/.changeset/few-maps-melt.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Set localhost variants and run host header validations to prevent DNS rebinding vulnerability

--- a/packages/theme/src/cli/utilities/theme-environment/host-validation.test.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/host-validation.test.ts
@@ -1,0 +1,95 @@
+import {createHostValidationHandler} from './host-validation.js'
+
+import {beforeEach, describe, expect, test, vi} from 'vitest'
+import {createEvent} from 'h3'
+
+import {networkInterfaces} from 'node:os'
+import {IncomingMessage, ServerResponse} from 'node:http'
+import {Socket} from 'node:net'
+
+vi.mock('node:os', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:os')>()
+  return {...actual, networkInterfaces: vi.fn()}
+})
+
+const dispatchHost = async (
+  handler: ReturnType<typeof createHostValidationHandler>,
+  host?: string,
+): Promise<number> => {
+  const req = new IncomingMessage(new Socket())
+  req.url = '/'
+  if (host !== undefined) req.headers = {host}
+  const res = new ServerResponse(req)
+  const event = createEvent(req, res)
+
+  await handler(event)
+
+  return res.statusCode
+}
+
+describe('createHostValidationHandler', () => {
+  describe('loopback bind', () => {
+    const handler = createHostValidationHandler('127.0.0.1', 9292)
+
+    test.each([['localhost:9292'], ['127.0.0.1:9292'], ['[::1]:9292'], ['LOCALHOST:9292'], ['localhost.:9292']])(
+      'accepts %s',
+      async (host) => {
+        const status = await dispatchHost(handler, host)
+        expect(status).not.toBe(400)
+      },
+    )
+
+    test.each([['attacker.com:9292'], ['localhost:1234'], ['127.0.0.1']])('rejects %s', async (host) => {
+      const status = await dispatchHost(handler, host)
+      expect(status).toBe(400)
+    })
+
+    test('rejects missing host header', async () => {
+      const status = await dispatchHost(handler)
+      expect(status).toBe(400)
+    })
+  })
+
+  describe('wildcard bind', () => {
+    beforeEach(() => {
+      vi.mocked(networkInterfaces).mockReturnValue({
+        en0: [
+          {
+            address: '192.168.1.50',
+            netmask: '255.255.255.0',
+            family: 'IPv4',
+            mac: '00:00:00:00:00:00',
+            internal: false,
+            cidr: '192.168.1.50/24',
+          },
+        ],
+      } as ReturnType<typeof networkInterfaces>)
+    })
+
+    const buildHandler = () => createHostValidationHandler('0.0.0.0', 9292)
+
+    test.each([['192.168.1.50:9292'], ['127.0.0.1:9292'], ['[::1]:9292']])('accepts %s', async (host) => {
+      const status = await dispatchHost(buildHandler(), host)
+      expect(status).not.toBe(400)
+    })
+
+    test.each([['192.168.1.50:1234'], ['attacker.com:9292']])('rejects %s', async (host) => {
+      const status = await dispatchHost(buildHandler(), host)
+      expect(status).toBe(400)
+    })
+  })
+
+  describe('non-wildcard LAN bind', () => {
+    const handler = createHostValidationHandler('192.168.1.50', 9292)
+
+    test.each([['192.168.1.50:9292']])('accepts %s', async (host) => {
+      const status = await dispatchHost(handler, host)
+      expect(status).not.toBe(400)
+    })
+
+    test.each([['192.168.1.99:9292']])('rejects %s', async (host) => {
+      const status = await dispatchHost(handler, host)
+      expect(status).toBe(400)
+    })
+  })
+})

--- a/packages/theme/src/cli/utilities/theme-environment/host-validation.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/host-validation.ts
@@ -1,0 +1,54 @@
+import {createError, defineEventHandler, sendError} from 'h3'
+
+function createAllowedHostsSet(host: string, port: number): Set<string> {
+  const allowedHosts = new Set<string>()
+  const portSuffix = `:${port}`
+  const normalizedHost = host.toLowerCase().trim()
+
+  allowedHosts.add(`${normalizedHost}${portSuffix}`)
+
+  // When binding to localhost variants or 0.0.0.0, allow all localhost forms
+  const localhostVariants = ['localhost', '127.0.0.1', '::1', '0.0.0.0']
+  if (localhostVariants.includes(normalizedHost)) {
+    allowedHosts.add(`localhost${portSuffix}`)
+    allowedHosts.add(`127.0.0.1${portSuffix}`)
+    allowedHosts.add(`[::1]${portSuffix}`)
+  }
+
+  return allowedHosts
+}
+
+function normalizeHostHeader(hostHeader: string | undefined): string | undefined {
+  if (!hostHeader) return undefined
+  // Lowercase, then strip trailing dot before port (or at end for plain hostname).
+  // IPv6 brackets: trailing dot would be after `]`, e.g. [::1].:9292
+  return hostHeader.toLowerCase().replace(/\.(?=:\d|$)/, '')
+}
+
+/**
+ * Creates an h3 event handler that validates the request's Host header
+ * against an allowlist of configured host/port and localhost variants.
+ *
+ * Used to mitigate DNS rebinding attacks on local dev servers.
+ *
+ * Returns a 400 Bad Request when the Host header is missing or not in the allowlist.
+ */
+export function createHostValidationHandler(host: string, port: number) {
+  const allowedHosts = createAllowedHostsSet(host, port)
+
+  return defineEventHandler((event) => {
+    const hostHeader = event.node.req.headers.host
+    const normalizedHost = normalizeHostHeader(hostHeader)
+
+    if (!normalizedHost || !allowedHosts.has(normalizedHost)) {
+      return sendError(
+        event,
+        createError({
+          statusCode: 400,
+          statusMessage: 'Bad Request',
+          message: 'Invalid Host header',
+        }),
+      )
+    }
+  })
+}

--- a/packages/theme/src/cli/utilities/theme-environment/host-validation.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/host-validation.ts
@@ -1,4 +1,5 @@
 import {createError, defineEventHandler, sendError} from 'h3'
+import * as os from 'node:os'
 
 function createAllowedHostsSet(host: string, port: number): Set<string> {
   const allowedHosts = new Set<string>()
@@ -7,7 +8,6 @@ function createAllowedHostsSet(host: string, port: number): Set<string> {
 
   allowedHosts.add(`${normalizedHost}${portSuffix}`)
 
-  // When binding to localhost variants or 0.0.0.0, allow all localhost forms
   const localhostVariants = ['localhost', '127.0.0.1', '::1', '0.0.0.0']
   if (localhostVariants.includes(normalizedHost)) {
     allowedHosts.add(`localhost${portSuffix}`)
@@ -15,24 +15,27 @@ function createAllowedHostsSet(host: string, port: number): Set<string> {
     allowedHosts.add(`[::1]${portSuffix}`)
   }
 
+  // When binding to a wildcard address, the server is also reachable through the machine's
+  // interface IPs (e.g. a LAN address like 192.168.x.x from another device on the network).
+  if (normalizedHost === '0.0.0.0' || normalizedHost === '::') {
+    for (const interfaces of Object.values(os.networkInterfaces())) {
+      for (const iface of interfaces ?? []) {
+        const address = iface.address.toLowerCase().split('%')[0]
+        const isIPv6 = iface.family === 'IPv6'
+        const formatted = isIPv6 ? `[${address}]` : address
+        allowedHosts.add(`${formatted}${portSuffix}`)
+      }
+    }
+  }
+
   return allowedHosts
 }
 
 function normalizeHostHeader(hostHeader: string | undefined): string | undefined {
   if (!hostHeader) return undefined
-  // Lowercase, then strip trailing dot before port (or at end for plain hostname).
-  // IPv6 brackets: trailing dot would be after `]`, e.g. [::1].:9292
   return hostHeader.toLowerCase().replace(/\.(?=:\d|$)/, '')
 }
 
-/**
- * Creates an h3 event handler that validates the request's Host header
- * against an allowlist of configured host/port and localhost variants.
- *
- * Used to mitigate DNS rebinding attacks on local dev servers.
- *
- * Returns a 400 Bad Request when the Host header is missing or not in the allowlist.
- */
 export function createHostValidationHandler(host: string, port: number) {
   const allowedHosts = createAllowedHostsSet(host, port)
 
@@ -43,11 +46,7 @@ export function createHostValidationHandler(host: string, port: number) {
     if (!normalizedHost || !allowedHosts.has(normalizedHost)) {
       return sendError(
         event,
-        createError({
-          statusCode: 400,
-          statusMessage: 'Bad Request',
-          message: 'Invalid Host header',
-        }),
+        createError({statusCode: 400, statusMessage: 'Bad Request', message: 'Invalid Host header'}),
       )
     }
   })

--- a/packages/theme/src/cli/utilities/theme-environment/theme-environment.test.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/theme-environment.test.ts
@@ -42,6 +42,46 @@ beforeEach(() => {
 })
 
 describe('setupDevServer', () => {
+  const decoder = new TextDecoder()
+
+  const createH3Event = (options: {url: string; headers?: Record<string, string>}) => {
+    const req = new IncomingMessage(new Socket())
+    req.url = options.url
+    if (options.headers) req.headers = options.headers
+    const res = new ServerResponse(req)
+    return createEvent(req, res)
+  }
+
+  const dispatchEvent = async (
+    server: ReturnType<typeof setupDevServer>,
+    url: string,
+    headers?: Record<string, string>,
+  ): Promise<{res: ServerResponse; status: number; body: string | Buffer}> => {
+    const event = createH3Event({url, headers})
+    const {res} = event.node
+    let body = ''
+    const resWrite = res.write.bind(res)
+    res.write = (chunk) => {
+      body ??= ''
+      body += decoder.decode(chunk)
+      return resWrite(chunk)
+    }
+    const resEnd = res.end.bind(res)
+    res.end = (content) => {
+      if (!body) body = content ?? ''
+      return resEnd(content)
+    }
+
+    await server.dispatchEvent(event)
+
+    if (!body && '_data' in res) {
+      // eslint-disable-next-line require-atomic-updates
+      body = await new Response(res._data as ReadableStream).text()
+    }
+
+    return {res, status: res.statusCode, body}
+  }
+
   const developmentTheme = buildTheme({id: 1, name: 'Theme', role: DEVELOPMENT_THEME_ROLE})!
   const localFiles = new Map([
     ['templates/asset.json', {checksum: '1', key: 'templates/asset.json'}],
@@ -206,59 +246,61 @@ describe('setupDevServer', () => {
     await expect(backgroundJobPromise).rejects.toThrow('Failed to fetch checksums from API')
   })
 
+  describe('DNS rebinding protection', () => {
+    const context = {...defaultServerContext}
+    const server = setupDevServer(developmentTheme, context)
+
+    test.each([
+      ['localhost:9292', 'localhost variant'],
+      ['127.0.0.1:9292', 'IPv4 loopback'],
+      ['[::1]:9292', 'IPv6 loopback'],
+      ['LOCALHOST:9292', 'case insensitive'],
+      ['localhost.:9292', 'trailing dot with port'],
+    ])('accepts %s (%s)', async (host) => {
+      const response = await dispatchEvent(server, '/wpm@something', {host})
+      expect(response.status).not.toBe(400)
+      expect(response.status).toBe(204)
+    })
+
+    test.each([
+      ['attacker.com:9292', 'attacker domain'],
+      ['poc.mzero.cloud:9292', 'DNS rebinding domain'],
+      ['localhost:1234', 'wrong port'],
+    ])('rejects %s (%s)', async (host) => {
+      const response = await dispatchEvent(server, '/', {host})
+      expect(response.status).toBe(400)
+    })
+
+    test('accepts requests when --host flag is uppercase (LOCALHOST)', async () => {
+      const uppercaseHostContext = {
+        ...defaultServerContext,
+        options: {...defaultServerContext.options, host: 'LOCALHOST'},
+      }
+      const uppercaseServer = setupDevServer(developmentTheme, uppercaseHostContext)
+      const response = await dispatchEvent(uppercaseServer, '/wpm@something', {host: 'localhost:9292'})
+      expect(response.status).not.toBe(400)
+      expect(response.status).toBe(204)
+    })
+  })
+
   describe('request handling', async () => {
     const context = {...defaultServerContext}
     const server = setupDevServer(developmentTheme, context)
 
     const html = String.raw
-    const decoder = new TextDecoder()
-
-    const createH3Event = (options: {url: string; headers?: Record<string, string>}) => {
-      const req = new IncomingMessage(new Socket())
-      req.url = options.url
-      if (options.headers) req.headers = options.headers
-      const res = new ServerResponse(req)
-      return createEvent(req, res)
-    }
-
-    const dispatchEvent = async (
-      url: string,
-      headers?: Record<string, string>,
-    ): Promise<{res: ServerResponse; status: number; body: string | Buffer}> => {
-      const event = createH3Event({url, headers})
-      const {res} = event.node
-      let body = ''
-      const resWrite = res.write.bind(res)
-      res.write = (chunk) => {
-        body ??= ''
-        body += decoder.decode(chunk)
-        return resWrite(chunk)
-      }
-      const resEnd = res.end.bind(res)
-      res.end = (content) => {
-        if (!body) body = content ?? ''
-        return resEnd(content)
-      }
-
-      await server.dispatchEvent(event)
-
-      if (!body && '_data' in res) {
-        // When returning a Response from H3, we get the body here:
-        // eslint-disable-next-line require-atomic-updates
-        body = await new Response(res._data as ReadableStream).text()
-      }
-
-      return {res, status: res.statusCode, body}
-    }
+    const defaultHost = `${context.options.host}:${context.options.port}`
 
     test('mocks known endpoints', async () => {
-      await expect(dispatchEvent('/wpm@something')).resolves.toHaveProperty('status', 204)
-      await expect(dispatchEvent('/.well-known/shopify/monorail')).resolves.toHaveProperty('status', 204)
+      await expect(dispatchEvent(server, '/wpm@something', {host: defaultHost})).resolves.toHaveProperty('status', 204)
+      await expect(dispatchEvent(server, '/.well-known/shopify/monorail', {host: defaultHost})).resolves.toHaveProperty(
+        'status',
+        204,
+      )
       expect(vi.mocked(render)).not.toHaveBeenCalled()
     })
 
     test('serves proxied local assets', async () => {
-      const eventPromise = dispatchEvent('/cdn/somepathhere/assets/file1.css')
+      const eventPromise = dispatchEvent(server, '/cdn/somepathhere/assets/file1.css', {host: defaultHost})
       await expect(eventPromise).resolves.not.toThrow()
 
       expect(vi.mocked(render)).not.toHaveBeenCalled()
@@ -273,7 +315,7 @@ describe('setupDevServer', () => {
 
     test('serves local assets from the root in a backward compatible way', async () => {
       // Also serves assets from the root, similar to what the old server did:
-      const eventPromise = dispatchEvent('/assets/file2.css')
+      const eventPromise = dispatchEvent(server, '/assets/file2.css', {host: defaultHost})
       await expect(eventPromise).resolves.not.toThrow()
 
       expect(vi.mocked(render)).not.toHaveBeenCalled()
@@ -284,7 +326,7 @@ describe('setupDevServer', () => {
     })
 
     test('handles non-breaking spaces in files correctly', async () => {
-      const eventPromise = dispatchEvent('/assets/file-with-nbsp.js')
+      const eventPromise = dispatchEvent(server, '/assets/file-with-nbsp.js', {host: defaultHost})
       await expect(eventPromise).resolves.not.toThrow()
 
       const {res, body} = await eventPromise
@@ -372,7 +414,7 @@ describe('setupDevServer', () => {
       localThemeFileSystem.files.set(snippetFile.key, snippetFile)
 
       // Request the compiled CSS
-      const response = await dispatchEvent('/compiled_assets/styles.css')
+      const response = await dispatchEvent(server, '/compiled_assets/styles.css', {host: defaultHost})
 
       // Just verify the content-type is set correctly
       expect(response.res.getHeader('content-type')).toEqual('text/css')
@@ -420,7 +462,7 @@ describe('setupDevServer', () => {
       localThemeFileSystem.files.set(blockFile2.key, blockFile2)
       localThemeFileSystem.files.set(blockFile3.key, blockFile3)
 
-      const eventPromise = dispatchEvent('/cdn/somepath/compiled_assets/block-scripts.js')
+      const eventPromise = dispatchEvent(server, '/cdn/somepath/compiled_assets/block-scripts.js', {host: defaultHost})
       await expect(eventPromise).resolves.not.toThrow()
 
       const {res, body} = await eventPromise
@@ -505,7 +547,9 @@ describe('setupDevServer', () => {
       localThemeFileSystem.files.set(snippetFile2.key, snippetFile2)
       localThemeFileSystem.files.set(snippetFile3.key, snippetFile3)
 
-      const eventPromise = dispatchEvent('/cdn/somepath/compiled_assets/snippet-scripts.js')
+      const eventPromise = dispatchEvent(server, '/cdn/somepath/compiled_assets/snippet-scripts.js', {
+        host: defaultHost,
+      })
       await expect(eventPromise).resolves.not.toThrow()
 
       const {res, body} = await eventPromise
@@ -589,7 +633,7 @@ describe('setupDevServer', () => {
       localThemeFileSystem.files.set(sectionFile1.key, sectionFile1)
       localThemeFileSystem.files.set(sectionFile2.key, sectionFile2)
       localThemeFileSystem.files.set(sectionFile3.key, sectionFile3)
-      const eventPromise = dispatchEvent('/cdn/somepath/compiled_assets/scripts.js')
+      const eventPromise = dispatchEvent(server, '/cdn/somepath/compiled_assets/scripts.js', {host: defaultHost})
       await expect(eventPromise).resolves.not.toThrow()
 
       const {res, body} = await eventPromise
@@ -655,7 +699,9 @@ describe('setupDevServer', () => {
 
       localThemeFileSystem.files.set(snippetFile.key, snippetFile)
 
-      const {res, body} = await dispatchEvent('/cdn/somepath/compiled_assets/snippet-scripts.js')
+      const {res, body} = await dispatchEvent(server, '/cdn/somepath/compiled_assets/snippet-scripts.js', {
+        host: defaultHost,
+      })
 
       const bodyString = body.toString()
       const bodyByteLength = Buffer.byteLength(bodyString)
@@ -671,7 +717,7 @@ describe('setupDevServer', () => {
       vi.stubGlobal('fetch', fetchStub)
 
       // Request a compiled asset that doesn't exist
-      await dispatchEvent('/compiled_assets/nonexistent.js')
+      await dispatchEvent(server, '/compiled_assets/nonexistent.js', {host: defaultHost})
 
       // Should fall back to proxy
       expect(fetchStub).toHaveBeenCalledOnce()
@@ -701,7 +747,7 @@ describe('setupDevServer', () => {
         ),
       )
 
-      const eventPromise = dispatchEvent('/', {accept: 'text/html'})
+      const eventPromise = dispatchEvent(server, '/', {host: defaultHost, accept: 'text/html'})
       await expect(eventPromise).resolves.not.toThrow()
 
       const {res, body} = await eventPromise
@@ -721,7 +767,7 @@ describe('setupDevServer', () => {
       vi.stubGlobal('fetch', fetchStub)
 
       // --- Unknown endpoint:
-      const eventPromise = dispatchEvent('/path/to/something-else.js')
+      const eventPromise = dispatchEvent(server, '/path/to/something-else.js', {host: defaultHost})
       await expect(eventPromise).resolves.not.toThrow()
       expect(vi.mocked(render)).not.toHaveBeenCalled()
 
@@ -747,7 +793,9 @@ describe('setupDevServer', () => {
 
       // --- Unknown assets:
       fetchStub.mockClear()
-      await expect(dispatchEvent('/cdn/somepathhere/assets/file42.css')).resolves.not.toThrow()
+      await expect(
+        dispatchEvent(server, '/cdn/somepathhere/assets/file42.css', {host: defaultHost}),
+      ).resolves.not.toThrow()
       expect(fetchStub).toHaveBeenCalledOnce()
       expect(fetchStub).toHaveBeenLastCalledWith(
         new URL(
@@ -779,7 +827,7 @@ describe('setupDevServer', () => {
 
       vi.stubGlobal('fetch', fetchStub)
 
-      const eventPromise = dispatchEvent('/cdn/shop/t/img/assets/file3.css')
+      const eventPromise = dispatchEvent(server, '/cdn/shop/t/img/assets/file3.css', {host: defaultHost})
       await expect(eventPromise).resolves.not.toThrow()
       expect(vi.mocked(render)).not.toHaveBeenCalled()
 
@@ -794,7 +842,7 @@ describe('setupDevServer', () => {
       const now = Date.now()
 
       const pathname = '/cdn/shop/t/img/assets/file4.js'
-      const eventPromise = dispatchEvent(`${pathname}?1234`)
+      const eventPromise = dispatchEvent(server, `${pathname}?1234`, {host: defaultHost})
       await expect(eventPromise).resolves.not.toThrow()
       expect(vi.mocked(render)).not.toHaveBeenCalled()
 
@@ -810,7 +858,7 @@ describe('setupDevServer', () => {
       fetchStub.mockResolvedValueOnce(new Response(null, {status: 302}))
       vi.mocked(render).mockResolvedValueOnce(new Response(null, {status: 401}))
 
-      const eventPromise = dispatchEvent('/non-renderable-path')
+      const eventPromise = dispatchEvent(server, '/non-renderable-path', {host: defaultHost})
       await expect(eventPromise).resolves.not.toThrow()
       expect(vi.mocked(render)).toHaveBeenCalled()
 
@@ -837,7 +885,7 @@ describe('setupDevServer', () => {
       fetchStub.mockResolvedValueOnce(new Response(null, {status: 404}))
       vi.mocked(render).mockResolvedValueOnce(new Response(null, {status: 401}))
 
-      const eventPromise = dispatchEvent('/non-renderable-path')
+      const eventPromise = dispatchEvent(server, '/non-renderable-path', {host: defaultHost})
       await expect(eventPromise).resolves.not.toThrow()
       expect(vi.mocked(render)).toHaveBeenCalled()
 
@@ -864,14 +912,22 @@ describe('setupDevServer', () => {
       fetchStub.mockResolvedValueOnce(new Response(null, {status: 200}))
       vi.mocked(render).mockResolvedValue(new Response(null, {status: 404}))
 
-      await expect(dispatchEvent('/non-renderable-path?sections=xyz')).resolves.toHaveProperty('status', 404)
-      await expect(dispatchEvent('/non-renderable-path?section_id=xyz')).resolves.toHaveProperty('status', 404)
-      await expect(dispatchEvent('/non-renderable-path?app_block_id=xyz')).resolves.toHaveProperty('status', 404)
+      await expect(
+        dispatchEvent(server, '/non-renderable-path?sections=xyz', {host: defaultHost}),
+      ).resolves.toHaveProperty('status', 404)
+      await expect(
+        dispatchEvent(server, '/non-renderable-path?section_id=xyz', {host: defaultHost}),
+      ).resolves.toHaveProperty('status', 404)
+      await expect(
+        dispatchEvent(server, '/non-renderable-path?app_block_id=xyz', {host: defaultHost}),
+      ).resolves.toHaveProperty('status', 404)
 
       expect(vi.mocked(render)).toHaveBeenCalledTimes(3)
       expect(fetchStub).not.toHaveBeenCalled()
 
-      await expect(dispatchEvent('/non-renderable-path?unknown=xyz')).resolves.toHaveProperty('status', 200)
+      await expect(
+        dispatchEvent(server, '/non-renderable-path?unknown=xyz', {host: defaultHost}),
+      ).resolves.toHaveProperty('status', 200)
       expect(fetchStub).toHaveBeenCalledOnce()
     })
 
@@ -887,7 +943,7 @@ describe('setupDevServer', () => {
       vi.stubGlobal('fetch', fetchStub)
 
       // When
-      const event = createH3Event({url: '/compiled_assets/styles.css'})
+      const event = createH3Event({url: '/compiled_assets/styles.css', headers: {host: defaultHost}})
       await themeExtServer.dispatchEvent(event)
 
       // Then
@@ -908,7 +964,7 @@ describe('setupDevServer', () => {
       fetchStub.mockClear()
 
       // When requesting the same compiled asset with theme context
-      const themeEvent = createH3Event({url: '/compiled_assets/styles.css'})
+      const themeEvent = createH3Event({url: '/compiled_assets/styles.css', headers: {host: defaultHost}})
       await server.dispatchEvent(themeEvent)
 
       // Then it should handle it locally, not proxy
@@ -920,7 +976,7 @@ describe('setupDevServer', () => {
       vi.stubGlobal('fetch', fetchStub)
       vi.mocked(render).mockRejectedValueOnce(new Error('Network error'))
 
-      const eventPromise = dispatchEvent('/')
+      const eventPromise = dispatchEvent(server, '/', {host: defaultHost})
       await expect(eventPromise).resolves.not.toThrow()
       expect(vi.mocked(render)).toHaveBeenCalled()
 
@@ -935,7 +991,7 @@ describe('setupDevServer', () => {
       vi.stubGlobal('fetch', fetchStub)
       localThemeFileSystem.uploadErrors.set('templates/asset.json', ['Error 1', 'Error 2'])
 
-      const eventPromise = dispatchEvent('/')
+      const eventPromise = dispatchEvent(server, '/', {host: defaultHost})
       await expect(eventPromise).resolves.not.toThrow()
       expect(vi.mocked(render)).not.toHaveBeenCalled()
 

--- a/packages/theme/src/cli/utilities/theme-environment/theme-environment.test.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/theme-environment.test.ts
@@ -42,6 +42,46 @@ beforeEach(() => {
 })
 
 describe('setupDevServer', () => {
+  const decoder = new TextDecoder()
+
+  const createH3Event = (options: {url: string; headers?: Record<string, string>}) => {
+    const req = new IncomingMessage(new Socket())
+    req.url = options.url
+    if (options.headers) req.headers = options.headers
+    const res = new ServerResponse(req)
+    return createEvent(req, res)
+  }
+
+  const dispatchEvent = async (
+    server: ReturnType<typeof setupDevServer>,
+    url: string,
+    headers?: Record<string, string>,
+  ): Promise<{res: ServerResponse; status: number; body: string | Buffer}> => {
+    const event = createH3Event({url, headers})
+    const {res} = event.node
+    let body = ''
+    const resWrite = res.write.bind(res)
+    res.write = (chunk) => {
+      body ??= ''
+      body += decoder.decode(chunk)
+      return resWrite(chunk)
+    }
+    const resEnd = res.end.bind(res)
+    res.end = (content) => {
+      if (!body) body = content ?? ''
+      return resEnd(content)
+    }
+
+    await server.dispatchEvent(event)
+
+    if (!body && '_data' in res) {
+      // eslint-disable-next-line require-atomic-updates
+      body = await new Response(res._data as ReadableStream).text()
+    }
+
+    return {res, status: res.statusCode, body}
+  }
+
   const developmentTheme = buildTheme({id: 1, name: 'Theme', role: DEVELOPMENT_THEME_ROLE})!
   const localFiles = new Map([
     ['templates/asset.json', {checksum: '1', key: 'templates/asset.json'}],
@@ -206,80 +246,82 @@ describe('setupDevServer', () => {
     await expect(backgroundJobPromise).rejects.toThrow('Failed to fetch checksums from API')
   })
 
+  describe('DNS rebinding protection', () => {
+    const context = {...defaultServerContext}
+    const server = setupDevServer(developmentTheme, context)
+
+    test.each([
+      ['localhost:9292', 'localhost variant'],
+      ['127.0.0.1:9292', 'IPv4 loopback'],
+      ['[::1]:9292', 'IPv6 loopback'],
+      ['LOCALHOST:9292', 'case insensitive'],
+      ['localhost.:9292', 'trailing dot with port'],
+    ])('accepts %s (%s)', async (host) => {
+      const response = await dispatchEvent(server, '/wpm@something', {host})
+      expect(response.status).not.toBe(400)
+      expect(response.status).toBe(204)
+    })
+
+    test.each([
+      ['attacker.com:9292', 'attacker domain'],
+      ['poc.mzero.cloud:9292', 'DNS rebinding domain'],
+      ['localhost:1234', 'wrong port'],
+    ])('rejects %s (%s)', async (host) => {
+      const response = await dispatchEvent(server, '/', {host})
+      expect(response.status).toBe(400)
+    })
+
+    test('accepts requests when --host flag is uppercase (LOCALHOST)', async () => {
+      const uppercaseHostContext = {
+        ...defaultServerContext,
+        options: {...defaultServerContext.options, host: 'LOCALHOST'},
+      }
+      const uppercaseServer = setupDevServer(developmentTheme, uppercaseHostContext)
+      const response = await dispatchEvent(uppercaseServer, '/wpm@something', {host: 'localhost:9292'})
+      expect(response.status).not.toBe(400)
+      expect(response.status).toBe(204)
+    })
+  })
+
   describe('request handling', async () => {
     const context = {...defaultServerContext}
     const server = setupDevServer(developmentTheme, context)
 
     const html = String.raw
-    const decoder = new TextDecoder()
-
-    const createH3Event = (options: {url: string; headers?: Record<string, string>}) => {
-      const req = new IncomingMessage(new Socket())
-      req.url = options.url
-      if (options.headers) req.headers = options.headers
-      const res = new ServerResponse(req)
-      return createEvent(req, res)
-    }
-
-    const dispatchEvent = async (
-      url: string,
-      headers?: Record<string, string>,
-    ): Promise<{res: ServerResponse; status: number; body: string | Buffer}> => {
-      const event = createH3Event({url, headers})
-      const {res} = event.node
-      let body = ''
-      const resWrite = res.write.bind(res)
-      res.write = (chunk) => {
-        body ??= ''
-        body += decoder.decode(chunk)
-        return resWrite(chunk)
-      }
-      const resEnd = res.end.bind(res)
-      res.end = (content) => {
-        if (!body) body = content ?? ''
-        return resEnd(content)
-      }
-
-      await server.dispatchEvent(event)
-
-      if (!body && '_data' in res) {
-        // When returning a Response from H3, we get the body here:
-        // eslint-disable-next-line require-atomic-updates
-        body = await new Response(res._data as ReadableStream).text()
-      }
-
-      return {res, status: res.statusCode, body}
-    }
+    const defaultHost = `${context.options.host}:${context.options.port}`
 
     test('mocks known endpoints', async () => {
-      await expect(dispatchEvent('/wpm@something')).resolves.toHaveProperty('status', 204)
-      await expect(dispatchEvent('/.well-known/shopify/monorail')).resolves.toHaveProperty('status', 204)
+      await expect(dispatchEvent(server, '/wpm@something', {host: defaultHost})).resolves.toHaveProperty('status', 204)
+      await expect(dispatchEvent(server, '/.well-known/shopify/monorail', {host: defaultHost})).resolves.toHaveProperty(
+        'status',
+        204,
+      )
       expect(vi.mocked(render)).not.toHaveBeenCalled()
     })
 
     test('CORS allows the theme editor (Online Store Editor) origin so hot reload works in the editor', async () => {
-      const {res} = await dispatchEvent('/assets/file2.css', {origin: 'https://online-store-web.shopifyapps.com'})
+      const {res} = await dispatchEvent(server, '/assets/file2.css', {host: defaultHost, origin: 'https://online-store-web.shopifyapps.com'})
       expect(res.getHeader('access-control-allow-origin')).toEqual('https://online-store-web.shopifyapps.com')
     })
 
     test('CORS allows the storefront origin', async () => {
       const origin = `https://${defaultServerContext.session.storeFqdn}`
-      const {res} = await dispatchEvent('/assets/file2.css', {origin})
+      const {res} = await dispatchEvent(server, '/assets/file2.css', {host: defaultHost, origin})
       expect(res.getHeader('access-control-allow-origin')).toEqual(origin)
     })
 
     test('CORS does not allow unknown origins', async () => {
-      const {res} = await dispatchEvent('/assets/file2.css', {origin: 'https://evil.example.com'})
+      const {res} = await dispatchEvent(server, '/assets/file2.css', {host: defaultHost, origin: 'https://evil.example.com'})
       expect(res.getHeader('access-control-allow-origin')).toBeUndefined()
     })
 
     test('CORS does not set headers on direct navigation without an Origin header', async () => {
-      const {res} = await dispatchEvent('/assets/file2.css')
+      const {res} = await dispatchEvent(server, '/assets/file2.css', {host: defaultHost})
       expect(res.getHeader('access-control-allow-origin')).toBeUndefined()
     })
 
     test('serves proxied local assets', async () => {
-      const eventPromise = dispatchEvent('/cdn/somepathhere/assets/file1.css')
+      const eventPromise = dispatchEvent(server, '/cdn/somepathhere/assets/file1.css', {host: defaultHost})
       await expect(eventPromise).resolves.not.toThrow()
 
       expect(vi.mocked(render)).not.toHaveBeenCalled()
@@ -294,7 +336,7 @@ describe('setupDevServer', () => {
 
     test('serves local assets from the root in a backward compatible way', async () => {
       // Also serves assets from the root, similar to what the old server did:
-      const eventPromise = dispatchEvent('/assets/file2.css')
+      const eventPromise = dispatchEvent(server, '/assets/file2.css', {host: defaultHost})
       await expect(eventPromise).resolves.not.toThrow()
 
       expect(vi.mocked(render)).not.toHaveBeenCalled()
@@ -305,7 +347,7 @@ describe('setupDevServer', () => {
     })
 
     test('handles non-breaking spaces in files correctly', async () => {
-      const eventPromise = dispatchEvent('/assets/file-with-nbsp.js')
+      const eventPromise = dispatchEvent(server, '/assets/file-with-nbsp.js', {host: defaultHost})
       await expect(eventPromise).resolves.not.toThrow()
 
       const {res, body} = await eventPromise
@@ -393,7 +435,7 @@ describe('setupDevServer', () => {
       localThemeFileSystem.files.set(snippetFile.key, snippetFile)
 
       // Request the compiled CSS
-      const response = await dispatchEvent('/compiled_assets/styles.css')
+      const response = await dispatchEvent(server, '/compiled_assets/styles.css', {host: defaultHost})
 
       // Just verify the content-type is set correctly
       expect(response.res.getHeader('content-type')).toEqual('text/css')
@@ -441,7 +483,7 @@ describe('setupDevServer', () => {
       localThemeFileSystem.files.set(blockFile2.key, blockFile2)
       localThemeFileSystem.files.set(blockFile3.key, blockFile3)
 
-      const eventPromise = dispatchEvent('/cdn/somepath/compiled_assets/block-scripts.js')
+      const eventPromise = dispatchEvent(server, '/cdn/somepath/compiled_assets/block-scripts.js', {host: defaultHost})
       await expect(eventPromise).resolves.not.toThrow()
 
       const {res, body} = await eventPromise
@@ -526,7 +568,9 @@ describe('setupDevServer', () => {
       localThemeFileSystem.files.set(snippetFile2.key, snippetFile2)
       localThemeFileSystem.files.set(snippetFile3.key, snippetFile3)
 
-      const eventPromise = dispatchEvent('/cdn/somepath/compiled_assets/snippet-scripts.js')
+      const eventPromise = dispatchEvent(server, '/cdn/somepath/compiled_assets/snippet-scripts.js', {
+        host: defaultHost,
+      })
       await expect(eventPromise).resolves.not.toThrow()
 
       const {res, body} = await eventPromise
@@ -610,7 +654,7 @@ describe('setupDevServer', () => {
       localThemeFileSystem.files.set(sectionFile1.key, sectionFile1)
       localThemeFileSystem.files.set(sectionFile2.key, sectionFile2)
       localThemeFileSystem.files.set(sectionFile3.key, sectionFile3)
-      const eventPromise = dispatchEvent('/cdn/somepath/compiled_assets/scripts.js')
+      const eventPromise = dispatchEvent(server, '/cdn/somepath/compiled_assets/scripts.js', {host: defaultHost})
       await expect(eventPromise).resolves.not.toThrow()
 
       const {res, body} = await eventPromise
@@ -676,7 +720,9 @@ describe('setupDevServer', () => {
 
       localThemeFileSystem.files.set(snippetFile.key, snippetFile)
 
-      const {res, body} = await dispatchEvent('/cdn/somepath/compiled_assets/snippet-scripts.js')
+      const {res, body} = await dispatchEvent(server, '/cdn/somepath/compiled_assets/snippet-scripts.js', {
+        host: defaultHost,
+      })
 
       const bodyString = body.toString()
       const bodyByteLength = Buffer.byteLength(bodyString)
@@ -692,7 +738,7 @@ describe('setupDevServer', () => {
       vi.stubGlobal('fetch', fetchStub)
 
       // Request a compiled asset that doesn't exist
-      await dispatchEvent('/compiled_assets/nonexistent.js')
+      await dispatchEvent(server, '/compiled_assets/nonexistent.js', {host: defaultHost})
 
       // Should fall back to proxy
       expect(fetchStub).toHaveBeenCalledOnce()
@@ -722,7 +768,7 @@ describe('setupDevServer', () => {
         ),
       )
 
-      const eventPromise = dispatchEvent('/', {accept: 'text/html'})
+      const eventPromise = dispatchEvent(server, '/', {host: defaultHost, accept: 'text/html'})
       await expect(eventPromise).resolves.not.toThrow()
 
       const {res, body} = await eventPromise
@@ -742,7 +788,7 @@ describe('setupDevServer', () => {
       vi.stubGlobal('fetch', fetchStub)
 
       // --- Unknown endpoint:
-      const eventPromise = dispatchEvent('/path/to/something-else.js')
+      const eventPromise = dispatchEvent(server, '/path/to/something-else.js', {host: defaultHost})
       await expect(eventPromise).resolves.not.toThrow()
       expect(vi.mocked(render)).not.toHaveBeenCalled()
 
@@ -768,7 +814,9 @@ describe('setupDevServer', () => {
 
       // --- Unknown assets:
       fetchStub.mockClear()
-      await expect(dispatchEvent('/cdn/somepathhere/assets/file42.css')).resolves.not.toThrow()
+      await expect(
+        dispatchEvent(server, '/cdn/somepathhere/assets/file42.css', {host: defaultHost}),
+      ).resolves.not.toThrow()
       expect(fetchStub).toHaveBeenCalledOnce()
       expect(fetchStub).toHaveBeenLastCalledWith(
         new URL(
@@ -800,7 +848,7 @@ describe('setupDevServer', () => {
 
       vi.stubGlobal('fetch', fetchStub)
 
-      const eventPromise = dispatchEvent('/cdn/shop/t/img/assets/file3.css')
+      const eventPromise = dispatchEvent(server, '/cdn/shop/t/img/assets/file3.css', {host: defaultHost})
       await expect(eventPromise).resolves.not.toThrow()
       expect(vi.mocked(render)).not.toHaveBeenCalled()
 
@@ -815,7 +863,7 @@ describe('setupDevServer', () => {
       const now = Date.now()
 
       const pathname = '/cdn/shop/t/img/assets/file4.js'
-      const eventPromise = dispatchEvent(`${pathname}?1234`)
+      const eventPromise = dispatchEvent(server, `${pathname}?1234`, {host: defaultHost})
       await expect(eventPromise).resolves.not.toThrow()
       expect(vi.mocked(render)).not.toHaveBeenCalled()
 
@@ -831,7 +879,7 @@ describe('setupDevServer', () => {
       fetchStub.mockResolvedValueOnce(new Response(null, {status: 302}))
       vi.mocked(render).mockResolvedValueOnce(new Response(null, {status: 401}))
 
-      const eventPromise = dispatchEvent('/non-renderable-path')
+      const eventPromise = dispatchEvent(server, '/non-renderable-path', {host: defaultHost})
       await expect(eventPromise).resolves.not.toThrow()
       expect(vi.mocked(render)).toHaveBeenCalled()
 
@@ -858,7 +906,7 @@ describe('setupDevServer', () => {
       fetchStub.mockResolvedValueOnce(new Response(null, {status: 404}))
       vi.mocked(render).mockResolvedValueOnce(new Response(null, {status: 401}))
 
-      const eventPromise = dispatchEvent('/non-renderable-path')
+      const eventPromise = dispatchEvent(server, '/non-renderable-path', {host: defaultHost})
       await expect(eventPromise).resolves.not.toThrow()
       expect(vi.mocked(render)).toHaveBeenCalled()
 
@@ -885,14 +933,22 @@ describe('setupDevServer', () => {
       fetchStub.mockResolvedValueOnce(new Response(null, {status: 200}))
       vi.mocked(render).mockResolvedValue(new Response(null, {status: 404}))
 
-      await expect(dispatchEvent('/non-renderable-path?sections=xyz')).resolves.toHaveProperty('status', 404)
-      await expect(dispatchEvent('/non-renderable-path?section_id=xyz')).resolves.toHaveProperty('status', 404)
-      await expect(dispatchEvent('/non-renderable-path?app_block_id=xyz')).resolves.toHaveProperty('status', 404)
+      await expect(
+        dispatchEvent(server, '/non-renderable-path?sections=xyz', {host: defaultHost}),
+      ).resolves.toHaveProperty('status', 404)
+      await expect(
+        dispatchEvent(server, '/non-renderable-path?section_id=xyz', {host: defaultHost}),
+      ).resolves.toHaveProperty('status', 404)
+      await expect(
+        dispatchEvent(server, '/non-renderable-path?app_block_id=xyz', {host: defaultHost}),
+      ).resolves.toHaveProperty('status', 404)
 
       expect(vi.mocked(render)).toHaveBeenCalledTimes(3)
       expect(fetchStub).not.toHaveBeenCalled()
 
-      await expect(dispatchEvent('/non-renderable-path?unknown=xyz')).resolves.toHaveProperty('status', 200)
+      await expect(
+        dispatchEvent(server, '/non-renderable-path?unknown=xyz', {host: defaultHost}),
+      ).resolves.toHaveProperty('status', 200)
       expect(fetchStub).toHaveBeenCalledOnce()
     })
 
@@ -908,7 +964,7 @@ describe('setupDevServer', () => {
       vi.stubGlobal('fetch', fetchStub)
 
       // When
-      const event = createH3Event({url: '/compiled_assets/styles.css'})
+      const event = createH3Event({url: '/compiled_assets/styles.css', headers: {host: defaultHost}})
       await themeExtServer.dispatchEvent(event)
 
       // Then
@@ -929,7 +985,7 @@ describe('setupDevServer', () => {
       fetchStub.mockClear()
 
       // When requesting the same compiled asset with theme context
-      const themeEvent = createH3Event({url: '/compiled_assets/styles.css'})
+      const themeEvent = createH3Event({url: '/compiled_assets/styles.css', headers: {host: defaultHost}})
       await server.dispatchEvent(themeEvent)
 
       // Then it should handle it locally, not proxy
@@ -941,7 +997,7 @@ describe('setupDevServer', () => {
       vi.stubGlobal('fetch', fetchStub)
       vi.mocked(render).mockRejectedValueOnce(new Error('Network error'))
 
-      const eventPromise = dispatchEvent('/')
+      const eventPromise = dispatchEvent(server, '/', {host: defaultHost})
       await expect(eventPromise).resolves.not.toThrow()
       expect(vi.mocked(render)).toHaveBeenCalled()
 
@@ -956,7 +1012,7 @@ describe('setupDevServer', () => {
       vi.stubGlobal('fetch', fetchStub)
       localThemeFileSystem.uploadErrors.set('templates/asset.json', ['Error 1', 'Error 2'])
 
-      const eventPromise = dispatchEvent('/')
+      const eventPromise = dispatchEvent(server, '/', {host: defaultHost})
       await expect(eventPromise).resolves.not.toThrow()
       expect(vi.mocked(render)).not.toHaveBeenCalled()
 

--- a/packages/theme/src/cli/utilities/theme-environment/theme-environment.test.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/theme-environment.test.ts
@@ -300,7 +300,10 @@ describe('setupDevServer', () => {
     })
 
     test('CORS allows the theme editor (Online Store Editor) origin so hot reload works in the editor', async () => {
-      const {res} = await dispatchEvent(server, '/assets/file2.css', {host: defaultHost, origin: 'https://online-store-web.shopifyapps.com'})
+      const {res} = await dispatchEvent(server, '/assets/file2.css', {
+        host: defaultHost,
+        origin: 'https://online-store-web.shopifyapps.com',
+      })
       expect(res.getHeader('access-control-allow-origin')).toEqual('https://online-store-web.shopifyapps.com')
     })
 
@@ -311,7 +314,10 @@ describe('setupDevServer', () => {
     })
 
     test('CORS does not allow unknown origins', async () => {
-      const {res} = await dispatchEvent(server, '/assets/file2.css', {host: defaultHost, origin: 'https://evil.example.com'})
+      const {res} = await dispatchEvent(server, '/assets/file2.css', {
+        host: defaultHost,
+        origin: 'https://evil.example.com',
+      })
       expect(res.getHeader('access-control-allow-origin')).toBeUndefined()
     })
 

--- a/packages/theme/src/cli/utilities/theme-environment/theme-environment.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/theme-environment.ts
@@ -8,7 +8,15 @@ import {renderTasksToStdErr} from '../theme-ui.js'
 import {renderThrownError} from '../errors.js'
 import {promiseWithResolvers} from '../../polyfills/promiseWithResolvers.js'
 
-import {createApp, defineEventHandler, defineLazyEventHandler, toNodeListener, handleCors} from 'h3'
+import {
+  createApp,
+  defineEventHandler,
+  defineLazyEventHandler,
+  toNodeListener,
+  handleCors,
+  sendError,
+  createError,
+} from 'h3'
 import {fetchChecksums} from '@shopify/cli-kit/node/themes/api'
 
 import {createServer} from 'node:http'
@@ -123,9 +131,54 @@ interface DevelopmentServerInstance {
   close: () => Promise<void>
 }
 
+function createAllowedHostsSet(host: string, port: string): Set<string> {
+  const allowedHosts = new Set<string>()
+  const portSuffix = `:${port}`
+  const normalizedHost = host.toLowerCase().trim()
+
+  allowedHosts.add(`${normalizedHost}${portSuffix}`)
+
+  // When binding to localhost variants or 0.0.0.0, allow all localhost forms
+  const localhostVariants = ['localhost', '127.0.0.1', '::1', '0.0.0.0']
+  if (localhostVariants.includes(normalizedHost)) {
+    allowedHosts.add(`localhost${portSuffix}`)
+    allowedHosts.add(`127.0.0.1${portSuffix}`)
+    allowedHosts.add(`[::1]${portSuffix}`)
+  }
+
+  return allowedHosts
+}
+
+function normalizeHostHeader(hostHeader: string | undefined): string | undefined {
+  if (!hostHeader) return undefined
+  // Lowercase, then strip trailing dot before port (or at end for plain hostname).
+  // IPv6 brackets: trailing dot would be after `]`, e.g. [::1].:9292
+  return hostHeader.toLowerCase().replace(/\.(?=:\d|$)/, '')
+}
+
 function createDevelopmentServer(theme: Theme, ctx: DevServerContext, initialWork: Promise<void>) {
   const app = createApp()
   const allowedOrigins = [`http://${ctx.options.host}:${ctx.options.port}`, `https://${ctx.session.storeFqdn}`]
+  const allowedHosts = createAllowedHostsSet(ctx.options.host, ctx.options.port)
+
+  // Host header validation
+  app.use(
+    defineEventHandler((event) => {
+      const hostHeader = event.node.req.headers.host
+      const normalizedHost = normalizeHostHeader(hostHeader)
+
+      if (!normalizedHost || !allowedHosts.has(normalizedHost)) {
+        return sendError(
+          event,
+          createError({
+            statusCode: 400,
+            statusMessage: 'Bad Request',
+            message: 'Invalid Host header',
+          }),
+        )
+      }
+    }),
+  )
 
   app.use(
     defineLazyEventHandler(async () => {

--- a/packages/theme/src/cli/utilities/theme-environment/theme-environment.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/theme-environment.ts
@@ -3,20 +3,13 @@ import {getHtmlHandler} from './html.js'
 import {getAssetsHandler} from './local-assets.js'
 import {getProxyHandler} from './proxy.js'
 import {reconcileAndPollThemeEditorChanges} from './remote-theme-watcher.js'
+import {createHostValidationHandler} from './host-validation.js'
 import {uploadTheme} from '../theme-uploader.js'
 import {renderTasksToStdErr} from '../theme-ui.js'
 import {renderThrownError} from '../errors.js'
 import {promiseWithResolvers} from '../../polyfills/promiseWithResolvers.js'
 
-import {
-  createApp,
-  defineEventHandler,
-  defineLazyEventHandler,
-  toNodeListener,
-  handleCors,
-  sendError,
-  createError,
-} from 'h3'
+import {createApp, defineEventHandler, defineLazyEventHandler, toNodeListener, handleCors} from 'h3'
 import {fetchChecksums} from '@shopify/cli-kit/node/themes/api'
 
 import {createServer} from 'node:http'
@@ -136,31 +129,6 @@ interface DevelopmentServerInstance {
   close: () => Promise<void>
 }
 
-function createAllowedHostsSet(host: string, port: string): Set<string> {
-  const allowedHosts = new Set<string>()
-  const portSuffix = `:${port}`
-  const normalizedHost = host.toLowerCase().trim()
-
-  allowedHosts.add(`${normalizedHost}${portSuffix}`)
-
-  // When binding to localhost variants or 0.0.0.0, allow all localhost forms
-  const localhostVariants = ['localhost', '127.0.0.1', '::1', '0.0.0.0']
-  if (localhostVariants.includes(normalizedHost)) {
-    allowedHosts.add(`localhost${portSuffix}`)
-    allowedHosts.add(`127.0.0.1${portSuffix}`)
-    allowedHosts.add(`[::1]${portSuffix}`)
-  }
-
-  return allowedHosts
-}
-
-function normalizeHostHeader(hostHeader: string | undefined): string | undefined {
-  if (!hostHeader) return undefined
-  // Lowercase, then strip trailing dot before port (or at end for plain hostname).
-  // IPv6 brackets: trailing dot would be after `]`, e.g. [::1].:9292
-  return hostHeader.toLowerCase().replace(/\.(?=:\d|$)/, '')
-}
-
 function createDevelopmentServer(theme: Theme, ctx: DevServerContext, initialWork: Promise<void>) {
   const app = createApp()
   const allowedOrigins = [
@@ -169,26 +137,8 @@ function createDevelopmentServer(theme: Theme, ctx: DevServerContext, initialWor
     // Required for HMR with the theme editor
     'https://online-store-web.shopifyapps.com',
   ]
-  const allowedHosts = createAllowedHostsSet(ctx.options.host, ctx.options.port)
 
-  // Host header validation
-  app.use(
-    defineEventHandler((event) => {
-      const hostHeader = event.node.req.headers.host
-      const normalizedHost = normalizeHostHeader(hostHeader)
-
-      if (!normalizedHost || !allowedHosts.has(normalizedHost)) {
-        return sendError(
-          event,
-          createError({
-            statusCode: 400,
-            statusMessage: 'Bad Request',
-            message: 'Invalid Host header',
-          }),
-        )
-      }
-    }),
-  )
+  app.use(createHostValidationHandler(ctx.options.host, ctx.options.port))
 
   app.use(
     defineLazyEventHandler(async () => {

--- a/packages/theme/src/cli/utilities/theme-environment/theme-environment.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/theme-environment.ts
@@ -8,7 +8,15 @@ import {renderTasksToStdErr} from '../theme-ui.js'
 import {renderThrownError} from '../errors.js'
 import {promiseWithResolvers} from '../../polyfills/promiseWithResolvers.js'
 
-import {createApp, defineEventHandler, defineLazyEventHandler, toNodeListener, handleCors} from 'h3'
+import {
+  createApp,
+  defineEventHandler,
+  defineLazyEventHandler,
+  toNodeListener,
+  handleCors,
+  sendError,
+  createError,
+} from 'h3'
 import {fetchChecksums} from '@shopify/cli-kit/node/themes/api'
 
 import {createServer} from 'node:http'
@@ -128,6 +136,31 @@ interface DevelopmentServerInstance {
   close: () => Promise<void>
 }
 
+function createAllowedHostsSet(host: string, port: string): Set<string> {
+  const allowedHosts = new Set<string>()
+  const portSuffix = `:${port}`
+  const normalizedHost = host.toLowerCase().trim()
+
+  allowedHosts.add(`${normalizedHost}${portSuffix}`)
+
+  // When binding to localhost variants or 0.0.0.0, allow all localhost forms
+  const localhostVariants = ['localhost', '127.0.0.1', '::1', '0.0.0.0']
+  if (localhostVariants.includes(normalizedHost)) {
+    allowedHosts.add(`localhost${portSuffix}`)
+    allowedHosts.add(`127.0.0.1${portSuffix}`)
+    allowedHosts.add(`[::1]${portSuffix}`)
+  }
+
+  return allowedHosts
+}
+
+function normalizeHostHeader(hostHeader: string | undefined): string | undefined {
+  if (!hostHeader) return undefined
+  // Lowercase, then strip trailing dot before port (or at end for plain hostname).
+  // IPv6 brackets: trailing dot would be after `]`, e.g. [::1].:9292
+  return hostHeader.toLowerCase().replace(/\.(?=:\d|$)/, '')
+}
+
 function createDevelopmentServer(theme: Theme, ctx: DevServerContext, initialWork: Promise<void>) {
   const app = createApp()
   const allowedOrigins = [
@@ -136,6 +169,26 @@ function createDevelopmentServer(theme: Theme, ctx: DevServerContext, initialWor
     // Required for HMR with the theme editor
     'https://online-store-web.shopifyapps.com',
   ]
+  const allowedHosts = createAllowedHostsSet(ctx.options.host, ctx.options.port)
+
+  // Host header validation
+  app.use(
+    defineEventHandler((event) => {
+      const hostHeader = event.node.req.headers.host
+      const normalizedHost = normalizeHostHeader(hostHeader)
+
+      if (!normalizedHost || !allowedHosts.has(normalizedHost)) {
+        return sendError(
+          event,
+          createError({
+            statusCode: 400,
+            statusMessage: 'Bad Request',
+            message: 'Invalid Host header',
+          }),
+        )
+      }
+    }),
+  )
 
   app.use(
     defineLazyEventHandler(async () => {

--- a/packages/theme/src/cli/utilities/theme-ext-environment/theme-ext-server.test.ts
+++ b/packages/theme/src/cli/utilities/theme-ext-environment/theme-ext-server.test.ts
@@ -1,0 +1,122 @@
+import {createDevelopmentExtensionServer} from './theme-ext-server.js'
+import {DevServerContext} from '../theme-environment/types.js'
+import {emptyThemeExtFileSystem, emptyThemeFileSystem} from '../theme-fs-empty.js'
+
+import {DEVELOPMENT_THEME_ROLE} from '@shopify/cli-kit/node/themes/utils'
+import {buildTheme} from '@shopify/cli-kit/node/themes/factories'
+import {describe, expect, test} from 'vitest'
+import {createEvent} from 'h3'
+
+import {IncomingMessage, ServerResponse} from 'node:http'
+import {Socket} from 'node:net'
+
+describe('createDevelopmentExtensionServer', () => {
+  const decoder = new TextDecoder()
+
+  const createH3Event = (options: {url: string; headers?: Record<string, string>}) => {
+    const req = new IncomingMessage(new Socket())
+    req.url = options.url
+    if (options.headers) req.headers = options.headers
+    const res = new ServerResponse(req)
+    return createEvent(req, res)
+  }
+
+  const dispatchEvent = async (
+    server: ReturnType<typeof createDevelopmentExtensionServer>,
+    url: string,
+    headers?: Record<string, string>,
+  ): Promise<{res: ServerResponse; status: number; body: string | Buffer}> => {
+    const event = createH3Event({url, headers})
+    const {res} = event.node
+    let body = ''
+    const resWrite = res.write.bind(res)
+    res.write = (chunk) => {
+      body ??= ''
+      body += decoder.decode(chunk)
+      return resWrite(chunk)
+    }
+    const resEnd = res.end.bind(res)
+    res.end = (content) => {
+      if (!body) body = content ?? ''
+      return resEnd(content)
+    }
+
+    await server.dispatch(event)
+
+    if (!body && '_data' in res) {
+      // eslint-disable-next-line require-atomic-updates
+      body = await new Response(res._data as ReadableStream).text()
+    }
+
+    return {res, status: res.statusCode, body}
+  }
+
+  const developmentTheme = buildTheme({id: 1, name: 'Theme', role: DEVELOPMENT_THEME_ROLE})!
+
+  const defaultServerContext: DevServerContext = {
+    session: {
+      storefrontToken: 'shptka_test_token_123',
+      token: '',
+      storeFqdn: 'my-store.myshopify.com',
+      sessionCookies: {_shopify_essential: 'test-cookie-value'},
+    },
+    lastRequestedPath: '',
+    localThemeFileSystem: emptyThemeFileSystem(),
+    localThemeExtensionFileSystem: emptyThemeExtFileSystem(),
+    directory: 'tmp',
+    type: 'theme-extension',
+    options: {
+      ignore: [],
+      only: [],
+      noDelete: false,
+      host: '127.0.0.1',
+      port: 9293,
+      liveReload: 'hot-reload',
+      open: false,
+      themeEditorSync: false,
+      errorOverlay: 'default',
+    },
+  }
+
+  describe('DNS rebinding protection', () => {
+    const context = {...defaultServerContext}
+    const server = createDevelopmentExtensionServer(developmentTheme, context)
+
+    test.each([
+      ['localhost:9293', 'localhost variant'],
+      ['127.0.0.1:9293', 'IPv4 loopback'],
+      ['[::1]:9293', 'IPv6 loopback'],
+      ['LOCALHOST:9293', 'case insensitive'],
+      ['localhost.:9293', 'trailing dot with port'],
+    ])('accepts %s (%s)', async (host) => {
+      const response = await dispatchEvent(server, '/wpm@something', {host})
+      expect(response.status).not.toBe(400)
+      expect(response.status).toBe(204)
+    })
+
+    test.each([
+      ['attacker.com:9293', 'attacker domain'],
+      ['poc.mzero.cloud:9293', 'DNS rebinding domain'],
+      ['localhost:1234', 'wrong port'],
+    ])('rejects %s (%s)', async (host) => {
+      const response = await dispatchEvent(server, '/', {host})
+      expect(response.status).toBe(400)
+    })
+
+    test('rejects requests with missing Host header', async () => {
+      const response = await dispatchEvent(server, '/')
+      expect(response.status).toBe(400)
+    })
+
+    test('accepts requests when --host flag is uppercase (LOCALHOST)', async () => {
+      const uppercaseHostContext = {
+        ...defaultServerContext,
+        options: {...defaultServerContext.options, host: 'LOCALHOST'},
+      }
+      const uppercaseServer = createDevelopmentExtensionServer(developmentTheme, uppercaseHostContext)
+      const response = await dispatchEvent(uppercaseServer, '/wpm@something', {host: 'localhost:9293'})
+      expect(response.status).not.toBe(400)
+      expect(response.status).toBe(204)
+    })
+  })
+})

--- a/packages/theme/src/cli/utilities/theme-ext-environment/theme-ext-server.ts
+++ b/packages/theme/src/cli/utilities/theme-ext-environment/theme-ext-server.ts
@@ -4,6 +4,7 @@ import {getHtmlHandler} from '../theme-environment/html.js'
 import {getAssetsHandler} from '../theme-environment/local-assets.js'
 import {getProxyHandler} from '../theme-environment/proxy.js'
 import {getHotReloadHandler, triggerHotReload} from '../theme-environment/hot-reload/server.js'
+import {createHostValidationHandler} from '../theme-environment/host-validation.js'
 import {emptyThemeFileSystem} from '../theme-fs-empty.js'
 import {initializeDevServerSession} from '../theme-environment/dev-server-session.js'
 import {createApp, toNodeListener} from 'h3'
@@ -36,6 +37,7 @@ export async function initializeDevelopmentExtensionServer(theme: Theme, devExt:
 export function createDevelopmentExtensionServer(theme: Theme, ctx: DevServerContext) {
   const app = createApp()
 
+  app.use(createHostValidationHandler(ctx.options.host, ctx.options.port))
   app.use(getHotReloadHandler(theme, ctx))
   app.use(getAssetsHandler(theme, ctx))
   app.use(getProxyHandler(theme, ctx))


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/developer-tools-team/issues/1092

When running `theme dev` a potential security vulnerability exists where a developer could visit a malicious site while the CLI is running that uses [DNS rebinding](https://en.wikipedia.org/wiki/DNS_rebinding) to extract data.

### WHAT is this pull request doing?
On `theme dev` boot up, create an allow list of localhost forms `'localhost', '127.0.0.1', '::1', '0.0.0.0'`. When requests come in, we deny those that aren't from the allow list.

> **Update:** This Host-header validation also covers the **theme app extension** dev server started by `shopify app dev` (default port `9293`), not just `theme dev` (`9292`). The same `createHostValidationHandler` middleware is wired into `theme-ext-server.ts` as well. Verified live on both servers: allowlisted localhost variants (`localhost`, `127.0.0.1`, `[::1]`, case-insensitive, trailing-dot) pass through, while bad or missing `Host` headers return `400`.

### How to test your changes?

**Note** This vulnerability does not exist when using an environment. You can test this by running the commands below using an environment and they should return a `401`.

On any current version of the CLI:
- run `theme dev` and in a separate terminal, try these curl commands:
    - `curl -s -I -H "Host: localhost:9292" http://localhost:9292/ | head -1`
    - `curl -s -I -H "Host: attacker.com:9292" http://localhost:9292/ | head -1`
    - `curl -s -I -H "Host: evil.local:9292" http://localhost:9292/ | head -1`
    - `curl -s -I -H "Host: localhost:1234" http://localhost:9292/ | head -1`
These should return a `200`

On the current branch:
- build the branch
- run `theme dev` and in a separate terminal, try the curl commands again:
    - `curl -s -I -H "Host: localhost:9292" http://localhost:9292/ | head -1` **This will return a `200` as it's on the allowlist**
   These commands should return a `400`
    - `curl -s -I -H "Host: attacker.com:9292" http://localhost:9292/ | head -1` **This will return
    - `curl -s -I -H "Host: evil.local:9292" http://localhost:9292/ | head -1`
    - `curl -s -I -H "Host: localhost:1234" http://localhost:9292/ | head -1`

To verify the theme app extension server is also protected, repeat the bad-host curls against port `9293` while running `shopify app dev` — they should likewise return `400`.

### Post-release steps

### Measuring impact

How do we know this change was effective? Please choose one:

- [ ] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
