### PR TITLE
Fix error for running build when there is multiple admin links and ui extensions

### DIFF
--- a/packages/app/src/cli/models/extensions/specification.integration.test.ts
+++ b/packages/app/src/cli/models/extensions/specification.integration.test.ts
@@ -109,6 +109,23 @@ describe('createExtensionSpecification', () => {
     // Then
     expect(got.clientSteps).toEqual(testClientSteps)
   })
+
+  test('does not let explicit-undefined spec keys shadow the computed defaults', () => {
+    // When — wrapper-helper style: optional fields are forwarded as `undefined`
+    const got = createExtensionSpecification({
+      identifier: 'test_extension',
+      appModuleFeatures: () => [],
+      experience: undefined,
+      uidStrategy: undefined,
+      buildConfig: undefined,
+      clientSteps: undefined,
+    })
+
+    // Then — defaults apply instead of `undefined` leaking through
+    expect(got.experience).toBe('extension')
+    expect(got.uidStrategy).toBe('uuid')
+    expect(got.buildConfig).toEqual({mode: 'none'})
+  })
 })
 
 describe('createConfigExtensionSpecification', () => {

--- a/packages/app/src/cli/models/extensions/specification.ts
+++ b/packages/app/src/cli/models/extensions/specification.ts
@@ -10,7 +10,7 @@ import {ApplicationURLs} from '../../services/dev/urls.js'
 import {Result} from '@shopify/cli-kit/node/result'
 import {capitalize} from '@shopify/cli-kit/common/string'
 import {ParseConfigurationResult, zod} from '@shopify/cli-kit/node/schema'
-import {getPathValue, setPathValue} from '@shopify/cli-kit/common/object'
+import {getPathValue, pickBy, setPathValue} from '@shopify/cli-kit/common/object'
 import {JsonMapType} from '@shopify/cli-kit/node/toml'
 
 export type ExtensionFeature =
@@ -222,7 +222,12 @@ export function createExtensionSpecification<TConfiguration extends BaseConfigTy
     clientSteps: spec.clientSteps,
     buildConfig: spec.buildConfig ?? {mode: 'none'},
   }
-  const merged = {...defaults, ...spec}
+  // Strip undefined keys from `spec` before merging so wrapper helpers that
+  // forward optional fields as explicit `undefined` don't shadow the defaults.
+  const definedSpec = pickBy(spec as unknown as Record<string, unknown>, (value) => value !== undefined) as Partial<
+    CreateExtensionSpecType<TConfiguration>
+  >
+  const merged = {...defaults, ...definedSpec} as typeof defaults & CreateExtensionSpecType<TConfiguration>
 
   return {
     ...merged,


### PR DESCRIPTION
### WHY are these changes introduced?

When wrapper helpers forward optional fields as explicit `undefined`, those `undefined` values were shadowing the computed defaults in `createExtensionSpecification`. This meant fields like `experience`, `uidStrategy`, and `buildConfig` could end up as `undefined` instead of their intended default values.

### WHAT is this pull request doing?

Before merging the caller-supplied `spec` object into the defaults, explicit `undefined` values are stripped from `spec` using `pickBy`. This ensures that defaults are preserved when optional fields are forwarded as `undefined` by wrapper helpers, rather than being overwritten.

A regression test is added to verify that explicitly passing `undefined` for `experience`, `uidStrategy`, `buildConfig`, and `clientSteps` still results in the correct defaults being applied.

### How to test your changes?

Run the integration tests for the extension specification:

```
pnpm test packages/app/src/cli/models/extensions/specification.integration.test.ts
```

The new test case `does not let explicit-undefined spec keys shadow the computed defaults` should pass.

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct bump type (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](../CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`