### PR TITLE
E2E: temporary time limit bump

### DIFF
--- a/.github/workflows/tests-pr.yml
+++ b/.github/workflows/tests-pr.yml
@@ -219,7 +219,7 @@ jobs:
     name: 'E2E tests'
     if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 40
     continue-on-error: true
     steps:
       - uses: actions/checkout@v3

--- a/packages/e2e/playwright.config.ts
+++ b/packages/e2e/playwright.config.ts
@@ -17,7 +17,7 @@ export default defineConfig({
   maxFailures: isCI ? 3 : 0, // Stop early in CI after 3 failures
   reporter: isCI ? [['html', {open: 'never'}], ['list']] : [['list']],
   timeout: TEST_TIMEOUT.default, // Heavy tests override via test.setTimeout()
-  globalTimeout: 20 * 60 * 1000,
+  globalTimeout: 35 * 60 * 1000, // Temporary: store creation adds time per test; will reduce with parallel workers
 
   use: {
     trace: isCI ? 'on' : 'off',


### PR DESCRIPTION
### WHY are these changes introduced?

With per-test store creation (next PR in stack), each test that uses `app dev` now creates and tears down a dev store. This adds ~30s per test, pushing the total suite time over the previous 20-minute Playwright `globalTimeout` and the 30-minute GitHub Actions job timeout on CI with 1 worker.

### WHAT is this pull request doing?

- Bumps Playwright `globalTimeout` from 20 min to 35 min in `playwright.config.ts`
- Bumps GitHub Actions E2E job `timeout-minutes` from 30 to 40 in `tests-pr.yml`

Both are temporary — will be reduced when parallel workers (5 workers) are enabled in #7309, which cuts total suite time significantly.

### How to test your changes?

```bash
pnpm test:e2e
# Should complete within 35 min on CI without hitting globalTimeout or job timeout
```

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing, so I've added a changelog entry with `pnpm changeset add`