### PR TITLE
Track installation package manager in analytics

### DIFF
--- a/packages/cli-kit/src/private/node/analytics.ts
+++ b/packages/cli-kit/src/private/node/analytics.ts
@@ -8,7 +8,7 @@ import * as metadata from '../../public/node/metadata.js'
 import {platformAndArch} from '../../public/node/os.js'
 import {ciPlatform, cloudEnvironment, macAddress} from '../../public/node/context/local.js'
 import {cwd} from '../../public/node/path.js'
-import {currentProcessIsGlobal} from '../../public/node/is-global.js'
+import {currentProcessIsGlobal, inferPackageManagerForGlobalCLI} from '../../public/node/is-global.js'
 import {isWsl} from '../../public/node/system.js'
 
 import {Command, Interfaces} from '@oclif/core'
@@ -64,6 +64,7 @@ interface EnvironmentData {
   env_device_id: string
   env_cloud: string
   env_package_manager: string
+  env_install_package_manager: string
   env_is_global: boolean
   env_auth_method: string
   env_is_wsl: boolean
@@ -90,6 +91,7 @@ export async function getEnvironmentData(config: Interfaces.Config): Promise<Env
     env_device_id: hashString(await macAddress()),
     env_cloud: cloudEnvironment().platform,
     env_package_manager: await getPackageManager(cwd()),
+    env_install_package_manager: inferPackageManagerForGlobalCLI(),
     env_is_global: currentProcessIsGlobal(),
     env_auth_method: await getLastSeenAuthMethod(),
     env_is_wsl: await isWsl(),

--- a/packages/cli-kit/src/public/node/monorail.ts
+++ b/packages/cli-kit/src/public/node/monorail.ts
@@ -167,6 +167,7 @@ export interface Schemas {
       env_ci_platform?: Optional<string>
       env_device_id?: Optional<string>
       env_package_manager?: Optional<string>
+      env_install_package_manager?: Optional<string>
       env_package_manager_workspaces?: Optional<boolean>
       env_plugin_installed_any_custom?: Optional<boolean>
       env_plugin_installed_shopify?: Optional<string>

--- a/packages/cli-kit/src/public/node/monorail.ts
+++ b/packages/cli-kit/src/public/node/monorail.ts
@@ -10,7 +10,7 @@ const url = 'https://monorail-edge.shopifysvc.com/v1/produce'
 type Optional<T> = T | null
 
 // This is the topic name of the main event we log to Monorail, the command tracker
-export const MONORAIL_COMMAND_TOPIC = 'app_cli3_command/1.21'
+export const MONORAIL_COMMAND_TOPIC = 'app_cli3_command/1.22'
 
 export interface Schemas {
   [MONORAIL_COMMAND_TOPIC]: {


### PR DESCRIPTION
## Problem

~34% of CLI users (77K unique devices in the last 30 days) have `unknown` as their package manager in analytics. This happens because `cmd_all_launcher` and `env_package_manager` both rely on `npm_config_user_agent`, which is only set when a package manager *spawns* the CLI process. Users who run the `shopify` binary directly from the shell (the common case for global installs) never have this env var set.

Global installs are 85% of all CLI traffic, and 39% of those events have `unknown` package manager.

## Solution

Add a new `env_install_package_manager` field to the analytics payload, populated by `inferPackageManagerForGlobalCLI()` — a function that was already written, tested, and used for upgrade logic, but never wired into analytics.

Detection logic (in priority order):
1. `SHOPIFY_HOMEBREW_FORMULA` env var → `homebrew` (injected by the brew formula wrapper — most reliable)
2. Resolved binary path contains `yarn` / `pnpm` / `bun` → respective PM
3. Resolved binary path contains `/cellar/` → `homebrew` (symlink resolved Intel/AS Mac path)
4. Fallback → `npm`

Paths are already lowercased before matching, so Windows paths with mixed case (e.g. `Yarn`) are handled correctly.

## What changes

- `analytics.ts`: import and call `inferPackageManagerForGlobalCLI()`, add `env_install_package_manager` to `EnvironmentData` interface and return value
- `monorail.ts`: add `env_install_package_manager` to the public payload schema

## Note on existing fields

This is intentionally a *new* field rather than replacing `env_package_manager`. The two fields mean different things:
- `env_package_manager` — the project's package manager (detected via lockfile in cwd)
- `env_install_package_manager` — how the CLI itself was installed globally

## Test plan

- [x] Existing tests pass (`analytics.test.ts`, `is-global.test.ts`)
- [ ] Verify `env_install_package_manager` appears in Monorail events after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)