### PR TITLE
Use function directory package manager for GraphQL typegen

### DIFF
--- a/packages/app/src/cli/services/function/build.test.ts
+++ b/packages/app/src/cli/services/function/build.test.ts
@@ -22,12 +22,20 @@ import {
 import {testApp, testFunctionExtension} from '../../models/app/app.test-data.js'
 import {beforeEach, describe, expect, test, vi} from 'vitest'
 import {exec} from '@shopify/cli-kit/node/system'
+import {packageManagerBinaryCommandForDirectory} from '@shopify/cli-kit/node/node-package-manager'
 import {dirname, joinPath} from '@shopify/cli-kit/node/path'
 import {inTemporaryDirectory, mkdir, readFileSync, writeFile, removeFile} from '@shopify/cli-kit/node/fs'
 import {build as esBuild} from 'esbuild'
 
 vi.mock('@shopify/cli-kit/node/fs')
 vi.mock('@shopify/cli-kit/node/system')
+vi.mock('@shopify/cli-kit/node/node-package-manager', async () => {
+  const actual: any = await vi.importActual('@shopify/cli-kit/node/node-package-manager')
+  return {
+    ...actual,
+    packageManagerBinaryCommandForDirectory: vi.fn(),
+  }
+})
 
 vi.mock('./binaries.js', async (importOriginal) => {
   const actual: any = await importOriginal()
@@ -76,6 +84,10 @@ beforeEach(async () => {
   stderr = {write: vi.fn()}
   stdout = {write: vi.fn()}
   signal = vi.fn()
+  vi.mocked(packageManagerBinaryCommandForDirectory).mockResolvedValue({
+    command: 'npm',
+    args: ['exec', '--', 'graphql-code-generator', '--config', 'package.json'],
+  })
 })
 
 describe('buildGraphqlTypes', () => {
@@ -88,7 +100,34 @@ describe('buildGraphqlTypes', () => {
 
     // Then
     await expect(got).resolves.toBeUndefined()
+    expect(packageManagerBinaryCommandForDirectory).toHaveBeenCalledTimes(1)
+    expect(packageManagerBinaryCommandForDirectory).toHaveBeenCalledWith(
+      ourFunction.directory,
+      'graphql-code-generator',
+      '--config',
+      'package.json',
+    )
     expect(exec).toHaveBeenCalledWith('npm', ['exec', '--', 'graphql-code-generator', '--config', 'package.json'], {
+      cwd: ourFunction.directory,
+      stderr,
+      signal,
+    })
+  })
+
+  test('generate types executes the command returned by the shared helper', {timeout: 20000}, async () => {
+    // Given
+    const ourFunction = await testFunctionExtension({entryPath: 'src/index.js'})
+    vi.mocked(packageManagerBinaryCommandForDirectory).mockResolvedValue({
+      command: 'pnpm',
+      args: ['exec', 'graphql-code-generator', '--config', 'package.json'],
+    })
+
+    // When
+    const got = buildGraphqlTypes(ourFunction, {stdout, stderr, signal, app})
+
+    // Then
+    await expect(got).resolves.toBeUndefined()
+    expect(exec).toHaveBeenCalledWith('pnpm', ['exec', 'graphql-code-generator', '--config', 'package.json'], {
       cwd: ourFunction.directory,
       stderr,
       signal,
@@ -105,6 +144,7 @@ describe('buildGraphqlTypes', () => {
 
     // Then
     await expect(got).rejects.toThrow(/No typegen_command specified/)
+    expect(packageManagerBinaryCommandForDirectory).not.toHaveBeenCalled()
   })
 
   test('runs custom typegen_command when provided', async () => {
@@ -129,6 +169,7 @@ describe('buildGraphqlTypes', () => {
 
     // Then
     await expect(got).resolves.toBeUndefined()
+    expect(packageManagerBinaryCommandForDirectory).not.toHaveBeenCalled()
     expect(exec).toHaveBeenCalledWith('npx', ['shopify-function-codegen', '--schema', 'schema.graphql'], {
       cwd: ourFunction.directory,
       stdout,
@@ -159,6 +200,7 @@ describe('buildGraphqlTypes', () => {
 
     // Then
     await expect(got).resolves.toBeUndefined()
+    expect(packageManagerBinaryCommandForDirectory).not.toHaveBeenCalled()
     expect(exec).toHaveBeenCalledWith('custom-typegen', ['--output', 'types.ts'], {
       cwd: ourFunction.directory,
       stdout,

--- a/packages/app/src/cli/services/function/build.ts
+++ b/packages/app/src/cli/services/function/build.ts
@@ -24,6 +24,7 @@ import {renderTasks} from '@shopify/cli-kit/node/ui'
 import {pickBy} from '@shopify/cli-kit/common/object'
 import {runWithTimer} from '@shopify/cli-kit/node/metadata'
 import {AbortError} from '@shopify/cli-kit/node/error'
+import {packageManagerBinaryCommandForDirectory} from '@shopify/cli-kit/node/node-package-manager'
 import {Writable} from 'stream'
 
 export const PREFERRED_FUNCTION_NPM_PACKAGE_MAJOR_VERSION = '2'
@@ -143,8 +144,15 @@ export async function buildGraphqlTypes(
     )
   }
 
+  const command = await packageManagerBinaryCommandForDirectory(
+    fun.directory,
+    'graphql-code-generator',
+    '--config',
+    'package.json',
+  )
+
   return runWithTimer('cmd_all_timing_network_ms')(async () => {
-    return exec('npm', ['exec', '--', 'graphql-code-generator', '--config', 'package.json'], {
+    return exec(command.command, command.args, {
       cwd: fun.directory,
       stderr: options.stderr,
       signal: options.signal,

--- a/packages/cli-kit/src/public/node/node-package-manager.test.ts
+++ b/packages/cli-kit/src/public/node/node-package-manager.test.ts
@@ -12,6 +12,7 @@ import {
   addResolutionOrOverride,
   writePackageJSON,
   getPackageManager,
+  packageManagerBinaryCommandForDirectory,
   installNPMDependenciesRecursively,
   addNPMDependencies,
   DependencyVersion,
@@ -880,10 +881,43 @@ describe('getPackageManager', () => {
     })
   })
 
+  test('finds if bun is being used from bun.lock', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      await writePackageJSON(tmpDir, {name: 'mock name'})
+      await writeFile(joinPath(tmpDir, 'bun.lock'), '')
+
+      const packageManager = await getPackageManager(tmpDir)
+      expect(packageManager).toEqual('bun')
+    })
+  })
+
+  test('finds if bun is being used from bun.lockb', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      await writePackageJSON(tmpDir, {name: 'mock name'})
+      await writeFile(joinPath(tmpDir, 'bun.lockb'), '')
+
+      const packageManager = await getPackageManager(tmpDir)
+      expect(packageManager).toEqual('bun')
+    })
+  })
+
   test('finds pnpm from a nested workspace package when the lockfile is only at the repo root', async () => {
     await inTemporaryDirectory(async (tmpDir) => {
       await writePackageJSON(tmpDir, {name: 'root'})
       await writeFile(joinPath(tmpDir, 'pnpm-lock.yaml'), '')
+      const nested = joinPath(tmpDir, 'extensions', 'cart-transformer')
+      await mkdir(nested)
+      await writePackageJSON(nested, {name: 'cart-transformer'})
+
+      const packageManager = await getPackageManager(nested)
+      expect(packageManager).toEqual('pnpm')
+    })
+  })
+
+  test('finds pnpm from a nested workspace package when pnpm-workspace.yaml is only at the repo root', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      await writePackageJSON(tmpDir, {name: 'root'})
+      await writeFile(joinPath(tmpDir, 'pnpm-workspace.yaml'), '')
       const nested = joinPath(tmpDir, 'extensions', 'cart-transformer')
       await mkdir(nested)
       await writePackageJSON(nested, {name: 'cart-transformer'})
@@ -913,6 +947,134 @@ describe('getPackageManager', () => {
       const packageManager = await getPackageManager(tmpDir)
       // pnpm is used locally and in CI
       expect(packageManager).toEqual('pnpm')
+    })
+  })
+})
+
+describe('packageManagerBinaryCommandForDirectory', () => {
+  test('uses npm exec with -- for npm', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      await writePackageJSON(tmpDir, {name: 'mock name'})
+      await writeFile(joinPath(tmpDir, npmLockfile), '')
+
+      await expect(
+        packageManagerBinaryCommandForDirectory(tmpDir, 'graphql-code-generator', '--config', 'package.json'),
+      ).resolves.toEqual({
+        command: 'npm',
+        args: ['exec', '--', 'graphql-code-generator', '--config', 'package.json'],
+      })
+    })
+  })
+
+  test('uses exec without -- for pnpm when detected from an ancestor workspace marker', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      await writePackageJSON(tmpDir, {name: 'app-root'})
+      await writeFile(joinPath(tmpDir, 'pnpm-workspace.yaml'), '')
+      const extensionDirectory = joinPath(tmpDir, 'extensions', 'my-function')
+      await mkdir(extensionDirectory)
+      await writePackageJSON(extensionDirectory, {name: 'my-function'})
+
+      await expect(
+        packageManagerBinaryCommandForDirectory(
+          extensionDirectory,
+          'graphql-code-generator',
+          '--config',
+          'package.json',
+        ),
+      ).resolves.toEqual({
+        command: 'pnpm',
+        args: ['exec', 'graphql-code-generator', '--config', 'package.json'],
+      })
+    })
+  })
+
+  test('uses yarn run when detected from yarn.lock', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      await writePackageJSON(tmpDir, {name: 'mock name'})
+      await writeFile(joinPath(tmpDir, 'yarn.lock'), '')
+
+      await expect(
+        packageManagerBinaryCommandForDirectory(tmpDir, 'graphql-code-generator', '--config', 'package.json'),
+      ).resolves.toEqual({
+        command: 'yarn',
+        args: ['run', 'graphql-code-generator', '--config', 'package.json'],
+      })
+    })
+  })
+
+  test('uses bun x for bun when detected from bun.lock', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      await writePackageJSON(tmpDir, {name: 'mock name'})
+      await writeFile(joinPath(tmpDir, 'bun.lock'), '')
+
+      await expect(
+        packageManagerBinaryCommandForDirectory(tmpDir, 'graphql-code-generator', '--config', 'package.json'),
+      ).resolves.toEqual({
+        command: 'bun',
+        args: ['x', 'graphql-code-generator', '--config', 'package.json'],
+      })
+    })
+  })
+
+  test('uses bun x for bun when detected from bun.lockb', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      await writePackageJSON(tmpDir, {name: 'mock name'})
+      await writeFile(joinPath(tmpDir, 'bun.lockb'), '')
+
+      await expect(
+        packageManagerBinaryCommandForDirectory(tmpDir, 'graphql-code-generator', '--config', 'package.json'),
+      ).resolves.toEqual({
+        command: 'bun',
+        args: ['x', 'graphql-code-generator', '--config', 'package.json'],
+      })
+    })
+  })
+
+  test('falls back to yarn run when the user agent is yarn', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      const extensionDirectory = joinPath(tmpDir, 'subdir')
+      await mkdir(extensionDirectory)
+      vi.stubEnv('npm_config_user_agent', 'yarn/1.22.0')
+
+      try {
+        await expect(
+          packageManagerBinaryCommandForDirectory(
+            extensionDirectory,
+            'graphql-code-generator',
+            '--config',
+            'package.json',
+          ),
+        ).resolves.toEqual({
+          command: 'yarn',
+          args: ['run', 'graphql-code-generator', '--config', 'package.json'],
+        })
+      } finally {
+        vi.unstubAllEnvs()
+      }
+    })
+  })
+
+  test('falls back to npm when no package manager markers or user agent are available', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      const extensionDirectory = joinPath(tmpDir, 'subdir')
+      await mkdir(extensionDirectory)
+      vi.stubEnv('npm_config_user_agent', '')
+
+      try {
+        await expect(
+          packageManagerBinaryCommandForDirectory(
+            extensionDirectory,
+            'graphql-code-generator',
+            '--config',
+            'package.json',
+          ),
+        ).resolves.toEqual({
+          command: 'npm',
+          args: ['exec', '--', 'graphql-code-generator', '--config', 'package.json'],
+        })
+      } finally {
+        vi.unstubAllEnvs()
+      }
     })
   })
 })

--- a/packages/cli-kit/src/public/node/node-package-manager.ts
+++ b/packages/cli-kit/src/public/node/node-package-manager.ts
@@ -27,6 +27,7 @@ export const pnpmLockfile = 'pnpm-lock.yaml'
 
 /** The name of the bun lock file */
 export const bunLockfile = 'bun.lockb'
+const modernBunLockfile = 'bun.lock'
 
 /** The name of the pnpm workspace file */
 export const pnpmWorkspaceFile = 'pnpm-workspace.yaml'
@@ -56,6 +57,7 @@ export type DependencyType = 'dev' | 'prod' | 'peer'
  */
 export const packageManager = ['yarn', 'npm', 'pnpm', 'bun', 'homebrew', 'unknown'] as const
 export type PackageManager = (typeof packageManager)[number]
+type ProjectPackageManager = Extract<PackageManager, 'yarn' | 'npm' | 'pnpm' | 'bun'>
 
 /**
  * Returns an abort error that's thrown when the package manager can't be determined.
@@ -109,6 +111,40 @@ export function packageManagerFromUserAgent(env = process.env): PackageManager {
   return 'unknown'
 }
 
+function hasBunLockfileSync(directory: string): boolean {
+  return fileExistsSync(joinPath(directory, bunLockfile)) || fileExistsSync(joinPath(directory, modernBunLockfile))
+}
+
+function normalizePackageManagerForProject(packageManager: PackageManager): ProjectPackageManager {
+  switch (packageManager) {
+    case 'yarn':
+    case 'npm':
+    case 'pnpm':
+    case 'bun':
+      return packageManager
+    case 'homebrew':
+    case 'unknown':
+      return 'npm'
+  }
+}
+
+function packageManagerBinaryCommand(
+  packageManager: ProjectPackageManager,
+  binary: string,
+  ...binaryArgs: string[]
+): {command: string; args: string[]} {
+  switch (packageManager) {
+    case 'npm':
+      return {command: 'npm', args: ['exec', '--', binary, ...binaryArgs]}
+    case 'pnpm':
+      return {command: 'pnpm', args: ['exec', binary, ...binaryArgs]}
+    case 'yarn':
+      return {command: 'yarn', args: ['run', binary, ...binaryArgs]}
+    case 'bun':
+      return {command: 'bun', args: ['x', binary, ...binaryArgs]}
+  }
+}
+
 /**
  * Returns the dependency manager used in a directory.
  * Walks upward from `fromDirectory` so workspace packages (e.g. `extensions/my-fn/package.json`)
@@ -123,8 +159,10 @@ export async function getPackageManager(fromDirectory: string): Promise<PackageM
   outputDebug(outputContent`Looking for a lockfile in ${outputToken.path(current)}...`)
   while (true) {
     if (fileExistsSync(joinPath(current, yarnLockfile))) return 'yarn'
-    if (fileExistsSync(joinPath(current, pnpmLockfile))) return 'pnpm'
-    if (fileExistsSync(joinPath(current, bunLockfile))) return 'bun'
+    if (fileExistsSync(joinPath(current, pnpmLockfile)) || fileExistsSync(joinPath(current, pnpmWorkspaceFile))) {
+      return 'pnpm'
+    }
+    if (hasBunLockfileSync(current)) return 'bun'
     if (fileExistsSync(joinPath(current, npmLockfile))) return 'npm'
     const parent = dirname(current)
     if (parent === current) break
@@ -135,6 +173,19 @@ export async function getPackageManager(fromDirectory: string): Promise<PackageM
   if (pm !== 'unknown') return pm
 
   return 'npm'
+}
+
+/**
+ * Builds the command and argv needed to execute a local binary using the package manager
+ * detected from the provided directory or its ancestors.
+ */
+export async function packageManagerBinaryCommandForDirectory(
+  fromDirectory: string,
+  binary: string,
+  ...binaryArgs: string[]
+): Promise<{command: string; args: string[]}> {
+  const packageManager = normalizePackageManagerForProject(await getPackageManager(fromDirectory))
+  return packageManagerBinaryCommand(packageManager, binary, ...binaryArgs)
 }
 
 interface InstallNPMDependenciesRecursivelyOptions {


### PR DESCRIPTION
## Stack context

This stack is not trying to reduce Shopify CLI's supported package managers or preserve every detail of npm's local-prefix behavior.

The real problem is that Shopify CLI answers several different package-manager questions through helpers that are too broad for the caller's intent.

The end state is to make callers choose intent, not implementation. Concretely, the codebase needs clearer helper boundaries for:
- launcher/global-install resolution
- broad upward-walk package-manager detection
- known project-root resolution
- directory-local execution

This PR establishes the directory-local execution boundary for function GraphQL typegen.

## What

Use the function directory to choose the package manager for the default JavaScript GraphQL typegen path instead of always running `npm exec`.

Add a `cli-kit` helper that builds the right command for running a project binary from a directory, and use it from `buildGraphqlTypes(...)`.

## Why

The current typegen path hardcodes `npm`, which breaks apps whose function directories are managed by `pnpm`, `yarn`, or `bun`.

This keeps the fix scoped to the function typegen problem. It does not change the broader `getPackageManager(...)` contract for other callers.

## How

Build `packageManagerBinaryCommandForDirectory(...)` on top of the current `main` upward-walk package-manager detection instead of introducing a separate detection path.

That helper resolves the package manager for the function directory and returns the right binary invocation shape for `npm`, `pnpm`, `yarn`, or `bun`.

While touching this path, restore missing marker coverage for directory-local resolution:
- `pnpm-workspace.yaml`
- `bun.lock`

Existing `bun.lockb` support remains in place.

## Testing

- `pnpm exec vitest run packages/cli-kit/src/public/node/node-package-manager.test.ts packages/app/src/cli/services/function/build.test.ts`

To test manually:
1. Create or use an app with a JavaScript function managed by `pnpm`, `yarn`, or `bun`
2. Run `shopify app function build`
3. Confirm GraphQL type generation runs through that package manager instead of `npm`
