### PR TITLE
E2E: trial for shards

### DIFF
--- a/.github/workflows/tests-pr.yml
+++ b/.github/workflows/tests-pr.yml
@@ -216,11 +216,15 @@ jobs:
         run: exit 1
 
   e2e-tests:
-    name: 'E2E tests'
+    name: "E2E tests (shard ${{ matrix.shard }})"
     if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 20
     continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: ['1/2', '2/2']
     steps:
       - uses: actions/checkout@v3
         with:
@@ -245,19 +249,19 @@ jobs:
           E2E_ACCOUNT_PASSWORD: ${{ secrets.E2E_ACCOUNT_PASSWORD }}
           E2E_STORE_FQDN: ${{ secrets.E2E_STORE_FQDN }}
           E2E_ORG_ID: ${{ secrets.E2E_ORG_ID }}
-        run: pnpm exec playwright test
+        run: pnpm exec playwright test --shard ${{ matrix.shard }}
       - name: Upload Playwright report
         uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}
         with:
-          name: playwright-report
+          name: playwright-report-${{ strategy.job-index }}
           path: packages/e2e/playwright-report/
           retention-days: 14
       - name: Upload test results
         uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}
         with:
-          name: playwright-results
+          name: playwright-results-${{ strategy.job-index }}
           path: packages/e2e/test-results/
           retention-days: 14
 


### PR DESCRIPTION
### WHY are these changes introduced?

Evaluate whether sharding E2E tests across 2 CI machines (as suggested by @gonzaloriestra in #7309) improves wall-clock time compared to running all tests on a single machine.

Currently E2E tests run on a single `ubuntu-latest` runner (4 vCPUs, 16 GB RAM — [GitHub docs](https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories)). With 2 shards, each machine runs ~half the test files with 5 workers each.

### WHAT is this pull request doing?

Adds a matrix strategy with `shard: ['1/2', '2/2']` to the E2E CI job, passing `--shard` to Playwright. Each shard uploads artifacts with unique names to avoid collisions.

**Benchmark Results:**
(under stable conditions, very few teardown failures or flaky retries)

| | #7309 | #7343 | #7349 |
|---|---|---|---|
| **Workers** | 5 | 10 | 5 |
| **Shards** | 1 | 1 | 2 |
| **CI runtime** | [11m 43s](https://github.com/Shopify/cli/actions/runs/24569664292/job/71839131367?pr=7309) | [8m 49s](https://github.com/Shopify/cli/actions/runs/24573531702/job/71852777661?pr=7343) | [8m 59s (shard 1/2)](https://github.com/Shopify/cli/actions/runs/24672937581/job/72148609087?pr=7349) <br> [7m 41s (shard 2/2)](https://github.com/Shopify/cli/actions/runs/24672937581/job/72148609070?pr=7349) |

### How to test your changes?

Compare CI run times between this PR, #7309 (5 workers baseline), and #7343 (10 workers).

### Post-release steps

N/A — trial branch, not intended to merge.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing, so I've added a changelog entry with `pnpm changeset add`