### PR TITLE
docs: fix typos and a broken image URL in top-level READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Learn more in the [commands docs](./packages/cli/README.md#commands).
 
 ## Before you begin
 
-Install the latest version of  [Node.js](https://nodejs.org/en/download/) and [npm](https://docs.npmjs.com/getting-started) (or another package manager of your choice).
+Install the latest version of [Node.js](https://nodejs.org/en/download/) and [npm](https://docs.npmjs.com/getting-started) (or another package manager of your choice).
 
 <p>&nbsp;</p>
 
@@ -39,13 +39,13 @@ To work with themes, the CLI needs to be installed globally with:
 
 - `npm install -g @shopify/cli`
 
-You can also use do it through Homebrew on macOS: `brew tap shopify/shopify && brew install shopify-cli`
+You can also do it through Homebrew on macOS: `brew tap shopify/shopify && brew install shopify-cli`
 
 Learn more in the docs: [Shopify CLI for themes](https://shopify.dev/docs/storefronts/themes/tools/cli)
 
 <p>&nbsp;</p>
 
-## Developing Hydrogen custom storefronts with Shopify CLI ##
+## Developing Hydrogen custom storefronts with Shopify CLI
 
 The Hydrogen code lives here: https://github.com/Shopify/hydrogen/tree/main/packages/cli
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-<img src="https://github.com/Shopify/shopify-cli/raw/main/assets/logo.png" alt="Shopify logo" width="150">
+<img src="https://github.com/Shopify/cli/raw/main/assets/logo.png" alt="Shopify logo" width="150">
 
 # Contributors documentation
 


### PR DESCRIPTION
### WHY are these changes introduced?

Four small, verifiable issues in the two top-of-repo README files.

### WHAT is this pull request doing?

\`README.md\`:
\`\`\`diff
-Install the latest version of  [Node.js](https://nodejs.org/en/download/) and [npm]...
+Install the latest version of [Node.js](https://nodejs.org/en/download/) and [npm]...
\`\`\`
Double space before the \`[Node.js]\` link.

\`\`\`diff
-You can also use do it through Homebrew on macOS: \`brew tap shopify/shopify && brew install shopify-cli\`
+You can also do it through Homebrew on macOS: \`brew tap shopify/shopify && brew install shopify-cli\`
\`\`\`
Stray \`use\` in \"You can also use do it\".

\`\`\`diff
-## Developing Hydrogen custom storefronts with Shopify CLI ##
+## Developing Hydrogen custom storefronts with Shopify CLI
\`\`\`
Trailing \`##\` on the heading (closing markers like that aren't rendered but they show up in auto-generated TOCs and some linters flag them).

\`docs/README.md\`:
\`\`\`diff
-<img src=\"https://github.com/Shopify/shopify-cli/raw/main/assets/logo.png\" alt=\"Shopify logo\" width=\"150\">
+<img src=\"https://github.com/Shopify/cli/raw/main/assets/logo.png\" alt=\"Shopify logo\" width=\"150\">
\`\`\`
The \`<img>\` src pointed at \`Shopify/shopify-cli\`, which is now archived. The current repo is \`Shopify/cli\`, and \`assets/logo.png\` exists there.

### How to test your changes?

Docs-only. The README renders differently in each case:
- Hover the \"Node.js\" link in the rendered \"Before you begin\" section — the double space is visible.
- Read the \"Developing themes\" section out loud — \"use do it\" is visibly wrong.
- The Hydrogen heading's TOC anchor was previously \`shopify-cli-\` (trailing dash from the \`##\`).
- \`docs/README.md\` now pulls the logo from a live repo instead of an archived one.

### Post-release steps

None — docs-only.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes — this *is* the docs change
- [x] I've considered analytics changes to measure impact — N/A, docs-only
- [ ] The change is user-facing, so I've added a changelog entry with \`pnpm changeset add\` — no changeset needed for docs-only changes