### PR TITLE
Use detected package manager for function typegen

### DIFF
--- a/packages/app/src/cli/services/function/binaries.ts
+++ b/packages/app/src/cli/services/function/binaries.ts
@@ -14,7 +14,7 @@ import {fileURLToPath} from 'node:url'
 export const PREFERRED_FUNCTION_RUNNER_VERSION = '9.1.2'
 
 // Javy dependencies.
-export const PREFERRED_JAVY_VERSION = '8.1.1'
+export const PREFERRED_JAVY_VERSION = '7.0.1'
 // The Javy plugin version should match the plugin version used in the
 // function-runner version specified above.
 export const PREFERRED_JAVY_PLUGIN_VERSION = '3'

--- a/packages/app/src/cli/services/function/binaries.ts
+++ b/packages/app/src/cli/services/function/binaries.ts
@@ -14,7 +14,7 @@ import {fileURLToPath} from 'node:url'
 export const PREFERRED_FUNCTION_RUNNER_VERSION = '9.1.2'
 
 // Javy dependencies.
-export const PREFERRED_JAVY_VERSION = '7.0.1'
+export const PREFERRED_JAVY_VERSION = '8.1.1'
 // The Javy plugin version should match the plugin version used in the
 // function-runner version specified above.
 export const PREFERRED_JAVY_PLUGIN_VERSION = '3'

--- a/packages/app/src/cli/services/function/build.test.ts
+++ b/packages/app/src/cli/services/function/build.test.ts
@@ -22,12 +22,20 @@ import {
 import {testApp, testFunctionExtension} from '../../models/app/app.test-data.js'
 import {beforeEach, describe, expect, test, vi} from 'vitest'
 import {exec} from '@shopify/cli-kit/node/system'
+import {getPackageManager} from '@shopify/cli-kit/node/node-package-manager'
 import {dirname, joinPath} from '@shopify/cli-kit/node/path'
 import {inTemporaryDirectory, mkdir, readFileSync, writeFile, removeFile} from '@shopify/cli-kit/node/fs'
 import {build as esBuild} from 'esbuild'
 
 vi.mock('@shopify/cli-kit/node/fs')
 vi.mock('@shopify/cli-kit/node/system')
+vi.mock('@shopify/cli-kit/node/node-package-manager', async (importOriginal) => {
+  const actual: any = await importOriginal()
+  return {
+    ...actual,
+    getPackageManager: vi.fn().mockResolvedValue('npm'),
+  }
+})
 
 vi.mock('./binaries.js', async (importOriginal) => {
   const actual: any = await importOriginal()
@@ -76,6 +84,7 @@ beforeEach(async () => {
   stderr = {write: vi.fn()}
   stdout = {write: vi.fn()}
   signal = vi.fn()
+  vi.mocked(getPackageManager).mockResolvedValue('npm')
 })
 
 describe('buildGraphqlTypes', () => {

--- a/packages/app/src/cli/services/function/build.test.ts
+++ b/packages/app/src/cli/services/function/build.test.ts
@@ -22,7 +22,7 @@ import {
 import {testApp, testFunctionExtension} from '../../models/app/app.test-data.js'
 import {beforeEach, describe, expect, test, vi} from 'vitest'
 import {exec} from '@shopify/cli-kit/node/system'
-import {inferPackageManager} from '@shopify/cli-kit/node/node-package-manager'
+import {getPackageManager} from '@shopify/cli-kit/node/node-package-manager'
 import {dirname, joinPath} from '@shopify/cli-kit/node/path'
 import {inTemporaryDirectory, mkdir, readFileSync, writeFile, removeFile} from '@shopify/cli-kit/node/fs'
 import {build as esBuild} from 'esbuild'
@@ -33,7 +33,7 @@ vi.mock('@shopify/cli-kit/node/node-package-manager', async (importOriginal) => 
   const actual: any = await importOriginal()
   return {
     ...actual,
-    inferPackageManager: vi.fn().mockReturnValue('npm'),
+    getPackageManager: vi.fn().mockResolvedValue('npm'),
   }
 })
 
@@ -84,7 +84,7 @@ beforeEach(async () => {
   stderr = {write: vi.fn()}
   stdout = {write: vi.fn()}
   signal = vi.fn()
-  vi.mocked(inferPackageManager).mockReturnValue('npm')
+  vi.mocked(getPackageManager).mockResolvedValue('npm')
 })
 
 describe('buildGraphqlTypes', () => {

--- a/packages/app/src/cli/services/function/build.test.ts
+++ b/packages/app/src/cli/services/function/build.test.ts
@@ -22,7 +22,7 @@ import {
 import {testApp, testFunctionExtension} from '../../models/app/app.test-data.js'
 import {beforeEach, describe, expect, test, vi} from 'vitest'
 import {exec} from '@shopify/cli-kit/node/system'
-import {getPackageManager} from '@shopify/cli-kit/node/node-package-manager'
+import {inferPackageManager} from '@shopify/cli-kit/node/node-package-manager'
 import {dirname, joinPath} from '@shopify/cli-kit/node/path'
 import {inTemporaryDirectory, mkdir, readFileSync, writeFile, removeFile} from '@shopify/cli-kit/node/fs'
 import {build as esBuild} from 'esbuild'
@@ -33,7 +33,7 @@ vi.mock('@shopify/cli-kit/node/node-package-manager', async (importOriginal) => 
   const actual: any = await importOriginal()
   return {
     ...actual,
-    getPackageManager: vi.fn().mockResolvedValue('npm'),
+    inferPackageManager: vi.fn().mockReturnValue('npm'),
   }
 })
 
@@ -84,7 +84,7 @@ beforeEach(async () => {
   stderr = {write: vi.fn()}
   stdout = {write: vi.fn()}
   signal = vi.fn()
-  vi.mocked(getPackageManager).mockResolvedValue('npm')
+  vi.mocked(inferPackageManager).mockReturnValue('npm')
 })
 
 describe('buildGraphqlTypes', () => {

--- a/packages/app/src/cli/services/function/build.ts
+++ b/packages/app/src/cli/services/function/build.ts
@@ -19,7 +19,7 @@ import {exec} from '@shopify/cli-kit/node/system'
 import {dirname, joinPath} from '@shopify/cli-kit/node/path'
 import {build as esBuild, BuildResult} from 'esbuild'
 import {findPathUp, inTemporaryDirectory, readFile, readFileSync, writeFile} from '@shopify/cli-kit/node/fs'
-import {inferPackageManager} from '@shopify/cli-kit/node/node-package-manager'
+import {getPackageManager} from '@shopify/cli-kit/node/node-package-manager'
 import {AbortSignal} from '@shopify/cli-kit/node/abort'
 import {renderTasks} from '@shopify/cli-kit/node/ui'
 import {pickBy} from '@shopify/cli-kit/common/object'
@@ -144,7 +144,7 @@ export async function buildGraphqlTypes(
     )
   }
 
-  const packageManager = inferPackageManager(undefined)
+  const packageManager = await getPackageManager(fun.directory)
   return runWithTimer('cmd_all_timing_network_ms')(async () => {
     return exec(packageManager, ['exec', '--', 'graphql-code-generator', '--config', 'package.json'], {
       cwd: fun.directory,

--- a/packages/app/src/cli/services/function/build.ts
+++ b/packages/app/src/cli/services/function/build.ts
@@ -19,6 +19,7 @@ import {exec} from '@shopify/cli-kit/node/system'
 import {dirname, joinPath} from '@shopify/cli-kit/node/path'
 import {build as esBuild, BuildResult} from 'esbuild'
 import {findPathUp, inTemporaryDirectory, readFile, readFileSync, writeFile} from '@shopify/cli-kit/node/fs'
+import {getPackageManager} from '@shopify/cli-kit/node/node-package-manager'
 import {AbortSignal} from '@shopify/cli-kit/node/abort'
 import {renderTasks} from '@shopify/cli-kit/node/ui'
 import {pickBy} from '@shopify/cli-kit/common/object'
@@ -143,8 +144,9 @@ export async function buildGraphqlTypes(
     )
   }
 
+  const packageManager = await getPackageManager(fun.directory)
   return runWithTimer('cmd_all_timing_network_ms')(async () => {
-    return exec('npm', ['exec', '--', 'graphql-code-generator', '--config', 'package.json'], {
+    return exec(packageManager, ['exec', '--', 'graphql-code-generator', '--config', 'package.json'], {
       cwd: fun.directory,
       stderr: options.stderr,
       signal: options.signal,

--- a/packages/app/src/cli/services/function/build.ts
+++ b/packages/app/src/cli/services/function/build.ts
@@ -19,7 +19,7 @@ import {exec} from '@shopify/cli-kit/node/system'
 import {dirname, joinPath} from '@shopify/cli-kit/node/path'
 import {build as esBuild, BuildResult} from 'esbuild'
 import {findPathUp, inTemporaryDirectory, readFile, readFileSync, writeFile} from '@shopify/cli-kit/node/fs'
-import {getPackageManager} from '@shopify/cli-kit/node/node-package-manager'
+import {inferPackageManager} from '@shopify/cli-kit/node/node-package-manager'
 import {AbortSignal} from '@shopify/cli-kit/node/abort'
 import {renderTasks} from '@shopify/cli-kit/node/ui'
 import {pickBy} from '@shopify/cli-kit/common/object'
@@ -144,7 +144,7 @@ export async function buildGraphqlTypes(
     )
   }
 
-  const packageManager = await getPackageManager(fun.directory)
+  const packageManager = inferPackageManager(undefined)
   return runWithTimer('cmd_all_timing_network_ms')(async () => {
     return exec(packageManager, ['exec', '--', 'graphql-code-generator', '--config', 'package.json'], {
       cwd: fun.directory,

--- a/packages/cli-kit/src/public/node/node-package-manager.test.ts
+++ b/packages/cli-kit/src/public/node/node-package-manager.test.ts
@@ -889,6 +889,23 @@ describe('getPackageManager', () => {
     })
   })
 
+  test('finds lockfile at parent when subdirectory has its own package.json', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given: app root has pnpm-lock.yaml, function subdir has its own package.json
+      await writePackageJSON(tmpDir, {name: 'app-root'})
+      await writeFile(joinPath(tmpDir, 'pnpm-lock.yaml'), '')
+      const functionDir = joinPath(tmpDir, 'extensions', 'my-function')
+      await mkdir(functionDir)
+      await writePackageJSON(functionDir, {name: 'my-function'})
+
+      // When: detecting from the function subdirectory
+      const packageManager = await getPackageManager(functionDir)
+
+      // Then: finds pnpm-lock.yaml at the app root
+      expect(packageManager).toEqual('pnpm')
+    })
+  })
+
   test('falls back to packageManagerFromUserAgent when no package.json is found', async () => {
     await inTemporaryDirectory(async (tmpDir) => {
       // Given

--- a/packages/cli-kit/src/public/node/node-package-manager.test.ts
+++ b/packages/cli-kit/src/public/node/node-package-manager.test.ts
@@ -850,7 +850,6 @@ describe('getPackageManager', () => {
 
       // When
       await writePackageJSON(tmpDir, packageJSON)
-      mockedCaptureOutput.mockReturnValueOnce(Promise.resolve(tmpDir))
 
       // Then
       const packageManager = await getPackageManager(tmpDir)
@@ -867,7 +866,6 @@ describe('getPackageManager', () => {
       // When
       await writePackageJSON(tmpDir, packageJSON)
       await writeFile(yarnLock, '')
-      mockedCaptureOutput.mockReturnValueOnce(Promise.resolve(tmpDir))
 
       // Then
       const packageManager = await getPackageManager(tmpDir)
@@ -884,7 +882,6 @@ describe('getPackageManager', () => {
       // When
       await writePackageJSON(tmpDir, packageJSON)
       await writeFile(pnpmLock, '')
-      mockedCaptureOutput.mockReturnValueOnce(Promise.resolve(tmpDir))
 
       // Then
       const packageManager = await getPackageManager(tmpDir)
@@ -892,22 +889,17 @@ describe('getPackageManager', () => {
     })
   })
 
-  test('falls back to packageManagerFromUserAgent when npm prefix fails', async () => {
+  test('falls back to packageManagerFromUserAgent when no package.json is found', async () => {
     await inTemporaryDirectory(async (tmpDir) => {
       // Given
       vi.stubEnv('npm_config_user_agent', 'yarn/1.22.0')
-
-      // Mock npm prefix to fail
-      mockedCaptureOutput.mockRejectedValueOnce(new Error('npm prefix failed'))
 
       // When
       const packageManager = await getPackageManager(tmpDir)
 
       // Then
-      expect(mockedCaptureOutput).toHaveBeenCalledWith('npm', ['prefix'], expect.anything())
       expect(packageManager).toEqual('yarn')
 
-      // Restore original implementation
       vi.unstubAllEnvs()
     })
   })
@@ -917,7 +909,6 @@ describe('getPackageManager', () => {
       // Given
       const subDirectory = joinPath(tmpDir, 'subdir')
       await mkdir(subDirectory)
-      mockedCaptureOutput.mockReturnValueOnce(Promise.resolve(tmpDir))
 
       // When/Then
       const packageManager = await getPackageManager(tmpDir)

--- a/packages/cli-kit/src/public/node/node-package-manager.ts
+++ b/packages/cli-kit/src/public/node/node-package-manager.ts
@@ -132,7 +132,9 @@ export async function getPackageManager(fromDirectory: string): Promise<PackageM
   }
   const packageJsonPath = await findPathUp('package.json', {cwd: fromDirectory, type: 'file'})
   if (packageJsonPath) {
-    outputDebug(outputContent`Found package.json but no lockfile in ${outputToken.path(dirname(packageJsonPath))}, defaulting to npm`)
+    outputDebug(
+      outputContent`Found package.json but no lockfile in ${outputToken.path(dirname(packageJsonPath))}, defaulting to npm`,
+    )
     return 'npm'
   }
   return packageManagerFromUserAgent()

--- a/packages/cli-kit/src/public/node/node-package-manager.ts
+++ b/packages/cli-kit/src/public/node/node-package-manager.ts
@@ -1,6 +1,6 @@
 import {AbortError, BugError} from './error.js'
 import {AbortController, AbortSignal} from './abort.js'
-import {captureOutput, exec} from './system.js'
+import {exec} from './system.js'
 import {fileExists, readFile, writeFile, findPathUp, glob} from './fs.js'
 import {dirname, joinPath} from './path.js'
 import {runWithTimer} from './metadata.js'
@@ -115,20 +115,12 @@ export function packageManagerFromUserAgent(env = process.env): PackageManager {
  * @returns The dependency manager
  */
 export async function getPackageManager(fromDirectory: string): Promise<PackageManager> {
-  let directory: string | undefined
-  let packageJson: string | undefined
-  try {
-    directory = await captureOutput('npm', ['prefix'], {cwd: fromDirectory})
-    outputDebug(outputContent`Obtaining the dependency manager in directory ${outputToken.path(directory)}...`)
-    packageJson = joinPath(directory, 'package.json')
-    // eslint-disable-next-line no-catch-all/no-catch-all
-  } catch {
-    // if problems locating directoy/package file, we use user agent instead
-  }
-
-  if (!directory || !packageJson || !(await fileExists(packageJson))) {
+  const packageJsonPath = await findPathUp('package.json', {cwd: fromDirectory, type: 'file'})
+  if (!packageJsonPath) {
     return packageManagerFromUserAgent()
   }
+  const directory = dirname(packageJsonPath)
+  outputDebug(outputContent`Obtaining the dependency manager in directory ${outputToken.path(directory)}...`)
   const yarnLockPath = joinPath(directory, yarnLockfile)
   const pnpmLockPath = joinPath(directory, pnpmLockfile)
   const bunLockPath = joinPath(directory, bunLockfile)

--- a/packages/cli-kit/src/public/node/node-package-manager.ts
+++ b/packages/cli-kit/src/public/node/node-package-manager.ts
@@ -115,24 +115,27 @@ export function packageManagerFromUserAgent(env = process.env): PackageManager {
  * @returns The dependency manager
  */
 export async function getPackageManager(fromDirectory: string): Promise<PackageManager> {
-  const packageJsonPath = await findPathUp('package.json', {cwd: fromDirectory, type: 'file'})
-  if (!packageJsonPath) {
-    return packageManagerFromUserAgent()
-  }
-  const directory = dirname(packageJsonPath)
-  outputDebug(outputContent`Obtaining the dependency manager in directory ${outputToken.path(directory)}...`)
-  const yarnLockPath = joinPath(directory, yarnLockfile)
-  const pnpmLockPath = joinPath(directory, pnpmLockfile)
-  const bunLockPath = joinPath(directory, bunLockfile)
-  if (await fileExists(yarnLockPath)) {
+  const yarnLockPath = await findPathUp(yarnLockfile, {cwd: fromDirectory, type: 'file'})
+  if (yarnLockPath) {
+    outputDebug(outputContent`Found ${yarnLockfile} in ${outputToken.path(dirname(yarnLockPath))}`)
     return 'yarn'
-  } else if (await fileExists(pnpmLockPath)) {
+  }
+  const pnpmLockPath = await findPathUp(pnpmLockfile, {cwd: fromDirectory, type: 'file'})
+  if (pnpmLockPath) {
+    outputDebug(outputContent`Found ${pnpmLockfile} in ${outputToken.path(dirname(pnpmLockPath))}`)
     return 'pnpm'
-  } else if (await fileExists(bunLockPath)) {
+  }
+  const bunLockPath = await findPathUp(bunLockfile, {cwd: fromDirectory, type: 'file'})
+  if (bunLockPath) {
+    outputDebug(outputContent`Found ${bunLockfile} in ${outputToken.path(dirname(bunLockPath))}`)
     return 'bun'
-  } else {
+  }
+  const packageJsonPath = await findPathUp('package.json', {cwd: fromDirectory, type: 'file'})
+  if (packageJsonPath) {
+    outputDebug(outputContent`Found package.json but no lockfile in ${outputToken.path(dirname(packageJsonPath))}, defaulting to npm`)
     return 'npm'
   }
+  return packageManagerFromUserAgent()
 }
 
 interface InstallNPMDependenciesRecursivelyOptions {


### PR DESCRIPTION
## Problem

Function builds fail in environments where npm is blocked:

```
Failed to build function.

Command failed with exit code 1: npm exec -- graphql-code-generator --config package.json
npm is no longer supported in a global context.
```

This affects all JS function extensions because `buildGraphqlTypes` hardcoded `npm exec` for the typegen step.

## Root cause

Two issues in `getPackageManager()` in cli-kit:

1. **Shelled out to `npm prefix`** to find the project root — which fails when npm itself is unavailable
2. **Anchored lockfile search to the nearest `package.json`** — function extensions have their own `package.json` in subdirectories (e.g., `extensions/my-function/package.json`), but the lockfile (`pnpm-lock.yaml`) lives at the app root. The old approach found the function's `package.json` first, saw no lockfile next to it, and defaulted to `npm`

## Fix

- Replaced `npm prefix` subprocess with `findPathUp` for pure filesystem-based detection — no subprocess needed
- Lockfiles are now searched for directly by walking up the directory tree, so `pnpm-lock.yaml` at the app root is found even when called from a nested function directory
- `buildGraphqlTypes` now uses the fixed `getPackageManager(fun.directory)` to detect the project's package manager

## Test plan
- [x] All 58 `node-package-manager.test.ts` tests pass, including new test for nested subdirectory with parent lockfile
- [x] All 25 `build.test.ts` tests pass
- [x] Manual test: Verified building a function using 0.0.0-snapshot-20260409154217