### PR TITLE
Prompt inline account selection when auth fails for wrong account

### DIFF
--- a/.changeset/prompt-account-switch-on-auth-error.md
+++ b/.changeset/prompt-account-switch-on-auth-error.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': minor
+---
+
+Prompt inline account selection when authentication fails due to wrong account, instead of requiring a separate `shopify auth login` command.

--- a/packages/cli-kit/src/private/node/session.test.ts
+++ b/packages/cli-kit/src/private/node/session.test.ts
@@ -12,6 +12,7 @@ import {
   exchangeCustomPartnerToken,
   refreshAccessToken,
   InvalidGrantError,
+  InvalidTargetError,
 } from './session/exchange.js'
 import {allDefaultScopes} from './session/scopes.js'
 import {store as storeSessions, fetch as fetchSessions, remove as secureRemove} from './session/store.js'
@@ -27,6 +28,7 @@ import {businessPlatformRequest} from '../../public/node/api/business-platform.j
 import {getAppAutomationToken} from '../../public/node/environment.js'
 import {nonRandomUUID} from '../../public/node/crypto.js'
 import {terminalSupportsPrompting} from '../../public/node/system.js'
+import {promptSessionSelect} from '../../public/node/session-prompt.js'
 
 import {vi, describe, expect, test, beforeEach} from 'vitest'
 
@@ -119,6 +121,7 @@ vi.mock('../../public/node/environment.js')
 vi.mock('./session/device-authorization')
 vi.mock('./conf-store')
 vi.mock('../../public/node/system.js')
+vi.mock('../../public/node/session-prompt')
 
 beforeEach(() => {
   vi.spyOn(fqdnModule, 'identityFqdn').mockResolvedValue(fqdn)
@@ -732,5 +735,88 @@ describe('ensureAuthenticated email fetch functionality', () => {
     const storedSession = vi.mocked(storeSessions).mock.calls[0]![0]
     expect(storedSession[fqdn]![userId]!.identity.alias).toBe(userId)
     expect(got).toEqual(validTokens)
+  })
+})
+
+describe('when auth fails with InvalidTargetError', () => {
+  test('prompts account selection and retries on InvalidTargetError during full auth', async () => {
+    // Given
+    vi.mocked(validateSession).mockResolvedValue('needs_full_auth')
+    vi.mocked(fetchSessions).mockResolvedValue(undefined)
+    vi.mocked(exchangeAccessForApplicationTokens)
+      .mockRejectedValueOnce(
+        new InvalidTargetError('You are not authorized to use the CLI to develop in the provided store: my-store'),
+      )
+      .mockResolvedValueOnce(appTokens)
+    vi.mocked(promptSessionSelect).mockResolvedValue('other-account')
+
+    // When
+    const got = await ensureAuthenticated(defaultApplications)
+
+    // Then
+    expect(promptSessionSelect).toHaveBeenCalledOnce()
+    expect(got).toEqual(validTokens)
+  })
+
+  test('prompts account selection and retries on InvalidTargetError during refresh', async () => {
+    // Given
+    vi.mocked(validateSession).mockResolvedValue('needs_refresh')
+    vi.mocked(fetchSessions).mockResolvedValue(validSessions)
+    vi.mocked(refreshAccessToken).mockResolvedValue(validIdentityToken)
+    vi.mocked(exchangeAccessForApplicationTokens)
+      .mockRejectedValueOnce(
+        new InvalidTargetError('You are not authorized to use the CLI to develop in the provided store: my-store'),
+      )
+      .mockResolvedValueOnce(appTokens)
+    vi.mocked(promptSessionSelect).mockResolvedValue('other-account')
+
+    // When
+    const got = await ensureAuthenticated(defaultApplications)
+
+    // Then
+    expect(promptSessionSelect).toHaveBeenCalledOnce()
+    expect(got).toEqual(validTokens)
+  })
+
+  test('throws InvalidTargetError without prompt when noPrompt is true', async () => {
+    // Given — use needs_refresh because needs_full_auth triggers throwOnNoPrompt before token exchange
+    vi.mocked(validateSession).mockResolvedValue('needs_refresh')
+    vi.mocked(fetchSessions).mockResolvedValue(validSessions)
+    vi.mocked(refreshAccessToken).mockResolvedValue(validIdentityToken)
+    vi.mocked(exchangeAccessForApplicationTokens).mockRejectedValueOnce(
+      new InvalidTargetError('You are not authorized to use the CLI to develop in the provided store: my-store'),
+    )
+
+    // When/Then
+    await expect(ensureAuthenticated(defaultApplications, process.env, {noPrompt: true})).rejects.toThrow()
+    expect(promptSessionSelect).not.toHaveBeenCalled()
+  })
+
+  test('throws InvalidTargetError without prompt in non-interactive terminal', async () => {
+    // Given
+    vi.mocked(terminalSupportsPrompting).mockReturnValue(false)
+    vi.mocked(validateSession).mockResolvedValue('needs_full_auth')
+    vi.mocked(fetchSessions).mockResolvedValue(undefined)
+    vi.mocked(exchangeAccessForApplicationTokens).mockRejectedValueOnce(
+      new InvalidTargetError('You are not authorized to use the CLI to develop in the provided store: my-store'),
+    )
+
+    // When/Then
+    await expect(ensureAuthenticated(defaultApplications)).rejects.toThrow()
+    expect(promptSessionSelect).not.toHaveBeenCalled()
+  })
+
+  test('throws on second consecutive InvalidTargetError after retry', async () => {
+    // Given
+    vi.mocked(validateSession).mockResolvedValue('needs_full_auth')
+    vi.mocked(fetchSessions).mockResolvedValue(undefined)
+    vi.mocked(exchangeAccessForApplicationTokens).mockRejectedValue(
+      new InvalidTargetError('You are not authorized to use the CLI to develop in the provided store: my-store'),
+    )
+    vi.mocked(promptSessionSelect).mockResolvedValue('other-account')
+
+    // When/Then
+    await expect(ensureAuthenticated(defaultApplications)).rejects.toThrow()
+    expect(promptSessionSelect).toHaveBeenCalledOnce()
   })
 })

--- a/packages/cli-kit/src/private/node/session.ts
+++ b/packages/cli-kit/src/private/node/session.ts
@@ -8,6 +8,7 @@ import {
   refreshAccessToken,
   InvalidGrantError,
   InvalidRequestError,
+  InvalidTargetError,
 } from './session/exchange.js'
 import {IdentityToken, Session, Sessions} from './session/schema.js'
 import * as sessionStore from './session/store.js'
@@ -16,6 +17,8 @@ import {isThemeAccessSession} from './api/rest.js'
 import {getCurrentSessionId, setCurrentSessionId} from './conf-store.js'
 import {UserEmailQueryString, UserEmailQuery} from './api/graphql/business-platform-destinations/user-email.js'
 import {outputContent, outputToken, outputDebug, outputCompleted} from '../../public/node/output.js'
+import {terminalSupportsPrompting} from '../../public/node/system.js'
+import {renderWarning} from '../../public/node/ui.js'
 import {firstPartyDev, themeToken} from '../../public/node/context/local.js'
 import {AbortError} from '../../public/node/error.js'
 import {normalizeStoreFqdn, identityFqdn} from '../../public/node/context/fqdn.js'
@@ -186,6 +189,10 @@ export interface EnsureAuthenticatedAdditionalOptions {
 /**
  * This method ensures that we have a valid session to authenticate against the given applications using the provided scopes.
  *
+ * If the current account lacks authorization for the requested store and the terminal supports prompting,
+ * the user is offered an inline account selection prompt to switch accounts and retry authentication
+ * without having to re-run the command.
+ *
  * @param applications - An object containing the applications we need to be authenticated with.
  * @param _env - Optional environment variables to use.
  * @param options - Optional extra options to use.
@@ -194,6 +201,24 @@ export interface EnsureAuthenticatedAdditionalOptions {
 export async function ensureAuthenticated(
   applications: OAuthApplications,
   _env?: NodeJS.ProcessEnv,
+  options: EnsureAuthenticatedAdditionalOptions = {},
+): Promise<OAuthSession> {
+  try {
+    return await performAuthentication(applications, options)
+  } catch (error) {
+    if (error instanceof InvalidTargetError && !options.noPrompt && terminalSupportsPrompting()) {
+      renderWarning({headline: error.message})
+      // Dynamic import to avoid circular dependency: session-prompt → session (public) → session (private)
+      const {promptSessionSelect} = await import('../../public/node/session-prompt.js')
+      await promptSessionSelect()
+      return performAuthentication(applications, options)
+    }
+    throw error
+  }
+}
+
+async function performAuthentication(
+  applications: OAuthApplications,
   {forceRefresh = false, noPrompt = false, forceNewSession = false}: EnsureAuthenticatedAdditionalOptions = {},
 ): Promise<OAuthSession> {
   const fqdn = await identityFqdn()

--- a/packages/cli-kit/src/private/node/session/exchange.ts
+++ b/packages/cli-kit/src/private/node/session/exchange.ts
@@ -13,7 +13,7 @@ import * as jose from 'jose'
 
 export class InvalidGrantError extends ExtendableError {}
 export class InvalidRequestError extends ExtendableError {}
-class InvalidTargetError extends AbortError {}
+export class InvalidTargetError extends AbortError {}
 
 export interface ExchangeScopes {
   admin: string[]


### PR DESCRIPTION
## WHY

When running commands like `shopify theme dev -s store` while logged into the wrong account, the CLI shows an error message suggesting to run `shopify auth login` separately. This requires the user to:

1. Read the error
2. Run `shopify auth login`
3. Select the correct account
4. Re-run the original command

This is unnecessary friction for developers working with multiple stores/accounts.

## WHAT

When authentication fails with an `InvalidTargetError` (wrong account for the target store), the CLI now:

1. Shows a warning with the error message
2. Immediately presents the account selection prompt (same UI as `shopify auth login`)
3. Retries authentication with the newly selected account
4. Continues the original command — no need to re-run

This only triggers in interactive terminals. CI and non-interactive environments preserve the existing error-and-exit behavior.

### Changes

- **`exchange.ts`**: Export `InvalidTargetError` so it can be caught upstream
- **`session.ts`**: Wrap `ensureAuthenticated` with retry logic that catches `InvalidTargetError`, shows account selector via `promptSessionSelect()`, and retries once
- **`session.test.ts`**: 5 new tests covering retry on full auth, retry on refresh, noPrompt, non-interactive terminal, and double-failure scenarios

### Before

```
╭─ error ─────────────────────────────────────────────╮
│                                                      │
│  You are not authorized to use the CLI to develop    │
│  in the provided store: my-store                     │
│                                                      │
│  Next steps                                          │
│    • Run `shopify auth login`                        │
│                                                      │
╰──────────────────────────────────────────────────────╯
```

### After

```
╭─ warning ────────────────────────────────────────────╮
│                                                      │
│  You are not authorized to use the CLI to develop    │
│  in the provided store: my-store                     │
│                                                      │
╰──────────────────────────────────────────────────────╯

? Which account would you like to use?
> work@example.com
  personal@example.com
  Log in with a different account
```

## How to test

1. Log in with `shopify auth login`
2. Run `shopify theme dev -s <store-you-dont-have-access-to>`
3. Verify the account selection prompt appears inline after the warning
4. Select a different account and verify the command continues

## Checklist

- [x] Considered cross-platform impacts (Mac, Linux, Windows) — uses existing `terminalSupportsPrompting()` guard
- [x] Added changeset via `pnpm changeset add`
- [x] CI/non-interactive environments are unaffected (tested with `noPrompt: true`)