### PR TITLE
E2E: utility - cleanup apps

### DIFF
--- a/packages/e2e/scripts/cleanup-apps.ts
+++ b/packages/e2e/scripts/cleanup-apps.ts
@@ -1,0 +1,410 @@
+/* eslint-disable no-console, no-restricted-imports, no-await-in-loop */
+
+/**
+ * E2E Cleanup Utility
+ *
+ * Finds and deletes leftover E2E test apps from the Dev Dashboard.
+ * Apps are matched by the "E2E-" prefix in their name.
+ *
+ * Usage:
+ *   pnpm --filter e2e exec tsx scripts/cleanup-apps.ts              # Full cleanup: uninstall + delete
+ *   pnpm --filter e2e exec tsx scripts/cleanup-apps.ts --list        # List matching apps without action
+ *   pnpm --filter e2e exec tsx scripts/cleanup-apps.ts --uninstall   # Uninstall from all stores only (no delete)
+ *   pnpm --filter e2e exec tsx scripts/cleanup-apps.ts --delete      # Delete only (skip uninstall — delete only apps with 0 installs)
+ *   pnpm --filter e2e exec tsx scripts/cleanup-apps.ts --headed      # Show browser window
+ *   pnpm --filter e2e exec tsx scripts/cleanup-apps.ts --pattern X   # Match apps containing "X" (default: "E2E-")
+ *
+ * Environment variables (loaded from packages/e2e/.env):
+ *   E2E_ACCOUNT_EMAIL    — Shopify account email for login
+ *   E2E_ACCOUNT_PASSWORD — Shopify account password
+ *   E2E_ORG_ID           — Organization ID to scan for apps
+ */
+
+import {config} from 'dotenv'
+import * as path from 'path'
+import {fileURLToPath} from 'url'
+import {chromium} from '@playwright/test'
+import {BROWSER_TIMEOUT} from '../setup/constants.js'
+import {navigateToDashboard, refreshIfPageError, trackMainFrameStatus} from '../setup/browser.js'
+import {deleteAppFromDevDashboard} from '../setup/app.js'
+import {uninstallAppFromStore} from '../setup/store.js'
+import {completeLogin} from '../helpers/browser-login.js'
+import type {Page} from '@playwright/test'
+
+// Load .env from packages/e2e/ (not cwd) only if not already configured
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+if (!process.env.E2E_ACCOUNT_EMAIL || !process.env.E2E_ACCOUNT_PASSWORD || !process.env.E2E_ORG_ID) {
+  config({path: path.resolve(__dirname, '../.env')})
+}
+
+// ---------------------------------------------------------------------------
+// Core cleanup logic — reusable from tests, teardown, or CLI
+// ---------------------------------------------------------------------------
+
+export type CleanupMode = 'full' | 'list' | 'uninstall' | 'delete'
+
+const MODE_LABELS: Record<CleanupMode, string> = {
+  full: 'Uninstall + Delete',
+  list: 'List only',
+  uninstall: 'Uninstall only',
+  delete: 'Delete only',
+}
+
+export interface CleanupOptions {
+  /** Cleanup mode (default: "full" — uninstall + delete) */
+  mode?: CleanupMode
+  /** App name pattern to match (default: "E2E-") */
+  pattern?: string
+  /** Show browser window */
+  headed?: boolean
+  /** Organization ID (default: from E2E_ORG_ID env) */
+  orgId?: string
+}
+
+/**
+ * Find and delete all E2E test apps matching a pattern.
+ * Handles browser login, dashboard navigation, uninstall, and deletion.
+ */
+export async function cleanupAllApps(opts: CleanupOptions = {}): Promise<void> {
+  const mode = opts.mode ?? 'full'
+  const pattern = opts.pattern ?? 'E2E-'
+  const orgId = opts.orgId ?? (process.env.E2E_ORG_ID ?? '').trim()
+  const email = process.env.E2E_ACCOUNT_EMAIL
+  const password = process.env.E2E_ACCOUNT_PASSWORD
+
+  // Banner
+  console.log('')
+  console.log(`[cleanup-apps] Mode:    ${MODE_LABELS[mode]}`)
+  console.log(`[cleanup-apps] Org:     ${orgId || '(not set)'}`)
+  console.log(`[cleanup-apps] Pattern: "${pattern}"`)
+  console.log('')
+
+  if (!email || !password) {
+    throw new Error('E2E_ACCOUNT_EMAIL and E2E_ACCOUNT_PASSWORD are required')
+  }
+
+  if (!orgId) {
+    throw new Error('E2E_ORG_ID is required')
+  }
+
+  const browser = await chromium.launch({headless: !opts.headed})
+  const context = await browser.newContext({
+    extraHTTPHeaders: {
+      'X-Shopify-Loadtest-Bf8d22e7-120e-4b5b-906c-39ca9d5499a9': 'true',
+    },
+  })
+  context.setDefaultTimeout(BROWSER_TIMEOUT.max)
+  context.setDefaultNavigationTimeout(BROWSER_TIMEOUT.max)
+  const page = await context.newPage()
+  trackMainFrameStatus(page)
+  const totalStart = Date.now()
+
+  try {
+    // Step 1: Log into Shopify directly in the browser
+    console.log('[cleanup-apps] Logging in...')
+    await completeLogin(page, 'https://accounts.shopify.com/lookup', email, password)
+    console.log('[cleanup-apps] Logged in successfully.')
+
+    // Step 2: Navigate to dashboard (retry on 500/502).
+    // navigateToDashboard already refreshes once on error; this loop is extra resilience.
+    console.log('[cleanup-apps] Navigating to dashboard...')
+    await navigateToDashboard({browserPage: page, email, orgId})
+    for (let attempt = 1; attempt <= 3; attempt++) {
+      if (!(await refreshIfPageError(page))) break
+      if (attempt === 3) throw new Error('Dashboard returned server error after 3 attempts, aborting cleanup')
+      console.log(`[cleanup-apps] Dashboard server error (${attempt}/3), retrying...`)
+    }
+    console.log('[cleanup-apps] Dashboard loaded.')
+
+    // Step 3: Find matching apps
+    console.log('[cleanup-apps] Finding matching apps...')
+    const apps = await findAppsOnDashboard(page, pattern)
+    console.log(`[cleanup-apps] Found ${apps.length} app(s) matching pattern "${pattern}"`)
+    console.log('')
+
+    if (apps.length === 0) return
+
+    for (let i = 0; i < apps.length; i++) {
+      const app = apps[i]!
+      console.log(`  ${i + 1}. ${app.name} (${app.installs} install${app.installs !== 1 ? 's' : ''})`)
+    }
+    console.log('')
+
+    if (mode === 'list') return
+
+    // Step 4: Process each app with retries
+    let succeeded = 0
+    let skipped = 0
+    let failed = 0
+
+    for (let i = 0; i < apps.length; i++) {
+      const app = apps[i]!
+      const tag = `[cleanup-apps] [${i + 1}/${apps.length}]`
+      const appStart = Date.now()
+      let uninstalled = false
+      let wasSkipped = false
+
+      console.log(`${tag} ${app.name}`)
+
+      for (let attempt = 1; attempt <= 3; attempt++) {
+        try {
+          if (attempt > 1) {
+            console.log(`  (${attempt}/3) retrying...`)
+            await navigateToDashboard({browserPage: page, email, orgId})
+          }
+
+          if (mode === 'full' || mode === 'uninstall') {
+            if (app.installs === 0) {
+              if (mode === 'uninstall') {
+                console.log('  Not installed (skipped)')
+                wasSkipped = true
+                skipped++
+                break
+              }
+              console.log('  Not installed')
+            } else {
+              console.log('  Uninstalling...')
+              const allUninstalled = await uninstallApp(page, app.url, app.name)
+              if (!allUninstalled) {
+                throw new Error('Uninstall incomplete — some stores may remain')
+              }
+              console.log('  Uninstalled')
+            }
+          }
+
+          if (mode === 'full' || mode === 'delete') {
+            if (mode === 'delete' && app.installs > 0) {
+              console.log('  Delete skipped (still installed)')
+              wasSkipped = true
+              skipped++
+              break
+            }
+            console.log('  Deleting...')
+            const deleted = await deleteAppFromDevDashboard(page, app.url)
+            if (!deleted) throw new Error('App deletion could not be verified')
+            console.log('  Deleted')
+          }
+
+          uninstalled = true
+          break
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err)
+          // Fail fast if the app still has installs — retries won't help
+          if (msg === 'STILL_HAS_INSTALLS') {
+            console.log('  Delete skipped (still has installs — dashboard count may be stale)')
+            wasSkipped = true
+            skipped++
+            break
+          }
+          if (attempt < 3) {
+            console.warn(`  (${attempt}/3) failed: ${msg}`)
+            await page.waitForTimeout(BROWSER_TIMEOUT.medium)
+          } else {
+            console.warn(`  Failed: ${msg}`)
+          }
+        }
+      }
+
+      if (uninstalled) succeeded++
+      else if (!wasSkipped) failed++
+      const appElapsed = ((Date.now() - appStart) / 1000).toFixed(1)
+      console.log(`  (${appElapsed}s)`)
+      console.log('')
+    }
+
+    // Summary
+    const parts = [`${succeeded} succeeded`]
+    if (skipped > 0) parts.push(`${skipped} skipped`)
+    if (failed > 0) parts.push(`${failed} failed`)
+    console.log('')
+    const totalElapsed = ((Date.now() - totalStart) / 1000).toFixed(1)
+    console.log(`[cleanup-apps] Complete: ${parts.join(', ')} (${totalElapsed}s total)`)
+    if (failed > 0) process.exitCode = 1
+  } finally {
+    await browser.close()
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Dashboard browser helpers — bulk discovery and cleanup
+// ---------------------------------------------------------------------------
+
+/** Find apps matching a name pattern on the dashboard. Handles pagination. */
+async function findAppsOnDashboard(
+  page: Page,
+  namePattern: string,
+): Promise<{name: string; url: string; installs: number}[]> {
+  const apps: {name: string; url: string; installs: number}[] = []
+  let totalSeen = 0
+
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    // Recover from transient 500/502 before parsing the page
+    for (let attempt = 1; attempt <= 3; attempt++) {
+      if (!(await refreshIfPageError(page))) break
+      if (attempt === 3) throw new Error('Apps page returned server error after 3 attempts')
+      console.log(`[cleanup-apps]   ...server error on apps page (${attempt}/3), retrying`)
+    }
+
+    const appCards = await page.locator('a[href*="/apps/"]').all()
+
+    for (const card of appCards) {
+      const href = await card.getAttribute('href')
+      const text = await card.textContent()
+      if (!href || !text || !href.match(/\/apps\/\d+/)) continue
+
+      totalSeen++
+
+      const name = text.split(/\d+\s+install/i)[0]?.trim() ?? text.split('\n')[0]?.trim() ?? text.trim()
+      if (!name || name.length > 200) continue
+      if (!name.includes(namePattern)) continue
+
+      const installMatch = text.match(/(\d+)\s+install/i)
+      const installs = installMatch ? parseInt(installMatch[1]!, 10) : 0
+
+      const url = href.startsWith('http') ? href : `https://dev.shopify.com${href}`
+      apps.push({name, url, installs})
+    }
+
+    console.log(`[cleanup-apps]   ...loaded ${totalSeen} apps`)
+
+    // Check for next page — navigate via href since the button click may not work
+    const nextLink = page.locator('a[href*="next_cursor"]').first()
+    if (!(await nextLink.isVisible({timeout: BROWSER_TIMEOUT.medium}).catch(() => false))) break
+    const nextHref = await nextLink.getAttribute('href')
+    if (!nextHref) break
+    const nextUrl = nextHref.startsWith('http') ? nextHref : `https://dev.shopify.com${nextHref}`
+    await page.goto(nextUrl, {waitUntil: 'domcontentloaded'})
+    await page.waitForTimeout(BROWSER_TIMEOUT.medium)
+  }
+
+  return apps
+}
+
+/** Uninstall an app from all stores via the admin UI menu. Returns true if fully uninstalled. */
+async function uninstallApp(
+  page: Page,
+  appUrl: string,
+  appName: string,
+): Promise<boolean> {
+  // Collect store slugs from the installs page (with pagination)
+  const storeSlugs: string[] = []
+  await page.goto(`${appUrl}/installs`, {waitUntil: 'domcontentloaded'})
+  await page.waitForTimeout(BROWSER_TIMEOUT.medium)
+
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    // Use full HTML to catch FQDNs in hrefs/attributes and visible text
+    const slugsBefore = storeSlugs.length
+    const pageHtml = await page.content()
+    const fqdnRegex = /([\w-]+)\.myshopify\.com/g
+    let fqdnMatch = fqdnRegex.exec(pageHtml)
+    while (fqdnMatch) {
+      const slug = fqdnMatch[1]!
+      if (!storeSlugs.includes(slug)) storeSlugs.push(slug)
+      fqdnMatch = fqdnRegex.exec(pageHtml)
+    }
+
+    // If no FQDNs found on this page, fall back to table row text (store names = slugs)
+    if (storeSlugs.length === slugsBefore) {
+      const rows = await page.locator('table tbody tr').all()
+      for (const row of rows) {
+        const firstCell = row.locator('td').first()
+        const text = (await firstCell.textContent())?.trim()
+        if (text && !text.toLowerCase().includes('no installed')) {
+          // Store name in the table is the slug (e.g., "e2e-w0-12345")
+          const slug = text.replace('.myshopify.com', '').trim()
+          if (slug && !storeSlugs.includes(slug)) storeSlugs.push(slug)
+        }
+      }
+    }
+
+    // Check for next page
+    const nextBtn = page.locator('button#nextURL')
+    if (!(await nextBtn.isVisible({timeout: BROWSER_TIMEOUT.short}).catch(() => false))) break
+    const isNextDisabled = await nextBtn.evaluate(
+      (el) => el.getAttribute('aria-disabled') === 'true' || el.hasAttribute('disabled'),
+    ).catch(() => true)
+    if (isNextDisabled) break
+
+    await nextBtn.click()
+    await page.waitForTimeout(BROWSER_TIMEOUT.medium)
+  }
+
+  if (storeSlugs.length === 0) return true
+
+  let allUninstalled = true
+  for (const storeSlug of storeSlugs) {
+    try {
+      const uninstalled = await uninstallAppFromStore(page, storeSlug, appName)
+      if (!uninstalled) allUninstalled = false
+      // eslint-disable-next-line no-catch-all/no-catch-all
+    } catch (err) {
+      console.warn(`    Failed to uninstall from ${storeSlug}: ${err instanceof Error ? err.message : String(err)}`)
+      allUninstalled = false
+    }
+  }
+
+  // Final verification: check the installs page shows 0 installs (with pagination)
+  await page.goto(`${appUrl}/installs`, {waitUntil: 'domcontentloaded'})
+  await page.waitForTimeout(BROWSER_TIMEOUT.medium)
+
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const remainingRows = await page.locator('table tbody tr').all()
+    for (const row of remainingRows) {
+      const text = (await row.locator('td').first().textContent())?.trim() ?? ''
+      if (text && !text.toLowerCase().includes('no installed')) {
+        return false
+      }
+    }
+
+    const nextBtn = page.locator('button#nextURL')
+    if (!(await nextBtn.isVisible({timeout: BROWSER_TIMEOUT.short}).catch(() => false))) break
+    const isNextDisabled = await nextBtn.evaluate(
+      (el) => el.getAttribute('aria-disabled') === 'true' || el.hasAttribute('disabled'),
+    ).catch(() => true)
+    if (isNextDisabled) break
+
+    await nextBtn.click()
+    await page.waitForTimeout(BROWSER_TIMEOUT.medium)
+  }
+
+  return allUninstalled
+}
+
+// ---------------------------------------------------------------------------
+// CLI entry point
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const args = process.argv.slice(2)
+  const headed = args.includes('--headed')
+  const patternIdx = args.indexOf('--pattern')
+  let pattern: string | undefined
+  if (patternIdx !== -1) {
+    const nextArg = args[patternIdx + 1]
+    if (!nextArg || nextArg.startsWith('--')) {
+      console.error('[cleanup-apps] --pattern requires a value')
+      process.exitCode = 1
+      return
+    }
+    pattern = nextArg
+  }
+
+  let mode: CleanupMode = 'full'
+  if (args.includes('--list')) mode = 'list'
+  else if (args.includes('--uninstall')) mode = 'uninstall'
+  else if (args.includes('--delete')) mode = 'delete'
+
+  await cleanupAllApps({mode, pattern, headed})
+}
+
+// Run if executed directly (not imported)
+const isDirectRun = process.argv[1] === fileURLToPath(import.meta.url)
+if (isDirectRun) {
+  main().catch((err) => {
+    console.error('[cleanup-apps] Fatal error:', err)
+    process.exitCode = 1
+  })
+}


### PR DESCRIPTION
### WHY are these changes introduced?

E2E tests create apps that can accumulate when tests fail mid-run, CI times out, or teardown fails. This script automates bulk-clean for leftover apps.

### WHAT is this pull request doing?

#### `cleanup-apps.ts`

Standalone cleanup script that finds leftover E2E test apps on the Dev Dashboard, uninstalls them from all stores, and deletes them.

```bash
pnpm --filter e2e exec tsx scripts/cleanup-apps.ts              # Full cleanup: uninstall + delete
pnpm --filter e2e exec tsx scripts/cleanup-apps.ts --list        # List matching apps with install counts
pnpm --filter e2e exec tsx scripts/cleanup-apps.ts --uninstall   # Uninstall from all stores only (no delete)
pnpm --filter e2e exec tsx scripts/cleanup-apps.ts --delete      # Delete only apps with 0 installs
pnpm --filter e2e exec tsx scripts/cleanup-apps.ts --headed      # Show browser window
pnpm --filter e2e exec tsx scripts/cleanup-apps.ts --pattern X   # Match apps containing "X" (default: "E2E-")
```

#### Logic

The per-app mechanics delegate to the shared `setup/` building blocks (`uninstallAppFromStore`, `deleteAppFromDevDashboard`, `refreshIfPageError`) — same primitives used by per-test teardown. The script adds bulk discovery, pagination, and per-app retry on top.

**Discovery phase:**
1. Log in via `completeLogin` helper
2. Navigate to Dev Dashboard, then loop `refreshIfPageError` up to 3× as extra resilience on 500/502 (hard-fails after 3 attempts)
3. Find app cards via `a[href*=\"/apps/\"]` selectors
4. Extract app name from card text (split on install count pattern), install count via regex, and URL from href
5. Filter by name pattern (default: `E2E-`)
6. Paginate via `a[href*=\"next_cursor\"]`; `refreshIfPageError` runs at the top of every iteration so error-page returns throw instead of silently yielding 0 apps

**Uninstall** (per app):
1. Navigate to `{appUrl}/installs`
2. Collect store slugs via FQDN regex on full page HTML (`page.content()`)
3. If no FQDNs found on this page: fall back to table row text (store name = slug)
4. Paginate via `button#nextURL` and repeat 2–3 on each page
5. For each store slug: call `uninstallAppFromStore(page, slug, appName)` — the shared setup helper navigates to the store's `/settings/apps`, clicks the ⋯ menu → Uninstall → confirm, then reloads and verifies the app is gone. Returns `true` if gone (or already absent), `false` if still listed.
6. If any store returns `false` or throws: mark `allUninstalled = false` and log the store slug + error
7. Final verification: navigate back to `{appUrl}/installs`, scan every row across all pages — any non-empty row → return `false`
8. Return `allUninstalled`

**Delete** (per app):
1. Call `deleteAppFromDevDashboard(page, appUrl)` — the shared setup helper navigates to `{appUrl}/settings`, clicks Delete app (scroll + reload-once fallback for the button's propagation lag), types \"DELETE\" if the confirm input is present, clicks confirm, then reloads and returns `true` on 404 (deleted) or `false` otherwise. Throws `STILL_HAS_INSTALLS` if the Delete button stays disabled after reload (fail-fast signal — retries won't help).
2. Treat `false` as \"deletion could not be verified\" and retry via the outer loop.

**Per-app retry wrapper:**
1. Each app gets up to 3 attempts
2. On failure: log the error (`(N/3) failed: ...`), wait, re-navigate to dashboard, retry the full uninstall + delete flow
3. `STILL_HAS_INSTALLS` short-circuits the retry loop → record as skipped
4. Per-app elapsed time printed (`(Xs)`); summary printed at end: `X succeeded, Y skipped, Z failed (Xs total)`

**`--list` mode**: runs discovery only, prints app names and install counts.

**`--uninstall` mode**: runs uninstall only, skips apps with 0 installs.

**`--delete` mode**: runs delete only, skips apps with installs > 0.

**Features:**
- Reuses `setup/` building blocks — single source of truth for per-store uninstall and per-app delete semantics (shared with per-test teardown)
- Dashboard error handling via shared `refreshIfPageError` helper — hard-fails after 3 consecutive 500/502 responses
- Store slug extraction via full HTML regex with per-page table text fallback
- Paginated final installs verification across all pages
- Error page differentiation: 404 = already deleted (success), 500/502 = server error (retry), disabled Delete button = `STILL_HAS_INSTALLS` (fail-fast skip)
- Exports `cleanupAllApps()` for use as a Playwright globalTeardown or from other scripts

#### How is this different from per-test teardown?

- **Per-test teardown** (`setup/teardown.ts`) — knows the specific app name and store FQDN, uses direct URLs, no discovery. Runs automatically in test \`finally\` blocks.
- **\`cleanup-apps.ts\`** (bulk, manual) — discovers all matching apps via dashboard pagination, discovers stores via installs page. Safety net for orphaned apps from failed/interrupted test runs.
- Both share the same underlying primitives in \`setup/\` (\`uninstallAppFromStore\`, \`deleteAppFromDevDashboard\`, \`refreshIfPageError\`), so browser automation semantics stay consistent.

### How to test your changes?

1. Create leftover apps by skipping cleanup:
   ```bash
   E2E_SKIP_TEARDOWN=1 DEBUG=1 pnpm --filter e2e exec playwright test app
   ```
2. List them:
   ```bash
   pnpm --filter e2e exec tsx scripts/cleanup-apps.ts --list
   ```
3. Clean up:
   ```bash
   pnpm --filter e2e exec tsx scripts/cleanup-apps.ts --headed
   ```

#### Example

   ```bash
   pnpm --filter e2e exec tsx scripts/cleanup-apps.ts --headed
   ```

https://github.com/user-attachments/assets/db621eb8-4272-4f3b-8856-6f8921047698


<details>
<summary>Expand for complete log</summary>

```bash
cli % pnpm --filter e2e exec tsx scripts/cleanup-apps.ts --headed

[cleanup-apps] Mode:    Uninstall + Delete
[cleanup-apps] Org:     161686155
[cleanup-apps] Pattern: "E2E-"

[cleanup-apps] Logging in...
[cleanup-apps] Logged in successfully.
[cleanup-apps] Navigating to dashboard...
[cleanup-apps] Dashboard loaded.
[cleanup-apps] Finding matching apps...
[cleanup-apps]   ...loaded 20 apps
[cleanup-apps]   ...loaded 40 apps
[cleanup-apps]   ...loaded 60 apps
[cleanup-apps]   ...loaded 73 apps
[cleanup-apps] Found 41 app(s) matching pattern "E2E-"

  1. E2E-dev-basic-1776959380611 (1 install)
  2. E2E-dev-basic-1776957041976 (0 installs)
  3. E2E-dev-basic-1776956913189 (0 installs)
  4. E2E-hot-create-1776956797812 (1 install)
  5. E2E-hot-reload-1776956796321 (1 install)
  6. E2E-dev-1776956791662 (1 install)
  7. E2E-multi-cfg-1776956790856 (1 install)
  8. E2E-dev-basic-1776955811113 (0 installs)
  9. E2E-hot-create-1776947144539 (1 install)
  10. E2E-dev-1776947140553 (1 install)
  11. E2E-hot-delete-1776947140856 (1 install)
  12. E2E-multi-cfg-1776947136959 (1 install)
  13. E2E-hot-reload-1776947140231 (1 install)
  14. E2E-multi-cfg-1776947138343 (0 installs)
  15. E2E-dev-1776947134834 (0 installs)
  16. E2E-hot-create-1776947136636 (0 installs)
  17. E2E-toml-dev-1776947144639 (1 install)
  18. E2E-multi-cfg-1776946913357 (0 installs)
  19. E2E-hot-create-1776943244407 (1 install)
  20. E2E-hot-reload-1776943242934 (1 install)
  21. E2E-multi-cfg-1776943243151 (0 installs)
  22. E2E-dev-1776942633118 (0 installs)
  23. E2E-multi-cfg-1776942630633 (0 installs)
  24. E2E-hot-create-1776942600305 (0 installs)
  25. E2E-hot-reload-1776942598644 (0 installs)
  26. E2E-dev-1776942598380 (1 install)
  27. E2E-hot-reload-1776942554353 (0 installs)
  28. E2E-dev-1776942552276 (1 install)
  29. E2E-hot-delete-1776942549780 (1 install)
  30. E2E-toml-deploy-1776942540447 (0 installs)
  31. E2E-hot-create-1776942343056 (0 installs)
  32. E2E-hot-reload-1776942340258 (1 install)
  33. E2E-multi-cfg-1776942333644 (1 install)
  34. E2E-scaffold-1776942269970 (0 installs)
  35. E2E-hot-reload-1776942269254 (0 installs)
  36. E2E-hot-delete-1776942264353 (1 install)
  37. E2E-dev-1776942284449 (0 installs)
  38. E2E-deploy-1776942269971 (0 installs)
  39. E2E-toml-dev-1776942268415 (0 installs)
  40. E2E-toml-deploy-1776942247534 (0 installs)
  41. E2E-ext-only-1776942269968 (0 installs)

[cleanup-apps] [1/41] E2E-dev-basic-1776959380611
  Uninstalling...
  Uninstalled
  Deleting...
  Deleted
  (15.0s)

[cleanup-apps] [2/41] E2E-dev-basic-1776957041976
  Not installed
  Deleting...
  Deleted
  (11.4s)

[cleanup-apps] [3/41] E2E-dev-basic-1776956913189
  Not installed
  Deleting...
  Deleted
  (11.3s)

...

```

</details>


### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label \"includes-post-release-steps\".
  If it doesn't, feel free to remove this section.
-->

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct bump type (\`patch\` for bug fixes · \`minor\` for new features · \`major\` for [breaking changes](../CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with \`pnpm changeset add\`