### PR TITLE
Upgrade Node version in update-graphql-deps.yml

### DIFF
--- a/.github/workflows/update-graphql-deps.yml
+++ b/.github/workflows/update-graphql-deps.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup deps
         uses: ./.github/actions/setup-cli-deps
         with:
-          node-version: '22.11.0'
+          node-version: '24.1.0'
       - name: Get schemas for codegen
         env:
           GH_TOKEN: ${{ secrets.SHOPIFY_GH_READ_CONTENT_TOKEN }}


### PR DESCRIPTION
### WHY are these changes introduced?

There's a Node version mismatch between workflows:
- update-graphql-deps.yml generates and commits codegen output using Node 22.11.0
- tests-pr.yml re-generates and verifies those files using Node 24.1.0

The codegen pipeline includes an eslint --fix formatting step (graphql-codegen:formatting), which can produce subtly different output across Node versions. So files committed by the update workflow (Node 22) don't always match what the PR check regenerates (Node 24) — even with identical schemas and queries.

This explains the flakiness: eslint --fix is mostly stable across Node versions, but occasionally produces different formatting for certain files.

More info: https://shopify.slack.com/archives/C05E3BDFDRB/p1776201817435039

### WHAT is this pull request doing?

Updates the Node version in update-graphql-deps.yml to match other workflows

### How to test your changes?

Merge and run it

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing, so I've added a changelog entry with `pnpm changeset add`
