### PR TITLE
Regenerate graphql-codegen output to match upstream schemas

### DIFF
--- a/packages/app/src/cli/api/graphql/admin/generated/metafield_definitions.ts
+++ b/packages/app/src/cli/api/graphql/admin/generated/metafield_definitions.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/consistent-type-definitions */
-import * as Types from './types.js'
+import * as Types from './types'
 
 import {TypedDocumentNode as DocumentNode} from '@graphql-typed-document-node/core'
 
@@ -113,7 +113,7 @@ export const MetafieldForImportFragmentDoc = {
     },
   ],
 } as unknown as DocumentNode<MetafieldForImportFragment, unknown>
-export const MetafieldDefinitions = {
+export const MetafieldDefinitionsDocument = {
   kind: 'Document',
   definitions: [
     {

--- a/packages/app/src/cli/api/graphql/admin/generated/metaobject_definitions.ts
+++ b/packages/app/src/cli/api/graphql/admin/generated/metaobject_definitions.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/consistent-type-definitions */
-import * as Types from './types.js'
+import * as Types from './types'
 
 import {TypedDocumentNode as DocumentNode} from '@graphql-typed-document-node/core'
 
@@ -171,7 +171,7 @@ export const MetaobjectForImportFragmentDoc = {
     },
   ],
 } as unknown as DocumentNode<MetaobjectForImportFragment, unknown>
-export const MetaobjectDefinitions = {
+export const MetaobjectDefinitionsDocument = {
   kind: 'Document',
   definitions: [
     {

--- a/packages/app/src/cli/api/graphql/app-dev/generated/dev-session-create.ts
+++ b/packages/app/src/cli/api/graphql/app-dev/generated/dev-session-create.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/consistent-type-definitions */
-import * as Types from './types.js'
+import * as Types from './types'
 import {JsonMapType} from '@shopify/cli-kit/node/toml'
 
 import {TypedDocumentNode as DocumentNode} from '@graphql-typed-document-node/core'
@@ -23,7 +23,7 @@ export type DevSessionCreateMutation = {
   } | null
 }
 
-export const DevSessionCreate = {
+export const DevSessionCreateDocument = {
   kind: 'Document',
   definitions: [
     {

--- a/packages/app/src/cli/api/graphql/app-dev/generated/dev-session-delete.ts
+++ b/packages/app/src/cli/api/graphql/app-dev/generated/dev-session-delete.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/consistent-type-definitions */
-import * as Types from './types.js'
+import * as Types from './types'
 
 import {TypedDocumentNode as DocumentNode} from '@graphql-typed-document-node/core'
 
@@ -9,7 +9,7 @@ export type DevSessionDeleteMutationVariables = Types.Exact<{
 
 export type DevSessionDeleteMutation = {devSessionDelete?: {userErrors: {message: string}[]} | null}
 
-export const DevSessionDelete = {
+export const DevSessionDeleteDocument = {
   kind: 'Document',
   definitions: [
     {

--- a/packages/app/src/cli/api/graphql/app-dev/generated/dev-session-update.ts
+++ b/packages/app/src/cli/api/graphql/app-dev/generated/dev-session-update.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/consistent-type-definitions */
-import * as Types from './types.js'
+import * as Types from './types'
 import {JsonMapType} from '@shopify/cli-kit/node/toml'
 
 import {TypedDocumentNode as DocumentNode} from '@graphql-typed-document-node/core'
@@ -23,7 +23,7 @@ export type DevSessionUpdateMutation = {
   } | null
 }
 
-export const DevSessionUpdate = {
+export const DevSessionUpdateDocument = {
   kind: 'Document',
   definitions: [
     {

--- a/packages/app/src/cli/api/graphql/app-management/generated/active-app-release-from-api-key.ts
+++ b/packages/app/src/cli/api/graphql/app-management/generated/active-app-release-from-api-key.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/consistent-type-definitions */
-import * as Types from './types.js'
+import * as Types from './types'
 import {JsonMapType} from '@shopify/cli-kit/node/toml'
 
 import {TypedDocumentNode as DocumentNode} from '@graphql-typed-document-node/core'
@@ -37,7 +37,7 @@ export type ActiveAppReleaseFromApiKeyQuery = {
   }
 }
 
-export const ActiveAppReleaseFromApiKey = {
+export const ActiveAppReleaseFromApiKeyDocument = {
   kind: 'Document',
   definitions: [
     {

--- a/packages/app/src/cli/api/graphql/app-management/generated/active-app-release.ts
+++ b/packages/app/src/cli/api/graphql/app-management/generated/active-app-release.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/consistent-type-definitions */
-import * as Types from './types.js'
+import * as Types from './types'
 import {JsonMapType} from '@shopify/cli-kit/node/toml'
 
 import {TypedDocumentNode as DocumentNode} from '@graphql-typed-document-node/core'
@@ -215,7 +215,7 @@ export const AppVersionInfoFragmentDoc = {
     },
   ],
 } as unknown as DocumentNode<AppVersionInfoFragment, unknown>
-export const ActiveAppRelease = {
+export const ActiveAppReleaseDocument = {
   kind: 'Document',
   definitions: [
     {

--- a/packages/app/src/cli/api/graphql/app-management/generated/app-install-count.ts
+++ b/packages/app/src/cli/api/graphql/app-management/generated/app-install-count.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/consistent-type-definitions */
-import * as Types from './types.js'
+import * as Types from './types'
 
 import {TypedDocumentNode as DocumentNode} from '@graphql-typed-document-node/core'
 
@@ -9,7 +9,7 @@ export type AppInstallCountQueryVariables = Types.Exact<{
 
 export type AppInstallCountQuery = {app: {installCount?: number | null}}
 
-export const AppInstallCount = {
+export const AppInstallCountDocument = {
   kind: 'Document',
   definitions: [
     {

--- a/packages/app/src/cli/api/graphql/app-management/generated/app-logs-subscribe.ts
+++ b/packages/app/src/cli/api/graphql/app-management/generated/app-logs-subscribe.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/consistent-type-definitions */
-import * as Types from './types.js'
+import * as Types from './types'
 
 import {TypedDocumentNode as DocumentNode} from '@graphql-typed-document-node/core'
 
@@ -12,7 +12,7 @@ export type AppLogsSubscribeMutation = {
   appLogsSubscribe?: {jwtToken?: string | null; success?: boolean | null; errors?: string[] | null} | null
 }
 
-export const AppLogsSubscribe = {
+export const AppLogsSubscribeDocument = {
   kind: 'Document',
   definitions: [
     {

--- a/packages/app/src/cli/api/graphql/app-management/generated/app-version-by-id.ts
+++ b/packages/app/src/cli/api/graphql/app-management/generated/app-version-by-id.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/consistent-type-definitions */
-import * as Types from './types.js'
+import * as Types from './types'
 import {JsonMapType} from '@shopify/cli-kit/node/toml'
 
 import {TypedDocumentNode as DocumentNode} from '@graphql-typed-document-node/core'
@@ -112,7 +112,7 @@ export const VersionInfoFragmentDoc = {
     },
   ],
 } as unknown as DocumentNode<VersionInfoFragment, unknown>
-export const AppVersionById = {
+export const AppVersionByIdDocument = {
   kind: 'Document',
   definitions: [
     {

--- a/packages/app/src/cli/api/graphql/app-management/generated/app-version-by-tag.ts
+++ b/packages/app/src/cli/api/graphql/app-management/generated/app-version-by-tag.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/consistent-type-definitions */
-import * as Types from './types.js'
+import * as Types from './types'
 import {JsonMapType} from '@shopify/cli-kit/node/toml'
 
 import {TypedDocumentNode as DocumentNode} from '@graphql-typed-document-node/core'
@@ -29,7 +29,7 @@ export type AppVersionByTagQuery = {
   }
 }
 
-export const AppVersionByTag = {
+export const AppVersionByTagDocument = {
   kind: 'Document',
   definitions: [
     {

--- a/packages/app/src/cli/api/graphql/app-management/generated/app-versions.ts
+++ b/packages/app/src/cli/api/graphql/app-management/generated/app-versions.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/consistent-type-definitions */
-import * as Types from './types.js'
+import * as Types from './types'
 
 import {TypedDocumentNode as DocumentNode} from '@graphql-typed-document-node/core'
 
@@ -25,7 +25,7 @@ export type AppVersionsQuery = {
   }
 }
 
-export const AppVersions = {
+export const AppVersionsDocument = {
   kind: 'Document',
   definitions: [
     {

--- a/packages/app/src/cli/api/graphql/app-management/generated/apps.ts
+++ b/packages/app/src/cli/api/graphql/app-management/generated/apps.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/consistent-type-definitions */
-import * as Types from './types.js'
+import * as Types from './types'
 
 import {TypedDocumentNode as DocumentNode} from '@graphql-typed-document-node/core'
 
@@ -14,7 +14,7 @@ export type ListAppsQuery = {
   } | null
 }
 
-export const ListApps = {
+export const ListAppsDocument = {
   kind: 'Document',
   definitions: [
     {

--- a/packages/app/src/cli/api/graphql/app-management/generated/create-app-version.ts
+++ b/packages/app/src/cli/api/graphql/app-management/generated/create-app-version.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/consistent-type-definitions */
-import * as Types from './types.js'
+import * as Types from './types'
 import {JsonMapType} from '@shopify/cli-kit/node/toml'
 
 import {TypedDocumentNode as DocumentNode} from '@graphql-typed-document-node/core'
@@ -40,7 +40,7 @@ export type CreateAppVersionMutation = {
   }
 }
 
-export const CreateAppVersion = {
+export const CreateAppVersionDocument = {
   kind: 'Document',
   definitions: [
     {

--- a/packages/app/src/cli/api/graphql/app-management/generated/create-app.ts
+++ b/packages/app/src/cli/api/graphql/app-management/generated/create-app.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/consistent-type-definitions */
-import * as Types from './types.js'
+import * as Types from './types'
 import {JsonMapType} from '@shopify/cli-kit/node/toml'
 
 import {TypedDocumentNode as DocumentNode} from '@graphql-typed-document-node/core'
@@ -16,7 +16,7 @@ export type CreateAppMutation = {
   }
 }
 
-export const CreateApp = {
+export const CreateAppDocument = {
   kind: 'Document',
   definitions: [
     {

--- a/packages/app/src/cli/api/graphql/app-management/generated/create-asset-url.ts
+++ b/packages/app/src/cli/api/graphql/app-management/generated/create-asset-url.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/consistent-type-definitions */
-import * as Types from './types.js'
+import * as Types from './types'
 
 import {TypedDocumentNode as DocumentNode} from '@graphql-typed-document-node/core'
 
@@ -15,7 +15,7 @@ export type CreateAssetUrlMutation = {
   }
 }
 
-export const CreateAssetUrl = {
+export const CreateAssetUrlDocument = {
   kind: 'Document',
   definitions: [
     {

--- a/packages/app/src/cli/api/graphql/app-management/generated/release-version.ts
+++ b/packages/app/src/cli/api/graphql/app-management/generated/release-version.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/consistent-type-definitions */
-import * as Types from './types.js'
+import * as Types from './types'
 import {JsonMapType} from '@shopify/cli-kit/node/toml'
 
 import {TypedDocumentNode as DocumentNode} from '@graphql-typed-document-node/core'
@@ -22,7 +22,7 @@ export type ReleaseVersionMutation = {
   }
 }
 
-export const ReleaseVersion = {
+export const ReleaseVersionDocument = {
   kind: 'Document',
   definitions: [
     {

--- a/packages/app/src/cli/api/graphql/app-management/generated/specifications.ts
+++ b/packages/app/src/cli/api/graphql/app-management/generated/specifications.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/consistent-type-definitions */
-import * as Types from './types.js'
+import * as Types from './types'
 
 import {TypedDocumentNode as DocumentNode} from '@graphql-typed-document-node/core'
 
@@ -22,7 +22,7 @@ export type FetchSpecificationsQuery = {
   }[]
 }
 
-export const FetchSpecifications = {
+export const FetchSpecificationsDocument = {
   kind: 'Document',
   definitions: [
     {

--- a/packages/app/src/cli/api/graphql/bulk-operations/generated/bulk-operation-cancel.ts
+++ b/packages/app/src/cli/api/graphql/bulk-operations/generated/bulk-operation-cancel.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/consistent-type-definitions */
-import * as Types from './types.js'
+import * as Types from './types'
 
 import {TypedDocumentNode as DocumentNode} from '@graphql-typed-document-node/core'
 
@@ -27,7 +27,7 @@ export type BulkOperationCancelMutation = {
   } | null
 }
 
-export const BulkOperationCancel = {
+export const BulkOperationCancelDocument = {
   kind: 'Document',
   definitions: [
     {

--- a/packages/app/src/cli/api/graphql/bulk-operations/generated/bulk-operation-run-mutation.ts
+++ b/packages/app/src/cli/api/graphql/bulk-operations/generated/bulk-operation-run-mutation.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/consistent-type-definitions */
-import * as Types from './types.js'
+import * as Types from './types'
 
 import {TypedDocumentNode as DocumentNode} from '@graphql-typed-document-node/core'
 
@@ -26,7 +26,7 @@ export type BulkOperationRunMutationMutation = {
   } | null
 }
 
-export const BulkOperationRunMutation = {
+export const BulkOperationRunMutationDocument = {
   kind: 'Document',
   definitions: [
     {

--- a/packages/app/src/cli/api/graphql/bulk-operations/generated/bulk-operation-run-query.ts
+++ b/packages/app/src/cli/api/graphql/bulk-operations/generated/bulk-operation-run-query.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/consistent-type-definitions */
-import * as Types from './types.js'
+import * as Types from './types'
 
 import {TypedDocumentNode as DocumentNode} from '@graphql-typed-document-node/core'
 
@@ -24,7 +24,7 @@ export type BulkOperationRunQueryMutation = {
   } | null
 }
 
-export const BulkOperationRunQuery = {
+export const BulkOperationRunQueryDocument = {
   kind: 'Document',
   definitions: [
     {

--- a/packages/app/src/cli/api/graphql/bulk-operations/generated/get-bulk-operation-by-id.ts
+++ b/packages/app/src/cli/api/graphql/bulk-operations/generated/get-bulk-operation-by-id.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/consistent-type-definitions */
-import * as Types from './types.js'
+import * as Types from './types'
 
 import {TypedDocumentNode as DocumentNode} from '@graphql-typed-document-node/core'
 
@@ -21,7 +21,7 @@ export type GetBulkOperationByIdQuery = {
   } | null
 }
 
-export const GetBulkOperationById = {
+export const GetBulkOperationByIdDocument = {
   kind: 'Document',
   definitions: [
     {

--- a/packages/app/src/cli/api/graphql/bulk-operations/generated/list-bulk-operations.ts
+++ b/packages/app/src/cli/api/graphql/bulk-operations/generated/list-bulk-operations.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/consistent-type-definitions */
-import * as Types from './types.js'
+import * as Types from './types'
 
 import {TypedDocumentNode as DocumentNode} from '@graphql-typed-document-node/core'
 
@@ -24,7 +24,7 @@ export type ListBulkOperationsQuery = {
   }
 }
 
-export const ListBulkOperations = {
+export const ListBulkOperationsDocument = {
   kind: 'Document',
   definitions: [
     {

--- a/packages/app/src/cli/api/graphql/bulk-operations/generated/staged-uploads-create.ts
+++ b/packages/app/src/cli/api/graphql/bulk-operations/generated/staged-uploads-create.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/consistent-type-definitions */
-import * as Types from './types.js'
+import * as Types from './types'
 
 import {TypedDocumentNode as DocumentNode} from '@graphql-typed-document-node/core'
 
@@ -20,7 +20,7 @@ export type StagedUploadsCreateMutation = {
   } | null
 }
 
-export const StagedUploadsCreate = {
+export const StagedUploadsCreateDocument = {
   kind: 'Document',
   definitions: [
     {

--- a/packages/app/src/cli/api/graphql/business-platform-destinations/generated/find-organizations.ts
+++ b/packages/app/src/cli/api/graphql/business-platform-destinations/generated/find-organizations.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/consistent-type-definitions */
-import * as Types from './types.js'
+import * as Types from './types'
 
 import {TypedDocumentNode as DocumentNode} from '@graphql-typed-document-node/core'
 
@@ -9,7 +9,7 @@ export type FindOrganizationsQueryVariables = Types.Exact<{
 
 export type FindOrganizationsQuery = {currentUserAccount?: {organization?: {id: string; name: string} | null} | null}
 
-export const FindOrganizations = {
+export const FindOrganizationsDocument = {
   kind: 'Document',
   definitions: [
     {

--- a/packages/app/src/cli/api/graphql/business-platform-destinations/generated/organizations.ts
+++ b/packages/app/src/cli/api/graphql/business-platform-destinations/generated/organizations.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/consistent-type-definitions */
-import * as Types from './types.js'
+import * as Types from './types'
 
 import {TypedDocumentNode as DocumentNode} from '@graphql-typed-document-node/core'
 
@@ -12,7 +12,7 @@ export type ListOrganizationsQuery = {
   } | null
 }
 
-export const ListOrganizations = {
+export const ListOrganizationsDocument = {
   kind: 'Document',
   definitions: [
     {

--- a/packages/app/src/cli/api/graphql/business-platform-destinations/generated/user-info.ts
+++ b/packages/app/src/cli/api/graphql/business-platform-destinations/generated/user-info.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/consistent-type-definitions */
-import * as Types from './types.js'
+import * as Types from './types'
 
 import {TypedDocumentNode as DocumentNode} from '@graphql-typed-document-node/core'
 
@@ -9,7 +9,7 @@ export type UserInfoQuery = {
   currentUserAccount?: {uuid: string; email: string; organizations: {nodes: {name: string}[]}} | null
 }
 
-export const UserInfo = {
+export const UserInfoDocument = {
   kind: 'Document',
   definitions: [
     {

--- a/packages/app/src/cli/api/graphql/business-platform-organizations/generated/fetch_store_by_domain.ts
+++ b/packages/app/src/cli/api/graphql/business-platform-organizations/generated/fetch_store_by_domain.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/consistent-type-definitions */
-import * as Types from './types.js'
+import * as Types from './types'
 
 import {TypedDocumentNode as DocumentNode} from '@graphql-typed-document-node/core'
 
@@ -29,7 +29,7 @@ export type FetchStoreByDomainQuery = {
   } | null
 }
 
-export const FetchStoreByDomain = {
+export const FetchStoreByDomainDocument = {
   kind: 'Document',
   definitions: [
     {

--- a/packages/app/src/cli/api/graphql/business-platform-organizations/generated/list_app_dev_stores.ts
+++ b/packages/app/src/cli/api/graphql/business-platform-organizations/generated/list_app_dev_stores.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/consistent-type-definitions */
-import * as Types from './types.js'
+import * as Types from './types'
 
 import {TypedDocumentNode as DocumentNode} from '@graphql-typed-document-node/core'
 
@@ -29,7 +29,7 @@ export type ListAppDevStoresQuery = {
   } | null
 }
 
-export const ListAppDevStores = {
+export const ListAppDevStoresDocument = {
   kind: 'Document',
   definitions: [
     {

--- a/packages/app/src/cli/api/graphql/business-platform-organizations/generated/organization_exp_flags.ts
+++ b/packages/app/src/cli/api/graphql/business-platform-organizations/generated/organization_exp_flags.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/consistent-type-definitions */
-import * as Types from './types.js'
+import * as Types from './types'
 
 import {TypedDocumentNode as DocumentNode} from '@graphql-typed-document-node/core'
 
@@ -10,7 +10,7 @@ export type OrganizationExpFlagsQueryVariables = Types.Exact<{
 
 export type OrganizationExpFlagsQuery = {organization?: {id: string; enabledFlags: boolean[]} | null}
 
-export const OrganizationExpFlags = {
+export const OrganizationExpFlagsDocument = {
   kind: 'Document',
   definitions: [
     {

--- a/packages/app/src/cli/api/graphql/business-platform-organizations/generated/provision_shop_access.ts
+++ b/packages/app/src/cli/api/graphql/business-platform-organizations/generated/provision_shop_access.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/consistent-type-definitions */
-import * as Types from './types.js'
+import * as Types from './types'
 
 import {TypedDocumentNode as DocumentNode} from '@graphql-typed-document-node/core'
 
@@ -11,7 +11,7 @@ export type ProvisionShopAccessMutation = {
   organizationUserProvisionShopAccess: {success?: boolean | null; userErrors?: {message: string}[] | null}
 }
 
-export const ProvisionShopAccess = {
+export const ProvisionShopAccessDocument = {
   kind: 'Document',
   definitions: [
     {

--- a/packages/app/src/cli/api/graphql/functions/generated/schema-definition-by-api-type.ts
+++ b/packages/app/src/cli/api/graphql/functions/generated/schema-definition-by-api-type.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/consistent-type-definitions */
-import * as Types from './types.js'
+import * as Types from './types'
 
 import {TypedDocumentNode as DocumentNode} from '@graphql-typed-document-node/core'
 
@@ -10,7 +10,7 @@ export type SchemaDefinitionByApiTypeQueryVariables = Types.Exact<{
 
 export type SchemaDefinitionByApiTypeQuery = {api?: {schema?: {definition: string} | null} | null}
 
-export const SchemaDefinitionByApiType = {
+export const SchemaDefinitionByApiTypeDocument = {
   kind: 'Document',
   definitions: [
     {

--- a/packages/app/src/cli/api/graphql/functions/generated/schema-definition-by-target.ts
+++ b/packages/app/src/cli/api/graphql/functions/generated/schema-definition-by-target.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/consistent-type-definitions */
-import * as Types from './types.js'
+import * as Types from './types'
 
 import {TypedDocumentNode as DocumentNode} from '@graphql-typed-document-node/core'
 
@@ -10,7 +10,7 @@ export type SchemaDefinitionByTargetQueryVariables = Types.Exact<{
 
 export type SchemaDefinitionByTargetQuery = {target?: {api: {schema?: {definition: string} | null}} | null}
 
-export const SchemaDefinitionByTarget = {
+export const SchemaDefinitionByTargetDocument = {
   kind: 'Document',
   definitions: [
     {

--- a/packages/app/src/cli/api/graphql/partners/generated/all-orgs.ts
+++ b/packages/app/src/cli/api/graphql/partners/generated/all-orgs.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/consistent-type-definitions */
-import * as Types from './types.js'
+import * as Types from './types'
 
 import {TypedDocumentNode as DocumentNode} from '@graphql-typed-document-node/core'
 
@@ -7,7 +7,7 @@ export type AllOrgsQueryVariables = Types.Exact<{[key: string]: never}>
 
 export type AllOrgsQuery = {organizations: {nodes?: ({id: string; businessName: string} | null)[] | null}}
 
-export const AllOrgs = {
+export const AllOrgsDocument = {
   kind: 'Document',
   definitions: [
     {

--- a/packages/app/src/cli/api/graphql/partners/generated/current-account-info.ts
+++ b/packages/app/src/cli/api/graphql/partners/generated/current-account-info.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/consistent-type-definitions */
-import * as Types from './types.js'
+import * as Types from './types'
 
 import {TypedDocumentNode as DocumentNode} from '@graphql-typed-document-node/core'
 
@@ -9,7 +9,7 @@ export type CurrentAccountInfoQuery = {
   currentAccountInfo: {__typename: 'ServiceAccount'; orgName: string} | {__typename: 'UserAccount'; email: string}
 }
 
-export const CurrentAccountInfo = {
+export const CurrentAccountInfoDocument = {
   kind: 'Document',
   definitions: [
     {

--- a/packages/app/src/cli/api/graphql/partners/generated/dev-stores-by-org.ts
+++ b/packages/app/src/cli/api/graphql/partners/generated/dev-stores-by-org.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/consistent-type-definitions */
-import * as Types from './types.js'
+import * as Types from './types'
 
 import {TypedDocumentNode as DocumentNode} from '@graphql-typed-document-node/core'
 
@@ -29,7 +29,7 @@ export type DevStoresByOrgQuery = {
   }
 }
 
-export const DevStoresByOrg = {
+export const DevStoresByOrgDocument = {
   kind: 'Document',
   definitions: [
     {

--- a/packages/app/src/cli/api/graphql/partners/generated/update-draft.ts
+++ b/packages/app/src/cli/api/graphql/partners/generated/update-draft.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/consistent-type-definitions */
-import * as Types from './types.js'
+import * as Types from './types'
 
 import {TypedDocumentNode as DocumentNode} from '@graphql-typed-document-node/core'
 
@@ -15,7 +15,7 @@ export type ExtensionUpdateDraftMutation = {
   extensionUpdateDraft?: {userErrors?: {field?: string[] | null; message: string}[] | null} | null
 }
 
-export const ExtensionUpdateDraft = {
+export const ExtensionUpdateDraftDocument = {
   kind: 'Document',
   definitions: [
     {

--- a/packages/app/src/cli/api/graphql/webhooks/generated/available-topics.ts
+++ b/packages/app/src/cli/api/graphql/webhooks/generated/available-topics.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/consistent-type-definitions */
-import * as Types from './types.js'
+import * as Types from './types'
 
 import {TypedDocumentNode as DocumentNode} from '@graphql-typed-document-node/core'
 
@@ -9,7 +9,7 @@ export type AvailableTopicsQueryVariables = Types.Exact<{
 
 export type AvailableTopicsQuery = {availableTopics?: string[] | null}
 
-export const AvailableTopics = {
+export const AvailableTopicsDocument = {
   kind: 'Document',
   definitions: [
     {

--- a/packages/app/src/cli/api/graphql/webhooks/generated/cli-testing.ts
+++ b/packages/app/src/cli/api/graphql/webhooks/generated/cli-testing.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/consistent-type-definitions */
-import * as Types from './types.js'
+import * as Types from './types'
 
 import {TypedDocumentNode as DocumentNode} from '@graphql-typed-document-node/core'
 
@@ -16,7 +16,7 @@ export type CliTestingMutation = {
   cliTesting?: {headers?: string | null; samplePayload?: string | null; success: boolean; errors: string[]} | null
 }
 
-export const CliTesting = {
+export const CliTestingDocument = {
   kind: 'Document',
   definitions: [
     {

--- a/packages/app/src/cli/api/graphql/webhooks/generated/public-api-versions.ts
+++ b/packages/app/src/cli/api/graphql/webhooks/generated/public-api-versions.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/consistent-type-definitions */
-import * as Types from './types.js'
+import * as Types from './types'
 
 import {TypedDocumentNode as DocumentNode} from '@graphql-typed-document-node/core'
 
@@ -7,7 +7,7 @@ export type PublicApiVersionsQueryVariables = Types.Exact<{[key: string]: never}
 
 export type PublicApiVersionsQuery = {publicApiVersions: {handle: string}[]}
 
-export const PublicApiVersions = {
+export const PublicApiVersionsDocument = {
   kind: 'Document',
   definitions: [
     {

--- a/packages/cli-kit/src/cli/api/graphql/admin/generated/find_development_theme_by_name.ts
+++ b/packages/cli-kit/src/cli/api/graphql/admin/generated/find_development_theme_by_name.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/consistent-type-definitions */
-import * as Types from './types.js'
+import * as Types from './types'
 
 import {TypedDocumentNode as DocumentNode} from '@graphql-typed-document-node/core'
 
@@ -11,7 +11,7 @@ export type FindDevelopmentThemeByNameQuery = {
   themes?: {nodes: {id: string; name: string; role: Types.ThemeRole; processing: boolean}[]} | null
 }
 
-export const FindDevelopmentThemeByName = {
+export const FindDevelopmentThemeByNameDocument = {
   kind: 'Document',
   definitions: [
     {

--- a/packages/cli-kit/src/cli/api/graphql/admin/generated/get_theme.ts
+++ b/packages/cli-kit/src/cli/api/graphql/admin/generated/get_theme.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/consistent-type-definitions */
-import * as Types from './types.js'
+import * as Types from './types'
 
 import {TypedDocumentNode as DocumentNode} from '@graphql-typed-document-node/core'
 
@@ -9,7 +9,7 @@ export type GetThemeQueryVariables = Types.Exact<{
 
 export type GetThemeQuery = {theme?: {id: string; name: string; role: Types.ThemeRole; processing: boolean} | null}
 
-export const GetTheme = {
+export const GetThemeDocument = {
   kind: 'Document',
   definitions: [
     {

--- a/packages/cli-kit/src/cli/api/graphql/admin/generated/get_theme_file_bodies.ts
+++ b/packages/cli-kit/src/cli/api/graphql/admin/generated/get_theme_file_bodies.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/consistent-type-definitions */
-import * as Types from './types.js'
+import * as Types from './types'
 
 import {TypedDocumentNode as DocumentNode} from '@graphql-typed-document-node/core'
 
@@ -27,7 +27,7 @@ export type GetThemeFileBodiesQuery = {
   } | null
 }
 
-export const GetThemeFileBodies = {
+export const GetThemeFileBodiesDocument = {
   kind: 'Document',
   definitions: [
     {

--- a/packages/cli-kit/src/cli/api/graphql/admin/generated/get_theme_file_checksums.ts
+++ b/packages/cli-kit/src/cli/api/graphql/admin/generated/get_theme_file_checksums.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/consistent-type-definitions */
-import * as Types from './types.js'
+import * as Types from './types'
 
 import {TypedDocumentNode as DocumentNode} from '@graphql-typed-document-node/core'
 
@@ -18,7 +18,7 @@ export type GetThemeFileChecksumsQuery = {
   } | null
 }
 
-export const GetThemeFileChecksums = {
+export const GetThemeFileChecksumsDocument = {
   kind: 'Document',
   definitions: [
     {

--- a/packages/cli-kit/src/cli/api/graphql/admin/generated/get_themes.ts
+++ b/packages/cli-kit/src/cli/api/graphql/admin/generated/get_themes.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/consistent-type-definitions */
-import * as Types from './types.js'
+import * as Types from './types'
 
 import {TypedDocumentNode as DocumentNode} from '@graphql-typed-document-node/core'
 
@@ -14,7 +14,7 @@ export type GetThemesQuery = {
   } | null
 }
 
-export const GetThemes = {
+export const GetThemesDocument = {
   kind: 'Document',
   definitions: [
     {

--- a/packages/cli-kit/src/cli/api/graphql/admin/generated/metafield_definitions_by_owner_type.ts
+++ b/packages/cli-kit/src/cli/api/graphql/admin/generated/metafield_definitions_by_owner_type.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/consistent-type-definitions */
-import * as Types from './types.js'
+import * as Types from './types'
 
 import {TypedDocumentNode as DocumentNode} from '@graphql-typed-document-node/core'
 
@@ -19,7 +19,7 @@ export type MetafieldDefinitionsByOwnerTypeQuery = {
   }
 }
 
-export const MetafieldDefinitionsByOwnerType = {
+export const MetafieldDefinitionsByOwnerTypeDocument = {
   kind: 'Document',
   definitions: [
     {

--- a/packages/cli-kit/src/cli/api/graphql/admin/generated/online_store_password_protection.ts
+++ b/packages/cli-kit/src/cli/api/graphql/admin/generated/online_store_password_protection.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/consistent-type-definitions */
-import * as Types from './types.js'
+import * as Types from './types'
 
 import {TypedDocumentNode as DocumentNode} from '@graphql-typed-document-node/core'
 
@@ -7,7 +7,7 @@ export type OnlineStorePasswordProtectionQueryVariables = Types.Exact<{[key: str
 
 export type OnlineStorePasswordProtectionQuery = {onlineStore: {passwordProtection: {enabled: boolean}}}
 
-export const OnlineStorePasswordProtection = {
+export const OnlineStorePasswordProtectionDocument = {
   kind: 'Document',
   definitions: [
     {

--- a/packages/cli-kit/src/cli/api/graphql/admin/generated/public_api_versions.ts
+++ b/packages/cli-kit/src/cli/api/graphql/admin/generated/public_api_versions.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/consistent-type-definitions */
-import * as Types from './types.js'
+import * as Types from './types'
 
 import {TypedDocumentNode as DocumentNode} from '@graphql-typed-document-node/core'
 
@@ -7,7 +7,7 @@ export type PublicApiVersionsQueryVariables = Types.Exact<{[key: string]: never}
 
 export type PublicApiVersionsQuery = {publicApiVersions: {handle: string; supported: boolean}[]}
 
-export const PublicApiVersions = {
+export const PublicApiVersionsDocument = {
   kind: 'Document',
   definitions: [
     {

--- a/packages/cli-kit/src/cli/api/graphql/admin/generated/theme_create.ts
+++ b/packages/cli-kit/src/cli/api/graphql/admin/generated/theme_create.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/consistent-type-definitions */
-import * as Types from './types.js'
+import * as Types from './types'
 
 import {TypedDocumentNode as DocumentNode} from '@graphql-typed-document-node/core'
 
@@ -16,7 +16,7 @@ export type ThemeCreateMutation = {
   } | null
 }
 
-export const ThemeCreate = {
+export const ThemeCreateDocument = {
   kind: 'Document',
   definitions: [
     {

--- a/packages/cli-kit/src/cli/api/graphql/admin/generated/theme_delete.ts
+++ b/packages/cli-kit/src/cli/api/graphql/admin/generated/theme_delete.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/consistent-type-definitions */
-import * as Types from './types.js'
+import * as Types from './types'
 
 import {TypedDocumentNode as DocumentNode} from '@graphql-typed-document-node/core'
 
@@ -14,7 +14,7 @@ export type ThemeDeleteMutation = {
   } | null
 }
 
-export const ThemeDelete = {
+export const ThemeDeleteDocument = {
   kind: 'Document',
   definitions: [
     {

--- a/packages/cli-kit/src/cli/api/graphql/admin/generated/theme_duplicate.ts
+++ b/packages/cli-kit/src/cli/api/graphql/admin/generated/theme_duplicate.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/consistent-type-definitions */
-import * as Types from './types.js'
+import * as Types from './types'
 
 import {TypedDocumentNode as DocumentNode} from '@graphql-typed-document-node/core'
 
@@ -15,7 +15,7 @@ export type ThemeDuplicateMutation = {
   } | null
 }
 
-export const ThemeDuplicate = {
+export const ThemeDuplicateDocument = {
   kind: 'Document',
   definitions: [
     {

--- a/packages/cli-kit/src/cli/api/graphql/admin/generated/theme_files_delete.ts
+++ b/packages/cli-kit/src/cli/api/graphql/admin/generated/theme_files_delete.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/consistent-type-definitions */
-import * as Types from './types.js'
+import * as Types from './types'
 
 import {TypedDocumentNode as DocumentNode} from '@graphql-typed-document-node/core'
 
@@ -19,7 +19,7 @@ export type ThemeFilesDeleteMutation = {
   } | null
 }
 
-export const ThemeFilesDelete = {
+export const ThemeFilesDeleteDocument = {
   kind: 'Document',
   definitions: [
     {

--- a/packages/cli-kit/src/cli/api/graphql/admin/generated/theme_files_upsert.ts
+++ b/packages/cli-kit/src/cli/api/graphql/admin/generated/theme_files_upsert.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/consistent-type-definitions */
-import * as Types from './types.js'
+import * as Types from './types'
 
 import {TypedDocumentNode as DocumentNode} from '@graphql-typed-document-node/core'
 
@@ -15,7 +15,7 @@ export type ThemeFilesUpsertMutation = {
   } | null
 }
 
-export const ThemeFilesUpsert = {
+export const ThemeFilesUpsertDocument = {
   kind: 'Document',
   definitions: [
     {

--- a/packages/cli-kit/src/cli/api/graphql/admin/generated/theme_publish.ts
+++ b/packages/cli-kit/src/cli/api/graphql/admin/generated/theme_publish.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/consistent-type-definitions */
-import * as Types from './types.js'
+import * as Types from './types'
 
 import {TypedDocumentNode as DocumentNode} from '@graphql-typed-document-node/core'
 
@@ -14,7 +14,7 @@ export type ThemePublishMutation = {
   } | null
 }
 
-export const ThemePublish = {
+export const ThemePublishDocument = {
   kind: 'Document',
   definitions: [
     {

--- a/packages/cli-kit/src/cli/api/graphql/admin/generated/theme_update.ts
+++ b/packages/cli-kit/src/cli/api/graphql/admin/generated/theme_update.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/consistent-type-definitions */
-import * as Types from './types.js'
+import * as Types from './types'
 
 import {TypedDocumentNode as DocumentNode} from '@graphql-typed-document-node/core'
 
@@ -15,7 +15,7 @@ export type ThemeUpdateMutation = {
   } | null
 }
 
-export const ThemeUpdate = {
+export const ThemeUpdateDocument = {
   kind: 'Document',
   definitions: [
     {


### PR DESCRIPTION
## Summary

Upstream GraphQL APIs updated their schemas, causing the "Check graphql-codegen has been run" CI check to fail for **all PRs** targeting main.

Running `pnpm graphql-codegen` on main HEAD produces 55 changed files — this is a repo-wide blocker, not specific to any PR.

## Changes

- 55 generated files regenerated across admin, app-management, business-platform-*, bulk-operations, functions, partners, and webhooks
- Two mechanical changes per file: import extension `.js` → extensionless, export name suffix `Document` added
- No query or config changes