### PR TITLE
Extract custom watch paths to specifications

### DIFF
--- a/packages/app/src/cli/models/app/loader.test.ts
+++ b/packages/app/src/cli/models/app/loader.test.ts
@@ -2070,12 +2070,9 @@ describe('load', () => {
     const app = await loadTestingApp()
 
     // Then
-    expect(app.allExtensions).toHaveLength(7)
+    expect(app.allExtensions).toHaveLength(6)
     const extensionsConfig = app.allExtensions.map((ext) => ext.configuration)
     expect(extensionsConfig).toEqual([
-      expect.objectContaining({
-        name: 'for-testing',
-      }),
       expect.objectContaining({
         name: 'for-testing',
       }),
@@ -2131,12 +2128,9 @@ describe('load', () => {
     const app = await loadTestingApp({remoteFlags: []})
 
     // Then
-    expect(app.allExtensions).toHaveLength(8)
+    expect(app.allExtensions).toHaveLength(7)
     const extensionsConfig = app.allExtensions.map((ext) => ext.configuration)
     expect(extensionsConfig).toEqual([
-      {
-        name: 'for-testing-webhooks',
-      },
       {
         name: 'for-testing-webhooks',
       },

--- a/packages/app/src/cli/models/app/loader.test.ts
+++ b/packages/app/src/cli/models/app/loader.test.ts
@@ -2070,9 +2070,12 @@ describe('load', () => {
     const app = await loadTestingApp()
 
     // Then
-    expect(app.allExtensions).toHaveLength(6)
+    expect(app.allExtensions).toHaveLength(7)
     const extensionsConfig = app.allExtensions.map((ext) => ext.configuration)
     expect(extensionsConfig).toEqual([
+      expect.objectContaining({
+        name: 'for-testing',
+      }),
       expect.objectContaining({
         name: 'for-testing',
       }),
@@ -2128,9 +2131,12 @@ describe('load', () => {
     const app = await loadTestingApp({remoteFlags: []})
 
     // Then
-    expect(app.allExtensions).toHaveLength(7)
+    expect(app.allExtensions).toHaveLength(8)
     const extensionsConfig = app.allExtensions.map((ext) => ext.configuration)
     expect(extensionsConfig).toEqual([
+      {
+        name: 'for-testing-webhooks',
+      },
       {
         name: 'for-testing-webhooks',
       },

--- a/packages/app/src/cli/models/extensions/extension-instance.test.ts
+++ b/packages/app/src/cli/models/extensions/extension-instance.test.ts
@@ -570,6 +570,36 @@ describe('draftMessages', async () => {
   })
 })
 
+describe('devSessionWatchConfig', () => {
+  test('returns undefined for extension experience (watch everything)', async () => {
+    const extensionInstance = await testUIExtension({type: 'ui_extension'})
+    expect(extensionInstance.devSessionWatchConfig).toBeUndefined()
+  })
+
+  test('returns empty paths for configuration experience (watch nothing)', async () => {
+    const extensionInstance = await testAppConfigExtensions()
+    expect(extensionInstance.devSessionWatchConfig).toEqual({paths: []})
+  })
+
+  test('delegates to specification devSessionWatchConfig when defined', async () => {
+    const config = functionConfiguration()
+    config.build = {
+      watch: 'src/**/*.rs',
+      wasm_opt: true,
+    }
+    const extensionInstance = await testFunctionExtension({config, dir: '/tmp/my-function'})
+    const watchConfig = extensionInstance.devSessionWatchConfig
+    expect(watchConfig).toBeDefined()
+    expect(watchConfig!.paths).toContain(joinPath('/tmp/my-function', 'src/**/*.rs'))
+  })
+
+  test('returns undefined for function extension without build.watch', async () => {
+    const config = functionConfiguration()
+    const extensionInstance = await testFunctionExtension({config})
+    expect(extensionInstance.devSessionWatchConfig).toBeUndefined()
+  })
+})
+
 describe('watchedFiles', async () => {
   test('returns files based on devSessionWatchPaths when defined', async () => {
     await inTemporaryDirectory(async (tmpDir) => {
@@ -604,6 +634,58 @@ describe('watchedFiles', async () => {
 
       // Clean up
       vi.mocked(extractImportPathsRecursively).mockReset()
+    })
+  })
+
+  test('respects custom ignore paths from devSessionWatchConfig', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given - create an extension with a spec that defines custom ignore paths
+      const config = functionConfiguration()
+      config.build = {
+        watch: '**/*',
+        wasm_opt: true,
+      }
+      const extensionInstance = await testFunctionExtension({
+        config,
+        dir: tmpDir,
+      })
+
+      // Override devSessionWatchConfig to include ignore paths
+      vi.spyOn(extensionInstance, 'devSessionWatchConfig', 'get').mockReturnValue({
+        paths: [joinPath(tmpDir, '**/*')],
+        ignore: ['**/ignored-dir/**'],
+      })
+
+      // Create files - one in a normal dir, one in the ignored dir
+      const srcDir = joinPath(tmpDir, 'src')
+      const ignoredDir = joinPath(tmpDir, 'ignored-dir')
+      await mkdir(srcDir)
+      await mkdir(ignoredDir)
+      await writeFile(joinPath(srcDir, 'index.js'), 'code')
+      await writeFile(joinPath(ignoredDir, 'should-be-ignored.js'), 'ignored')
+
+      // When
+      const watchedFiles = extensionInstance.watchedFiles()
+
+      // Then
+      expect(watchedFiles).toContain(joinPath(srcDir, 'index.js'))
+      expect(watchedFiles).not.toContain(joinPath(ignoredDir, 'should-be-ignored.js'))
+    })
+  })
+
+  test('returns empty watched files for configuration extensions', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      const extensionInstance = await testAppConfigExtensions(false, tmpDir)
+
+      // Create files that should not be watched
+      await writeFile(joinPath(tmpDir, 'some-file.ts'), 'code')
+
+      // When
+      const watchedFiles = extensionInstance.watchedFiles()
+
+      // Then - configuration extensions default to empty paths, so no files watched
+      expect(watchedFiles).toHaveLength(0)
     })
   })
 

--- a/packages/app/src/cli/models/extensions/extension-instance.ts
+++ b/packages/app/src/cli/models/extensions/extension-instance.ts
@@ -1,6 +1,6 @@
 import {BaseConfigType, MAX_EXTENSION_HANDLE_LENGTH, MAX_UID_LENGTH} from './schemas.js'
 import {FunctionConfigType} from './specifications/function.js'
-import {ExtensionFeature, ExtensionSpecification} from './specification.js'
+import {DevSessionWatchConfig, ExtensionFeature, ExtensionSpecification} from './specification.js'
 import {SingleWebhookSubscriptionType} from './specifications/app_config_webhook_schemas/webhooks_schema.js'
 import {ExtensionBuildOptions, bundleFunctionExtension} from '../../services/build/extension.js'
 import {bundleThemeExtension} from '../../services/extensions/bundle.js'
@@ -277,20 +277,15 @@ export class ExtensionInstance<TConfiguration extends BaseConfigType = BaseConfi
     return [this.entrySourceFilePath]
   }
 
-  // Custom paths to be watched in a dev session
-  // Return undefiend if there aren't custom configured paths (everything is watched)
-  // If there are, include some default paths.
-  get devSessionCustomWatchPaths() {
-    const config = this.configuration as unknown as FunctionConfigType
-    if (!config.build || !config.build.watch) return undefined
+  // Custom watch configuration for dev sessions
+  // Return undefined to watch everything (default for 'extension' experience)
+  // Return a config with empty paths to watch nothing (default for 'configuration' experience)
+  get devSessionWatchConfig(): DevSessionWatchConfig | undefined {
+    if (this.specification.devSessionWatchConfig) {
+      return this.specification.devSessionWatchConfig(this)
+    }
 
-    const watchPaths = [config.build.watch].flat().map((path) => joinPath(this.directory, path))
-
-    watchPaths.push(joinPath(this.directory, 'locales', '**.json'))
-    watchPaths.push(joinPath(this.directory, '**', '!(.)*.graphql'))
-    watchPaths.push(joinPath(this.directory, '**.toml'))
-
-    return watchPaths
+    return this.specification.experience === 'configuration' ? {paths: []} : undefined
   }
 
   async watchConfigurationPaths() {
@@ -436,20 +431,31 @@ export class ExtensionInstance<TConfiguration extends BaseConfigType = BaseConfi
   watchedFiles(): string[] {
     const watchedFiles: string[] = []
 
-    // Add extension directory files based on devSessionCustomWatchPaths or all files
-    const patterns = this.devSessionCustomWatchPaths ?? ['**/*']
+    const defaultIgnore = [
+      '**/node_modules/**',
+      '**/.git/**',
+      '**/*.test.*',
+      '**/dist/**',
+      '**/*.swp',
+      '**/generated/**',
+      '**/.gitignore',
+    ]
+    const watchConfig = this.devSessionWatchConfig
+
+    const patterns = watchConfig?.paths ?? ['**/*']
+    const ignore = watchConfig?.ignore ?? defaultIgnore
     const files = patterns.flatMap((pattern) =>
       globSync(pattern, {
         cwd: this.directory,
         absolute: true,
         followSymbolicLinks: false,
-        ignore: ['**/node_modules/**', '**/.git/**', '**/dist/**', '**/*.swp', '**/generated/**'],
+        ignore,
       }),
     )
     watchedFiles.push(...files.flat())
 
-    // Add imported files from outside the extension directory unless custom watch paths are defined
-    if (!this.devSessionCustomWatchPaths) {
+    // Add imported files from outside the extension directory unless custom watch config is defined
+    if (!watchConfig) {
       const importedFiles = this.scanImports()
       watchedFiles.push(...importedFiles)
     }

--- a/packages/app/src/cli/models/extensions/specification.ts
+++ b/packages/app/src/cli/models/extensions/specification.ts
@@ -136,6 +136,20 @@ export interface ExtensionSpecification<TConfiguration extends BaseConfigType = 
    * Copy static assets from the extension directory to the output path
    */
   copyStaticAssets?: (configuration: TConfiguration, directory: string, outputPath: string) => Promise<void>
+
+  /**
+   * Custom watch configuration for dev sessions.
+   * Return a DevSessionWatchConfig with paths to watch and optionally paths to ignore,
+   * or undefined to watch all files in the extension directory.
+   */
+  devSessionWatchConfig?: (extension: ExtensionInstance<TConfiguration>) => DevSessionWatchConfig | undefined
+}
+
+export interface DevSessionWatchConfig {
+  /** Absolute paths or globs to watch */
+  paths: string[]
+  /** Additional glob patterns to ignore (on top of the default ignore list) */
+  ignore?: string[]
 }
 
 /**
@@ -294,6 +308,7 @@ export function createContractBasedModuleSpecification<TConfiguration extends Ba
     | 'clientSteps'
     | 'experience'
     | 'transformRemoteToLocal'
+    | 'devSessionWatchConfig'
   >,
 ) {
   return createExtensionSpecification({

--- a/packages/app/src/cli/models/extensions/specification.ts
+++ b/packages/app/src/cli/models/extensions/specification.ts
@@ -320,6 +320,7 @@ export function createContractBasedModuleSpecification<TConfiguration extends Ba
     clientSteps: spec.clientSteps,
     uidStrategy: spec.uidStrategy,
     transformRemoteToLocal: spec.transformRemoteToLocal,
+    devSessionWatchConfig: spec.devSessionWatchConfig,
     deployConfig: async (config, directory) => {
       let parsedConfig = configWithoutFirstClassFields(config)
       if (spec.appModuleFeatures().includes('localization')) {

--- a/packages/app/src/cli/models/extensions/specification.ts
+++ b/packages/app/src/cli/models/extensions/specification.ts
@@ -148,7 +148,7 @@ export interface ExtensionSpecification<TConfiguration extends BaseConfigType = 
 export interface DevSessionWatchConfig {
   /** Absolute paths or globs to watch */
   paths: string[]
-  /** Additional glob patterns to ignore (on top of the default ignore list) */
+  /** Glob patterns to ignore. When provided, replaces the default ignore list entirely. */
   ignore?: string[]
 }
 

--- a/packages/app/src/cli/models/extensions/specifications/admin.ts
+++ b/packages/app/src/cli/models/extensions/specifications/admin.ts
@@ -1,9 +1,9 @@
 import {createExtensionSpecification} from '../specification.js'
-import {BaseSchemaWithoutHandle} from '../schemas.js'
+import {BaseConfigType, ZodSchemaType} from '../schemas.js'
 import {zod} from '@shopify/cli-kit/node/schema'
 import {joinPath} from '@shopify/cli-kit/node/path'
 
-const AdminSchema = BaseSchemaWithoutHandle.extend({
+const AdminSchema = zod.object({
   admin: zod
     .object({
       static_root: zod.string().optional(),
@@ -11,11 +11,13 @@ const AdminSchema = BaseSchemaWithoutHandle.extend({
     .optional(),
 })
 
-const adminSpecificationSpec = createExtensionSpecification({
+type AdminConfigType = zod.infer<typeof AdminSchema> & BaseConfigType
+
+const adminSpecificationSpec = createExtensionSpecification<AdminConfigType>({
   identifier: 'admin',
   uidStrategy: 'single',
   experience: 'configuration',
-  schema: AdminSchema,
+  schema: AdminSchema as ZodSchemaType<AdminConfigType>,
   deployConfig: async (config, _) => {
     return {admin: config.admin}
   },

--- a/packages/app/src/cli/models/extensions/specifications/admin.ts
+++ b/packages/app/src/cli/models/extensions/specifications/admin.ts
@@ -1,8 +1,31 @@
-import {createContractBasedModuleSpecification} from '../specification.js'
+import {createExtensionSpecification} from '../specification.js'
+import {BaseSchemaWithoutHandle} from '../schemas.js'
+import {zod} from '@shopify/cli-kit/node/schema'
+import {joinPath} from '@shopify/cli-kit/node/path'
 
-const adminSpecificationSpec = createContractBasedModuleSpecification({
+const AdminSchema = BaseSchemaWithoutHandle.extend({
+  admin: zod
+    .object({
+      static_root: zod.string().optional(),
+    })
+    .optional(),
+})
+
+const adminSpecificationSpec = createExtensionSpecification({
   identifier: 'admin',
   uidStrategy: 'single',
+  experience: 'configuration',
+  schema: AdminSchema,
+  deployConfig: async (config, _) => {
+    return {admin: config.admin}
+  },
+  devSessionWatchConfig: (extension) => {
+    const staticRoot = extension.configuration.admin?.static_root
+    if (!staticRoot) return {paths: []}
+
+    const path = joinPath(extension.directory, staticRoot, '**/*')
+    return {paths: [path], ignore: []}
+  },
   transformRemoteToLocal: (remoteContent) => {
     return {
       admin: {

--- a/packages/app/src/cli/models/extensions/specifications/function.ts
+++ b/packages/app/src/cli/models/extensions/specifications/function.ts
@@ -90,6 +90,18 @@ const functionSpec = createExtensionSpecification({
   appModuleFeatures: (_) => ['function'],
   buildConfig: {mode: 'function'},
   getOutputRelativePath: (_extension: ExtensionInstance<FunctionConfigType>) => joinPath('dist', 'index.wasm'),
+  devSessionWatchConfig: (extension: ExtensionInstance<FunctionConfigType>) => {
+    const config = extension.configuration
+    if (!config.build || !config.build.watch) return undefined
+
+    const paths = [config.build.watch].flat().map((path) => joinPath(extension.directory, path))
+
+    paths.push(joinPath(extension.directory, 'locales', '**.json'))
+    paths.push(joinPath(extension.directory, '**', '!(.)*.graphql'))
+    paths.push(joinPath(extension.directory, '**.toml'))
+
+    return {paths}
+  },
   clientSteps: [
     {
       lifecycle: 'deploy',

--- a/packages/app/src/cli/services/dev/app-events/file-watcher.test.ts
+++ b/packages/app/src/cli/services/dev/app-events/file-watcher.test.ts
@@ -274,6 +274,7 @@ describe('file-watcher events', () => {
 
       // Then
       expect(watchSpy).toHaveBeenCalledWith([joinPath(dir, '/shopify.app.toml'), joinPath(dir, '/extensions')], {
+        ignored: ['**/node_modules/**', '**/.git/**'],
         ignoreInitial: true,
         persistent: true,
       })

--- a/packages/app/src/cli/services/dev/app-events/file-watcher.test.ts
+++ b/packages/app/src/cli/services/dev/app-events/file-watcher.test.ts
@@ -274,15 +274,6 @@ describe('file-watcher events', () => {
 
       // Then
       expect(watchSpy).toHaveBeenCalledWith([joinPath(dir, '/shopify.app.toml'), joinPath(dir, '/extensions')], {
-        ignored: [
-          '**/node_modules/**',
-          '**/.git/**',
-          '**/*.test.*',
-          '**/dist/**',
-          '**/*.swp',
-          '**/generated/**',
-          '**/.gitignore',
-        ],
         ignoreInitial: true,
         persistent: true,
       })

--- a/packages/app/src/cli/services/dev/app-events/file-watcher.ts
+++ b/packages/app/src/cli/services/dev/app-events/file-watcher.ts
@@ -118,15 +118,6 @@ export class FileWatcher {
     // Create new watcher
     const {default: chokidar} = await import('chokidar')
     this.watcher = chokidar.watch(watchPaths, {
-      ignored: [
-        '**/node_modules/**',
-        '**/.git/**',
-        '**/*.test.*',
-        '**/dist/**',
-        '**/*.swp',
-        '**/generated/**',
-        '**/.gitignore',
-      ],
       persistent: true,
       ignoreInitial: true,
     })

--- a/packages/app/src/cli/services/dev/app-events/file-watcher.ts
+++ b/packages/app/src/cli/services/dev/app-events/file-watcher.ts
@@ -118,6 +118,7 @@ export class FileWatcher {
     // Create new watcher
     const {default: chokidar} = await import('chokidar')
     this.watcher = chokidar.watch(watchPaths, {
+      ignored: ['**/node_modules/**', '**/.git/**'],
       persistent: true,
       ignoreInitial: true,
     })


### PR DESCRIPTION
### WHY are these changes introduced?

The current file watching system for dev sessions uses a hardcoded approach where function extensions have custom watch paths while other extensions watch everything. This creates inconsistent behavior and makes it difficult for different extension types to define their own watching requirements.

### WHAT is this pull request doing?

Refactors the dev session file watching system to use a specification-based approach:

- Replaces `devSessionCustomWatchPaths` with a new `devSessionWatchConfig` method on extension specifications
- Introduces a `DevSessionWatchConfig` interface that allows extensions to define both paths to watch and patterns to ignore
- Moves function-specific watch logic from the base `ExtensionInstance` class to the function specification
- Adds watch configuration for admin extensions that only watches the `static_root` directory when configured
- Sets default behavior where 'configuration' experience extensions watch nothing and 'extension' experience extensions watch everything
- Moves default ignore patterns from the file watcher service to the extension instance level

### How to test your changes?

1. Create a function extension with custom `build.watch` configuration and verify it only watches the specified paths plus default files (locales, GraphQL, TOML)
2. Create an admin extension with `static_root` configured and verify it only watches files in that directory
3. Create other extension types and verify they follow the default watching behavior based on their experience type
4. Run dev sessions and confirm file changes trigger rebuilds appropriately for each extension type

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing, so I've added a changelog entry with `pnpm changeset add`