### PR TITLE
Stop reporting user/environment errors as unexpected bugs

### DIFF
--- a/packages/cli-kit/src/public/node/error.test.ts
+++ b/packages/cli-kit/src/public/node/error.test.ts
@@ -74,4 +74,12 @@ describe('shouldReportErrorAsUnexpected helper', () => {
   test('returns false for user-aborted requests', () => {
     expect(shouldReportErrorAsUnexpected(new Error('The user aborted a request.'))).toBe(false)
   })
+
+  test('returns false for EPIPE errors', () => {
+    expect(shouldReportErrorAsUnexpected(new Error('write EPIPE'))).toBe(false)
+  })
+
+  test('returns false for unsupported platform errors', () => {
+    expect(shouldReportErrorAsUnexpected(new Error('Unsupported platform: win32 arm64 LE'))).toBe(false)
+  })
 })

--- a/packages/cli-kit/src/public/node/error.ts
+++ b/packages/cli-kit/src/public/node/error.ts
@@ -234,6 +234,8 @@ function errorMessageImpliesEnvironmentIssue(message: string): boolean {
     'spawn EPERM',
     'socket hang up',
     'The user aborted a request.',
+    'write EPIPE',
+    'Unsupported platform',
   ]
   const anyMatches = environmentIssueMessages.some((issueMessage) => message.includes(issueMessage))
   return anyMatches


### PR DESCRIPTION
## Summary

Adds 2 new patterns to `errorMessageImpliesEnvironmentIssue` in `cli-kit/error.ts` to prevent common user environment errors from being reported as unhandled CLI bugs in Bugsnag/error-analytics.

These errors are caused by the user's environment, not CLI bugs. They were showing up as `handled=false` (unexpected) in error-analytics, creating noise.

### Patterns added

| Pattern | Events (7d) | Cause | Observe |
|---------|-------------|-------|---------|
| `write EPIPE` | ~1,540 | User's process exits or terminal closes mid-output, breaking the pipe. Stacks are 100% `node:internal/stream_base_commons`. | [293820890752078061](https://observe.shopify.io/a/observe/errors/293820890752078061?r=%7B%22from%22%3A%22now-7d%22%2C%22to%22%3A%22now%22%7D&tz=browser&f=%7B%7D), [10594213926861919143](https://observe.shopify.io/a/observe/errors/10594213926861919143?r=%7B%22from%22%3A%22now-7d%22%2C%22to%22%3A%22now%22%7D&tz=browser&f=%7B%7D) |
| `Unsupported platform` | ~16 | User runs CLI on an unsupported OS/arch combination (e.g. win32 arm64). Stacks originate from `workerd/lib/main.js` platform check. | [12730362776183823558](https://observe.shopify.io/a/observe/errors/12730362776183823558?r=%7B%22from%22%3A%22now-7d%22%2C%22to%22%3A%22now%22%7D&tz=browser&f=%7B%7D) |

### Patterns considered but excluded

| Pattern | Reason |
|---------|--------|
| `Cannot find module` | ~1% of events are missing files inside `@shopify/cli/dist/` which could indicate packaging bugs. |
| `does not provide an export named` | Matches minified Shopify admin bundle errors (e.g. `FlowBasedAutomationsQuery...export 'f'`) — those are real bugs, not user issues. |
| `is not exported by` | Same concern — could match internal Shopify code bundle failures. |
| `Build failed` | Could mask real package bugs (e.g. our vite plugin or preset breaking builds). |
| `Build function failed` | Same — e.g. Hydrogen preset throws plain `Error` for unsupported config like `buildEnd`, which is our code. |

Each included pattern was verified by inspecting individual stack traces to confirm zero CLI/Shopify code is involved.

## Test plan

- [x] Added test cases for both new patterns in `error.test.ts`
- [x] All existing tests continue to pass
- [ ] Verify error volume reduction in Observe after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)