### PR TITLE
Faster startup: Inline app-init and hydrogen-init hooks

### DIFF
--- a/packages/cli/src/hooks/app-init.ts
+++ b/packages/cli/src/hooks/app-init.ts
@@ -1,1 +1,20 @@
-export {AppInitHook as default} from '@shopify/app'
+import {Hook} from '@oclif/core'
+import {randomUUID} from 'crypto'
+
+/**
+ * Inlined version of the `\@shopify/app` init hook.
+ * The original hook imports `\@shopify/app` → local-storage → cli-kit error chain (~1s).
+ * This inlined version avoids those imports entirely. It lazily imports the
+ * LocalStorage class only at call time, and uses Node's native crypto.
+ */
+const init: Hook<'init'> = async (_options) => {
+  // Lazy import to clear the command storage (equivalent to clearCachedCommandInfo)
+  const {LocalStorage} = await import('@shopify/cli-kit/node/local-storage')
+  const store = new LocalStorage({projectName: 'shopify-cli-app-command'})
+  store.clear()
+
+  // Set a unique run ID so parallel commands don't collide in the cache
+  process.env.COMMAND_RUN_ID = randomUUID()
+}
+
+export default init

--- a/packages/cli/src/hooks/hydrogen-init.ts
+++ b/packages/cli/src/hooks/hydrogen-init.ts
@@ -1,5 +1,19 @@
-import {HOOKS} from '@shopify/cli-hydrogen'
-import type {Hook} from '@oclif/core'
+import {Hook} from '@oclif/core'
 
-const hook = HOOKS.init as unknown as Hook<'init'>
+/**
+ * Hydrogen init hook — only loads `@shopify/cli-hydrogen` when running a hydrogen command.
+ * This avoids the ~300ms+ import cost for non-hydrogen commands.
+ */
+const hook: Hook<'init'> = async (options) => {
+  if (!options.id?.startsWith('hydrogen:') || options.id === 'hydrogen:init') {
+    return
+  }
+
+  const {HOOKS} = await import('@shopify/cli-hydrogen')
+  if (HOOKS.init && typeof HOOKS.init === 'function') {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (HOOKS.init as any).call(this, options)
+  }
+}
+
 export default hook


### PR DESCRIPTION
### WHY are these changes introduced?

The CLI requires too much time to start working, it feels slow

### WHAT is this pull request doing?

Replaces the re-export hook stubs from PR 1 with inlined implementations that avoid loading heavy package dependency chains.

- **Inlined** **`app-init.ts`**: lazily imports `LocalStorage` instead of pulling in the entire `@shopify/app` chain (~1s of imports). Uses Node's native `crypto.randomUUID()` instead of importing from cli-kit
- **Inlined** **`hydrogen-init.ts`**: skips loading `@shopify/cli-hydrogen` entirely for non-hydrogen commands (~300ms+ saved). Only loads the module when `options.id` starts with `hydrogen:`

### How to test your changes?

- `shopify app dev` still initializes correctly (LocalStorage cleared, run ID set)
- `shopify hydrogen dev` still runs hydrogen init hook
- Non-hydrogen commands skip hydrogen module loading

### Measuring impact

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes