### PR TITLE
Bump Shopify/theme-tools packages

### DIFF
--- a/.changeset/bump-theme-tools-2026-04-15.md
+++ b/.changeset/bump-theme-tools-2026-04-15.md
@@ -1,0 +1,11 @@
+---
+'@shopify/theme': patch
+'@shopify/app': patch
+---
+
+Bump Shopify/theme-tools packages
+
+- @shopify/theme-check-node: 3.24.0 → 3.25.0
+- @shopify/theme-language-server-node: 2.20.2 → 2.21.0
+
+Includes ValidScopedCSSClass theme check, color_palette input support, and various fixes.

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -55,7 +55,7 @@
     "@shopify/polaris": "12.27.0",
     "@shopify/polaris-icons": "8.11.1",
     "@shopify/theme": "3.93.0",
-    "@shopify/theme-check-node": "3.24.0",
+    "@shopify/theme-check-node": "3.25.0",
     "@shopify/toml-patch": "0.3.0",
     "chokidar": "3.6.0",
     "diff": "5.2.2",

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -43,8 +43,8 @@
   "dependencies": {
     "@oclif/core": "4.5.3",
     "@shopify/cli-kit": "3.93.0",
-    "@shopify/theme-check-node": "3.24.0",
-    "@shopify/theme-language-server-node": "2.20.2",
+    "@shopify/theme-check-node": "3.25.0",
+    "@shopify/theme-language-server-node": "2.21.0",
     "chokidar": "3.6.0",
     "h3": "1.15.9",
     "yaml": "2.8.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -170,8 +170,8 @@ importers:
         specifier: 3.93.0
         version: link:../theme
       '@shopify/theme-check-node':
-        specifier: 3.24.0
-        version: 3.24.0
+        specifier: 3.25.0
+        version: 3.25.0
       '@shopify/toml-patch':
         specifier: 0.3.0
         version: 0.3.0
@@ -630,11 +630,11 @@ importers:
         specifier: 3.93.0
         version: link:../cli-kit
       '@shopify/theme-check-node':
-        specifier: 3.24.0
-        version: 3.24.0
+        specifier: 3.25.0
+        version: 3.25.0
       '@shopify/theme-language-server-node':
-        specifier: 2.20.2
-        version: 2.20.2
+        specifier: 2.21.0
+        version: 2.21.0
       chokidar:
         specifier: 3.6.0
         version: 3.6.0
@@ -3539,28 +3539,28 @@ packages:
       react: ^18.0.0
       react-dom: ^18.0.0
 
-  '@shopify/theme-check-common@3.24.0':
-    resolution: {integrity: sha512-gbUsv+vK7GeZNkA30wXKc5ncZjLMJZquI9K6CZR0jJaArV+/dAc9zGA73nqyiIgEGd2pw0S/Vly6FgBIVcPmMg==}
+  '@shopify/theme-check-common@3.25.0':
+    resolution: {integrity: sha512-kzlKzt2gEWTlBPF3wSIFxL4DD1ko91z8MROqEyfilAXIyFX3d4TFbBvYmcZIC99id15v+8UPfcs316CChOAuQQ==}
 
-  '@shopify/theme-check-docs-updater@3.24.0':
-    resolution: {integrity: sha512-IX8jEMke6uaL6KiUerBoy6xkV7LTFmY5HKmZuiAQPfd2IP1q280T5jaYzYa52vqy85JDja4HGxMQItiwJG3J4w==}
+  '@shopify/theme-check-docs-updater@3.25.0':
+    resolution: {integrity: sha512-U1mJXXHv7Xa8GsC5XRmvu3IQF9Jac2cJDB+omS3wWaCIlqDI7njC0hkvUBXXYU7jPQ0NNnqZ339KvEuQYzqmLg==}
     hasBin: true
 
-  '@shopify/theme-check-node@3.24.0':
-    resolution: {integrity: sha512-8AQLCoLxeREWENc4ELGQbn1GkZO6lVVKxhAPSeXEg9VGI/oc1G+fPXEdN4VnExqW5aP/dJCAnb/JH89bkIrm4Q==}
+  '@shopify/theme-check-node@3.25.0':
+    resolution: {integrity: sha512-QUbIzfZ58xm2RuT/dpSG8EQjW+qai6BmjXJxqPN0EY8S1mRQ6lmt6MgEh+L0B1s8bHbtNFCDOeeRpLXkbwEPtA==}
 
-  '@shopify/theme-graph@0.2.3':
-    resolution: {integrity: sha512-UsnAJlBmG5b7L4FqL8An+RWqLvAd/hCD52H+RUMb/xECkfRnrjOOOVRrPVYOawRhd56Wu3XNjkLdP2WHS25OKQ==}
+  '@shopify/theme-graph@0.2.4':
+    resolution: {integrity: sha512-ro9PL+5FGMxkLzYfhC6hfv/WlpxK7tUXDlv5uWson/TQIfbs1fo7Nm+VePpJXry0Y+umRDppTRWNmud7YnSuvA==}
     hasBin: true
 
   '@shopify/theme-hot-reload@0.0.18':
     resolution: {integrity: sha512-l+IBuk+rG5T+5PKYyPrwgh7PDCxmEMpBFJeen6PM+h6RI4CDhAGRaiwUo5eN1o1JX51HdHHCts3rTEW+KUgq+Q==}
 
-  '@shopify/theme-language-server-common@2.20.2':
-    resolution: {integrity: sha512-Cc6IU2e250l0jfRtlxaEtPJ0qfjiFwHBq2hfcozRcX2vYMzcbgNDVeVsmApMFXSe5K/vthA2plzrijy2IG1MOw==}
+  '@shopify/theme-language-server-common@2.21.0':
+    resolution: {integrity: sha512-/jdb51pAEAsSBKGMxrSV/n/xVWbPsJ00aUQHqL2VXtiFkb5x3Ny4PShlENAee9OIOyJxxmnrOqObKkpzfeg+aA==}
 
-  '@shopify/theme-language-server-node@2.20.2':
-    resolution: {integrity: sha512-BA4IzknQLspg+j7k9NnYgfLKMaCF8MMJp6larzL6sF916Hf1Fp8dOdsw4cG5floCUSYJPjaL9q+2rayEeMJsUw==}
+  '@shopify/theme-language-server-node@2.21.0':
+    resolution: {integrity: sha512-Zq/vJZw166VBe815zGLP9dnLhImR1PM7JCkBTVyyVqpPfbuqIfRRIIQEpcLE8ftskWzqVJs+p79JO0y23jOkIw==}
 
   '@shopify/toml-patch@0.3.0':
     resolution: {integrity: sha512-ruv2FT17FW3CfWx8jXEyfx3xZDdo22PDaFQ9R7QYOovXQbgQCIKY+5QjGVBA7jsyLm+Wa2ngVANmt7MS0M/g+w==}
@@ -4918,6 +4918,11 @@ packages:
 
   css.escape@1.5.1:
     resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
+
+  cssesc@3.0.0:
+    resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
+    engines: {node: '>=4'}
+    hasBin: true
 
   cssstyle@4.6.0:
     resolution: {integrity: sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==}
@@ -6655,6 +6660,9 @@ packages:
   lodash@4.17.23:
     resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
 
+  lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
+
   log-symbols@4.1.0:
     resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
     engines: {node: '>=10'}
@@ -7418,6 +7426,20 @@ packages:
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
+
+  postcss-safe-parser@7.0.1:
+    resolution: {integrity: sha512-0AioNCJZ2DPYz5ABT6bddIqlhgwhpHZ/l65YAYo0BCIn0xiDpsnTHz0gnoTGk0OXZW0JRs+cDwL8u/teRdz+8A==}
+    engines: {node: '>=18.0'}
+    peerDependencies:
+      postcss: ^8.4.31
+
+  postcss-selector-parser@7.1.1:
+    resolution: {integrity: sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==}
+    engines: {node: '>=4'}
+
+  postcss@8.5.10:
+    resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
+    engines: {node: ^10 || ^12 || >=14}
 
   postcss@8.5.6:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
@@ -8809,11 +8831,6 @@ packages:
   yaml@1.10.3:
     resolution: {integrity: sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==}
     engines: {node: '>= 6'}
-
-  yaml@2.7.0:
-    resolution: {integrity: sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==}
-    engines: {node: '>= 14'}
-    hasBin: true
 
   yaml@2.8.2:
     resolution: {integrity: sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==}
@@ -12597,42 +12614,45 @@ snapshots:
       react-fast-compare: 3.2.2
       react-transition-group: 4.4.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
 
-  '@shopify/theme-check-common@3.24.0':
+  '@shopify/theme-check-common@3.25.0':
     dependencies:
       '@shopify/liquid-html-parser': 2.9.2
       cross-fetch: 4.1.0
       jsonc-parser: 3.3.1
       line-column: 1.0.2
-      lodash: 4.17.23
+      lodash: 4.18.1
       minimatch: 10.2.4
+      postcss: 8.5.10
+      postcss-safe-parser: 7.0.1(postcss@8.5.10)
+      postcss-selector-parser: 7.1.1
       vscode-json-languageservice: 5.7.2
       vscode-uri: 3.1.0
     transitivePeerDependencies:
       - encoding
 
-  '@shopify/theme-check-docs-updater@3.24.0':
+  '@shopify/theme-check-docs-updater@3.25.0':
     dependencies:
-      '@shopify/theme-check-common': 3.24.0
+      '@shopify/theme-check-common': 3.25.0
       env-paths: 2.2.1
       node-fetch: 2.7.0
     transitivePeerDependencies:
       - encoding
 
-  '@shopify/theme-check-node@3.24.0':
+  '@shopify/theme-check-node@3.25.0':
     dependencies:
-      '@shopify/theme-check-common': 3.24.0
-      '@shopify/theme-check-docs-updater': 3.24.0
+      '@shopify/theme-check-common': 3.25.0
+      '@shopify/theme-check-docs-updater': 3.25.0
+      '@shopify/theme-graph': 0.2.4
       glob: 8.1.0
       vscode-uri: 3.1.0
-      yaml: 2.7.0
+      yaml: 2.8.3
     transitivePeerDependencies:
       - encoding
 
-  '@shopify/theme-graph@0.2.3':
+  '@shopify/theme-graph@0.2.4':
     dependencies:
       '@shopify/liquid-html-parser': 2.9.2
-      '@shopify/theme-check-common': 3.24.0
-      '@shopify/theme-check-node': 3.24.0
+      '@shopify/theme-check-common': 3.25.0
       acorn: 8.16.0
       acorn-walk: 8.3.5
       vscode-uri: 3.1.0
@@ -12641,11 +12661,11 @@ snapshots:
 
   '@shopify/theme-hot-reload@0.0.18': {}
 
-  '@shopify/theme-language-server-common@2.20.2':
+  '@shopify/theme-language-server-common@2.21.0':
     dependencies:
       '@shopify/liquid-html-parser': 2.9.2
-      '@shopify/theme-check-common': 3.24.0
-      '@shopify/theme-graph': 0.2.3
+      '@shopify/theme-check-common': 3.25.0
+      '@shopify/theme-graph': 0.2.4
       '@vscode/web-custom-data': 0.4.13
       vscode-css-languageservice: 6.3.2
       vscode-json-languageservice: 5.7.2
@@ -12655,11 +12675,11 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@shopify/theme-language-server-node@2.20.2':
+  '@shopify/theme-language-server-node@2.21.0':
     dependencies:
-      '@shopify/theme-check-docs-updater': 3.24.0
-      '@shopify/theme-check-node': 3.24.0
-      '@shopify/theme-language-server-common': 2.20.2
+      '@shopify/theme-check-docs-updater': 3.25.0
+      '@shopify/theme-check-node': 3.25.0
+      '@shopify/theme-language-server-common': 2.21.0
       glob: 8.1.0
       node-fetch: 2.7.0
       vscode-languageserver: 8.1.0
@@ -14316,6 +14336,8 @@ snapshots:
 
   css.escape@1.5.1: {}
 
+  cssesc@3.0.0: {}
+
   cssstyle@4.6.0:
     dependencies:
       '@asamuzakjp/css-color': 3.2.0
@@ -15359,7 +15381,7 @@ snapshots:
     dependencies:
       foreground-child: 3.3.1
       jackspeak: 3.4.3
-      minimatch: 9.0.9
+      minimatch: 9.0.8
       minipass: 7.1.3
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
@@ -15476,7 +15498,7 @@ snapshots:
       cosmiconfig: 8.3.6(typescript@5.9.3)
       graphql: 16.10.0
       jiti: 2.6.1
-      minimatch: 9.0.9
+      minimatch: 9.0.8
       string-env-interpolation: 1.0.1
       tslib: 2.8.1
     transitivePeerDependencies:
@@ -15499,7 +15521,7 @@ snapshots:
       cosmiconfig: 8.3.6(typescript@5.9.3)
       graphql: 16.10.0
       jiti: 2.6.1
-      minimatch: 9.0.9
+      minimatch: 9.0.8
       string-env-interpolation: 1.0.1
       tslib: 2.8.1
     transitivePeerDependencies:
@@ -16314,6 +16336,8 @@ snapshots:
 
   lodash@4.17.23: {}
 
+  lodash@4.18.1: {}
+
   log-symbols@4.1.0:
     dependencies:
       chalk: 4.1.2
@@ -17125,6 +17149,21 @@ snapshots:
   pluralize@8.0.0: {}
 
   possible-typed-array-names@1.1.0: {}
+
+  postcss-safe-parser@7.0.1(postcss@8.5.10):
+    dependencies:
+      postcss: 8.5.10
+
+  postcss-selector-parser@7.1.1:
+    dependencies:
+      cssesc: 3.0.0
+      util-deprecate: 1.0.2
+
+  postcss@8.5.10:
+    dependencies:
+      nanoid: 3.3.8
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
 
   postcss@8.5.6:
     dependencies:
@@ -18712,8 +18751,6 @@ snapshots:
   yallist@3.1.1: {}
 
   yaml@1.10.3: {}
-
-  yaml@2.7.0: {}
 
   yaml@2.8.2: {}
 


### PR DESCRIPTION
## Summary

Updates theme-tools packages to get the latest features and fixes:

- `@shopify/theme-check-node`: 3.24.0 → 3.25.0
- `@shopify/theme-language-server-node`: 2.20.2 → 2.21.0
