### PR TITLE
hydrogen/Bump cli-hydrogen to 11.1.14

### DIFF
--- a/.changeset/stable-update-hydrogen-cli-11.1.14.md
+++ b/.changeset/stable-update-hydrogen-cli-11.1.14.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli': patch
+---
+
+Update cli-hydrogen 11.1.14

--- a/packages/app/src/cli/api/graphql/bulk-operations/generated/types.d.ts
+++ b/packages/app/src/cli/api/graphql/bulk-operations/generated/types.d.ts
@@ -182,7 +182,7 @@ export type BulkOperationStatus =
    * [BulkOperation.errorCode](https://shopify.dev/api/admin-graphql/latest/enums/bulkoperationerrorcode).
    */
   | 'FAILED'
-  /** The bulk operation is runnning. */
+  /** The bulk operation is running. */
   | 'RUNNING';
 
 /** The valid values for the bulk operation's type. */

--- a/packages/app/src/cli/api/graphql/business-platform-organizations/generated/types.d.ts
+++ b/packages/app/src/cli/api/graphql/business-platform-organizations/generated/types.d.ts
@@ -26,6 +26,8 @@ export type Scalars = {
   BulkDataOperationID: { input: any; output: any; }
   /** The ID for a BusinessUser. */
   BusinessUserID: { input: any; output: any; }
+  /** The ID for a BusinessUsersImport. */
+  BusinessUsersImportID: { input: any; output: any; }
   /** A signed decimal number, which supports arbitrary precision and is serialized as a string. */
   Decimal: { input: any; output: any; }
   /** The ID for a DocumentAttachment. */

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1433,9 +1433,8 @@ USAGE
     [--typescript]
 
 ARGUMENTS
-  ROUTENAME  (home|page|cart|products|collections|policies|blogs|account|search|robots|sitemap|tokenlessApi|all) The
-             route to generate. One of
-             home,page,cart,products,collections,policies,blogs,account,search,robots,sitemap,tokenlessApi,all.
+  ROUTENAME  (home|page|cart|products|collections|policies|blogs|account|search|robots|sitemap|all) The route to
+             generate. One of home,page,cart,products,collections,policies,blogs,account,search,robots,sitemap,all.
 
 FLAGS
   -f, --force                 [env: SHOPIFY_HYDROGEN_FLAG_FORCE] Overwrites the destination directory and files if they

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -4326,7 +4326,7 @@
       ],
       "args": {
         "routeName": {
-          "description": "The route to generate. One of home,page,cart,products,collections,policies,blogs,account,search,robots,sitemap,tokenlessApi,all.",
+          "description": "The route to generate. One of home,page,cart,products,collections,policies,blogs,account,search,robots,sitemap,all.",
           "name": "routeName",
           "options": [
             "home",
@@ -4340,7 +4340,6 @@
             "search",
             "robots",
             "sitemap",
-            "tokenlessApi",
             "all"
           ],
           "required": true

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -64,7 +64,7 @@
     "@shopify/plugin-cloudflare": "3.92.1",
     "@shopify/plugin-did-you-mean": "3.92.1",
     "@shopify/theme": "3.92.1",
-    "@shopify/cli-hydrogen": "11.1.10",
+    "@shopify/cli-hydrogen": "11.1.14",
     "@types/global-agent": "3.0.0",
     "@vitest/coverage-istanbul": "^3.1.4",
     "esbuild-plugin-copy": "^2.1.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -292,8 +292,8 @@ importers:
         specifier: 3.92.1
         version: link:../app
       '@shopify/cli-hydrogen':
-        specifier: 11.1.10
-        version: 11.1.10(@graphql-codegen/cli@5.0.4(@parcel/watcher@2.5.1)(@types/node@24.7.0)(crossws@0.3.5)(enquirer@2.4.1)(graphql@16.10.0)(typescript@5.9.3))(graphql-config@5.1.5(@types/node@24.7.0)(crossws@0.3.5)(graphql@16.10.0)(typescript@5.9.3))(graphql@16.10.0)(react-dom@19.2.4(react@18.3.1))(react@18.3.1)(vite@6.4.1(@types/node@24.7.0)(jiti@2.4.2)(sass@1.89.1)(yaml@2.8.2))
+        specifier: 11.1.14
+        version: 11.1.14(@graphql-codegen/cli@5.0.4(@parcel/watcher@2.5.1)(@types/node@24.7.0)(crossws@0.3.5)(enquirer@2.4.1)(graphql@16.10.0)(typescript@5.9.3))(graphql-config@5.1.5(@types/node@24.7.0)(crossws@0.3.5)(graphql@16.10.0)(typescript@5.9.3))(graphql@16.10.0)(react-dom@19.2.4(react@18.3.1))(react@18.3.1)(vite@6.4.1(@types/node@24.7.0)(jiti@2.4.2)(sass@1.89.1)(yaml@2.8.2))
       '@shopify/cli-kit':
         specifier: 3.92.1
         version: link:../cli-kit
@@ -3928,15 +3928,15 @@ packages:
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
 
-  '@shopify/cli-hydrogen@11.1.10':
-    resolution: {integrity: sha512-MEnTbWVeNMeV/0dawod4y2AuhhFFLlwpaYzbaqQXJ2HMm20g+bPoOogqSnGF04DoySIT9nEVXI9CXm/TgBsvoA==}
+  '@shopify/cli-hydrogen@11.1.14':
+    resolution: {integrity: sha512-rCa61SidFsB5qXCSDe/0bGdsi5DzEBmQ1eoQVPOzDS2aBO7PSzKx4P4ptLfFU7Yf0negqTsLB0sO+Uc/009h3A==}
     engines: {node: ^20 || ^22 || ^24}
     hasBin: true
     peerDependencies:
       '@graphql-codegen/cli': ^5.0.2
-      '@react-router/dev': 7.12.0
+      '@react-router/dev': ^7.12.0
       '@shopify/hydrogen-codegen': 0.3.3
-      '@shopify/mini-oxygen': 4.0.1
+      '@shopify/mini-oxygen': 4.0.2
       graphql-config: ^5.0.3
       vite: 6.4.1
     peerDependenciesMeta:
@@ -13485,7 +13485,7 @@ snapshots:
     dependencies:
       string-width: 5.1.2
       string-width-cjs: string-width@4.2.3
-      strip-ansi: 7.1.2
+      strip-ansi: 7.1.0
       strip-ansi-cjs: strip-ansi@6.0.1
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: wrap-ansi@7.0.0
@@ -14352,7 +14352,7 @@ snapshots:
 
   '@shikijs/vscode-textmate@10.0.2': {}
 
-  '@shopify/cli-hydrogen@11.1.10(@graphql-codegen/cli@5.0.4(@parcel/watcher@2.5.1)(@types/node@24.7.0)(crossws@0.3.5)(enquirer@2.4.1)(graphql@16.10.0)(typescript@5.9.3))(graphql-config@5.1.5(@types/node@24.7.0)(crossws@0.3.5)(graphql@16.10.0)(typescript@5.9.3))(graphql@16.10.0)(react-dom@19.2.4(react@18.3.1))(react@18.3.1)(vite@6.4.1(@types/node@24.7.0)(jiti@2.4.2)(sass@1.89.1)(yaml@2.8.2))':
+  '@shopify/cli-hydrogen@11.1.14(@graphql-codegen/cli@5.0.4(@parcel/watcher@2.5.1)(@types/node@24.7.0)(crossws@0.3.5)(enquirer@2.4.1)(graphql@16.10.0)(typescript@5.9.3))(graphql-config@5.1.5(@types/node@24.7.0)(crossws@0.3.5)(graphql@16.10.0)(typescript@5.9.3))(graphql@16.10.0)(react-dom@19.2.4(react@18.3.1))(react@18.3.1)(vite@6.4.1(@types/node@24.7.0)(jiti@2.4.2)(sass@1.89.1)(yaml@2.8.2))':
     dependencies:
       '@ast-grep/napi': 0.34.1
       '@oclif/core': 3.26.5
@@ -17831,7 +17831,7 @@ snapshots:
     dependencies:
       foreground-child: 3.3.1
       jackspeak: 4.1.1
-      minimatch: 10.1.1
+      minimatch: 10.2.4
       minipass: 7.1.2
       package-json-from-dist: 1.0.1
       path-scurry: 2.0.0
@@ -20640,7 +20640,7 @@ snapshots:
     dependencies:
       eastasianwidth: 0.2.0
       emoji-regex: 9.2.2
-      strip-ansi: 7.1.2
+      strip-ansi: 7.1.0
 
   string-width@7.2.0:
     dependencies:
@@ -21624,7 +21624,7 @@ snapshots:
     dependencies:
       ansi-styles: 6.2.3
       string-width: 5.1.2
-      strip-ansi: 7.1.2
+      strip-ansi: 7.1.0
 
   wrap-ansi@9.0.2:
     dependencies:


### PR DESCRIPTION
Bumps `@shopify/cli-hydrogen` from `11.1.10` to `11.1.14`.

This is a consolidated update covering cli-hydrogen releases for Hydrogen 2026.1.2, 2026.1.4, and 2026.4.0. This is the stable branch PR (with changeset) — see the equivalent main branch PR for context.

## Release Notes

### @shopify/cli-hydrogen@11.1.14 (Hydrogen 2026.4.0)

**Patch Changes**

- Widen React Router peer dependencies from exact versions to caret ranges (`^7.12.0`). Allows Hydrogen projects to use newer React Router minor versions without peer dependency conflicts with npm's strict resolver. ([#3677](https://github.com/Shopify/hydrogen/pull/3677))

- Update Storefront API and Customer Account API from 2026-01 to 2026-04. ([#3651](https://github.com/Shopify/hydrogen/pull/3651))

  **Breaking changes**

  **JSON metafield values limited to 128KB**: When using API version 2026-04 or later, the Storefront API limits JSON type metafield writes to 128KB. Apps created after April 1, 2026 are subject to this limit; existing apps are grandfathered at 2MB.

  **New `MERCHANDISE_LINE_TRANSFORMERS_RUN_ERROR` cart error code**: Cart operations now return a specific error code when a Cart Transform Function fails, instead of the generic `INVALID` code.

- Remove `proxyStandardRoutes` option from `createRequestHandler`. The Storefront API proxy is now always enabled. ([#3649](https://github.com/Shopify/hydrogen/pull/3649))

- Enable backend consent mode for Customer Privacy API — `window.Shopify.customerPrivacy.backendConsentEnabled` is now set to `true` automatically. ([#3649](https://github.com/Shopify/hydrogen/pull/3649))

### @shopify/cli-hydrogen@11.1.13 (Hydrogen 2026.1.4)

**Patch Changes**

- Add Storefront MCP proxy support to enable AI agent integration. Hydrogen now automatically proxies requests to `/api/mcp` to Shopify's Storefront MCP server. ([#3572](https://github.com/Shopify/hydrogen/pull/3572))

- Remove redundant Storefront API proxy route from skeleton template. ([#3572](https://github.com/Shopify/hydrogen/pull/3572))

- GraphQL access denied error is now handled as an expected user error. ([#3654](https://github.com/Shopify/hydrogen/pull/3654))

### @shopify/cli-hydrogen@11.1.11 (Hydrogen 2026.1.2)

- Update SFAPI and CAAPI to 2026-01 version. ([#3601](https://github.com/Shopify/hydrogen/pull/3601))

## Related PRs

- Equivalent PR to main branch (without changeset): https://github.com/Shopify/cli/pull/7234