### PR TITLE
Fix `shopify app build` failing for UI extensions with same-path copy

### DIFF
--- a/.changeset/fix-bundle-ui-same-path-copy.md
+++ b/.changeset/fix-bundle-ui-same-path-copy.md
@@ -1,5 +1,0 @@
----
-'@shopify/app': patch
----
-
-Fix `shopify app build` failing for UI extensions with `Source and destination must not be the same`. The bundle_ui step was unconditionally copying the bundled output into the extension's bundle directory, but during a plain build those paths are the same directory.

--- a/.changeset/fix-bundle-ui-same-path-copy.md
+++ b/.changeset/fix-bundle-ui-same-path-copy.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Fix `shopify app build` failing for UI extensions with `Source and destination must not be the same`. The bundle_ui step was unconditionally copying the bundled output into the extension's bundle directory, but during a plain build those paths are the same directory.

--- a/packages/app/src/cli/services/build/steps/bundle-ui-step.test.ts
+++ b/packages/app/src/cli/services/build/steps/bundle-ui-step.test.ts
@@ -1,0 +1,60 @@
+import {executeBundleUIStep} from './bundle-ui-step.js'
+import * as buildExtension from '../extension.js'
+import {BundleUIStep, BuildContext} from '../client-steps.js'
+import {ExtensionInstance} from '../../../models/extensions/extension-instance.js'
+import {describe, expect, test, vi, beforeEach} from 'vitest'
+import * as fs from '@shopify/cli-kit/node/fs'
+
+vi.mock('@shopify/cli-kit/node/fs')
+vi.mock('../extension.js')
+
+describe('executeBundleUIStep', () => {
+  let mockContext: BuildContext
+
+  beforeEach(() => {
+    mockContext = {
+      extension: {
+        directory: '/test/extension',
+        outputPath: '/test/extension/dist/handle.js',
+        configuration: {},
+      } as ExtensionInstance,
+      options: {
+        stdout: {write: vi.fn()} as any,
+        stderr: {write: vi.fn()} as any,
+        app: {} as any,
+        environment: 'production',
+      },
+      stepResults: new Map(),
+    }
+  })
+
+  const step: BundleUIStep = {
+    id: 'bundle-ui',
+    name: 'Bundle UI Extension',
+    type: 'bundle_ui',
+    config: {generatesAssetsManifest: false},
+  }
+
+  test('skips the copy when local and bundle output directories are identical', async () => {
+    // Given
+    vi.mocked(buildExtension.buildUIExtension).mockResolvedValue('/test/extension/dist/handle.js')
+
+    // When
+    await executeBundleUIStep(step, mockContext)
+
+    // Then — fs-extra would throw "Source and destination must not be the same"
+    expect(fs.copyFile).not.toHaveBeenCalled()
+  })
+
+  test('copies when local and bundle output directories differ', async () => {
+    // Given
+    mockContext.extension.outputPath = '/bundle/handle/handle.js'
+    vi.mocked(buildExtension.buildUIExtension).mockResolvedValue('/test/extension/dist/handle.js')
+
+    // When
+    await executeBundleUIStep(step, mockContext)
+
+    // Then
+    expect(fs.copyFile).toHaveBeenCalledWith('/test/extension/dist', '/bundle/handle')
+  })
+})

--- a/packages/app/src/cli/services/build/steps/bundle-ui-step.ts
+++ b/packages/app/src/cli/services/build/steps/bundle-ui-step.ts
@@ -21,8 +21,12 @@ interface ExtensionPointWithBuildManifest {
 export async function executeBundleUIStep(step: BundleUIStep, context: BuildContext): Promise<void> {
   const config = context.extension.configuration
   const localOutputPath = await buildUIExtension(context.extension, context.options)
-  // Copy the locally built files into the bundle
-  await copyFile(dirname(localOutputPath), dirname(context.extension.outputPath))
+  // When invoked outside a bundle directory (e.g. `shopify app build`), localOutputPath and outputPath collapse onto the same directory; fs-extra rejects same-path copies.
+  const localOutputDir = dirname(localOutputPath)
+  const bundleOutputDir = dirname(context.extension.outputPath)
+  if (localOutputDir !== bundleOutputDir) {
+    await copyFile(localOutputDir, bundleOutputDir)
+  }
 
   if (!step.config?.generatesAssetsManifest) return
 


### PR DESCRIPTION
### WHY are these changes introduced?

Running `pnpm shopify app build` for an app with a UI extension fails with:

```
Build step "Bundle UI Extension" failed: Source and destination must not be the same.
  at (.pnpm/fs-extra@11.1.0/node_modules/fs-extra/lib/util/stat.js:49)
```

The `bundle_ui` client step (added in #7334) unconditionally copies the locally-bundled extension output into the bundle directory. During a plain build the extension's `outputPath` is never reassigned to a separate bundle directory (that only happens via `buildForBundle`/`copyIntoBundle` in the deploy flow), so source and destination collapse onto the same directory and `fs-extra` rejects the copy.

### WHAT is this pull request doing?

Skip the copy when both `dirname(localOutputPath)` and `dirname(extension.outputPath)` resolve to the same directory.

- `packages/app/src/cli/services/build/steps/bundle-ui-step.ts` — guard the `copyFile` call.
- `packages/app/src/cli/services/build/steps/bundle-ui-step.test.ts` — new unit test covering both branches (same-directory no-op and different-directory copy).
- `.changeset/fix-bundle-ui-same-path-copy.md` — patch changeset against `@shopify/app`.

### How to test your changes?

```sh
pnpm shopify app build --path /path/to/app-with-ui-extension
```

Should succeed and produce `dist/<handle>.js` inside the extension directory.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [x] The change is user-facing — `patch` changeset added against `@shopify/app`