### PR TITLE
Automate patch release post-publish steps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,6 +116,26 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SHOPIFY_CLI_BUILD_REPO: ${{ github.repository }}
 
+      - name: Create git tag and GitHub Release
+        if: steps.changesets.outputs.hasChangesets == 'false' && startsWith(github.ref_name, 'stable/')
+        run: |
+          VERSION=$(node -p "require('./packages/cli-kit/package.json').version")
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag "v${VERSION}"
+          git push origin "v${VERSION}"
+          gh release create "v${VERSION}" \
+            --title "${VERSION}" \
+            --notes "See the [CHANGELOG](https://github.com/Shopify/cli/blob/${{ github.ref_name }}/packages/cli/CHANGELOG.md) for details."
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Open post-release PRs
+        if: steps.changesets.outputs.hasChangesets == 'false' && startsWith(github.ref_name, 'stable/')
+        run: pnpm post-release --skip-notification
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   # Manual/Cron release job - runs on schedule or manual trigger with tag
   manual-cron-release:
     name: Manual & Cron Release

--- a/bin/post-release
+++ b/bin/post-release
@@ -1,6 +1,12 @@
 #! /usr/bin/env bash
 
-tag=$1
+# Parse flags
+skip_notification=false
+for arg in "$@"; do
+  case $arg in
+    --skip-notification) skip_notification=true ;;
+  esac
+done
 
 # Check if current branch starts with "stable"
 current_branch=$(git branch --show-current)
@@ -9,18 +15,20 @@ if [[ ! $current_branch =~ ^stable ]]; then
     exit 1
 fi
 
-# Check if git working directory is clean
-if [[ -n $(git status -s) ]]; then
-    echo "Error: Git working directory is not clean"
-    git status
-    exit 1
-fi
+if [[ -z "$CI" ]]; then
+  # Check if git working directory is clean
+  if [[ -n $(git status -s) ]]; then
+      echo "Error: Git working directory is not clean"
+      git status
+      exit 1
+  fi
 
-# Check if github print-auth is working
-if ! $(/opt/dev/bin/dev github print-auth --password > /dev/null 2>&1); then
-    echo "Error: GitHub CLI authentication failed"
-    echo "Try running \`dev github print-auth\` manually"
-    exit 1
+  # Check if github print-auth is working
+  if ! $(/opt/dev/bin/dev github print-auth --password > /dev/null 2>&1); then
+      echo "Error: GitHub CLI authentication failed"
+      echo "Try running \`dev github print-auth\` manually"
+      exit 1
+  fi
 fi
 
 # Create a PR to update homebrew
@@ -30,5 +38,8 @@ node ./bin/create-homebrew-pr.js
 node ./bin/create-doc-pr.js
 
 # Create a PR to add the release notification
-node ./bin/create-notification-pr.js
+# Skipped for patch releases (--skip-notification) — notifications are not sent for patches
+if [[ "$skip_notification" == "false" ]]; then
+  node ./bin/create-notification-pr.js
+fi
 


### PR DESCRIPTION
### WHY are these changes introduced?

Patch releases currently require several manual steps after CI publishes to npm: creating the git tag, opening the GitHub Release, and running \`pnpm post-release\`. These are mechanical and can be automated, reducing the patch release process to just two human decisions: the cherry-pick PR review and the Homebrew/docs PR review.

### WHAT is this pull request doing?

**\`bin/post-release\`:**
- Skips the \`dev github print-auth\` and \`git status\` checks when running in CI — \`withOctokit\` already picks up \`GITHUB_TOKEN\` automatically so these guards are not needed there.
- Adds \`--skip-notification\` flag — patch releases do not send notifications.

**\`.github/workflows/release.yml\`:**
Adds two steps after publish that only fire on \`stable/*\` branches:
1. Creates and pushes the git tag, then opens the GitHub Release linking to the CHANGELOG.
2. Runs \`pnpm post-release --skip-notification\` to open the Homebrew and docs PRs.

### Updated patch release steps

**Before (7 steps):**
1. Open a cherry-pick PR against \`stable/X.Y\` and merge it.
2. Locate and merge the "Version Packages - X.Y" PR — verify it is patch-only.
3. CI publishes to npm.
4. \`git tag X.Y.Z && git push --tags\`
5. Create GitHub Release manually.
6. Run \`pnpm post-release\` from the stable branch; close the notification PR.
7. Update Observe SLOs and error management rules.

**After (4 steps):**
1. Open a cherry-pick PR against \`stable/X.Y\` and merge it.
2. Locate and merge the "Version Packages - X.Y" PR — verify it is patch-only.
3. ~~CI publishes to npm, creates the git tag, opens the GitHub Release, and opens the Homebrew and docs PRs automatically.~~
4. Review and merge the Homebrew and docs PRs.
5. Update Observe SLOs and error management rules.

### How to test

The workflow steps can only be fully exercised by a real publish on a stable branch. However:

**Test \`post-release\` changes locally:**

Verify the CI path skips the \`dev\` auth check and notification PR:
\`\`\`bash
# From a stable branch, with a clean or dirty working directory:
CI=true pnpm post-release --skip-notification
# Expected: skips git status check, skips dev auth check, skips notification PR, opens Homebrew + docs PRs
\`\`\`

Verify the flag is required to suppress the notification (i.e. without the flag it still creates it):
\`\`\`bash
CI=true pnpm post-release
# Expected: opens Homebrew + docs + notification PRs
\`\`\`

**Verify the workflow condition logic:**

The two new steps only fire when both conditions are true:
- \`steps.changesets.outputs.hasChangesets == 'false'\` — a publish actually happened
- \`startsWith(github.ref_name, 'stable/')\` — we are on a stable branch, not \`main\`

You can verify this by triggering the workflow manually on \`main\` after a publish and confirming the new steps are skipped.

**End-to-end test:**

Cherry-pick a trivial fix to \`stable/X.Y\` with a \`patch\` changeset, merge the resulting "Version Packages" PR, and confirm CI creates the tag, GitHub Release, and Homebrew/docs PRs without manual intervention.