### PR TITLE
hydrogen/Bump cli-hydrogen to 11.1.14 (main)

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1465,9 +1465,8 @@ USAGE
     [--typescript]
 
 ARGUMENTS
-  ROUTENAME  (home|page|cart|products|collections|policies|blogs|account|search|robots|sitemap|tokenlessApi|all) The
-             route to generate. One of
-             home,page,cart,products,collections,policies,blogs,account,search,robots,sitemap,tokenlessApi,all.
+  ROUTENAME  (home|page|cart|products|collections|policies|blogs|account|search|robots|sitemap|all) The route to
+             generate. One of home,page,cart,products,collections,policies,blogs,account,search,robots,sitemap,all.
 
 FLAGS
   -f, --force                 [env: SHOPIFY_HYDROGEN_FLAG_FORCE] Overwrites the destination directory and files if they

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -4426,7 +4426,7 @@
       ],
       "args": {
         "routeName": {
-          "description": "The route to generate. One of home,page,cart,products,collections,policies,blogs,account,search,robots,sitemap,tokenlessApi,all.",
+          "description": "The route to generate. One of home,page,cart,products,collections,policies,blogs,account,search,robots,sitemap,all.",
           "name": "routeName",
           "options": [
             "home",
@@ -4440,7 +4440,6 @@
             "search",
             "robots",
             "sitemap",
-            "tokenlessApi",
             "all"
           ],
           "required": true

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -65,7 +65,7 @@
     "@shopify/plugin-cloudflare": "3.93.0",
     "@shopify/plugin-did-you-mean": "3.93.0",
     "@shopify/theme": "3.93.0",
-    "@shopify/cli-hydrogen": "11.1.10",
+    "@shopify/cli-hydrogen": "11.1.14",
     "@types/global-agent": "3.0.0",
     "@vitest/coverage-istanbul": "^3.1.4",
     "esbuild-plugin-copy": "^2.1.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -265,8 +265,8 @@ importers:
         specifier: 3.93.0
         version: link:../app
       '@shopify/cli-hydrogen':
-        specifier: 11.1.10
-        version: 11.1.10(@graphql-codegen/cli@6.0.1(@parcel/watcher@2.5.6)(@types/node@18.19.70)(crossws@0.3.5)(graphql@16.10.0)(typescript@5.9.3))(graphql-config@5.1.5(@types/node@22.19.15)(crossws@0.3.5)(graphql@16.10.0)(typescript@5.9.3))(graphql@16.10.0)(react-dom@19.2.4(react@18.3.1))(react@18.3.1)(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(sass@1.97.3)(yaml@2.8.3))
+        specifier: 11.1.14
+        version: 11.1.14(@graphql-codegen/cli@6.0.1(@parcel/watcher@2.5.6)(@types/node@18.19.70)(crossws@0.3.5)(graphql@16.10.0)(typescript@5.9.3))(graphql-config@5.1.5(@types/node@22.19.15)(crossws@0.3.5)(graphql@16.10.0)(typescript@5.9.3))(graphql@16.10.0)(react-dom@19.2.4(react@18.3.1))(react@18.3.1)(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(sass@1.97.3)(yaml@2.8.3))
       '@shopify/cli-kit':
         specifier: 3.93.0
         version: link:../cli-kit
@@ -3462,15 +3462,15 @@ packages:
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
 
-  '@shopify/cli-hydrogen@11.1.10':
-    resolution: {integrity: sha512-MEnTbWVeNMeV/0dawod4y2AuhhFFLlwpaYzbaqQXJ2HMm20g+bPoOogqSnGF04DoySIT9nEVXI9CXm/TgBsvoA==}
+  '@shopify/cli-hydrogen@11.1.14':
+    resolution: {integrity: sha512-rCa61SidFsB5qXCSDe/0bGdsi5DzEBmQ1eoQVPOzDS2aBO7PSzKx4P4ptLfFU7Yf0negqTsLB0sO+Uc/009h3A==}
     engines: {node: ^20 || ^22 || ^24}
     hasBin: true
     peerDependencies:
       '@graphql-codegen/cli': ^5.0.2
-      '@react-router/dev': 7.12.0
+      '@react-router/dev': ^7.12.0
       '@shopify/hydrogen-codegen': 0.3.3
-      '@shopify/mini-oxygen': 4.0.1
+      '@shopify/mini-oxygen': 4.0.2
       graphql-config: ^5.0.3
       vite: 6.4.1
     peerDependenciesMeta:
@@ -11539,7 +11539,7 @@ snapshots:
     dependencies:
       string-width: 5.1.2
       string-width-cjs: string-width@4.2.3
-      strip-ansi: 7.2.0
+      strip-ansi: 7.1.0
       strip-ansi-cjs: strip-ansi@6.0.1
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: wrap-ansi@7.0.0
@@ -11836,7 +11836,7 @@ snapshots:
       indent-string: 4.0.0
       is-wsl: 2.2.0
       js-yaml: 3.14.2
-      minimatch: 9.0.9
+      minimatch: 9.0.8
       natural-orderby: 2.0.3
       object-treeify: 1.1.33
       password-prompt: 1.1.3
@@ -11925,7 +11925,7 @@ snapshots:
 
   '@oclif/plugin-help@6.2.40':
     dependencies:
-      '@oclif/core': 4.9.0
+      '@oclif/core': 4.5.3
 
   '@oclif/plugin-not-found@3.2.77(@types/node@18.19.70)':
     dependencies:
@@ -11954,7 +11954,7 @@ snapshots:
 
   '@oclif/plugin-warn-if-update-available@3.1.57':
     dependencies:
-      '@oclif/core': 4.9.0
+      '@oclif/core': 4.5.3
       ansis: 3.17.0
       debug: 4.4.3(supports-color@8.1.1)
       http-call: 5.3.0
@@ -12446,7 +12446,7 @@ snapshots:
 
   '@shikijs/vscode-textmate@10.0.2': {}
 
-  '@shopify/cli-hydrogen@11.1.10(@graphql-codegen/cli@6.0.1(@parcel/watcher@2.5.6)(@types/node@18.19.70)(crossws@0.3.5)(graphql@16.10.0)(typescript@5.9.3))(graphql-config@5.1.5(@types/node@22.19.15)(crossws@0.3.5)(graphql@16.10.0)(typescript@5.9.3))(graphql@16.10.0)(react-dom@19.2.4(react@18.3.1))(react@18.3.1)(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(sass@1.97.3)(yaml@2.8.3))':
+  '@shopify/cli-hydrogen@11.1.14(@graphql-codegen/cli@6.0.1(@parcel/watcher@2.5.6)(@types/node@18.19.70)(crossws@0.3.5)(graphql@16.10.0)(typescript@5.9.3))(graphql-config@5.1.5(@types/node@22.19.15)(crossws@0.3.5)(graphql@16.10.0)(typescript@5.9.3))(graphql@16.10.0)(react-dom@19.2.4(react@18.3.1))(react@18.3.1)(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(sass@1.97.3)(yaml@2.8.3))':
     dependencies:
       '@ast-grep/napi': 0.34.1
       '@oclif/core': 3.26.5
@@ -13157,7 +13157,7 @@ snapshots:
 
   '@types/mute-stream@0.0.4':
     dependencies:
-      '@types/node': 22.19.15
+      '@types/node': 18.19.70
 
   '@types/node@12.20.55': {}
 
@@ -16629,7 +16629,7 @@ snapshots:
   normalize-package-data@6.0.2:
     dependencies:
       hosted-git-info: 7.0.2
-      semver: 7.7.4
+      semver: 7.6.3
       validate-npm-package-license: 3.0.4
 
   normalize-path@2.1.1:
@@ -16644,7 +16644,7 @@ snapshots:
     dependencies:
       hosted-git-info: 7.0.2
       proc-log: 4.2.0
-      semver: 7.7.4
+      semver: 7.6.3
       validate-npm-package-name: 5.0.1
 
   npm-run-path@4.0.1:
@@ -17728,7 +17728,7 @@ snapshots:
       get-stdin: 9.0.0
       git-hooks-list: 3.2.0
       is-plain-obj: 4.1.0
-      semver: 7.7.4
+      semver: 7.6.3
       sort-object-keys: 1.1.3
       tinyglobby: 0.2.15
 
@@ -17828,7 +17828,7 @@ snapshots:
     dependencies:
       eastasianwidth: 0.2.0
       emoji-regex: 9.2.2
-      strip-ansi: 7.2.0
+      strip-ansi: 7.1.0
 
   string-width@7.2.0:
     dependencies:
@@ -18681,7 +18681,7 @@ snapshots:
     dependencies:
       ansi-styles: 6.2.3
       string-width: 5.1.2
-      strip-ansi: 7.2.0
+      strip-ansi: 7.1.0
 
   wrap-ansi@9.0.2:
     dependencies:


### PR DESCRIPTION
Bumps `@shopify/cli-hydrogen` from `11.1.10` to `11.1.14`.

This is a consolidated update covering cli-hydrogen releases for Hydrogen 2026.1.2, 2026.1.3, 2026.1.4, and 2026.4.0.

## Release Notes

### @shopify/cli-hydrogen@11.1.14 (Hydrogen 2026.4.0)

**Patch Changes**

- Widen React Router peer dependencies from exact versions to caret ranges (`^7.12.0`). Allows Hydrogen projects to use newer React Router minor versions without peer dependency conflicts with npm's strict resolver. ([#3677](https://github.com/Shopify/hydrogen/pull/3677))

- Update Storefront API and Customer Account API from 2026-01 to 2026-04. ([#3651](https://github.com/Shopify/hydrogen/pull/3651))

  **Breaking changes**

  **JSON metafield values limited to 128KB**: When using API version 2026-04 or later, the Storefront API limits JSON type metafield writes to 128KB. Apps created after April 1, 2026 are subject to this limit; existing apps are grandfathered at 2MB.

  **New `MERCHANDISE_LINE_TRANSFORMERS_RUN_ERROR` cart error code**: Cart operations now return a specific error code when a Cart Transform Function fails, instead of the generic `INVALID` code.

- Remove `proxyStandardRoutes` option from `createRequestHandler`. The Storefront API proxy is now always enabled. ([#3649](https://github.com/Shopify/hydrogen/pull/3649))

- Enable backend consent mode for Customer Privacy API — `window.Shopify.customerPrivacy.backendConsentEnabled` is now set to `true` automatically. ([#3649](https://github.com/Shopify/hydrogen/pull/3649))

### @shopify/cli-hydrogen@11.1.13 (Hydrogen 2026.1.4)

**Patch Changes**

- Add Storefront MCP proxy support to enable AI agent integration. Hydrogen now automatically proxies requests to `/api/mcp` to Shopify's Storefront MCP server. ([#3572](https://github.com/Shopify/hydrogen/pull/3572))

- Remove redundant Storefront API proxy route from skeleton template. ([#3572](https://github.com/Shopify/hydrogen/pull/3572))

- GraphQL access denied error is now handled as an expected user error. ([#3654](https://github.com/Shopify/hydrogen/pull/3654))

### @shopify/cli-hydrogen@11.1.12 (Hydrogen 2026.1.3)

**Patch Changes**

- Improve screen reader experience for paginated product grids by hiding decorative arrow characters from assistive technology. ([#3557](https://github.com/Shopify/hydrogen/pull/3557))

- Fix `hydrogen dev` with `--port 0` when using `--customer-account-push`. Port 0 (OS-assigned) caused cloudflared to target `localhost:0` while Vite resolved to a concrete port internally. The port is now resolved upfront so both cloudflared and Vite bind to the same origin. ([#3532](https://github.com/Shopify/hydrogen/pull/3532))

- Fix broken `aria-label` on territory code input in address form. The label was the raw developer string `"territoryCode"` instead of a human-readable `"Country code"`. ([#3607](https://github.com/Shopify/hydrogen/pull/3607))

- Fix `hydrogen upgrade` failing with yarn and pnpm by using the correct package-specific install subcommand (`add` for yarn/pnpm, `install` for npm/bun) when upgrading dependencies. ([#3462](https://github.com/Shopify/hydrogen/pull/3462))

- Fix `h2 upgrade` to correctly handle dependency removals when upgrading across multiple versions. ([#3527](https://github.com/Shopify/hydrogen/pull/3527))

- Add `aria-label` to `ProductPrice` for improved screen reader accessibility. ([#3558](https://github.com/Shopify/hydrogen/pull/3558))

- Fix multi-version upgrades to accumulate intermediate dependency bumps; apply `--legacy-peer-deps` for npm to resolve ERESOLVE conflicts during upgrade. ([#3507](https://github.com/Shopify/hydrogen/pull/3507))

### @shopify/cli-hydrogen@11.1.11 (Hydrogen 2026.1.2)

- Update SFAPI and CAAPI to 2026-01 version. ([#3601](https://github.com/Shopify/hydrogen/pull/3601))

This is the main branch PR (no changeset). See the stable branch PR for the changeset and actual release.

## Related PRs

- Stable branch PR (with changeset): https://github.com/Shopify/cli/pull/7246