### PR TITLE
Fix --reset flag regression: skip spurious TOML selection prompt before link flow

### DIFF
--- a/.changeset/fix-reset-spurious-toml-prompt.md
+++ b/.changeset/fix-reset-spurious-toml-prompt.md
@@ -2,8 +2,4 @@
 '@shopify/app': patch
 ---
 
-Fix `--reset` flag regression: skip spurious TOML file selection prompt before the link flow
-
-When running `shopify app dev --reset`, `getAppConfigurationState()` was called unconditionally before checking `forceRelink`. If the cached config file didn't exist on disk, this would prompt the user to select a TOML file — only to immediately discard the result when `link()` runs. This was a regression from #6612 which merged the `forceRelink` and `!isLinked` branches back together, undoing the fix from #5676.
-
-The fix separates the two paths again: when `forceRelink` is true, we call `link()` directly without loading config state first.
+Avoid config prompt when using --reset flag

--- a/.changeset/fix-reset-spurious-toml-prompt.md
+++ b/.changeset/fix-reset-spurious-toml-prompt.md
@@ -1,0 +1,9 @@
+---
+'@shopify/app': patch
+---
+
+Fix `--reset` flag regression: skip spurious TOML file selection prompt before the link flow
+
+When running `shopify app dev --reset`, `getAppConfigurationState()` was called unconditionally before checking `forceRelink`. If the cached config file didn't exist on disk, this would prompt the user to select a TOML file — only to immediately discard the result when `link()` runs. This was a regression from #6612 which merged the `forceRelink` and `!isLinked` branches back together, undoing the fix from #5676.
+
+The fix separates the two paths again: when `forceRelink` is true, we call `link()` directly without loading config state first.

--- a/.changeset/fix-reset-spurious-toml-prompt.md
+++ b/.changeset/fix-reset-spurious-toml-prompt.md
@@ -2,4 +2,6 @@
 '@shopify/app': patch
 ---
 
-Avoid config prompt when using --reset flag
+Avoid spurious config prompts:
+- Skip TOML selection prompt when using --reset flag
+- Use default shopify.app.toml without prompting when running `config link --client-id` with no existing TOML files

--- a/packages/app/src/cli/api/graphql/business-platform-organizations/generated/types.d.ts
+++ b/packages/app/src/cli/api/graphql/business-platform-organizations/generated/types.d.ts
@@ -80,13 +80,16 @@ export type Scalars = {
   URL: { input: string; output: string; }
 };
 
-/** Operators for user filter queries. */
+/** Operators for filter queries. */
 export type Operator =
   /** Between operator. */
   | 'BETWEEN'
   /** Equals operator. */
   | 'EQUALS'
-  /** In operator. */
+  /**
+   * In operator. Accepts a comma-separated string of values (e.g.
+   * "value1,value2,value3"). Not supported for all filter fields.
+   */
   | 'IN';
 
 export type OrganizationUserProvisionShopAccessInput = {
@@ -115,17 +118,23 @@ export type ShopFilterField =
    * `inactive`, `cancelled`, `client_transfer`, `plus_client_transfer`,
    * `development_legacy`, `custom`, `fraudulent`, `staff`, `trial`,
    * `plus_development`, `retail`, `shop_pay_commerce_components`, `non_profit`.
+   * With the `In` operator, use raw plan names (e.g. "professional,shopify_plus").
    */
   | 'SHOP_PLAN'
   /** The active/inactive status of the shop. Values: `active`, `inactive`. */
   | 'STORE_STATUS'
   /**
-   * The type of the shop. Values: `development`, `production`, `app_development`,
-   * `development_superset`, `client_transfer`, `collaborator`.
+   * The type of the shop. Does not support the `In` operator. Values:
+   * `development`, `production`, `app_development`, `development_superset`,
+   * `client_transfer`, `collaborator`.
    */
   | 'STORE_TYPE';
 
-/** Represents a single filter option for shop queries. */
+/**
+ * Represents a single filter option for shop queries. When using the `In`
+ * operator, pass a comma-separated string of values (e.g. "value1,value2").
+ * Maximum 20 values.
+ */
 export type ShopFilterInput = {
   field: ShopFilterField;
   operator: Operator;

--- a/packages/app/src/cli/api/graphql/business-platform-organizations/generated/types.d.ts
+++ b/packages/app/src/cli/api/graphql/business-platform-organizations/generated/types.d.ts
@@ -80,16 +80,13 @@ export type Scalars = {
   URL: { input: string; output: string; }
 };
 
-/** Operators for filter queries. */
+/** Operators for user filter queries. */
 export type Operator =
   /** Between operator. */
   | 'BETWEEN'
   /** Equals operator. */
   | 'EQUALS'
-  /**
-   * In operator. Accepts a comma-separated string of values (e.g.
-   * "value1,value2,value3"). Not supported for all filter fields.
-   */
+  /** In operator. */
   | 'IN';
 
 export type OrganizationUserProvisionShopAccessInput = {
@@ -118,23 +115,17 @@ export type ShopFilterField =
    * `inactive`, `cancelled`, `client_transfer`, `plus_client_transfer`,
    * `development_legacy`, `custom`, `fraudulent`, `staff`, `trial`,
    * `plus_development`, `retail`, `shop_pay_commerce_components`, `non_profit`.
-   * With the `In` operator, use raw plan names (e.g. "professional,shopify_plus").
    */
   | 'SHOP_PLAN'
   /** The active/inactive status of the shop. Values: `active`, `inactive`. */
   | 'STORE_STATUS'
   /**
-   * The type of the shop. Does not support the `In` operator. Values:
-   * `development`, `production`, `app_development`, `development_superset`,
-   * `client_transfer`, `collaborator`.
+   * The type of the shop. Values: `development`, `production`, `app_development`,
+   * `development_superset`, `client_transfer`, `collaborator`.
    */
   | 'STORE_TYPE';
 
-/**
- * Represents a single filter option for shop queries. When using the `In`
- * operator, pass a comma-separated string of values (e.g. "value1,value2").
- * Maximum 20 values.
- */
+/** Represents a single filter option for shop queries. */
 export type ShopFilterInput = {
   field: ShopFilterField;
   operator: Operator;

--- a/packages/app/src/cli/models/app/loader.ts
+++ b/packages/app/src/cli/models/app/loader.ts
@@ -253,8 +253,13 @@ export async function loadApp<TModuleSpec extends ExtensionSpecification = Exten
   specifications: TModuleSpec[]
   remoteFlags?: Flag[]
   ignoreUnknownExtensions?: boolean
+  skipPrompts?: boolean
 }): Promise<AppInterface<CurrentAppConfiguration, TModuleSpec>> {
-  const {project, activeConfig} = await getAppConfigurationContext(options.directory, options.userProvidedConfigName)
+  const {project, activeConfig} = await getAppConfigurationContext(
+    options.directory,
+    options.userProvidedConfigName,
+    options.skipPrompts ? {skipPrompts: true} : undefined,
+  )
   return loadAppFromContext({
     project,
     activeConfig,
@@ -395,11 +400,16 @@ export async function loadOpaqueApp(options: {
   configName?: string
   specifications: ExtensionSpecification[]
   remoteFlags?: Flag[]
+  skipPrompts?: boolean
 }): Promise<OpaqueAppLoadResult> {
   // Try to load the app normally first — the loader always collects validation errors,
   // so only structural failures (TOML parse, missing files) will throw.
   try {
-    const {project, activeConfig} = await getAppConfigurationContext(options.directory, options.configName)
+    const {project, activeConfig} = await getAppConfigurationContext(
+      options.directory,
+      options.configName,
+      options.skipPrompts ? {skipPrompts: true} : undefined,
+    )
     const app = await loadAppFromContext({
       project,
       activeConfig,
@@ -913,9 +923,10 @@ type ConfigurationLoaderResult<
 export async function getAppConfigurationContext(
   workingDirectory: string,
   userProvidedConfigName?: string,
+  options?: {skipPrompts?: boolean},
 ): Promise<{project: Project; activeConfig: ActiveConfig}> {
   const project = await Project.load(workingDirectory)
-  const activeConfig = await selectActiveConfig(project, userProvidedConfigName)
+  const activeConfig = await selectActiveConfig(project, userProvidedConfigName, options)
   return {project, activeConfig}
 }
 

--- a/packages/app/src/cli/models/project/active-config.ts
+++ b/packages/app/src/cli/models/project/active-config.ts
@@ -53,15 +53,20 @@ export interface ActiveConfig {
  * config's client_id.
  * @public
  */
-export async function selectActiveConfig(project: Project, userProvidedConfigName?: string): Promise<ActiveConfig> {
+export async function selectActiveConfig(
+  project: Project,
+  userProvidedConfigName?: string,
+  options?: {skipPrompts?: boolean},
+): Promise<ActiveConfig> {
   let configName = userProvidedConfigName
 
   // Check cache for previously selected config
   const cachedConfigName = getCachedAppInfo(project.directory)?.configFile
   const cachedConfigPath = cachedConfigName ? joinPath(project.directory, cachedConfigName) : null
+  const cacheIsStale = Boolean(!configName && cachedConfigPath && !fileExistsSync(cachedConfigPath))
 
   // Handle stale cache: cached config file no longer exists
-  if (!configName && cachedConfigPath && !fileExistsSync(cachedConfigPath)) {
+  if (cacheIsStale && !options?.skipPrompts) {
     const warningContent = {
       headline: `Couldn't find ${cachedConfigName}`,
       body: [
@@ -71,7 +76,8 @@ export async function selectActiveConfig(project: Project, userProvidedConfigNam
     configName = await use({directory: project.directory, warningContent, shouldRenderSuccess: false})
   }
 
-  configName = configName ?? cachedConfigName
+  // Don't fall back to stale cached name — it points to a non-existent file
+  configName = configName ?? (cacheIsStale ? undefined : cachedConfigName)
 
   // Determine source after resolution so it reflects the actual selection path
   let source: ConfigSource

--- a/packages/app/src/cli/services/app-context.test.ts
+++ b/packages/app/src/cli/services/app-context.test.ts
@@ -176,6 +176,44 @@ client_id="test-api-key"`
     })
   })
 
+  test('forceRelink skips config selection before link to avoid spurious TOML prompt', async () => {
+    await inTemporaryDirectory(async (tmp) => {
+      // Given — no config file on disk, so getAppConfigurationContext would prompt for TOML selection
+      // if called before link. We verify link is called first (without a prior config load).
+      const content = `
+name = "test-app"
+client_id="test-api-key"`
+      await writeAppConfig(tmp, content)
+
+      const getAppConfigSpy = vi.spyOn(loader, 'getAppConfigurationContext')
+
+      vi.mocked(link).mockResolvedValue({
+        remoteApp: mockRemoteApp,
+        configFileName: 'shopify.app.toml',
+        configuration: {
+          client_id: 'test-api-key',
+          name: 'test-app',
+          path: normalizePath(joinPath(tmp, 'shopify.app.toml')),
+        } as any,
+      })
+
+      // When
+      await linkedAppContext({
+        directory: tmp,
+        forceRelink: true,
+        userProvidedConfigName: undefined,
+        clientId: undefined,
+      })
+
+      // Then — getAppConfigurationContext should only be called AFTER link, not before
+      const linkCallOrder = vi.mocked(link).mock.invocationCallOrder[0]!
+      const configCallOrders = getAppConfigSpy.mock.invocationCallOrder
+      expect(configCallOrders.every((order) => order > linkCallOrder)).toBe(true)
+
+      getAppConfigSpy.mockRestore()
+    })
+  })
+
   test('logs metadata', async () => {
     await inTemporaryDirectory(async (tmp) => {
       // Given

--- a/packages/app/src/cli/services/app-context.ts
+++ b/packages/app/src/cli/services/app-context.ts
@@ -82,21 +82,34 @@ export async function linkedAppContext({
   userProvidedConfigName,
   unsafeTolerateErrors = false,
 }: LoadedAppContextOptions): Promise<LoadedAppContextOutput> {
-  let {project, activeConfig} = await getAppConfigurationContext(directory, userProvidedConfigName)
+  let project: Project
+  let activeConfig: ActiveConfig
   let remoteApp: OrganizationApp | undefined
 
-  if (activeConfig.file.errors.length > 0) {
-    throw new AbortError(activeConfig.file.errors.map((err) => err.message).join('\n'))
-  }
-
-  if (!activeConfig.isLinked || forceRelink) {
-    const configName = forceRelink ? undefined : basename(activeConfig.file.path)
-    const result = await link({directory, apiKey: clientId, configName})
+  if (forceRelink) {
+    // Skip getAppConfigurationContext() when force-relinking — it may prompt the
+    // user to select a TOML file that will be immediately discarded by link().
+    const result = await link({directory, apiKey: clientId})
     remoteApp = result.remoteApp
-    // Re-load project and re-select active config since link may have written new config
     const reloaded = await getAppConfigurationContext(directory, result.configFileName)
     project = reloaded.project
     activeConfig = reloaded.activeConfig
+  } else {
+    const loaded = await getAppConfigurationContext(directory, userProvidedConfigName)
+    project = loaded.project
+    activeConfig = loaded.activeConfig
+
+    if (activeConfig.file.errors.length > 0) {
+      throw new AbortError(activeConfig.file.errors.map((err) => err.message).join('\n'))
+    }
+
+    if (!activeConfig.isLinked) {
+      const result = await link({directory, apiKey: clientId, configName: basename(activeConfig.file.path)})
+      remoteApp = result.remoteApp
+      const reloaded = await getAppConfigurationContext(directory, result.configFileName)
+      project = reloaded.project
+      activeConfig = reloaded.activeConfig
+    }
   }
 
   // Determine the effective client ID

--- a/packages/app/src/cli/services/app/config/link.test.ts
+++ b/packages/app/src/cli/services/app/config/link.test.ts
@@ -453,6 +453,9 @@ url = "https://api-client-config.com/preferences"
           },
         } as CurrentAppConfiguration,
       }
+      // Write actual TOML file so getTomls() finds it and reuses existing config
+      const filePath = joinPath(tmp, 'shopify.app.development.toml')
+      writeFileSync(filePath, 'client_id = "12345"\nname = "my app"')
       await mockLoadOpaqueAppWithApp(tmp, localApp, [], 'current')
       vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue(
         testOrganizationApp({
@@ -460,7 +463,6 @@ url = "https://api-client-config.com/preferences"
           developerPlatformClient,
         }),
       )
-      vi.mocked(selectConfigName).mockResolvedValue('shopify.app.staging.toml')
       const remoteConfiguration = {
         ...DEFAULT_REMOTE_CONFIGURATION,
         name: 'my app',
@@ -472,8 +474,9 @@ url = "https://api-client-config.com/preferences"
       // When
       const {configuration} = await link(options)
 
-      // Then
-      const content = await readFile(joinPath(tmp, 'shopify.app.staging.toml'))
+      // Then - since client_id matches and file exists, reuse shopify.app.development.toml
+      expect(selectConfigName).not.toHaveBeenCalled()
+      const content = await readFile(joinPath(tmp, 'shopify.app.development.toml'))
       const expectedContent = `# Learn more about configuring your app at https://shopify.dev/docs/apps/tools/cli/configuration
 
 client_id = "12345"
@@ -501,14 +504,14 @@ embedded = false
 `
 
       expect(setCurrentConfigPreference).toHaveBeenCalledWith(configuration, {
-        configFileName: 'shopify.app.staging.toml',
+        configFileName: 'shopify.app.development.toml',
         directory: tmp,
       })
       expect(renderSuccess).toHaveBeenCalledWith({
-        headline: 'shopify.app.staging.toml is now linked to "my app" on Shopify',
-        body: 'Using shopify.app.staging.toml as your default config.',
+        headline: 'shopify.app.development.toml is now linked to "my app" on Shopify',
+        body: 'Using shopify.app.development.toml as your default config.',
         nextSteps: [
-          [`Make updates to shopify.app.staging.toml in your local project`],
+          [`Make updates to shopify.app.development.toml in your local project`],
           ['To upload your config, run', {command: 'yarn shopify app deploy'}],
         ],
         reference: [
@@ -569,6 +572,9 @@ embedded = false
           },
         },
       }
+      // Write actual TOML file so getTomls() finds it (needed for selectConfigName logic)
+      const filePath = joinPath(tmp, 'shopify.app.toml')
+      writeFileSync(filePath, 'client_id = "12345"\nname = "my app"')
       await mockLoadOpaqueAppWithApp(tmp, localApp, [], 'current')
       vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue(
         testOrganizationApp({
@@ -981,6 +987,30 @@ embedded = false
         },
       })
       expect(content).toEqual(expectedContent)
+      // Should use default filename without prompting when no TOMLs exist
+      expect(selectConfigName).not.toHaveBeenCalled()
+    })
+  })
+
+  test('uses default shopify.app.toml without prompting when no config files exist and client-id is provided', async () => {
+    await inTemporaryDirectory(async (tmp) => {
+      // Given - no TOML files in directory, but client-id is provided
+      // This simulates: shopify app config link --client-id=12345
+      const developerPlatformClient = buildDeveloperPlatformClient()
+      const options: LinkOptions = {
+        directory: tmp,
+        apiKey: '12345',
+        developerPlatformClient,
+      }
+      mockLoadOpaqueAppWithError()
+      vi.mocked(appFromIdentifiers).mockResolvedValue(mockRemoteApp({developerPlatformClient}))
+
+      // When
+      const {configFileName} = await link(options)
+
+      // Then - should use default filename without prompting
+      expect(configFileName).toBe('shopify.app.toml')
+      expect(selectConfigName).not.toHaveBeenCalled()
     })
   })
 
@@ -1323,6 +1353,9 @@ embedded = false
           embedded: true,
         },
       }
+      // Write actual TOML file so getTomls() finds it and reuses the existing config
+      const filePath = joinPath(tmp, 'shopify.app.toml')
+      writeFileSync(filePath, 'client_id = "12345"\nname = "my app"')
       await mockLoadOpaqueAppWithApp(tmp, localApp, [], 'current')
       vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue(
         testOrganizationApp({
@@ -1330,7 +1363,6 @@ embedded = false
           developerPlatformClient,
         }),
       )
-      vi.mocked(selectConfigName).mockResolvedValue('shopify.app.staging.toml')
       const remoteConfiguration = {
         ...DEFAULT_REMOTE_CONFIGURATION,
         name: 'my app',
@@ -1347,8 +1379,9 @@ embedded = false
       // When
       await link(options)
 
-      // Then
-      const content = await readFile(joinPath(tmp, 'shopify.app.staging.toml'))
+      // Then - since client_id matches, the existing shopify.app.toml is reused (no prompt)
+      expect(selectConfigName).not.toHaveBeenCalled()
+      const content = await readFile(joinPath(tmp, 'shopify.app.toml'))
       const expectedContent = `# Learn more about configuring your app at https://shopify.dev/docs/apps/tools/cli/configuration
 
 client_id = "12345"
@@ -1375,10 +1408,10 @@ embedded = true
 `
       expect(content).toEqual(expectedContent)
       expect(renderSuccess).toHaveBeenCalledWith({
-        headline: 'shopify.app.staging.toml is now linked to "my app" on Shopify',
-        body: 'Using shopify.app.staging.toml as your default config.',
+        headline: 'shopify.app.toml is now linked to "my app" on Shopify',
+        body: 'Using shopify.app.toml as your default config.',
         nextSteps: [
-          [`Make updates to shopify.app.staging.toml in your local project`],
+          [`Make updates to shopify.app.toml in your local project`],
           ['To upload your config, run', {command: 'yarn shopify app deploy'}],
         ],
         reference: [

--- a/packages/app/src/cli/services/app/config/link.ts
+++ b/packages/app/src/cli/services/app/config/link.ts
@@ -310,6 +310,9 @@ async function loadConfigurationFileName(
   const currentToml = existingTomls[remoteApp.apiKey]
   if (currentToml) return currentToml
 
+  // If no TOML files exist at all, use the default filename without prompting
+  if (Object.keys(existingTomls).length === 0) return 'shopify.app.toml'
+
   return selectConfigName(localAppInfo.appDirectory ?? options.directory, remoteApp.title)
 }
 

--- a/packages/app/src/cli/services/app/config/link.ts
+++ b/packages/app/src/cli/services/app/config/link.ts
@@ -165,6 +165,7 @@ async function getAppCreationDefaultsFromLocalApp(options: LinkOptions): Promise
       directory: options.directory,
       userProvidedConfigName: options.configName,
       remoteFlags: undefined,
+      skipPrompts: true,
     })
 
     return {creationOptions: app.creationDefaultOptions(), appDirectory: app.directory}
@@ -231,6 +232,7 @@ export async function loadLocalAppOptions(
     configName: options.configName,
     specifications,
     remoteFlags,
+    skipPrompts: true,
   })
 
   switch (result.state) {

--- a/packages/app/src/cli/services/app/config/link.ts
+++ b/packages/app/src/cli/services/app/config/link.ts
@@ -311,7 +311,7 @@ async function loadConfigurationFileName(
   if (currentToml) return currentToml
 
   // If no TOML files exist at all, use the default filename without prompting
-  if (Object.keys(existingTomls).length === 0) return 'shopify.app.toml'
+  if (isEmpty(existingTomls)) return 'shopify.app.toml'
 
   return selectConfigName(localAppInfo.appDirectory ?? options.directory, remoteApp.title)
 }


### PR DESCRIPTION
## Bug

**Bug 1:** `shopify app dev --reset` spuriously prompts TOML file selection before the reset flow (org → app → config name). The selected TOML is immediately discarded.

**Bug 2:** `shopify app config link --client-id=x` prompts for a config name when no TOML files exist, instead of using the default `shopify.app.toml`.

Fixes shop/issues-develop#22531 and https://community.shopify.dev/t/shopify-app-config-link-client-id-prompts-for-config-name/33039

## Root Cause

### Bug 1 (--reset)
Regression introduced by #6612 ("Remove legacy app schema", merged Mar 2026). Commit `1f8dcceaec` ("Simplify code") merged the `forceRelink` and `!isLinked` branches back together, undoing a prior fix from #5676 (Apr 2025) which fixed #5653 by separating the `forceRelink` path so it skips config state loading.

`getAppConfigurationContext()` is called unconditionally before checking `forceRelink`. When the cached config file doesn't exist on disk, it calls `selectConfigFile()`, prompting the user to pick a TOML — even though `forceRelink` will discard the result.

### Bug 2 (config link --client-id)
In `loadConfigurationFileName()`, when no existing TOML matches the remote app's API key, the code falls through to `selectConfigName()` which prompts the user — even when there are zero TOML files and the obvious default is `shopify.app.toml`.

## Fix

1. **`app-context.ts`** — Separate the `forceRelink` and `!isLinked` paths so `forceRelink` skips `getAppConfigurationContext()` entirely and calls `link()` directly.
2. **`link.ts` / `loader.ts` / `active-config.ts`** — Thread a `skipPrompts` option through `link()` → `loadApp()` / `loadOpaqueApp()` → `getAppConfigurationContext()` → `selectActiveConfig()` so that the stale-cache prompt is also skipped when called from *inside* the link flow.
3. **`link.ts`** — When no TOML files exist at all, use the default `shopify.app.toml` without prompting.

## Test

- Added test verifying `getAppConfigurationContext` is only called *after* `link()` when `forceRelink` is true (using `invocationCallOrder` tracking).
- Added test verifying `selectConfigName` is not called when no TOML files exist.

All 24 tests pass ✅

## 🎩
### Expected Results:
#### `shopify app dev --reset`
####  Using latest:

<img width="799" height="335" alt="Screenshot 2026-04-10 at 3 07 28 PM" src="https://github.com/user-attachments/assets/b92dba8d-4b8d-4814-9d57-f8fc4aef1514" />

#### Using snapshot (0.0.0-snapshot-20260413221738):
<img width="667" height="231" alt="Screenshot 2026-04-14 at 10 28 04 AM" src="https://github.com/user-attachments/assets/99763c88-72ca-439f-af71-496463a17a0b" />

#### `shopify app config link --client-id=<your-client-id>`
####  Using latest:
<img width="933" height="171" alt="Screenshot 2026-04-14 at 10 30 04 AM" src="https://github.com/user-attachments/assets/0912c89b-5e86-44d0-b8e6-7c0b3d59978a" />


#### Using snapshot (0.0.0-snapshot-20260413221738):
<img width="938" height="245" alt="image" src="https://github.com/user-attachments/assets/fa9385f1-b55a-468b-a320-4232507cec53" />

### Setup

Navigate to any Shopify app directory that has **multiple** `shopify.app.*.toml` files, then delete the currently cached/active TOML so the stale-cache path is triggered.

> [!Warning]
> Make sure to double check the version change is working by using 
> `which shopify && shopify version`
> If the version is not changing use these commands:
> `pnpm remove -g @shopify/cli`
> `pnpm add -g @shopify/cli@[version]`
> `which shopify && shopify version`

### 1. Reproduce the --reset bug (`@latest`)

```bash
pnpm i -g --@shopify:registry=https://registry.npmjs.org @shopify/cli@latest
shopify app dev --reset --path /path/to/your/app
```

**Expected (broken):** You get prompted to select a TOML file *before* the org → app → config name flow. The selection is immediately discarded.

### 2. Reproduce the config link bug (`@latest`)

```bash
pnpm i -g --@shopify:registry=https://registry.npmjs.org @shopify/cli@latest
cd /path/to/app/with/no/toml/files
shopify app config link --client-id=<your-client-id>
```

**Expected (broken):** You get prompted for "Configuration file name:" (or an error in non-interactive mode).

### 3. Verify both fixes (snapshot)

```bash
pnpm i -g --@shopify:registry=https://registry.npmjs.org @shopify/cli@0.0.0-snapshot-20260413221738
# Test --reset
shopify app dev --reset --path /path/to/your/app
# Test config link (remove any TOMLs first)
shopify app config link --client-id=<your-client-id>
```

**Expected (fixed):** 
- `--reset` goes straight into the org → app → config name flow with no spurious TOML selection prompt.
- `config link --client-id` creates `shopify.app.toml` without prompting for a name.