### PR TITLE
E2E: improve error context in assertions

### DIFF
--- a/packages/e2e/tests/app-dev-server.spec.ts
+++ b/packages/e2e/tests/app-dev-server.spec.ts
@@ -23,7 +23,9 @@ test.describe('App dev server', () => {
         packageManager: 'pnpm',
         orgId: env.orgId,
       })
-      expect(initResult.exitCode).toBe(0)
+      expect(initResult.exitCode, `createApp failed:\nstdout: ${initResult.stdout}\nstderr: ${initResult.stderr}`).toBe(
+        0,
+      )
       const appDir = initResult.appDir
 
       // Step 2: Start dev server via PTY
@@ -42,7 +44,7 @@ test.describe('App dev server', () => {
 
       // Step 6: Wait for clean exit
       const exitCode = await dev.waitForExit(CLI_TIMEOUT.short)
-      expect(exitCode).toBe(0)
+      expect(exitCode, `dev exited with non-zero code. Output:\n${dev.getOutput()}`).toBe(0)
     } finally {
       fs.rmSync(parentDir, {recursive: true, force: true})
       await teardownApp({browserPage, appName, email: process.env.E2E_ACCOUNT_EMAIL, orgId: env.orgId})

--- a/packages/e2e/tests/app-scaffold.spec.ts
+++ b/packages/e2e/tests/app-scaffold.spec.ts
@@ -25,7 +25,9 @@ test.describe('App scaffold', () => {
         packageManager: 'pnpm',
         orgId: env.orgId,
       })
-      expect(initResult.exitCode).toBe(0)
+      expect(initResult.exitCode, `createApp failed:\nstdout: ${initResult.stdout}\nstderr: ${initResult.stderr}`).toBe(
+        0,
+      )
       const initOutput = initResult.stdout + initResult.stderr
       expect(initOutput).toContain('is ready for you to build!')
       const appDir = initResult.appDir
@@ -37,7 +39,10 @@ test.describe('App scaffold', () => {
 
       // Step 3: Build the app
       const buildResult = await buildApp({cli, appDir})
-      expect(buildResult.exitCode, `build failed:\nstderr: ${buildResult.stderr}`).toBe(0)
+      expect(
+        buildResult.exitCode,
+        `buildApp failed:\nstdout: ${buildResult.stdout}\nstderr: ${buildResult.stderr}`,
+      ).toBe(0)
     } finally {
       fs.rmSync(parentDir, {recursive: true, force: true})
       await teardownApp({browserPage, appName, email: process.env.E2E_ACCOUNT_EMAIL, orgId: env.orgId})
@@ -60,7 +65,9 @@ test.describe('App scaffold', () => {
         packageManager: 'pnpm',
         orgId: env.orgId,
       })
-      expect(initResult.exitCode).toBe(0)
+      expect(initResult.exitCode, `createApp failed:\nstdout: ${initResult.stdout}\nstderr: ${initResult.stderr}`).toBe(
+        0,
+      )
       expect(fs.existsSync(initResult.appDir)).toBe(true)
       expect(fs.existsSync(path.join(initResult.appDir, 'shopify.app.toml'))).toBe(true)
     } finally {
@@ -89,7 +96,9 @@ test.describe('App scaffold', () => {
         packageManager: 'pnpm',
         orgId: env.orgId,
       })
-      expect(initResult.exitCode).toBe(0)
+      expect(initResult.exitCode, `createApp failed:\nstdout: ${initResult.stdout}\nstderr: ${initResult.stderr}`).toBe(
+        0,
+      )
       const appDir = initResult.appDir
 
       const extensionConfigs = [
@@ -100,11 +109,17 @@ test.describe('App scaffold', () => {
       for (const ext of extensionConfigs) {
         // eslint-disable-next-line no-await-in-loop
         const result = await generateExtension({cli, appDir, ...ext})
-        expect(result.exitCode, `generate "${ext.name}" failed:\nstderr: ${result.stderr}`).toBe(0)
+        expect(
+          result.exitCode,
+          `generateExtension "${ext.name}" failed:\nstdout: ${result.stdout}\nstderr: ${result.stderr}`,
+        ).toBe(0)
       }
 
       const buildResult = await buildApp({cli, appDir})
-      expect(buildResult.exitCode, `build failed:\nstderr: ${buildResult.stderr}`).toBe(0)
+      expect(
+        buildResult.exitCode,
+        `buildApp failed:\nstdout: ${buildResult.stdout}\nstderr: ${buildResult.stderr}`,
+      ).toBe(0)
     } finally {
       fs.rmSync(parentDir, {recursive: true, force: true})
       await teardownApp({browserPage, appName, email: process.env.E2E_ACCOUNT_EMAIL, orgId: env.orgId})

--- a/packages/e2e/tests/commands.spec.ts
+++ b/packages/e2e/tests/commands.spec.ts
@@ -30,7 +30,7 @@ const normalize = (value: string) => value.replace(/\r\n/g, '\n').trimEnd()
 test.describe('Command snapshot', () => {
   test('shopify commands --tree matches snapshot', async ({cli}) => {
     const result = await cli.exec(['commands', '--tree'])
-    expect(result.exitCode).toBe(0)
+    expect(result.exitCode, `commands --tree failed:\nstdout: ${result.stdout}\nstderr: ${result.stderr}`).toBe(0)
 
     const snapshot = await fs.readFile(snapshotPath, {encoding: 'utf8'})
     expect(normalize(result.stdout), errorMessage).toBe(normalize(snapshot))

--- a/packages/e2e/tests/smoke-pty.spec.ts
+++ b/packages/e2e/tests/smoke-pty.spec.ts
@@ -6,7 +6,7 @@ test.describe('PTY smoke test', () => {
     const proc = await cli.spawn(['version'])
     await proc.waitForOutput('3.')
     const code = await proc.waitForExit()
-    expect(code).toBe(0)
+    expect(code, `shopify version (PTY) failed. Output:\n${proc.getOutput()}`).toBe(0)
     expect(proc.getOutput()).toMatch(/\d+\.\d+\.\d+/)
   })
 })

--- a/packages/e2e/tests/smoke.spec.ts
+++ b/packages/e2e/tests/smoke.spec.ts
@@ -4,7 +4,7 @@ import {expect} from '@playwright/test'
 test.describe('Smoke test', () => {
   test('shopify version runs successfully', async ({cli}) => {
     const result = await cli.exec(['version'])
-    expect(result.exitCode).toBe(0)
+    expect(result.exitCode, `shopify version failed:\nstdout: ${result.stdout}\nstderr: ${result.stderr}`).toBe(0)
     expect(result.stdout).toMatch(/\d+\.\d+\.\d+/)
   })
 })


### PR DESCRIPTION
Closed https://github.com/Shopify/cli/issues/7275

### WHY are these changes introduced?

When E2E tests fail, some assertions already had error context (e.g., `build failed:\nstderr: ...`) but others didn't, the error message only shows "Expected: 0, Received: 1" without the CLI output that caused the failure. This makes it hard to diagnose issues, especially in CI where you can't re-run interactively.

### WHAT is this pull request doing?

Adds error context (stdout/stderr) to all `expect(exitCode).toBe(0)` assertions that were missing it.

Before:
```typescript
expect(initResult.exitCode).toBe(0)
```

After:
```typescript
expect(initResult.exitCode, `create-app failed:\nstdout: ${initResult.stdout}\nstderr: ${initResult.stderr}`).toBe(0)
```

**Files changed:** 6 test files — `app-dev-server`, `app-scaffold`, `commands`, `smoke`, `smoke-pty`

### How to test your changes?

No behavior change — assertions only show the added context when a test fails.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing, so I've added a changelog entry with `pnpm changeset add`