### PR TITLE
Make auto-upgrade enabled by default, remove activation prompt

### DIFF
--- a/packages/cli-kit/src/private/node/conf-store.ts
+++ b/packages/cli-kit/src/private/node/conf-store.ts
@@ -268,11 +268,12 @@ export async function runWithRateLimit(options: RunWithRateLimitOptions, config 
 
 /**
  * Get auto-upgrade preference.
+ * Defaults to true if the preference has never been explicitly set.
  *
- * @returns Whether auto-upgrade is enabled, or undefined if never set.
+ * @returns Whether auto-upgrade is enabled.
  */
-export function getAutoUpgradeEnabled(config: LocalStorage<ConfSchema> = cliKitStore()): boolean | undefined {
-  return config.get('autoUpgradeEnabled')
+export function getAutoUpgradeEnabled(config: LocalStorage<ConfSchema> = cliKitStore()): boolean {
+  return config.get('autoUpgradeEnabled') ?? true
 }
 
 /**

--- a/packages/cli-kit/src/public/node/upgrade.test.ts
+++ b/packages/cli-kit/src/public/node/upgrade.test.ts
@@ -230,11 +230,11 @@ describe('versionToAutoUpgrade', () => {
     expect(versionToAutoUpgrade()).toBeUndefined()
   })
 
-  test('returns undefined when auto-upgrade preference has never been set', () => {
+  test('returns the newer version when auto-upgrade preference has never been set (default enabled)', () => {
     vi.mocked(checkForCachedNewVersion).mockReturnValue('3.91.0')
     vi.mocked(isCI).mockReturnValue(false)
-    vi.mocked(getAutoUpgradeEnabled).mockReturnValue(undefined)
-    expect(versionToAutoUpgrade()).toBeUndefined()
+    vi.mocked(getAutoUpgradeEnabled).mockReturnValue(true)
+    expect(versionToAutoUpgrade()).toBe('3.91.0')
   })
 
   test('returns the newer version for a major version change when auto-upgrade is enabled', () => {

--- a/packages/cli-kit/src/public/node/upgrade.ts
+++ b/packages/cli-kit/src/public/node/upgrade.ts
@@ -14,10 +14,10 @@ import {outputContent, outputDebug, outputInfo, outputToken, outputWarn} from '.
 import {cwd, moduleDirectory, sniffForPath} from './path.js'
 import {exec, isCI} from './system.js'
 import {isPreReleaseVersion} from './version.js'
-import {getAutoUpgradeEnabled, runAtMinimumInterval} from '../../private/node/conf-store.js'
+import {getAutoUpgradeEnabled, setAutoUpgradeEnabled, runAtMinimumInterval} from '../../private/node/conf-store.js'
 import {CLI_KIT_VERSION} from '../common/version.js'
 
-export {getAutoUpgradeEnabled}
+export {getAutoUpgradeEnabled, setAutoUpgradeEnabled}
 
 /**
  * Utility function for generating an install command for the user to run

--- a/packages/cli-kit/src/public/node/upgrade.ts
+++ b/packages/cli-kit/src/public/node/upgrade.ts
@@ -13,12 +13,11 @@ import {
 import {outputContent, outputDebug, outputInfo, outputToken, outputWarn} from './output.js'
 import {cwd, moduleDirectory, sniffForPath} from './path.js'
 import {exec, isCI} from './system.js'
-import {renderConfirmationPrompt} from './ui.js'
 import {isPreReleaseVersion} from './version.js'
-import {getAutoUpgradeEnabled, setAutoUpgradeEnabled, runAtMinimumInterval} from '../../private/node/conf-store.js'
+import {getAutoUpgradeEnabled, runAtMinimumInterval} from '../../private/node/conf-store.js'
 import {CLI_KIT_VERSION} from '../common/version.js'
 
-export {getAutoUpgradeEnabled, setAutoUpgradeEnabled}
+export {getAutoUpgradeEnabled}
 
 /**
  * Utility function for generating an install command for the user to run
@@ -81,7 +80,7 @@ export async function runCLIUpgrade(): Promise<void> {
 
 /**
  * Returns the version to auto-upgrade to, or undefined if auto-upgrade should be skipped.
- * Auto-upgrade is disabled by default and must be enabled via `shopify upgrade`.
+ * Auto-upgrade is enabled by default and can be disabled via `setAutoUpgradeEnabled(false)`.
  * Also skips for CI, pre-release versions, or when no newer version is available.
  *
  * @returns The version string to upgrade to, or undefined if no upgrade should happen.
@@ -152,24 +151,6 @@ export function getOutputUpdateCLIReminder(version: string, isMajor = false): st
   }
 
   return base
-}
-
-/**
- * Prompts the user to enable or disable automatic upgrades, then persists their choice.
- *
- * @returns Whether the user chose to enable auto-upgrade.
- */
-export async function promptAutoUpgrade(): Promise<boolean> {
-  const current = getAutoUpgradeEnabled()
-  if (current !== undefined) return current
-
-  const enabled = await renderConfirmationPrompt({
-    message: 'Enable automatic updates for Shopify CLI?',
-    confirmationMessage: 'Yes, automatically update',
-    cancellationMessage: "No, I'll update manually",
-  })
-  setAutoUpgradeEnabled(enabled)
-  return enabled
 }
 
 async function upgradeLocalShopify(projectDir: string, currentVersion: string) {

--- a/packages/cli/src/cli/commands/config/autoupgrade/constants.ts
+++ b/packages/cli/src/cli/commands/config/autoupgrade/constants.ts
@@ -1,5 +1,4 @@
 export const autoUpgradeStatus = {
   on: 'Auto-upgrade on. Shopify CLI will update automatically after each command.',
   off: "Auto-upgrade off. You'll need to run `shopify upgrade` to update manually.",
-  notConfigured: 'Auto-upgrade not configured. Run `shopify config autoupgrade on` to enable it.',
 } as const

--- a/packages/cli/src/cli/commands/config/autoupgrade/status.test.ts
+++ b/packages/cli/src/cli/commands/config/autoupgrade/status.test.ts
@@ -49,9 +49,9 @@ describe('AutoupgradeStatus', () => {
     `)
   })
 
-  test('displays not configured message when never set', async () => {
+  test('displays auto-upgrade on message when never explicitly set (default enabled)', async () => {
     // Given
-    vi.mocked(getAutoUpgradeEnabled).mockReturnValue(undefined)
+    vi.mocked(getAutoUpgradeEnabled).mockReturnValue(true)
     const config = new Config({root: __dirname})
     const outputMock = mockAndCaptureOutput()
     outputMock.clear()
@@ -63,8 +63,7 @@ describe('AutoupgradeStatus', () => {
     expect(outputMock.info()).toMatchInlineSnapshot(`
     "╭─ info ───────────────────────────────────────────────────────────────────────╮
     │                                                                              │
-    │  Auto-upgrade not configured. Run \`shopify config autoupgrade on\` to enable  │
-    │   it.                                                                        │
+    │  Auto-upgrade on. Shopify CLI will update automatically after each command.  │
     │                                                                              │
     ╰──────────────────────────────────────────────────────────────────────────────╯
     "

--- a/packages/cli/src/cli/commands/config/autoupgrade/status.ts
+++ b/packages/cli/src/cli/commands/config/autoupgrade/status.ts
@@ -17,9 +17,7 @@ export default class AutoupgradeStatus extends Command {
 
   async run(): Promise<void> {
     const enabled = getAutoUpgradeEnabled()
-    if (enabled === undefined) {
-      renderInfo({body: autoUpgradeStatus.notConfigured})
-    } else if (enabled) {
+    if (enabled) {
       renderInfo({body: autoUpgradeStatus.on})
     } else {
       renderInfo({body: autoUpgradeStatus.off})

--- a/packages/cli/src/cli/commands/upgrade.test.ts
+++ b/packages/cli/src/cli/commands/upgrade.test.ts
@@ -1,45 +1,15 @@
 import Upgrade from './upgrade.js'
-import {promptAutoUpgrade, runCLIUpgrade} from '@shopify/cli-kit/node/upgrade'
-import {addPublicMetadata} from '@shopify/cli-kit/node/metadata'
-import {describe, test, vi, expect, afterEach} from 'vitest'
+import {runCLIUpgrade} from '@shopify/cli-kit/node/upgrade'
+import {describe, test, vi, expect} from 'vitest'
 
 vi.mock('@shopify/cli-kit/node/upgrade')
-vi.mock('@shopify/cli-kit/node/metadata', () => ({
-  addPublicMetadata: vi.fn().mockResolvedValue(undefined),
-}))
-
-afterEach(() => {
-  vi.mocked(addPublicMetadata).mockClear()
-})
 
 describe('upgrade command', () => {
-  test('calls promptAutoUpgrade and runCLIUpgrade', async () => {
-    vi.mocked(promptAutoUpgrade).mockResolvedValue(true)
+  test('calls runCLIUpgrade directly without prompting', async () => {
     vi.mocked(runCLIUpgrade).mockResolvedValue(undefined)
 
     await Upgrade.run([], import.meta.url)
 
-    expect(promptAutoUpgrade).toHaveBeenCalledOnce()
     expect(runCLIUpgrade).toHaveBeenCalledOnce()
-  })
-
-  test('records env_auto_upgrade_accepted=true when user opts in', async () => {
-    vi.mocked(promptAutoUpgrade).mockResolvedValue(true)
-    vi.mocked(runCLIUpgrade).mockResolvedValue(undefined)
-
-    await Upgrade.run([], import.meta.url)
-
-    const calls = vi.mocked(addPublicMetadata).mock.calls.map((call) => call[0]())
-    expect(calls).toContainEqual(expect.objectContaining({env_auto_upgrade_accepted: true}))
-  })
-
-  test('records env_auto_upgrade_accepted=false when user opts out', async () => {
-    vi.mocked(promptAutoUpgrade).mockResolvedValue(false)
-    vi.mocked(runCLIUpgrade).mockResolvedValue(undefined)
-
-    await Upgrade.run([], import.meta.url)
-
-    const calls = vi.mocked(addPublicMetadata).mock.calls.map((call) => call[0]())
-    expect(calls).toContainEqual(expect.objectContaining({env_auto_upgrade_accepted: false}))
   })
 })

--- a/packages/cli/src/cli/commands/upgrade.ts
+++ b/packages/cli/src/cli/commands/upgrade.ts
@@ -1,6 +1,5 @@
 import Command from '@shopify/cli-kit/node/base-command'
-import {promptAutoUpgrade, runCLIUpgrade} from '@shopify/cli-kit/node/upgrade'
-import {addPublicMetadata} from '@shopify/cli-kit/node/metadata'
+import {runCLIUpgrade} from '@shopify/cli-kit/node/upgrade'
 
 export default class Upgrade extends Command {
   static summary = 'Upgrades Shopify CLI.'
@@ -10,8 +9,6 @@ export default class Upgrade extends Command {
   static description = this.descriptionWithoutMarkdown()
 
   async run(): Promise<void> {
-    const accepted = await promptAutoUpgrade()
-    await addPublicMetadata(() => ({env_auto_upgrade_accepted: accepted}))
     await runCLIUpgrade()
   }
 }


### PR DESCRIPTION
🚨 NOTE: DON'T MERGE UNTIL VERSION 4.0.0 🚨

### WHY are these changes introduced?

Auto-upgrade was opt-in, requiring users to run `shopify upgrade` and answer a prompt before it would ever activate automatically. This made it effectively a no-op for most users who never ran that command. Auto-upgrade should be on by default so everyone benefits from staying up to date.

### WHAT is this pull request doing?

- **`getAutoUpgradeEnabled`** **now defaults to** **`true`** — returns `true` when the preference has never been explicitly set (previously returned `undefined`, which disabled auto-upgrade)
- **Removed** **`promptAutoUpgrade`** — the interactive "Enable automatic updates?" prompt that was the only way to activate auto-upgrade; no longer needed
- **`shopify upgrade`** **runs directly** without prompting the user first
- **`shopify config autoupgrade status`** no longer has a "not configured" state — users see either "on" (the default) or "off"
- **`notConfigured`** **constant removed** from `autoUpgradeStatus`
- Users who previously ran `shopify config autoupgrade off` are unaffected — an explicit `false` stored in their config is respected

### How to test your changes?

1. Fresh install (no prior `autoUpgradeEnabled` in config): run any CLI command — it should auto-upgrade after completion without any setup
2. `shopify config autoupgrade status` → should show "on" by default
3. `shopify config autoupgrade off` → should show "off"; subsequent `status` should show "off"
4. `shopify config autoupgrade on` → re-enables; `status` shows "on"
5. `shopify upgrade` → should run the upgrade directly without any prompt

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [x] The change is user-facing, so I've added a changelog entry with `pnpm changeset add`