### PR TITLE
Fix flaky runWithRateLimit test by using fake timers

### DIFF
--- a/packages/cli-kit/src/private/node/conf-store.test.ts
+++ b/packages/cli-kit/src/private/node/conf-store.test.ts
@@ -474,6 +474,7 @@ describe('runWithRateLimit', () => {
   test('throttles the task when the cache is populated recently', async () => {
     await inTemporaryDirectory(async (cwd) => {
       // Given
+      vi.useFakeTimers()
       const config = new LocalStorage<any>({cwd})
       for (let i = 0; i < limit; i++) {
         // eslint-disable-next-line no-await-in-loop
@@ -511,6 +512,7 @@ describe('runWithRateLimit', () => {
   test("runs the task as usual when the cache is populated recently but the rate limit isn't used up", async () => {
     await inTemporaryDirectory(async (cwd) => {
       // Given
+      vi.useFakeTimers()
       const config = new LocalStorage<any>({cwd})
       // Run the task once, but the rate limit is 2
       await runWithRateLimit(


### PR DESCRIPTION
### WHY are these changes introduced?

Flaky test: https://github.com/Shopify/cli/actions/runs/24396106090

```
FAIL   @shopify/cli-kit  src/private/node/conf-store.test.ts > runWithRateLimit > throttles the task when the cache is populated recently
AssertionError: expected true to be false // Object.is equality

- Expected
+ Received

- false
+ true

 ❯ src/private/node/conf-store.test.ts:506:19
    504| 
    505|       // Then
    506|       expect(got).toBe(false)
       |                   ^
    507|       expect(taskRan).toBe(false)
    508|     })
 ❯ Module.inTemporaryDirectory src/public/node/fs.ts:81:12
 ❯ src/private/node/conf-store.test.ts:475:5
```

The 'throttles the task when the cache is populated recently' test was flaky because it used real time with a 1-second timeout window. Under CI load, the time between filling the rate limit cache and checking it could exceed 1 second, causing the old occurrences to be swept out and the rate limit to no longer be exceeded.

### WHAT is this pull request doing?

Fix by using `vi.useFakeTimers()` to freeze time during the test, matching the pattern already used by the 'cache is populated but outdated' test in the same describe block. The existing afterEach hook already calls `vi.useRealTimers()` for cleanup.

Also applied the same fix to the 'rate limit isn't used up' test to prevent the same class of flake.

### How to test your changes?

CI

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing, so I've added a changelog entry with `pnpm changeset add`
