### PR TITLE
Remove is-interactive, inline the TTY check

### DIFF
--- a/packages/cli-kit/package.json
+++ b/packages/cli-kit/package.json
@@ -137,7 +137,6 @@
     "ignore": "6.0.2",
     "ink": "6.8.0",
     "is-executable": "2.0.1",
-    "is-interactive": "2.0.0",
     "is-wsl": "3.1.0",
     "jose": "5.9.6",
     "latest-version": "7.0.0",

--- a/packages/cli-kit/src/public/node/context/local.test.ts
+++ b/packages/cli-kit/src/public/node/context/local.test.ts
@@ -4,6 +4,7 @@ import {
   isDevelopment,
   isHostedAppsMode,
   isShopify,
+  isTerminalInteractive,
   isUnitTest,
   analyticsDisabled,
   cloudEnvironment,
@@ -14,11 +15,61 @@ import {
 import {fileExists} from '../fs.js'
 import {exec} from '../system.js'
 
-import {expect, describe, vi, test} from 'vitest'
+import {afterEach, expect, describe, vi, test} from 'vitest'
 
 vi.mock('../fs.js')
 vi.mock('../system.js')
 vi.mock('../environment.js')
+
+describe('isTerminalInteractive', () => {
+  const originalIsTTY = process.stdout.isTTY
+  const originalEnv = {...process.env}
+
+  afterEach(() => {
+    process.stdout.isTTY = originalIsTTY
+    process.env.TERM = originalEnv.TERM
+    if (originalEnv.CI === undefined) {
+      delete process.env.CI
+    } else {
+      process.env.CI = originalEnv.CI
+    }
+  })
+
+  test('returns true when stdout is a TTY, TERM is not dumb, and not in CI', () => {
+    process.stdout.isTTY = true
+    delete process.env.CI
+    process.env.TERM = 'xterm-256color'
+    expect(isTerminalInteractive()).toBe(true)
+  })
+
+  test('returns false when stdout is not a TTY', () => {
+    process.stdout.isTTY = false
+    delete process.env.CI
+    process.env.TERM = 'xterm-256color'
+    expect(isTerminalInteractive()).toBe(false)
+  })
+
+  test('returns false when TERM is dumb', () => {
+    process.stdout.isTTY = true
+    delete process.env.CI
+    process.env.TERM = 'dumb'
+    expect(isTerminalInteractive()).toBe(false)
+  })
+
+  test('returns false when CI env var is set', () => {
+    process.stdout.isTTY = true
+    process.env.CI = 'true'
+    process.env.TERM = 'xterm-256color'
+    expect(isTerminalInteractive()).toBe(false)
+  })
+
+  test('returns false when CI env var is empty string (still set)', () => {
+    process.stdout.isTTY = true
+    process.env.CI = ''
+    process.env.TERM = 'xterm-256color'
+    expect(isTerminalInteractive()).toBe(false)
+  })
+})
 
 describe('isUnitTest', () => {
   test('returns true when SHOPIFY_UNIT_TEST is truthy', () => {

--- a/packages/cli-kit/src/public/node/context/local.ts
+++ b/packages/cli-kit/src/public/node/context/local.ts
@@ -4,7 +4,6 @@ import {defaultThemeKitAccessDomain, environmentVariables, pathConstants} from '
 import {fileExists} from '../fs.js'
 import {exec} from '../system.js'
 
-import isInteractive from 'is-interactive'
 import macaddress from 'macaddress'
 
 import {homedir} from 'os'
@@ -15,7 +14,7 @@ import {homedir} from 'os'
  * @returns True if the terminal is interactive.
  */
 export function isTerminalInteractive(): boolean {
-  return isInteractive()
+  return Boolean(process.stdout.isTTY && process.env.TERM !== 'dumb' && !('CI' in process.env))
 }
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -396,9 +396,6 @@ importers:
       is-executable:
         specifier: 2.0.1
         version: 2.0.1
-      is-interactive:
-        specifier: 2.0.0
-        version: 2.0.0
       is-wsl:
         specifier: 3.1.0
         version: 3.1.0
@@ -6253,10 +6250,6 @@ packages:
   is-interactive@1.0.0:
     resolution: {integrity: sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==}
     engines: {node: '>=8'}
-
-  is-interactive@2.0.0:
-    resolution: {integrity: sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==}
-    engines: {node: '>=12'}
 
   is-lower-case@2.0.2:
     resolution: {integrity: sha512-bVcMJy4X5Og6VZfdOZstSexlEy20Sr0k/p/b2IlQJlfdKAQuMpiv5w2Ccxb8sKdRUNAG1PnHVHjFSdRDVS6NlQ==}
@@ -15884,8 +15877,6 @@ snapshots:
       is-docker: 3.0.0
 
   is-interactive@1.0.0: {}
-
-  is-interactive@2.0.0: {}
 
   is-lower-case@2.0.2:
     dependencies:


### PR DESCRIPTION
## Summary
- Replace `is-interactive` package with inline logic: `process.stdout.isTTY && TERM !== 'dumb' && !CI`
- The package was 6 lines; the inline replacement is identical behavior
- Works cross-OS: `isTTY` is a Node.js built-in available on all platforms

## Test plan
- [x] 5 new tests covering all branches (TTY, non-TTY, dumb terminal, CI set, CI empty string)
- [x] All 29 local.test.ts tests pass
- [x] `tsc --noEmit` passes
- [x] Lint passes