### PR TITLE
Use Project follow-up command helper for display-only paths

### DIFF
--- a/packages/app/src/cli/services/deploy.ts
+++ b/packages/app/src/cli/services/deploy.ts
@@ -8,6 +8,7 @@ import {AppLinkedInterface} from '../models/app/app.js'
 import {Project} from '../models/project/project.js'
 import {updateAppIdentifiers} from '../models/app/identifiers.js'
 import {DeveloperPlatformClient} from '../utilities/developer-platform-client.js'
+import {formatProjectFollowUpCommand} from '../utilities/project-command.js'
 import {Organization, OrganizationApp} from '../models/organization.js'
 import {reloadApp} from '../models/app/loader.js'
 import {ExtensionRegistration} from '../api/graphql/all_app_extension_registrations.js'
@@ -15,7 +16,7 @@ import {getTomls} from '../utilities/app/config/getTomls.js'
 import {renderInfo, renderSuccess, renderTasks, renderConfirmationPrompt, isTTY} from '@shopify/cli-kit/node/ui'
 import {mkdir} from '@shopify/cli-kit/node/fs'
 import {joinPath, dirname} from '@shopify/cli-kit/node/path'
-import {outputNewline, outputInfo, formatPackageManagerCommand} from '@shopify/cli-kit/node/output'
+import {outputNewline, outputInfo} from '@shopify/cli-kit/node/output'
 import {getArrayRejectingUndefined} from '@shopify/cli-kit/common/array'
 import {AbortError, AbortSilentError} from '@shopify/cli-kit/node/error'
 import type {AlertCustomSection, Task, TokenItem} from '@shopify/cli-kit/node/ui'
@@ -327,7 +328,7 @@ async function outputCompletionMessage({
       body.push(
         '• Map extension IDs to other copies of your app by running',
         {
-          command: formatPackageManagerCommand(project.packageManager, 'shopify app deploy'),
+          command: formatProjectFollowUpCommand(project, 'shopify app deploy'),
         },
         'for: ',
         {
@@ -378,8 +379,8 @@ async function outputCompletionMessage({
       [
         'Run',
         {
-          command: formatPackageManagerCommand(
-            project.packageManager,
+          command: formatProjectFollowUpCommand(
+            project,
             'shopify app release',
             `--version=${uploadExtensionsBundleResult.versionTag}`,
           ),

--- a/packages/app/src/cli/services/dev.ts
+++ b/packages/app/src/cli/services/dev.ts
@@ -28,6 +28,7 @@ import {DevSessionStatusManager} from './dev/processes/dev-session/dev-session-s
 import {TunnelMode} from './dev/tunnel-mode.js'
 import {PortDetail, renderPortWarnings} from './dev/port-warnings.js'
 import {DeveloperPlatformClient} from '../utilities/developer-platform-client.js'
+import {formatProjectFollowUpCommand} from '../utilities/project-command.js'
 import {Web, getAppScopesArray, AppLinkedInterface} from '../models/app/app.js'
 import {Project} from '../models/project/project.js'
 import {Organization, OrganizationApp, OrganizationStore} from '../models/organization.js'
@@ -47,7 +48,7 @@ import {getBackendPort} from '@shopify/cli-kit/node/environment'
 import {basename} from '@shopify/cli-kit/node/path'
 import {renderWarning} from '@shopify/cli-kit/node/ui'
 import {reportAnalyticsEvent} from '@shopify/cli-kit/node/analytics'
-import {OutputProcess, formatPackageManagerCommand} from '@shopify/cli-kit/node/output'
+import {OutputProcess} from '@shopify/cli-kit/node/output'
 import {hashString} from '@shopify/cli-kit/node/crypto'
 import {AbortError} from '@shopify/cli-kit/node/error'
 
@@ -221,7 +222,7 @@ export async function warnIfScopesDifferBeforeDev({
     const nextSteps = [
       [
         'Run',
-        {command: formatPackageManagerCommand(commandOptions.project.packageManager, 'shopify app deploy')},
+        {command: formatProjectFollowUpCommand(commandOptions.project, 'shopify app deploy')},
         'to push your scopes to the Partner Dashboard',
       ],
     ]

--- a/packages/app/src/cli/services/generate.ts
+++ b/packages/app/src/cli/services/generate.ts
@@ -6,6 +6,7 @@ import {
   ExtensionFlavorValue,
 } from './generate/extension.js'
 import {DeveloperPlatformClient} from '../utilities/developer-platform-client.js'
+import {formatProjectFollowUpCommand} from '../utilities/project-command.js'
 import {AppInterface, AppLinkedInterface} from '../models/app/app.js'
 import {Project} from '../models/project/project.js'
 import generateExtensionPrompts, {
@@ -16,12 +17,10 @@ import metadata from '../metadata.js'
 import {ExtensionTemplate} from '../models/app/template.js'
 import {ExtensionSpecification, RemoteAwareExtensionSpecification} from '../models/extensions/specification.js'
 import {OrganizationApp} from '../models/organization.js'
-import {PackageManager} from '@shopify/cli-kit/node/node-package-manager'
 import {isShopify} from '@shopify/cli-kit/node/context/local'
 import {joinPath} from '@shopify/cli-kit/node/path'
 import {RenderAlertOptions, renderSuccess} from '@shopify/cli-kit/node/ui'
 import {AbortError} from '@shopify/cli-kit/node/error'
-import {formatPackageManagerCommand} from '@shopify/cli-kit/node/output'
 import {groupBy} from '@shopify/cli-kit/common/collection'
 
 interface GenerateOptions {
@@ -56,7 +55,7 @@ async function generate(options: GenerateOptions) {
   const generateExtensionOptions = buildGenerateOptions(promptAnswers, app, options, developerPlatformClient)
   const generatedExtension = await generateExtensionTemplate(generateExtensionOptions)
 
-  renderSuccessMessage(generatedExtension, options.project.packageManager)
+  renderSuccessMessage(generatedExtension, options.project)
 }
 
 async function buildPromptOptions(
@@ -128,11 +127,11 @@ function buildGenerateOptions(
   }
 }
 
-function renderSuccessMessage(extension: GeneratedExtension, packageManager: PackageManager) {
+function renderSuccessMessage(extension: GeneratedExtension, project: Project) {
   const formattedSuccessfulMessage = formatSuccessfulRunMessage(
     extension.extensionTemplate,
     extension.directory,
-    packageManager,
+    project,
   )
   renderSuccess(formattedSuccessfulMessage)
 }
@@ -153,7 +152,7 @@ function validateExtensionFlavor(extensionTemplate?: ExtensionTemplate, flavor?:
 function formatSuccessfulRunMessage(
   extensionTemplate: ExtensionTemplate,
   extensionDirectory: string,
-  depndencyManager: PackageManager,
+  project: Project,
 ): RenderAlertOptions {
   const options: RenderAlertOptions = {
     headline: ['Your extension was created in', {filePath: extensionDirectory}, {char: '.'}],
@@ -164,7 +163,7 @@ function formatSuccessfulRunMessage(
   if (extensionTemplate.type !== 'function') {
     options.nextSteps!.push([
       'To preview this extension along with the rest of the project, run',
-      {command: formatPackageManagerCommand(depndencyManager, 'shopify app dev')},
+      {command: formatProjectFollowUpCommand(project, 'shopify app dev')},
     ])
   }
 

--- a/packages/app/src/cli/services/info.ts
+++ b/packages/app/src/cli/services/info.ts
@@ -1,5 +1,6 @@
 import {outputEnv} from './app/env/show.js'
 import {DeveloperPlatformClient} from '../utilities/developer-platform-client.js'
+import {formatProjectFollowUpCommand} from '../utilities/project-command.js'
 import {AppLinkedInterface, getAppScopes} from '../models/app/app.js'
 import {Project} from '../models/project/project.js'
 import {configurationFileNames} from '../constants.js'
@@ -8,12 +9,7 @@ import {Organization, OrganizationApp} from '../models/organization.js'
 import {isServiceAccount, isUserAccount} from '@shopify/cli-kit/node/session'
 import {platformAndArch} from '@shopify/cli-kit/node/os'
 import {basename, relativePath} from '@shopify/cli-kit/node/path'
-import {
-  OutputMessage,
-  formatPackageManagerCommand,
-  outputContent,
-  shouldDisplayColors,
-} from '@shopify/cli-kit/node/output'
+import {OutputMessage, outputContent, shouldDisplayColors} from '@shopify/cli-kit/node/output'
 import {AlertCustomSection, InlineToken} from '@shopify/cli-kit/node/ui'
 import {CLI_KIT_VERSION} from '@shopify/cli-kit/common/version'
 
@@ -172,7 +168,7 @@ class AppInfo {
       {
         body: [
           '💡 To change these, run',
-          {command: formatPackageManagerCommand(this.project.packageManager, 'shopify app config link')},
+          {command: formatProjectFollowUpCommand(this.project, 'shopify app config link')},
         ],
       },
     ]

--- a/packages/app/src/cli/utilities/project-command.test.ts
+++ b/packages/app/src/cli/utilities/project-command.test.ts
@@ -1,0 +1,31 @@
+import {formatProjectFollowUpCommand} from './project-command.js'
+import {beforeEach, describe, expect, test, vi} from 'vitest'
+import {formatPackageManagerCommand} from '@shopify/cli-kit/node/output'
+
+vi.mock('@shopify/cli-kit/node/output', async () => {
+  const actual: any = await vi.importActual('@shopify/cli-kit/node/output')
+  return {
+    ...actual,
+    formatPackageManagerCommand: vi.fn(),
+  }
+})
+
+describe('formatProjectFollowUpCommand', () => {
+  beforeEach(() => {
+    vi.mocked(formatPackageManagerCommand).mockReturnValue('formatted command')
+  })
+
+  test('delegates known package managers to formatPackageManagerCommand', () => {
+    const result = formatProjectFollowUpCommand({packageManager: 'pnpm'} as any, 'shopify app dev', '--reset')
+
+    expect(formatPackageManagerCommand).toHaveBeenCalledWith('pnpm', 'shopify app dev', '--reset')
+    expect(result).toBe('formatted command')
+  })
+
+  test('delegates unknown package manager metadata for display-only callers', () => {
+    const result = formatProjectFollowUpCommand({packageManager: 'unknown'} as any, 'shopify app config link')
+
+    expect(formatPackageManagerCommand).toHaveBeenCalledWith('unknown', 'shopify app config link')
+    expect(result).toBe('formatted command')
+  })
+})

--- a/packages/app/src/cli/utilities/project-command.ts
+++ b/packages/app/src/cli/utilities/project-command.ts
@@ -1,0 +1,16 @@
+import {Project} from '../models/project/project.js'
+import {formatPackageManagerCommand} from '@shopify/cli-kit/node/output'
+
+/**
+ * Formats a follow-up command for the current project.
+ *
+ * Display-only paths should use this helper instead of branching on the
+ * project's package manager directly.
+ */
+export function formatProjectFollowUpCommand(
+  project: Pick<Project, 'packageManager'>,
+  command: string,
+  ...args: string[]
+) {
+  return formatPackageManagerCommand(project.packageManager, command, ...args)
+}


### PR DESCRIPTION
## What

This follow-up continues the same package-manager stack as #7239, #7241, and #7242.

Add a `formatProjectFollowUpCommand(...)` helper for Project-backed follow-up commands, and use it in the display-only callers in deploy, dev, info, and generate instead of formatting commands from `project.packageManager` directly.

## Why

The stack goal is to make callers choose intent, not implementation.

`#7242` added an explicit package-manager boundary for project operations. This PR applies the same idea to display-only paths: when a caller only needs the right follow-up command for a project, it should ask for that command shape instead of reaching into package-manager state and formatting it itself.

This keeps the slice narrow. It does not change the package-manager values still surfaced for project info output, and it does not reopen the loader/config-link paths.

## How

Add `formatProjectFollowUpCommand(...)` in `packages/app/src/cli/utilities/project-command.ts`.

Use it from:
- deploy completion messaging
- dev scope mismatch warnings
- info follow-up messaging
- generate success messaging
