### PR TITLE
Add GitHub release URL to major version upgrade reminder

### DIFF
--- a/packages/cli-kit/src/public/node/hooks/postrun.test.ts
+++ b/packages/cli-kit/src/public/node/hooks/postrun.test.ts
@@ -90,6 +90,7 @@ describe('autoUpgradeIfNeeded', () => {
 
     // Then
     expect(runCLIUpgrade).not.toHaveBeenCalled()
+    expect(getOutputUpdateCLIReminder).toHaveBeenCalledWith('4.0.0', true)
     expect(outputMock.warn()).toMatch(installReminder)
   })
 })

--- a/packages/cli-kit/src/public/node/hooks/postrun.ts
+++ b/packages/cli-kit/src/public/node/hooks/postrun.ts
@@ -69,7 +69,7 @@ export async function autoUpgradeIfNeeded(): Promise<void> {
 
 async function performAutoUpgrade(newerVersion: string): Promise<void> {
   if (isMajorVersionChange(CLI_KIT_VERSION, newerVersion)) {
-    return outputWarn(getOutputUpdateCLIReminder(newerVersion))
+    return outputWarn(getOutputUpdateCLIReminder(newerVersion, true))
   }
 
   try {

--- a/packages/cli-kit/src/public/node/upgrade.test.ts
+++ b/packages/cli-kit/src/public/node/upgrade.test.ts
@@ -2,7 +2,7 @@ import {isDevelopment} from './context/local.js'
 import {currentProcessIsGlobal, inferPackageManagerForGlobalCLI} from './is-global.js'
 import {checkForCachedNewVersion, packageManagerFromUserAgent, PackageManager} from './node-package-manager.js'
 import {exec, isCI} from './system.js'
-import {cliInstallCommand, runCLIUpgrade, versionToAutoUpgrade} from './upgrade.js'
+import {cliInstallCommand, getOutputUpdateCLIReminder, runCLIUpgrade, versionToAutoUpgrade} from './upgrade.js'
 import {isPreReleaseVersion} from './version.js'
 import {getAutoUpgradeEnabled} from '../../private/node/conf-store.js'
 import {vi, describe, test, expect, beforeEach} from 'vitest'
@@ -96,6 +96,38 @@ describe('cliInstallCommand', () => {
     expect(got).toBeUndefined()
   })
 })
+describe('getOutputUpdateCLIReminder', () => {
+  test('returns a basic upgrade message for a minor version bump', () => {
+    vi.mocked(inferPackageManagerForGlobalCLI).mockReturnValue('homebrew')
+
+    const message = getOutputUpdateCLIReminder('3.91.0')
+
+    expect(message).toContain('3.91.0')
+    expect(message).toContain('brew upgrade shopify-cli')
+    expect(message).not.toContain('major version')
+  })
+
+  test('appends the GitHub release URL for a major version bump', () => {
+    vi.mocked(inferPackageManagerForGlobalCLI).mockReturnValue('homebrew')
+
+    const message = getOutputUpdateCLIReminder('4.0.0', true)
+
+    expect(message).toContain('4.0.0')
+    expect(message).toContain('brew upgrade shopify-cli')
+    expect(message).toContain('major version')
+    expect(message).toContain('https://github.com/Shopify/cli/releases/tag/v4.0.0')
+  })
+
+  test('does not append the release URL for a minor version bump even when isMajor is false', () => {
+    vi.mocked(inferPackageManagerForGlobalCLI).mockReturnValue('npm')
+
+    const message = getOutputUpdateCLIReminder('3.91.0', false)
+
+    expect(message).not.toContain('major version')
+    expect(message).not.toContain('releases/tag')
+  })
+})
+
 describe('runCLIUpgrade', () => {
   beforeEach(() => {
     // Mock isDevelopment to return false by default (not in CLI development mode)

--- a/packages/cli-kit/src/public/node/upgrade.test.ts
+++ b/packages/cli-kit/src/public/node/upgrade.test.ts
@@ -115,7 +115,7 @@ describe('getOutputUpdateCLIReminder', () => {
     expect(message).toContain('4.0.0')
     expect(message).toContain('brew upgrade shopify-cli')
     expect(message).toContain('major version')
-    expect(message).toContain('https://github.com/Shopify/cli/releases/tag/v4.0.0')
+    expect(message).toContain('https://github.com/Shopify/cli/releases/tag/4.0.0')
   })
 
   test('does not append the release URL for a minor version bump even when isMajor is false', () => {

--- a/packages/cli-kit/src/public/node/upgrade.ts
+++ b/packages/cli-kit/src/public/node/upgrade.ts
@@ -128,16 +128,28 @@ export async function warnIfUpgradeAvailable(): Promise<void> {
 
 /**
  * Generates a message to remind the user to update the CLI.
+ * For major version bumps, appends a link to the GitHub release notes so users
+ * can review breaking changes before deciding to upgrade.
  *
  * @param version - The version to update to.
+ * @param isMajor - Whether the version bump is a major version change.
  * @returns The message to remind the user to update the CLI.
  */
-export function getOutputUpdateCLIReminder(version: string): string {
+export function getOutputUpdateCLIReminder(version: string, isMajor = false): string {
   const installCommand = cliInstallCommand()
-  if (installCommand) {
-    return outputContent`💡 Version ${version} available! Run ${outputToken.genericShellCommand(installCommand)}`.value
+  const base = installCommand
+    ? outputContent`💡 Version ${version} available! Run ${outputToken.genericShellCommand(installCommand)}`.value
+    : outputContent`💡 Version ${version} available!`.value
+
+  if (isMajor) {
+    const releaseUrl = `https://github.com/Shopify/cli/releases/tag/v${version}`
+    const majorNotice =
+      outputContent`⚠️  This is a major version — review breaking changes before upgrading:\n   ${outputToken.link(releaseUrl, releaseUrl)}`
+        .value
+    return `${base}\n\n${majorNotice}`
   }
-  return outputContent`💡 Version ${version} available!`.value
+
+  return base
 }
 
 /**

--- a/packages/cli-kit/src/public/node/upgrade.ts
+++ b/packages/cli-kit/src/public/node/upgrade.ts
@@ -142,7 +142,7 @@ export function getOutputUpdateCLIReminder(version: string, isMajor = false): st
     : outputContent`💡 Version ${version} available!`.value
 
   if (isMajor) {
-    const releaseUrl = `https://github.com/Shopify/cli/releases/tag/v${version}`
+    const releaseUrl = `https://github.com/Shopify/cli/releases/tag/${version}`
     const majorNotice =
       outputContent`⚠️  This is a major version — review breaking changes before upgrading:\n   ${outputToken.link(releaseUrl, releaseUrl)}`
         .value


### PR DESCRIPTION
## Summary

Implements Option A from https://github.com/shop/issues-develop/issues/22372.

When `isMajorVersionChange()` returns true, the upgrade notification now includes a link to the GitHub release notes so users can review breaking changes before deciding to upgrade.

**Before:**

```
💡 Version 4.0.0 available! Run brew upgrade shopify-cli
```

**After:**

```
💡 Version 4.0.0 available! Run brew upgrade shopify-cli

⚠️  This is a major version — review breaking changes before upgrading:
   https://github.com/Shopify/cli/releases/tag/4.0.0
```

## Changes

- `packages/cli-kit/src/public/node/upgrade.ts` — extended `getOutputUpdateCLIReminder(version, isMajor = false)` to append the GitHub release URL when `isMajor` is true
- `packages/cli-kit/src/public/node/hooks/postrun.ts` — pass `true` as `isMajor` to `getOutputUpdateCLIReminder` when a major version change is detected

## Test plan

- [ ] Unit tests added for `getOutputUpdateCLIReminder`: major version includes URL, minor/patch does not
- [ ] Updated `autoUpgradeIfNeeded` test to assert `getOutputUpdateCLIReminder` is called with `isMajor: true` for major bumps
- [ ] Type-check passes (`pnpm nx type-check cli-kit`)
- [ ] Lint passes (`pnpm nx lint cli-kit`)
- [ ] All 25 tests pass

Closes https://github.com/shop/issues-develop/issues/22372