### PR TITLE
Use directory-based package manager inference for project mutation helpers

### DIFF
--- a/packages/cli-kit/src/public/node/node-package-manager.test.ts
+++ b/packages/cli-kit/src/public/node/node-package-manager.test.ts
@@ -713,7 +713,6 @@ describe('addResolutionOrOverride', () => {
   test('when no package.json then an abort exception is thrown', async () => {
     await inTemporaryDirectory(async (tmpDir) => {
       // Given/When
-      mockedCaptureOutput.mockReturnValueOnce(Promise.resolve(tmpDir))
       const result = () => addResolutionOrOverride(tmpDir, {'@types/react': '17.0.30'})
 
       // Then
@@ -731,7 +730,6 @@ describe('addResolutionOrOverride', () => {
       await touchFile(joinPath(tmpDir, 'yarn.lock'))
 
       // When
-      mockedCaptureOutput.mockReturnValueOnce(Promise.resolve(tmpDir))
       await addResolutionOrOverride(tmpDir, reactType)
 
       // Then
@@ -752,7 +750,6 @@ describe('addResolutionOrOverride', () => {
       await touchFile(joinPath(tmpDir, 'pnpm-lock.yaml'))
 
       // When
-      mockedCaptureOutput.mockReturnValueOnce(Promise.resolve(tmpDir))
       await addResolutionOrOverride(tmpDir, reactType)
 
       // Then
@@ -773,7 +770,6 @@ describe('addResolutionOrOverride', () => {
       await touchFile(joinPath(tmpDir, 'pnpm-workspace.yaml'))
 
       // When
-      mockedCaptureOutput.mockReturnValueOnce(Promise.resolve(tmpDir))
       await addResolutionOrOverride(tmpDir, reactType)
 
       // Then
@@ -794,7 +790,6 @@ describe('addResolutionOrOverride', () => {
       await touchFile(joinPath(tmpDir, 'yarn.lock'))
 
       // When
-      mockedCaptureOutput.mockReturnValueOnce(Promise.resolve(tmpDir))
       await addResolutionOrOverride(tmpDir, reactType)
 
       // Then
@@ -815,7 +810,6 @@ describe('addResolutionOrOverride', () => {
       await touchFile(joinPath(tmpDir, 'yarn.lock'))
 
       // When
-      mockedCaptureOutput.mockReturnValueOnce(Promise.resolve(tmpDir))
       await addResolutionOrOverride(tmpDir, reactType)
 
       // Then
@@ -823,6 +817,48 @@ describe('addResolutionOrOverride', () => {
       expect(packageJsonContent.resolutions).toBeDefined()
       expect(packageJsonContent.resolutions).toEqual({'@types/node': '^17.0.38', '@types/react': '17.0.30'})
       expect(packageJsonContent.overrides).toBeUndefined()
+    })
+  })
+
+  test('when nested package.json uses a parent yarn lockfile then resolutions are added to the nested package', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      const reactType = {'@types/react': '17.0.30'}
+      await writeFile(joinPath(tmpDir, 'yarn.lock'), '')
+      const packageDirectory = joinPath(tmpDir, 'extensions', 'my-extension')
+      await mkdir(packageDirectory)
+      const packageJsonPath = joinPath(packageDirectory, 'package.json')
+      await writeFile(packageJsonPath, JSON.stringify({}))
+
+      // When
+      await addResolutionOrOverride(packageDirectory, reactType)
+
+      // Then
+      const packageJsonContent = await readAndParsePackageJson(packageJsonPath)
+      expect(packageJsonContent.resolutions).toEqual(reactType)
+      expect(packageJsonContent.overrides).toBeUndefined()
+    })
+  })
+
+  test('when package.json has no lockfile and the user agent is yarn then overrides still default to npm behavior', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      const reactType = {'@types/react': '17.0.30'}
+      const packageJsonPath = joinPath(tmpDir, 'package.json')
+      await writeFile(packageJsonPath, JSON.stringify({}))
+      vi.stubEnv('npm_config_user_agent', 'yarn/1.22.0')
+
+      try {
+        // When
+        await addResolutionOrOverride(tmpDir, reactType)
+
+        // Then
+        const packageJsonContent = await readAndParsePackageJson(packageJsonPath)
+        expect(packageJsonContent.overrides).toEqual(reactType)
+        expect(packageJsonContent.resolutions).toBeUndefined()
+      } finally {
+        vi.unstubAllEnvs()
+      }
     })
   })
 })

--- a/packages/cli-kit/src/public/node/node-package-manager.ts
+++ b/packages/cli-kit/src/public/node/node-package-manager.ts
@@ -761,7 +761,7 @@ export async function findUpAndReadPackageJson(fromDirectory: string): Promise<{
 }
 
 export async function addResolutionOrOverride(directory: string, dependencies: Record<string, string>): Promise<void> {
-  const packageManager = await getPackageManager(directory)
+  const packageManager = await inferPackageManagerForDirectory(directory, {})
   const packageJsonPath = joinPath(directory, 'package.json')
   const packageJsonContent = await readAndParsePackageJson(packageJsonPath)
 

--- a/packages/cli-kit/src/public/node/upgrade.test.ts
+++ b/packages/cli-kit/src/public/node/upgrade.test.ts
@@ -1,6 +1,16 @@
 import {isDevelopment} from './context/local.js'
-import {currentProcessIsGlobal, inferPackageManagerForGlobalCLI} from './is-global.js'
-import {checkForCachedNewVersion, packageManagerFromUserAgent, PackageManager} from './node-package-manager.js'
+import {currentProcessIsGlobal, getProjectDir, inferPackageManagerForGlobalCLI} from './is-global.js'
+import {
+  addNPMDependencies,
+  checkForCachedNewVersion,
+  checkForNewVersion,
+  findUpAndReadPackageJson,
+  getPackageManager,
+  inferPackageManagerForDirectory,
+  packageManagerFromUserAgent,
+  PackageManager,
+  usesWorkspaces,
+} from './node-package-manager.js'
 import {exec, isCI} from './system.js'
 import {cliInstallCommand, runCLIUpgrade, versionToAutoUpgrade} from './upgrade.js'
 import {isPreReleaseVersion} from './version.js'
@@ -161,6 +171,57 @@ describe('runCLIUpgrade', () => {
 
     // Then
     expect(exec).not.toHaveBeenCalled()
+  })
+
+  test('uses directory-based package manager inference with npm default semantics for local project upgrades', async () => {
+    // Given
+    vi.mocked(currentProcessIsGlobal).mockReturnValue(false)
+    vi.mocked(isDevelopment).mockReturnValue(false)
+    vi.mocked(getProjectDir).mockReturnValue('/project')
+    vi.mocked(findUpAndReadPackageJson)
+      .mockResolvedValueOnce({
+        path: '/project/package.json',
+        content: {
+          dependencies: {'@shopify/cli': '3.0.0'},
+          devDependencies: {'@shopify/plugin-example': '1.0.0'},
+        },
+      })
+      .mockResolvedValueOnce({
+        path: '/cli-kit/package.json',
+        content: {name: '@shopify/cli', oclif: {plugins: ['@shopify/plugin-example']}},
+      })
+    vi.mocked(checkForNewVersion).mockResolvedValue(undefined)
+    vi.mocked(usesWorkspaces).mockResolvedValue(false)
+    vi.mocked(inferPackageManagerForDirectory).mockResolvedValue('pnpm')
+    vi.mocked(addNPMDependencies).mockResolvedValue()
+
+    // When
+    await runCLIUpgrade()
+
+    // Then
+    expect(inferPackageManagerForDirectory).toHaveBeenNthCalledWith(1, '/project', {})
+    expect(inferPackageManagerForDirectory).toHaveBeenNthCalledWith(2, '/project', {})
+    expect(getPackageManager).not.toHaveBeenCalled()
+    expect(addNPMDependencies).toHaveBeenNthCalledWith(
+      1,
+      [{name: '@shopify/cli', version: 'latest'}],
+      expect.objectContaining({
+        packageManager: 'pnpm',
+        type: 'prod',
+        directory: '/project',
+        addToRootDirectory: false,
+      }),
+    )
+    expect(addNPMDependencies).toHaveBeenNthCalledWith(
+      2,
+      [{name: '@shopify/plugin-example', version: 'latest'}],
+      expect.objectContaining({
+        packageManager: 'pnpm',
+        type: 'dev',
+        directory: '/project',
+        addToRootDirectory: false,
+      }),
+    )
   })
 })
 

--- a/packages/cli-kit/src/public/node/upgrade.ts
+++ b/packages/cli-kit/src/public/node/upgrade.ts
@@ -8,7 +8,7 @@ import {
   DependencyType,
   usesWorkspaces,
   addNPMDependencies,
-  getPackageManager,
+  inferPackageManagerForDirectory,
 } from './node-package-manager.js'
 import {outputContent, outputDebug, outputInfo, outputToken, outputWarn} from './output.js'
 import {cwd, moduleDirectory, sniffForPath} from './path.js'
@@ -198,7 +198,7 @@ async function installJsonDependencies(
 
   if (packagesToUpdate.length > 0) {
     await addNPMDependencies(packagesToUpdate, {
-      packageManager: await getPackageManager(directory),
+      packageManager: await inferPackageManagerForDirectory(directory, {}),
       type: depsEnv,
       directory,
       stdout: process.stdout,


### PR DESCRIPTION
## What

Use directory-based package manager inference for project mutation helpers in `cli-kit`.

This updates local CLI upgrades and `addResolutionOrOverride(...)` to choose the package manager from the target project directory instead of going through the older `getPackageManager(...)` path.

## Why

PR #7230 adds the directory-first helper, and PR #7231 applies it to function typegen.

This PR applies the same idea to the next class of call sites: helpers that mutate a project based on its package manager. Those paths should use the package manager for the project being changed, not the CLI install context.

## How

- use `inferPackageManagerForDirectory(...)` for local project upgrades
- use `inferPackageManagerForDirectory(...)` for `addResolutionOrOverride(...)`
- keep npm as the default when a project has a `package.json` but no lockfile or workspace marker

This keeps the change scoped to project mutation helpers without changing broader metadata or suggestion call sites.
