### PR TITLE
fix(cli-kit): respect package manager when installNodeModules adds specific packages

### DIFF
--- a/.changeset/fix-install-node-modules-subcommand.md
+++ b/.changeset/fix-install-node-modules-subcommand.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': patch
+---
+
+Fix `installNodeModules()` using the wrong subcommand for yarn, pnpm, and bun when adding specific packages. The function now accepts an optional `packages: string[]` parameter; when provided, yarn, pnpm, and bun use their `add` subcommand (required for adding new packages) while npm continues to use `install`. Existing call sites that pass only `args` are unaffected.

--- a/packages/cli-kit/src/public/node/node-package-manager.test.ts
+++ b/packages/cli-kit/src/public/node/node-package-manager.test.ts
@@ -130,6 +130,109 @@ describe('install', () => {
       cwd: directory,
     })
   })
+
+  test('uses `install` when packages are provided for npm', async () => {
+    // Given
+    const directory = '/path/to/project'
+
+    // When
+    await installNodeModules({
+      directory,
+      packageManager: 'npm',
+      packages: ['@shopify/hydrogen@2025.7.1'],
+    })
+
+    // Then
+    expect(mockedExec).toHaveBeenCalledWith('npm', ['install', '@shopify/hydrogen@2025.7.1'], {
+      cwd: directory,
+    })
+  })
+
+  test('uses `add` when packages are provided for yarn', async () => {
+    // Given
+    const directory = '/path/to/project'
+
+    // When
+    await installNodeModules({
+      directory,
+      packageManager: 'yarn',
+      packages: ['@shopify/hydrogen@2025.7.1'],
+    })
+
+    // Then
+    expect(mockedExec).toHaveBeenCalledWith('yarn', ['add', '@shopify/hydrogen@2025.7.1'], {
+      cwd: directory,
+    })
+  })
+
+  test('uses `add` when packages are provided for pnpm', async () => {
+    // Given
+    const directory = '/path/to/project'
+
+    // When
+    await installNodeModules({
+      directory,
+      packageManager: 'pnpm',
+      packages: ['@shopify/hydrogen@2025.7.1'],
+    })
+
+    // Then
+    expect(mockedExec).toHaveBeenCalledWith('pnpm', ['add', '@shopify/hydrogen@2025.7.1'], {
+      cwd: directory,
+    })
+  })
+
+  test('uses `add` when packages are provided for bun', async () => {
+    // Given
+    const directory = '/path/to/project'
+
+    // When
+    await installNodeModules({
+      directory,
+      packageManager: 'bun',
+      packages: ['@shopify/hydrogen@2025.7.1'],
+    })
+
+    // Then
+    expect(mockedExec).toHaveBeenCalledWith('bun', ['add', '@shopify/hydrogen@2025.7.1'], {
+      cwd: directory,
+    })
+  })
+
+  test('appends `args` after `packages` so flags follow the package specifiers', async () => {
+    // Given
+    const directory = '/path/to/project'
+
+    // When
+    await installNodeModules({
+      directory,
+      packageManager: 'yarn',
+      packages: ['@shopify/hydrogen@2025.7.1'],
+      args: ['--exact'],
+    })
+
+    // Then
+    expect(mockedExec).toHaveBeenCalledWith('yarn', ['add', '@shopify/hydrogen@2025.7.1', '--exact'], {
+      cwd: directory,
+    })
+  })
+
+  test('uses `install` (unchanged) when no packages are provided, even for yarn', async () => {
+    // Given
+    const directory = '/path/to/project'
+
+    // When
+    await installNodeModules({
+      directory,
+      packageManager: 'yarn',
+      args: ['--network-concurrency', '1'],
+    })
+
+    // Then
+    expect(mockedExec).toHaveBeenCalledWith('yarn', ['install', '--network-concurrency', '1'], {
+      cwd: directory,
+    })
+  })
 })
 
 describe('getPackageName', () => {

--- a/packages/cli-kit/src/public/node/node-package-manager.ts
+++ b/packages/cli-kit/src/public/node/node-package-manager.ts
@@ -242,7 +242,20 @@ export async function installNPMDependenciesRecursively(
 
 interface InstallNodeModulesOptions {
   directory: string
+  /**
+   * Additional flags passed to the package manager after the subcommand and
+   * any `packages`. Use this for things like `--network-concurrency 1`.
+   */
   args?: string[]
+  /**
+   * Specific package specifiers (e.g. `['@shopify/hydrogen@2025.7.1']`) to
+   * add to the project. When provided, `yarn`, `pnpm`, and `bun` use their
+   * `add` subcommand instead of `install`, since those package managers'
+   * `install` subcommand installs from the lockfile rather than adding new
+   * packages. When omitted, the function runs `<pm> install` to install
+   * dependencies from the lockfile (the existing behaviour).
+   */
+  packages?: string[]
   packageManager: PackageManager
   stdout?: Writable
   stderr?: Writable
@@ -257,7 +270,16 @@ export async function installNodeModules(options: InstallNodeModulesOptions): Pr
     stderr: options.stderr,
     signal: options.signal,
   }
-  let args = ['install']
+  const hasPackages = Boolean(options.packages?.length)
+  const usesAddSubcommand =
+    hasPackages &&
+    (options.packageManager === 'yarn' ||
+      options.packageManager === 'pnpm' ||
+      options.packageManager === 'bun')
+  let args = [usesAddSubcommand ? 'add' : 'install']
+  if (options.packages) {
+    args = args.concat(options.packages)
+  }
   if (options.args) {
     args = args.concat(options.args)
   }


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #7042.

\`installNodeModules()\` in \`packages/cli-kit/src/public/node/node-package-manager.ts\` always ran \`<pm> install <args>\`, but \`yarn\`, \`pnpm\`, and \`bun\` all require the \`add\` subcommand to install a specific package with a version specifier — their \`install\` subcommand installs from the lockfile.

So a call like
\`\`\`ts
installNodeModules({packageManager: 'yarn', args: ['@shopify/hydrogen@2025.7.1']})
\`\`\`
produced \`yarn install @shopify/hydrogen@2025.7.1\`, which yarn rejects. Same for pnpm. Hydrogen PR [#3462](https://github.com/Shopify/hydrogen/pull/3462) worked around this by bypassing \`installNodeModules()\` with a direct \`exec()\` call that mapped the subcommand per package manager; this upstream fix lets that workaround be removed ([@kdaviduik's original suggestion](https://github.com/Shopify/hydrogen/pull/3462#discussion_r2874002471)).

### WHAT is this pull request doing?

Rather than silently change the meaning of \`args\` — which would break \`packages/app/src/cli/services/init/template/npm.ts\`, the only other call site, which uses \`args\` for flags like \`['--network-concurrency', '1']\` — added a new optional \`packages?: string[]\` field to \`InstallNodeModulesOptions\`.

When \`packages\` is provided:
- \`npm\` keeps using \`install\` (no change, and npm supports both).
- \`yarn\`, \`pnpm\`, and \`bun\` use \`add\`, matching the existing internal helpers \`argumentsToAddDependenciesWith{Yarn,PNPM,Bun}\` further down the same file.

When \`packages\` is omitted the function behaves identically to before, so every existing call site is unaffected.

\`\`\`diff
-  let args = ['install']
+  const hasPackages = Boolean(options.packages?.length)
+  const usesAddSubcommand =
+    hasPackages &&
+    (options.packageManager === 'yarn' ||
+      options.packageManager === 'pnpm' ||
+      options.packageManager === 'bun')
+  let args = [usesAddSubcommand ? 'add' : 'install']
+  if (options.packages) {
+    args = args.concat(options.packages)
+  }
   if (options.args) {
     args = args.concat(options.args)
   }
\`\`\`

### Full-path trace

- \`installNodeModules\` is used from two files inside this repo: \`packages/app/src/cli/services/init/template/npm.ts\` (passes \`args\` as *flags*, not packages) and \`packages/app/src/cli/services/generate/extension.ts\` (calls without \`args\` — pure lockfile install). Neither is affected by this change.
- External consumers (Hydrogen's \`upgrade\` command, among others) previously worked around the bug; they can migrate to the new \`packages\` field when they want to drop the workaround.
- The existing internal helpers \`addNPMDependencies\` / \`argumentsToAddDependenciesWith{Yarn,PNPM,Bun}\` already use \`add\` for yarn/pnpm/bun — this fix brings \`installNodeModules\` in line with the same convention when it's used to add specific packages.
- The \`homebrew\` and \`unknown\` \`PackageManager\` variants keep the existing \`install\` behaviour (\`homebrew install <pkg>\` isn't reachable in practice — \`addNPMDependencies\` throws for it — and \`unknown\` is an error state).

### How to test your changes?

Six new tests in \`packages/cli-kit/src/public/node/node-package-manager.test.ts\`:

1. \`uses \`install\` when packages are provided for npm\`
2. \`uses \`add\` when packages are provided for yarn\`
3. \`uses \`add\` when packages are provided for pnpm\`
4. \`uses \`add\` when packages are provided for bun\`
5. \`appends \`args\` after \`packages\`\` — verifies ordering when both are passed
6. \`uses \`install\` (unchanged) when no packages are provided, even for yarn\` — regression guard for the existing \`init/template/npm.ts\` call path

Run locally:
\`\`\`bash
pnpm --filter @shopify/cli-kit test node-package-manager
\`\`\`

### Post-release steps

None in this repo. Downstream note: Hydrogen's [\`upgrade.ts\` workaround](https://github.com/Shopify/hydrogen/pull/3462) can be removed once this change ships in a \`@shopify/cli-kit\` release and a matching Hydrogen PR is opened.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows) — no OS-specific code
- [x] I've considered possible [documentation](https://shopify.dev) changes — the new option has a JSDoc block explaining when to use it
- [x] I've considered analytics changes to measure impact — N/A
- [x] The change is user-facing, so I've added a changelog entry with \`pnpm changeset add\` — \`.changeset/fix-install-node-modules-subcommand.md\`, patch bump for \`@shopify/cli-kit\`