### PR TITLE
Fix spread syntax runtime error on non-iterable values

### DIFF
--- a/packages/app/src/cli/models/extensions/specifications/transform/app_config_webhook.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/transform/app_config_webhook.test.ts
@@ -282,4 +282,34 @@ describe('reduceWebhooks', () => {
       },
     ])
   })
+
+  test('with property set, merges compliance_topics for subscriptions with the same uri', () => {
+    // Given
+    const subscriptions = [
+      {uri: 'https://example.com', compliance_topics: ['customers/redact']},
+      {uri: 'https://example.com', compliance_topics: ['customers/data_request']},
+    ]
+
+    // When
+    const result = reduceWebhooks(subscriptions, 'compliance_topics')
+
+    // Then
+    expect(result).toEqual([
+      {uri: 'https://example.com', compliance_topics: ['customers/redact', 'customers/data_request']},
+    ])
+  })
+
+  test('with property set, initializes the property array when existing subscription has none', () => {
+    // Given
+    const subscriptions = [
+      {uri: 'https://example.com'},
+      {uri: 'https://example.com', compliance_topics: ['customers/redact']},
+    ]
+
+    // When
+    const result = reduceWebhooks(subscriptions, 'compliance_topics')
+
+    // Then
+    expect(result).toEqual([{uri: 'https://example.com', compliance_topics: ['customers/redact']}])
+  })
 })

--- a/packages/app/src/cli/models/extensions/specifications/transform/app_config_webhook.ts
+++ b/packages/app/src/cli/models/extensions/specifications/transform/app_config_webhook.ts
@@ -80,15 +80,15 @@ export function reduceWebhooks(
   return subscriptions.reduce<WebhookSubscription[]>((accumulator, subscription) => {
     const existingSubscription = findSubscription(accumulator, subscription)
     if (existingSubscription) {
-      if (property && subscription?.[property]?.length) {
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
-        existingSubscription[property]?.push(...subscription[property]!)
+      if (property && Array.isArray(subscription?.[property]) && subscription[property].length) {
+        existingSubscription[property] ??= []
+        existingSubscription[property].push(...subscription[property])
       } else {
-        if (subscription.topics) {
+        if (Array.isArray(subscription.topics)) {
           existingSubscription.topics ??= []
           existingSubscription.topics.push(...subscription.topics)
         }
-        if (subscription.compliance_topics) {
+        if (Array.isArray(subscription.compliance_topics)) {
           existingSubscription.compliance_topics ??= []
           existingSubscription.compliance_topics.push(...subscription.compliance_topics)
         }

--- a/packages/app/src/cli/services/app-logs/sources.ts
+++ b/packages/app/src/cli/services/app-logs/sources.ts
@@ -15,7 +15,8 @@ export function sources(app: AppInterface) {
         sourcesByNamespace.set(sourceNamespace, [])
       }
 
-      sourcesByNamespace.set(sourceNamespace, [...sourcesByNamespace.get(sourceNamespace)!, source])
+      const existing = sourcesByNamespace.get(sourceNamespace) ?? []
+      sourcesByNamespace.set(sourceNamespace, [...existing, source])
     }
   })
 

--- a/packages/app/src/cli/services/dev/app-events/app-watcher-esbuild.ts
+++ b/packages/app/src/cli/services/dev/app-events/app-watcher-esbuild.ts
@@ -116,7 +116,7 @@ export class ESBuildContextManager {
   }
 
   async deleteContexts(extensions: ExtensionInstance[]) {
-    const promises = extensions.map((ext) => this.contexts[ext.uid]?.map((context) => context.dispose())).flat()
+    const promises = extensions.flatMap((ext) => this.contexts[ext.uid]?.map((context) => context.dispose()) ?? [])
     await Promise.all(promises)
     extensions.forEach((ext) => {
       const {[ext.uid]: _, ...rest} = this.contexts


### PR DESCRIPTION
## Summary
- Guard array spread sites that could receive non-iterable values at runtime, fixing "Spread syntax requires ...iterable[Symbol.iterator] to be a function" errors reported by Observe (7 events, 2 users over 7 days)
- Replace `!` non-null assertions and truthy checks with `Array.isArray` guards in `reduceWebhooks` webhook config transform — also fixes a silent data-loss bug where topics were dropped when `existingSubscription[property]` was undefined (the old `?.push` would silently no-op)
- Replace `.map().flat()` with `.flatMap(... ?? [])` in esbuild watcher `deleteContexts` to handle missing context entries
- Remove fragile `Map.get()!` pattern in app-logs `sources` by using `?? []` fallback
- Add tests for `reduceWebhooks` property-branch merging, covering the `??= []` initialization case

## Why
Observe reports a "Spread syntax requires ...iterable[Symbol.iterator] to be a function" runtime error in the `app` slice. The strongest candidate is `reduceWebhooks` in the webhook config transform, where subscription data is spread using `!` non-null assertions — if the data has unexpected shape, the spread throws. The `Map.get()!` in sources.ts is the only such pattern in the codebase and is fragile if the `has()` guard above is ever refactored away. The esbuild watcher uses `flatMap` as the idiomatic replacement for optional-chaining inside `.map().flat()`.

## Test plan
- [x] `pnpm vitest run packages/app/src/cli/models/extensions/specifications/transform/app_config_webhook.test.ts` — 9 tests pass (7 existing + 2 new)
- [x] `pnpm vitest run packages/app/src/cli/services/dev/app-events/app-watcher-esbuild.test.ts` — 8 tests pass
- [x] `pnpm vitest run packages/app/src/cli/services/app-logs/sources.test.ts` — 1 test passes
- [x] TypeScript compilation — no new errors in changed files
