### PR TITLE
E2E: trial for more workers

### DIFF
--- a/packages/e2e/playwright.config.ts
+++ b/packages/e2e/playwright.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: isCI,
   retries: 0,
-  workers: 5,
+  workers: 10,
   maxFailures: isCI ? 3 : 0, // Stop early in CI after 3 failures
   reporter: isCI ? [['html', {open: 'never'}], ['list']] : [['list']],
   timeout: TEST_TIMEOUT.default, // Heavy tests override via test.setTimeout()


### PR DESCRIPTION
### WHY are these changes introduced?

Evaluate whether increasing E2E parallel workers from 5 (#7309) to 10 improves CI run time enough to justify the added resource pressure on our 4 vCPU CI runners.

### WHAT is this pull request doing?

Bumps E2E worker count to 10 for benchmarking against the 5-worker baseline in #7309.

**Benchmark Results:**
(under stable conditions, very few teardown failures or flaky retries)

| | 5 workers (#7309) | 10 workers (#7343) | Savings |
|---|---|---|---|
| Local | 8.8 min | 6.3 min | 2.5 min (28%) |
| CI | [11m 43s](https://github.com/Shopify/cli/actions/runs/24569664292/job/71839131367?pr=7309) | [8m 49s](https://github.com/Shopify/cli/actions/runs/24573531702/job/71852777661?pr=7343) | 2m 54s (25%) |

**Conclusion:** Sticking with 5 workers. ~3 min CI savings is nice but not worth the tradeoff:
- More parallel store creation/teardown = more surface area for flaky cleanup
- 4 vCPU CI runner is already tight with 5 workers; 10 doubles contention
- Once teardown is more robust, bumping workers is a one-line config change

**CI runner specs:** `ubuntu-latest` = 4 vCPUs, 16 GB RAM ([GitHub docs](https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories)).

### How to test your changes?

Compare CI run times between this PR and #7309.

### Post-release steps

N/A — trial branch, not intended to merge.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing, so I've added a changelog entry with `pnpm changeset add`