### PR TITLE
Add install count warning for safer deploys

### DIFF
--- a/packages/app/src/cli/api/graphql/app-management/generated/app-install-count.ts
+++ b/packages/app/src/cli/api/graphql/app-management/generated/app-install-count.ts
@@ -1,0 +1,51 @@
+/* eslint-disable @typescript-eslint/consistent-type-definitions */
+import * as Types from './types.js'
+
+import {TypedDocumentNode as DocumentNode} from '@graphql-typed-document-node/core'
+
+export type AppInstallCountQueryVariables = Types.Exact<{
+  appId: Types.Scalars['ID']['input']
+}>
+
+export type AppInstallCountQuery = {app: {installCount?: number | null}}
+
+export const AppInstallCount = {
+  kind: 'Document',
+  definitions: [
+    {
+      kind: 'OperationDefinition',
+      operation: 'query',
+      name: {kind: 'Name', value: 'AppInstallCount'},
+      variableDefinitions: [
+        {
+          kind: 'VariableDefinition',
+          variable: {kind: 'Variable', name: {kind: 'Name', value: 'appId'}},
+          type: {kind: 'NonNullType', type: {kind: 'NamedType', name: {kind: 'Name', value: 'ID'}}},
+        },
+      ],
+      selectionSet: {
+        kind: 'SelectionSet',
+        selections: [
+          {
+            kind: 'Field',
+            name: {kind: 'Name', value: 'app'},
+            arguments: [
+              {
+                kind: 'Argument',
+                name: {kind: 'Name', value: 'id'},
+                value: {kind: 'Variable', name: {kind: 'Name', value: 'appId'}},
+              },
+            ],
+            selectionSet: {
+              kind: 'SelectionSet',
+              selections: [
+                {kind: 'Field', name: {kind: 'Name', value: 'installCount'}},
+                {kind: 'Field', name: {kind: 'Name', value: '__typename'}},
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<AppInstallCountQuery, AppInstallCountQueryVariables>

--- a/packages/app/src/cli/api/graphql/app-management/queries/app-install-count.graphql
+++ b/packages/app/src/cli/api/graphql/app-management/queries/app-install-count.graphql
@@ -1,0 +1,5 @@
+query AppInstallCount($appId: ID!) {
+  app(id: $appId) {
+    installCount
+  }
+}

--- a/packages/app/src/cli/models/app/app.test-data.ts
+++ b/packages/app/src/cli/models/app/app.test-data.ts
@@ -1376,6 +1376,7 @@ export function testDeveloperPlatformClient(stubs: Partial<DeveloperPlatformClie
     orgFromId: (_organizationId: string) => Promise.resolve(testOrganization()),
     appsForOrg: (_organizationId: string) => Promise.resolve({apps: [testOrganizationApp()], hasMorePages: false}),
     specifications: (_app: MinimalAppIdentifiers) => Promise.resolve(testRemoteSpecifications),
+    appInstallCount: (_app: MinimalAppIdentifiers) => Promise.resolve(0),
     templateSpecifications: (_app: MinimalAppIdentifiers) =>
       Promise.resolve({templates: testRemoteExtensionTemplates, groupOrder: []}),
     orgAndApps: (_orgId: string) =>

--- a/packages/app/src/cli/prompts/deploy-release.test.ts
+++ b/packages/app/src/cli/prompts/deploy-release.test.ts
@@ -227,13 +227,13 @@ describe('deployOrReleaseConfirmationPrompt', () => {
       // Then
       expect(renderDangerousConfirmationPromptSpyOn).toHaveBeenCalledWith(
         expect.objectContaining({
-          installCount: 1243,
+          warningItem: expect.arrayContaining([{error: '1243'}]),
         }),
       )
       expect(result).toBe(true)
     })
 
-    test('and no force with deleted extensions but installCount 0 should not pass installCount to danger prompt', async () => {
+    test('and no force with deleted extensions but installCount 0 should not pass warningItem to danger prompt', async () => {
       // Given
       const breakdownInfo = buildCompleteBreakdownInfo()
       const renderDangerousConfirmationPromptSpyOn = vi
@@ -254,7 +254,7 @@ describe('deployOrReleaseConfirmationPrompt', () => {
       // Then
       expect(renderDangerousConfirmationPromptSpyOn).toHaveBeenCalledWith(
         expect.not.objectContaining({
-          installCount: expect.anything(),
+          warningItem: expect.anything(),
         }),
       )
       expect(result).toBe(true)

--- a/packages/app/src/cli/prompts/deploy-release.test.ts
+++ b/packages/app/src/cli/prompts/deploy-release.test.ts
@@ -206,6 +206,60 @@ describe('deployOrReleaseConfirmationPrompt', () => {
       expect(result).toBe(true)
     })
 
+    test('and no force with deleted extensions and installCount should pass installCount to danger prompt', async () => {
+      // Given
+      const breakdownInfo = buildCompleteBreakdownInfo()
+      const renderDangerousConfirmationPromptSpyOn = vi
+        .spyOn(ui, 'renderDangerousConfirmationPrompt')
+        .mockResolvedValue(true)
+      vi.spyOn(metadata, 'addPublicMetadata').mockImplementation(async () => {})
+      const appTitle = 'app title'
+
+      // When
+      const result = await deployOrReleaseConfirmationPrompt({
+        ...breakdownInfo,
+        appTitle,
+        release: true,
+        force: false,
+        installCount: 1243,
+      })
+
+      // Then
+      expect(renderDangerousConfirmationPromptSpyOn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          installCount: 1243,
+        }),
+      )
+      expect(result).toBe(true)
+    })
+
+    test('and no force with deleted extensions but installCount 0 should not pass installCount to danger prompt', async () => {
+      // Given
+      const breakdownInfo = buildCompleteBreakdownInfo()
+      const renderDangerousConfirmationPromptSpyOn = vi
+        .spyOn(ui, 'renderDangerousConfirmationPrompt')
+        .mockResolvedValue(true)
+      vi.spyOn(metadata, 'addPublicMetadata').mockImplementation(async () => {})
+      const appTitle = 'app title'
+
+      // When
+      const result = await deployOrReleaseConfirmationPrompt({
+        ...breakdownInfo,
+        appTitle,
+        release: true,
+        force: false,
+        installCount: 0,
+      })
+
+      // Then
+      expect(renderDangerousConfirmationPromptSpyOn).toHaveBeenCalledWith(
+        expect.not.objectContaining({
+          installCount: expect.anything(),
+        }),
+      )
+      expect(result).toBe(true)
+    })
+
     test('and no force with deleted extensions but without app title should display the complete confirmation prompt', async () => {
       // Given
       const breakdownInfo = buildCompleteBreakdownInfo()

--- a/packages/app/src/cli/prompts/deploy-release.ts
+++ b/packages/app/src/cli/prompts/deploy-release.ts
@@ -162,7 +162,11 @@ async function deployConfirmationPrompt({
       confirmation: appTitle,
       ...(showInstallCountWarning
         ? {
-            body: `This ${release ? 'release' : 'version'} removes extensions and related data from ${installCount} app installations.\nUse caution as this may include production data on live stores.`,
+            warningItem: [
+              'This release removes extensions and related data from',
+              {error: installCount.toString()},
+              'app installations.\nUse caution as this may include production data on live stores.',
+            ],
           }
         : {}),
     })

--- a/packages/app/src/cli/prompts/deploy-release.ts
+++ b/packages/app/src/cli/prompts/deploy-release.ts
@@ -162,7 +162,7 @@ async function deployConfirmationPrompt({
       confirmation: appTitle,
       ...(showInstallCountWarning
         ? {
-            body: `This release removes extensions and related data from ${installCount} app installations.\nUse caution as this may include production data on live stores.`,
+            body: `This ${release ? 'release' : 'version'} removes extensions and related data from ${installCount} app installations.\nUse caution as this may include production data on live stores.`,
           }
         : {}),
     })

--- a/packages/app/src/cli/prompts/deploy-release.ts
+++ b/packages/app/src/cli/prompts/deploy-release.ts
@@ -24,6 +24,7 @@ interface DeployOrReleaseConfirmationPromptOptions {
   /** If true, allow removing extensions and configuration without user confirmation */
   allowDeletes?: boolean
   showConfig?: boolean
+  installCount?: number
 }
 
 interface DeployConfirmationPromptOptions {
@@ -36,6 +37,7 @@ interface DeployConfirmationPromptOptions {
     configInfoTable: InfoTableSection
   }
   release: boolean
+  installCount?: number
 }
 
 /**
@@ -97,6 +99,7 @@ export async function deployOrReleaseConfirmationPrompt({
   configExtensionIdentifiersBreakdown,
   appTitle,
   release,
+  installCount,
 }: DeployOrReleaseConfirmationPromptOptions): Promise<boolean> {
   await metadata.addPublicMetadata(() => buildConfigurationBreakdownMetadata(configExtensionIdentifiersBreakdown))
 
@@ -117,6 +120,7 @@ export async function deployOrReleaseConfirmationPrompt({
     extensionsContentPrompt,
     configContentPrompt,
     release,
+    installCount,
   })
 }
 
@@ -125,6 +129,7 @@ async function deployConfirmationPrompt({
   extensionsContentPrompt: {extensionsInfoTable, hasDeletedExtensions},
   configContentPrompt,
   release,
+  installCount,
 }: DeployConfirmationPromptOptions): Promise<boolean> {
   const timeBeforeConfirmationMs = new Date().valueOf()
   let confirmationResponse = true
@@ -149,11 +154,17 @@ async function deployConfirmationPrompt({
   }
 
   const question = `${release ? 'Release' : 'Create'} a new version${appTitle ? ` of ${appTitle}` : ''}?`
+  const showInstallCountWarning = hasDeletedExtensions && installCount !== undefined && installCount > 0
   if (isDangerous) {
     confirmationResponse = await renderDangerousConfirmationPrompt({
       message: question,
       infoTable,
       confirmation: appTitle,
+      ...(showInstallCountWarning
+        ? {
+            body: `This release removes extensions and related data from ${installCount} app installations.\nUse caution as this may include production data on live stores.`,
+          }
+        : {}),
     })
   } else {
     confirmationResponse = await renderConfirmationPrompt({

--- a/packages/app/src/cli/services/context/identifiers.test.ts
+++ b/packages/app/src/cli/services/context/identifiers.test.ts
@@ -1,4 +1,9 @@
-import {configExtensionsIdentifiersBreakdown, extensionsIdentifiersDeployBreakdown} from './breakdown-extensions.js'
+import {
+  buildExtensionBreakdownInfo,
+  configExtensionsIdentifiersBreakdown,
+  ExtensionIdentifierBreakdownInfo,
+  extensionsIdentifiersDeployBreakdown,
+} from './breakdown-extensions.js'
 import {ensureDeploymentIdsPresence} from './identifiers.js'
 import {deployConfirmed} from './identifiers-extensions.js'
 import {deployOrReleaseConfirmationPrompt} from '../../prompts/deploy-release.js'
@@ -32,6 +37,152 @@ describe('ensureDeploymentIdsPresence', () => {
       release: true,
     }
     await expect(ensureDeploymentIdsPresence(params)).rejects.toThrow(AbortSilentError)
+  })
+
+  test('when there are remote-only extensions and not forced, appInstallCount is called with remoteApp.id', async () => {
+    // Given
+    const breakdown = buildExtensionsBreakdown()
+    breakdown.extensionIdentifiersBreakdown.onlyRemote = [buildExtensionBreakdownInfo('removed', 'uuid-1')]
+    vi.mocked(extensionsIdentifiersDeployBreakdown).mockResolvedValue(breakdown)
+    vi.mocked(configExtensionsIdentifiersBreakdown).mockResolvedValue(buildConfigBreakdown())
+    vi.mocked(deployOrReleaseConfirmationPrompt).mockResolvedValue(false)
+
+    const remoteApp = testOrganizationApp({id: 'real-app-id', apiKey: 'api-key-different'})
+    const client = testDeveloperPlatformClient({
+      appInstallCount: vi.fn().mockResolvedValue(42),
+    })
+
+    const params = {
+      app: testApp(),
+      developerPlatformClient: client,
+      appId: 'api-key-different',
+      appName: 'appName',
+      remoteApp,
+      envIdentifiers: {},
+      force: false,
+      release: true,
+    }
+
+    // When
+    await expect(ensureDeploymentIdsPresence(params)).rejects.toThrow()
+
+    // Then
+    expect(client.appInstallCount).toHaveBeenCalledWith({
+      id: 'real-app-id',
+      apiKey: 'api-key-different',
+      organizationId: remoteApp.organizationId,
+    })
+  })
+
+  test('when force is true, appInstallCount is not called even with remote-only extensions', async () => {
+    // Given
+    const breakdown = buildExtensionsBreakdown()
+    breakdown.extensionIdentifiersBreakdown.onlyRemote = [buildExtensionBreakdownInfo('removed', 'uuid-1')]
+    vi.mocked(extensionsIdentifiersDeployBreakdown).mockResolvedValue(breakdown)
+    vi.mocked(configExtensionsIdentifiersBreakdown).mockResolvedValue(buildConfigBreakdown())
+    vi.mocked(deployOrReleaseConfirmationPrompt).mockResolvedValue(true)
+    vi.mocked(deployConfirmed).mockResolvedValue({
+      extensions: {},
+      extensionIds: {},
+      extensionsNonUuidManaged: {},
+    })
+
+    const client = testDeveloperPlatformClient({
+      appInstallCount: vi.fn().mockResolvedValue(42),
+    })
+
+    const params = {
+      app: testApp(),
+      developerPlatformClient: client,
+      appId: 'appId',
+      appName: 'appName',
+      remoteApp: testOrganizationApp(),
+      envIdentifiers: {},
+      force: true,
+      release: true,
+    }
+
+    // When
+    await ensureDeploymentIdsPresence(params)
+
+    // Then
+    expect(client.appInstallCount).not.toHaveBeenCalled()
+  })
+
+  test('when allowUpdates and allowDeletes are both true, appInstallCount is not called', async () => {
+    // Given
+    const breakdown = buildExtensionsBreakdown()
+    breakdown.extensionIdentifiersBreakdown.onlyRemote = [buildExtensionBreakdownInfo('removed', 'uuid-1')]
+    vi.mocked(extensionsIdentifiersDeployBreakdown).mockResolvedValue(breakdown)
+    vi.mocked(configExtensionsIdentifiersBreakdown).mockResolvedValue(buildConfigBreakdown())
+    vi.mocked(deployOrReleaseConfirmationPrompt).mockResolvedValue(true)
+    vi.mocked(deployConfirmed).mockResolvedValue({
+      extensions: {},
+      extensionIds: {},
+      extensionsNonUuidManaged: {},
+    })
+
+    const client = testDeveloperPlatformClient({
+      appInstallCount: vi.fn().mockResolvedValue(42),
+    })
+
+    const params = {
+      app: testApp(),
+      developerPlatformClient: client,
+      appId: 'appId',
+      appName: 'appName',
+      remoteApp: testOrganizationApp(),
+      envIdentifiers: {},
+      force: false,
+      allowUpdates: true,
+      allowDeletes: true,
+      release: true,
+    }
+
+    // When
+    await ensureDeploymentIdsPresence(params)
+
+    // Then
+    expect(client.appInstallCount).not.toHaveBeenCalled()
+  })
+
+  test('when appInstallCount throws, installCount is undefined and deploy proceeds', async () => {
+    // Given
+    const breakdown = buildExtensionsBreakdown()
+    breakdown.extensionIdentifiersBreakdown.onlyRemote = [buildExtensionBreakdownInfo('removed', 'uuid-1')]
+    vi.mocked(extensionsIdentifiersDeployBreakdown).mockResolvedValue(breakdown)
+    vi.mocked(configExtensionsIdentifiersBreakdown).mockResolvedValue(buildConfigBreakdown())
+    vi.mocked(deployOrReleaseConfirmationPrompt).mockResolvedValue(true)
+    vi.mocked(deployConfirmed).mockResolvedValue({
+      extensions: {},
+      extensionIds: {},
+      extensionsNonUuidManaged: {},
+    })
+
+    const client = testDeveloperPlatformClient({
+      appInstallCount: vi.fn().mockRejectedValue(new Error('API error')),
+    })
+
+    const params = {
+      app: testApp(),
+      developerPlatformClient: client,
+      appId: 'appId',
+      appName: 'appName',
+      remoteApp: testOrganizationApp(),
+      envIdentifiers: {},
+      force: false,
+      release: true,
+    }
+
+    // When
+    await ensureDeploymentIdsPresence(params)
+
+    // Then - installCount should be undefined in the prompt call
+    expect(deployOrReleaseConfirmationPrompt).toHaveBeenCalledWith(
+      expect.objectContaining({
+        installCount: undefined,
+      }),
+    )
   })
 
   test('when the prompt is confirmed post-confirmation actions as run and the result is returned', async () => {
@@ -75,7 +226,7 @@ describe('ensureDeploymentIdsPresence', () => {
 function buildExtensionsBreakdown() {
   return {
     extensionIdentifiersBreakdown: {
-      onlyRemote: [],
+      onlyRemote: [] as ExtensionIdentifierBreakdownInfo[],
       toCreate: [],
       toUpdate: [],
       fromDashboard: [],

--- a/packages/app/src/cli/services/context/identifiers.ts
+++ b/packages/app/src/cli/services/context/identifiers.ts
@@ -58,6 +58,20 @@ export async function ensureDeploymentIdsPresence(options: EnsureDeploymentIdsPr
     activeAppVersion: options.activeAppVersion,
   })
 
+  let installCount: number | undefined
+  if (extensionIdentifiersBreakdown.onlyRemote.length > 0) {
+    try {
+      installCount = await options.developerPlatformClient.appInstallCount({
+        id: options.appId,
+        apiKey: options.remoteApp.apiKey,
+        organizationId: options.remoteApp.organizationId,
+      })
+      // eslint-disable-next-line no-catch-all/no-catch-all
+    } catch (_error) {
+      installCount = undefined
+    }
+  }
+
   const confirmed = await deployOrReleaseConfirmationPrompt({
     extensionIdentifiersBreakdown,
     configExtensionIdentifiersBreakdown,
@@ -66,6 +80,7 @@ export async function ensureDeploymentIdsPresence(options: EnsureDeploymentIdsPr
     force: options.force,
     allowUpdates: options.allowUpdates,
     allowDeletes: options.allowDeletes,
+    installCount,
   })
   if (!confirmed) throw new AbortSilentError()
 

--- a/packages/app/src/cli/services/context/identifiers.ts
+++ b/packages/app/src/cli/services/context/identifiers.ts
@@ -58,11 +58,16 @@ export async function ensureDeploymentIdsPresence(options: EnsureDeploymentIdsPr
     activeAppVersion: options.activeAppVersion,
   })
 
+  const shouldFetchInstallCount =
+    extensionIdentifiersBreakdown.onlyRemote.length > 0 &&
+    !options.force &&
+    !(options.allowUpdates && options.allowDeletes)
+
   let installCount: number | undefined
-  if (extensionIdentifiersBreakdown.onlyRemote.length > 0) {
+  if (shouldFetchInstallCount) {
     try {
       installCount = await options.developerPlatformClient.appInstallCount({
-        id: options.appId,
+        id: options.remoteApp.id,
         apiKey: options.remoteApp.apiKey,
         organizationId: options.remoteApp.organizationId,
       })

--- a/packages/app/src/cli/utilities/developer-platform-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client.ts
@@ -260,6 +260,7 @@ export interface DeveloperPlatformClient {
     activeAppVersion?: AppVersion,
   ) => Promise<AllAppExtensionRegistrationsQuerySchema>
   appVersions: (app: OrganizationApp) => Promise<AppVersionsQuerySchema>
+  appInstallCount: (app: MinimalAppIdentifiers) => Promise<number>
   activeAppVersion: (app: MinimalAppIdentifiers) => Promise<AppVersion | undefined>
   appVersionByTag: (app: MinimalOrganizationApp, tag: string) => Promise<AppVersionWithContext>
   appVersionsDiff: (app: MinimalOrganizationApp, version: AppVersionIdentifiers) => Promise<AppVersionsDiffSchema>

--- a/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
@@ -114,6 +114,7 @@ import {
 import {CreateAssetUrl} from '../../api/graphql/app-management/generated/create-asset-url.js'
 import {AppVersionById} from '../../api/graphql/app-management/generated/app-version-by-id.js'
 import {AppVersions} from '../../api/graphql/app-management/generated/app-versions.js'
+import {AppInstallCount} from '../../api/graphql/app-management/generated/app-install-count.js'
 import {CreateApp, CreateAppMutationVariables} from '../../api/graphql/app-management/generated/create-app.js'
 import {FetchSpecifications} from '../../api/graphql/app-management/generated/specifications.js'
 import {ListApps} from '../../api/graphql/app-management/generated/apps.js'
@@ -642,6 +643,13 @@ export class AppManagementClient implements DeveloperPlatformClient {
         },
       },
     }
+  }
+
+  async appInstallCount({id}: MinimalAppIdentifiers): Promise<number> {
+    const query = AppInstallCount
+    const variables = {appId: id}
+    const result = await this.appManagementRequest({query, variables})
+    return result.app.installCount
   }
 
   async appVersionByTag(

--- a/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
@@ -649,7 +649,7 @@ export class AppManagementClient implements DeveloperPlatformClient {
     const query = AppInstallCount
     const variables = {appId: id}
     const result = await this.appManagementRequest({query, variables})
-    return result.app.installCount
+    return result.app.installCount ?? 0
   }
 
   async appVersionByTag(

--- a/packages/app/src/cli/utilities/developer-platform-client/partners-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/partners-client.ts
@@ -428,6 +428,11 @@ export class PartnersClient implements DeveloperPlatformClient {
     return this.request(AppVersionsQuery, variables)
   }
 
+  async appInstallCount(_app: MinimalAppIdentifiers): Promise<number> {
+    // Install count is not supported in partners client.
+    throw new Error('Unsupported operation')
+  }
+
   async appVersionByTag({apiKey}: MinimalOrganizationApp, versionTag: string): Promise<AppVersionWithContext> {
     const input: AppVersionByTagVariables = {apiKey, versionTag}
     const result: AppVersionByTagSchema = await this.request(AppVersionByTagQuery, input)

--- a/packages/cli-kit/src/private/node/ui/components/DangerousConfirmationPrompt.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/DangerousConfirmationPrompt.tsx
@@ -16,6 +16,7 @@ export interface DangerousConfirmationPromptProps {
   message: string
   confirmation: string
   infoTable?: InfoTableProps['table']
+  warningItem?: TokenItem<InlineToken>
   onSubmit: (value: boolean) => void
   abortSignal?: AbortSignal
 }
@@ -24,6 +25,7 @@ const DangerousConfirmationPrompt: FunctionComponent<DangerousConfirmationPrompt
   message,
   confirmation,
   infoTable,
+  warningItem,
   onSubmit,
   abortSignal,
 }) => {
@@ -101,6 +103,12 @@ const DangerousConfirmationPrompt: FunctionComponent<DangerousConfirmationPrompt
                 gap={1}
               >
                 <InfoTable table={infoTable} />
+              </Box>
+            ) : null}
+            {warningItem ? (
+              <Box flexDirection="column">
+                <Text color="red">{figures.warning} WARNING</Text>
+                <TokenizedText item={warningItem} />
               </Box>
             ) : null}
             <Box>


### PR DESCRIPTION
## What

Surfaces the number of affected app installations in the `app deploy` / `app release` confirmation prompt when a release removes extensions. This gives developers a clear picture of the blast radius before they confirm a destructive operation.

![Screenshot 2026-04-10 at 17.30.24.png](https://app.graphite.com/user-attachments/assets/fe59b023-ce4c-44f0-bea9-91100309106a.png)

Closes https://github.com/shop/issues-develop/issues/22421

## How

**New GraphQL query** (`app-install-count.graphql`) — queries `installCount` on the `App` type, exposed by the Management API in shop/world#532386.

**New** **`appInstallCount()`** **method** on `DeveloperPlatformClient` + `AppManagementClient` implementation. `PartnersClient` stubs it as unsupported.

**Fetched lazily in** **`ensureDeploymentIdsPresence()`** — only when the extension breakdown contains removals (`onlyRemote.length > 0`), right before the confirmation prompt. Wrapped in try/catch so a failure never blocks the deploy.

**Warning rendered in** **`deploy-release.ts`** — added to the dangerous confirmation prompt (the one requiring the user to type the app name) when `hasDeletedExtensions && installCount > 0`.

## Behaviour unchanged in these paths

- Non-interactive (`--no-interactive` / piped input) — prompt is skipped entirely
- `--force` / `--allow-deletes` — prompt is skipped entirely
- API call failure — warning is silently omitted, deploy proceeds normally