### PR TITLE
Fix ui_extension manifest.json

### DIFF
--- a/packages/app/src/cli/models/extensions/extension-instance.ts
+++ b/packages/app/src/cli/models/extensions/extension-instance.ts
@@ -47,6 +47,7 @@ export class ExtensionInstance<TConfiguration extends BaseConfigType = BaseConfi
   configuration: TConfiguration
   configurationPath: string
   outputPath: string
+  bundleRoot: string
   handle: string
   specification: ExtensionSpecification
   uid: string
@@ -124,6 +125,10 @@ export class ExtensionInstance<TConfiguration extends BaseConfigType = BaseConfi
     return this.specification.getOutputRelativePath?.(this) ?? ''
   }
 
+  get localOutputPath() {
+    return joinPath(this.directory, this.outputRelativePath)
+  }
+
   constructor(options: {
     configuration: TConfiguration
     configurationPath: string
@@ -139,9 +144,11 @@ export class ExtensionInstance<TConfiguration extends BaseConfigType = BaseConfi
     this.handle = this.buildHandle()
     this.localIdentifier = this.handle
     this.idEnvironmentVariableName = `SHOPIFY_${constantize(this.localIdentifier)}_ID`
-    this.outputPath = joinPath(this.directory, this.outputRelativePath)
+    this.outputPath = this.localOutputPath
     this.uid = this.buildUIDFromStrategy()
     this.devUUID = `dev-${this.uid}`
+    // We're not yet doing dev or deploy so the default bundle root is the extension directory
+    this.bundleRoot = this.directory
   }
 
   get draftMessages() {
@@ -328,17 +335,18 @@ export class ExtensionInstance<TConfiguration extends BaseConfigType = BaseConfi
   }
 
   async buildForBundle(options: ExtensionBuildOptions, bundleDirectory: string, outputId?: string) {
-    this.outputPath = this.getOutputPathForDirectory(bundleDirectory, outputId)
+    this.bundleRoot = joinPath(bundleDirectory, this.getOutputFolderId(outputId))
+    this.outputPath = joinPath(this.bundleRoot, this.outputRelativePath)
     await this.build(options)
 
-    const bundleInputPath = joinPath(bundleDirectory, this.getOutputFolderId(outputId))
-    await this.keepBuiltSourcemapsLocally(bundleInputPath)
+    await this.keepBuiltSourcemapsLocally(this.bundleRoot)
   }
 
   async copyIntoBundle(options: ExtensionBuildOptions, bundleDirectory: string, extensionUuid?: string) {
     const defaultOutputPath = this.outputPath
 
-    this.outputPath = this.getOutputPathForDirectory(bundleDirectory, extensionUuid)
+    this.bundleRoot = joinPath(bundleDirectory, this.getOutputFolderId(extensionUuid))
+    this.outputPath = joinPath(this.bundleRoot, this.outputRelativePath)
 
     const buildMode = this.specification.buildConfig.mode
 

--- a/packages/app/src/cli/services/build/extension.ts
+++ b/packages/app/src/cli/services/build/extension.ts
@@ -68,7 +68,7 @@ export async function buildUIExtension(extension: ExtensionInstance, options: Ex
   }
 
   // Always build into the extension's local directory (e.g. ext/dist/handle.js)
-  const localOutputPath = joinPath(extension.directory, extension.outputRelativePath)
+  const localOutputPath = extension.localOutputPath
 
   const {main, assets} = extension.getBundleExtensionStdinContent()
 
@@ -175,7 +175,7 @@ export async function buildFunctionExtension(
       await runTrampoline(extension.outputPath)
     }
 
-    const projectOutputPath = joinPath(extension.directory, extension.outputRelativePath)
+    const projectOutputPath = extension.localOutputPath
 
     if (
       fileExistsSync(extension.outputPath) &&

--- a/packages/app/src/cli/services/build/steps/bundle-ui-step.ts
+++ b/packages/app/src/cli/services/build/steps/bundle-ui-step.ts
@@ -2,7 +2,7 @@ import {createOrUpdateManifestFile} from './include-assets/generate-manifest.js'
 import {buildUIExtension} from '../extension.js'
 import {BuildManifest} from '../../../models/extensions/specifications/ui_extension.js'
 import {copyFile} from '@shopify/cli-kit/node/fs'
-import {dirname} from '@shopify/cli-kit/node/path'
+import {dirname, joinPath, relativePath} from '@shopify/cli-kit/node/path'
 import type {BundleUIStep, BuildContext} from '../client-steps.js'
 
 interface ExtensionPointWithBuildManifest {
@@ -32,7 +32,8 @@ export async function executeBundleUIStep(step: BundleUIStep, context: BuildCont
     (ep): ep is ExtensionPointWithBuildManifest => typeof ep === 'object' && ep.build_manifest,
   )
 
-  const entries = extractBuiltAssetEntries(pointsWithManifest)
+  const outputDirRelative = relativePath(context.extension.bundleRoot, dirname(context.extension.outputPath))
+  const entries = extractBuiltAssetEntries(pointsWithManifest, outputDirRelative)
   if (Object.keys(entries).length > 0) {
     await createOrUpdateManifestFile(context, entries)
   }
@@ -40,9 +41,14 @@ export async function executeBundleUIStep(step: BundleUIStep, context: BuildCont
 
 /**
  * Extracts built asset filepaths from `build_manifest` on each extension point,
- * grouped by target. Returns a map of target → `{assetName: filepath}`.
+ * grouped by target. Returns a map of target → `{assetName: filepath}`. Filepaths
+ * are rewritten to be bundle-root-relative so downstream consumers (dev asset
+ * server, deploy server) resolve them consistently against the bundle root.
  */
-function extractBuiltAssetEntries(extensionPoints: {target: string; build_manifest: BuildManifest}[]): {
+function extractBuiltAssetEntries(
+  extensionPoints: {target: string; build_manifest: BuildManifest}[],
+  outputDirRelative: string,
+): {
   [target: string]: {[assetName: string]: string}
 } {
   const entries: {[target: string]: {[assetName: string]: string}} = {}
@@ -50,7 +56,7 @@ function extractBuiltAssetEntries(extensionPoints: {target: string; build_manife
     if (!buildManifest?.assets) continue
     const assets: {[name: string]: string} = {}
     for (const [name, asset] of Object.entries(buildManifest.assets)) {
-      if (asset?.filepath) assets[name] = asset.filepath
+      if (asset?.filepath) assets[name] = joinPath(outputDirRelative, asset.filepath)
     }
     if (Object.keys(assets).length > 0) entries[target] = assets
   }

--- a/packages/app/src/cli/services/build/steps/include-assets-step.test.ts
+++ b/packages/app/src/cli/services/build/steps/include-assets-step.test.ts
@@ -18,6 +18,7 @@ describe('executeIncludeAssetsStep', () => {
     mockExtension = {
       directory: '/test/extension',
       outputPath: '/test/output/extension.js',
+      bundleRoot: '/test/output',
     } as ExtensionInstance
 
     mockContext = {

--- a/packages/app/src/cli/services/build/steps/include-assets-step.ts
+++ b/packages/app/src/cli/services/build/steps/include-assets-step.ts
@@ -2,7 +2,7 @@ import {generateManifestFile} from './include-assets/generate-manifest.js'
 import {copyByPattern} from './include-assets/copy-by-pattern.js'
 import {copySourceEntry} from './include-assets/copy-source-entry.js'
 import {copyConfigKeyEntry} from './include-assets/copy-config-key-entry.js'
-import {joinPath, dirname, extname, sanitizeRelativePath} from '@shopify/cli-kit/node/path'
+import {joinPath, sanitizeRelativePath} from '@shopify/cli-kit/node/path'
 import {z} from 'zod'
 import type {LifecycleStep, BuildContext} from '../client-steps.js'
 
@@ -68,7 +68,7 @@ const InclusionEntrySchema = z.discriminatedUnion('type', [PatternEntrySchema, S
  * then `pattern` and `static` entries run in parallel.
  *
  * When `generatesAssetsManifest` is `true`, a `manifest.json` file is written
- * to the output directory after all inclusions complete. All entry types
+ * to the bundle root after all inclusions complete. All entry types
  * contribute their copied output paths to the manifest. `configKey` entries
  * with `anchor` and `groupBy` produce structured manifest entries; `pattern`
  * and `static` entries contribute their paths under a `"files"` key.
@@ -107,15 +107,18 @@ type IncludeAssetsConfig = z.input<typeof IncludeAssetsConfigSchema>
  *
  * Iterates over `config.inclusions` and dispatches each entry by type:
  *
- * - `type: 'static'` — copy a file or directory into the output.
+ * - `type: 'static'` — copy a file or directory into the bundle root.
  * - `type: 'configKey'` — resolve a path from the extension's
- *   config and copy into the output; silently skipped if absent.
+ *   config and copy into the bundle root; silently skipped if absent.
  *   Runs sequentially to avoid filesystem race conditions.
  * - `type: 'pattern'` — glob-based file selection from a source directory
- *   (defaults to extension root when `source` is omitted).
+ *   (defaults to extension root when `baseDir` is omitted).
+ *
+ * All static assets copy to `extension.bundleRoot`. The `bundle_ui` step is
+ * responsible for placing built JS into `dist/`.
  *
  * When `generatesAssetsManifest` is `true`, all entry types contribute their
- * copied output paths to `manifest.json`.
+ * copied output paths (bundle-root-relative) to `manifest.json`.
  */
 export async function executeIncludeAssetsStep(
   step: LifecycleStep,
@@ -123,9 +126,7 @@ export async function executeIncludeAssetsStep(
 ): Promise<{filesCopied: number}> {
   const config = IncludeAssetsConfigSchema.parse(step.config)
   const {extension, options} = context
-  // When outputPath is a file (e.g. index.js, index.wasm), the output directory is its
-  // parent. When outputPath has no extension, it IS the output directory.
-  const outputDir = extname(extension.outputPath) ? dirname(extension.outputPath) : extension.outputPath
+  const bundleRoot = extension.bundleRoot
 
   const aggregatedPathMap = new Map<string, string | string[]>()
   // Track basenames written across all configKey entries in this build to detect
@@ -145,7 +146,7 @@ export async function executeIncludeAssetsStep(
     const result = await copyConfigKeyEntry({
       key: entry.key,
       baseDir: extension.directory,
-      outputDir,
+      outputDir: bundleRoot,
       context,
       destination: sanitizedDest,
       usedBasenames,
@@ -164,7 +165,7 @@ export async function executeIncludeAssetsStep(
 
         if (entry.type === 'pattern') {
           const sourceDir = entry.baseDir ? joinPath(extension.directory, entry.baseDir) : extension.directory
-          const destinationDir = sanitizedDest ? joinPath(outputDir, sanitizedDest) : outputDir
+          const destinationDir = sanitizedDest ? joinPath(bundleRoot, sanitizedDest) : bundleRoot
           const result = await copyByPattern(
             {
               sourceDir,
@@ -174,7 +175,7 @@ export async function executeIncludeAssetsStep(
             },
             options,
           )
-          // result.outputPaths are relative to destinationDir; prefix with sanitizedDest for outer outputDir relativity
+          // result.outputPaths are relative to destinationDir; prefix with sanitizedDest for bundle-root relativity
           const outputPaths = sanitizedDest
             ? result.outputPaths.map((outputPath) => joinPath(sanitizedDest, outputPath))
             : result.outputPaths
@@ -187,7 +188,7 @@ export async function executeIncludeAssetsStep(
               source: entry.source,
               destination: sanitizedDest,
               baseDir: extension.directory,
-              outputDir,
+              outputDir: bundleRoot,
             },
             options,
           )

--- a/packages/app/src/cli/services/build/steps/include-assets/generate-manifest.ts
+++ b/packages/app/src/cli/services/build/steps/include-assets/generate-manifest.ts
@@ -1,5 +1,5 @@
 import {getNestedValue, tokenizePath} from './copy-config-key-entry.js'
-import {joinPath, dirname, extname} from '@shopify/cli-kit/node/path'
+import {joinPath} from '@shopify/cli-kit/node/path'
 import {fileExists, mkdir, readFile, writeFile} from '@shopify/cli-kit/node/fs'
 import {outputDebug} from '@shopify/cli-kit/node/output'
 import type {BuildContext} from '../../client-steps.js'
@@ -121,18 +121,11 @@ export async function createOrUpdateManifestFile(
   context: BuildContext,
   entries: {[key: string]: unknown},
 ): Promise<void> {
-  const outputPath = context.extension.outputPath
-  /**
-   * Resolves the output directory from an extension's outputPath.
-   * When outputPath is a file (has extension), uses dirname. Otherwise uses outputPath directly.
-   */
-  const outputDir = extname(outputPath) ? dirname(outputPath) : outputPath
+  const bundleRoot = context.extension.bundleRoot
+  const manifestPath = joinPath(bundleRoot, 'manifest.json')
 
-  const manifestPath = joinPath(outputDir, 'manifest.json')
-
-  // Create the output directory
-  if (!(await fileExists(outputDir))) {
-    await mkdir(outputDir)
+  if (!(await fileExists(bundleRoot))) {
+    await mkdir(bundleRoot)
   }
 
   let existing: {[key: string]: unknown} = {}
@@ -163,7 +156,7 @@ export async function createOrUpdateManifestFile(
   }
 
   await writeFile(manifestPath, JSON.stringify(existing, null, 2))
-  outputDebug(`Updated manifest.json in ${outputDir}\n`, context.options.stdout)
+  outputDebug(`Updated manifest.json in ${bundleRoot}\n`, context.options.stdout)
 }
 
 /**

--- a/packages/app/src/cli/services/dev/extension.ts
+++ b/packages/app/src/cli/services/dev/extension.ts
@@ -124,8 +124,7 @@ export async function devUIExtensions(options: ExtensionDevOptions): Promise<voi
   // NOTE: Always use `payloadOptions`, never `options` directly. This way we can mutate `payloadOptions` without
   // affecting the original `options` object and we only need to care about `payloadOptions` in this function.
 
-  const bundlePath = payloadOptions.appWatcher.buildOutputPath
-  const payloadStoreRawPayload = await getExtensionsPayloadStoreRawPayload(payloadOptions, bundlePath)
+  const payloadStoreRawPayload = await getExtensionsPayloadStoreRawPayload(payloadOptions)
   const payloadStore = new ExtensionsPayloadStore(payloadStoreRawPayload, payloadOptions)
   let extensions = payloadOptions.extensions.filter((ext) => ext.isPreviewable)
 
@@ -173,10 +172,10 @@ export async function devUIExtensions(options: ExtensionDevOptions): Promise<voi
             // eslint-disable-next-line require-atomic-updates
             payloadOptions.checkoutCartUrl = cartUrl
           }
-          await payloadStore.addExtension(event.extension, bundlePath)
+          await payloadStore.addExtension(event.extension)
           break
         case EventType.Updated:
-          await payloadStore.updateExtension(event.extension, payloadOptions, bundlePath, {status, error})
+          await payloadStore.updateExtension(event.extension, payloadOptions, {status, error})
           break
         case EventType.Deleted:
           payloadOptions.extensions = payloadOptions.extensions.filter((ext) => ext.devUUID !== event.extension.devUUID)

--- a/packages/app/src/cli/services/dev/extension/payload.test.ts
+++ b/packages/app/src/cli/services/dev/extension/payload.test.ts
@@ -48,7 +48,11 @@ describe('getUIExtensionPayload', () => {
     const buildDir = extname(extensionOutputPath) ? dirname(extensionOutputPath) : extensionOutputPath
     await mkdir(buildDir)
     if (extname(extensionOutputPath)) await touchFile(extensionOutputPath)
-    await writeFile(joinPath(buildDir, 'manifest.json'), JSON.stringify(manifest))
+    // Simulate post-buildForBundle state: bundleRoot is the extension's bundle folder,
+    // where manifest.json is written.
+    extension.bundleRoot = joinPath(bundlePath, extension.uid)
+    await mkdir(extension.bundleRoot)
+    await writeFile(joinPath(extension.bundleRoot, 'manifest.json'), JSON.stringify(manifest))
 
     for (const [filepath, content] of Object.entries(sourceFiles)) {
       const fullPath = joinPath(extension.directory, filepath)
@@ -110,7 +114,7 @@ describe('getUIExtensionPayload', () => {
         devUUID: 'devUUID',
       })
 
-      const got = await getUIExtensionPayload(uiExtension, 'mock-bundle-path', {
+      const got = await getUIExtensionPayload(uiExtension, {
         ...createMockOptions(tmpDir, [uiExtension]),
         currentDevelopmentPayload: {hidden: true, status: 'success'},
       })
@@ -181,7 +185,7 @@ describe('getUIExtensionPayload', () => {
         {'tools.json': '{"tools": []}', 'instructions.md': '# Instructions'},
       )
 
-      const got = await getUIExtensionPayload(uiExtension, tmpDir, {
+      const got = await getUIExtensionPayload(uiExtension, {
         ...createMockOptions(tmpDir, [uiExtension]),
         currentDevelopmentPayload: {hidden: true, status: 'success'},
       })
@@ -243,7 +247,7 @@ describe('getUIExtensionPayload', () => {
         {},
       )
 
-      const got = await getUIExtensionPayload(uiExtension, tmpDir, {
+      const got = await getUIExtensionPayload(uiExtension, {
         ...createMockOptions(tmpDir, [uiExtension]),
         currentDevelopmentPayload: {hidden: true, status: 'success'},
       })
@@ -296,7 +300,7 @@ describe('getUIExtensionPayload', () => {
         {'intents/create-schema.json': '{"type": "object"}', 'intents/update-schema.json': '{"type": "object"}'},
       )
 
-      const got = await getUIExtensionPayload(uiExtension, tmpDir, {
+      const got = await getUIExtensionPayload(uiExtension, {
         ...createMockOptions(tmpDir, [uiExtension]),
         currentDevelopmentPayload: {hidden: true, status: 'success'},
       })
@@ -344,7 +348,7 @@ describe('getUIExtensionPayload', () => {
       })
 
       // No setupBuildOutput — manifest.json doesn't exist
-      const got = await getUIExtensionPayload(uiExtension, tmpDir, {
+      const got = await getUIExtensionPayload(uiExtension, {
         ...createMockOptions(tmpDir, [uiExtension]),
         currentDevelopmentPayload: {hidden: true, status: 'success'},
       })
@@ -373,8 +377,9 @@ describe('getUIExtensionPayload', () => {
         devUUID: 'devUUID',
       })
 
-      // Use a non-existent bundle path — parent directory doesn't exist
-      const got = await getUIExtensionPayload(uiExtension, joinPath(tmpDir, 'nonexistent', 'bundle'), {
+      // Point bundleRoot at a non-existent directory so manifest.json lookup fails.
+      uiExtension.bundleRoot = joinPath(tmpDir, 'nonexistent', 'bundle')
+      const got = await getUIExtensionPayload(uiExtension, {
         ...createMockOptions(tmpDir, [uiExtension]),
         currentDevelopmentPayload: {hidden: true, status: 'success'},
       })
@@ -409,7 +414,7 @@ describe('getUIExtensionPayload', () => {
         {'tools.json': '{"tools": []}'},
       )
 
-      const got = await getUIExtensionPayload(adminLinkExtension, tmpDir, {
+      const got = await getUIExtensionPayload(adminLinkExtension, {
         ...createMockOptions(tmpDir, [adminLinkExtension]),
         currentDevelopmentPayload: {hidden: true, status: 'success'},
       })
@@ -458,7 +463,7 @@ describe('getUIExtensionPayload', () => {
         devUUID: 'devUUID',
       })
 
-      const got = await getUIExtensionPayload(postPurchaseExtension, 'mock-bundle-path', {
+      const got = await getUIExtensionPayload(postPurchaseExtension, {
         ...createMockOptions(tmpDir, [postPurchaseExtension]),
         currentDevelopmentPayload: {hidden: true, status: 'success'},
       })
@@ -486,7 +491,7 @@ describe('getUIExtensionPayload', () => {
     await inTemporaryDirectory(async (tmpDir) => {
       const uiExtension = await testUIExtension({directory: tmpDir})
 
-      const got = await getUIExtensionPayload(uiExtension, 'mock-bundle-path', {
+      const got = await getUIExtensionPayload(uiExtension, {
         ...({} as ExtensionsPayloadStoreOptions),
         currentDevelopmentPayload: {},
       })
@@ -519,7 +524,7 @@ describe('getUIExtensionPayload', () => {
           },
         })
 
-        const got = await getUIExtensionPayload(uiExtension, 'mock-bundle-path', {
+        const got = await getUIExtensionPayload(uiExtension, {
           ...({} as ExtensionsPayloadStoreOptions),
           currentDevelopmentPayload: {},
         })
@@ -542,7 +547,7 @@ describe('getUIExtensionPayload', () => {
           },
         })
 
-        const got = await getUIExtensionPayload(uiExtension, 'mock-bundle-path', {
+        const got = await getUIExtensionPayload(uiExtension, {
           ...({} as ExtensionsPayloadStoreOptions),
           currentDevelopmentPayload: {},
         })
@@ -564,7 +569,7 @@ describe('getUIExtensionPayload', () => {
           },
         })
 
-        const got = await getUIExtensionPayload(uiExtension, 'mock-bundle-path', {
+        const got = await getUIExtensionPayload(uiExtension, {
           ...({} as ExtensionsPayloadStoreOptions),
           currentDevelopmentPayload: {},
         })
@@ -597,7 +602,7 @@ describe('getUIExtensionPayload', () => {
         },
       })
 
-      const got = await getUIExtensionPayload(uiExtension, 'mock-bundle-path', {
+      const got = await getUIExtensionPayload(uiExtension, {
         ...({} as ExtensionsPayloadStoreOptions),
         currentDevelopmentPayload: {},
         url: 'http://tunnel-url.com',
@@ -651,7 +656,7 @@ describe('getUIExtensionPayload', () => {
         },
       })
 
-      const got = await getUIExtensionPayload(uiExtension, 'mock-bundle-path', {
+      const got = await getUIExtensionPayload(uiExtension, {
         ...({} as ExtensionsPayloadStoreOptions),
         currentDevelopmentPayload: {},
         url: 'http://tunnel-url.com',

--- a/packages/app/src/cli/services/dev/extension/payload.ts
+++ b/packages/app/src/cli/services/dev/extension/payload.ts
@@ -23,18 +23,13 @@ interface AssetMapperContext {
 
 export async function getUIExtensionPayload(
   extension: ExtensionInstance,
-  bundlePath: string,
   options: GetUIExtensionPayloadOptions,
 ): Promise<UIExtensionPayload> {
   return useConcurrentOutputContext({outputPrefix: extension.outputPrefix}, async () => {
-    const extensionOutputPath = extension.getOutputPathForDirectory(bundlePath)
     const url = `${options.url}/extensions/${extension.devUUID}`
     const {localization, status: localizationStatus} = await getLocalization(extension, options)
     const renderer = await getUIExtensionRendererVersion(extension)
-    // If the extension has a custom output relative path, use that as the build directory
-    // ex. ext/dist/handle.js -> ext/dist
-    const buildDirectory = extension.outputRelativePath ? dirname(extensionOutputPath) : extensionOutputPath
-    const extensionPoints = await getExtensionPoints(extension, url, buildDirectory)
+    const extensionPoints = await getExtensionPoints(extension, url)
 
     let metafields: {namespace: string; key: string}[] | null = null
     if (
@@ -47,11 +42,8 @@ export async function getUIExtensionPayload(
 
     const defaultConfig = {
       assets: {
-        main: {
-          name: 'main',
-          url: `${url}/assets/${extension.outputFileName}`,
-          lastUpdated: (await fileLastUpdatedTimestamp(extensionOutputPath)) ?? 0,
-        },
+        // Always use the local output path for the main asset
+        main: await getAssetPayload('main', extension.outputFileName, url, extension, extension.localOutputPath),
       },
       supportedFeatures: {
         runsOffline: extension.configuration.supported_features?.runs_offline ?? false,
@@ -104,7 +96,7 @@ export async function getUIExtensionPayload(
   })
 }
 
-async function getExtensionPoints(extension: ExtensionInstance, url: string, buildDirectory: string) {
+async function getExtensionPoints(extension: ExtensionInstance, url: string) {
   const config = extension.configuration as Record<string, unknown>
   let extensionPoints = (config.extension_points ?? config.targeting) as DevNewExtensionPointSchema[]
 
@@ -114,7 +106,7 @@ async function getExtensionPoints(extension: ExtensionInstance, url: string, bui
   }
 
   if (isNewExtensionPointsSchema(extensionPoints)) {
-    const manifest = await readBundleManifest(buildDirectory)
+    const manifest = await readBundleManifest(extension.bundleRoot)
 
     return Promise.all(
       extensionPoints.map(async (extensionPoint) => {
@@ -185,7 +177,8 @@ async function defaultAssetMapper({
   const buildManifest = extensionPoint.build_manifest
   const asset = buildManifest?.assets?.[identifier as keyof typeof buildManifest.assets]
   if (asset?.filepath) {
-    const payload = await getAssetPayload(identifier, asset.filepath, url, extension, asset.module)
+    const builtPath = joinPath(dirname(extension.localOutputPath), asset.filepath)
+    const payload = await getAssetPayload(identifier, asset.filepath, url, extension, builtPath)
     return {assets: {[payload.name]: payload}}
   }
 
@@ -261,10 +254,9 @@ export function isNewExtensionPointsSchema(extensionPoints: unknown): extensionP
 /**
  * Builds an asset payload entry.
  *
- * @param sourcePath - Optional source file path for the timestamp. When provided
- *   (e.g. for compiled assets), the URL uses `filepath` (the build output name)
- *   while `lastUpdated` is read from `sourcePath` (the source module). For static
- *   assets, `filepath` is used for both.
+ * @param sourcePath - Absolute path of the file whose mtime should be used for
+ *   `lastUpdated`. When omitted, defaults to `extension.directory/<filepath>`
+ *   (the source location for static assets).
  */
 async function getAssetPayload(
   name: string,
@@ -276,6 +268,6 @@ async function getAssetPayload(
   return {
     name,
     url: `${url}${joinPath('/assets/', filepath)}`,
-    lastUpdated: (await fileLastUpdatedTimestamp(joinPath(extension.directory, sourcePath ?? filepath))) ?? 0,
+    lastUpdated: (await fileLastUpdatedTimestamp(sourcePath ?? joinPath(extension.directory, filepath))) ?? 0,
   }
 }

--- a/packages/app/src/cli/services/dev/extension/payload/store.test.ts
+++ b/packages/app/src/cli/services/dev/extension/payload/store.test.ts
@@ -41,7 +41,7 @@ describe('getExtensionsPayloadStoreRawPayload()', () => {
     } as unknown as ExtensionsPayloadStoreOptions
 
     // When
-    const rawPayload = await getExtensionsPayloadStoreRawPayload(options, 'mock-bundle-path')
+    const rawPayload = await getExtensionsPayloadStoreRawPayload(options)
 
     // Then
     expect(rawPayload).toMatchObject({
@@ -84,7 +84,7 @@ describe('getExtensionsPayloadStoreRawPayload()', () => {
     } as unknown as ExtensionsPayloadStoreOptions
 
     // When
-    const rawPayload = await getExtensionsPayloadStoreRawPayload(options, 'bundle-path')
+    const rawPayload = await getExtensionsPayloadStoreRawPayload(options)
 
     // Then
     expect(rawPayload.app.allowedDomains).toStrictEqual(['https://cdn.example.com'])
@@ -113,7 +113,7 @@ describe('getExtensionsPayloadStoreRawPayload()', () => {
     } as unknown as ExtensionsPayloadStoreOptions
 
     // When
-    const rawPayload = await getExtensionsPayloadStoreRawPayload(options, 'bundle-path')
+    const rawPayload = await getExtensionsPayloadStoreRawPayload(options)
 
     // Then
     expect(rawPayload.app.allowedDomains).toBeUndefined()
@@ -136,7 +136,7 @@ describe('getExtensionsPayloadStoreRawPayload()', () => {
     } as unknown as ExtensionsPayloadStoreOptions
 
     // When
-    const rawPayload = await getExtensionsPayloadStoreRawPayload(options, 'bundle-path')
+    const rawPayload = await getExtensionsPayloadStoreRawPayload(options)
 
     // Then
     expect(rawPayload.app.allowedDomains).toStrictEqual(['https://cdn.example.com'])
@@ -159,7 +159,7 @@ describe('getExtensionsPayloadStoreRawPayload()', () => {
     } as unknown as ExtensionsPayloadStoreOptions
 
     // When
-    const rawPayload = await getExtensionsPayloadStoreRawPayload(options, 'bundle-path')
+    const rawPayload = await getExtensionsPayloadStoreRawPayload(options)
 
     // Then
     expect(rawPayload.app.allowedDomains).toStrictEqual([])
@@ -411,10 +411,10 @@ describe('ExtensionsPayloadStore()', () => {
       const updatedExtension = {devUUID: '123', updated: 'extension'} as unknown as ExtensionInstance
 
       // When
-      await extensionsPayloadStore.updateExtension(updatedExtension, mockOptions, 'mock-bundle-path', {hidden: true})
+      await extensionsPayloadStore.updateExtension(updatedExtension, mockOptions, {hidden: true})
 
       // Then
-      expect(payload.getUIExtensionPayload).toHaveBeenCalledWith(updatedExtension, 'mock-bundle-path', {
+      expect(payload.getUIExtensionPayload).toHaveBeenCalledWith(updatedExtension, {
         ...mockOptions,
         currentDevelopmentPayload: {hidden: true},
       })
@@ -438,10 +438,10 @@ describe('ExtensionsPayloadStore()', () => {
       const updatedExtension = {devUUID: '123', updated: 'extension'} as unknown as ExtensionInstance
 
       // When
-      await extensionsPayloadStore.updateExtension(updatedExtension, mockOptions, 'mock-bundle-path')
+      await extensionsPayloadStore.updateExtension(updatedExtension, mockOptions)
 
       // Then
-      expect(payload.getUIExtensionPayload).toHaveBeenCalledWith(updatedExtension, 'mock-bundle-path', {
+      expect(payload.getUIExtensionPayload).toHaveBeenCalledWith(updatedExtension, {
         ...mockOptions,
         currentDevelopmentPayload: {
           status: 'success',
@@ -469,10 +469,10 @@ describe('ExtensionsPayloadStore()', () => {
       const updatedExtension = {devUUID: '123', updated: 'extension'} as unknown as ExtensionInstance
 
       // When
-      await extensionsPayloadStore.updateExtension(updatedExtension, mockOptions, 'mock-bundle-path')
+      await extensionsPayloadStore.updateExtension(updatedExtension, mockOptions)
 
       // Then
-      expect(payload.getUIExtensionPayload).toHaveBeenCalledWith(updatedExtension, 'mock-bundle-path', {
+      expect(payload.getUIExtensionPayload).toHaveBeenCalledWith(updatedExtension, {
         ...mockOptions,
         currentDevelopmentPayload: {
           status: 'success',
@@ -497,7 +497,7 @@ describe('ExtensionsPayloadStore()', () => {
       extensionsPayloadStore.on(ExtensionsPayloadStoreEvent.Update, onUpdateSpy)
 
       // When
-      await extensionsPayloadStore.updateExtension(updatedExtension, mockOptions, 'mock-bundle-path')
+      await extensionsPayloadStore.updateExtension(updatedExtension, mockOptions)
 
       // Then
       expect(onUpdateSpy).toHaveBeenCalledWith(['123'])
@@ -517,7 +517,7 @@ describe('ExtensionsPayloadStore()', () => {
       extensionsPayloadStore.on(ExtensionsPayloadStoreEvent.Update, onUpdateSpy)
 
       // When
-      await extensionsPayloadStore.updateExtension(updatedExtension, mockOptions, 'mock-bundle-path')
+      await extensionsPayloadStore.updateExtension(updatedExtension, mockOptions)
 
       // Then
       expect(initialRawPayload).toStrictEqual(extensionsPayloadStore.getRawPayload())

--- a/packages/app/src/cli/services/dev/extension/payload/store.ts
+++ b/packages/app/src/cli/services/dev/extension/payload/store.ts
@@ -35,7 +35,6 @@ export enum ExtensionsPayloadStoreEvent {
 
 export async function getExtensionsPayloadStoreRawPayload(
   options: Omit<ExtensionsPayloadStoreOptions, 'appWatcher'>,
-  bundlePath: string,
 ): Promise<ExtensionsEndpointPayload> {
   const payload: ExtensionsEndpointPayload = {
     app: {
@@ -57,9 +56,7 @@ export async function getExtensionsPayloadStoreRawPayload(
     },
     store: options.storeFqdn,
     extensions: await Promise.all(
-      options.extensions
-        .filter((ext) => ext.isPreviewable)
-        .map((ext) => getUIExtensionPayload(ext, bundlePath, options)),
+      options.extensions.filter((ext) => ext.isPreviewable).map((ext) => getUIExtensionPayload(ext, options)),
     ),
   }
 
@@ -178,7 +175,6 @@ export class ExtensionsPayloadStore extends EventEmitter {
   async updateExtension(
     extension: ExtensionInstance,
     options: Omit<ExtensionsPayloadStoreOptions, 'appWatcher'>,
-    bundlePath: string,
     development?: Partial<UIExtensionPayload['development']>,
   ) {
     const payloadExtensions = this.rawPayload.extensions
@@ -192,7 +188,7 @@ export class ExtensionsPayloadStore extends EventEmitter {
       return
     }
 
-    payloadExtensions[index] = await getUIExtensionPayload(extension, bundlePath, {
+    payloadExtensions[index] = await getUIExtensionPayload(extension, {
       ...this.options,
       currentDevelopmentPayload: development ?? {status: payloadExtensions[index]?.development.status},
       currentLocalizationPayload: payloadExtensions[index]?.localization,
@@ -211,8 +207,8 @@ export class ExtensionsPayloadStore extends EventEmitter {
     }
   }
 
-  async addExtension(extension: ExtensionInstance, bundlePath: string) {
-    this.rawPayload.extensions.push(await getUIExtensionPayload(extension, bundlePath, this.options))
+  async addExtension(extension: ExtensionInstance) {
+    this.rawPayload.extensions.push(await getUIExtensionPayload(extension, this.options))
     this.emitUpdate([extension.devUUID])
   }
 

--- a/packages/app/src/cli/services/dev/extension/server/middlewares.ts
+++ b/packages/app/src/cli/services/dev/extension/server/middlewares.ts
@@ -195,8 +195,6 @@ export function getExtensionPayloadMiddleware({devOptions, getExtensions}: GetEx
         return sendRedirect(event, url, 307)
       }
     }
-    const bundlePath = devOptions.appWatcher.buildOutputPath
-
     setResponseHeader(event, 'content-type', 'application/json')
     return {
       app: {
@@ -213,7 +211,7 @@ export function getExtensionPayloadMiddleware({devOptions, getExtensions}: GetEx
         url: new URL('/extensions/dev-console', devOptions.url).toString(),
       },
       store: devOptions.storeFqdn,
-      extension: await getUIExtensionPayload(extension, bundlePath, devOptions),
+      extension: await getUIExtensionPayload(extension, devOptions),
     }
   })
 }


### PR DESCRIPTION
### WHY are these changes introduced?

The manifest.json was being generated inside `/dist` even though `/dist` should only affect the `bundle_ui` step. Manifest files should be generated in the root of the bundle for consistency.

### **Before**

admin_link

<img src="https://github.com/user-attachments/assets/9b4b6129-c7a6-40a9-9f50-a37228c455cf" alt="image">

```
{
  "admin.app.intent.link": {
    "tools": "tools.json",
    "instructions": "instructions.md",
    "intents": [
      {
        "schema": "intent-schema.json"
      }
    ]
  }
}
```

ui_extension
<img src="https://github.com/user-attachments/assets/78f10208-132c-45c1-9b48-74d32d4303fe" alt="image">

```
{
  "admin.app.tools.data": {
    "main": "app-tools.js",
    "tools": "tools.json",
    "instructions": "instructions.md"
  }
}
```

### After

admin_link (unchanged)

<img src="https://github.com/user-attachments/assets/9b4b6129-c7a6-40a9-9f50-a37228c455cf" alt="image">

```
{
  "admin.app.intent.link": {
    "tools": "tools.json",
    "instructions": "instructions.md",
    "intents": [
      {
        "schema": "intent-schema.json"
      }
    ]
  }
}
```

ui_extension

<img src="https://github.com/user-attachments/assets/7f366670-1ad2-41fe-b50b-e53d00242d39" alt="image">

```
{
  "admin.app.tools.data": {
    "main": "dist/app-tools.js",
    "tools": "tools.json",
    "instructions": "instructions.md"
  }
}
```

### WHAT is this pull request doing?

- Add `bundleRoot` property to `ExtensionInstance` to track the root directory for bundled extensions
- Add `localOutputPath` getter that consistently resolves the extension's local output path
- Refactor `buildForBundle` and `copyIntoBundle` methods to use `bundleRoot` for determining bundle locations
- Update asset inclusion steps to write static assets to `bundleRoot` instead of output directory
- Modify manifest generation to write `manifest.json` to `bundleRoot`
- Update bundle UI step to rewrite asset paths relative to bundle root for consistent resolution
- Remove `bundlePath` parameter from payload generation functions since extensions now track their own bundle locations
- Fix asset payload generation to use correct file paths for timestamp resolution

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing, so I've added a changelog entry with `pnpm changeset add`