### PR TITLE
fix: typos in a user-facing success message, comments, and test descriptions

### DIFF
--- a/.changeset/fix-webhook-trigger-typo.md
+++ b/.changeset/fix-webhook-trigger-typo.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Fix "Localhost delivery sucessful" → "Localhost delivery successful" typo in the success message printed by `shopify app webhook trigger --delivery-method=localhost`.

--- a/packages/app/src/cli/services/app/config/link.ts
+++ b/packages/app/src/cli/services/app/config/link.ts
@@ -351,7 +351,7 @@ export async function overwriteLocalConfigFileWithRemoteAppConfiguration(options
       },
       replaceLocalArrayStrategy,
     ),
-    // Always use our prefered build options
+    // Always use our preferred build options
     build: buildOptionsForGeneratedConfigFile({
       existingBuildOptions: localAppOptions.existingBuildOptions,
       linkedAppAndClientIdFromFileAreInSync: localAppOptions.localAppIdMatchedRemote,

--- a/packages/app/src/cli/services/dev/extension/localization.test.ts
+++ b/packages/app/src/cli/services/dev/extension/localization.test.ts
@@ -111,7 +111,7 @@ describe('when there are locale files', () => {
     })
     vi.useRealTimers()
   })
-  test('returns the last succesful locale built when there are JSON errors', async () => {
+  test('returns the last successful locale built when there are JSON errors', async () => {
     const timestamp = 0
     vi.setSystemTime(new Date(timestamp))
 

--- a/packages/app/src/cli/services/webhook/trigger.test.ts
+++ b/packages/app/src/cli/services/webhook/trigger.test.ts
@@ -213,7 +213,7 @@ describe('webhookTriggerService', () => {
         anOrganizationId,
       )
       expect(triggerLocalWebhook).toHaveBeenCalledWith(aFullLocalAddress, samplePayload, sampleHeaders)
-      expect(outputSuccess).toHaveBeenCalledWith('Localhost delivery sucessful')
+      expect(outputSuccess).toHaveBeenCalledWith('Localhost delivery successful')
     })
 
     test('shows an error if localhost is not ready', async () => {

--- a/packages/app/src/cli/services/webhook/trigger.ts
+++ b/packages/app/src/cli/services/webhook/trigger.ts
@@ -84,7 +84,7 @@ async function sendSample(options: WebhookTriggerOptions) {
     const result = await triggerLocalWebhook(options.address, sample.samplePayload, sample.headers)
 
     if (result) {
-      outputSuccess('Localhost delivery sucessful')
+      outputSuccess('Localhost delivery successful')
       return
     }
 

--- a/packages/cli-kit/src/public/node/context/local.test.ts
+++ b/packages/cli-kit/src/public/node/context/local.test.ts
@@ -239,7 +239,7 @@ describe('cloudEnvironment', () => {
     expect(got.platform).toBe('gitpod')
   })
 
-  test('returns localhost when no cloud enviroment varible exist', () => {
+  test('returns localhost when no cloud environment variable exists', () => {
     // Given
     const env = {}
 

--- a/packages/cli-kit/src/public/node/json-schema.ts
+++ b/packages/cli-kit/src/public/node/json-schema.ts
@@ -233,7 +233,7 @@ function simplifyUnionErrors(rawErrors: AjvError[], subject: object, schema: Sch
     // we start by assuming only the union error itself is useful, and not the errors from the candidate schemas
     let simplifiedUnionRelatedErrors: AjvError[] = [unionError]
 
-    // get the schema list from where the union issue occured
+    // get the schema list from where the union issue occurred
     const dottedSchemaPath = unionError.schemaPath.replace('#/', '').replace(/\//g, '.')
     const unionSchemas = getPathValue<SchemaObject[]>(schema, dottedSchemaPath)
     // and the slice of the subject that caused the issue

--- a/packages/theme/src/cli/utilities/repl/evaluator.test.ts
+++ b/packages/theme/src/cli/utilities/repl/evaluator.test.ts
@@ -47,7 +47,7 @@ describe('evaluate', () => {
     })
   })
 
-  test('should add succesful assignments to the session', async () => {
+  test('should add successful assignments to the session', async () => {
     const mockResponse = createMockResponse({
       status: 200,
       text: '<div id="shopify-section-announcement-bar" class="shopify-section">\n[{ "type": "context", "value": "assign x = 1" }]</div>',

--- a/packages/theme/src/cli/utilities/theme-uploader.ts
+++ b/packages/theme/src/cli/utilities/theme-uploader.ts
@@ -282,7 +282,7 @@ function buildUploadJob(
     Promise.resolve(),
   )
 
-  // Dependant and independant files are uploaded concurrently
+  // Dependent and independent files are uploaded concurrently
   const independentFilesUploadPromise = Promise.resolve().then(() => uploadFileBatches(independentFiles.flat()))
 
   const promise = Promise.all([dependentFilesUploadPromise, independentFilesUploadPromise]).then(() => {


### PR DESCRIPTION
### WHY are these changes introduced?

A handful of typos across the codebase, including one in a user-facing CLI success message. All are 1:1 character fixes; no identifiers, no runtime behaviour, no types touched.

### WHAT is this pull request doing?

**User-facing CLI output** (the one change that actually needs a changeset):

\`\`\`diff
- outputSuccess('Localhost delivery sucessful')
+ outputSuccess('Localhost delivery successful')
\`\`\`
(\`packages/app/src/cli/services/webhook/trigger.ts\`) — printed when \`shopify app webhook trigger --delivery-method=localhost\` succeeds. The matching assertion in \`trigger.test.ts\` is updated in the same commit.

**Code comments**:
- \`packages/cli-kit/src/public/node/json-schema.ts\` — \"where the union issue occured\" → \"occurred\".
- \`packages/theme/src/cli/utilities/theme-uploader.ts\` — \"Dependant and independant files are uploaded concurrently\" → \"Dependent and independent\".
- \`packages/app/src/cli/services/app/config/link.ts\` — \"Always use our prefered build options\" → \"preferred\".

**Test descriptions** (strings passed to \`test()\`/\`describe()\`, safe to rename — no identifiers reference them):
- \`packages/theme/src/cli/utilities/repl/evaluator.test.ts\` — \"should add succesful assignments\" → \"successful\".
- \`packages/app/src/cli/services/dev/extension/localization.test.ts\` — \"returns the last succesful locale built\" → \"successful\".
- \`packages/cli-kit/src/public/node/context/local.test.ts\` — \"returns localhost when no cloud enviroment varible exist\" had two typos on one line plus a subject-verb agreement slip, now \"when no cloud environment variable exists\".

### How to test your changes?

The only runtime-visible change is the webhook success message. The existing test in \`trigger.test.ts\` is updated to assert on the corrected string, so the unit test still passes after the fix. Everything else is inside a comment or a test description — no functional impact.

\`\`\`bash
pnpm --filter @shopify/app test trigger
\`\`\`

### Post-release steps

None.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows) — no platform-specific code touched
- [x] I've considered possible [documentation](https://shopify.dev) changes — string changes don't affect published docs
- [x] I've considered analytics changes to measure impact — N/A
- [x] The change is user-facing, so I've added a changelog entry with \`pnpm changeset add\` — patch bump for \`@shopify/app\` covering the webhook trigger message