### PR TITLE
fix: regenerate oclif manifests for nightly packaging

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -49,7 +49,7 @@
     "clean": "nx clean",
     "lint": "nx lint",
     "lint:fix": "nx lint:fix",
-    "prepack": "NODE_ENV=production pnpm nx build && cp ../../README.md README.md",
+    "prepack": "NODE_ENV=production pnpm nx build && pnpm oclif manifest && cp ../../README.md README.md",
     "vitest": "vitest",
     "type-check": "nx type-check"
   },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -47,7 +47,7 @@
     "clean": "nx clean",
     "lint": "nx lint",
     "lint:fix": "nx lint:fix",
-    "prepack": "NODE_ENV=production node ../../bin/update-bugsnag cli && cp ../../README.md README.md",
+    "prepack": "NODE_ENV=production node ../../bin/update-bugsnag cli && pnpm oclif manifest && cp ../../README.md README.md",
     "vitest": "vitest",
     "type-check": "nx type-check"
   },

--- a/packages/cli/src/cli/repo-health.test.ts
+++ b/packages/cli/src/cli/repo-health.test.ts
@@ -122,8 +122,11 @@ describe('oclif manifest packaging', () => {
         scripts?: {prepack?: string}
       }
 
-      if (!packageJson.files?.includes('/oclif.manifest.json')) continue
-      if (!packageJson.scripts?.prepack?.includes('pnpm oclif manifest')) {
+      const shipsOclifManifest = packageJson.files?.some((file) =>
+        file.replace(/^\.?\//, '').endsWith('oclif.manifest.json'),
+      )
+      if (!shipsOclifManifest) continue
+      if (!/\boclif\s+manifest\b/.test(packageJson.scripts?.prepack ?? '')) {
         missingManifestRefresh.push(path.relative(repoRoot, packageJsonPath))
       }
     }

--- a/packages/cli/src/cli/repo-health.test.ts
+++ b/packages/cli/src/cli/repo-health.test.ts
@@ -109,3 +109,32 @@ describe('Node dependency version sync', () => {
     expect(different, errorMessage).toHaveLength(0)
   })
 })
+
+describe('oclif manifest packaging', () => {
+  test('packages that ship oclif.manifest.json regenerate it in prepack', async () => {
+    const packageJsonPaths = await glob('packages/*/package.json', {cwd: repoRoot, absolute: true})
+
+    const missingManifestRefresh: string[] = []
+
+    for (const packageJsonPath of packageJsonPaths) {
+      const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf-8')) as {
+        files?: string[]
+        scripts?: {prepack?: string}
+      }
+
+      if (!packageJson.files?.includes('/oclif.manifest.json')) continue
+      if (!packageJson.scripts?.prepack?.includes('pnpm oclif manifest')) {
+        missingManifestRefresh.push(path.relative(repoRoot, packageJsonPath))
+      }
+    }
+
+    expect(
+      missingManifestRefresh,
+      [
+        'The following packages publish oclif.manifest.json without regenerating it in prepack:\n',
+        ...missingManifestRefresh.map((packageJsonPath) => `  - ${packageJsonPath}\n`),
+        '\nAdd `pnpm oclif manifest` to the package prepack script so snapshot/nightly versions do not ship stale manifests.',
+      ].join(''),
+    ).toHaveLength(0)
+  })
+})

--- a/packages/create-app/package.json
+++ b/packages/create-app/package.json
@@ -45,7 +45,7 @@
     "clean": "nx clean",
     "lint": "nx lint",
     "lint:fix": "nx lint:fix",
-    "prepack": "NODE_ENV=production node ../../bin/update-bugsnag create-app && cp ../../README.md README.md",
+    "prepack": "NODE_ENV=production node ../../bin/update-bugsnag create-app && pnpm oclif manifest && cp ../../README.md README.md",
     "vitest": "vitest",
     "type-check": "nx type-check"
   },

--- a/packages/plugin-cloudflare/package.json
+++ b/packages/plugin-cloudflare/package.json
@@ -36,7 +36,7 @@
     "clean": "nx clean",
     "lint": "nx lint",
     "lint:fix": "nx lint:fix",
-    "prepack": "NODE_ENV=production pnpm nx build && cp ../../README.md README.md",
+    "prepack": "NODE_ENV=production pnpm nx build && pnpm oclif manifest && cp ../../README.md README.md",
     "vitest": "vitest",
     "type-check": "nx type-check"
   },

--- a/packages/plugin-did-you-mean/package.json
+++ b/packages/plugin-did-you-mean/package.json
@@ -31,7 +31,7 @@
     "clean": "nx clean",
     "lint": "nx lint",
     "lint:fix": "nx lint:fix",
-    "prepack": "NODE_ENV=production pnpm nx build && cp ../../README.md README.md",
+    "prepack": "NODE_ENV=production pnpm nx build && pnpm oclif manifest && cp ../../README.md README.md",
     "vitest": "vitest",
     "type-check": "nx type-check"
   },

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -30,7 +30,7 @@
     "clean": "nx clean",
     "lint": "nx lint",
     "lint:fix": "nx lint:fix",
-    "prepack": "NODE_ENV=production pnpm nx build && cp ../../README.md README.md",
+    "prepack": "NODE_ENV=production pnpm nx build && pnpm oclif manifest && cp ../../README.md README.md",
     "vitest": "vitest",
     "type-check": "nx type-check"
   },

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -31,7 +31,7 @@
     "clean": "nx clean",
     "lint": "nx lint",
     "lint:fix": "nx lint:fix",
-    "prepack": "NODE_ENV=production pnpm nx build && cp ../../README.md README.md",
+    "prepack": "NODE_ENV=production pnpm nx build && pnpm oclif manifest && cp ../../README.md README.md",
     "vitest": "vitest",
     "type-check": "nx type-check"
   },


### PR DESCRIPTION
### WHY are these changes introduced?

Snapshot and nightly releases were shipping stale `oclif.manifest.json` files because the manifest was not being regenerated during the `prepack` step. This meant published packages could have outdated command metadata.

### WHAT is this pull request doing?

Adds `pnpm oclif manifest` to the `prepack` script for all packages that include `/oclif.manifest.json` in their published files (`app`, `cli`, `create-app`, `plugin-cloudflare`, `plugin-did-you-mean`, and `theme`). This ensures the manifest is always freshly generated before a package is published.

A new repo-health test is also added to enforce this going forward — it checks that any package publishing `oclif.manifest.json` includes `pnpm oclif manifest` in its `prepack` script, preventing regressions.

### How to test your changes?

- Run the repo-health tests (`vitest`) and confirm the new `oclif manifest packaging` test passes.
- Trigger a prepack on one of the affected packages and verify that `oclif.manifest.json` is regenerated with up-to-date content.

### Measuring impact

- [x] n/a - this doesn't need measurement, e.g. a linting rule or a bug-fix

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes