### PR TITLE
fix: stop reporting expected function errors

### DIFF
--- a/packages/cli-kit/src/public/node/error-handler.test.ts
+++ b/packages/cli-kit/src/public/node/error-handler.test.ts
@@ -200,11 +200,11 @@ describe('sends errors to Bugsnag', () => {
     expect(onNotify).toHaveBeenCalledWith(res.error)
   })
 
-  test('processes AbortErrors as handled', async () => {
+  test('skips reporting for expected errors', async () => {
     const res = await sendErrorToBugsnag(new error.AbortError('In test'), 'expected_error')
-    expect(res.reported).toEqual(true)
+    expect(res.reported).toEqual(false)
     expect(res.unhandled).toEqual(false)
-    expect(onNotify).toHaveBeenCalledWith(res.error)
+    expect(onNotify).not.toHaveBeenCalled()
   })
 
   test.each([null, undefined, {}, {message: 'nope'}])('deals with strange things to throw %s', async (throwable) => {

--- a/packages/cli-kit/src/public/node/error-handler.test.ts
+++ b/packages/cli-kit/src/public/node/error-handler.test.ts
@@ -209,7 +209,6 @@ describe('sends errors to Bugsnag', () => {
     expect(onNotify).toHaveBeenCalledWith(res.error)
   })
 
-
   test.each([null, undefined, {}, {message: 'nope'}])('deals with strange things to throw %s', async (throwable) => {
     const res = await sendErrorToBugsnag(throwable, 'unexpected_error')
     expect(res.reported).toEqual(false)

--- a/packages/cli-kit/src/public/node/error-handler.test.ts
+++ b/packages/cli-kit/src/public/node/error-handler.test.ts
@@ -174,6 +174,15 @@ describe('skips sending errors to Bugsnag', () => {
     expect(onNotify).not.toHaveBeenCalled()
     expect(mockOutput.debug()).toMatch('Skipping Bugsnag report')
   })
+
+  test('when error is expected', async () => {
+    const mockOutput = mockAndCaptureOutput()
+    const res = await sendErrorToBugsnag(new error.AbortError('In test'), 'expected_error')
+    expect(res.reported).toEqual(false)
+    expect(res.unhandled).toBeUndefined()
+    expect(onNotify).not.toHaveBeenCalled()
+    expect(mockOutput.debug()).toMatch('Skipping Bugsnag report for expected error')
+  })
 })
 
 describe('sends errors to Bugsnag', () => {
@@ -200,12 +209,6 @@ describe('sends errors to Bugsnag', () => {
     expect(onNotify).toHaveBeenCalledWith(res.error)
   })
 
-  test('skips reporting for expected errors', async () => {
-    const res = await sendErrorToBugsnag(new error.AbortError('In test'), 'expected_error')
-    expect(res.reported).toEqual(false)
-    expect(res.unhandled).toEqual(false)
-    expect(onNotify).not.toHaveBeenCalled()
-  })
 
   test.each([null, undefined, {}, {message: 'nope'}])('deals with strange things to throw %s', async (throwable) => {
     const res = await sendErrorToBugsnag(throwable, 'unexpected_error')

--- a/packages/cli-kit/src/public/node/error-handler.ts
+++ b/packages/cli-kit/src/public/node/error-handler.ts
@@ -78,7 +78,7 @@ export async function sendErrorToBugsnag(
 
     if (exitMode === 'expected_error') {
       outputDebug(`Skipping Bugsnag report for expected error`)
-      return {reported: false, error, unhandled: false}
+      return {reported: false, error, unhandled: undefined}
     }
 
     // If the error was unexpected, we flag it as "unhandled" in Bugsnag. This is a helpful distinction.

--- a/packages/cli-kit/src/public/node/error-handler.ts
+++ b/packages/cli-kit/src/public/node/error-handler.ts
@@ -76,6 +76,11 @@ export async function sendErrorToBugsnag(
       return {reported: false, error, unhandled: undefined}
     }
 
+    if (exitMode === 'expected_error') {
+      outputDebug(`Skipping Bugsnag report for expected error`)
+      return {reported: false, error, unhandled: false}
+    }
+
     // If the error was unexpected, we flag it as "unhandled" in Bugsnag. This is a helpful distinction.
     const unhandled = exitMode === 'unexpected_error'
 


### PR DESCRIPTION
## Summary

`sendErrorToBugsnag` reports **all** `Error` instances regardless of their classification. This means `AbortError` — whose docstring says _"shouldn't be reported as a bug"_ — still gets sent, generating significant noise in Observe.

This PR adds an early return when `exitMode === 'expected_error'`, making the reporting layer respect the classification that `shouldReportErrorAsUnexpected` already computes correctly.

## Problem

The [Observe error group](https://observe.shopify.io/a/observe/errors/13415323998419387790) `Build step "Build Function" failed: Failed to build function.` has ~12k events/month across all CLI versions (3.82.0+). Investigation showed:

- The error group appeared in Observe on April 2 because 3.93.0 introduced a `client-steps.ts` wrapper that changed the message format, creating a new grouping hash
- The underlying errors are **user code compilation failures** (broken Rust/JS function code), not CLI bugs
- `buildFunctionExtension` wraps these in `AbortError` with the comment _"To avoid random user-code errors being reported as CLI bugs"_ — but `sendErrorToBugsnag` ignores that and reports them anyway

The classification chain works correctly:
```
AbortError (type=Abort) → shouldReportErrorAsUnexpected() returns false
  → exitMode='expected_error' → sendErrorToBugsnag() ignores exitMode, reports anyway
```

## Fix

5-line early return in `sendErrorToBugsnag`:

```typescript
if (exitMode === 'expected_error') {
  outputDebug(`Skipping Bugsnag report for expected error`)
  return {reported: false, error, unhandled: false}
}
```

## Impact

6 callsites use `sendErrorToBugsnag`. 5 use hardcoded `exitMode`, 1 computes it dynamically:

| Callsite | exitMode | After change |
|---|---|---|
| Main error handler (`errorHandler`) | dynamic | AbortError/ExternalError → **skipped**. BugError/plain Error → still reported |
| Analytics flush errors | `expected_error` | **Skipped** (telemetry plumbing, not bugs) |
| Notification system errors | `unexpected_error` | Still reported |
| Metadata provider errors | `unexpected_error` | Still reported |
| Auto-upgrade errors | `expected_error` | **Skipped** (tracked separately via analytics metadata `env_auto_upgrade_success`) |
| Notification list errors | `expected_error` | **Skipped** (hidden command) |

Every callsite that stops reporting was already explicitly classified as `expected_error` — either by `shouldReportErrorAsUnexpected` or by the developer hardcoding it. No signal is lost that isn't tracked through other channels.

## Test plan

- [x] Updated existing test: `processes AbortErrors as handled` → `skips reporting for expected errors`
- [x] All 25 error-handler tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes shop/issues#32997