### PR TITLE
Send store to analytics on store commands

### DIFF
--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -5741,7 +5741,6 @@
       },
       "description": "Authenticates the app against the specified store for store commands and stores an online access token for later reuse.\n\nRe-run this command if the stored token is missing, expires, or no longer has the scopes you need.",
       "descriptionWithMarkdown": "Authenticates the app against the specified store for store commands and stores an online access token for later reuse.\n\nRe-run this command if the stored token is missing, expires, or no longer has the scopes you need.",
-      "enableJsonFlag": false,
       "examples": [
         "<%= config.bin %> <%= command.id %> --store shop.myshopify.com --scopes read_products,write_products",
         "<%= config.bin %> <%= command.id %> --store shop.myshopify.com --scopes read_products,write_products --json"
@@ -5809,7 +5808,6 @@
       },
       "description": "Executes an Admin API GraphQL query or mutation on the specified store using previously stored app authentication.\n\nRun `shopify store auth` first to create stored auth for the store.\n\nMutations are disabled by default. Re-run with `--allow-mutations` if you intend to modify store data.",
       "descriptionWithMarkdown": "Executes an Admin API GraphQL query or mutation on the specified store using previously stored app authentication.\n\nRun `shopify store auth` first to create stored auth for the store.\n\nMutations are disabled by default. Re-run with `--allow-mutations` if you intend to modify store data.",
-      "enableJsonFlag": false,
       "examples": [
         "<%= config.bin %> <%= command.id %> --store shop.myshopify.com --query \"query { shop { name } }\"",
         "<%= config.bin %> <%= command.id %> --store shop.myshopify.com --query-file ./operation.graphql --variables '{\"id\":\"gid://shopify/Product/1\"}'",

--- a/packages/cli/src/cli/commands/store/auth.ts
+++ b/packages/cli/src/cli/commands/store/auth.ts
@@ -1,11 +1,11 @@
 import {authenticateStoreWithApp} from '../../services/store/auth/index.js'
 import {createStoreAuthPresenter} from '../../services/store/auth/result.js'
-import Command from '@shopify/cli-kit/node/base-command'
+import StoreCommand from '../../utilities/store-command.js'
 import {globalFlags, jsonFlag} from '@shopify/cli-kit/node/cli'
 import {normalizeStoreFqdn} from '@shopify/cli-kit/node/context/fqdn'
 import {Flags} from '@oclif/core'
 
-export default class StoreAuth extends Command {
+export default class StoreAuth extends StoreCommand {
   static summary = 'Authenticate an app against a store for store commands.'
 
   static descriptionWithMarkdown = `Authenticates the app against the specified store for store commands and stores an online access token for later reuse.
@@ -36,7 +36,7 @@ Re-run this command if the stored token is missing, expires, or no longer has th
     }),
   }
 
-  async run(): Promise<void> {
+  public async run(): Promise<void> {
     const {flags} = await this.parse(StoreAuth)
 
     await authenticateStoreWithApp(

--- a/packages/cli/src/cli/commands/store/execute.ts
+++ b/packages/cli/src/cli/commands/store/execute.ts
@@ -1,12 +1,12 @@
 import {executeStoreOperation} from '../../services/store/execute/index.js'
 import {writeOrOutputStoreExecuteResult} from '../../services/store/execute/result.js'
-import Command from '@shopify/cli-kit/node/base-command'
+import StoreCommand from '../../utilities/store-command.js'
 import {globalFlags, jsonFlag} from '@shopify/cli-kit/node/cli'
 import {normalizeStoreFqdn} from '@shopify/cli-kit/node/context/fqdn'
 import {resolvePath} from '@shopify/cli-kit/node/path'
 import {Flags} from '@oclif/core'
 
-export default class StoreExecute extends Command {
+export default class StoreExecute extends StoreCommand {
   static summary = 'Execute GraphQL queries and mutations on a store.'
 
   static descriptionWithMarkdown = `Executes an Admin API GraphQL query or mutation on the specified store using previously stored app authentication.
@@ -75,7 +75,7 @@ Mutations are disabled by default. Re-run with \`--allow-mutations\` if you inte
     }),
   }
 
-  async run(): Promise<void> {
+  public async run(): Promise<void> {
     const {flags} = await this.parse(StoreExecute)
 
     const result = await executeStoreOperation({

--- a/packages/cli/src/cli/utilities/store-command.ts
+++ b/packages/cli/src/cli/utilities/store-command.ts
@@ -1,0 +1,27 @@
+import Command, {type ArgOutput, type FlagOutput} from '@shopify/cli-kit/node/base-command'
+import {addSensitiveMetadata} from '@shopify/cli-kit/node/metadata'
+
+import type {Input, ParserOutput} from '@oclif/core/parser'
+
+/**
+ * Base class that includes shared behavior for all store commands.
+ */
+export default abstract class StoreCommand extends Command {
+  public abstract run(): Promise<void>
+
+  protected async parse<
+    TFlags extends FlagOutput & {path?: string; verbose?: boolean},
+    TGlobalFlags extends FlagOutput,
+    TArgs extends ArgOutput,
+  >(
+    options?: Input<TFlags, TGlobalFlags, TArgs>,
+    argv?: string[],
+  ): Promise<ParserOutput<TFlags, TGlobalFlags, TArgs> & {argv: string[]}> {
+    const result = await super.parse<TFlags, TGlobalFlags, TArgs>(options, argv)
+    const storeFqdn = (result.flags as {store?: unknown}).store
+    if (typeof storeFqdn === 'string' && storeFqdn.length > 0) {
+      await addSensitiveMetadata(() => ({store_fqdn: storeFqdn}))
+    }
+    return result
+  }
+}


### PR DESCRIPTION
### WHY are these changes introduced?

Store commands are not sending analytics about the selected store

See https://shopify.slack.com/archives/C0ASQECGH2Q/p1776287082626409?thread_ts=1776203153.988669&cid=C0ASQECGH2Q

### WHAT is this pull request doing?

Adds the `store` as sensitive metadata for Monorail on store commands

### How to test your changes?

- `pnpm i -g --@shopify:registry=https://registry.npmjs.org @shopify/cli@0.0.0-snapshot-20260416101554`
- `shopify store auth --verbose`
- `shopify store execute --verbose`

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing, so I've added a changelog entry with `pnpm changeset add`
