### PR TITLE
Run web builds before extension builds during deploy

### DIFF
--- a/packages/app/src/cli/services/deploy/bundle.test.ts
+++ b/packages/app/src/cli/services/deploy/bundle.test.ts
@@ -256,7 +256,7 @@ describe('bundleAndBuildExtensions', () => {
     })
   })
 
-  test('runs web build command concurrently with extensions when build command is defined', async () => {
+  test('runs web build before extensions when build command is defined', async () => {
     await file.inTemporaryDirectory(async (tmpDir: string) => {
       // Given
       const bundlePath = joinPath(tmpDir, 'bundle.zip')

--- a/packages/app/src/cli/services/deploy/bundle.ts
+++ b/packages/app/src/cli/services/deploy/bundle.ts
@@ -68,8 +68,16 @@ export async function bundleAndBuildExtensions(options: BundleOptions) {
     },
   }))
 
+  // Web builds must complete before extension builds start. Extensions like
+  // the admin module copy output from web builds (e.g. dist/) into the bundle
+  // via include_assets. Running them in parallel causes a race condition where
+  // dist/ is empty or missing when the admin extension tries to copy it.
+  if (webBuildProcesses.length > 0) {
+    await renderConcurrent({processes: webBuildProcesses, showTimestamps: false})
+  }
+
   await renderConcurrent({
-    processes: [webBuildProcesses, extensionBuildProcesses].flat(),
+    processes: extensionBuildProcesses,
     showTimestamps: false,
   })
 


### PR DESCRIPTION
## Problem

When deploying an app with `[admin] static_root`, the web build (e.g. Vite) and extension builds run in parallel via a single `renderConcurrent` call. The admin extension's `include_assets` step can attempt to copy files from `static_root` before the web build has finished populating it. Vite's `emptyOutDir: true` deletes `dist/` at the start of its build, so the admin extension either sees a missing or empty directory and skips the copy. The result:

```
index_missing: index.html must be present in the bundle.
```

## Solution

Split the single `renderConcurrent` call into two sequential phases:

1. **Web builds first** — run all web build processes (Vite, etc.) to completion
2. **Extension builds second** — run extension builds which may copy from web build output

Extensions within each phase still run concurrently with each other.

This makes the dependency between web builds and extensions explicit rather than relying on timing or polling.