### PR TITLE
Default to pnpm/pnpx internally

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,6 @@ jobs:
             > If the versions don't match, you might have multiple global instances installed.
 
             > Use `which shopify` to find out which one you are running and uninstall it."
-          comment_package_manager: 'npm'
           comment_command_flags: '--@shopify:registry=https://registry.npmjs.org'
           build_script: "node bin/update-cli-kit-version.js && pnpm nx run-many --target=bundle --all --skip-nx-cache --output-style=stream && pnpm refresh-manifests"
         env:

--- a/.github/workflows/tests-pr.yml
+++ b/.github/workflows/tests-pr.yml
@@ -234,7 +234,7 @@ jobs:
       - name: Build
         run: pnpm nx run-many --all --skip-nx-cache --target=build --output-style=stream
       - name: Install Playwright Chromium
-        run: npx playwright install chromium
+        run: pnpm exec playwright install chromium
         working-directory: packages/e2e
       - name: Rebuild node-pty
         run: pnpm rebuild node-pty
@@ -245,7 +245,7 @@ jobs:
           E2E_ACCOUNT_PASSWORD: ${{ secrets.E2E_ACCOUNT_PASSWORD }}
           E2E_STORE_FQDN: ${{ secrets.E2E_STORE_FQDN }}
           E2E_ORG_ID: ${{ secrets.E2E_ORG_ID }}
-        run: npx playwright test
+        run: pnpm exec playwright test
       - name: Upload Playwright report
         uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}

--- a/bin/create-notification-pr.js
+++ b/bin/create-notification-pr.js
@@ -65,7 +65,7 @@ async function createPR() {
         '**Please update the release highlights before merging.**',
         '',
         '### How to test',
-        '- `npx http-server ~/src/github.com/Shopify/static-cdn-assets`',
+        '- `pnpx http-server ~/src/github.com/Shopify/static-cdn-assets`',
         '- `SHOPIFY_CLI_NOTIFICATIONS_URL=http://127.0.0.1:8080/static-24h/cli/notifications.json shopify version`',
         "- You may need to clear the CLI cache with `shopify cache clear` and run the command twice to see the notification (it's fetched in the background).",
         '',

--- a/bin/docs/build-dev-docs.sh
+++ b/bin/docs/build-dev-docs.sh
@@ -1,12 +1,12 @@
 echo "STARTING"
-COMPILE_DOCS="npx tsc --project bin/docs/tsconfig.docs.json --moduleResolution node --target esNext && npx generate-docs --overridePath ./bin/docs/typeOverride.json --input ./docs-shopify.dev/commands  --output ./docs-shopify.dev/generated && rm -rf docs-shopify.dev/commands/**/*.doc.js docs-shopify.dev/commands/*.doc.js"
-COMPILE_STATIC_PAGES="npx tsc docs-shopify.dev/static/*.doc.ts --moduleResolution node  --target esNext && npx generate-docs --isLandingPage --input ./docs-shopify.dev/static --output ./docs-shopify.dev/generated && rm -rf docs-shopify.dev/static/*.doc.js"
-COMPILE_CATEGORY_PAGES="npx tsc docs-shopify.dev/categories/*.doc.ts --moduleResolution node  --target esNext && generate-docs --isCategoryPage --input ./docs-shopify.dev/categories --output ./docs-shopify.dev/generated && rm -rf docs-shopify.dev/categories/*.doc.js"
+COMPILE_DOCS="pnpx tsc --project bin/docs/tsconfig.docs.json --moduleResolution node --target esNext && pnpx generate-docs --overridePath ./bin/docs/typeOverride.json --input ./docs-shopify.dev/commands  --output ./docs-shopify.dev/generated && rm -rf docs-shopify.dev/commands/**/*.doc.js docs-shopify.dev/commands/*.doc.js"
+COMPILE_STATIC_PAGES="pnpx tsc docs-shopify.dev/static/*.doc.ts --moduleResolution node  --target esNext && pnpx generate-docs --isLandingPage --input ./docs-shopify.dev/static --output ./docs-shopify.dev/generated && rm -rf docs-shopify.dev/static/*.doc.js"
+COMPILE_CATEGORY_PAGES="pnpx tsc docs-shopify.dev/categories/*.doc.ts --moduleResolution node  --target esNext && pnpx generate-docs --isCategoryPage --input ./docs-shopify.dev/categories --output ./docs-shopify.dev/generated && rm -rf docs-shopify.dev/categories/*.doc.js"
 
 if [ "$1" = "isTest" ];
 then
-COMPILE_DOCS="npx tsc --project bin/docs/tsconfig.docs.json --moduleResolution node  --target esNext && npx generate-docs --overridePath ./bin/docs/typeOverride.json --input ./docs-shopify.dev/commands --output ./docs-shopify.dev/static/temp && rm -rf docs-shopify.dev/commands/**/*.doc.js docs-shopify.dev/commands/*.doc.js"
-COMPILE_STATIC_PAGES="npx tsc docs-shopify.dev/static/*.doc.ts --moduleResolution node  --target esNext && npx generate-docs --isLandingPage --input ./docs-shopify.dev/static/docs-shopify.dev  --output ./docs-shopify.dev/static/temp && rm -rf docs-shopify.dev/static/*.doc.js"
+COMPILE_DOCS="pnpx tsc --project bin/docs/tsconfig.docs.json --moduleResolution node  --target esNext && pnpx generate-docs --overridePath ./bin/docs/typeOverride.json --input ./docs-shopify.dev/commands --output ./docs-shopify.dev/static/temp && rm -rf docs-shopify.dev/commands/**/*.doc.js docs-shopify.dev/commands/*.doc.js"
+COMPILE_STATIC_PAGES="pnpx tsc docs-shopify.dev/static/*.doc.ts --moduleResolution node  --target esNext && pnpx generate-docs --isLandingPage --input ./docs-shopify.dev/static/docs-shopify.dev  --output ./docs-shopify.dev/static/temp && rm -rf docs-shopify.dev/static/*.doc.js"
 fi
 
 echo $1

--- a/dev.yml
+++ b/dev.yml
@@ -23,7 +23,7 @@ up:
       meet: 'true'
   - custom:
       name: 'Install Playwright Chromium'
-      met?: cd packages/e2e && npx playwright install chromium
+      met?: cd packages/e2e && pnpx playwright install chromium
       meet: 'true'
   - custom:
       name: 'Rebuild node-pty'

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "bundle-for-release": "nx run-many --target=bundle --all --skip-nx-cache",
     "changeset-manifests": "changeset version && pnpm install --no-frozen-lockfile && pnpm refresh-manifests && pnpm refresh-readme && pnpm refresh-code-documentation && bin/update-cli-kit-version.js",
     "clean": "nx run-many --target=clean --all --skip-nx-cache && nx reset",
-    "create-app": "nx build create-app && node packages/create-app/bin/dev.js --package-manager npm",
+    "create-app": "nx build create-app && node packages/create-app/bin/dev.js --package-manager pnpm",
     "deploy-experimental": "node bin/deploy-experimental.js",
     "graph": "nx graph",
     "graphql-codegen:get-graphql-schemas": "bin/get-graphql-schemas.js",

--- a/packages/e2e/scripts/cleanup-test-apps.ts
+++ b/packages/e2e/scripts/cleanup-test-apps.ts
@@ -1,6 +1,6 @@
 /**
  * Deletes all test apps from the dev dashboard via browser automation.
- * Run: npx tsx packages/e2e/scripts/cleanup-test-apps.ts
+ * Run: pnpx tsx packages/e2e/scripts/cleanup-test-apps.ts
  *
  * Pass --dry-run to list apps without deleting.
  * Pass --filter <pattern> to only delete apps matching the pattern.
@@ -128,7 +128,7 @@ async function main() {
     await page.waitForTimeout(2000)
 
     // Check for 500 error and retry
-    const pageText = await page.textContent('body') ?? ''
+    const pageText = (await page.textContent('body')) ?? ''
     if (pageText.includes('500') || pageText.includes('Internal Server Error')) {
       console.log('Got 500 error, retrying...')
       await page.reload({waitUntil: 'domcontentloaded'})
@@ -136,7 +136,10 @@ async function main() {
     }
 
     // Check for org selection page
-    const orgLink = page.locator('a, button').filter({hasText: /core-build|cli-e2e/i}).first()
+    const orgLink = page
+      .locator('a, button')
+      .filter({hasText: /core-build|cli-e2e/i})
+      .first()
     if (await orgLink.isVisible({timeout: 3000}).catch(() => false)) {
       console.log('Org selection detected, clicking...')
       await orgLink.click()

--- a/packages/e2e/scripts/create-test-apps.ts
+++ b/packages/e2e/scripts/create-test-apps.ts
@@ -1,6 +1,6 @@
 /**
  * Creates test apps in the authenticated org and prints their client IDs.
- * Run: npx tsx packages/e2e/scripts/create-test-apps.ts
+ * Run: pnpx tsx packages/e2e/scripts/create-test-apps.ts
  */
 
 import * as fs from 'fs'
@@ -39,7 +39,7 @@ if (!email || !password) {
 }
 
 const baseEnv: Record<string, string> = {
-  ...process.env as Record<string, string>,
+  ...(process.env as Record<string, string>),
   NODE_OPTIONS: '',
   SHOPIFY_RUN_AS_USER: '0',
   FORCE_COLOR: '0',
@@ -86,16 +86,16 @@ async function createAppInteractive(tmpDir: string, appName: string): Promise<st
   fs.mkdirSync(appDir)
 
   const nodePty = await import('node-pty')
-  const pty = nodePty.spawn('node', [
-    createAppPath,
-    '--name', appName,
-    '--path', appDir,
-    '--template', 'none',
-    '--package-manager', 'npm',
-    '--local',
-  ], {
-    name: 'xterm-color', cols: 120, rows: 30, env: baseEnv,
-  })
+  const pty = nodePty.spawn(
+    'node',
+    [createAppPath, '--name', appName, '--path', appDir, '--template', 'none', '--package-manager', 'pnpm', '--local'],
+    {
+      name: 'xterm-color',
+      cols: 120,
+      rows: 30,
+      env: baseEnv,
+    },
+  )
 
   let output = ''
   pty.onData((data: string) => {
@@ -104,11 +104,7 @@ async function createAppInteractive(tmpDir: string, appName: string): Promise<st
   })
 
   // Answer each interactive prompt as it appears
-  const prompts = [
-    'Which organization',
-    'Create this project as a new app',
-    'App name',
-  ]
+  const prompts = ['Which organization', 'Create this project as a new app', 'App name']
   for (const prompt of prompts) {
     try {
       await waitForText(() => output, prompt, 60_000)
@@ -130,9 +126,7 @@ async function createAppInteractive(tmpDir: string, appName: string): Promise<st
 
   // Find the app dir and extract client_id
   const entries = fs.readdirSync(appDir, {withFileTypes: true})
-  const created = entries.find(
-    (e) => e.isDirectory() && fs.existsSync(path.join(appDir, e.name, 'shopify.app.toml')),
-  )
+  const created = entries.find((e) => e.isDirectory() && fs.existsSync(path.join(appDir, e.name, 'shopify.app.toml')))
   if (!created) throw new Error(`No app directory found in ${appDir}`)
 
   const tomlPath = path.join(appDir, created.name, 'shopify.app.toml')
@@ -147,11 +141,16 @@ async function oauthLogin() {
   const nodePty = await import('node-pty')
   const spawnEnv = {...baseEnv, BROWSER: 'none'}
   const pty = nodePty.spawn('node', [cliPath, 'auth', 'login'], {
-    name: 'xterm-color', cols: 120, rows: 30, env: spawnEnv,
+    name: 'xterm-color',
+    cols: 120,
+    rows: 30,
+    env: spawnEnv,
   })
 
   let output = ''
-  pty.onData((data: string) => { output += data })
+  pty.onData((data: string) => {
+    output += data
+  })
 
   await waitForText(() => output, 'Press any key to open the login page', 30_000)
   pty.write(' ')
@@ -169,7 +168,9 @@ async function oauthLogin() {
   await completeLogin(page, urlMatch[0], email!, password!)
 
   await waitForText(() => output, 'Logged in', 60_000)
-  try { pty.kill() } catch {}
+  try {
+    pty.kill()
+  } catch {}
   await browser.close()
 }
 

--- a/packages/e2e/setup/app.ts
+++ b/packages/e2e/setup/app.ts
@@ -26,7 +26,7 @@ export async function createApp(ctx: {
   const name = ctx.name ?? 'e2e-test-app'
   const template = ctx.template ?? 'reactRouter'
   const packageManager =
-    ctx.packageManager ?? (process.env.E2E_PACKAGE_MANAGER as 'npm' | 'yarn' | 'pnpm' | 'bun') ?? 'npm'
+    ctx.packageManager ?? (process.env.E2E_PACKAGE_MANAGER as 'npm' | 'yarn' | 'pnpm' | 'bun') ?? 'pnpm'
 
   const args = [
     '--name',


### PR DESCRIPTION
### WHY are these changes introduced?

We should align internal tooling with the repo’s default package manager (pnpm), so contributors and CI use the same commands.

### WHAT is this pull request doing?

- **Root** **`create-app`** **script**: Passes `--package-manager pnpm` into the create-app dev entrypoint.
- **E2E**: Default `packageManager` in `packages/e2e/setup/app.ts` is `pnpm` when `E2E_PACKAGE_MANAGER` is unset; Playwright steps in `tests-pr.yml` use `pnpm exec playwright` so CI uses the workspace’s pinned Playwright (avoids `pnpx` pulling a different version). E2E helper script comments / create-app flows updated for pnpm where relevant.
- **Misc**: Small script and workflow/doc tweaks (e.g. `dev.yml`, `build-dev-docs.sh`, `create-notification-pr.js`, `release.yml`) for consistency with pnpm-first usage.

### How to test your changes?

CI

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing, so I've added a changelog entry with `pnpm changeset add`