### PR TITLE
Use directory-based package manager inference for function typegen

### DIFF
--- a/packages/app/src/cli/services/function/build.test.ts
+++ b/packages/app/src/cli/services/function/build.test.ts
@@ -22,12 +22,20 @@ import {
 import {testApp, testFunctionExtension} from '../../models/app/app.test-data.js'
 import {beforeEach, describe, expect, test, vi} from 'vitest'
 import {exec} from '@shopify/cli-kit/node/system'
+import {inferPackageManagerForDirectory} from '@shopify/cli-kit/node/node-package-manager'
 import {dirname, joinPath} from '@shopify/cli-kit/node/path'
 import {inTemporaryDirectory, mkdir, readFileSync, writeFile, removeFile} from '@shopify/cli-kit/node/fs'
 import {build as esBuild} from 'esbuild'
 
 vi.mock('@shopify/cli-kit/node/fs')
 vi.mock('@shopify/cli-kit/node/system')
+vi.mock('@shopify/cli-kit/node/node-package-manager', async () => {
+  const actual: any = await vi.importActual('@shopify/cli-kit/node/node-package-manager')
+  return {
+    ...actual,
+    inferPackageManagerForDirectory: vi.fn(),
+  }
+})
 
 vi.mock('./binaries.js', async (importOriginal) => {
   const actual: any = await importOriginal()
@@ -76,6 +84,7 @@ beforeEach(async () => {
   stderr = {write: vi.fn()}
   stdout = {write: vi.fn()}
   signal = vi.fn()
+  vi.mocked(inferPackageManagerForDirectory).mockResolvedValue('npm')
 })
 
 describe('buildGraphqlTypes', () => {
@@ -88,7 +97,43 @@ describe('buildGraphqlTypes', () => {
 
     // Then
     await expect(got).resolves.toBeUndefined()
+    expect(inferPackageManagerForDirectory).toHaveBeenCalledTimes(1)
+    expect(inferPackageManagerForDirectory).toHaveBeenCalledWith(ourFunction.directory)
     expect(exec).toHaveBeenCalledWith('npm', ['exec', '--', 'graphql-code-generator', '--config', 'package.json'], {
+      cwd: ourFunction.directory,
+      stderr,
+      signal,
+    })
+  })
+
+  test('generate types uses pnpm-specific exec args when pnpm is inferred', {timeout: 20000}, async () => {
+    // Given
+    const ourFunction = await testFunctionExtension({entryPath: 'src/index.js'})
+    vi.mocked(inferPackageManagerForDirectory).mockResolvedValue('pnpm')
+
+    // When
+    const got = buildGraphqlTypes(ourFunction, {stdout, stderr, signal, app})
+
+    // Then
+    await expect(got).resolves.toBeUndefined()
+    expect(exec).toHaveBeenCalledWith('pnpm', ['exec', 'graphql-code-generator', '--config', 'package.json'], {
+      cwd: ourFunction.directory,
+      stderr,
+      signal,
+    })
+  })
+
+  test('generate types uses bun-specific exec args when bun is inferred', {timeout: 20000}, async () => {
+    // Given
+    const ourFunction = await testFunctionExtension({entryPath: 'src/index.js'})
+    vi.mocked(inferPackageManagerForDirectory).mockResolvedValue('bun')
+
+    // When
+    const got = buildGraphqlTypes(ourFunction, {stdout, stderr, signal, app})
+
+    // Then
+    await expect(got).resolves.toBeUndefined()
+    expect(exec).toHaveBeenCalledWith('bun', ['x', 'graphql-code-generator', '--config', 'package.json'], {
       cwd: ourFunction.directory,
       stderr,
       signal,
@@ -105,6 +150,7 @@ describe('buildGraphqlTypes', () => {
 
     // Then
     await expect(got).rejects.toThrow(/No typegen_command specified/)
+    expect(inferPackageManagerForDirectory).not.toHaveBeenCalled()
   })
 
   test('runs custom typegen_command when provided', async () => {
@@ -129,6 +175,7 @@ describe('buildGraphqlTypes', () => {
 
     // Then
     await expect(got).resolves.toBeUndefined()
+    expect(inferPackageManagerForDirectory).not.toHaveBeenCalled()
     expect(exec).toHaveBeenCalledWith('npx', ['shopify-function-codegen', '--schema', 'schema.graphql'], {
       cwd: ourFunction.directory,
       stdout,
@@ -159,6 +206,7 @@ describe('buildGraphqlTypes', () => {
 
     // Then
     await expect(got).resolves.toBeUndefined()
+    expect(inferPackageManagerForDirectory).not.toHaveBeenCalled()
     expect(exec).toHaveBeenCalledWith('custom-typegen', ['--output', 'types.ts'], {
       cwd: ourFunction.directory,
       stdout,

--- a/packages/app/src/cli/services/function/build.ts
+++ b/packages/app/src/cli/services/function/build.ts
@@ -24,6 +24,7 @@ import {renderTasks} from '@shopify/cli-kit/node/ui'
 import {pickBy} from '@shopify/cli-kit/common/object'
 import {runWithTimer} from '@shopify/cli-kit/node/metadata'
 import {AbortError} from '@shopify/cli-kit/node/error'
+import {inferPackageManagerForDirectory, packageManagerBinaryCommand} from '@shopify/cli-kit/node/node-package-manager'
 import {Writable} from 'stream'
 
 export const PREFERRED_FUNCTION_NPM_PACKAGE_MAJOR_VERSION = '2'
@@ -143,8 +144,11 @@ export async function buildGraphqlTypes(
     )
   }
 
+  const packageManager = await inferPackageManagerForDirectory(fun.directory)
+  const command = packageManagerBinaryCommand(packageManager, 'graphql-code-generator', '--config', 'package.json')
+
   return runWithTimer('cmd_all_timing_network_ms')(async () => {
-    return exec('npm', ['exec', '--', 'graphql-code-generator', '--config', 'package.json'], {
+    return exec(command.command, command.args, {
       cwd: fun.directory,
       stderr: options.stderr,
       signal: options.signal,

--- a/packages/cli-kit/src/public/node/node-package-manager.test.ts
+++ b/packages/cli-kit/src/public/node/node-package-manager.test.ts
@@ -13,6 +13,7 @@ import {
   writePackageJSON,
   getPackageManager,
   inferPackageManagerForDirectory,
+  packageManagerBinaryCommand,
   installNPMDependenciesRecursively,
   addNPMDependencies,
   DependencyVersion,
@@ -1060,7 +1061,20 @@ describe('inferPackageManagerForDirectory', () => {
     })
   })
 
-  test('detects bun from bun.lockb', async () => {
+  test('detects bun from bun.lock', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      const packageJson = joinPath(tmpDir, 'package.json')
+      const bunLockfile = joinPath(tmpDir, 'bun.lock')
+      await writeFile(packageJson, JSON.stringify({}))
+      await writeFile(bunLockfile, '')
+
+      const packageManager = await inferPackageManagerForDirectory(tmpDir, {})
+
+      expect(packageManager).toEqual('bun')
+    })
+  })
+
+  test('detects bun from legacy bun.lockb', async () => {
     await inTemporaryDirectory(async (tmpDir) => {
       const packageJson = joinPath(tmpDir, 'package.json')
       const bunLockfile = joinPath(tmpDir, 'bun.lockb')
@@ -1104,7 +1118,7 @@ describe('inferPackageManagerForDirectory', () => {
   test('prefers bun over npm when both lockfiles exist in the same directory', async () => {
     await inTemporaryDirectory(async (tmpDir) => {
       const packageJson = joinPath(tmpDir, 'package.json')
-      const bunLockfile = joinPath(tmpDir, 'bun.lockb')
+      const bunLockfile = joinPath(tmpDir, 'bun.lock')
       const npmLockfile = joinPath(tmpDir, 'package-lock.json')
       await writeFile(packageJson, JSON.stringify({}))
       await writeFile(bunLockfile, '')
@@ -1126,6 +1140,33 @@ describe('inferPackageManagerForDirectory', () => {
       expect(packageManager).toEqual('npm')
       expect(mockedCaptureOutput).not.toHaveBeenCalled()
       expect(inferPackageManagerForGlobalCLI).not.toHaveBeenCalled()
+    })
+  })
+})
+
+describe('packageManagerBinaryCommand', () => {
+  test('uses npm exec with -- for npm', () => {
+    expect(packageManagerBinaryCommand('npm', 'graphql-code-generator', '--config', 'package.json')).toEqual({
+      command: 'npm',
+      args: ['exec', '--', 'graphql-code-generator', '--config', 'package.json'],
+    })
+  })
+
+  test('uses exec without -- for pnpm and yarn', () => {
+    expect(packageManagerBinaryCommand('pnpm', 'graphql-code-generator', '--config', 'package.json')).toEqual({
+      command: 'pnpm',
+      args: ['exec', 'graphql-code-generator', '--config', 'package.json'],
+    })
+    expect(packageManagerBinaryCommand('yarn', 'graphql-code-generator', '--config', 'package.json')).toEqual({
+      command: 'yarn',
+      args: ['exec', 'graphql-code-generator', '--config', 'package.json'],
+    })
+  })
+
+  test('uses bun x for bun', () => {
+    expect(packageManagerBinaryCommand('bun', 'graphql-code-generator', '--config', 'package.json')).toEqual({
+      command: 'bun',
+      args: ['x', 'graphql-code-generator', '--config', 'package.json'],
     })
   })
 })

--- a/packages/cli-kit/src/public/node/node-package-manager.ts
+++ b/packages/cli-kit/src/public/node/node-package-manager.ts
@@ -56,6 +56,7 @@ export type DependencyType = 'dev' | 'prod' | 'peer'
  */
 export const packageManager = ['yarn', 'npm', 'pnpm', 'bun', 'homebrew', 'unknown'] as const
 export type PackageManager = (typeof packageManager)[number]
+export type ProjectPackageManager = 'yarn' | 'npm' | 'pnpm' | 'bun'
 
 /**
  * Returns an abort error that's thrown when the package manager can't be determined.
@@ -137,22 +138,23 @@ export async function getPackageManager(fromDirectory: string): Promise<PackageM
   return (await detectPackageManagerFromDirectory(directory)) ?? 'npm'
 }
 
-async function inferPackageManagerAtDirectory(directory: string): Promise<PackageManager | undefined> {
+async function inferPackageManagerAtDirectory(directory: string): Promise<ProjectPackageManager | undefined> {
   const yarnLockPath = joinPath(directory, yarnLockfile)
   const pnpmLockPath = joinPath(directory, pnpmLockfile)
   const pnpmWorkspacePath = joinPath(directory, pnpmWorkspaceFile)
   const bunLockPath = joinPath(directory, bunLockfile)
+  const modernBunLockPath = joinPath(directory, 'bun.lock')
   const npmLockPath = joinPath(directory, npmLockfile)
 
   if (await fileExists(yarnLockPath)) return 'yarn'
   if ((await fileExists(pnpmLockPath)) || (await fileExists(pnpmWorkspacePath))) return 'pnpm'
-  if (await fileExists(bunLockPath)) return 'bun'
+  if ((await fileExists(bunLockPath)) || (await fileExists(modernBunLockPath))) return 'bun'
   if (await fileExists(npmLockPath)) return 'npm'
 
   return undefined
 }
 
-async function detectPackageManagerFromDirectory(fromDirectory: string): Promise<PackageManager | undefined> {
+async function detectPackageManagerFromDirectory(fromDirectory: string): Promise<ProjectPackageManager | undefined> {
   const packageManager = await inferPackageManagerAtDirectory(fromDirectory)
   if (packageManager) return packageManager
 
@@ -160,6 +162,25 @@ async function detectPackageManagerFromDirectory(fromDirectory: string): Promise
   if (parentDirectory === fromDirectory) return undefined
 
   return detectPackageManagerFromDirectory(parentDirectory)
+}
+
+/**
+ * Builds the command and argv needed to execute a local binary through a project package manager.
+ */
+export function packageManagerBinaryCommand(
+  packageManager: ProjectPackageManager,
+  binary: string,
+  ...binaryArgs: string[]
+): {command: string; args: string[]} {
+  switch (packageManager) {
+    case 'npm':
+      return {command: 'npm', args: ['exec', '--', binary, ...binaryArgs]}
+    case 'pnpm':
+    case 'yarn':
+      return {command: packageManager, args: ['exec', binary, ...binaryArgs]}
+    case 'bun':
+      return {command: 'bun', args: ['x', binary, ...binaryArgs]}
+  }
 }
 
 /**
@@ -175,12 +196,24 @@ async function detectPackageManagerFromDirectory(fromDirectory: string): Promise
 export async function inferPackageManagerForDirectory(
   fromDirectory: string,
   env = process.env,
-): Promise<PackageManager> {
+): Promise<ProjectPackageManager> {
   const packageManager = await detectPackageManagerFromDirectory(fromDirectory)
   if (packageManager) return packageManager
 
   const userAgentPackageManager = packageManagerFromUserAgent(env)
-  return userAgentPackageManager === 'unknown' ? 'npm' : userAgentPackageManager
+  switch (userAgentPackageManager) {
+    case 'npm':
+      return 'npm'
+    case 'pnpm':
+      return 'pnpm'
+    case 'yarn':
+      return 'yarn'
+    case 'bun':
+      return 'bun'
+    case 'homebrew':
+    case 'unknown':
+      return 'npm'
+  }
 }
 
 interface InstallNPMDependenciesRecursivelyOptions {


### PR DESCRIPTION
## What

Use directory-based package manager inference for the default function GraphQL typegen path.

Move the package-manager-specific binary invocation logic into `cli-kit`, and update function typegen to execute `graphql-code-generator` through that shared helper instead of hardcoding `npm exec`.

## Why

The default JS function typegen path still assumes `npm`, which breaks in projects that are managed with pnpm, Yarn, or Bun.

PR #7230 adds the shared inference groundwork. This PR is the first call-site adoption in the stack: fix function typegen so it uses the package manager for the function directory rather than the CLI's old npm-shaped default.

## How

- infer the package manager from `fun.directory` with `inferPackageManagerForDirectory(...)`
- build the binary invocation through shared `cli-kit` helper `packageManagerBinaryCommand(...)`
- keep `typegen_command` behavior unchanged, including the existing custom-command override path

This keeps the seam explicit:
- `cli-kit` owns package-manager detection and command-shape differences
- `function/build.ts` just chooses the default codegen binary to run

This helper is intentionally narrow. If we need broader package-manager handling later, we should evaluate a dedicated dependency instead of continuing to grow this surface ad hoc.
