### PR TITLE
Improve user_id detection for analytics

### DIFF
--- a/packages/cli-kit/src/private/node/session.test.ts
+++ b/packages/cli-kit/src/private/node/session.test.ts
@@ -327,7 +327,8 @@ describe('when existing session is valid', () => {
     expect(exchangeAccessForApplicationTokens).not.toBeCalled()
     expect(refreshAccessToken).not.toBeCalled()
     expect(got).toEqual(expected)
-    await expect(getLastSeenUserIdAfterAuth()).resolves.toBe('1234-5678')
+    // Env automation token takes precedence for getLastSeenUserIdAfterAuth (analytics identity).
+    await expect(getLastSeenUserIdAfterAuth()).resolves.toBe(nonRandomUUID('custom_cli_token'))
     await expect(getLastSeenAuthMethod()).resolves.toEqual('partners_token')
     expect(fetchSessions).toHaveBeenCalledOnce()
   })

--- a/packages/cli-kit/src/private/node/session.ts
+++ b/packages/cli-kit/src/private/node/session.ts
@@ -120,25 +120,27 @@ let userId: undefined | string
 let authMethod: AuthMethod = 'none'
 
 /**
- * Retrieves the user ID from the current session or returns 'unknown' if not found.
+ * Retrieves a stable user identifier for analytics, or `'unknown'` if none applies.
  *
- * This function performs the following steps:
- * 1. Checks for a cached user ID in memory (obtained in the current run).
- * 2. Attempts to fetch it from the local storage (from a previous auth session).
- * 3. Checks if a custom token was used (either as a theme password or partners token).
- * 4. If a custom token is present in the environment, generates a UUID and uses it as userId.
- * 5. If after all this we don't have a userId, then reports as 'unknown'.
+ * Evaluation order:
+ * 1. If an app automation token or theme token is used, returns a deterministic UUID
+ *    derived from that secret.
+ * 2. Otherwise, if `setLastSeenUserIdAfterAuth` was called (e.g. after OAuth), returns that value.
+ * 3. Otherwise, if a persisted CLI session id is available, returns it.
+ * 4. Otherwise returns `'unknown'`.
  *
  * @returns A Promise that resolves to the user ID as a string.
  */
 export async function getLastSeenUserIdAfterAuth(): Promise<string> {
+  const customToken = getAppAutomationToken() ?? themeToken()
+  if (customToken) return nonRandomUUID(customToken)
+
   if (userId) return userId
 
   const currentSessionId = getCurrentSessionId()
   if (currentSessionId) return currentSessionId
 
-  const customToken = getAppAutomationToken() ?? themeToken()
-  return customToken ? nonRandomUUID(customToken) : 'unknown'
+  return 'unknown'
 }
 
 export function setLastSeenUserIdAfterAuth(id: string) {


### PR DESCRIPTION
### WHY are these changes introduced?

When you have a stored session, but you are also using a token (like `SHOPIFY_APP_AUTOMATION_TOKEN`), we are sending to monorail the saved user ID from the session, but that's not actually used.

See https://shopify.slack.com/archives/C0ASQECGH2Q/p1776243522246889?thread_ts=1776203153.988669&cid=C0ASQECGH2Q

### WHAT is this pull request doing?

If a token is being used, send the user ID generated from that instead of the stored session.

### How to test your changes?

- `shopify app deploy --verbose`
- `SHOPIFY_APP_AUTOMATION_TOKEN=xxx shopify app deploy --verbose`

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing, so I've added a changelog entry with `pnpm changeset add`
