### PR TITLE
E2E: replace npm with pnpm

### DIFF
--- a/packages/e2e/setup/constants.ts
+++ b/packages/e2e/setup/constants.ts
@@ -16,7 +16,7 @@ export const CLI_TIMEOUT = {
   short: 1 * 60_000,
   /** 3 min — standard commands (deploy, build, config link) */
   medium: 3 * 60_000,
-  /** 5 min — slow commands (create app, scaffold + npm install) */
+  /** 5 min — slow commands (create app, scaffold) */
   long: 5 * 60_000,
 } as const
 

--- a/packages/e2e/tests/app-deploy.spec.ts
+++ b/packages/e2e/tests/app-deploy.spec.ts
@@ -20,7 +20,7 @@ test.describe('App deploy', () => {
         parentDir,
         name: appName,
         template: 'none',
-        packageManager: 'npm',
+        packageManager: 'pnpm',
         orgId: env.orgId,
       })
       expect(initResult.exitCode, `createApp failed:\nstdout: ${initResult.stdout}\nstderr: ${initResult.stderr}`).toBe(

--- a/packages/e2e/tests/app-dev-server.spec.ts
+++ b/packages/e2e/tests/app-dev-server.spec.ts
@@ -20,7 +20,7 @@ test.describe('App dev server', () => {
         parentDir,
         name: appName,
         template: 'none',
-        packageManager: 'npm',
+        packageManager: 'pnpm',
         orgId: env.orgId,
       })
       expect(initResult.exitCode).toBe(0)

--- a/packages/e2e/tests/app-scaffold.spec.ts
+++ b/packages/e2e/tests/app-scaffold.spec.ts
@@ -22,7 +22,7 @@ test.describe('App scaffold', () => {
         name: appName,
         template: 'reactRouter',
         flavor: 'javascript',
-        packageManager: 'npm',
+        packageManager: 'pnpm',
         orgId: env.orgId,
       })
       expect(initResult.exitCode).toBe(0)
@@ -57,7 +57,7 @@ test.describe('App scaffold', () => {
         parentDir,
         name: appName,
         template: 'none',
-        packageManager: 'npm',
+        packageManager: 'pnpm',
         orgId: env.orgId,
       })
       expect(initResult.exitCode).toBe(0)
@@ -86,7 +86,7 @@ test.describe('App scaffold', () => {
         name: appName,
         template: 'reactRouter',
         flavor: 'javascript',
-        packageManager: 'npm',
+        packageManager: 'pnpm',
         orgId: env.orgId,
       })
       expect(initResult.exitCode).toBe(0)


### PR DESCRIPTION
### WHY are these changes introduced?

E2E tests hardcoded `packageManager: 'npm'` in all `createApp` calls. npm is no longer supported in Shopify's internal dev environment (`npm install` fails with "npm is no longer supported in a global context. Please migrate to pnpm"). This blocks local test runs.

### WHAT is this pull request doing?

- Switches all E2E test `packageManager` from `'npm'` to `'pnpm'` across `app-scaffold`, `app-deploy`, and `app-dev-server` specs
- Updates a comment in `constants.ts` to remove the npm reference

No test behavior changes — the tests exercise the same CLI commands (`app init`, `app build`, `app dev`, `app deploy`), just with pnpm handling dependency installation instead of npm.

### How to test your changes?

```bash
DEBUG=1 pnpm --filter e2e exec playwright test
```

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing, so I've added a changelog entry with `pnpm changeset add`