### PR TITLE
Expose allowed_domains on the app

### DIFF
--- a/packages/app/src/cli/models/app/app.ts
+++ b/packages/app/src/cli/models/app/app.ts
@@ -3,6 +3,7 @@ import {ensurePathStartsWithSlash} from './validation/common.js'
 import {Identifiers} from './identifiers.js'
 import {ExtensionInstance} from '../extensions/extension-instance.js'
 import {FunctionConfigType} from '../extensions/specifications/function.js'
+import {AdminConfigType} from '../extensions/specifications/admin.js'
 import {ExtensionSpecification, RemoteAwareExtensionSpecification} from '../extensions/specification.js'
 import {AppConfigurationUsedByCli} from '../extensions/specifications/types/app_config.js'
 import {EditorExtensionCollectionType} from '../extensions/specifications/editor_extension_collection.js'
@@ -230,6 +231,7 @@ export interface AppInterface<
   nonConfigExtensions: ExtensionInstance[]
   draftableExtensions: ExtensionInstance[]
   appAssetsConfigs: Record<string, string> | undefined
+  allowedDomains: string[] | undefined
   errors: AppErrors
   hiddenConfig: AppHiddenConfig
   includeConfigOnDeploy: boolean | undefined
@@ -342,6 +344,11 @@ export class App<
       if (config) acc[config.assetsKey] = joinPath(this.directory, config.assetsDir)
       return acc
     }, {})
+  }
+
+  get allowedDomains(): string[] | undefined {
+    const adminExt = this.realExtensions.find((ext) => ext.specification.identifier === 'admin')
+    return (adminExt?.configuration as AdminConfigType | undefined)?.admin?.allowed_domains
   }
 
   setDevApplicationURLs(devApplicationURLs: ApplicationURLs) {

--- a/packages/app/src/cli/models/extensions/specifications/admin.ts
+++ b/packages/app/src/cli/models/extensions/specifications/admin.ts
@@ -7,11 +7,12 @@ const AdminSchema = zod.object({
   admin: zod
     .object({
       static_root: zod.string().optional(),
+      allowed_domains: zod.array(zod.string()).optional(),
     })
     .optional(),
 })
 
-type AdminConfigType = zod.infer<typeof AdminSchema> & BaseConfigType
+export type AdminConfigType = zod.infer<typeof AdminSchema> & BaseConfigType
 
 const adminSpecificationSpec = createExtensionSpecification<AdminConfigType>({
   identifier: 'admin',
@@ -33,6 +34,8 @@ const adminSpecificationSpec = createExtensionSpecification<AdminConfigType>({
       admin: {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         static_root: (remoteContent as any).admin.static_root,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        allowed_domains: (remoteContent as any).admin.allowed_domains,
       },
     }
   },

--- a/packages/app/src/cli/services/dev/extension.ts
+++ b/packages/app/src/cli/services/dev/extension.ts
@@ -118,6 +118,11 @@ export interface ExtensionDevOptions {
    * Map of asset key to absolute directory path for app-level assets (e.g., admin static_root)
    */
   appAssets?: Record<string, string>
+
+  /**
+   * Allowed domains from the admin module config
+   */
+  allowedDomains?: string[]
 }
 
 export async function devUIExtensions(options: ExtensionDevOptions): Promise<void> {

--- a/packages/app/src/cli/services/dev/extension/payload/models.ts
+++ b/packages/app/src/cli/services/dev/extension/payload/models.ts
@@ -14,6 +14,7 @@ interface ExtensionsPayloadInterface {
         lastUpdated: number
       }
     }
+    allowedDomains?: string[]
   }
   appId?: string
   store: string

--- a/packages/app/src/cli/services/dev/extension/payload/store.test.ts
+++ b/packages/app/src/cli/services/dev/extension/payload/store.test.ts
@@ -52,6 +52,52 @@ describe('getExtensionsPayloadStoreRawPayload()', () => {
       extensions: [{mock: 'extension-payload'}, {mock: 'extension-payload'}, {mock: 'extension-payload'}],
     })
   })
+  test('includes allowedDomains in app when provided', async () => {
+    // Given
+    vi.spyOn(payload, 'getUIExtensionPayload').mockResolvedValue({
+      mock: 'extension-payload',
+    } as unknown as UIExtensionPayload)
+
+    const options = {
+      apiKey: 'mock-api-key',
+      appName: 'mock-app-name',
+      url: 'https://mock-url.com',
+      websocketURL: 'wss://mock-websocket-url.com',
+      extensions: [],
+      storeFqdn: 'mock-store-fqdn.myshopify.com',
+      manifestVersion: '3',
+      allowedDomains: ['example.com', 'cdn.example.com'],
+    } as unknown as ExtensionsPayloadStoreOptions
+
+    // When
+    const rawPayload = await getExtensionsPayloadStoreRawPayload(options, 'mock-bundle-path')
+
+    // Then
+    expect(rawPayload.app.allowedDomains).toEqual(['example.com', 'cdn.example.com'])
+  })
+
+  test('does not include allowedDomains in app when not provided', async () => {
+    // Given
+    vi.spyOn(payload, 'getUIExtensionPayload').mockResolvedValue({
+      mock: 'extension-payload',
+    } as unknown as UIExtensionPayload)
+
+    const options = {
+      apiKey: 'mock-api-key',
+      appName: 'mock-app-name',
+      url: 'https://mock-url.com',
+      websocketURL: 'wss://mock-websocket-url.com',
+      extensions: [],
+      storeFqdn: 'mock-store-fqdn.myshopify.com',
+      manifestVersion: '3',
+    } as unknown as ExtensionsPayloadStoreOptions
+
+    // When
+    const rawPayload = await getExtensionsPayloadStoreRawPayload(options, 'mock-bundle-path')
+
+    // Then
+    expect(rawPayload.app.allowedDomains).toBeUndefined()
+  })
 })
 
 describe('ExtensionsPayloadStore()', () => {

--- a/packages/app/src/cli/services/dev/extension/payload/store.ts
+++ b/packages/app/src/cli/services/dev/extension/payload/store.ts
@@ -52,6 +52,11 @@ export async function getExtensionsPayloadStoreRawPayload(
     }
     payload.app.assets = assets
   }
+
+  if (options.allowedDomains) {
+    payload.app.allowedDomains = options.allowedDomains
+  }
+
   return payload
 }
 

--- a/packages/app/src/cli/services/dev/processes/previewable-extension.ts
+++ b/packages/app/src/cli/services/dev/processes/previewable-extension.ts
@@ -25,6 +25,7 @@ interface PreviewableExtensionOptions {
   previewableExtensions: ExtensionInstance[]
   appWatcher: AppEventWatcher
   appAssetsConfigs: Record<string, string> | undefined
+  allowedDomains?: string[]
 }
 
 export interface PreviewableExtensionProcess extends BaseProcess<PreviewableExtensionOptions> {
@@ -49,6 +50,7 @@ export const launchPreviewableExtensionProcess: DevProcessFunction<PreviewableEx
     appDirectory,
     appWatcher,
     appAssetsConfigs,
+    allowedDomains,
   },
 ) => {
   await devUIExtensions({
@@ -71,6 +73,7 @@ export const launchPreviewableExtensionProcess: DevProcessFunction<PreviewableEx
     manifestVersion: MANIFEST_VERSION,
     appWatcher,
     appAssets: appAssetsConfigs,
+    allowedDomains,
   })
 }
 

--- a/packages/app/src/cli/services/dev/processes/setup-dev-processes.ts
+++ b/packages/app/src/cli/services/dev/processes/setup-dev-processes.ts
@@ -163,6 +163,7 @@ export async function setupDevProcesses({
       appDirectory: reloadedApp.directory,
       appWatcher,
       appAssetsConfigs: reloadedApp.appAssetsConfigs,
+      allowedDomains: reloadedApp.allowedDomains,
     }),
     developerPlatformClient.supportsDevSessions
       ? await setupDevSessionProcess({


### PR DESCRIPTION
### WHY are these changes introduced?

Part 1/2 in https://github.com/shop/issues-admin-extensibility/issues/2397

Exposes `allowed_domains` in app object sent through extensions websocket so that we can construct a CSP meta tag in dev mode for static apps. 

### WHAT is this pull request doing?

- Expose `allowed_domains` from the admin module config on the App model and pass it through the extension dev server payload                 
- Add `allowed_domains` to the admin spec's transformRemoteToLocal so the field round-trips correctly
- Thread `allowedDomains` through the previewable extension process options down to the payload store    

### How to test your changes?

#### Step 1: Build the CLI from source                                                            

From the repo root:
                                                                                                                     
```bash
dev up
```

#### Step 2: Set up a test app with `allowed_domains`                    

You need a Shopify app directory with a `shopify.app.toml` that includes the admin config.

The key part of the TOML is: 

```toml                                                                                                            
[admin]                                                                                                                                   
static_root = "./dist"
allowed_domains = ["example.com", "cdn.example.com"]
```

#### Step 3: Run `shopify app` dev using the local CLI                        

`pnpm shopify app dev --path /path/to/your/test/app`                                                           

This will:
- Start the extension dev server (HTTP + WebSocket)
- Print a URL like `https://some-tunnel-url.trycloudflare.com  `                   

#### Step 4: Inspect the HTTP payload                                                                                        

You can open this URL in your browser:

`https://<your-tunnel>.trycloudflare.com/extensions `                                                                                                                                                         

This returns the full JSON payload. Look for `app.allowedDomains` in the response. 

You can also pipe it through `jq` for readability:                
  
`curl https://<your-tunnel>.trycloudflare.com/extensions | jq '.app'`                                                                  

You should see:

```json
{                                                                                                                                           
  "apiKey": "...",                                                                                                                        
  "title": "...", 
  "url": "...",  
  "mobileUrl": "...",
  "assets": { ... },                                                                                                                        
  "allowedDomains": ["example.com", "cdn.example.com"]
  }    
```                                                                                                                                       

#### Step 5: Inspect WebSocket messages

1. Open admin and dev tools and go to the network tab                                                                                                           
2. Click the "socket" filter                                                                                         
3. Navigate to the dev console preview URL that the CLI prints 
4. You'll see an "extensions" websocket connection    
5. Click on it, then click the Messages tab
6. Confirm that it contains the full app object including `allowedDomains`  


![Screenshot 2026-04-09 at 5.13.14 PM.png](https://app.graphite.com/user-attachments/assets/b184fac1-efff-4225-ae19-514f23bd19f6.png)


### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [x] The change is user-facing, so I've added a changelog entry with `pnpm changeset add`
