### PR TITLE
E2E: parallel workers

### DIFF
--- a/.github/workflows/tests-pr.yml
+++ b/.github/workflows/tests-pr.yml
@@ -219,7 +219,7 @@ jobs:
     name: 'E2E tests'
     if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
-    timeout-minutes: 40
+    timeout-minutes: 20
     continue-on-error: true
     steps:
       - uses: actions/checkout@v3

--- a/packages/e2e/playwright.config.ts
+++ b/packages/e2e/playwright.config.ts
@@ -10,14 +10,14 @@ const isCI = Boolean(process.env.CI)
 export default defineConfig({
   globalSetup: './setup/global-auth.ts',
   testDir: './tests',
-  fullyParallel: false,
+  fullyParallel: true,
   forbidOnly: isCI,
   retries: 0,
-  workers: 1,
+  workers: 5,
   maxFailures: isCI ? 3 : 0, // Stop early in CI after 3 failures
   reporter: isCI ? [['html', {open: 'never'}], ['list']] : [['list']],
   timeout: TEST_TIMEOUT.default, // Heavy tests override via test.setTimeout()
-  globalTimeout: 35 * 60 * 1000, // Temporary: store creation adds time per test; will reduce with parallel workers
+  globalTimeout: 20 * 60 * 1000,
 
   use: {
     trace: isCI ? 'on' : 'off',


### PR DESCRIPTION
Addressed https://github.com/Shopify/cli/issues/7268

### WHY are these changes introduced?

E2E tests currently run sequentially with 1 worker, making the suite slow (~25 min on CI). With per-test store creation (PR #7279), each store-dependent test adds ~30s of overhead, compounding the problem.

### WHAT is this pull request doing?

Enables parallel test execution in `playwright.config.ts`:

- `fullyParallel: true` — tests run concurrently across workers
- `workers: 5` — 5 parallel Playwright workers
- `globalTimeout: 20 * 60 * 1000` — reduced from 35 min to 20 min (parallel execution is much faster)
- GitHub Actions `timeout-minutes` reverted from 40 back to 20 (no longer needs the temporary bump from #7282)

This is safe because the store isolation PR (#7279) gives each worker its own dev store with unique ports per worker (`SHOPIFY_FLAG_GRAPHIQL_PORT`, `SHOPIFY_FLAG_THEME_APP_EXTENSION_PORT`), preventing `EADDRINUSE` conflicts. Tests use `pnpm` (not `npm`) for dependency installation, which is reliable under parallel load on CI runners.

**CI result:** Current test suite completes in [~10 min with 5 workers](https://github.com/Shopify/cli/actions/runs/24536672959/job/71733210252?pr=7309), down from [~27 min with 1 worker](https://github.com/Shopify/cli/actions/runs/24536672587/job/71733214057?pr=7279). The `globalTimeout` is set to 20 min to leave headroom as more tests will be added — will be re-evaluated once test coverage is finalized.

### How to test your changes?

```bash
# Run full suite — should complete in ~5-10 min instead of ~25 min
pnpm --filter e2e exec playwright test

# Verify no port conflicts with headed mode
E2E_HEADED=1 DEBUG=1 pnpm --filter e2e exec playwright test
```

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing, so I've added a changelog entry with `pnpm changeset add`