### PR TITLE
Default allowed_domains to empty array when not configured

### DIFF
--- a/packages/app/src/cli/services/dev/extension/payload/store.test.ts
+++ b/packages/app/src/cli/services/dev/extension/payload/store.test.ts
@@ -142,6 +142,28 @@ describe('getExtensionsPayloadStoreRawPayload()', () => {
     expect(rawPayload.app.allowedDomains).toStrictEqual(['https://cdn.example.com'])
     expect(rawPayload.app.assets).toBeUndefined()
   })
+
+  test('defaults allowed_domains to empty array when admin has no allowed_domains configured', async () => {
+    // Given
+    vi.spyOn(payload, 'getUIExtensionPayload').mockResolvedValue({mock: 'ext'} as unknown as UIExtensionPayload)
+    const adminExt = createAdminExtension({})
+
+    const options = {
+      apiKey: 'api-key',
+      appName: 'my-app',
+      url: 'https://tunnel.example.com',
+      websocketURL: 'wss://tunnel.example.com',
+      extensions: [adminExt],
+      storeFqdn: 'store.myshopify.com',
+      manifestVersion: '3',
+    } as unknown as ExtensionsPayloadStoreOptions
+
+    // When
+    const rawPayload = await getExtensionsPayloadStoreRawPayload(options, 'bundle-path')
+
+    // Then
+    expect(rawPayload.app.allowedDomains).toStrictEqual([])
+  })
 })
 
 describe('ExtensionsPayloadStore()', () => {

--- a/packages/app/src/cli/services/dev/extension/payload/store.test.ts
+++ b/packages/app/src/cli/services/dev/extension/payload/store.test.ts
@@ -522,7 +522,7 @@ describe('ExtensionsPayloadStore()', () => {
       store.updateAdminConfigFromExtensionEvents([{extension: adminExt} as unknown as ExtensionEvent])
 
       // Then
-      expect(store.getRawPayload().app.allowedDomains).toBeUndefined()
+      expect(store.getRawPayload().app.allowedDomains).toStrictEqual([])
     })
 
     test('does nothing when no admin extension event is present', () => {

--- a/packages/app/src/cli/services/dev/extension/payload/store.ts
+++ b/packages/app/src/cli/services/dev/extension/payload/store.ts
@@ -15,7 +15,7 @@ export interface ExtensionsPayloadStoreOptions extends ExtensionDevOptions {
 }
 
 interface AdminConfig {
-  allowedDomains?: string[]
+  allowedDomains: string[]
   staticRoot?: string
 }
 

--- a/packages/app/src/cli/services/dev/extension/payload/store.ts
+++ b/packages/app/src/cli/services/dev/extension/payload/store.ts
@@ -24,7 +24,7 @@ function getAdminConfig(extensions: ExtensionInstance[]): AdminConfig | undefine
   if (!adminExtension) return undefined
   const admin = (adminExtension.configuration as AdminConfigType).admin
   return {
-    allowedDomains: admin?.allowed_domains,
+    allowedDomains: admin?.allowed_domains ?? [],
     staticRoot: admin?.static_root,
   }
 }


### PR DESCRIPTION
When `allowed_domains` is not set in the app toml, the websocket payload now sends `[]` instead of omitting the field. This makes it easier for clients to handle the field without null checks.

## Changes
- `getAdminConfig()` in `store.ts`: `allowed_domains ?? []` instead of bare `allowed_domains`
- Updated test expectation from `toBeUndefined()` to `toStrictEqual([])`