### PR TITLE
Fix package manager from Snapit comment

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -59,7 +59,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@4bdb89f48054571735e3792627da6195c57459e2 # v3
+        uses: github/codeql-action/init@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -87,6 +87,6 @@ jobs:
           exit 1
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@4bdb89f48054571735e3792627da6195c57459e2 # v3
+        uses: github/codeql-action/analyze@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3
         with:
           category: "/language:${{matrix.language}}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Force snapshot changeset
         run: "mv .changeset/force-snapshot-build.md.ignore .changeset/force-snapshot-build.md"
       - name: Create snapshot version
-        uses: Shopify/snapit@ee98df3a4a2b221fc3f06d56b9a6b60996613102 # registry-and-package-manager
+        uses: Shopify/snapit@0fec17dd6a0ae66f2672738dc8086f394218436c # registry-and-package-manager
         with:
           comment_is_global: 'true'
           comment_packages: '@shopify/cli'
@@ -99,7 +99,7 @@ jobs:
           node-version: 24.12.0
       - name: Create Release Pull Request
         id: changesets
-        uses: changesets/action@e0145edc7d9d8679003495b11f87bd8ef63c0cba # v1
+        uses: changesets/action@6a0a831ff30acef54f2c6aa1cbbc1096b066edaf # v1
         with:
           version: pnpm changeset-manifests
           title: Version Packages - ${{ github.ref_name }}

--- a/.github/workflows/workflow-cleaner.yml
+++ b/.github/workflows/workflow-cleaner.yml
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Delete workflow runs
-        uses: Mattraks/delete-workflow-runs@bd2822c9d98065c9766fb1f4bbc32325c47de4fb # v2
+        uses: Mattraks/delete-workflow-runs@b3018382ca039b53d238908238bd35d1fb14f8ee # v2
         with:
           token: ${{ github.token }}
           repository: ${{ github.repository }}


### PR DESCRIPTION
### WHY are these changes introduced?

In https://github.com/Shopify/cli/pull/7254 I removed the `npm` setting for snapit, to let it use the default package manager of the repo (pnpm), but [something is not working](https://github.com/Shopify/cli/pull/7325#issuecomment-4258792152):

<img width="913" height="212" alt="16-38-6nmxy-valp9" src="https://github.com/user-attachments/assets/30aa1ac2-129d-4f2d-87ae-40039e5d6d23" />


### WHAT is this pull request doing?

Updates the snapit version so it includes [this fix](https://github.com/Shopify/snapit/pull/55)

### How to test your changes?

Merge and try `/snapit`

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing, so I've added a changelog entry with `pnpm changeset add`
