### PR TITLE
Preserve structured app validation issues internally

### DIFF
--- a/packages/app/src/cli/models/app/error-parsing.test.ts
+++ b/packages/app/src/cli/models/app/error-parsing.test.ts
@@ -1,4 +1,4 @@
-import {parseHumanReadableError} from './error-parsing.js'
+import {parseHumanReadableError, parseStructuredErrors} from './error-parsing.js'
 import {describe, expect, test} from 'vitest'
 
 describe('parseHumanReadableError', () => {
@@ -233,5 +233,152 @@ describe('parseHumanReadableError', () => {
     expect(result).not.toContain('Expected boolean, received string')
     expect(result).not.toContain('Must be valid URL')
     expect(result).not.toContain('Union validation failed')
+  })
+})
+
+describe('parseStructuredErrors', () => {
+  test('preserves regular issues with file path and path string', () => {
+    const issues = [
+      {
+        path: ['name'],
+        message: 'Required field is missing',
+        code: 'invalid_type',
+      },
+      {
+        path: ['version'],
+        message: 'Must be a valid semver string',
+        code: 'custom',
+      },
+    ]
+
+    const result = parseStructuredErrors(issues, '/tmp/shopify.app.toml')
+
+    expect(result).toEqual([
+      {
+        filePath: '/tmp/shopify.app.toml',
+        path: ['name'],
+        pathString: 'name',
+        message: 'Required field is missing',
+        code: 'invalid_type',
+      },
+      {
+        filePath: '/tmp/shopify.app.toml',
+        path: ['version'],
+        pathString: 'version',
+        message: 'Must be a valid semver string',
+        code: 'custom',
+      },
+    ])
+  })
+
+  test('uses the best matching union variant for structured issues', () => {
+    const issues = [
+      {
+        code: 'invalid_union',
+        unionErrors: [
+          {
+            issues: [
+              {
+                code: 'invalid_type',
+                path: ['web', 'roles'],
+                message: 'Expected array, received number',
+              },
+              {
+                code: 'invalid_type',
+                path: ['web', 'commands', 'build'],
+                message: 'Required',
+              },
+            ],
+            name: 'ZodError',
+          },
+          {
+            issues: [
+              {
+                code: 'invalid_literal',
+                path: ['web', 'type'],
+                message: "Invalid literal value, expected 'frontend'",
+              },
+            ],
+            name: 'ZodError',
+          },
+        ],
+        path: ['web'],
+        message: 'Invalid input',
+      },
+    ]
+
+    const result = parseStructuredErrors(issues, '/tmp/shopify.web.toml')
+
+    expect(result).toEqual([
+      {
+        filePath: '/tmp/shopify.web.toml',
+        path: ['web', 'roles'],
+        pathString: 'web.roles',
+        message: 'Expected array, received number',
+        code: 'invalid_type',
+      },
+      {
+        filePath: '/tmp/shopify.web.toml',
+        path: ['web', 'commands', 'build'],
+        pathString: 'web.commands.build',
+        message: 'Required',
+        code: 'invalid_type',
+      },
+    ])
+  })
+
+  test('falls back to recovered nested union issues before returning a synthetic root issue', () => {
+    const unionIssues = Array.from({length: 51}, (_, index) => ({
+      code: 'custom',
+      path: ['variants', index],
+      message: `Invalid variant ${index + 1}`,
+    }))
+
+    const issues = [
+      {
+        code: 'invalid_union',
+        unionErrors: [{issues: unionIssues, name: 'ZodError'}],
+        path: ['root'],
+        message: 'Invalid input',
+      },
+    ]
+
+    const result = parseStructuredErrors(issues, '/tmp/shopify.app.toml')
+
+    expect(result).toEqual(
+      unionIssues.map((issue, index) => ({
+        filePath: '/tmp/shopify.app.toml',
+        path: ['variants', index],
+        pathString: `variants.${index}`,
+        message: issue.message,
+        code: 'custom',
+      })),
+    )
+  })
+
+  test('falls back to a synthetic root issue when union variants expose no nested issues', () => {
+    const issues = [
+      {
+        code: 'invalid_union',
+        unionErrors: [
+          {issues: [], name: 'ZodError'},
+          {issues: [], name: 'ZodError'},
+        ],
+        path: ['root'],
+        message: 'Invalid input',
+      },
+    ]
+
+    const result = parseStructuredErrors(issues, '/tmp/shopify.app.toml')
+
+    expect(result).toEqual([
+      {
+        filePath: '/tmp/shopify.app.toml',
+        path: ['root'],
+        pathString: 'root',
+        message: "Configuration doesn't match any expected format",
+        code: 'invalid_union',
+      },
+    ])
   })
 })

--- a/packages/app/src/cli/models/app/error-parsing.ts
+++ b/packages/app/src/cli/models/app/error-parsing.ts
@@ -1,5 +1,13 @@
+import type {OutputMessage} from '@shopify/cli-kit/node/output'
+
+interface UnionErrorIssue {
+  path?: (string | number)[]
+  message: string
+  code?: string
+}
+
 interface UnionError {
-  issues?: {path?: (string | number)[]; message: string}[]
+  issues?: UnionErrorIssue[]
   name: string
 }
 
@@ -8,6 +16,20 @@ interface ExtendedZodIssue {
   message?: string
   code?: string
   unionErrors?: UnionError[]
+}
+
+export interface AppValidationIssue {
+  filePath: string
+  path: (string | number)[]
+  pathString: string
+  message: string
+  code?: string
+}
+
+export interface AppValidationFileIssues {
+  filePath: string
+  message: OutputMessage
+  issues: AppValidationIssue[]
 }
 
 /**
@@ -56,13 +78,66 @@ function findBestMatchingVariant(unionErrors: UnionError[]): UnionError | null {
   return bestVariant
 }
 
+function getIssuePath(path?: (string | number)[]) {
+  return path ?? []
+}
+
+function getIssuePathString(path?: (string | number)[]) {
+  const resolvedPath = getIssuePath(path)
+  return resolvedPath.length > 0 ? resolvedPath.map(String).join('.') : 'root'
+}
+
 /**
  * Formats an issue into a human-readable error line
  */
 function formatErrorLine(issue: {path?: (string | number)[]; message?: string}, indent = '') {
-  const path = issue.path && issue.path.length > 0 ? issue.path.map(String).join('.') : 'root'
+  const pathString = getIssuePathString(issue.path)
   const message = issue.message ?? 'Unknown error'
-  return `${indent}• [${path}]: ${message}\n`
+  return `${indent}• [${pathString}]: ${message}\n`
+}
+
+function toStructuredIssue(filePath: string, issue: Pick<ExtendedZodIssue, 'path' | 'message' | 'code'>) {
+  return {
+    filePath,
+    path: getIssuePath(issue.path),
+    pathString: getIssuePathString(issue.path),
+    message: issue.message ?? 'Unknown error',
+    code: issue.code,
+  }
+}
+
+export function parseStructuredErrors(issues: ExtendedZodIssue[], filePath: string): AppValidationIssue[] {
+  return issues.flatMap((issue) => {
+    if (issue.code === 'invalid_union' && issue.unionErrors) {
+      // Intentionally mirror the current human-readable union selection heuristic
+      // so structured/internal issues stay aligned with existing CLI behavior.
+      // If we change this heuristic later, text and structured output should move together.
+      const bestVariant = findBestMatchingVariant(issue.unionErrors)
+
+      if (bestVariant?.issues?.length) {
+        return bestVariant.issues.map((nestedIssue) => toStructuredIssue(filePath, nestedIssue))
+      }
+
+      const fallbackIssues = issue.unionErrors.flatMap((unionError) => unionError.issues ?? [])
+      if (fallbackIssues.length > 0) {
+        // Preserve any concrete nested issues we were able to recover before
+        // falling back to a synthetic root issue. This structured path is still
+        // internal, and retaining leaf issues is more actionable than erasing
+        // them behind a generic union failure.
+        return fallbackIssues.map((nestedIssue) => toStructuredIssue(filePath, nestedIssue))
+      }
+
+      return [
+        toStructuredIssue(filePath, {
+          path: issue.path,
+          message: "Configuration doesn't match any expected format",
+          code: issue.code,
+        }),
+      ]
+    }
+
+    return [toStructuredIssue(filePath, issue)]
+  })
 }
 
 export function parseHumanReadableError(issues: ExtendedZodIssue[]) {

--- a/packages/app/src/cli/models/app/loader.test.ts
+++ b/packages/app/src/cli/models/app/loader.test.ts
@@ -5,11 +5,13 @@ import {
   loadOpaqueApp,
   parseConfigurationObject,
   checkFolderIsValidApp,
+  AppErrors,
   getAppConfigurationContext,
   loadConfigForAppCreation,
   reloadApp,
   ConfigurationError,
 } from './loader.js'
+import {LocalConfigError} from './local-config-error.js'
 import {App, AppInterface, AppLinkedInterface, AppSchema, WebConfigurationSchema} from './app.js'
 import {DEFAULT_CONFIG, buildVersionedAppSchema, getWebhookConfig} from './app.test-data.js'
 import {ExtensionInstance} from '../extensions/extension-instance.js'
@@ -2779,6 +2781,35 @@ describe('parseConfigurationObject', () => {
     expect(() => parseConfigurationObject(AppSchema, 'tmp', configurationObject)).toThrow('[client_id]: Required')
   })
 
+  test('captures structured issues on configuration errors', async () => {
+    const configurationObject = {
+      scopes: [],
+    }
+
+    let thrown: ConfigurationError | undefined
+    try {
+      parseConfigurationObject(AppSchema, '/tmp/shopify.app.toml', configurationObject)
+      expect.fail('Expected ConfigurationError to be thrown')
+    } catch (err) {
+      if (err instanceof ConfigurationError) {
+        thrown = err
+      } else {
+        throw err
+      }
+    }
+
+    expect(thrown).toBeInstanceOf(LocalConfigError)
+    expect(thrown.issues).toEqual([
+      {
+        filePath: '/tmp/shopify.app.toml',
+        path: ['client_id'],
+        pathString: 'client_id',
+        message: 'Required',
+        code: 'invalid_type',
+      },
+    ])
+  })
+
   test('throws an error if fields are missing in a frontend config web TOML file', async () => {
     const configurationObject = {
       type: 11,
@@ -2806,6 +2837,133 @@ describe('parseConfigurationObject', () => {
     expect(thrown.message).not.toContain('Union validation failed')
     expect(thrown.message).not.toContain('Option 1:')
     expect(thrown.message).not.toContain('Option 2:')
+  })
+})
+
+describe('AppErrors', () => {
+  test('preserves structured issues while keeping existing rendered message accessors', () => {
+    const errors = new AppErrors()
+    errors.addError('tmp/shopify.app.toml', 'rendered error', [
+      {
+        filePath: 'tmp/shopify.app.toml',
+        path: ['client_id'],
+        pathString: 'client_id',
+        message: 'Required',
+        code: 'invalid_type',
+      },
+    ])
+    errors.addError('tmp/shopify.app.toml', 'replacement rendered error')
+
+    expect(errors.getError('tmp/shopify.app.toml')).toBe('replacement rendered error')
+    expect(errors.getIssues('tmp/shopify.app.toml')).toEqual([
+      {
+        filePath: 'tmp/shopify.app.toml',
+        path: ['client_id'],
+        pathString: 'client_id',
+        message: 'Required',
+        code: 'invalid_type',
+      },
+    ])
+    expect(errors.toJSON()).toEqual(['replacement rendered error'])
+    expect(errors.toStructuredJSON()).toEqual([
+      {
+        filePath: 'tmp/shopify.app.toml',
+        message: 'replacement rendered error',
+        issues: [
+          {
+            filePath: 'tmp/shopify.app.toml',
+            path: ['client_id'],
+            pathString: 'client_id',
+            message: 'Required',
+            code: 'invalid_type',
+          },
+        ],
+      },
+    ])
+  })
+
+  test('accumulates issues across multiple addError calls for the same path', () => {
+    const errors = new AppErrors()
+
+    errors.addError('tmp/shopify.app.toml', 'first rendered error', [
+      {
+        filePath: 'tmp/shopify.app.toml',
+        path: ['client_id'],
+        pathString: 'client_id',
+        message: 'Required',
+        code: 'invalid_type',
+      },
+    ])
+    errors.addError('tmp/shopify.app.toml', 'second rendered error', [
+      {
+        filePath: 'tmp/shopify.app.toml',
+        path: ['name'],
+        pathString: 'name',
+        message: 'Must be set',
+        code: 'custom',
+      },
+    ])
+
+    expect(errors.getError('tmp/shopify.app.toml')).toBe('second rendered error')
+    expect(errors.getIssues('tmp/shopify.app.toml')).toEqual([
+      {
+        filePath: 'tmp/shopify.app.toml',
+        path: ['client_id'],
+        pathString: 'client_id',
+        message: 'Required',
+        code: 'invalid_type',
+      },
+      {
+        filePath: 'tmp/shopify.app.toml',
+        path: ['name'],
+        pathString: 'name',
+        message: 'Must be set',
+        code: 'custom',
+      },
+    ])
+  })
+
+  test('keeps issues isolated per file path and returns an empty array for unknown paths', () => {
+    const errors = new AppErrors()
+
+    errors.addError('tmp/shopify.app.toml', 'app error', [
+      {
+        filePath: 'tmp/shopify.app.toml',
+        path: ['client_id'],
+        pathString: 'client_id',
+        message: 'Required',
+        code: 'invalid_type',
+      },
+    ])
+    errors.addError('tmp/extensions/foo/shopify.extension.toml', 'extension error', [
+      {
+        filePath: 'tmp/extensions/foo/shopify.extension.toml',
+        path: ['name'],
+        pathString: 'name',
+        message: 'Must be set',
+        code: 'custom',
+      },
+    ])
+
+    expect(errors.getIssues('tmp/shopify.app.toml')).toEqual([
+      {
+        filePath: 'tmp/shopify.app.toml',
+        path: ['client_id'],
+        pathString: 'client_id',
+        message: 'Required',
+        code: 'invalid_type',
+      },
+    ])
+    expect(errors.getIssues('tmp/extensions/foo/shopify.extension.toml')).toEqual([
+      {
+        filePath: 'tmp/extensions/foo/shopify.extension.toml',
+        path: ['name'],
+        pathString: 'name',
+        message: 'Must be set',
+        code: 'custom',
+      },
+    ])
+    expect(errors.getIssues('tmp/missing.toml')).toEqual([])
   })
 })
 
@@ -3325,7 +3483,7 @@ describe('WebhooksSchema', () => {
     expect(result.parsedConfiguration.webhooks).toMatchObject(webhookConfig)
   })
 
-  async function setupParsing(errorObj: zod.ZodIssue | {}, webhookConfigOverrides: WebhooksConfig) {
+  function setupParsing(errorObj: zod.ZodIssue | {}, webhookConfigOverrides: WebhooksConfig) {
     const toParse = getWebhookConfig(webhookConfigOverrides)
     try {
       const parsedConfiguration = parseConfigurationObject(WebhooksSchema, 'tmp', toParse)

--- a/packages/app/src/cli/models/app/loader.ts
+++ b/packages/app/src/cli/models/app/loader.ts
@@ -12,7 +12,13 @@ import {
   SchemaForConfig,
   AppLinkedInterface,
 } from './app.js'
-import {parseHumanReadableError} from './error-parsing.js'
+import {
+  AppValidationFileIssues,
+  AppValidationIssue,
+  parseHumanReadableError,
+  parseStructuredErrors,
+} from './error-parsing.js'
+import {LocalConfigError} from './local-config-error.js'
 import {
   getAppConfigurationFileName,
   getAppConfigurationShorthand,
@@ -66,14 +72,7 @@ interface ReloadState {
   previousDevURLs?: ApplicationURLs
 }
 
-export class ConfigurationError extends AbortError {
-  constructor(
-    message: OutputMessage,
-    public readonly configurationPath: string,
-  ) {
-    super(message)
-  }
-}
+export class ConfigurationError extends LocalConfigError {}
 
 /**
  * Loads a configuration file, validates it against a schema, and returns the parsed object.
@@ -123,6 +122,7 @@ export function parseConfigurationObject<TSchema extends zod.ZodType>(
         filepath,
       )}:\n\n${parseHumanReadableError(parseResult.error.issues)}`,
       filepath,
+      parseStructuredErrors(parseResult.error.issues, filepath),
     )
   }
   return parseResult.data
@@ -149,6 +149,7 @@ export function parseConfigurationObjectAgainstSpecification<TSchema extends zod
           filepath,
         )}:\n\n${parseHumanReadableError(parsed.errors)}`,
         filepath,
+        parseStructuredErrors(parsed.errors, filepath),
       )
     }
   }
@@ -156,15 +157,28 @@ export function parseConfigurationObjectAgainstSpecification<TSchema extends zod
 
 export class AppErrors {
   private errors: {
-    [key: string]: OutputMessage
+    [key: string]: {
+      message: OutputMessage
+      issues: AppValidationIssue[]
+    }
   } = {}
 
-  addError(path: string, message: OutputMessage): void {
-    this.errors[path] = message
+  /**
+   * Replaces the rendered message for a path while preserving previously
+   * collected structured issues unless new issues are provided, in which case
+   * the new issues are appended.
+   */
+  addError(path: string, message: OutputMessage, issues: AppValidationIssue[] = []): void {
+    const existingIssues = this.errors[path]?.issues ?? []
+    this.errors[path] = {message, issues: issues.length > 0 ? [...existingIssues, ...issues] : existingIssues}
   }
 
   getError(path: string) {
-    return this.errors[path]
+    return this.errors[path]?.message
+  }
+
+  getIssues(path: string): AppValidationIssue[] {
+    return this.errors[path]?.issues ?? []
   }
 
   isEmpty() {
@@ -172,7 +186,11 @@ export class AppErrors {
   }
 
   toJSON(): OutputMessage[] {
-    return Object.values(this.errors)
+    return Object.values(this.errors).map(({message}) => message)
+  }
+
+  toStructuredJSON(): AppValidationFileIssues[] {
+    return Object.entries(this.errors).map(([filePath, {message, issues}]) => ({filePath, message, issues}))
   }
 }
 
@@ -527,7 +545,7 @@ class AppLoader<TConfig extends CurrentAppConfiguration, TModuleSpec extends Ext
           return await loadSingleWeb(webFile.path, webFile.content)
         } catch (err) {
           if (err instanceof ConfigurationError) {
-            this.errors.addError(err.configurationPath, err.message)
+            this.errors.addError(err.configurationPath, err.message, err.issues)
             return undefined
           }
           throw err
@@ -629,7 +647,7 @@ class AppLoader<TConfig extends CurrentAppConfiguration, TModuleSpec extends Ext
       return extensionInstance
     } catch (err) {
       if (err instanceof ConfigurationError) {
-        this.errors.addError(err.configurationPath, err.message)
+        this.errors.addError(err.configurationPath, err.message, err.issues)
         return undefined
       }
       throw err
@@ -697,7 +715,7 @@ class AppLoader<TConfig extends CurrentAppConfiguration, TModuleSpec extends Ext
           configuration = await parseConfigurationFile(UnifiedSchema, configurationPath, extensionFile.content)
         } catch (err) {
           if (err instanceof ConfigurationError) {
-            this.errors.addError(err.configurationPath, err.message)
+            this.errors.addError(err.configurationPath, err.message, err.issues)
             return []
           }
           throw err
@@ -744,7 +762,7 @@ class AppLoader<TConfig extends CurrentAppConfiguration, TModuleSpec extends Ext
       specConfiguration = parseConfigurationObject(WebhooksSchema, configPath, appConfiguration)
     } catch (err) {
       if (err instanceof ConfigurationError) {
-        this.errors.addError(err.configurationPath, err.message)
+        this.errors.addError(err.configurationPath, err.message, err.issues)
         return []
       }
       throw err
@@ -786,7 +804,7 @@ class AppLoader<TConfig extends CurrentAppConfiguration, TModuleSpec extends Ext
             )
           } catch (err) {
             if (err instanceof ConfigurationError) {
-              this.errors.addError(err.configurationPath, err.message)
+              this.errors.addError(err.configurationPath, err.message, err.issues)
               return [null, [] as string[]] as const
             }
             throw err

--- a/packages/app/src/cli/models/app/local-config-error.ts
+++ b/packages/app/src/cli/models/app/local-config-error.ts
@@ -1,0 +1,20 @@
+import {AbortError} from '@shopify/cli-kit/node/error'
+import type {OutputMessage} from '@shopify/cli-kit/node/output'
+import type {AppValidationIssue} from './error-parsing.js'
+
+/**
+ * Structured local configuration failure shared by lower layers.
+ *
+ * This stays below command/JSON serialization concerns: callers can surface the
+ * same file/path-aware issues through CLI output, machine-readable validation
+ * results, or other higher-level flows.
+ */
+export class LocalConfigError extends AbortError {
+  constructor(
+    message: OutputMessage,
+    public readonly configurationPath: string,
+    public readonly issues: AppValidationIssue[] = [],
+  ) {
+    super(message)
+  }
+}


### PR DESCRIPTION
## What

Preserve structured app validation issues internally during app loading.

This keeps the current CLI behavior the same while retaining structured issue metadata alongside rendered validation messages.

## Why

`app config validate --json` needs file-oriented issue data, but the validation pipeline still flattens schema issues into strings too early.

To support repair loops and future automation work, the CLI needs to retain structured validation details before deciding how to render them publicly.

## How

- add structured issue parsing alongside the existing human-readable formatter
- preserve structured issue metadata at the loader/report boundary
- update `AppErrors` to retain both rendered messages and structured issues
- introduce `LocalConfigError` as a shared lower-layer local configuration error
- keep current text output and existing public behavior unchanged
