### PR TITLE
fix: validate --path flag is a directory, not a file

### DIFF
--- a/.changeset/fix-theme-check-path-file-validation.md
+++ b/.changeset/fix-theme-check-path-file-validation.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Fix `ENOTDIR` error when a file path is passed to `--path` flag in theme commands. The flag now validates that the provided path is a directory and shows a helpful error message suggesting the parent directory instead.

--- a/packages/theme/src/cli/flags.test.ts
+++ b/packages/theme/src/cli/flags.test.ts
@@ -1,8 +1,8 @@
 import {themeFlags} from './flags.js'
 import {describe, expect, test} from 'vitest'
 import Command from '@shopify/cli-kit/node/base-command'
-import {inTemporaryDirectory} from '@shopify/cli-kit/node/fs'
-import {cwd, resolvePath} from '@shopify/cli-kit/node/path'
+import {inTemporaryDirectory, writeFileSync} from '@shopify/cli-kit/node/fs'
+import {cwd, joinPath, resolvePath} from '@shopify/cli-kit/node/path'
 import {mockAndCaptureOutput} from '@shopify/cli-kit/node/testing/output'
 
 class MockCommand extends Command {
@@ -26,7 +26,7 @@ describe('themeFlags', () => {
       expect(flags.path).toEqual(cwd())
     })
 
-    test('can be expclitly provided', async () => {
+    test('can be explicitly provided', async () => {
       await inTemporaryDirectory(async (tmpDir) => {
         const flags = await MockCommand.run(['--path', tmpDir])
 
@@ -34,12 +34,26 @@ describe('themeFlags', () => {
       })
     })
 
-    test("renders an error message and exists when the path doesn't exist", async () => {
+    test("renders an error message and exits when the path doesn't exist", async () => {
       const mockOutput = mockAndCaptureOutput()
 
       await MockCommand.run(['--path', 'boom'])
 
       expect(mockOutput.error()).toMatch("A path was explicitly provided but doesn't exist")
+    })
+
+    test('renders an error message and exits when the path is a file instead of a directory', async () => {
+      await inTemporaryDirectory(async (tmpDir) => {
+        const filePath = joinPath(tmpDir, 'section.liquid')
+        writeFileSync(filePath, '{% schema %}{% endschema %}')
+
+        const mockOutput = mockAndCaptureOutput()
+
+        await MockCommand.run(['--path', filePath])
+
+        expect(mockOutput.error()).toMatch('The path must be a directory, not a file')
+        expect(mockOutput.error()).toMatch('section.liquid')
+      })
     })
   })
 })

--- a/packages/theme/src/cli/flags.ts
+++ b/packages/theme/src/cli/flags.ts
@@ -28,7 +28,7 @@ export const themeFlags = {
       if (!isDirectorySync(resolvedPath)) {
         renderError({
           headline: 'The path must be a directory, not a file.',
-          body: [`The provided path is a file: ${resolvedPath}`, `Did you mean: ${dirname(resolvedPath)}`],
+          body: [`The provided path is not a directory: ${resolvedPath}`, `Did you mean: ${dirname(resolvedPath)}`],
         })
         return process.exit(1)
       }

--- a/packages/theme/src/cli/flags.ts
+++ b/packages/theme/src/cli/flags.ts
@@ -1,7 +1,7 @@
 import {Flags} from '@oclif/core'
 import {normalizeStoreFqdn} from '@shopify/cli-kit/node/context/fqdn'
-import {resolvePath, cwd} from '@shopify/cli-kit/node/path'
-import {fileExistsSync} from '@shopify/cli-kit/node/fs'
+import {resolvePath, cwd, dirname} from '@shopify/cli-kit/node/path'
+import {fileExistsSync, isDirectorySync} from '@shopify/cli-kit/node/fs'
 import {renderError} from '@shopify/cli-kit/node/ui'
 
 /**
@@ -15,17 +15,25 @@ export const themeFlags = {
     parse: async (input) => {
       const resolvedPath = resolvePath(input)
 
-      if (fileExistsSync(resolvedPath)) {
-        return resolvedPath
+      if (!fileExistsSync(resolvedPath)) {
+        // We can't use AbortError because oclif catches it and adds its own
+        // messaging that breaks our UI
+        renderError({
+          headline: "A path was explicitly provided but doesn't exist.",
+          body: [`Please check the path and try again: ${resolvedPath}`],
+        })
+        return process.exit(1)
       }
 
-      // We can't use AbortError because oclif catches it and adds its own
-      // messaging that breaks our UI
-      renderError({
-        headline: "A path was explicitly provided but doesn't exist.",
-        body: [`Please check the path and try again: ${resolvedPath}`],
-      })
-      process.exit(1)
+      if (!isDirectorySync(resolvedPath)) {
+        renderError({
+          headline: 'The path must be a directory, not a file.',
+          body: [`The provided path is a file: ${resolvedPath}`, `Did you mean: ${dirname(resolvedPath)}`],
+        })
+        return process.exit(1)
+      }
+
+      return resolvedPath
     },
     default: async () => cwd(),
     noCacheDefault: true,


### PR DESCRIPTION
## Summary

- Adds `isDirectorySync()` validation to the `--path` flag in theme commands
- Shows a clear error message with a "Did you mean:" suggestion pointing to the parent directory
- Adds `return` before `process.exit(1)` calls for safety when `process.exit` is mocked in tests

## Problem

The `--path` flag in all theme commands (`theme check`, `theme dev`, `theme push`, etc.) validated that the provided path **existed** using `fileExistsSync()`, but did not check whether it was a **directory**. Since `fileExistsSync()` returns `true` for both files and directories, users could pass a file path like `sections/foo.liquid` and the validation would accept it.

Downstream, `@shopify/theme-check-node`'s `loadConfig()` calls `fs.readdir(root)` on the path, which throws `ENOTDIR: not a directory, scandir` when the path is a file.

**Impact:** ~490 error events across 220+ affected users in the last 7 days (first seen in CLI 3.93.0).

The errors appear across all platforms (macOS, Windows, Linux) and affect many different theme files (`sections/*.liquid`, `snippets/*.liquid`, `templates/*.json`, `blocks/*.liquid`, `locales/*.json`). The likely cause is IDE integrations or editor tasks that pass the currently open file as the `--path` argument.

**Related issue:** https://github.com/shop/issues/issues/33774
**Observe dashboard:** https://observe.shopify.io/a/observe/errors/13708469716602397840

## Test plan

- [x] New test: verifies error message when a file path is passed to `--path`
- [x] Existing test: verifies error message when a non-existent path is passed
- [x] Existing test: verifies directory paths are accepted
- [x] All 565 theme tests pass (58 test files)
- [x] `check.test.ts` tests pass (these mock `process.exit` and use fake paths)
- [x] Lint and type checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)