### PR TITLE
Fix autoupgrade incorrectly skipping in development mode

### DIFF
--- a/packages/cli-kit/src/public/node/upgrade.ts
+++ b/packages/cli-kit/src/public/node/upgrade.ts
@@ -55,7 +55,7 @@ export async function runCLIUpgrade(): Promise<void> {
   const isGlobal = currentProcessIsGlobal()
 
   // Don't auto-upgrade for development mode
-  if (!isGlobal && isDevelopment()) {
+  if (isDevelopment()) {
     outputInfo('Skipping upgrade in development mode.')
     return
   }


### PR DESCRIPTION
### WHY are these changes introduced?

When running \`pnpm shopify\` from the CLI repo itself, autoupgrade incorrectly fires as if the CLI were globally installed. This causes contributors to see unexpected upgrade attempts during local development.

**Root cause:** The previous guard was \`!isGlobal && isDevelopment()\`, which only skipped the upgrade when both conditions were true. But \`currentProcessIsGlobal()\` misidentified a pnpm run from the CLI repo as global (since there's no \`shopify.app.toml\` to detect a local project), so the guard never triggered.

### WHAT is this pull request doing?

Simplifies the guard to just \`isDevelopment()\`. \`isDevelopment()\` checks \`SHOPIFY_CLI_ENV === development\`, which is only set by the CLI repo's pnpm dev scripts — not by a globally-installed binary, even if run from the CLI folder. So contributors are protected and regular users are unaffected.

### How to test your changes?

1. From the root of the CLI repo, run any command: \`pnpm shopify version\`
2. Enable autoupgrade first if needed: \`pnpm shopify upgrade\` → opt in
3. Confirm no upgrade attempt is made after the command completes

You can also force the autoupgrade check with:

\`\`\`
SHOPIFY_CLI_FORCE_AUTO_UPGRADE=1 pnpm shopify version
\`\`\`

Before this fix: upgrade runs (SHOPIFY_CLI_ENV=development is set but \`!isGlobal\` was false, so the guard was skipped).
After this fix: upgrade is skipped (isDevelopment() returns true).

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing, so I've added a changelog entry with \`pnpm changeset add\`