### PR TITLE
Add CLI support for order_attribution_config extension type

### DIFF
--- a/packages/app/src/cli/models/extensions/load-specifications.ts
+++ b/packages/app/src/cli/models/extensions/load-specifications.ts
@@ -27,6 +27,7 @@ import uiExtensionSpec from './specifications/ui_extension.js'
 import webPixelSpec from './specifications/web_pixel_extension.js'
 import editorExtensionCollectionSpecification from './specifications/editor_extension_collection.js'
 import channelSpecificationSpec from './specifications/channel.js'
+import orderAttributionConfigSpec from './specifications/order_attribution_config.js'
 import adminSpecificationSpec from './specifications/admin.js'
 
 const SORTED_CONFIGURATION_SPEC_IDENTIFIERS = [
@@ -80,6 +81,7 @@ function loadSpecifications() {
     webPixelSpec,
     editorExtensionCollectionSpecification,
     channelSpecificationSpec,
+    orderAttributionConfigSpec,
   ]
 
   return [...configModuleSpecs, ...moduleSpecs] as ExtensionSpecification[]

--- a/packages/app/src/cli/models/extensions/specifications/order_attribution_config.ts
+++ b/packages/app/src/cli/models/extensions/specifications/order_attribution_config.ts
@@ -1,5 +1,4 @@
 import {createContractBasedModuleSpecification} from '../specification.js'
-import {joinPath} from '@shopify/cli-kit/node/path'
 
 const ICONS_SUBDIRECTORY = 'icons'
 const FILE_EXTENSIONS = ['svg']
@@ -8,10 +7,6 @@ const orderAttributionConfigSpec = createContractBasedModuleSpecification({
   identifier: 'order_attribution_config',
   uidStrategy: 'single',
   experience: 'extension',
-  buildConfig: {
-    mode: 'copy_files',
-    filePatterns: FILE_EXTENSIONS.map((ext) => joinPath(ICONS_SUBDIRECTORY, '**', `*.${ext}`)),
-  },
   clientSteps: [
     {
       lifecycle: 'deploy',

--- a/packages/app/src/cli/models/extensions/specifications/order_attribution_config.ts
+++ b/packages/app/src/cli/models/extensions/specifications/order_attribution_config.ts
@@ -1,0 +1,40 @@
+import {createContractBasedModuleSpecification} from '../specification.js'
+import {joinPath} from '@shopify/cli-kit/node/path'
+
+const ICONS_SUBDIRECTORY = 'icons'
+const FILE_EXTENSIONS = ['svg']
+
+const orderAttributionConfigSpec = createContractBasedModuleSpecification({
+  identifier: 'order_attribution_config',
+  uidStrategy: 'single',
+  experience: 'extension',
+  buildConfig: {
+    mode: 'copy_files',
+    filePatterns: FILE_EXTENSIONS.map((ext) => joinPath(ICONS_SUBDIRECTORY, '**', `*.${ext}`)),
+  },
+  clientSteps: [
+    {
+      lifecycle: 'deploy',
+      steps: [
+        {
+          id: 'copy-files',
+          name: 'Copy Files',
+          type: 'include_assets',
+          config: {
+            inclusions: [
+              {
+                type: 'pattern',
+                baseDir: ICONS_SUBDIRECTORY,
+                destination: ICONS_SUBDIRECTORY,
+                include: FILE_EXTENSIONS.map((ext) => `**/*.${ext}`),
+              },
+            ],
+          },
+        },
+      ],
+    },
+  ],
+  appModuleFeatures: () => [],
+})
+
+export default orderAttributionConfigSpec


### PR DESCRIPTION
## Summary

- Add `order_attribution_config` specification in `packages/app/src/cli/models/extensions/specifications/order_attribution_config.ts`
- Register it in `load-specifications.ts`
- Uses `createContractBasedModuleSpecification` with `copy_files` build config for SVG icons (same pattern as `channel_config`)

## Changes

- **New file**: `order_attribution_config.ts` — specification with `uidStrategy: 'single'`, `experience: 'extension'`, copies `icons/**/*.svg` on deploy
- **Modified**: `load-specifications.ts` — import and register the new spec in `moduleSpecs`

## Test plan

- [ ] `shopify app generate extension` lists `order_attribution_config` as an option
- [ ] Scaffolded extension has correct TOML structure
- [ ] `shopify app deploy` succeeds with the new extension type

Closes https://github.com/shop/issues-multi-channel-management/issues/3127

🤖 Generated with [Claude Code](https://claude.com/claude-code)