### PR TITLE
Run web build commands during deploy for hosted apps

### DIFF
--- a/packages/app/src/cli/services/deploy/bundle.test.ts
+++ b/packages/app/src/cli/services/deploy/bundle.test.ts
@@ -1,13 +1,15 @@
 import {bundleAndBuildExtensions} from './bundle.js'
 import {testApp, testFunctionExtension, testThemeExtensions, testUIExtension} from '../../models/app/app.test-data.js'
-import {AppInterface, AppManifest} from '../../models/app/app.js'
+import {AppInterface, AppManifest, WebType} from '../../models/app/app.js'
 import * as bundle from '../bundle.js'
 import * as functionBuild from '../function/build.js'
+import * as webService from '../web.js'
 import {describe, expect, test, vi} from 'vitest'
 import * as file from '@shopify/cli-kit/node/fs'
 import {joinPath} from '@shopify/cli-kit/node/path'
 
 vi.mock('../function/build.js')
+vi.mock('../web.js')
 
 describe('bundleAndBuildExtensions', () => {
   let app: AppInterface
@@ -251,6 +253,153 @@ describe('bundleAndBuildExtensions', () => {
       expect(extensionBuildMock).not.toHaveBeenCalled()
       expect(extensionCopyIntoBundleMock).toHaveBeenCalledTimes(1)
       await expect(file.fileExists(bundlePath)).resolves.toBeTruthy()
+    })
+  })
+
+  test('runs web build command concurrently with extensions when build command is defined', async () => {
+    await file.inTemporaryDirectory(async (tmpDir: string) => {
+      // Given
+      const bundlePath = joinPath(tmpDir, 'bundle.zip')
+      const mockBuildWeb = vi.mocked(webService.default)
+
+      const functionExtension = await testFunctionExtension()
+      const extensionBuildMock = vi.fn().mockImplementation(async (options, bundleDirectory) => {
+        file.writeFileSync(joinPath(bundleDirectory, 'index.wasm'), '')
+      })
+      functionExtension.buildForBundle = extensionBuildMock
+
+      const app = testApp({
+        allExtensions: [functionExtension],
+        directory: tmpDir,
+        webs: [
+          {
+            directory: '/tmp/web',
+            configuration: {
+              roles: [WebType.Backend],
+              commands: {dev: 'npm run dev', build: 'npm run build'},
+            },
+          },
+        ],
+      })
+
+      const identifiers = {
+        app: 'app-id',
+        extensions: {[functionExtension.localIdentifier]: functionExtension.localIdentifier},
+        extensionIds: {},
+        extensionsNonUuidManaged: {},
+      }
+      appManifest = await app.manifest(identifiers)
+
+      // When
+      await bundleAndBuildExtensions({
+        app,
+        appManifest,
+        identifiers,
+        bundlePath,
+        skipBuild: false,
+        isDevDashboardApp: false,
+      })
+
+      // Then
+      expect(mockBuildWeb).toHaveBeenCalledWith('build', expect.objectContaining({web: app.webs[0]}))
+    })
+  })
+
+  test('skips web build for webs without a build command defined', async () => {
+    await file.inTemporaryDirectory(async (tmpDir: string) => {
+      // Given
+      const bundlePath = joinPath(tmpDir, 'bundle.zip')
+      const mockBuildWeb = vi.mocked(webService.default)
+
+      const functionExtension = await testFunctionExtension()
+      const extensionBuildMock = vi.fn().mockImplementation(async (options, bundleDirectory) => {
+        file.writeFileSync(joinPath(bundleDirectory, 'index.wasm'), '')
+      })
+      functionExtension.buildForBundle = extensionBuildMock
+
+      const app = testApp({
+        allExtensions: [functionExtension],
+        directory: tmpDir,
+        webs: [
+          {
+            directory: '/tmp/web',
+            configuration: {
+              roles: [WebType.Backend],
+              commands: {dev: 'npm run dev'},
+            },
+          },
+        ],
+      })
+
+      const identifiers = {
+        app: 'app-id',
+        extensions: {[functionExtension.localIdentifier]: functionExtension.localIdentifier},
+        extensionIds: {},
+        extensionsNonUuidManaged: {},
+      }
+      appManifest = await app.manifest(identifiers)
+
+      // When
+      await bundleAndBuildExtensions({
+        app,
+        appManifest,
+        identifiers,
+        bundlePath,
+        skipBuild: false,
+        isDevDashboardApp: false,
+      })
+
+      // Then
+      expect(mockBuildWeb).not.toHaveBeenCalled()
+    })
+  })
+
+  test('skips web build command when skipBuild is true', async () => {
+    await file.inTemporaryDirectory(async (tmpDir: string) => {
+      // Given
+      const bundlePath = joinPath(tmpDir, 'bundle.zip')
+      const mockBuildWeb = vi.mocked(webService.default)
+
+      const functionExtension = await testFunctionExtension()
+      const extensionCopyMock = vi.fn().mockImplementation(async (options, bundleDirectory) => {
+        file.writeFileSync(joinPath(bundleDirectory, 'index.wasm'), '')
+      })
+      functionExtension.copyIntoBundle = extensionCopyMock
+
+      const app = testApp({
+        allExtensions: [functionExtension],
+        directory: tmpDir,
+        webs: [
+          {
+            directory: '/tmp/web',
+            configuration: {
+              roles: [WebType.Backend],
+              commands: {dev: 'npm run dev', build: 'npm run build'},
+            },
+          },
+        ],
+      })
+
+      const identifiers = {
+        app: 'app-id',
+        extensions: {[functionExtension.localIdentifier]: functionExtension.localIdentifier},
+        extensionIds: {},
+        extensionsNonUuidManaged: {},
+      }
+      appManifest = await app.manifest(identifiers)
+
+      // When
+      await bundleAndBuildExtensions({
+        app,
+        appManifest,
+        identifiers,
+        bundlePath,
+        skipBuild: true,
+        isDevDashboardApp: false,
+      })
+
+      // Then
+      expect(mockBuildWeb).not.toHaveBeenCalled()
     })
   })
 

--- a/packages/app/src/cli/services/deploy/bundle.ts
+++ b/packages/app/src/cli/services/deploy/bundle.ts
@@ -1,6 +1,7 @@
 import {AppInterface, AppManifest} from '../../models/app/app.js'
 import {Identifiers} from '../../models/app/identifiers.js'
 import {installJavy} from '../function/build.js'
+import buildWeb from '../web.js'
 import {compressBundle, writeManifestToBundle} from '../bundle.js'
 import {AbortSignal} from '@shopify/cli-kit/node/abort'
 import {mkdir, rmdir} from '@shopify/cli-kit/node/fs'
@@ -30,33 +31,45 @@ export async function bundleAndBuildExtensions(options: BundleOptions) {
     await installJavy(options.app)
   }
 
-  await renderConcurrent({
-    processes: options.app.allExtensions.map((extension) => {
-      return {
-        prefix: extension.localIdentifier,
-        action: async (stdout: Writable, stderr: Writable, signal: AbortSignal) => {
-          // This outputId is the UID for AppManagement, and UUID for Partners
-          // Comes from the matching logic in `ensureDeployContext`
-          const outputId = options.isDevDashboardApp
-            ? undefined
-            : options.identifiers?.extensions[extension.localIdentifier]
+  const webBuildProcesses = options.skipBuild
+    ? []
+    : options.app.webs
+        .filter((web) => web.configuration.commands.build)
+        .map((web) => ({
+          prefix: ['web', ...web.configuration.roles].join('-'),
+          action: async (stdout: Writable, stderr: Writable, signal: AbortSignal) => {
+            if (options.skipBuild) return
+            await buildWeb('build', {web, stdout, stderr, signal})
+          },
+        }))
 
-          if (options.skipBuild) {
-            await extension.copyIntoBundle(
-              {stderr, stdout, signal, app: options.app, environment: 'production'},
-              bundleDirectory,
-              outputId,
-            )
-          } else {
-            await extension.buildForBundle(
-              {stderr, stdout, signal, app: options.app, environment: 'production'},
-              bundleDirectory,
-              outputId,
-            )
-          }
-        },
+  const extensionBuildProcesses = options.app.allExtensions.map((extension) => ({
+    prefix: extension.localIdentifier,
+    action: async (stdout: Writable, stderr: Writable, signal: AbortSignal) => {
+      // This outputId is the UID for AppManagement, and UUID for Partners
+      // Comes from the matching logic in `ensureDeployContext`
+      const outputId = options.isDevDashboardApp
+        ? undefined
+        : options.identifiers?.extensions[extension.localIdentifier]
+
+      if (options.skipBuild) {
+        await extension.copyIntoBundle(
+          {stderr, stdout, signal, app: options.app, environment: 'production'},
+          bundleDirectory,
+          outputId,
+        )
+      } else {
+        await extension.buildForBundle(
+          {stderr, stdout, signal, app: options.app, environment: 'production'},
+          bundleDirectory,
+          outputId,
+        )
       }
-    }),
+    },
+  }))
+
+  await renderConcurrent({
+    processes: [webBuildProcesses, extensionBuildProcesses].flat(),
     showTimestamps: false,
   })
 


### PR DESCRIPTION
Closes https://github.com/shop/issues-admin-extensibility/issues/2398

## Summary

- `bundleAndBuildExtensions` now runs `web.toml` `build` commands concurrently alongside extension bundling during `shopify app deploy`
- Scoped to webs that explicitly define a `build` command — extension-only apps and dev-only webs are unaffected
- Respects `--no-build` / `skipBuild` flag

**Root cause:** `deploy` called `bundleAndBuildExtensions` (extensions only) but never invoked `buildWeb('build', ...)`, unlike `shopify app build` which does. Users had to manually run `build` before `deploy`.

Closes shop/issues-admin-extensibility#2398

## Manual test instructions

**Setup:** You need an app with a `web/` directory and a `web.toml` that defines a `build` command:

```toml
# web/web.toml
[commands]
dev = "npm run dev"
build = "npm run build"
```

**Test: build command runs on deploy**
1. Make a change to your web app source that only reflects after a build
2. Run `shopify app deploy`
3. Confirm your `build` command output appears in the concurrent output alongside extensions
4. Confirm the deploy succeeds

**Test: `--no-build` skips web build**
1. Run `shopify app deploy --no-build`
2. Confirm the `build` command does NOT run (no web-prefixed process in output)

**Test: extension-only apps unaffected**
1. Use an app whose `web.toml` has no `build` command (or no webs at all)
2. Run `shopify app deploy` — confirm no new web-prefixed process appears in output

## Test plan

- [x] `runs web build command concurrently with extensions when build command is defined`
- [x] `skips web build for webs without a build command defined`
- [x] `skips web build command when skipBuild is true`
- [ ] Manual test with a hosted app
- [ ] Manual test with `--no-build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)