### PR TITLE
Add Dev Console shortcut for non-embedded apps in app dev

### DIFF
--- a/.changeset/blue-taxes-cry.md
+++ b/.changeset/blue-taxes-cry.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': minor
+---
+
+Added a separate Dev Console link to the `app dev` output for non-embedded apps

--- a/.changeset/dev-console-shortcut.md
+++ b/.changeset/dev-console-shortcut.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': minor
+---
+
+Add (c) Dev Console shortcut for non-embedded apps in `app dev`

--- a/.changeset/dev-console-shortcut.md
+++ b/.changeset/dev-console-shortcut.md
@@ -1,5 +1,0 @@
----
-'@shopify/app': minor
----
-
-Add (c) Dev Console shortcut for non-embedded apps in `app dev`

--- a/packages/app/src/cli/services/dev/processes/dev-session/dev-session-status-manager.ts
+++ b/packages/app/src/cli/services/dev/processes/dev-session/dev-session-status-manager.ts
@@ -17,6 +17,7 @@ export interface DevSessionStatus {
   isReady: boolean
   previewURL?: string
   graphiqlURL?: string
+  appEmbedded?: boolean
   statusMessage?: {message: string; type: DevSessionStatusMessageType}
 }
 

--- a/packages/app/src/cli/services/dev/processes/dev-session/dev-session.ts
+++ b/packages/app/src/cli/services/dev/processes/dev-session/dev-session.ts
@@ -265,7 +265,7 @@ export class DevSession {
     const hasPreview = event.app.allExtensions.filter((ext) => ext.isPreviewable).length > 0
     const useDevConsole = firstPartyDev() && hasPreview
     const newPreviewURL = useDevConsole ? this.options.appLocalProxyURL : this.options.appPreviewURL
-    this.statusManager.updateStatus({previewURL: newPreviewURL})
+    this.statusManager.updateStatus({previewURL: newPreviewURL, appEmbedded: event.app.configuration.embedded})
   }
 
   /**

--- a/packages/app/src/cli/services/dev/processes/setup-dev-processes.ts
+++ b/packages/app/src/cli/services/dev/processes/setup-dev-processes.ts
@@ -125,7 +125,8 @@ export async function setupDevProcesses({
     ? `http://localhost:${graphiqlPort}/graphiql?key=${encodeURIComponent(resolvedGraphiqlKey)}`
     : undefined
 
-  const devSessionStatusManager = new DevSessionStatusManager({isReady: false, previewURL, graphiqlURL})
+  const appEmbedded = reloadedApp.configuration.embedded
+  const devSessionStatusManager = new DevSessionStatusManager({isReady: false, previewURL, graphiqlURL, appEmbedded})
 
   const processes = [
     ...(await setupWebProcesses({

--- a/packages/app/src/cli/services/dev/ui/components/DevSessionUI.test.tsx
+++ b/packages/app/src/cli/services/dev/ui/components/DevSessionUI.test.tsx
@@ -121,10 +121,12 @@ describe('DevSessionUI', () => {
     expect(output).toContain('(q) Quit')
 
     // Shortcuts and URLs should be visible
-    expect(output).toContain('(g) Open GraphiQL')
-    expect(output).toContain('(p) Preview in your browser')
+    expect(output).toContain('(g) Open GraphiQL (Admin API)')
+    expect(output).toContain('(p) Open app preview')
+    expect(output).toContain('(c) Open Dev Console for extension previews')
     expect(output).toContain('Preview URL: https://shopify.com')
     expect(output).toContain('GraphiQL URL: https://graphiql.shopify.com')
+    expect(output).toContain('Dev Console URL: https://mystore.myshopify.com/admin?dev-console=show')
 
     renderInstance.unmount()
   })
@@ -167,6 +169,55 @@ describe('DevSessionUI', () => {
 
     // Then
     expect(vi.mocked(openURL)).toHaveBeenNthCalledWith(1, 'https://graphiql.shopify.com')
+
+    renderInstance.unmount()
+  })
+
+  test('opens the dev console URL when c is pressed for non-embedded apps', async () => {
+    // Given
+    devSessionStatusManager.updateStatus({appEmbedded: false})
+
+    // When
+    const renderInstance = render(
+      <DevSessionUI
+        processes={[]}
+        abortController={new AbortController()}
+        devSessionStatusManager={devSessionStatusManager}
+        shopFqdn="mystore.myshopify.com"
+        onAbort={onAbort}
+      />,
+    )
+
+    await waitForInputsToBeReady()
+    await sendInputAndWait(renderInstance, 10, 'c')
+
+    // Then
+    expect(vi.mocked(openURL)).toHaveBeenNthCalledWith(1, 'https://mystore.myshopify.com/admin?dev-console=show')
+
+    renderInstance.unmount()
+  })
+
+  test('does not show dev console shortcut when app is embedded', async () => {
+    // Given
+    devSessionStatusManager.updateStatus({appEmbedded: true})
+
+    // When
+    const renderInstance = render(
+      <DevSessionUI
+        processes={[]}
+        abortController={new AbortController()}
+        devSessionStatusManager={devSessionStatusManager}
+        shopFqdn="mystore.myshopify.com"
+        onAbort={onAbort}
+      />,
+    )
+
+    await waitForInputsToBeReady()
+
+    // Then
+    const output = unstyled(renderInstance.lastFrame()!)
+    expect(output).not.toContain('(c) Open Dev Console')
+    expect(output).not.toContain('Dev Console URL')
 
     renderInstance.unmount()
   })
@@ -356,7 +407,7 @@ describe('DevSessionUI', () => {
     await waitForInputsToBeReady()
 
     // Initial state
-    expect(unstyled(renderInstance.lastFrame()!)).not.toContain('preview in your browser')
+    expect(unstyled(renderInstance.lastFrame()!)).not.toContain('Open app preview')
 
     // When status updates
     devSessionStatusManager.updateStatus({
@@ -365,7 +416,7 @@ describe('DevSessionUI', () => {
       graphiqlURL: 'https://new-graphiql.shopify.com',
     })
 
-    await waitForContent(renderInstance, 'Preview in your browser')
+    await waitForContent(renderInstance, 'Open app preview')
 
     // Then
     expect(unstyled(renderInstance.lastFrame()!)).toContain('Preview URL: https://new-preview-url.shopify.com')

--- a/packages/app/src/cli/services/dev/ui/components/DevSessionUI.test.tsx
+++ b/packages/app/src/cli/services/dev/ui/components/DevSessionUI.test.tsx
@@ -40,6 +40,7 @@ const initialStatus: DevSessionStatus = {
   isReady: true,
   previewURL: 'https://shopify.com',
   graphiqlURL: 'https://graphiql.shopify.com',
+  appEmbedded: false,
 }
 
 const onAbort = vi.fn()

--- a/packages/app/src/cli/services/dev/ui/components/DevSessionUI.tsx
+++ b/packages/app/src/cli/services/dev/ui/components/DevSessionUI.tsx
@@ -7,6 +7,7 @@ import {
   DevSessionStatusMessageType,
 } from '../../processes/dev-session/dev-session-status-manager.js'
 import {MAX_EXTENSION_HANDLE_LENGTH} from '../../../../models/extensions/schemas.js'
+import {buildDevConsoleURL} from '../../../../utilities/app/app-url.js'
 import {OutputProcess} from '@shopify/cli-kit/node/output'
 import {Alert, ConcurrentOutput, Link, TabularData} from '@shopify/cli-kit/node/ui/components'
 import {useAbortSignal} from '@shopify/cli-kit/node/ui/hooks'
@@ -147,6 +148,13 @@ const DevSessionUI: FunctionComponent<DevSesionUIProps> = ({
             }
           },
         },
+        {
+          key: 'c',
+          condition: () => Boolean(!status.appEmbedded && status.isReady),
+          action: async () => {
+            await openURL(buildDevConsoleURL(shopFqdn))
+          },
+        },
       ],
       content: (
         <>
@@ -157,14 +165,19 @@ const DevSessionUI: FunctionComponent<DevSesionUIProps> = ({
           )}
           {canUseShortcuts && (
             <Box marginTop={1} flexDirection="column">
-              {status.graphiqlURL && status.isReady ? (
-                <Text>
-                  {figures.pointerSmall} <Text bold>(g)</Text> Open GraphiQL (Admin API) in your browser
-                </Text>
-              ) : null}
               {status.isReady ? (
                 <Text>
-                  {figures.pointerSmall} <Text bold>(p)</Text> Preview in your browser
+                  {figures.pointerSmall} <Text bold>(p)</Text> Open app preview
+                </Text>
+              ) : null}
+              {!status.appEmbedded && status.isReady ? (
+                <Text>
+                  {figures.pointerSmall} <Text bold>(c)</Text> Open Dev Console for extension previews
+                </Text>
+              ) : null}
+              {status.graphiqlURL && status.isReady ? (
+                <Text>
+                  {figures.pointerSmall} <Text bold>(g)</Text> Open GraphiQL (Admin API)
                 </Text>
               ) : null}
             </Box>
@@ -179,6 +192,11 @@ const DevSessionUI: FunctionComponent<DevSesionUIProps> = ({
                     {status.previewURL ? (
                       <Text>
                         Preview URL: <Link url={status.previewURL} />
+                      </Text>
+                    ) : null}
+                    {!status.appEmbedded ? (
+                      <Text>
+                        Dev Console URL: <Link url={buildDevConsoleURL(shopFqdn)} />
                       </Text>
                     ) : null}
                     {status.graphiqlURL ? (

--- a/packages/app/src/cli/services/dev/ui/components/DevSessionUI.tsx
+++ b/packages/app/src/cli/services/dev/ui/components/DevSessionUI.tsx
@@ -194,7 +194,7 @@ const DevSessionUI: FunctionComponent<DevSesionUIProps> = ({
                         Preview URL: <Link url={status.previewURL} />
                       </Text>
                     ) : null}
-                    {!status.appEmbedded ? (
+                    {status.appEmbedded === false ? (
                       <Text>
                         Dev Console URL: <Link url={buildDevConsoleURL(shopFqdn)} />
                       </Text>

--- a/packages/app/src/cli/services/dev/ui/components/DevSessionUI.tsx
+++ b/packages/app/src/cli/services/dev/ui/components/DevSessionUI.tsx
@@ -152,6 +152,9 @@ const DevSessionUI: FunctionComponent<DevSesionUIProps> = ({
           key: 'c',
           condition: () => Boolean(!status.appEmbedded && status.isReady),
           action: async () => {
+            await metadata.addPublicMetadata(() => ({
+              cmd_dev_preview_url_opened: true,
+            }))
             await openURL(buildDevConsoleURL(shopFqdn))
           },
         },

--- a/packages/app/src/cli/utilities/app/app-url.ts
+++ b/packages/app/src/cli/utilities/app/app-url.ts
@@ -13,6 +13,10 @@ export function buildAppURLForAdmin(storeFqdn: string, apiKey: string, adminDoma
   return `https://${adminDomain}/store/${storeName}/apps/${apiKey}?dev-console=show`
 }
 
+export function buildDevConsoleURL(storeFqdn: string) {
+  return `https://${storeFqdn}/admin?dev-console=show`
+}
+
 export function buildAppURLForMobile(storeFqdn: string, apiKey: string) {
   const normalizedFQDN = normalizeStoreFqdn(storeFqdn)
   const adminUrl = storeAdminUrl(normalizedFQDN)

--- a/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
@@ -366,6 +366,7 @@ export class AppManagementClient implements DeveloperPlatformClient {
       organizationId: String(numberFromGid(app.organizationId)),
       grantedScopes: app.activeRoot.grantedShopifyApprovalScopes,
       applicationUrl: appHomeModule?.config?.app_url as string | undefined,
+      embedded: appHomeModule?.config?.embedded as boolean | undefined,
       flags: [],
       developerPlatformClient: this,
     }


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### WHY are these changes introduced?

Improves the `app dev` experience for non-embedded apps. The default preview link opens the app outside of admin for non-embedded apps, so there is not an easy way to navigate to the Dev Console. They'd need to open admin themselves.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Conditionally adds an additional `(c)` action and preview link for opening the Dev Console, which opens admin w/ `?dev-console=show` to ensure it's not minimized.

I also simplified/clarified the existing preview and GraphiQL link descriptions. `in browser` seems unecessary.

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?

Run `app dev` on a non-embeddeed app.

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [x] The change is user-facing, so I've added a changelog entry with `pnpm changeset add`