### PR TITLE
fix: copy raw binary to dist/index.wasm during standalone builds, not base64

### DIFF
--- a/packages/app/src/cli/services/build/extension.test.ts
+++ b/packages/app/src/cli/services/build/extension.test.ts
@@ -7,7 +7,7 @@ import {beforeEach, describe, expect, test, vi} from 'vitest'
 import {exec} from '@shopify/cli-kit/node/system'
 import lockfile from 'proper-lockfile'
 import {AbortError} from '@shopify/cli-kit/node/error'
-import {fileExistsSync, touchFile, writeFile} from '@shopify/cli-kit/node/fs'
+import {copyFile, fileExistsSync, touchFile, writeFile} from '@shopify/cli-kit/node/fs'
 import {joinPath} from '@shopify/cli-kit/node/path'
 
 vi.mock('@shopify/cli-kit/node/system')
@@ -418,7 +418,32 @@ describe('buildFunctionExtension', () => {
     expect(runWasmOpt).toHaveBeenCalled()
   })
 
-  test('does not rebundle when build.path stays in the default output directory', async () => {
+  test('copies raw binary (not base64) to dist/index.wasm when build.path is in a different dir (standalone build)', async () => {
+    // Given
+    extension.configuration.build!.path = 'target/wasm32-wasi/release/my_func.wasm'
+    vi.mocked(fileExistsSync).mockReturnValue(true)
+
+    // When
+    await expect(
+      buildFunctionExtension(extension, {
+        stdout,
+        stderr,
+        signal,
+        app,
+        environment: 'production',
+      }),
+    ).resolves.toBeUndefined()
+
+    // Then: copyFile is used (raw binary copy), NOT base64 bundling via touchFile/writeFile
+    expect(copyFile).toHaveBeenCalledWith(
+      joinPath(extension.directory, 'target/wasm32-wasi/release/my_func.wasm'),
+      joinPath(extension.directory, 'dist', 'index.wasm'),
+    )
+    expect(touchFile).not.toHaveBeenCalled()
+    expect(writeFile).not.toHaveBeenCalled()
+  })
+
+  test('copies raw binary to dist/index.wasm when build.path stays in the default output directory', async () => {
     // Given
     extension.configuration.build!.path = 'dist/custom.wasm'
     vi.mocked(fileExistsSync).mockReturnValue(true)
@@ -434,8 +459,11 @@ describe('buildFunctionExtension', () => {
       }),
     ).resolves.toBeUndefined()
 
-    // Then
-    expect(fileExistsSync).toHaveBeenCalledWith(joinPath(extension.directory, 'dist/custom.wasm'))
+    // Then: copyFile is used (raw binary copy), NOT base64 bundling via touchFile/writeFile
+    expect(copyFile).toHaveBeenCalledWith(
+      joinPath(extension.directory, 'dist/custom.wasm'),
+      joinPath(extension.directory, 'dist', 'index.wasm'),
+    )
     expect(touchFile).not.toHaveBeenCalled()
     expect(writeFile).not.toHaveBeenCalled()
   })

--- a/packages/app/src/cli/services/build/extension.ts
+++ b/packages/app/src/cli/services/build/extension.ts
@@ -10,7 +10,7 @@ import {AbortError, AbortSilentError} from '@shopify/cli-kit/node/error'
 import lockfile from 'proper-lockfile'
 import {dirname, joinPath} from '@shopify/cli-kit/node/path'
 import {outputDebug} from '@shopify/cli-kit/node/output'
-import {readFile, touchFile, writeFile, fileExistsSync} from '@shopify/cli-kit/node/fs'
+import {copyFile, readFile, touchFile, writeFile, fileExistsSync} from '@shopify/cli-kit/node/fs'
 import {Writable} from 'stream'
 
 export interface ExtensionBuildOptions {
@@ -161,12 +161,17 @@ export async function buildFunctionExtension(
       await runTrampoline(extension.outputPath)
     }
 
-    if (
-      fileExistsSync(extension.outputPath) &&
-      bundlePath !== extension.outputPath &&
-      dirname(bundlePath) !== dirname(extension.outputPath)
-    ) {
-      await bundleFunctionExtension(extension.outputPath, bundlePath)
+    if (fileExistsSync(extension.outputPath) && bundlePath !== extension.outputPath) {
+      const projectOutputPath = joinPath(extension.directory, extension.outputRelativePath)
+      if (bundlePath === projectOutputPath) {
+        // Standalone build (e.g. `shopify app build`): copy raw binary to dist/index.wasm so
+        // vitest and other local tooling can load the wasm directly.
+        await copyFile(extension.outputPath, bundlePath)
+      } else if (dirname(bundlePath) !== dirname(extension.outputPath)) {
+        // Bundle build for deploy: base64-encode into the bundle directory to satisfy the
+        // server-side contract of uploaded_files["dist/index.wasm"].
+        await bundleFunctionExtension(extension.outputPath, bundlePath)
+      }
     }
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   } catch (error: any) {


### PR DESCRIPTION
### WHY are these changes introduced?

**Community regression ([CLI 3.93.0](https://community.shopify.dev/t/cli-3-93-0-regression-vitest-wasm-tests-fail-for-rust-function-extensions-base64-written-to-dist-index-wasm-instead-of-raw-binary/33061)):** after `shopify app build`, `dist/index.wasm` contains base64-encoded text instead of raw binary, causing vitest to fail immediately when loading the wasm.

---

#### How the bug was introduced — the full chain

There are **two independent concerns** that `outputPath` has been confusingly conflating:

| Concern | Meaning |
|---|---|
| **Local build output path** | Where the compiler writes the wasm on disk (configured via `build.path` in TOML, e.g. `target/wasm32-wasi/release/my_func.wasm`) |
| **Bundle destination path** | Where the wasm lands inside the deploy artifact (always `dist/index.wasm` — a hard server-side contract) |

**1. Commit `4446834` (bad refactor):** changed `getOutputRelativePath` to return `build.path ?? dist/index.wasm`. This caused `extension.outputPath` at *construction* time to point at the compiler output path, which meant the wasm ended up under the wrong key in the deploy bundle — breaking all Function deploys.

**2. PR #7085 (fix, Mar 24):** restored `getOutputRelativePath` to always return `dist/index.wasm`. This fixed deploys. However, it also means `extension.outputPath` starts as `<project>/dist/index.wasm` again. Inside `buildFunctionExtension`:

```
bundlePath = extension.outputPath          // ← <project>/dist/index.wasm
extension.outputPath = <project>/<build.path>  // mutated to compiler output
// build runs, raw wasm at <project>/<build.path>
if bundlePath !== extension.outputPath && dirname differs:
    bundleFunctionExtension(...)           // ← writes BASE64 to <project>/dist/index.wasm ✗
```

When called from **`shopify app build`** (i.e. `ext.build()` directly), `bundlePath` is the project's own `dist/index.wasm`, so base64 is written straight into the developer's project.

**3. PR #7161 (partial fix, Apr 2):** added a `dirname` check to skip bundling when `build.path` is in the same directory as `dist/` (e.g. `dist/custom.wasm`). This helps only that narrow case. Typical Rust functions have `build.path = "target/wasm32-wasi/release/func.wasm"` — a completely different directory — so the base64 encoding still runs.

**4. Community report (Apr 7):** users on CLI 3.93.0 see vitest fail because `dist/index.wasm` has base64 text, not raw WASM bytes.

---

#### Why the same code works correctly for `shopify app deploy`

When called from `buildForBundle` (the deploy path), `buildForBundle` **pre-sets** `extension.outputPath` to the temp bundle directory before calling `build()`:

```
// in buildForBundle:
this.outputPath = this.getOutputPathForDirectory(bundleDirectory, outputId)
//   = <appDir>/.shopify/deploy-bundle/<id>/dist/index.wasm  ← bundle dir, not project
await this.build(options)
```

So inside `buildFunctionExtension`, `bundlePath` = `<bundleDir>/dist/index.wasm` (outside the project), and the base64 encoding goes into the bundle directory — exactly right for the zip upload. The project's `dist/index.wasm` is never touched.

The problem is that `shopify app build` skips `buildForBundle` and calls `ext.build()` directly, so `bundlePath` is the project's own `dist/index.wasm`.

---

### WHAT is this pull request doing?

Adds a check in `buildFunctionExtension` to distinguish between the two call sites using a simple, unambiguous condition:

```typescript
const projectOutputPath = joinPath(extension.directory, extension.outputRelativePath)
// projectOutputPath is always <project>/dist/index.wasm

if (bundlePath === projectOutputPath) {
  // Standalone build — copy raw binary so vitest and local tooling can load the wasm
  await copyFile(extension.outputPath, bundlePath)
} else if (dirname(bundlePath) !== dirname(extension.outputPath)) {
  // Deploy bundle build — base64-encode for the server contract
  await bundleFunctionExtension(extension.outputPath, bundlePath)
}
```

| Scenario | `bundlePath` | Behaviour |
|---|---|---|
| `shopify app build` (standalone) | `<project>/dist/index.wasm` | Raw binary copied → vitest works ✓ |
| `shopify app deploy` / `buildForBundle` | `<bundleDir>/<id>/dist/index.wasm` | Base64 encoded → server contract satisfied ✓ |
| `build.path = dist/custom.wasm` (same dir, standalone) | `<project>/dist/index.wasm` | Raw binary copied from `dist/custom.wasm` → `dist/index.wasm` ✓ |
| `build.path = dist/custom.wasm` (same dir, bundle) | `<bundleDir>/<id>/dist/index.wasm` | Base64 encoded → server contract satisfied ✓ |

### How to test your changes?

1. Create a Rust function extension with a custom `build.path` pointing to the Cargo output:
   ```toml
   [build]
   command = "cargo wasi build --release"
   path = "target/wasm32-wasi/release/my_func.wasm"
   ```
2. Run `shopify app build` — verify `dist/index.wasm` is **raw binary** (e.g. starts with `\0asm` magic bytes), not base64 text.
3. Run your vitest suite — verify function tests pass.
4. Run `shopify app deploy` — verify the function deploys successfully (wasm uploaded under `dist/index.wasm`).
5. Run `shopify app dev` — verify dev draft updates work correctly.

### Measuring impact

- [x] n/a — bug fix for a confirmed community regression; no new behaviour surface

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes