### PR TITLE
E2E: trial for more workers + shards

### DIFF
--- a/.github/workflows/tests-pr.yml
+++ b/.github/workflows/tests-pr.yml
@@ -216,11 +216,15 @@ jobs:
         run: exit 1
 
   e2e-tests:
-    name: 'E2E tests'
+    name: "E2E tests (shard ${{ matrix.shard }})"
     if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 20
     continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: ['1/2', '2/2']
     steps:
       - uses: actions/checkout@v3
         with:
@@ -245,19 +249,19 @@ jobs:
           E2E_ACCOUNT_PASSWORD: ${{ secrets.E2E_ACCOUNT_PASSWORD }}
           E2E_STORE_FQDN: ${{ secrets.E2E_STORE_FQDN }}
           E2E_ORG_ID: ${{ secrets.E2E_ORG_ID }}
-        run: pnpm exec playwright test
+        run: pnpm exec playwright test --shard ${{ matrix.shard }}
       - name: Upload Playwright report
         uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}
         with:
-          name: playwright-report
+          name: playwright-report-${{ strategy.job-index }}
           path: packages/e2e/playwright-report/
           retention-days: 14
       - name: Upload test results
         uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}
         with:
-          name: playwright-results
+          name: playwright-results-${{ strategy.job-index }}
           path: packages/e2e/test-results/
           retention-days: 14
 

--- a/packages/e2e/playwright.config.ts
+++ b/packages/e2e/playwright.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: isCI,
   retries: 0,
-  workers: 5,
+  workers: 10,
   maxFailures: isCI ? 3 : 0, // Stop early in CI after 3 failures
   reporter: isCI ? [['html', {open: 'never'}], ['list']] : [['list']],
   timeout: TEST_TIMEOUT.default, // Heavy tests override via test.setTimeout()


### PR DESCRIPTION
### WHY are these changes introduced?

Evaluate whether combining more workers (10) with sharding (2 CI machines) gives the best E2E runtime, since each shard gets its own 4 vCPU runner — avoiding the contention that hurt 10 workers on a single machine.

CI runner specs: `ubuntu-latest` = 4 vCPUs, 16 GB RAM ([GitHub docs](https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories)).

### Decision: ship this PR

**Cost is not a concern** — GitHub Actions standard runners are [free for public repositories](https://docs.github.com/en/billing/concepts/product-billing/github-actions#how-use-of-github-actions-is-measured), and `Shopify/cli` is public. The "2x CI machine cost" con listed below does not apply.

**CPU contention is the same as baseline** — with 2 shards, each machine runs ~5 workers on 4 vCPUs. That's identical to the current 5 workers / 1 shard setup. The contention concern only applied to 10 workers / 1 shard (#7343).

**Only real tradeoffs:**
- 2x setup overhead (build, Playwright install, OAuth auth duplicated per shard)
- Split artifacts — two Playwright reports instead of one
- 2x concurrent API pressure on the same org (up to 10 tests hitting Shopify APIs simultaneously instead of 5) — could increase transient failures, but flakiness observed so far appears to be inherent to the UI, not load-related

**~4 min wall-clock savings (34% reduction)** justifies these tradeoffs, especially if E2E becomes a required check. This is also a one-line config change to revert if needed.

([Slack discussion](https://shopify.slack.com/archives/C05E3BDFDRB/p1776701093844949))

### WHAT is this pull request doing?

- Bumps workers to 10 in `playwright.config.ts`
- Adds a matrix strategy with `shard: ['1/2', '2/2']` to the E2E CI job
- Each shard uploads artifacts with unique names to avoid collisions

**Benchmark Results:**
(under stable conditions, very few teardown failures or flaky retries)

| | #7309 | #7343 | #7349 | #7350 |
|---|---|---|---|---|
| **Workers** | 5 | 10 | 5 | 10 |
| **Shards** | 1 | 1 | 2 | 2 |
| **CI runtime** | [11m 43s](https://github.com/Shopify/cli/actions/runs/24569664292/job/71839131367?pr=7309) | [8m 49s](https://github.com/Shopify/cli/actions/runs/24573531702/job/71852777661?pr=7343) | [8m 59s (shard 1/2)](https://github.com/Shopify/cli/actions/runs/24672937581/job/72148609087?pr=7349) <br> [7m 41s (shard 2/2)](https://github.com/Shopify/cli/actions/runs/24672937581/job/72148609070?pr=7349) | [7m 44s (shard 1/2)](https://github.com/Shopify/cli/actions/runs/24673491666/job/72150708359?pr=7350) <br> [5m 48s (shard 2/2)](https://github.com/Shopify/cli/actions/runs/24673491666/job/72150708366?pr=7350) |

**10 workers + 2 shards vs 5 workers + 1 shard (baseline #7309):**

Pros:
- ~4 min faster wall clock (7m 44s vs 11m 43s, 34% reduction), or even faster without teardown failure.
- Sharding distributes load across machines, reducing per-runner CPU/memory pressure

Cons:
- ~~2x CI machine cost (two runners instead of one)~~ — not applicable, free for public repos
- 2x setup overhead (build, playwright install, OAuth auth — all duplicated per shard)
- Split artifacts — two separate Playwright reports to check instead of one
- ~~10 workers on 4 vCPU is still tight per machine~~ — same ratio as baseline with 2 shards (5 workers per 4 vCPU)

Note: Total number of stores/apps created is the same regardless of workers/shards — it's determined by the number of tests. More workers/shards only increases how many run *concurrently*, not the total count.

### How to test your changes?

Compare CI run times across all four trial PRs.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing, so I've added a changelog entry with `pnpm changeset add`