### PR TITLE
Add directory-based package manager inference helper

### DIFF
--- a/packages/cli-kit/src/public/node/node-package-manager.test.ts
+++ b/packages/cli-kit/src/public/node/node-package-manager.test.ts
@@ -1050,7 +1050,9 @@ describe('inferPackageManagerForDirectory', () => {
       const nestedDirectory = joinPath(tmpDir, 'extensions', 'discount-function')
       await mkdir(nestedDirectory)
 
-      const packageManager = await inferPackageManagerForDirectory(nestedDirectory, {npm_config_user_agent: 'yarn/1.22.0'})
+      const packageManager = await inferPackageManagerForDirectory(nestedDirectory, {
+        npm_config_user_agent: 'yarn/1.22.0',
+      })
 
       expect(packageManager).toEqual('yarn')
       expect(mockedCaptureOutput).not.toHaveBeenCalled()

--- a/packages/cli-kit/src/public/node/node-package-manager.test.ts
+++ b/packages/cli-kit/src/public/node/node-package-manager.test.ts
@@ -12,6 +12,7 @@ import {
   addResolutionOrOverride,
   writePackageJSON,
   getPackageManager,
+  inferPackageManagerForDirectory,
   installNPMDependenciesRecursively,
   addNPMDependencies,
   DependencyVersion,
@@ -892,6 +893,25 @@ describe('getPackageManager', () => {
     })
   })
 
+  test('finds pnpm from an ancestor workspace root', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      const workspaceFile = joinPath(tmpDir, 'pnpm-workspace.yaml')
+      const extensionDirectory = joinPath(tmpDir, 'extensions', 'discount-function')
+      const extensionPackageJson = joinPath(extensionDirectory, 'package.json')
+
+      // When
+      await mkdir(extensionDirectory)
+      await writeFile(workspaceFile, 'packages:\n  - extensions/*\n')
+      await writeFile(extensionPackageJson, JSON.stringify({name: 'mock name'}))
+      mockedCaptureOutput.mockReturnValueOnce(Promise.resolve(extensionDirectory))
+
+      // Then
+      const packageManager = await getPackageManager(extensionDirectory)
+      expect(packageManager).toEqual('pnpm')
+    })
+  })
+
   test('falls back to packageManagerFromUserAgent when npm prefix fails', async () => {
     await inTemporaryDirectory(async (tmpDir) => {
       // Given
@@ -923,6 +943,187 @@ describe('getPackageManager', () => {
       const packageManager = await getPackageManager(tmpDir)
       // pnpm is used locally and in CI
       expect(packageManager).toEqual('pnpm')
+    })
+  })
+})
+
+describe('inferPackageManagerForDirectory', () => {
+  beforeEach(() => {
+    mockedCaptureOutput.mockClear()
+    vi.mocked(inferPackageManagerForGlobalCLI).mockClear()
+  })
+
+  test('finds pnpm from a workspace root above the nearest package.json', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      const workspaceRootPackageJson = joinPath(tmpDir, 'package.json')
+      const workspaceFile = joinPath(tmpDir, 'pnpm-workspace.yaml')
+      const functionDirectory = joinPath(tmpDir, 'extensions', 'discount-function')
+      const functionPackageJson = joinPath(functionDirectory, 'package.json')
+
+      await mkdir(functionDirectory)
+      await writeFile(workspaceRootPackageJson, JSON.stringify({}))
+      await writeFile(workspaceFile, 'packages:\n  - extensions/*\n')
+      await writeFile(functionPackageJson, JSON.stringify({}))
+
+      const packageManager = await inferPackageManagerForDirectory(functionDirectory, {})
+
+      expect(packageManager).toEqual('pnpm')
+      expect(mockedCaptureOutput).not.toHaveBeenCalled()
+      expect(inferPackageManagerForGlobalCLI).not.toHaveBeenCalled()
+    })
+  })
+
+  test('finds pnpm from a workspace root without a root package.json', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      const workspaceFile = joinPath(tmpDir, 'pnpm-workspace.yaml')
+      const functionDirectory = joinPath(tmpDir, 'extensions', 'discount-function')
+      const functionPackageJson = joinPath(functionDirectory, 'package.json')
+
+      await mkdir(functionDirectory)
+      await writeFile(workspaceFile, 'packages:\n  - extensions/*\n')
+      await writeFile(functionPackageJson, JSON.stringify({}))
+
+      const packageManager = await inferPackageManagerForDirectory(functionDirectory, {})
+
+      expect(packageManager).toEqual('pnpm')
+      expect(mockedCaptureOutput).not.toHaveBeenCalled()
+      expect(inferPackageManagerForGlobalCLI).not.toHaveBeenCalled()
+    })
+  })
+
+  test('works from a nested child directory below the package root', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      const workspaceRootPackageJson = joinPath(tmpDir, 'package.json')
+      const workspaceLockfile = joinPath(tmpDir, 'pnpm-lock.yaml')
+      const functionDirectory = joinPath(tmpDir, 'extensions', 'discount-function')
+      const srcDirectory = joinPath(functionDirectory, 'src')
+      const functionPackageJson = joinPath(functionDirectory, 'package.json')
+
+      await mkdir(srcDirectory)
+      await writeFile(workspaceRootPackageJson, JSON.stringify({}))
+      await writeFile(workspaceLockfile, 'lockfileVersion: 9.0\n')
+      await writeFile(functionPackageJson, JSON.stringify({}))
+
+      const packageManager = await inferPackageManagerForDirectory(srcDirectory, {})
+
+      expect(packageManager).toEqual('pnpm')
+      expect(mockedCaptureOutput).not.toHaveBeenCalled()
+      expect(inferPackageManagerForGlobalCLI).not.toHaveBeenCalled()
+    })
+  })
+
+  test('prefers the nearest lockfile over an ancestor workspace lockfile', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      const workspaceRootPackageJson = joinPath(tmpDir, 'package.json')
+      const workspaceLockfile = joinPath(tmpDir, 'pnpm-lock.yaml')
+      const functionDirectory = joinPath(tmpDir, 'extensions', 'discount-function')
+      const functionPackageJson = joinPath(functionDirectory, 'package.json')
+      const functionLockfile = joinPath(functionDirectory, 'yarn.lock')
+
+      await mkdir(functionDirectory)
+      await writeFile(workspaceRootPackageJson, JSON.stringify({}))
+      await writeFile(workspaceLockfile, 'lockfileVersion: 9.0\n')
+      await writeFile(functionPackageJson, JSON.stringify({}))
+      await writeFile(functionLockfile, '')
+
+      const packageManager = await inferPackageManagerForDirectory(functionDirectory, {})
+
+      expect(packageManager).toEqual('yarn')
+    })
+  })
+
+  test('falls back to the user agent when no lockfile is found in the package tree', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      const packageJson = joinPath(tmpDir, 'package.json')
+      await writeFile(packageJson, JSON.stringify({}))
+
+      const packageManager = await inferPackageManagerForDirectory(tmpDir, {npm_config_user_agent: 'bun/1.0.0'})
+
+      expect(packageManager).toEqual('bun')
+      expect(mockedCaptureOutput).not.toHaveBeenCalled()
+      expect(inferPackageManagerForGlobalCLI).not.toHaveBeenCalled()
+    })
+  })
+
+  test('falls back to the user agent when no package.json exists in the ancestry', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      const nestedDirectory = joinPath(tmpDir, 'extensions', 'discount-function')
+      await mkdir(nestedDirectory)
+
+      const packageManager = await inferPackageManagerForDirectory(nestedDirectory, {npm_config_user_agent: 'yarn/1.22.0'})
+
+      expect(packageManager).toEqual('yarn')
+      expect(mockedCaptureOutput).not.toHaveBeenCalled()
+      expect(inferPackageManagerForGlobalCLI).not.toHaveBeenCalled()
+    })
+  })
+
+  test('detects bun from bun.lockb', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      const packageJson = joinPath(tmpDir, 'package.json')
+      const bunLockfile = joinPath(tmpDir, 'bun.lockb')
+      await writeFile(packageJson, JSON.stringify({}))
+      await writeFile(bunLockfile, '')
+
+      const packageManager = await inferPackageManagerForDirectory(tmpDir, {})
+
+      expect(packageManager).toEqual('bun')
+    })
+  })
+
+  test('detects npm from package-lock.json', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      const packageJson = joinPath(tmpDir, 'package.json')
+      const npmLockfile = joinPath(tmpDir, 'package-lock.json')
+      await writeFile(packageJson, JSON.stringify({}))
+      await writeFile(npmLockfile, '{}')
+
+      const packageManager = await inferPackageManagerForDirectory(tmpDir, {})
+
+      expect(packageManager).toEqual('npm')
+    })
+  })
+
+  test('prefers yarn when multiple lockfiles exist in the same directory', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      const packageJson = joinPath(tmpDir, 'package.json')
+      const yarnLockfile = joinPath(tmpDir, 'yarn.lock')
+      const pnpmLockfile = joinPath(tmpDir, 'pnpm-lock.yaml')
+      await writeFile(packageJson, JSON.stringify({}))
+      await writeFile(yarnLockfile, '')
+      await writeFile(pnpmLockfile, 'lockfileVersion: 9.0\n')
+
+      const packageManager = await inferPackageManagerForDirectory(tmpDir, {})
+
+      expect(packageManager).toEqual('yarn')
+    })
+  })
+
+  test('prefers bun over npm when both lockfiles exist in the same directory', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      const packageJson = joinPath(tmpDir, 'package.json')
+      const bunLockfile = joinPath(tmpDir, 'bun.lockb')
+      const npmLockfile = joinPath(tmpDir, 'package-lock.json')
+      await writeFile(packageJson, JSON.stringify({}))
+      await writeFile(bunLockfile, '')
+      await writeFile(npmLockfile, '{}')
+
+      const packageManager = await inferPackageManagerForDirectory(tmpDir, {})
+
+      expect(packageManager).toEqual('bun')
+    })
+  })
+
+  test('defaults to npm when neither the package tree nor the user agent identify a package manager', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      const packageJson = joinPath(tmpDir, 'package.json')
+      await writeFile(packageJson, JSON.stringify({}))
+
+      const packageManager = await inferPackageManagerForDirectory(tmpDir, {})
+
+      expect(packageManager).toEqual('npm')
+      expect(mockedCaptureOutput).not.toHaveBeenCalled()
+      expect(inferPackageManagerForGlobalCLI).not.toHaveBeenCalled()
     })
   })
 })

--- a/packages/cli-kit/src/public/node/node-package-manager.ts
+++ b/packages/cli-kit/src/public/node/node-package-manager.ts
@@ -110,7 +110,12 @@ export function packageManagerFromUserAgent(env = process.env): PackageManager {
 }
 
 /**
- * Returns the dependency manager used in a directory.
+ * Returns the dependency manager for the package root resolved from a directory.
+ *
+ * This preserves the existing `npm prefix`-based behavior: first ask npm for the
+ * package root, then detect lockfiles/workspace markers from that resolved root upward.
+ * If `npm prefix` or the package.json lookup fails, fall back to the current user agent.
+ *
  * @param fromDirectory - The starting directory
  * @returns The dependency manager
  */
@@ -129,18 +134,56 @@ export async function getPackageManager(fromDirectory: string): Promise<PackageM
   if (!directory || !packageJson || !(await fileExists(packageJson))) {
     return packageManagerFromUserAgent()
   }
+  return (await detectPackageManagerFromDirectory(directory)) ?? 'npm'
+}
+
+async function inferPackageManagerAtDirectory(directory: string): Promise<PackageManager | undefined> {
   const yarnLockPath = joinPath(directory, yarnLockfile)
   const pnpmLockPath = joinPath(directory, pnpmLockfile)
+  const pnpmWorkspacePath = joinPath(directory, pnpmWorkspaceFile)
   const bunLockPath = joinPath(directory, bunLockfile)
-  if (await fileExists(yarnLockPath)) {
-    return 'yarn'
-  } else if (await fileExists(pnpmLockPath)) {
-    return 'pnpm'
-  } else if (await fileExists(bunLockPath)) {
-    return 'bun'
-  } else {
-    return 'npm'
+  const npmLockPath = joinPath(directory, npmLockfile)
+
+  if (await fileExists(yarnLockPath)) return 'yarn'
+  if ((await fileExists(pnpmLockPath)) || (await fileExists(pnpmWorkspacePath))) return 'pnpm'
+  if (await fileExists(bunLockPath)) return 'bun'
+  if (await fileExists(npmLockPath)) return 'npm'
+
+  return undefined
+}
+
+async function detectPackageManagerFromDirectory(fromDirectory: string): Promise<PackageManager | undefined> {
+  let currentDirectory = fromDirectory
+
+  while (true) {
+    const packageManager = await inferPackageManagerAtDirectory(currentDirectory)
+    if (packageManager) return packageManager
+
+    const parentDirectory = dirname(currentDirectory)
+    if (parentDirectory === currentDirectory) return undefined
+    currentDirectory = parentDirectory
   }
+}
+
+/**
+ * Infers the dependency manager directly from filesystem context starting at a directory,
+ * without spawning package-manager subprocesses.
+ *
+ * Unlike `getPackageManager`, this helper does not call `npm prefix` to resolve a package root first.
+ * It walks upward from the provided directory itself, prefers the closest lockfile/workspace marker,
+ * and falls back to the current user agent before defaulting to npm.
+ *
+ * Unlike `inferPackageManager`, this helper never uses global CLI installation detection.
+ */
+export async function inferPackageManagerForDirectory(
+  fromDirectory: string,
+  env = process.env,
+): Promise<PackageManager> {
+  const packageManager = await detectPackageManagerFromDirectory(fromDirectory)
+  if (packageManager) return packageManager
+
+  const userAgentPackageManager = packageManagerFromUserAgent(env)
+  return userAgentPackageManager === 'unknown' ? 'npm' : userAgentPackageManager
 }
 
 interface InstallNPMDependenciesRecursivelyOptions {

--- a/packages/cli-kit/src/public/node/node-package-manager.ts
+++ b/packages/cli-kit/src/public/node/node-package-manager.ts
@@ -153,16 +153,13 @@ async function inferPackageManagerAtDirectory(directory: string): Promise<Packag
 }
 
 async function detectPackageManagerFromDirectory(fromDirectory: string): Promise<PackageManager | undefined> {
-  let currentDirectory = fromDirectory
+  const packageManager = await inferPackageManagerAtDirectory(fromDirectory)
+  if (packageManager) return packageManager
 
-  while (true) {
-    const packageManager = await inferPackageManagerAtDirectory(currentDirectory)
-    if (packageManager) return packageManager
+  const parentDirectory = dirname(fromDirectory)
+  if (parentDirectory === fromDirectory) return undefined
 
-    const parentDirectory = dirname(currentDirectory)
-    if (parentDirectory === currentDirectory) return undefined
-    currentDirectory = parentDirectory
-  }
+  return detectPackageManagerFromDirectory(parentDirectory)
 }
 
 /**


### PR DESCRIPTION
## What

Add `inferPackageManagerForDirectory` to `cli-kit` and expand package manager detection to walk ancestor directories for lockfiles and `pnpm-workspace.yaml`.

Also update `getPackageManager(fromDirectory)` to reuse the same ancestor-aware directory detection once `npm prefix` has resolved a package root, and add coverage for ancestor workspace roots, nested directories, and lockfile precedence.

## Why

This is groundwork for reducing reliance on `npm prefix` in project-directory package-manager detection, without changing call sites yet.

The CLI still needs a way to infer the package manager for a project directory when `npm` subprocesses are unavailable or are the wrong source of truth. This PR introduces that directory-first path first, so follow-up PRs can adopt it in specific call sites starting with function typegen.

## How

This PR keeps both entrypoints, but makes their difference explicit:

- `getPackageManager(fromDirectory)` remains the existing **npm-prefix-based** API. It first asks `npm prefix` for the package root, then detects lockfiles/workspace markers from that resolved root upward. If `npm prefix` or package discovery fails, it falls back to the current user agent.
- `inferPackageManagerForDirectory(fromDirectory)` is the new **directory-first** API. It never shells out to `npm` and never consults global CLI installation detection. It walks upward from the provided directory itself, then falls back to the current user agent and finally `npm`.

Shared directory detection now:
- prefers the closest matching lockfile or workspace marker
- covers ancestor `pnpm-workspace.yaml` / lockfile cases
- keeps the existing fallback policy of each public API intact
