### PR TITLE
QA to E2E: hydrogen

### DIFF
--- a/packages/e2e/setup/auth.ts
+++ b/packages/e2e/setup/auth.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-restricted-imports */
 import {cliFixture} from './cli.js'
 import {executables} from './env.js'
 import {stripAnsi} from '../helpers/strip-ansi.js'

--- a/packages/e2e/tests/hydrogen.spec.ts
+++ b/packages/e2e/tests/hydrogen.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-imports */
 import {cliFixture as test} from '../setup/cli.js'
 import {expect} from '@playwright/test'
 import * as path from 'path'
@@ -35,9 +36,6 @@ test.describe('Hydrogen basic flow (mock shop)', () => {
       },
     )
     const initOutput = initResult.stdout + initResult.stderr
-
-    // console.log('[e2e] hydrogen init output:\n', initOutput)
-
     expect(initResult.exitCode, `hydrogen init failed:\n${initOutput}`).toBe(0)
     expect(initOutput).toContain('Storefront setup complete!')
     expect(initOutput).toContain('Mock.shop')
@@ -50,13 +48,15 @@ test.describe('Hydrogen basic flow (mock shop)', () => {
     expect(buildResult.exitCode, `hydrogen build failed:\n${buildOutput}`).toBe(0)
 
     // Step 3: Start dev server and verify it serves requests
-    const port = 14712 // fixed port to avoid conflicts
+    // fixed port to avoid conflicts
+    const port = 14712
     const dev = await cli.spawn(['hydrogen', 'dev', '--path', hydrogenDir, '--port', String(port)], {
       env: {CI: ''},
     })
     try {
       await dev.waitForOutput('View Hydrogen app:', 3 * 60 * 1000)
 
+      // eslint-disable-next-line no-restricted-globals
       const response = await fetch(`http://localhost:${port}/`)
       expect(response.status, `hydrogen dev server returned unexpected status`).toBe(200)
     } finally {

--- a/packages/e2e/tests/hydrogen.spec.ts
+++ b/packages/e2e/tests/hydrogen.spec.ts
@@ -1,0 +1,66 @@
+import {cliFixture as test} from '../setup/cli.js'
+import {expect} from '@playwright/test'
+import * as path from 'path'
+
+test.describe('Hydrogen basic flow (mock shop)', () => {
+  test('init, build, dev', async ({cli, env}) => {
+    // No store credentials needed — uses mock.shop as data source
+    test.setTimeout(10 * 60 * 1000)
+
+    const hydrogenDir = path.join(env.tempDir, 'hydrogen-app')
+
+    // Step 1: Scaffold and install dependencies via hydrogen init.
+    // Force npm by overriding npm_config_user_agent (otherwise pnpm is detected
+    // from the monorepo environment and used to install deps in the temp project).
+    const initResult = await cli.exec(
+      [
+        'hydrogen',
+        'init',
+        '--path',
+        hydrogenDir,
+        '--mock-shop',
+        '--language',
+        'js',
+        '--markets',
+        'none',
+        '--no-shortcut',
+        '--no-git',
+        '--install-deps',
+        '--styling',
+        'tailwind',
+      ],
+      {
+        env: {npm_config_user_agent: 'npm'},
+        timeout: 5 * 60 * 1000,
+      },
+    )
+    const initOutput = initResult.stdout + initResult.stderr
+
+    // console.log('[e2e] hydrogen init output:\n', initOutput)
+
+    expect(initResult.exitCode, `hydrogen init failed:\n${initOutput}`).toBe(0)
+    expect(initOutput).toContain('Storefront setup complete!')
+    expect(initOutput).toContain('Mock.shop')
+
+    // Step 2: Build for production
+    const buildResult = await cli.exec(['hydrogen', 'build', '--path', hydrogenDir], {
+      timeout: 3 * 60 * 1000,
+    })
+    const buildOutput = buildResult.stdout + buildResult.stderr
+    expect(buildResult.exitCode, `hydrogen build failed:\n${buildOutput}`).toBe(0)
+
+    // Step 3: Start dev server and verify it serves requests
+    const port = 14712 // fixed port to avoid conflicts
+    const dev = await cli.spawn(['hydrogen', 'dev', '--path', hydrogenDir, '--port', String(port)], {
+      env: {CI: ''},
+    })
+    try {
+      await dev.waitForOutput('View Hydrogen app:', 3 * 60 * 1000)
+
+      const response = await fetch(`http://localhost:${port}/`)
+      expect(response.status, `hydrogen dev server returned unexpected status`).toBe(200)
+    } finally {
+      dev.kill()
+    }
+  })
+})


### PR DESCRIPTION
### WHY are these changes introduced?

To replace manual CLI QA with automated end-to-end tests that validate the complete app development workflow in a real environment. This is a part of [Vault project #gsd:49408](https://vault.shopify.io/gsd/projects/49408-Developer-Platform-Agentic-Validation-of-app-configuraiton).

### WHAT is this pull request doing?
Adds `packages/e2e/tests/hydrogen.spec.ts` — an e2e test for the Hydrogen basic flow using mock.shop:
1. `hydrogen init --install-deps --mock-shop` — scaffolds the storefront and installs dependencies via npm (forced via `npm_config_user_agent` to avoid pnpm being detected from the monorepo environment). Asserts on "Storefront setup complete!"
   - Previously blocked: `hydrogen init` normally requires selecting a connected Shopify store with Hydrogen channel access. The`--mock-shop` flag bypasses this by routing all Storefront API calls to `mock.shop`, so no real store or Hydrogen channel is needed.
2. `hydrogen build` — builds the storefront for production
3. `hydrogen dev` — starts the MiniOxygen dev server and makes an HTTP request to verify it returns 200

### How to test your changes?

Run the e2e test suite to verify the new Hydrogen test passes:
```bash
  DEBUG=1 pnpm --filter e2e exec playwright test hydrogen
```
The test should complete successfully, demonstrating that all three Hydrogen CLI commands work as expected.

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes