### PR TITLE
Update dev store link text for clarity

### DIFF
--- a/packages/app/src/cli/models/app/app.test-data.ts
+++ b/packages/app/src/cli/models/app/app.test-data.ts
@@ -1438,7 +1438,7 @@ export function testDeveloperPlatformClient(stubs: Partial<DeveloperPlatformClie
     devSessionDelete: (_input: DevSessionDeleteOptions) => Promise.resolve({devSessionDelete: {userErrors: []}}),
     getCreateDevStoreLink: (org: Organization) =>
       Promise.resolve(
-        `Looks like you don't have any dev stores associated with ${org.businessName}'s Partner Dashboard. Create one now https://partners.shopify.com/1234/stores`,
+        `Looks like you don't have any dev stores associated with ${org.businessName}'s Partner Dashboard. Create a store in Partner Dashboard https://partners.shopify.com/1234/stores`,
       ),
     ...stubs,
   }

--- a/packages/app/src/cli/services/dev/select-store.test.ts
+++ b/packages/app/src/cli/services/dev/select-store.test.ts
@@ -214,7 +214,7 @@ describe('selectStore', async () => {
       clientName: ClientName.AppManagement,
       getCreateDevStoreLink: (org: Organization) =>
         Promise.resolve(
-          `Looks like you don't have any dev stores associated with ${org.businessName}'s Dev Dashboard. Create one now https://dev.shopify.com/dashboard/1234/stores`,
+          `Looks like you don't have any dev stores associated with ${org.businessName}'s Dev Dashboard. Create a store in Dev Dashboard https://dev.shopify.com/dashboard/1234/stores`,
         ),
     })
 

--- a/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
@@ -1064,7 +1064,7 @@ export class AppManagementClient implements DeveloperPlatformClient {
     const url = `https://${await developerDashboardFqdn()}/dashboard/${org.id}/stores`
     return [
       `Looks like you don't have any dev stores associated with ${org.businessName}'s Dev Dashboard.`,
-      {link: {url, label: 'Create one now'}},
+      {link: {url, label: 'Create a store in Dev Dashboard'}},
     ]
   }
 

--- a/packages/app/src/cli/utilities/developer-platform-client/partners-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/partners-client.ts
@@ -674,7 +674,7 @@ export class PartnersClient implements DeveloperPlatformClient {
     const url = `https://${await partnersFqdn()}/${org.id}/stores`
     return [
       `Looks like you don't have any dev stores associated with ${org.businessName}'s Partner Dashboard.`,
-      {link: {url, label: 'Create one now'}},
+      {link: {url, label: 'Create a store in Partner Dashboard'}},
     ]
   }
 


### PR DESCRIPTION
Change the 'Create one now' link label to 'Create a store in Dev Dashboard' (or 'Create a store in Partner Dashboard' for the partners client) to make the call-to-action clearer about what the link does and where it goes.