### PR TITLE
Align project-backed config failures with app config validate JSON

### DIFF
--- a/packages/app/src/cli/models/app/loader.test.ts
+++ b/packages/app/src/cli/models/app/loader.test.ts
@@ -29,6 +29,7 @@ import {installNodeModules, PackageJson} from '@shopify/cli-kit/node/node-packag
 import {inTemporaryDirectory, moveFile, mkdir, mkTmpDir, rmdir, writeFile} from '@shopify/cli-kit/node/fs'
 import {joinPath, dirname, cwd, normalizePath} from '@shopify/cli-kit/node/path'
 import {platformAndArch} from '@shopify/cli-kit/node/os'
+import {stringifyMessage} from '@shopify/cli-kit/node/output'
 import {zod} from '@shopify/cli-kit/node/schema'
 import colors from '@shopify/cli-kit/node/colors'
 import {showMultipleCLIWarningIfNeeded} from '@shopify/cli-kit/node/multiple-installation-warning'
@@ -608,6 +609,27 @@ describe('load', () => {
     expect(app.errors.isEmpty()).toBe(false)
   })
 
+  test('collects a malformed discovered extension TOML as an app error', async () => {
+    // Given
+    await writeConfig(appConfiguration)
+    const configurationPath = blockConfigurationPath({name: 'my-extension'})
+    await writeBlockConfig({
+      blockConfiguration: '{{broken toml',
+      name: 'my-extension',
+    })
+
+    // When
+    const app = await loadTestingApp()
+
+    // Then
+    expect(getRealExtensions(app)).toHaveLength(0)
+    const error = app.errors.getError(configurationPath)
+    expect(error).toBeDefined()
+    expect(stringifyMessage(error!)).toContain(configurationPath)
+    expect(stringifyMessage(error!)).toContain('Unknown character')
+    expect(app.errors.getIssues(configurationPath)).toEqual([])
+  })
+
   test('collects an error if the extension configuration is missing both extensions and type', async () => {
     // Given
     await writeConfig(appConfiguration, {
@@ -630,6 +652,24 @@ describe('load', () => {
     const app = await loadTestingApp()
     // Then — errors are collected, not thrown
     expect(app.errors.isEmpty()).toBe(false)
+  })
+
+  test('collects a malformed discovered web TOML as an app error', async () => {
+    // Given
+    const {webDirectory} = await writeConfig(appConfiguration)
+    const configurationPath = joinPath(webDirectory, blocks.web.configurationName)
+    await writeFile(configurationPath, '{{broken toml')
+
+    // When
+    const app = await loadTestingApp()
+
+    // Then
+    expect(app.webs).toHaveLength(0)
+    const error = app.errors.getError(configurationPath)
+    expect(error).toBeDefined()
+    expect(stringifyMessage(error!)).toContain(configurationPath)
+    expect(stringifyMessage(error!)).toContain('Unknown character')
+    expect(app.errors.getIssues(configurationPath)).toEqual([])
   })
 
   test('loads the app with web blocks', async () => {

--- a/packages/app/src/cli/models/app/loader.ts
+++ b/packages/app/src/cli/models/app/loader.ts
@@ -40,6 +40,8 @@ import {
   resolveDotEnv,
   resolveHiddenConfig,
   extensionFilesForConfig,
+  malformedExtensionFilesForConfig,
+  malformedWebFilesForConfig,
   webFilesForConfig,
 } from '../project/config-selection.js'
 import {showMultipleCLIWarningIfNeeded} from '@shopify/cli-kit/node/multiple-installation-warning'
@@ -538,6 +540,14 @@ class AppLoader<TConfig extends CurrentAppConfiguration, TModuleSpec extends Ext
   async loadWebs(appDirectory: string, webDirectories?: string[]): Promise<{webs: Web[]; usedCustomLayout: boolean}> {
     const activeConfig = this.activeConfigFile
     const webFiles = activeConfig ? webFilesForConfig(this.project, activeConfig) : this.project.webConfigFiles
+    const malformedWebFiles = activeConfig
+      ? malformedWebFilesForConfig(this.project, activeConfig)
+      : this.project.malformedWebConfigFiles
+
+    for (const malformedWebFile of malformedWebFiles) {
+      this.errors.addError(malformedWebFile.path, malformedWebFile.message)
+    }
+
     const webTomlPaths = webFiles.map((file) => file.path)
     const webResults = await Promise.all(
       webFiles.map(async (webFile) => {
@@ -692,6 +702,13 @@ class AppLoader<TConfig extends CurrentAppConfiguration, TModuleSpec extends Ext
     const extensionFiles = activeConfig
       ? extensionFilesForConfig(this.project, activeConfig)
       : this.project.extensionConfigFiles
+    const malformedExtensionFiles = activeConfig
+      ? malformedExtensionFilesForConfig(this.project, activeConfig)
+      : this.project.malformedExtensionConfigFiles
+
+    for (const malformedExtensionFile of malformedExtensionFiles) {
+      this.errors.addError(malformedExtensionFile.path, malformedExtensionFile.message)
+    }
 
     return extensionFiles.map(async (extensionFile) => {
       const configurationPath = extensionFile.path

--- a/packages/app/src/cli/models/app/local-config-error.ts
+++ b/packages/app/src/cli/models/app/local-config-error.ts
@@ -1,6 +1,6 @@
+import {toRootValidationIssue, type AppValidationIssue} from './error-parsing.js'
 import {AbortError} from '@shopify/cli-kit/node/error'
-import type {OutputMessage} from '@shopify/cli-kit/node/output'
-import type {AppValidationIssue} from './error-parsing.js'
+import {stringifyMessage, type OutputMessage} from '@shopify/cli-kit/node/output'
 
 /**
  * Structured local configuration failure shared by lower layers.
@@ -10,11 +10,15 @@ import type {AppValidationIssue} from './error-parsing.js'
  * results, or other higher-level flows.
  */
 export class LocalConfigError extends AbortError {
+  public readonly issues: AppValidationIssue[]
+
   constructor(
     message: OutputMessage,
     public readonly configurationPath: string,
-    public readonly issues: AppValidationIssue[] = [],
+    issues: AppValidationIssue[] = [],
   ) {
     super(message)
+    this.issues =
+      issues.length > 0 ? issues : [toRootValidationIssue(configurationPath, stringifyMessage(message).trim())]
   }
 }

--- a/packages/app/src/cli/models/project/active-config.test.ts
+++ b/packages/app/src/cli/models/project/active-config.test.ts
@@ -1,8 +1,9 @@
 import {selectActiveConfig} from './active-config.js'
 import {Project} from './project.js'
+import {LocalConfigError} from '../app/local-config-error.js'
 import {describe, expect, test, vi, beforeEach} from 'vitest'
 import {inTemporaryDirectory, writeFile, mkdir} from '@shopify/cli-kit/node/fs'
-import {joinPath, basename} from '@shopify/cli-kit/node/path'
+import {joinPath, basename, normalizePath} from '@shopify/cli-kit/node/path'
 
 vi.mock('../../services/local-storage.js', () => ({
   getCachedAppInfo: vi.fn().mockReturnValue(undefined),
@@ -155,34 +156,66 @@ describe('selectActiveConfig', () => {
     })
   })
 
-  test('throws when requested config does not exist', async () => {
+  test('throws LocalConfigError when requested config does not exist', async () => {
     await inTemporaryDirectory(async (dir) => {
       await writeFile(joinPath(dir, 'shopify.app.toml'), 'client_id = "default"')
       const project = await Project.load(dir)
 
-      await expect(selectActiveConfig(project, 'nonexistent')).rejects.toThrow()
+      try {
+        await selectActiveConfig(project, 'nonexistent')
+        expect.fail('Expected selectActiveConfig to throw')
+      } catch (error) {
+        if (!(error instanceof LocalConfigError)) throw error
+        expect(error.configurationPath).toBe(joinPath(dir, 'shopify.app.nonexistent.toml'))
+        expect(error.message).toBe(`Couldn't find shopify.app.nonexistent.toml in ${normalizePath(dir)}.`)
+        expect(error.issues[0]).toMatchObject({
+          filePath: joinPath(dir, 'shopify.app.nonexistent.toml'),
+          path: [],
+          pathString: 'root',
+        })
+      }
     })
   })
 
-  test('throws when the only app config is malformed (no valid configs to fall back to)', async () => {
+  test('throws a structured parse error when the only app config is malformed', async () => {
     await inTemporaryDirectory(async (dir) => {
-      // The only config is broken TOML — Project.load skips it and finds 0 valid configs
+      // The only config is broken TOML — Project.load should surface the parse error.
       await writeFile(joinPath(dir, 'shopify.app.toml'), '{{invalid toml')
 
-      await expect(Project.load(dir)).rejects.toThrow(/Could not find/)
+      try {
+        await Project.load(dir)
+        expect.fail('Expected Project.load to throw')
+      } catch (error) {
+        if (!(error instanceof LocalConfigError)) throw error
+        expect(error.message).toMatch(/Unknown character/)
+        expect(error.issues[0]).toMatchObject({
+          filePath: joinPath(dir, 'shopify.app.toml'),
+          path: [],
+          pathString: 'root',
+        })
+      }
     })
   })
 
   test('surfaces parse error when selecting a broken config while a valid one exists', async () => {
     await inTemporaryDirectory(async (dir) => {
-      // Two configs: one good, one broken. Selecting the broken one by name should
-      // surface the real parse error via the fallback re-read, not a generic "not found".
       await writeFile(joinPath(dir, 'shopify.app.toml'), 'client_id = "good"')
       await writeFile(joinPath(dir, 'shopify.app.broken.toml'), '{{invalid toml')
 
       const project = await Project.load(dir)
 
-      await expect(selectActiveConfig(project, 'shopify.app.broken.toml')).rejects.toThrow()
+      try {
+        await selectActiveConfig(project, 'shopify.app.broken.toml')
+        expect.fail('Expected selectActiveConfig to throw')
+      } catch (error) {
+        if (!(error instanceof LocalConfigError)) throw error
+        expect(error.message).toMatch(/Unknown character/)
+        expect(error.issues[0]).toMatchObject({
+          filePath: joinPath(dir, 'shopify.app.broken.toml'),
+          path: [],
+          pathString: 'root',
+        })
+      }
     })
   })
 

--- a/packages/app/src/cli/models/project/active-config.ts
+++ b/packages/app/src/cli/models/project/active-config.ts
@@ -1,6 +1,7 @@
 import {Project} from './project.js'
 import {resolveDotEnv, resolveHiddenConfig} from './config-selection.js'
 import {AppHiddenConfig} from '../app/app.js'
+import {LocalConfigError} from '../app/local-config-error.js'
 import {getAppConfigurationFileName} from '../app/config-file-naming.js'
 import {getCachedAppInfo} from '../../services/local-storage.js'
 import use from '../../services/app/config/use.js'
@@ -8,7 +9,6 @@ import {TomlFile} from '@shopify/cli-kit/node/toml/toml-file'
 import {DotEnvFile} from '@shopify/cli-kit/node/dot-env'
 import {fileExistsSync} from '@shopify/cli-kit/node/fs'
 import {joinPath} from '@shopify/cli-kit/node/path'
-import {AbortError} from '@shopify/cli-kit/node/error'
 import {outputContent, outputToken} from '@shopify/cli-kit/node/output'
 
 /** @public */
@@ -87,8 +87,14 @@ export async function selectActiveConfig(project: Project, userProvidedConfigNam
   const configurationFileName = getAppConfigurationFileName(configName)
   const file = project.appConfigByName(configurationFileName)
   if (!file) {
-    throw new AbortError(
+    const malformedFile = project.malformedAppConfigByName(configurationFileName)
+    if (malformedFile) {
+      throw new LocalConfigError(malformedFile.message, malformedFile.path)
+    }
+
+    throw new LocalConfigError(
       outputContent`Couldn't find ${configurationFileName} in ${outputToken.path(project.directory)}.`,
+      joinPath(project.directory, configurationFileName),
     )
   }
 

--- a/packages/app/src/cli/models/project/config-selection.test.ts
+++ b/packages/app/src/cli/models/project/config-selection.test.ts
@@ -1,4 +1,11 @@
-import {resolveDotEnv, resolveHiddenConfig, extensionFilesForConfig, webFilesForConfig} from './config-selection.js'
+import {
+  resolveDotEnv,
+  resolveHiddenConfig,
+  extensionFilesForConfig,
+  malformedExtensionFilesForConfig,
+  malformedWebFilesForConfig,
+  webFilesForConfig,
+} from './config-selection.js'
 import {Project} from './project.js'
 import {describe, expect, test} from 'vitest'
 import {inTemporaryDirectory, writeFile, mkdir} from '@shopify/cli-kit/node/fs'
@@ -230,6 +237,33 @@ describe('extensionFilesForConfig', () => {
       expect(stagingExts[0]!.content.name).toBe('func2')
     })
   })
+
+  test('filters malformed extension files to the active config extension_directories', async () => {
+    await inTemporaryDirectory(async (dir) => {
+      await writeFile(joinPath(dir, 'shopify.app.toml'), 'client_id = "default"\nextension_directories = ["ext-a/*"]')
+      await writeFile(
+        joinPath(dir, 'shopify.app.staging.toml'),
+        'client_id = "staging"\nextension_directories = ["ext-b/*"]',
+      )
+
+      await mkdir(joinPath(dir, 'ext-a', 'broken-default'))
+      await writeFile(joinPath(dir, 'ext-a', 'broken-default', 'shopify.extension.toml'), '{{broken toml')
+      await mkdir(joinPath(dir, 'ext-b', 'broken-staging'))
+      await writeFile(joinPath(dir, 'ext-b', 'broken-staging', 'shopify.extension.toml'), '{{broken toml')
+
+      const project = await Project.load(dir)
+      const defaultConfig = project.appConfigByName('shopify.app.toml')!
+      const stagingConfig = project.appConfigByName('shopify.app.staging.toml')!
+
+      const defaultMalformed = malformedExtensionFilesForConfig(project, defaultConfig)
+      expect(defaultMalformed).toHaveLength(1)
+      expect(defaultMalformed[0]!.path).toContain('ext-a/broken-default/shopify.extension.toml')
+
+      const stagingMalformed = malformedExtensionFilesForConfig(project, stagingConfig)
+      expect(stagingMalformed).toHaveLength(1)
+      expect(stagingMalformed[0]!.path).toContain('ext-b/broken-staging/shopify.extension.toml')
+    })
+  })
 })
 
 describe('webFilesForConfig', () => {
@@ -285,6 +319,30 @@ describe('webFilesForConfig', () => {
       const webFiles = webFilesForConfig(project, defaultConfig)
       expect(webFiles).toHaveLength(1)
       expect(webFiles[0]!.content.name).toBe('web-a')
+    })
+  })
+
+  test('filters malformed web files to the active config web_directories', async () => {
+    await inTemporaryDirectory(async (dir) => {
+      await writeFile(joinPath(dir, 'shopify.app.toml'), 'client_id = "default"\nweb_directories = ["web-a"]')
+      await writeFile(joinPath(dir, 'shopify.app.staging.toml'), 'client_id = "staging"\nweb_directories = ["web-b"]')
+
+      await mkdir(joinPath(dir, 'web-a'))
+      await writeFile(joinPath(dir, 'web-a', 'shopify.web.toml'), '{{broken toml')
+      await mkdir(joinPath(dir, 'web-b'))
+      await writeFile(joinPath(dir, 'web-b', 'shopify.web.toml'), '{{broken toml')
+
+      const project = await Project.load(dir)
+      const defaultConfig = project.appConfigByName('shopify.app.toml')!
+      const stagingConfig = project.appConfigByName('shopify.app.staging.toml')!
+
+      const defaultMalformed = malformedWebFilesForConfig(project, defaultConfig)
+      expect(defaultMalformed).toHaveLength(1)
+      expect(defaultMalformed[0]!.path).toContain('web-a/shopify.web.toml')
+
+      const stagingMalformed = malformedWebFilesForConfig(project, stagingConfig)
+      expect(stagingMalformed).toHaveLength(1)
+      expect(stagingMalformed[0]!.path).toContain('web-b/shopify.web.toml')
     })
   })
 })

--- a/packages/app/src/cli/models/project/config-selection.ts
+++ b/packages/app/src/cli/models/project/config-selection.ts
@@ -1,4 +1,4 @@
-import {Project} from './project.js'
+import {Project, type MalformedTomlFile} from './project.js'
 import {AppHiddenConfig} from '../app/app.js'
 import {getAppConfigurationShorthand} from '../app/loader.js'
 import {dotEnvFileNames} from '../../constants.js'
@@ -76,14 +76,18 @@ export async function resolveHiddenConfig(project: Project, clientId: string | u
  * @public
  */
 export function extensionFilesForConfig(project: Project, activeConfig: TomlFile): TomlFile[] {
-  const configDirs = activeConfig.content.extension_directories
-  const dirs = Array.isArray(configDirs) && configDirs.length > 0 ? (configDirs as string[]) : ['extensions/*']
-
-  // Replicate the same glob patterns used by discoverExtensionFiles in project.ts:
-  // each directory pattern becomes "<dir>/*.extension.toml"
-  const globPatterns = dirs.map((dir) => `${dir}/*.extension.toml`)
+  const globPatterns = extensionGlobPatternsForConfig(activeConfig)
 
   return project.extensionConfigFiles.filter((file) => {
+    const relPath = relativePath(project.directory, file.path).replace(/\\/g, '/')
+    return globPatterns.some((pattern) => matchGlob(relPath, pattern))
+  })
+}
+
+export function malformedExtensionFilesForConfig(project: Project, activeConfig: TomlFile): MalformedTomlFile[] {
+  const globPatterns = extensionGlobPatternsForConfig(activeConfig)
+
+  return project.malformedExtensionConfigFiles.filter((file) => {
     const relPath = relativePath(project.directory, file.path).replace(/\\/g, '/')
     return globPatterns.some((pattern) => matchGlob(relPath, pattern))
   })
@@ -98,17 +102,35 @@ export function extensionFilesForConfig(project: Project, activeConfig: TomlFile
  * @public
  */
 export function webFilesForConfig(project: Project, activeConfig: TomlFile): TomlFile[] {
-  const configDirs = activeConfig.content.web_directories
-  if (!Array.isArray(configDirs) || configDirs.length === 0) {
-    return project.webConfigFiles
-  }
-
-  // Replicate the same glob patterns used by discoverWebFiles in project.ts:
-  // each directory pattern becomes "<dir>/shopify.web.toml"
-  const globPatterns = (configDirs as string[]).map((dir) => `${dir}/shopify.web.toml`)
+  const globPatterns = webGlobPatternsForConfig(activeConfig)
 
   return project.webConfigFiles.filter((file) => {
     const relPath = relativePath(project.directory, file.path).replace(/\\/g, '/')
     return globPatterns.some((pattern) => matchGlob(relPath, pattern))
   })
+}
+
+export function malformedWebFilesForConfig(project: Project, activeConfig: TomlFile): MalformedTomlFile[] {
+  const globPatterns = webGlobPatternsForConfig(activeConfig)
+
+  return project.malformedWebConfigFiles.filter((file) => {
+    const relPath = relativePath(project.directory, file.path).replace(/\\/g, '/')
+    return globPatterns.some((pattern) => matchGlob(relPath, pattern))
+  })
+}
+
+function extensionGlobPatternsForConfig(activeConfig: TomlFile): string[] {
+  const configDirs = activeConfig.content.extension_directories
+  const dirs = Array.isArray(configDirs) && configDirs.length > 0 ? (configDirs as string[]) : ['extensions/*']
+
+  return dirs.map((dir) => `${dir}/*.extension.toml`)
+}
+
+function webGlobPatternsForConfig(activeConfig: TomlFile): string[] {
+  const configDirs = activeConfig.content.web_directories
+  if (!Array.isArray(configDirs) || configDirs.length === 0) {
+    return ['**/shopify.web.toml']
+  }
+
+  return (configDirs as string[]).map((dir) => `${dir}/shopify.web.toml`)
 }

--- a/packages/app/src/cli/models/project/project.test.ts
+++ b/packages/app/src/cli/models/project/project.test.ts
@@ -1,4 +1,5 @@
 import {Project} from './project.js'
+import {LocalConfigError} from '../app/local-config-error.js'
 import {describe, expect, test} from 'vitest'
 import {inTemporaryDirectory, writeFile, mkdir} from '@shopify/cli-kit/node/fs'
 import {joinPath, normalizePath} from '@shopify/cli-kit/node/path'
@@ -116,9 +117,21 @@ describe('Project', () => {
       })
     })
 
-    test('throws when no app config files found', async () => {
+    test('throws a LocalConfigError when no app config files are found', async () => {
       await inTemporaryDirectory(async (dir) => {
-        await expect(Project.load(dir)).rejects.toThrow()
+        try {
+          await Project.load(dir)
+          expect.fail('Expected Project.load to throw')
+        } catch (error) {
+          if (!(error instanceof LocalConfigError)) throw error
+          expect(error.configurationPath).toBe(dir)
+          expect(error.message).toMatch(/Could not find a Shopify app configuration file/)
+          expect(error.issues[0]).toMatchObject({
+            filePath: dir,
+            path: [],
+            pathString: 'root',
+          })
+        }
       })
     })
 
@@ -180,9 +193,11 @@ describe('Project', () => {
 
         const project = await Project.load(dir)
 
-        // Only the valid extension is loaded
+        // Only the valid extension is loaded, but malformed files are retained as discovery metadata
         expect(project.extensionConfigFiles).toHaveLength(1)
         expect(project.extensionConfigFiles[0]!.content.name).toBe('good')
+        expect(project.malformedExtensionConfigFiles).toHaveLength(1)
+        expect(project.malformedExtensionConfigFiles[0]!.path).toContain('bad-ext/shopify.extension.toml')
       })
     })
 
@@ -194,9 +209,11 @@ describe('Project', () => {
 
         const project = await Project.load(dir)
 
-        // Only the valid web config is loaded
+        // Only the valid web config is loaded, but malformed files are retained as discovery metadata
         expect(project.webConfigFiles).toHaveLength(1)
         expect(project.webConfigFiles[0]!.content.name).toBe('good')
+        expect(project.malformedWebConfigFiles).toHaveLength(1)
+        expect(project.malformedWebConfigFiles[0]!.path).toContain('bad-web/shopify.web.toml')
       })
     })
 

--- a/packages/app/src/cli/models/project/project.ts
+++ b/packages/app/src/cli/models/project/project.ts
@@ -1,4 +1,5 @@
 import {configurationFileNames} from '../../constants.js'
+import {LocalConfigError} from '../app/local-config-error.js'
 import {TomlFile} from '@shopify/cli-kit/node/toml/toml-file'
 import {readAndParseDotEnv, DotEnvFile} from '@shopify/cli-kit/node/dot-env'
 import {fileExists, glob, findPathUp, readFile} from '@shopify/cli-kit/node/fs'
@@ -9,7 +10,6 @@ import {
   usesWorkspaces as detectUsesWorkspaces,
 } from '@shopify/cli-kit/node/node-package-manager'
 import {joinPath, basename} from '@shopify/cli-kit/node/path'
-import {AbortError} from '@shopify/cli-kit/node/error'
 import {outputDebug} from '@shopify/cli-kit/node/output'
 import {JsonMapType} from '@shopify/cli-kit/node/toml'
 
@@ -20,6 +20,11 @@ const WEB_TOML = 'shopify.web.toml'
 const DEFAULT_EXTENSION_DIR = 'extensions/*'
 const NODE_MODULES_EXCLUDE = '**/node_modules/**'
 const DOTENV_GLOB = '.env*'
+
+export interface MalformedTomlFile {
+  path: string
+  message: string
+}
 
 /**
  * A Project is the Shopify app as it exists on the filesystem.
@@ -45,9 +50,14 @@ export class Project {
     const directory = await findProjectRoot(startDirectory)
 
     // Discover all app config files
-    const appConfigFiles = await discoverAppConfigFiles(directory)
+    const {appConfigFiles, malformedAppConfigFiles} = await discoverAppConfigFiles(directory)
     if (appConfigFiles.length === 0) {
-      throw new AbortError(`Could not find a Shopify app TOML file in ${directory}`)
+      const preferredMalformedConfig = getPreferredMalformedAppConfig(malformedAppConfigFiles)
+      if (preferredMalformedConfig) {
+        throw new LocalConfigError(preferredMalformedConfig.message, preferredMalformedConfig.path)
+      }
+
+      throw new LocalConfigError(`Could not find a Shopify app TOML file in ${directory}`, directory)
     }
 
     // Discover extension files from all app configs' extension_directories (union).
@@ -61,7 +71,9 @@ export class Project {
         allExtensionDirs.add(DEFAULT_EXTENSION_DIR)
       }
     }
-    const extensionConfigFiles = await discoverExtensionFiles(directory, [...allExtensionDirs])
+    const {extensionConfigFiles, malformedExtensionConfigFiles} = await discoverExtensionFiles(directory, [
+      ...allExtensionDirs,
+    ])
 
     // Discover web files from all app configs' web_directories (union)
     const allWebDirs = new Set<string>()
@@ -71,7 +83,10 @@ export class Project {
         for (const dir of dirs) allWebDirs.add(dir as string)
       }
     }
-    const webConfigFiles = await discoverWebFiles(directory, allWebDirs.size > 0 ? [...allWebDirs] : undefined)
+    const {webConfigFiles, malformedWebConfigFiles} = await discoverWebFiles(
+      directory,
+      allWebDirs.size > 0 ? [...allWebDirs] : undefined,
+    )
 
     // Project metadata
     const packageJSONPath = joinPath(directory, 'package.json')
@@ -92,8 +107,11 @@ export class Project {
       nodeDependencies,
       usesWorkspaces,
       appConfigFiles,
+      malformedAppConfigFiles,
       extensionConfigFiles,
+      malformedExtensionConfigFiles,
       webConfigFiles,
+      malformedWebConfigFiles,
       dotenvFiles,
       hiddenConfigRaw,
     })
@@ -104,8 +122,11 @@ export class Project {
   readonly nodeDependencies: Record<string, string>
   readonly usesWorkspaces: boolean
   readonly appConfigFiles: TomlFile[]
+  readonly malformedAppConfigFiles: MalformedTomlFile[]
   readonly extensionConfigFiles: TomlFile[]
+  readonly malformedExtensionConfigFiles: MalformedTomlFile[]
   readonly webConfigFiles: TomlFile[]
+  readonly malformedWebConfigFiles: MalformedTomlFile[]
 
   /** All .env* files discovered in the project root, keyed by filename */
   readonly dotenvFiles: Map<string, DotEnvFile>
@@ -119,8 +140,11 @@ export class Project {
     nodeDependencies: Record<string, string>
     usesWorkspaces: boolean
     appConfigFiles: TomlFile[]
+    malformedAppConfigFiles: MalformedTomlFile[]
     extensionConfigFiles: TomlFile[]
+    malformedExtensionConfigFiles: MalformedTomlFile[]
     webConfigFiles: TomlFile[]
+    malformedWebConfigFiles: MalformedTomlFile[]
     dotenvFiles: Map<string, DotEnvFile>
     hiddenConfigRaw: JsonMapType
   }) {
@@ -129,8 +153,11 @@ export class Project {
     this.nodeDependencies = options.nodeDependencies
     this.usesWorkspaces = options.usesWorkspaces
     this.appConfigFiles = options.appConfigFiles
+    this.malformedAppConfigFiles = options.malformedAppConfigFiles
     this.extensionConfigFiles = options.extensionConfigFiles
+    this.malformedExtensionConfigFiles = options.malformedExtensionConfigFiles
     this.webConfigFiles = options.webConfigFiles
+    this.malformedWebConfigFiles = options.malformedWebConfigFiles
     this.dotenvFiles = options.dotenvFiles
     this.hiddenConfigRaw = options.hiddenConfigRaw
   }
@@ -145,6 +172,11 @@ export class Project {
   /** Find an app config file by client_id */
   appConfigByClientId(clientId: string): TomlFile | undefined {
     return this.appConfigFiles.find((file) => file.content.client_id === clientId)
+  }
+
+  /** Find a malformed app config file by filename. */
+  malformedAppConfigByName(fileName: string): MalformedTomlFile | undefined {
+    return this.malformedAppConfigFiles.find((file) => basename(file.path) === fileName)
   }
 
   /** The default app config (shopify.app.toml), if it exists */
@@ -167,34 +199,46 @@ async function findProjectRoot(startDirectory: string): Promise<string> {
     },
   )
   if (!found) {
-    throw new AbortError(
+    throw new LocalConfigError(
       `Could not find a Shopify app configuration file. Looked in ${startDirectory} and parent directories.`,
+      startDirectory,
     )
   }
   return found
 }
 
-async function discoverAppConfigFiles(directory: string): Promise<TomlFile[]> {
+async function discoverAppConfigFiles(
+  directory: string,
+): Promise<{appConfigFiles: TomlFile[]; malformedAppConfigFiles: MalformedTomlFile[]}> {
   const pattern = joinPath(directory, APP_CONFIG_GLOB)
   const paths = await glob(pattern)
   const validPaths = paths.filter((filePath) => APP_CONFIG_REGEX.test(basename(filePath)))
-  return readTomlFilesSafe(validPaths)
+  const {files, malformedFiles} = await readTomlFiles(validPaths)
+  return {appConfigFiles: files, malformedAppConfigFiles: malformedFiles}
 }
 
-async function discoverExtensionFiles(directory: string, extensionDirectories?: string[]): Promise<TomlFile[]> {
+async function discoverExtensionFiles(
+  directory: string,
+  extensionDirectories?: string[],
+): Promise<{extensionConfigFiles: TomlFile[]; malformedExtensionConfigFiles: MalformedTomlFile[]}> {
   const dirs = extensionDirectories ?? [DEFAULT_EXTENSION_DIR]
   const patterns = dirs.map((dir) => joinPath(directory, dir, EXTENSION_TOML))
   patterns.push(`!${joinPath(directory, NODE_MODULES_EXCLUDE)}`)
   const paths = await glob(patterns)
-  return readTomlFilesSafe(paths)
+  const {files, malformedFiles} = await readTomlFiles(paths)
+  return {extensionConfigFiles: files, malformedExtensionConfigFiles: malformedFiles}
 }
 
-async function discoverWebFiles(directory: string, webDirectories?: string[]): Promise<TomlFile[]> {
+async function discoverWebFiles(
+  directory: string,
+  webDirectories?: string[],
+): Promise<{webConfigFiles: TomlFile[]; malformedWebConfigFiles: MalformedTomlFile[]}> {
   const dirs = webDirectories ?? ['**']
   const patterns = dirs.map((dir) => joinPath(directory, dir, WEB_TOML))
   patterns.push(`!${joinPath(directory, NODE_MODULES_EXCLUDE)}`)
   const paths = await glob(patterns)
-  return readTomlFilesSafe(paths)
+  const {files, malformedFiles} = await readTomlFiles(paths)
+  return {webConfigFiles: files, malformedWebConfigFiles: malformedFiles}
 }
 
 /**
@@ -202,19 +246,40 @@ async function discoverWebFiles(directory: string, webDirectories?: string[]): P
  * This prevents a malformed inactive config or extension TOML
  * from blocking the active config from loading.
  */
-async function readTomlFilesSafe(paths: string[]): Promise<TomlFile[]> {
+async function readTomlFiles(paths: string[]): Promise<{files: TomlFile[]; malformedFiles: MalformedTomlFile[]}> {
   const results = await Promise.all(
     paths.map(async (filePath) => {
       try {
-        return await TomlFile.read(filePath)
+        return {file: await TomlFile.read(filePath)}
         // eslint-disable-next-line no-catch-all/no-catch-all
-      } catch {
+      } catch (error) {
         outputDebug(`Skipping malformed TOML file: ${filePath}`)
-        return undefined
+        return {
+          malformedFile: {
+            path: filePath,
+            message: error instanceof Error ? error.message : `Failed to parse ${filePath}`,
+          },
+        }
       }
     }),
   )
-  return results.filter((file): file is TomlFile => file !== undefined)
+
+  const files: TomlFile[] = []
+  const malformedFiles: MalformedTomlFile[] = []
+
+  for (const result of results) {
+    if ('file' in result && result.file) {
+      files.push(result.file)
+    } else {
+      malformedFiles.push(result.malformedFile)
+    }
+  }
+
+  return {files, malformedFiles}
+}
+
+function getPreferredMalformedAppConfig(malformedFiles: MalformedTomlFile[]): MalformedTomlFile | undefined {
+  return malformedFiles.find((file) => basename(file.path) === configurationFileNames.app) ?? malformedFiles[0]
 }
 
 /** Discover all .env* files in the project root */


### PR DESCRIPTION
## What

Align the remaining project-backed local configuration failures with `shopify app config validate --json`.

This PR extends the same `LocalConfigError` path to Project / ActiveConfig-backed failures and surfaces malformed discovered extension and web configs through the existing validation flow.

## Why

After the Project-based app discovery changes, some local failures were still bypassing the JSON validation contract:

- missing app roots
- malformed selected app configs
- missing selected app configs
- malformed discovered extension configs
- malformed discovered web configs

That left `app config validate --json` inconsistent depending on where a local configuration failure originated.

## How

- use `LocalConfigError` for Project-backed app discovery failures
- use `LocalConfigError` for ActiveConfig selection failures
- preserve malformed app, extension, and web TOML metadata in `Project`
- filter malformed discovered extension and web configs to the active app config
- report those malformed discovered configs through the loader’s existing error aggregation path

## Notes

This keeps the layering aligned with the Project extraction:

- `Project` owns discovery facts
- `ActiveConfig` owns selection
- loader owns validation aggregation
- command/service own public JSON serialization

## Testing

Manual checks against a local test app:

- run `app config validate --json` against an app with an existing validation error (for example, an extension config missing a required `name`) and confirm it returns `{valid: false, issues: [...]}`
- run with `--path` pointing outside any app and confirm it returns a root issue in JSON
- break `shopify.app.toml` with invalid TOML (for example, replace the file contents with `{{invalid toml`) and confirm the parse failure returns a root issue in JSON
- run with `--config missing` and confirm the command returns a root issue for `shopify.app.missing.toml`
- create a broken selected config such as `shopify.app.broken.toml` containing `{{invalid toml`, run with `--config broken`, and confirm it returns a root issue in JSON
- break a discovered `shopify.extension.toml` with invalid TOML (for example, replace the file contents with `{{invalid toml`) and confirm the command returns `valid: false` instead of reporting a valid app
