### PR TITLE
Remove HOSTED_APPS env var, make extension-only template the default

### DIFF
--- a/.changeset/ninety-doodles-scream.md
+++ b/.changeset/ninety-doodles-scream.md
@@ -1,0 +1,6 @@
+---
+'@shopify/cli-kit': minor
+'@shopify/app': minor
+---
+
+Update extension-only template to include app home by default

--- a/packages/app/src/cli/prompts/init/init.test.ts
+++ b/packages/app/src/cli/prompts/init/init.test.ts
@@ -1,4 +1,4 @@
-import init, {InitOptions} from './init.js'
+import init, {InitOptions, visibleTemplates} from './init.js'
 import {describe, expect, vi, test, beforeEach} from 'vitest'
 import {renderSelectPrompt} from '@shopify/cli-kit/node/ui'
 import {installGlobalCLIPrompt} from '@shopify/cli-kit/node/is-global'
@@ -29,15 +29,22 @@ describe('init', () => {
     expect(renderSelectPrompt).toHaveBeenCalledWith({
       choices: [
         {label: 'Build a React Router app (recommended)', value: 'reactRouter'},
-        {
-          label: 'Build an extension-only app (Shopify-hosted Preact app home and extensions, no back-end)',
-          value: 'none',
-        },
+        {label: 'Build an extension-only app', value: 'none'},
       ],
       message: 'Get started building your app:',
       defaultValue: 'reactRouter',
     })
     expect(got).toEqual({...options, ...answers, templateType: 'none', globalCLIResult})
+  })
+
+  describe('visibleTemplates', () => {
+    test('omits the deprecated remix template so it is not advertised in --template help text', () => {
+      expect(visibleTemplates).not.toContain('remix')
+    })
+
+    test('exposes only the templates that are still actively offered', () => {
+      expect(visibleTemplates).toEqual(['reactRouter', 'none'])
+    })
   })
 
   test('it renders branches for templates that have them', async () => {
@@ -58,7 +65,7 @@ describe('init', () => {
       choices: [
         {label: 'Build a React Router app (recommended)', value: 'reactRouter'},
         {
-          label: 'Build an extension-only app (Shopify-hosted Preact app home and extensions, no back-end)',
+          label: 'Build an extension-only app',
           value: 'none',
         },
       ],

--- a/packages/app/src/cli/prompts/init/init.test.ts
+++ b/packages/app/src/cli/prompts/init/init.test.ts
@@ -1,12 +1,10 @@
-import init, {buildNoneTemplate, InitOptions, visibleTemplates} from './init.js'
+import init, {InitOptions} from './init.js'
 import {describe, expect, vi, test, beforeEach} from 'vitest'
 import {renderSelectPrompt} from '@shopify/cli-kit/node/ui'
 import {installGlobalCLIPrompt} from '@shopify/cli-kit/node/is-global'
-import {isHostedAppsMode} from '@shopify/cli-kit/node/context/local'
 
 vi.mock('@shopify/cli-kit/node/ui')
 vi.mock('@shopify/cli-kit/node/is-global')
-vi.mock('@shopify/cli-kit/node/context/local')
 
 const globalCLIResult = {install: true, alreadyInstalled: false}
 
@@ -17,7 +15,7 @@ describe('init', () => {
 
   test('it renders the label for the template options', async () => {
     const answers = {
-      template: 'https://github.com/Shopify/shopify-app-template-none',
+      template: 'https://github.com/Shopify/shopify-app-template-extension-only',
     }
     const options: InitOptions = {}
 
@@ -31,46 +29,15 @@ describe('init', () => {
     expect(renderSelectPrompt).toHaveBeenCalledWith({
       choices: [
         {label: 'Build a React Router app (recommended)', value: 'reactRouter'},
-        {label: 'Build an extension-only app', value: 'none'},
+        {
+          label: 'Build an extension-only app (Shopify-hosted Preact app home and extensions, no back-end)',
+          value: 'none',
+        },
       ],
       message: 'Get started building your app:',
       defaultValue: 'reactRouter',
     })
     expect(got).toEqual({...options, ...answers, templateType: 'none', globalCLIResult})
-  })
-
-  describe('visibleTemplates', () => {
-    test('omits the deprecated remix template so it is not advertised in --template help text', () => {
-      expect(visibleTemplates).not.toContain('remix')
-    })
-
-    test('exposes only the templates that are still actively offered', () => {
-      expect(visibleTemplates).toEqual(['reactRouter', 'none'])
-    })
-  })
-
-  describe('buildNoneTemplate', () => {
-    test('returns extension-only template URL when HOSTED_APPS is enabled', () => {
-      // Given
-      vi.mocked(isHostedAppsMode).mockReturnValue(true)
-
-      // When
-      const got = buildNoneTemplate()
-
-      // Then
-      expect(got.url).toBe('https://github.com/Shopify/shopify-app-template-extension-only')
-    })
-
-    test('returns default template URL when HOSTED_APPS is not set', () => {
-      // Given
-      vi.mocked(isHostedAppsMode).mockReturnValue(false)
-
-      // When
-      const got = buildNoneTemplate()
-
-      // Then
-      expect(got.url).toBe('https://github.com/Shopify/shopify-app-template-none')
-    })
   })
 
   test('it renders branches for templates that have them', async () => {
@@ -90,7 +57,10 @@ describe('init', () => {
     expect(renderSelectPrompt).toHaveBeenCalledWith({
       choices: [
         {label: 'Build a React Router app (recommended)', value: 'reactRouter'},
-        {label: 'Build an extension-only app', value: 'none'},
+        {
+          label: 'Build an extension-only app (Shopify-hosted Preact app home and extensions, no back-end)',
+          value: 'none',
+        },
       ],
       message: 'Get started building your app:',
       defaultValue: 'reactRouter',

--- a/packages/app/src/cli/prompts/init/init.ts
+++ b/packages/app/src/cli/prompts/init/init.ts
@@ -59,7 +59,7 @@ export const templates = {
   } as Template,
   none: {
     url: 'https://github.com/Shopify/shopify-app-template-extension-only',
-    label: 'Build an extension-only app (Shopify-hosted Preact app home and extensions, no back-end)',
+    label: 'Build an extension-only app',
     visible: true,
   } as Template,
   node: {

--- a/packages/app/src/cli/prompts/init/init.ts
+++ b/packages/app/src/cli/prompts/init/init.ts
@@ -1,5 +1,4 @@
 import {InstallGlobalCLIPromptResult, installGlobalCLIPrompt} from '@shopify/cli-kit/node/is-global'
-import {isHostedAppsMode} from '@shopify/cli-kit/node/context/local'
 import {renderSelectPrompt} from '@shopify/cli-kit/node/ui'
 
 export interface InitOptions {
@@ -26,16 +25,6 @@ interface Template {
   branches?: {
     prompt: string
     options: {[key: string]: TemplateBranch}
-  }
-}
-
-export function buildNoneTemplate(): Template {
-  return {
-    url: isHostedAppsMode()
-      ? 'https://github.com/Shopify/shopify-app-template-extension-only'
-      : 'https://github.com/Shopify/shopify-app-template-none',
-    label: 'Build an extension-only app',
-    visible: true,
   }
 }
 
@@ -68,7 +57,11 @@ export const templates = {
       },
     },
   } as Template,
-  none: buildNoneTemplate(),
+  none: {
+    url: 'https://github.com/Shopify/shopify-app-template-extension-only',
+    label: 'Build an extension-only app (Shopify-hosted Preact app home and extensions, no back-end)',
+    visible: true,
+  } as Template,
   node: {
     url: 'https://github.com/Shopify/shopify-app-template-node',
     visible: false,
@@ -77,7 +70,7 @@ export const templates = {
     url: 'https://github.com/Shopify/shopify-app-template-ruby',
     visible: false,
   } as Template,
-}
+} as const
 type PredefinedTemplate = keyof typeof templates
 
 const allTemplates = Object.keys(templates) as Readonly<PredefinedTemplate[]>

--- a/packages/cli-kit/src/private/node/constants.ts
+++ b/packages/cli-kit/src/private/node/constants.ts
@@ -49,7 +49,6 @@ export const environmentVariables = {
   skipNetworkLevelRetry: 'SHOPIFY_CLI_SKIP_NETWORK_LEVEL_RETRY',
   maxRequestTimeForNetworkCalls: 'SHOPIFY_CLI_MAX_REQUEST_TIME_FOR_NETWORK_CALLS',
   disableImportScanning: 'SHOPIFY_CLI_DISABLE_IMPORT_SCANNING',
-  hostedApps: 'HOSTED_APPS',
 }
 
 export const defaultThemeKitAccessDomain = 'theme-kit-access.shopifyapps.com'

--- a/packages/cli-kit/src/private/node/constants.ts
+++ b/packages/cli-kit/src/private/node/constants.ts
@@ -20,7 +20,6 @@ export const environmentVariables = {
   enableCliRedirect: 'SHOPIFY_CLI_ENABLE_CLI_REDIRECT',
   env: 'SHOPIFY_CLI_ENV',
   firstPartyDev: 'SHOPIFY_CLI_1P_DEV',
-  hostedApps: 'HOSTED_APPS',
   noAnalytics: 'SHOPIFY_CLI_NO_ANALYTICS',
   optOutInstrumentation: 'OPT_OUT_INSTRUMENTATION',
   appAutomationToken: 'SHOPIFY_APP_AUTOMATION_TOKEN',

--- a/packages/cli-kit/src/public/node/context/local.test.ts
+++ b/packages/cli-kit/src/public/node/context/local.test.ts
@@ -2,7 +2,6 @@ import {
   ciPlatform,
   hasGit,
   isDevelopment,
-  isHostedAppsMode,
   isShopify,
   isTerminalInteractive,
   isUnitTest,
@@ -94,30 +93,6 @@ describe('isDevelopment', () => {
 
     // Then
     expect(got).toBe(true)
-  })
-})
-
-describe('isHostedAppsMode', () => {
-  test('returns true when HOSTED_APPS is truthy', () => {
-    // Given
-    const env = {HOSTED_APPS: '1'}
-
-    // When
-    const got = isHostedAppsMode(env)
-
-    // Then
-    expect(got).toBe(true)
-  })
-
-  test('returns false when HOSTED_APPS is not set', () => {
-    // Given
-    const env = {}
-
-    // When
-    const got = isHostedAppsMode(env)
-
-    // Then
-    expect(got).toBe(false)
   })
 })
 

--- a/packages/cli-kit/src/public/node/context/local.test.ts
+++ b/packages/cli-kit/src/public/node/context/local.test.ts
@@ -2,7 +2,6 @@ import {
   ciPlatform,
   hasGit,
   isDevelopment,
-  isHostedAppsMode,
   isShopify,
   isTerminalInteractive,
   isUnitTest,
@@ -81,30 +80,6 @@ describe('isUnitTest', () => {
 
     // Then
     expect(got).toBe(true)
-  })
-})
-
-describe('isHostedAppsMode', () => {
-  test('returns true when HOSTED_APPS is truthy', () => {
-    // Given
-    const env = {HOSTED_APPS: '1'}
-
-    // When
-    const got = isHostedAppsMode(env)
-
-    // Then
-    expect(got).toBe(true)
-  })
-
-  test('returns false when HOSTED_APPS is not set', () => {
-    // Given
-    const env = {}
-
-    // When
-    const got = isHostedAppsMode(env)
-
-    // Then
-    expect(got).toBe(false)
   })
 })
 

--- a/packages/cli-kit/src/public/node/context/local.ts
+++ b/packages/cli-kit/src/public/node/context/local.ts
@@ -55,16 +55,6 @@ export function isVerbose(env = process.env): boolean {
 }
 
 /**
- * Returns true if the hosted apps mode is enabled.
- *
- * @param env - The environment variables from the environment of the current process.
- * @returns True if HOSTED_APPS is truthy.
- */
-export function isHostedAppsMode(env = process.env): boolean {
-  return isTruthy(env[environmentVariables.hostedApps])
-}
-
-/**
  * Returns true if the environment in which the CLI is running is either
  * a local environment (where dev is present).
  *

--- a/packages/cli-kit/src/public/node/context/local.ts
+++ b/packages/cli-kit/src/public/node/context/local.ts
@@ -101,15 +101,6 @@ export function isUnitTest(env = process.env): boolean {
   return isTruthy(env[environmentVariables.unitTest])
 }
 
-/**
- * Returns true if the CLI is running in hosted apps mode.
- *
- * @param env - The environment variables from the environment of the current process.
- * @returns True if the HOSTED_APPS environment variable is truthy.
- */
-export function isHostedAppsMode(env = process.env): boolean {
-  return isTruthy(env[environmentVariables.hostedApps])
-}
 
 /**
  * Returns true if reporting analytics is enabled.

--- a/packages/cli-kit/src/public/node/context/local.ts
+++ b/packages/cli-kit/src/public/node/context/local.ts
@@ -101,7 +101,6 @@ export function isUnitTest(env = process.env): boolean {
   return isTruthy(env[environmentVariables.unitTest])
 }
 
-
 /**
  * Returns true if reporting analytics is enabled.
  *


### PR DESCRIPTION
**Hold on merging until we are ready to go live with the new template!**

Closes https://github.com/shop/issues-admin-extensibility/issues/2391

## Summary
- Removes the `HOSTED_APPS` environment variable gate introduced in #7096
- Makes the `shopify-app-template-extension-only` template the default for the "none" (extension-only) option in `shopify app init`, without requiring any env var

## Test plan
- [ ] On in this branch in the CLI, run `pnpm run shopify app init` (no `HOSTED_APPS` env var is needed)
- [ ] Choose extension-only option 
- [ ] Open the generated app and confirm that you have the app home extension 

🤖 Generated with [Claude Code](https://claude.com/claude-code)