### PR TITLE
Add root-known package manager helper

### DIFF
--- a/packages/app/src/cli/models/project/project-integration.test.ts
+++ b/packages/app/src/cli/models/project/project-integration.test.ts
@@ -6,7 +6,7 @@ import {loadLocalExtensionsSpecifications} from '../extensions/load-specificatio
 import {handleWatcherEvents} from '../../services/dev/app-events/app-event-watcher-handler.js'
 import {EventType} from '../../services/dev/app-events/app-event-watcher.js'
 import {describe, expect, test} from 'vitest'
-import {inTemporaryDirectory, writeFile, mkdir} from '@shopify/cli-kit/node/fs'
+import {inTemporaryDirectory, writeFile, mkdir, removeFile} from '@shopify/cli-kit/node/fs'
 import {joinPath} from '@shopify/cli-kit/node/path'
 import {AbortController} from '@shopify/cli-kit/node/abort'
 
@@ -194,6 +194,19 @@ describe('Project integration', () => {
       const project = await Project.load(dir)
 
       expect(project.packageManager).toBe('npm')
+      expect(project.nodeDependencies).toStrictEqual({})
+      expect(project.usesWorkspaces).toBe(false)
+    })
+  })
+
+  test('Project uses unknown package manager metadata when the app root has no package.json', async () => {
+    await inTemporaryDirectory(async (dir) => {
+      await setupRealApp(dir)
+      await removeFile(joinPath(dir, 'package.json'))
+
+      const project = await Project.load(dir)
+
+      expect(project.packageManager).toBe('unknown')
       expect(project.nodeDependencies).toStrictEqual({})
       expect(project.usesWorkspaces).toBe(false)
     })

--- a/packages/app/src/cli/models/project/project.ts
+++ b/packages/app/src/cli/models/project/project.ts
@@ -4,8 +4,8 @@ import {readAndParseDotEnv, DotEnvFile} from '@shopify/cli-kit/node/dot-env'
 import {fileExists, glob, findPathUp, readFile} from '@shopify/cli-kit/node/fs'
 import {
   getDependencies,
-  getPackageManager,
-  PackageManager,
+  getPackageManagerForProjectRoot,
+  ProjectPackageManager,
   usesWorkspaces as detectUsesWorkspaces,
 } from '@shopify/cli-kit/node/node-package-manager'
 import {joinPath, basename} from '@shopify/cli-kit/node/path'
@@ -76,7 +76,7 @@ export class Project {
     // Project metadata
     const packageJSONPath = joinPath(directory, 'package.json')
     const hasPackageJson = await fileExists(packageJSONPath)
-    const packageManager = hasPackageJson ? await getPackageManager(directory) : 'unknown'
+    const packageManager = hasPackageJson ? await getPackageManagerForProjectRoot(directory) : 'unknown'
     const nodeDependencies = hasPackageJson ? await getDependencies(packageJSONPath) : {}
     const usesWorkspaces = hasPackageJson ? await detectUsesWorkspaces(directory) : false
 
@@ -101,7 +101,7 @@ export class Project {
   }
 
   readonly directory: string
-  readonly packageManager: PackageManager
+  readonly packageManager: ProjectPackageManager | 'unknown'
   readonly nodeDependencies: Record<string, string>
   readonly usesWorkspaces: boolean
   readonly appConfigFiles: TomlFile[]
@@ -119,7 +119,7 @@ export class Project {
 
   private constructor(options: {
     directory: string
-    packageManager: PackageManager
+    packageManager: ProjectPackageManager | 'unknown'
     nodeDependencies: Record<string, string>
     usesWorkspaces: boolean
     appConfigFiles: TomlFile[]

--- a/packages/cli-kit/src/public/node/node-package-manager.test.ts
+++ b/packages/cli-kit/src/public/node/node-package-manager.test.ts
@@ -12,6 +12,7 @@ import {
   addResolutionOrOverride,
   writePackageJSON,
   getPackageManager,
+  getPackageManagerForProjectRoot,
   packageManagerBinaryCommandForDirectory,
   installNPMDependenciesRecursively,
   addNPMDependencies,
@@ -784,6 +785,23 @@ describe('addResolutionOrOverride', () => {
     })
   })
 
+  test('when package.json has no lockfile then npm overrides are used by default', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      const reactType = {'@types/react': '17.0.30'}
+      const packageJsonPath = joinPath(tmpDir, 'package.json')
+      await writeFile(packageJsonPath, JSON.stringify({}))
+
+      // When
+      await addResolutionOrOverride(tmpDir, reactType)
+
+      // Then
+      const packageJsonContent = await readAndParsePackageJson(packageJsonPath)
+      expect(packageJsonContent.overrides).toEqual(reactType)
+      expect(packageJsonContent.resolutions).toBeUndefined()
+    })
+  })
+
   test('when package.json with existing resolution type and yarn manager then dependency version is overwritten', async () => {
     await inTemporaryDirectory(async (tmpDir) => {
       // Given
@@ -947,6 +965,43 @@ describe('getPackageManager', () => {
       const packageManager = await getPackageManager(tmpDir)
       // pnpm is used locally and in CI
       expect(packageManager).toEqual('pnpm')
+    })
+  })
+})
+
+describe('getPackageManagerForProjectRoot', () => {
+  test('detects the package manager from root markers without consulting the user agent', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      await writePackageJSON(tmpDir, {name: 'mock name'})
+      await writeFile(joinPath(tmpDir, 'yarn.lock'), '')
+      vi.stubEnv('npm_config_user_agent', 'pnpm/9.0.0')
+
+      try {
+        await expect(getPackageManagerForProjectRoot(tmpDir)).resolves.toBe('yarn')
+      } finally {
+        vi.unstubAllEnvs()
+      }
+    })
+  })
+
+  test('defaults to npm when the project root has a package.json but no lockfile markers', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      await writePackageJSON(tmpDir, {name: 'mock name'})
+      vi.stubEnv('npm_config_user_agent', 'pnpm/9.0.0')
+
+      try {
+        await expect(getPackageManagerForProjectRoot(tmpDir)).resolves.toBe('npm')
+      } finally {
+        vi.unstubAllEnvs()
+      }
+    })
+  })
+
+  test('throws when the provided root does not contain a package.json', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      await expect(getPackageManagerForProjectRoot(tmpDir)).rejects.toThrow(
+        new PackageJsonNotFoundError(normalizePath(tmpDir)),
+      )
     })
   })
 })

--- a/packages/cli-kit/src/public/node/node-package-manager.ts
+++ b/packages/cli-kit/src/public/node/node-package-manager.ts
@@ -57,7 +57,7 @@ export type DependencyType = 'dev' | 'prod' | 'peer'
  */
 export const packageManager = ['yarn', 'npm', 'pnpm', 'bun', 'homebrew', 'unknown'] as const
 export type PackageManager = (typeof packageManager)[number]
-type ProjectPackageManager = Extract<PackageManager, 'yarn' | 'npm' | 'pnpm' | 'bun'>
+export type ProjectPackageManager = Extract<PackageManager, 'yarn' | 'npm' | 'pnpm' | 'bun'>
 
 /**
  * Returns an abort error that's thrown when the package manager can't be determined.
@@ -145,6 +145,17 @@ function packageManagerBinaryCommand(
   }
 }
 
+function getProjectPackageManagerAtDirectory(directory: string): ProjectPackageManager | undefined {
+  if (fileExistsSync(joinPath(directory, yarnLockfile))) return 'yarn'
+  if (fileExistsSync(joinPath(directory, pnpmLockfile)) || fileExistsSync(joinPath(directory, pnpmWorkspaceFile))) {
+    return 'pnpm'
+  }
+  if (hasBunLockfileSync(directory)) return 'bun'
+  if (fileExistsSync(joinPath(directory, npmLockfile))) return 'npm'
+
+  return undefined
+}
+
 /**
  * Returns the dependency manager used in a directory.
  * Walks upward from `fromDirectory` so workspace packages (e.g. `extensions/my-fn/package.json`)
@@ -158,12 +169,9 @@ export async function getPackageManager(fromDirectory: string): Promise<PackageM
   let current = fromDirectory
   outputDebug(outputContent`Looking for a lockfile in ${outputToken.path(current)}...`)
   while (true) {
-    if (fileExistsSync(joinPath(current, yarnLockfile))) return 'yarn'
-    if (fileExistsSync(joinPath(current, pnpmLockfile)) || fileExistsSync(joinPath(current, pnpmWorkspaceFile))) {
-      return 'pnpm'
-    }
-    if (hasBunLockfileSync(current)) return 'bun'
-    if (fileExistsSync(joinPath(current, npmLockfile))) return 'npm'
+    const detectedPackageManager = getProjectPackageManagerAtDirectory(current)
+    if (detectedPackageManager) return detectedPackageManager
+
     const parent = dirname(current)
     if (parent === current) break
     current = parent
@@ -173,6 +181,25 @@ export async function getPackageManager(fromDirectory: string): Promise<PackageM
   if (pm !== 'unknown') return pm
 
   return 'npm'
+}
+
+/**
+ * Resolves the package manager for a directory already known to be the project root.
+ *
+ * Use this when the caller already knows the root directory and wants to inspect that root
+ * directly rather than walking upward from a child directory.
+ *
+ * @param rootDirectory - The known project root directory.
+ * @returns The package manager detected from root markers, defaulting to `npm` when no marker exists.
+ * @throws PackageJsonNotFoundError if the provided directory does not contain a package.json.
+ */
+export async function getPackageManagerForProjectRoot(rootDirectory: string): Promise<ProjectPackageManager> {
+  const packageJsonPath = joinPath(rootDirectory, 'package.json')
+  if (!(await fileExists(packageJsonPath))) {
+    throw new PackageJsonNotFoundError(rootDirectory)
+  }
+
+  return getProjectPackageManagerAtDirectory(rootDirectory) ?? 'npm'
 }
 
 /**
@@ -733,7 +760,7 @@ export async function findUpAndReadPackageJson(fromDirectory: string): Promise<{
 }
 
 export async function addResolutionOrOverride(directory: string, dependencies: Record<string, string>): Promise<void> {
-  const packageManager = await getPackageManager(directory)
+  const packageManager = await getPackageManagerForProjectRoot(directory)
   const packageJsonPath = joinPath(directory, 'package.json')
   const packageJsonContent = await readAndParsePackageJson(packageJsonPath)
 

--- a/packages/cli-kit/src/public/node/upgrade.ts
+++ b/packages/cli-kit/src/public/node/upgrade.ts
@@ -8,7 +8,7 @@ import {
   DependencyType,
   usesWorkspaces,
   addNPMDependencies,
-  getPackageManager,
+  getPackageManagerForProjectRoot,
 } from './node-package-manager.js'
 import {outputContent, outputDebug, outputInfo, outputToken, outputWarn} from './output.js'
 import {cwd, moduleDirectory, sniffForPath} from './path.js'
@@ -210,7 +210,7 @@ async function installJsonDependencies(
 
   if (packagesToUpdate.length > 0) {
     await addNPMDependencies(packagesToUpdate, {
-      packageManager: await getPackageManager(directory),
+      packageManager: await getPackageManagerForProjectRoot(directory),
       type: depsEnv,
       directory,
       stdout: process.stdout,


### PR DESCRIPTION
## What

This follow-up continues the same package-manager stack as #7239.

Add a helper for callers that already know the project root, and use it for project metadata and root dependency update paths instead of depending on the broader upward-walk package-manager helper.

## Why

This stack is not about reducing Shopify CLI's supported package managers.

The stack goal is to make callers choose intent, not implementation.

`#7239` handles directory-local execution for function typegen. This PR handles callers that already know the project root.

Even if `getPackageManager(...)` remains a broad upward-walk helper, callers that already know the project root should not depend on its broader root-finding and fallback behavior.

## How

Add `getPackageManagerForProjectRoot(...)` to inspect a known project root directly.

Use it from:
- `Project.load(...)`
- `addResolutionOrOverride(...)`
- local upgrade dependency updates

Also narrow `Project.packageManager` to project-valid values plus `'unknown'` when the app root has no `package.json`.
