### PR TITLE
Warn when schema.graphql api_version mismatches extension TOML

### DIFF
--- a/packages/app/src/cli/services/build/extension.test.ts
+++ b/packages/app/src/cli/services/build/extension.test.ts
@@ -7,13 +7,15 @@ import {beforeEach, describe, expect, test, vi} from 'vitest'
 import {exec} from '@shopify/cli-kit/node/system'
 import lockfile from 'proper-lockfile'
 import {AbortError} from '@shopify/cli-kit/node/error'
-import {fileExistsSync, touchFile, writeFile} from '@shopify/cli-kit/node/fs'
+import {fileExistsSync, readFile, touchFile, writeFile} from '@shopify/cli-kit/node/fs'
 import {joinPath} from '@shopify/cli-kit/node/path'
+import {outputWarn} from '@shopify/cli-kit/node/output'
 
 vi.mock('@shopify/cli-kit/node/system')
 vi.mock('../function/build.js')
 vi.mock('proper-lockfile')
 vi.mock('@shopify/cli-kit/node/fs')
+vi.mock('@shopify/cli-kit/node/output')
 
 describe('buildFunctionExtension', () => {
   let extension: ExtensionInstance<FunctionConfigType>
@@ -438,5 +440,57 @@ describe('buildFunctionExtension', () => {
     expect(fileExistsSync).toHaveBeenCalledWith(joinPath(extension.directory, 'dist/custom.wasm'))
     expect(touchFile).not.toHaveBeenCalled()
     expect(writeFile).not.toHaveBeenCalled()
+  })
+
+  describe('schema version mismatch warning', () => {
+    function mockSchemaFile(content: string) {
+      vi.mocked(readFile).mockResolvedValueOnce(content as any)
+    }
+
+    function mockSchemaNotFound() {
+      const err = new Error('ENOENT') as NodeJS.ErrnoException
+      err.code = 'ENOENT'
+      vi.mocked(readFile).mockRejectedValueOnce(err)
+    }
+
+    test('warns when schema version does not match toml version', async () => {
+      vi.mocked(outputWarn).mockReset()
+      mockSchemaFile('schema @apiVersion(version: "2025-01") {\n  query: QueryRoot\n}')
+
+      await buildFunctionExtension(extension, {stdout, stderr, signal, app, environment: 'production'})
+
+      expect(outputWarn).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'schema.graphql was generated for API version 2025-01 but your extension targets 2022-07',
+        ),
+      )
+    })
+
+    test('does not warn when schema version matches toml version', async () => {
+      vi.mocked(outputWarn).mockReset()
+      mockSchemaFile('schema @apiVersion(version: "2022-07") {\n  query: QueryRoot\n}')
+
+      await buildFunctionExtension(extension, {stdout, stderr, signal, app, environment: 'production'})
+
+      expect(outputWarn).not.toHaveBeenCalled()
+    })
+
+    test('does not warn when schema has no apiVersion directive', async () => {
+      vi.mocked(outputWarn).mockReset()
+      mockSchemaFile('type Query { shop: Shop }')
+
+      await buildFunctionExtension(extension, {stdout, stderr, signal, app, environment: 'production'})
+
+      expect(outputWarn).not.toHaveBeenCalled()
+    })
+
+    test('does not warn when schema file does not exist', async () => {
+      vi.mocked(outputWarn).mockReset()
+      mockSchemaNotFound()
+
+      await buildFunctionExtension(extension, {stdout, stderr, signal, app, environment: 'production'})
+
+      expect(outputWarn).not.toHaveBeenCalled()
+    })
   })
 })

--- a/packages/app/src/cli/services/build/extension.ts
+++ b/packages/app/src/cli/services/build/extension.ts
@@ -8,7 +8,7 @@ import {AbortSignal} from '@shopify/cli-kit/node/abort'
 import {AbortError, AbortSilentError} from '@shopify/cli-kit/node/error'
 import lockfile from 'proper-lockfile'
 import {dirname, joinPath} from '@shopify/cli-kit/node/path'
-import {outputDebug} from '@shopify/cli-kit/node/output'
+import {outputDebug, outputWarn} from '@shopify/cli-kit/node/output'
 import {readFile, touchFile, writeFile, fileExistsSync} from '@shopify/cli-kit/node/fs'
 import {Writable} from 'stream'
 
@@ -124,6 +124,8 @@ export async function buildFunctionExtension(
   extension: ExtensionInstance,
   options: BuildFunctionExtensionOptions,
 ): Promise<void> {
+  await warnIfSchemaMismatch(extension as ExtensionInstance<FunctionConfigType>)
+
   const lockfilePath = joinPath(extension.directory, '.build-lock')
   let releaseLock
   try {
@@ -223,6 +225,30 @@ async function buildOtherFunction(extension: ExtensionInstance, options: BuildFu
     await buildGraphqlTypes(extension, options)
   }
   return runCommand(extension.buildCommand, extension, options)
+}
+
+const API_VERSION_DIRECTIVE_RE = /@apiVersion\(version:\s*"([^"]+)"\)/
+
+async function warnIfSchemaMismatch(extension: ExtensionInstance<FunctionConfigType>) {
+  const schemaPath = joinPath(extension.directory, 'schema.graphql')
+  let content: string
+  try {
+    content = await readFile(schemaPath)
+  } catch (error) {
+    if (error instanceof Error && 'code' in error) return
+    throw error
+  }
+
+  const match = API_VERSION_DIRECTIVE_RE.exec(content)
+  if (!match) return
+
+  const schemaVersion = match[1]!
+  const tomlVersion = extension.configuration.api_version
+  if (schemaVersion !== tomlVersion) {
+    outputWarn(
+      `schema.graphql was generated for API version ${schemaVersion} but your extension targets ${tomlVersion}. Run \`shopify app function schema\` to update.`,
+    )
+  }
 }
 
 async function runCommand(buildCommand: string, extension: ExtensionInstance, options: BuildFunctionExtensionOptions) {


### PR DESCRIPTION
### WHY are these changes introduced?

When a developer changes `api_version` in their `shopify.extension.toml`, the local `schema.graphql` becomes stale. The build then fails with cryptic type errors from typegen, with no indication that the schema simply needs to be re-fetched. This is a common failure case when working with Shopify Functions.

### WHAT is this pull request doing?

Adds a lightweight check at the start of `buildFunctionExtension` that reads the first 512 bytes of `schema.graphql` looking for the server-stamped `@apiVersion` directive (e.g. `schema @apiVersion(version: "2025-04") {`). If present and it doesn't match the TOML's `api_version`, a warning is printed before the build runs:

> schema.graphql was generated for API version 2025-01 but your extension targets 2025-04. Run `shopify app function schema` to update.

If the directive isn't present (legacy schema files, or server hasn't adopted stamping yet), the check is silently skipped — no false positives.

Depends on https://github.com/shop/world/pull/543227 for the server to stamp schemas with the `@apiVersion` directive.

### How to test your changes?

1. Create a function extension with `api_version: "2025-01"`
2. Run `shopify app function schema` to fetch the schema (requires server-side directive stamping to be live, or manually add `schema @apiVersion(version: "2025-01") {` to the top of `schema.graphql`)
3. Change `api_version` to `"2025-04"` in `shopify.extension.toml`
4. Run `shopify app function build`
5. Observe the warning before the build proceeds

### Measuring impact

How do we know this change was effective? Please choose one:

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix
- [ ] Existing analytics will cater for this addition
- [ ] PR includes analytics changes to measure impact

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes