### PR TITLE
Fix flaky Dev component polling tests

### DIFF
--- a/packages/app/src/cli/services/dev/ui/components/Dev.test.tsx
+++ b/packages/app/src/cli/services/dev/ui/components/Dev.test.tsx
@@ -502,13 +502,16 @@ describe('Dev', () => {
     )
 
     // Then
-    // Wait long enough for multiple polling cycles
-    await sleep(0.05)
+    // Wait for polling to call fetchMode multiple times (avoids timing-dependent flakiness)
+    await vi.waitFor(
+      () => {
+        expect(developerPreview.fetchMode.mock.calls.length).toBeGreaterThanOrEqual(2)
+      },
+      {timeout: 2000, interval: 10},
+    )
 
     // enable should be called once at startup
     expect(developerPreview.enable).toHaveBeenCalledTimes(1)
-    // fetchMode should be called multiple times due to polling
-    expect(developerPreview.fetchMode.mock.calls.length).toBeGreaterThanOrEqual(2)
 
     // unmount so that polling is cleared after every test
     renderInstance.unmount()
@@ -525,9 +528,14 @@ describe('Dev', () => {
       },
     }
 
-    vi.mocked(developerPreview.fetchMode).mockReset()
-    vi.mocked(developerPreview.fetchMode).mockResolvedValue(true)
-    vi.mocked(developerPreview.enable).mockReset()
+    // Use a locally-scoped mock to isolate from any leaked polling intervals
+    // from previous tests that might call the module-level developerPreview mock
+    const localDeveloperPreview = {
+      fetchMode: vi.fn(async () => true),
+      enable: vi.fn(async () => true),
+      disable: vi.fn(async () => {}),
+      update: vi.fn(async (_state: boolean) => true),
+    }
 
     // When
     const renderInstance = render(
@@ -543,13 +551,13 @@ describe('Dev', () => {
         }}
         // Set a very short polling time for tests
         pollingTime={10}
-        developerPreview={developerPreview}
+        developerPreview={localDeveloperPreview}
         shopFqdn="mystore.shopify.io"
       />,
     )
 
     // Then
-    // Wait long enough for multiple polling cycles
+    // Wait to ensure no polling occurs
     await sleep(0.05)
     expect(unstyled(renderInstance.lastFrame()!).replace(/\d/g, '0')).toMatchInlineSnapshot(`
       "00:00:00 │ backend │ first backend message
@@ -566,13 +574,13 @@ describe('Dev', () => {
       GraphiQL URL: http://localhost:0000/graphiql
       "
     `)
-    expect(developerPreview.enable).not.toHaveBeenCalled()
-    expect(developerPreview.fetchMode).not.toHaveBeenCalled()
+    expect(localDeveloperPreview.enable).not.toHaveBeenCalled()
+    expect(localDeveloperPreview.fetchMode).not.toHaveBeenCalled()
 
     // Verify 'd' input doesn't trigger update when app doesn't support preview
     await waitForInputsToBeReady()
     await sendInputAndWait(renderInstance, 10, 'd')
-    expect(developerPreview.update).not.toHaveBeenCalled()
+    expect(localDeveloperPreview.update).not.toHaveBeenCalled()
 
     // unmount so that polling is cleared after every test
     renderInstance.unmount()


### PR DESCRIPTION
### WHY are these changes introduced?

Flaky tests: https://github.com/Shopify/cli/actions/runs/24343909340

```
FAIL   @shopify/app  src/cli/services/dev/ui/components/Dev.test.tsx > Dev > polls for preview mode
AssertionError: expected 1 to be greater than or equal to 2
 ❯ src/cli/services/dev/ui/components/Dev.test.tsx:511:58
    509|     expect(developerPreview.enable).toHaveBeenCalledTimes(1)
    510|     // fetchMode should be called multiple times due to polling
    511|     expect(developerPreview.fetchMode.mock.calls.length).toBeGreaterTh…
       |                                                          ^
    512| 
    513|     // unmount so that polling is cleared after every test

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/2]⎯

 FAIL   @shopify/app  src/cli/services/dev/ui/components/Dev.test.tsx > Dev > doesn't poll for preview mode when the app does not support it
AssertionError: expected "spy" to not be called at all, but actually been called 4 times

Received: 

  1st spy call:

    Array []

  2nd spy call:

    Array []

  3rd spy call:

    Array []

  4th spy call:

    Array []



Number of calls: 4

 ❯ src/cli/services/dev/ui/components/Dev.test.tsx:570:44
    568|     `)
    569|     expect(developerPreview.enable).not.toHaveBeenCalled()
    570|     expect(developerPreview.fetchMode).not.toHaveBeenCalled()
       |                                            ^
    571| 
    572|     // Verify 'd' input doesn't trigger update when app doesn't suppor…
```

### WHAT is this pull request doing?

Two timing-dependent test failures are fixed:

1. 'polls for preview mode': Replaced sleep-based timing with vi.waitFor() to reliably wait for the polling condition instead of hoping 50ms is enough.

2. 'doesn't poll for preview mode when the app does not support it': Used a locally-scoped mock to isolate from leaked polling intervals from previous tests that call the shared module-level developerPreview mock.


### How to test your changes?

CI

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing, so I've added a changelog entry with `pnpm changeset add`
