### PR TITLE
E2E: one-time global auth before test start

### DIFF
--- a/packages/e2e/playwright.config.ts
+++ b/packages/e2e/playwright.config.ts
@@ -8,6 +8,7 @@ config()
 const isCI = Boolean(process.env.CI)
 
 export default defineConfig({
+  globalSetup: './setup/global-auth.ts',
   testDir: './tests',
   fullyParallel: false,
   forbidOnly: isCI,

--- a/packages/e2e/setup/auth.ts
+++ b/packages/e2e/setup/auth.ts
@@ -51,7 +51,7 @@ export const authFixture = browserFixture.extend<{}, {authLogin: void}>({
       }
 
       // Fallback: run auth login directly (single-worker / no global setup)
-      log.log(env, ' authenticating automatically')
+      log.log(env, 'authenticating automatically')
 
       await execa('node', [executables.cli, 'auth', 'logout'], {
         env: env.processEnv,

--- a/packages/e2e/setup/auth.ts
+++ b/packages/e2e/setup/auth.ts
@@ -7,26 +7,10 @@ import {waitForText} from '../helpers/wait-for-text.js'
 import {completeLogin} from '../helpers/browser-login.js'
 import {execa} from 'execa'
 import * as fs from 'fs'
-import * as path from 'path'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const log = {log: (_ctx: any, msg: string) => globalLog('auth', msg)}
 
-/**
- * Copy directory contents recursively.
- */
-function copyDirSync(src: string, dest: string): void {
-  fs.mkdirSync(dest, {recursive: true})
-  for (const entry of fs.readdirSync(src, {withFileTypes: true})) {
-    const srcPath = path.join(src, entry.name)
-    const destPath = path.join(dest, entry.name)
-    if (entry.isDirectory()) {
-      copyDirSync(srcPath, destPath)
-    } else {
-      fs.copyFileSync(srcPath, destPath)
-    }
-  }
-}
 
 /**
  * Worker-scoped fixture that provides an authenticated CLI session.
@@ -57,10 +41,10 @@ export const authFixture = browserFixture.extend<{}, {authLogin: void}>({
         // Copy pre-authenticated session from global setup
         log.log(env, 'copying session from global setup')
 
-        copyDirSync(authConfigDir, env.processEnv.XDG_CONFIG_HOME!)
-        copyDirSync(authDataDir, env.processEnv.XDG_DATA_HOME!)
-        copyDirSync(authStateDir, env.processEnv.XDG_STATE_HOME!)
-        copyDirSync(authCacheDir, env.processEnv.XDG_CACHE_HOME!)
+        fs.cpSync(authConfigDir, env.processEnv.XDG_CONFIG_HOME!, {recursive: true})
+        fs.cpSync(authDataDir, env.processEnv.XDG_DATA_HOME!, {recursive: true})
+        fs.cpSync(authStateDir, env.processEnv.XDG_STATE_HOME!, {recursive: true})
+        fs.cpSync(authCacheDir, env.processEnv.XDG_CACHE_HOME!, {recursive: true})
 
         await use()
         return

--- a/packages/e2e/setup/auth.ts
+++ b/packages/e2e/setup/auth.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-restricted-imports */
 import {browserFixture} from './browser.js'
 import {CLI_TIMEOUT, BROWSER_TIMEOUT} from './constants.js'
 import {globalLog, executables} from './env.js'
@@ -10,7 +9,6 @@ import * as fs from 'fs'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const log = {log: (_ctx: any, msg: string) => globalLog('auth', msg)}
-
 
 /**
  * Worker-scoped fixture that provides an authenticated CLI session.

--- a/packages/e2e/setup/auth.ts
+++ b/packages/e2e/setup/auth.ts
@@ -1,17 +1,39 @@
-import {CLI_TIMEOUT, BROWSER_TIMEOUT} from './constants.js'
+/* eslint-disable no-restricted-imports */
 import {browserFixture} from './browser.js'
-import {executables} from './env.js'
+import {CLI_TIMEOUT, BROWSER_TIMEOUT} from './constants.js'
+import {globalLog, executables} from './env.js'
 import {stripAnsi} from '../helpers/strip-ansi.js'
 import {waitForText} from '../helpers/wait-for-text.js'
 import {completeLogin} from '../helpers/browser-login.js'
 import {execa} from 'execa'
+import * as fs from 'fs'
+import * as path from 'path'
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const log = {log: (_ctx: any, msg: string) => globalLog('auth', msg)}
 
 /**
- * Worker-scoped fixture that performs OAuth login using the shared browser page.
+ * Copy directory contents recursively.
+ */
+function copyDirSync(src: string, dest: string): void {
+  fs.mkdirSync(dest, {recursive: true})
+  for (const entry of fs.readdirSync(src, {withFileTypes: true})) {
+    const srcPath = path.join(src, entry.name)
+    const destPath = path.join(dest, entry.name)
+    if (entry.isDirectory()) {
+      copyDirSync(srcPath, destPath)
+    } else {
+      fs.copyFileSync(srcPath, destPath)
+    }
+  }
+}
+
+/**
+ * Worker-scoped fixture that provides an authenticated CLI session.
  *
- * Extends browserFixture — the browser is already running when auth starts.
- * After login, the CLI session is stored in XDG dirs and the browser page
- * remains available for other browser-based actions (dashboard navigation, etc.).
+ * If globalSetup already ran auth (E2E_AUTH_CONFIG_DIR is set), copies the
+ * pre-authenticated session files into this worker's isolated XDG dirs.
+ * Otherwise falls back to running auth login directly (single-worker mode).
  *
  * Fixture chain: envFixture → cliFixture → browserFixture → authFixture
  */
@@ -26,22 +48,38 @@ export const authFixture = browserFixture.extend<{}, {authLogin: void}>({
         return
       }
 
-      process.stdout.write('[e2e] Authenticating automatically — no action required.\n')
+      const authConfigDir = process.env.E2E_AUTH_CONFIG_DIR
+      const authDataDir = process.env.E2E_AUTH_DATA_DIR
+      const authStateDir = process.env.E2E_AUTH_STATE_DIR
+      const authCacheDir = process.env.E2E_AUTH_CACHE_DIR
 
-      // Clear any existing session
+      if (authConfigDir && authDataDir && authStateDir && authCacheDir) {
+        // Copy pre-authenticated session from global setup
+        log.log(env, 'copying session from global setup')
+
+        copyDirSync(authConfigDir, env.processEnv.XDG_CONFIG_HOME!)
+        copyDirSync(authDataDir, env.processEnv.XDG_DATA_HOME!)
+        copyDirSync(authStateDir, env.processEnv.XDG_STATE_HOME!)
+        copyDirSync(authCacheDir, env.processEnv.XDG_CACHE_HOME!)
+
+        await use()
+        return
+      }
+
+      // Fallback: run auth login directly (single-worker / no global setup)
+      log.log(env, ' authenticating automatically')
+
       await execa('node', [executables.cli, 'auth', 'logout'], {
         env: env.processEnv,
         reject: false,
       })
 
-      // Spawn auth login via PTY (must not have CI=1)
       const nodePty = await import('node-pty')
       const spawnEnv: {[key: string]: string} = {}
       for (const [key, value] of Object.entries(env.processEnv)) {
         if (value !== undefined) spawnEnv[key] = value
       }
       spawnEnv.CI = ''
-      // Print login URL directly instead of opening system browser
       spawnEnv.CODESPACES = 'true'
 
       const ptyProcess = nodePty.spawn('node', [executables.cli, 'auth', 'login'], {

--- a/packages/e2e/setup/auth.ts
+++ b/packages/e2e/setup/auth.ts
@@ -39,6 +39,15 @@ export const authFixture = browserFixture.extend<{}, {authLogin: void}>({
         // Copy pre-authenticated session from global setup
         log.log(env, 'copying session from global setup')
 
+        if (
+          !fs.existsSync(authConfigDir) ||
+          !fs.existsSync(authDataDir) ||
+          !fs.existsSync(authStateDir) ||
+          !fs.existsSync(authCacheDir)
+        ) {
+          throw new Error('Global auth dirs missing — global setup may not have completed successfully')
+        }
+
         fs.cpSync(authConfigDir, env.processEnv.XDG_CONFIG_HOME!, {recursive: true})
         fs.cpSync(authDataDir, env.processEnv.XDG_DATA_HOME!, {recursive: true})
         fs.cpSync(authStateDir, env.processEnv.XDG_STATE_HOME!, {recursive: true})

--- a/packages/e2e/setup/browser.ts
+++ b/packages/e2e/setup/browser.ts
@@ -28,10 +28,12 @@ export const browserFixture = cliFixture.extend<{}, {browserPage: Page}>({
     // eslint-disable-next-line no-empty-pattern
     async ({}, use) => {
       const browser = await chromium.launch({headless: !process.env.E2E_HEADED})
+      const storageStatePath = process.env.E2E_BROWSER_STATE_PATH
       const context = await browser.newContext({
         extraHTTPHeaders: {
           'X-Shopify-Loadtest-Bf8d22e7-120e-4b5b-906c-39ca9d5499a9': 'true',
         },
+        ...(storageStatePath ? {storageState: storageStatePath} : {}),
       })
       context.setDefaultTimeout(BROWSER_TIMEOUT.max)
       context.setDefaultNavigationTimeout(BROWSER_TIMEOUT.max)

--- a/packages/e2e/setup/browser.ts
+++ b/packages/e2e/setup/browser.ts
@@ -1,6 +1,7 @@
 import {cliFixture} from './cli.js'
 import {BROWSER_TIMEOUT} from './constants.js'
 import {chromium, type Page} from '@playwright/test'
+import * as fs from 'fs'
 
 // ---------------------------------------------------------------------------
 // Shared browser context type
@@ -29,11 +30,12 @@ export const browserFixture = cliFixture.extend<{}, {browserPage: Page}>({
     async ({}, use) => {
       const browser = await chromium.launch({headless: !process.env.E2E_HEADED})
       const storageStatePath = process.env.E2E_BROWSER_STATE_PATH
+      const hasValidStorageState = storageStatePath && fs.existsSync(storageStatePath)
       const context = await browser.newContext({
         extraHTTPHeaders: {
           'X-Shopify-Loadtest-Bf8d22e7-120e-4b5b-906c-39ca9d5499a9': 'true',
         },
-        ...(storageStatePath ? {storageState: storageStatePath} : {}),
+        ...(hasValidStorageState ? {storageState: storageStatePath} : {}),
       })
       context.setDefaultTimeout(BROWSER_TIMEOUT.max)
       context.setDefaultNavigationTimeout(BROWSER_TIMEOUT.max)

--- a/packages/e2e/setup/env.ts
+++ b/packages/e2e/setup/env.ts
@@ -72,6 +72,13 @@ export function requireEnv(env: E2EEnv, ...keys: (keyof Pick<E2EEnv, 'storeFqdn'
   }
 }
 
+/** Log a message during global setup (before workers start). Only prints when DEBUG=1. */
+export function globalLog(tag: string, msg: string): void {
+  if (process.env.DEBUG === '1') {
+    process.stdout.write(`[e2e][${tag}] ${msg}\n`)
+  }
+}
+
 /**
  * Worker-scoped fixture providing environment configuration.
  * Env vars are optional — tests that need them should call requireEnv().

--- a/packages/e2e/setup/global-auth.ts
+++ b/packages/e2e/setup/global-auth.ts
@@ -1,0 +1,147 @@
+/**
+ * Playwright globalSetup — authenticates once before any workers start.
+ *
+ * Performs CLI `auth login` with a dedicated temp dir, then stores the
+ * path in E2E_AUTH_CONFIG_DIR so each worker can copy the session files
+ * into its own isolated XDG dirs.
+ */
+
+/* eslint-disable no-restricted-imports, @shopify/cli/no-process-cwd */
+import {createIsolatedEnv, executables, globalLog} from './env.js'
+import {CLI_TIMEOUT, BROWSER_TIMEOUT} from './constants.js'
+import {stripAnsi} from '../helpers/strip-ansi.js'
+import {waitForText} from '../helpers/wait-for-text.js'
+import {completeLogin} from '../helpers/browser-login.js'
+import {execa} from 'execa'
+import {chromium} from '@playwright/test'
+import * as path from 'path'
+import * as fs from 'fs'
+
+export default async function globalSetup() {
+  const email = process.env.E2E_ACCOUNT_EMAIL
+  const password = process.env.E2E_ACCOUNT_PASSWORD
+
+  if (!email || !password) return
+
+  const debug = process.env.DEBUG === '1'
+  globalLog('auth', 'global setup starting')
+
+  // Create a temp dir for the auth session
+  const tmpBase = process.env.E2E_TEMP_DIR ?? path.join(process.cwd(), '.e2e-tmp')
+  fs.mkdirSync(tmpBase, {recursive: true})
+  const {xdgEnv} = createIsolatedEnv(tmpBase)
+
+  const processEnv: NodeJS.ProcessEnv = {
+    ...process.env,
+    ...xdgEnv,
+    SHOPIFY_RUN_AS_USER: '0',
+    NODE_OPTIONS: '',
+    CI: '1',
+    SHOPIFY_CLI_1P_DEV: undefined,
+    SHOPIFY_FLAG_CLIENT_ID: undefined,
+  }
+
+  // Clear any existing session
+  await execa('node', [executables.cli, 'auth', 'logout'], {
+    env: processEnv,
+    reject: false,
+  })
+
+  // Spawn auth login via PTY
+  const nodePty = await import('node-pty')
+  const spawnEnv: {[key: string]: string} = {}
+  for (const [key, value] of Object.entries(processEnv)) {
+    if (value !== undefined) spawnEnv[key] = value
+  }
+  spawnEnv.CI = ''
+  spawnEnv.CODESPACES = 'true'
+
+  const ptyProcess = nodePty.spawn('node', [executables.cli, 'auth', 'login'], {
+    name: 'xterm-color',
+    cols: 120,
+    rows: 30,
+    env: spawnEnv,
+  })
+
+  let output = ''
+  ptyProcess.onData((data: string) => {
+    output += data
+    if (debug) process.stdout.write(data)
+  })
+
+  await waitForText(() => output, 'Open this link to start the auth process', CLI_TIMEOUT.short)
+
+  const stripped = stripAnsi(output)
+  const urlMatch = stripped.match(/https:\/\/accounts\.shopify\.com\S+/)
+  if (!urlMatch) {
+    throw new Error(`[e2e] global-auth: could not find login URL in output:\n${stripped}`)
+  }
+
+  // Complete login in a headless browser
+  const browser = await chromium.launch({headless: !process.env.E2E_HEADED})
+  const context = await browser.newContext({
+    extraHTTPHeaders: {
+      'X-Shopify-Loadtest-Bf8d22e7-120e-4b5b-906c-39ca9d5499a9': 'true',
+    },
+  })
+  const page = await context.newPage()
+
+  await completeLogin(page, urlMatch[0], email, password)
+
+  await waitForText(() => output, 'Logged in', BROWSER_TIMEOUT.max)
+  try {
+    ptyProcess.kill()
+    // eslint-disable-next-line no-catch-all/no-catch-all
+  } catch (_error) {
+    // Process may already be dead
+  }
+
+  // Visit admin.shopify.com and dev.shopify.com to establish session cookies
+  // (completeLogin only authenticates on accounts.shopify.com)
+  const orgId = (process.env.E2E_ORG_ID ?? '').trim()
+  if (orgId) {
+    // Establish admin.shopify.com cookies
+    await page.goto('https://admin.shopify.com/', {waitUntil: 'domcontentloaded'})
+    await page.waitForTimeout(BROWSER_TIMEOUT.medium)
+
+    // Handle account picker if shown
+    if (page.url().includes('accounts.shopify.com')) {
+      const accountButton = page.locator(`text=${email}`).first()
+      if (await accountButton.isVisible({timeout: BROWSER_TIMEOUT.long}).catch(() => false)) {
+        await accountButton.click()
+        await page.waitForTimeout(BROWSER_TIMEOUT.medium)
+      }
+    }
+
+    // Establish dev.shopify.com cookies
+    await page.goto(`https://dev.shopify.com/dashboard/${orgId}/apps`, {waitUntil: 'domcontentloaded'})
+    await page.waitForTimeout(BROWSER_TIMEOUT.medium)
+
+    if (page.url().includes('accounts.shopify.com')) {
+      const accountButton = page.locator(`text=${email}`).first()
+      if (await accountButton.isVisible({timeout: BROWSER_TIMEOUT.long}).catch(() => false)) {
+        await accountButton.click()
+        await page.waitForTimeout(BROWSER_TIMEOUT.medium)
+      }
+    }
+
+    globalLog('auth', 'browser sessions established for admin + dev dashboard')
+  }
+
+  // Save browser cookies/storage so workers can reuse the session
+  // Now includes cookies for both accounts.shopify.com AND admin.shopify.com
+  const storageStatePath = path.join(tmpBase, 'browser-storage-state.json')
+  await context.storageState({path: storageStatePath})
+  await browser.close()
+
+  // Store paths so workers can copy CLI auth + load browser state
+  /* eslint-disable require-atomic-updates */
+  process.env.E2E_AUTH_CONFIG_DIR = xdgEnv.XDG_CONFIG_HOME
+  process.env.E2E_AUTH_DATA_DIR = xdgEnv.XDG_DATA_HOME
+  process.env.E2E_AUTH_STATE_DIR = xdgEnv.XDG_STATE_HOME
+  process.env.E2E_AUTH_CACHE_DIR = xdgEnv.XDG_CACHE_HOME
+  process.env.E2E_BROWSER_STATE_PATH = storageStatePath
+  /* eslint-enable require-atomic-updates */
+
+  globalLog('auth', `global setup done, config at ${xdgEnv.XDG_CONFIG_HOME}`)
+}

--- a/packages/e2e/setup/global-auth.ts
+++ b/packages/e2e/setup/global-auth.ts
@@ -6,8 +6,8 @@
  * into its own isolated XDG dirs.
  */
 
-/* eslint-disable no-restricted-imports, @shopify/cli/no-process-cwd */
-import {createIsolatedEnv, executables, globalLog} from './env.js'
+/* eslint-disable no-restricted-imports */
+import {createIsolatedEnv, directories, executables, globalLog} from './env.js'
 import {CLI_TIMEOUT, BROWSER_TIMEOUT} from './constants.js'
 import {stripAnsi} from '../helpers/strip-ansi.js'
 import {waitForText} from '../helpers/wait-for-text.js'
@@ -36,7 +36,7 @@ export default async function globalSetup() {
   globalLog('auth', 'global setup starting')
 
   // Create a temp dir for the auth session
-  const tmpBase = process.env.E2E_TEMP_DIR ?? path.join(process.cwd(), '.e2e-tmp')
+  const tmpBase = process.env.E2E_TEMP_DIR ?? path.join(directories.root, '.e2e-tmp')
   fs.mkdirSync(tmpBase, {recursive: true})
   const {xdgEnv} = createIsolatedEnv(tmpBase)
 

--- a/packages/e2e/setup/global-auth.ts
+++ b/packages/e2e/setup/global-auth.ts
@@ -1,10 +1,8 @@
 /**
  * Playwright globalSetup — authenticates once before any workers start.
  *
- * Uses a stable `global-auth/` dir for session caching across runs.
- * On subsequent runs, validates the cached browser session before
- * re-authenticating. Workers copy the session files into their own
- * isolated XDG dirs via E2E_AUTH_* env vars.
+ * Auth artifacts are stored in a stable `global-auth/` dir. Workers copy
+ * the session files into their own isolated XDG dirs via E2E_AUTH_* env vars.
  */
 
 /* eslint-disable no-restricted-imports */
@@ -36,7 +34,7 @@ export default async function globalSetup() {
   const debug = process.env.DEBUG === '1'
   globalLog('auth', 'global setup starting')
 
-  // Use a stable auth dir (reused across runs for session caching)
+  // All auth artifacts stored in a stable dir
   const tmpBase = process.env.E2E_TEMP_DIR ?? path.join(directories.root, '.e2e-tmp')
   fs.mkdirSync(tmpBase, {recursive: true})
   const authDir = path.join(tmpBase, 'global-auth')
@@ -57,29 +55,6 @@ export default async function globalSetup() {
     CI: '1',
     SHOPIFY_CLI_1P_DEV: undefined,
     SHOPIFY_FLAG_CLIENT_ID: undefined,
-  }
-
-  // Check if cached session from a previous run is still valid
-  if (fs.existsSync(storageStatePath)) {
-    const browser = await chromium.launch({headless: true})
-    try {
-      const context = await browser.newContext({storageState: storageStatePath})
-      const page = await context.newPage()
-      await page.goto('https://admin.shopify.com/', {waitUntil: 'domcontentloaded', timeout: BROWSER_TIMEOUT.long})
-      if (!isAccountsShopifyUrl(page.url())) {
-        globalLog('auth', 'reusing cached session')
-        setAuthEnvVars(xdgEnv, storageStatePath)
-        return
-      }
-      // eslint-disable-next-line no-catch-all/no-catch-all
-    } catch (_error) {
-      // Browser check failed — fall through to re-authenticate
-    } finally {
-      await browser.close().catch(() => {})
-    }
-    globalLog('auth', 'cached session expired, re-authenticating')
-  } else {
-    globalLog('auth', 'no cached session found')
   }
 
   // Create fresh XDG dirs
@@ -161,7 +136,15 @@ export default async function globalSetup() {
     }
   }
 
-  setAuthEnvVars(xdgEnv, storageStatePath)
+  // Store paths so workers can copy CLI auth + load browser state
+  /* eslint-disable require-atomic-updates */
+  process.env.E2E_AUTH_CONFIG_DIR = xdgEnv.XDG_CONFIG_HOME
+  process.env.E2E_AUTH_DATA_DIR = xdgEnv.XDG_DATA_HOME
+  process.env.E2E_AUTH_STATE_DIR = xdgEnv.XDG_STATE_HOME
+  process.env.E2E_AUTH_CACHE_DIR = xdgEnv.XDG_CACHE_HOME
+  process.env.E2E_BROWSER_STATE_PATH = storageStatePath
+  /* eslint-enable require-atomic-updates */
+
   globalLog('auth', `global setup done, config at ${xdgEnv.XDG_CONFIG_HOME}`)
 }
 
@@ -176,12 +159,4 @@ async function visitAndHandleAccountPicker(page: Page, url: string, email: strin
       await page.waitForTimeout(BROWSER_TIMEOUT.medium)
     }
   }
-}
-
-function setAuthEnvVars(xdgEnv: Record<string, string>, storageStatePath: string): void {
-  process.env.E2E_AUTH_CONFIG_DIR = xdgEnv.XDG_CONFIG_HOME
-  process.env.E2E_AUTH_DATA_DIR = xdgEnv.XDG_DATA_HOME
-  process.env.E2E_AUTH_STATE_DIR = xdgEnv.XDG_STATE_HOME
-  process.env.E2E_AUTH_CACHE_DIR = xdgEnv.XDG_CACHE_HOME
-  process.env.E2E_BROWSER_STATE_PATH = storageStatePath
 }

--- a/packages/e2e/setup/global-auth.ts
+++ b/packages/e2e/setup/global-auth.ts
@@ -1,19 +1,20 @@
 /**
  * Playwright globalSetup — authenticates once before any workers start.
  *
- * Performs CLI `auth login` with a dedicated temp dir, then stores the
- * path in E2E_AUTH_CONFIG_DIR so each worker can copy the session files
- * into its own isolated XDG dirs.
+ * Uses a stable `global-auth/` dir for session caching across runs.
+ * On subsequent runs, validates the cached browser session before
+ * re-authenticating. Workers copy the session files into their own
+ * isolated XDG dirs via E2E_AUTH_* env vars.
  */
 
 /* eslint-disable no-restricted-imports */
-import {createIsolatedEnv, directories, executables, globalLog} from './env.js'
+import {directories, executables, globalLog} from './env.js'
 import {CLI_TIMEOUT, BROWSER_TIMEOUT} from './constants.js'
 import {stripAnsi} from '../helpers/strip-ansi.js'
 import {waitForText} from '../helpers/wait-for-text.js'
 import {completeLogin} from '../helpers/browser-login.js'
 import {execa} from 'execa'
-import {chromium} from '@playwright/test'
+import {chromium, type Page} from '@playwright/test'
 import * as path from 'path'
 import * as fs from 'fs'
 
@@ -35,10 +36,18 @@ export default async function globalSetup() {
   const debug = process.env.DEBUG === '1'
   globalLog('auth', 'global setup starting')
 
-  // Create a temp dir for the auth session
+  // Use a stable auth dir (reused across runs for session caching)
   const tmpBase = process.env.E2E_TEMP_DIR ?? path.join(directories.root, '.e2e-tmp')
   fs.mkdirSync(tmpBase, {recursive: true})
-  const {xdgEnv} = createIsolatedEnv(tmpBase)
+  const authDir = path.join(tmpBase, 'global-auth')
+  const storageStatePath = path.join(authDir, 'browser-storage-state.json')
+
+  const xdgEnv = {
+    XDG_DATA_HOME: path.join(authDir, 'XDG_DATA_HOME'),
+    XDG_CONFIG_HOME: path.join(authDir, 'XDG_CONFIG_HOME'),
+    XDG_STATE_HOME: path.join(authDir, 'XDG_STATE_HOME'),
+    XDG_CACHE_HOME: path.join(authDir, 'XDG_CACHE_HOME'),
+  }
 
   const processEnv: NodeJS.ProcessEnv = {
     ...process.env,
@@ -48,6 +57,34 @@ export default async function globalSetup() {
     CI: '1',
     SHOPIFY_CLI_1P_DEV: undefined,
     SHOPIFY_FLAG_CLIENT_ID: undefined,
+  }
+
+  // Check if cached session from a previous run is still valid
+  if (fs.existsSync(storageStatePath)) {
+    const browser = await chromium.launch({headless: true})
+    try {
+      const context = await browser.newContext({storageState: storageStatePath})
+      const page = await context.newPage()
+      await page.goto('https://admin.shopify.com/', {waitUntil: 'domcontentloaded', timeout: BROWSER_TIMEOUT.long})
+      if (!isAccountsShopifyUrl(page.url())) {
+        globalLog('auth', 'reusing cached session')
+        setAuthEnvVars(xdgEnv, storageStatePath)
+        return
+      }
+      // eslint-disable-next-line no-catch-all/no-catch-all
+    } catch (_error) {
+      // Browser check failed — fall through to re-authenticate
+    } finally {
+      await browser.close().catch(() => {})
+    }
+    globalLog('auth', 'cached session expired, re-authenticating')
+  } else {
+    globalLog('auth', 'no cached session found')
+  }
+
+  // Create fresh XDG dirs
+  for (const dir of Object.values(xdgEnv)) {
+    fs.mkdirSync(dir, {recursive: true})
   }
 
   // Clear any existing session
@@ -78,8 +115,6 @@ export default async function globalSetup() {
     if (debug) process.stdout.write(data)
   })
 
-  const storageStatePath = path.join(tmpBase, 'browser-storage-state.json')
-
   try {
     await waitForText(() => output, 'Open this link to start the auth process', CLI_TIMEOUT.short)
 
@@ -107,31 +142,8 @@ export default async function globalSetup() {
       // (completeLogin only authenticates on accounts.shopify.com)
       const orgId = (process.env.E2E_ORG_ID ?? '').trim()
       if (orgId) {
-        // Establish admin.shopify.com cookies
-        await page.goto('https://admin.shopify.com/', {waitUntil: 'domcontentloaded'})
-        await page.waitForTimeout(BROWSER_TIMEOUT.medium)
-
-        // Handle account picker if shown
-        if (isAccountsShopifyUrl(page.url())) {
-          const accountButton = page.locator(`text=${email}`).first()
-          if (await accountButton.isVisible({timeout: BROWSER_TIMEOUT.long}).catch(() => false)) {
-            await accountButton.click()
-            await page.waitForTimeout(BROWSER_TIMEOUT.medium)
-          }
-        }
-
-        // Establish dev.shopify.com cookies
-        await page.goto(`https://dev.shopify.com/dashboard/${orgId}/apps`, {waitUntil: 'domcontentloaded'})
-        await page.waitForTimeout(BROWSER_TIMEOUT.medium)
-
-        if (isAccountsShopifyUrl(page.url())) {
-          const accountButton = page.locator(`text=${email}`).first()
-          if (await accountButton.isVisible({timeout: BROWSER_TIMEOUT.long}).catch(() => false)) {
-            await accountButton.click()
-            await page.waitForTimeout(BROWSER_TIMEOUT.medium)
-          }
-        }
-
+        await visitAndHandleAccountPicker(page, 'https://admin.shopify.com/', email)
+        await visitAndHandleAccountPicker(page, `https://dev.shopify.com/dashboard/${orgId}/apps`, email)
         globalLog('auth', 'browser sessions established for admin + dev dashboard')
       }
 
@@ -149,14 +161,27 @@ export default async function globalSetup() {
     }
   }
 
-  // Store paths so workers can copy CLI auth + load browser state
-  /* eslint-disable require-atomic-updates */
+  setAuthEnvVars(xdgEnv, storageStatePath)
+  globalLog('auth', `global setup done, config at ${xdgEnv.XDG_CONFIG_HOME}`)
+}
+
+/** Navigate to a URL and dismiss the account picker if it appears. */
+async function visitAndHandleAccountPicker(page: Page, url: string, email: string) {
+  await page.goto(url, {waitUntil: 'domcontentloaded'})
+  await page.waitForTimeout(BROWSER_TIMEOUT.medium)
+  if (isAccountsShopifyUrl(page.url())) {
+    const accountButton = page.locator(`text=${email}`).first()
+    if (await accountButton.isVisible({timeout: BROWSER_TIMEOUT.long}).catch(() => false)) {
+      await accountButton.click()
+      await page.waitForTimeout(BROWSER_TIMEOUT.medium)
+    }
+  }
+}
+
+function setAuthEnvVars(xdgEnv: Record<string, string>, storageStatePath: string): void {
   process.env.E2E_AUTH_CONFIG_DIR = xdgEnv.XDG_CONFIG_HOME
   process.env.E2E_AUTH_DATA_DIR = xdgEnv.XDG_DATA_HOME
   process.env.E2E_AUTH_STATE_DIR = xdgEnv.XDG_STATE_HOME
   process.env.E2E_AUTH_CACHE_DIR = xdgEnv.XDG_CACHE_HOME
   process.env.E2E_BROWSER_STATE_PATH = storageStatePath
-  /* eslint-enable require-atomic-updates */
-
-  globalLog('auth', `global setup done, config at ${xdgEnv.XDG_CONFIG_HOME}`)
 }

--- a/packages/e2e/setup/global-auth.ts
+++ b/packages/e2e/setup/global-auth.ts
@@ -17,6 +17,15 @@ import {chromium} from '@playwright/test'
 import * as path from 'path'
 import * as fs from 'fs'
 
+function isAccountsShopifyUrl(rawUrl: string): boolean {
+  try {
+    return new URL(rawUrl).hostname === 'accounts.shopify.com'
+    // eslint-disable-next-line no-catch-all/no-catch-all
+  } catch {
+    return false
+  }
+}
+
 export default async function globalSetup() {
   const email = process.env.E2E_ACCOUNT_EMAIL
   const password = process.env.E2E_ACCOUNT_PASSWORD
@@ -105,7 +114,7 @@ export default async function globalSetup() {
     await page.waitForTimeout(BROWSER_TIMEOUT.medium)
 
     // Handle account picker if shown
-    if (page.url().includes('accounts.shopify.com')) {
+    if (isAccountsShopifyUrl(page.url())) {
       const accountButton = page.locator(`text=${email}`).first()
       if (await accountButton.isVisible({timeout: BROWSER_TIMEOUT.long}).catch(() => false)) {
         await accountButton.click()
@@ -117,7 +126,7 @@ export default async function globalSetup() {
     await page.goto(`https://dev.shopify.com/dashboard/${orgId}/apps`, {waitUntil: 'domcontentloaded'})
     await page.waitForTimeout(BROWSER_TIMEOUT.medium)
 
-    if (page.url().includes('accounts.shopify.com')) {
+    if (isAccountsShopifyUrl(page.url())) {
       const accountButton = page.locator(`text=${email}`).first()
       if (await accountButton.isVisible({timeout: BROWSER_TIMEOUT.long}).catch(() => false)) {
         await accountButton.click()

--- a/packages/e2e/setup/global-auth.ts
+++ b/packages/e2e/setup/global-auth.ts
@@ -78,70 +78,76 @@ export default async function globalSetup() {
     if (debug) process.stdout.write(data)
   })
 
-  await waitForText(() => output, 'Open this link to start the auth process', CLI_TIMEOUT.short)
-
-  const stripped = stripAnsi(output)
-  const urlMatch = stripped.match(/https:\/\/accounts\.shopify\.com\S+/)
-  if (!urlMatch) {
-    throw new Error(`[e2e] global-auth: could not find login URL in output:\n${stripped}`)
-  }
-
-  // Complete login in a headless browser
-  const browser = await chromium.launch({headless: !process.env.E2E_HEADED})
-  const context = await browser.newContext({
-    extraHTTPHeaders: {
-      'X-Shopify-Loadtest-Bf8d22e7-120e-4b5b-906c-39ca9d5499a9': 'true',
-    },
-  })
-  const page = await context.newPage()
-
-  await completeLogin(page, urlMatch[0], email, password)
-
-  await waitForText(() => output, 'Logged in', BROWSER_TIMEOUT.max)
-  try {
-    ptyProcess.kill()
-    // eslint-disable-next-line no-catch-all/no-catch-all
-  } catch (_error) {
-    // Process may already be dead
-  }
-
-  // Visit admin.shopify.com and dev.shopify.com to establish session cookies
-  // (completeLogin only authenticates on accounts.shopify.com)
-  const orgId = (process.env.E2E_ORG_ID ?? '').trim()
-  if (orgId) {
-    // Establish admin.shopify.com cookies
-    await page.goto('https://admin.shopify.com/', {waitUntil: 'domcontentloaded'})
-    await page.waitForTimeout(BROWSER_TIMEOUT.medium)
-
-    // Handle account picker if shown
-    if (isAccountsShopifyUrl(page.url())) {
-      const accountButton = page.locator(`text=${email}`).first()
-      if (await accountButton.isVisible({timeout: BROWSER_TIMEOUT.long}).catch(() => false)) {
-        await accountButton.click()
-        await page.waitForTimeout(BROWSER_TIMEOUT.medium)
-      }
-    }
-
-    // Establish dev.shopify.com cookies
-    await page.goto(`https://dev.shopify.com/dashboard/${orgId}/apps`, {waitUntil: 'domcontentloaded'})
-    await page.waitForTimeout(BROWSER_TIMEOUT.medium)
-
-    if (isAccountsShopifyUrl(page.url())) {
-      const accountButton = page.locator(`text=${email}`).first()
-      if (await accountButton.isVisible({timeout: BROWSER_TIMEOUT.long}).catch(() => false)) {
-        await accountButton.click()
-        await page.waitForTimeout(BROWSER_TIMEOUT.medium)
-      }
-    }
-
-    globalLog('auth', 'browser sessions established for admin + dev dashboard')
-  }
-
-  // Save browser cookies/storage so workers can reuse the session
-  // Now includes cookies for both accounts.shopify.com AND admin.shopify.com
   const storageStatePath = path.join(tmpBase, 'browser-storage-state.json')
-  await context.storageState({path: storageStatePath})
-  await browser.close()
+
+  try {
+    await waitForText(() => output, 'Open this link to start the auth process', CLI_TIMEOUT.short)
+
+    const stripped = stripAnsi(output)
+    const urlMatch = stripped.match(/https:\/\/accounts\.shopify\.com\S+/)
+    if (!urlMatch) {
+      throw new Error(`[e2e] global-auth: could not find login URL in output:\n${stripped}`)
+    }
+
+    // Complete login in a headless browser
+    const browser = await chromium.launch({headless: !process.env.E2E_HEADED})
+    try {
+      const context = await browser.newContext({
+        extraHTTPHeaders: {
+          'X-Shopify-Loadtest-Bf8d22e7-120e-4b5b-906c-39ca9d5499a9': 'true',
+        },
+      })
+      const page = await context.newPage()
+
+      await completeLogin(page, urlMatch[0], email, password)
+
+      await waitForText(() => output, 'Logged in', BROWSER_TIMEOUT.max)
+
+      // Visit admin.shopify.com and dev.shopify.com to establish session cookies
+      // (completeLogin only authenticates on accounts.shopify.com)
+      const orgId = (process.env.E2E_ORG_ID ?? '').trim()
+      if (orgId) {
+        // Establish admin.shopify.com cookies
+        await page.goto('https://admin.shopify.com/', {waitUntil: 'domcontentloaded'})
+        await page.waitForTimeout(BROWSER_TIMEOUT.medium)
+
+        // Handle account picker if shown
+        if (isAccountsShopifyUrl(page.url())) {
+          const accountButton = page.locator(`text=${email}`).first()
+          if (await accountButton.isVisible({timeout: BROWSER_TIMEOUT.long}).catch(() => false)) {
+            await accountButton.click()
+            await page.waitForTimeout(BROWSER_TIMEOUT.medium)
+          }
+        }
+
+        // Establish dev.shopify.com cookies
+        await page.goto(`https://dev.shopify.com/dashboard/${orgId}/apps`, {waitUntil: 'domcontentloaded'})
+        await page.waitForTimeout(BROWSER_TIMEOUT.medium)
+
+        if (isAccountsShopifyUrl(page.url())) {
+          const accountButton = page.locator(`text=${email}`).first()
+          if (await accountButton.isVisible({timeout: BROWSER_TIMEOUT.long}).catch(() => false)) {
+            await accountButton.click()
+            await page.waitForTimeout(BROWSER_TIMEOUT.medium)
+          }
+        }
+
+        globalLog('auth', 'browser sessions established for admin + dev dashboard')
+      }
+
+      // Save browser cookies/storage so workers can reuse the session
+      await context.storageState({path: storageStatePath})
+    } finally {
+      await browser.close()
+    }
+  } finally {
+    try {
+      ptyProcess.kill()
+      // eslint-disable-next-line no-catch-all/no-catch-all
+    } catch (_error) {
+      // Process may already be dead
+    }
+  }
 
   // Store paths so workers can copy CLI auth + load browser state
   /* eslint-disable require-atomic-updates */


### PR DESCRIPTION
### WHY are these changes introduced?

E2E tests currently authenticate the CLI and browser per worker on every test run. This PR centralizes authentication into a single `globalSetup` step that runs once before tests start.

This lays the foundation for:
- **Parallel workers** (future PR): Without global auth, each worker would need to authenticate independently, causing redundant OAuth flows and potential rate limiting
- **Per-test store creation** (future PR): Browser needs pre-authenticated cookies for `admin.shopify.com` to create dev stores via the store creation form

### WHAT is this pull request doing?

Adds a Playwright `globalSetup` that authenticates **once** before tests start, then reuses the session:

1. **CLI auth** (`setup/global-auth.ts`): Spawns `shopify auth login` via PTY, completes OAuth in a headless browser (with passkey/WebAuthn bypass), waits for "Logged in"
2. **Browser session establishment**: Visits `admin.shopify.com` and `dev.shopify.com` to establish cookies for both domains (not just `accounts.shopify.com`)
3. **Session reuse** (`setup/auth.ts`): Copies the pre-authenticated CLI session files (XDG dirs) and loads browser `storageState` — no re-authentication needed

Also includes a CodeQL fix: URL checks for `accounts.shopify.com` redirects now use `new URL().hostname` comparison instead of substring matching.

### Design decisions: session persistence

**Approach:** Follows [Playwright's recommended `storageState` pattern](https://playwright.dev/docs/auth) — global setup authenticates once and saves browser cookies to a JSON file. Workers load the saved state into their browser context.

**Always re-authenticate each run:** Both local and CI use the same flow — full auth every run. This keeps the logic simple and consistent. No cross-run caching (on CI this is impossible since each run is a fresh container; locally the ~30s auth cost is acceptable).

**Why per-worker copies of CLI config dirs?** Browser auth shares one `browser-storage-state.json` fine — Playwright handles that natively. But CLI commands (`app dev`, `app deploy`) read **and write** to config directories at runtime (session tokens, cached app state). If parallel workers shared the same dirs, they'd corrupt each other's files. Each worker copies the auth artifacts into its own isolated XDG dirs.

**Directory structure:**
```
.e2e-tmp/
├── global-auth/                    ← stable dir, all auth artifacts together
│   ├── XDG_CONFIG_HOME/            ← CLI tokens (used on Linux CI)
│   ├── XDG_DATA_HOME/
│   ├── XDG_STATE_HOME/
│   ├── XDG_CACHE_HOME/
│   └── browser-storage-state.json  ← browser cookies (used everywhere)
├── e2e-{worker0}/                  ← per-worker isolated dirs
└── e2e-{worker1}/
```

**Cross-platform note:** On macOS, the CLI's `conf` package ignores XDG env vars and writes to `~/Library/Preferences/`. The XDG dirs in `global-auth/` are only populated on Linux. Browser `storageState` works on all platforms.

**Files changed:**
| File | Change |
|------|--------|
| `setup/global-auth.ts` | New: one-time auth + browser cookie establishment |
| `setup/auth.ts` | Copies session from global setup instead of re-authenticating |
| `setup/browser.ts` | Loads `storageState` from global setup |
| `setup/env.ts` | Adds `globalLog()` helper for pre-test logging |
| `playwright.config.ts` | Adds `globalSetup` entry |

### How to test your changes?

```bash
# Run all tests
DEBUG=1 pnpm --filter e2e exec playwright test

# Quick test with a single spec
DEBUG=1 pnpm --filter e2e exec playwright test app-deploy

# Watch browser behavior (headed mode)
E2E_HEADED=1 DEBUG=1 pnpm --filter e2e exec playwright test

# Expected output before tests start:
# [e2e][auth] global setup starting
# [e2e][auth] browser sessions established for admin + dev dashboard
# [e2e][auth] global setup done, config at ...
```

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing, so I've added a changelog entry with `pnpm changeset add`