### PR TITLE
E2E: automatic teardown polish

### DIFF
--- a/packages/e2e/helpers/browser-login.ts
+++ b/packages/e2e/helpers/browser-login.ts
@@ -1,3 +1,4 @@
+import {isVisibleWithin} from '../setup/browser.js'
 import {BROWSER_TIMEOUT} from '../setup/constants.js'
 import type {Page} from '@playwright/test'
 
@@ -47,12 +48,12 @@ export async function completeLogin(page: Page, loginUrl: string, email: string,
     ]).catch(() => {})
 
     // If passkey page shown, navigate to password login
-    if (await differentMethodBtn.isVisible({timeout: BROWSER_TIMEOUT.short}).catch(() => false)) {
+    if (await isVisibleWithin(differentMethodBtn, BROWSER_TIMEOUT.short)) {
       await differentMethodBtn.click()
       await page.waitForTimeout(BROWSER_TIMEOUT.short)
 
       const continueWithPassword = page.locator('text=Continue with password')
-      if (await continueWithPassword.isVisible({timeout: BROWSER_TIMEOUT.medium}).catch(() => false)) {
+      if (await isVisibleWithin(continueWithPassword, BROWSER_TIMEOUT.medium)) {
         await continueWithPassword.click()
         await page.waitForTimeout(BROWSER_TIMEOUT.short)
       }
@@ -67,7 +68,7 @@ export async function completeLogin(page: Page, loginUrl: string, email: string,
     await page.waitForTimeout(BROWSER_TIMEOUT.medium)
     try {
       const btn = page.locator('button[type="submit"]').first()
-      if (await btn.isVisible({timeout: BROWSER_TIMEOUT.long})) await btn.click()
+      if (await isVisibleWithin(btn, BROWSER_TIMEOUT.long)) await btn.click()
       // eslint-disable-next-line no-catch-all/no-catch-all
     } catch (_error) {
       // No confirmation page — expected

--- a/packages/e2e/setup/app.ts
+++ b/packages/e2e/setup/app.ts
@@ -9,6 +9,24 @@ import * as fs from 'fs'
 import type {CLIContext, CLIProcess, ExecResult} from './cli.js'
 import type {Page} from '@playwright/test'
 
+/**
+ * Race the given promise builders. When the winner resolves, losers are
+ * cancelled via `AbortController.abort()` so their timers and `outputWaiters`
+ * entries inside `waitForOutput` are freed immediately rather than lingering
+ * until they hit their own timeout. Loser rejections are swallowed so they
+ * don't surface as unhandled promise rejections.
+ */
+async function raceWaiters<T>(build: (signal: AbortSignal) => Promise<T>[]): Promise<T> {
+  const ctrl = new AbortController()
+  const promises = build(ctrl.signal)
+  promises.forEach((promise) => promise.catch(() => {}))
+  try {
+    return await Promise.race(promises)
+  } finally {
+    ctrl.abort()
+  }
+}
+
 // ---------------------------------------------------------------------------
 // CLI helpers — thin wrappers around cli.exec()
 // ---------------------------------------------------------------------------
@@ -236,11 +254,15 @@ export async function configLink(
   try {
     // The first prompt is either the multi-org selector or — when the account
     // has only one org, or none of the orgs have existing apps — we jump
-    // straight to `createAsNewAppPrompt`. Race both.
-    const firstPrompt = await Promise.race([
-      proc.waitForOutput('Which organization', CLI_TIMEOUT.medium).then(() => 'org' as const),
-      proc.waitForOutput('Create this project as a new app', CLI_TIMEOUT.medium).then(() => 'create' as const),
-      proc.waitForOutput('App name', CLI_TIMEOUT.medium).then(() => 'appName' as const),
+    // straight to `createAsNewAppPrompt`. Race all three; the loser
+    // waitForOutput calls are cancelled via AbortSignal so their timers and
+    // outputWaiter entries are freed immediately when the winner resolves.
+    const firstPrompt = await raceWaiters((signal) => [
+      proc.waitForOutput('Which organization', {timeoutMs: CLI_TIMEOUT.medium, signal}).then(() => 'org' as const),
+      proc
+        .waitForOutput('Create this project as a new app', {timeoutMs: CLI_TIMEOUT.medium, signal})
+        .then(() => 'create' as const),
+      proc.waitForOutput('App name', {timeoutMs: CLI_TIMEOUT.medium, signal}).then(() => 'appName' as const),
     ])
 
     if (firstPrompt === 'org') {
@@ -255,9 +277,11 @@ export async function configLink(
       // After org selection the CLI fetches apps for the chosen org. If
       // the org has existing apps → "Create this project" prompt. If it has
       // zero apps → selectOrCreateApp skips straight to appNamePrompt.
-      const next = await Promise.race([
-        proc.waitForOutput('Create this project as a new app', CLI_TIMEOUT.medium).then(() => 'create' as const),
-        proc.waitForOutput('App name', CLI_TIMEOUT.medium).then(() => 'appName' as const),
+      const next = await raceWaiters((signal) => [
+        proc
+          .waitForOutput('Create this project as a new app', {timeoutMs: CLI_TIMEOUT.medium, signal})
+          .then(() => 'create' as const),
+        proc.waitForOutput('App name', {timeoutMs: CLI_TIMEOUT.medium, signal}).then(() => 'appName' as const),
       ])
       if (next === 'create') {
         await settle()

--- a/packages/e2e/setup/app.ts
+++ b/packages/e2e/setup/app.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-restricted-imports, no-await-in-loop */
 import {authFixture} from './auth.js'
-import {getLastPageStatus, navigateToDashboard, refreshIfPageError} from './browser.js'
+import {getLastPageStatus, isVisibleWithin, navigateToDashboard, refreshIfPageError} from './browser.js'
 import {CLI_TIMEOUT, BROWSER_TIMEOUT} from './constants.js'
 import {updateTomlValues} from '@shopify/toml-patch'
 import * as toml from '@iarna/toml'
@@ -334,7 +334,7 @@ export async function findAppOnDevDashboard(page: Page, appName: string, orgId?:
 
     // Check for next page
     const nextLink = page.locator('a[href*="next_cursor"]').first()
-    if (!(await nextLink.isVisible({timeout: BROWSER_TIMEOUT.medium}).catch(() => false))) break
+    if (!(await isVisibleWithin(nextLink, BROWSER_TIMEOUT.medium))) break
     const nextHref = await nextLink.getAttribute('href')
     if (!nextHref) break
     const nextUrl = nextHref.startsWith('http') ? nextHref : `https://dev.shopify.com${nextHref}`
@@ -380,7 +380,7 @@ export async function deleteAppFromDevDashboard(page: Page, appUrl: string): Pro
 
   // Step 3: Some confirmation modals require typing "DELETE". Fill if the input is present.
   const confirmInput = page.locator('input[type="text"]').last()
-  if (await confirmInput.isVisible({timeout: BROWSER_TIMEOUT.medium}).catch(() => false)) {
+  if (await isVisibleWithin(confirmInput, BROWSER_TIMEOUT.medium)) {
     await confirmInput.fill('DELETE')
     await page.waitForTimeout(BROWSER_TIMEOUT.short)
   }

--- a/packages/e2e/setup/app.ts
+++ b/packages/e2e/setup/app.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-restricted-imports, no-await-in-loop */
 import {authFixture} from './auth.js'
-import {navigateToDashboard, refreshIfPageError} from './browser.js'
+import {getLastPageStatus, navigateToDashboard, refreshIfPageError} from './browser.js'
 import {CLI_TIMEOUT, BROWSER_TIMEOUT} from './constants.js'
 import {updateTomlValues} from '@shopify/toml-patch'
 import * as toml from '@iarna/toml'
@@ -334,10 +334,10 @@ export async function deleteAppFromDevDashboard(page: Page, appUrl: string): Pro
   // Step 1: Navigate to the app's settings page. 404 → already deleted. 5xx → throw for retry.
   await page.goto(`${appUrl}/settings`, {waitUntil: 'domcontentloaded'})
   await page.waitForTimeout(BROWSER_TIMEOUT.medium)
-  const bodyText = (await page.textContent('body')) ?? ''
-  if (bodyText.includes('404: Not Found')) return true
-  if (bodyText.includes('500: Internal Server Error') || bodyText.includes('502 Bad Gateway')) {
-    throw new Error('Server error loading app settings page')
+  const gotoStatus = getLastPageStatus(page)
+  if (gotoStatus === 404) return true
+  if (gotoStatus !== undefined && gotoStatus >= 500) {
+    throw new Error(`Server error loading app settings page (status ${gotoStatus})`)
   }
 
   // Step 2: Click "Delete app" to open the confirmation modal.
@@ -371,10 +371,10 @@ export async function deleteAppFromDevDashboard(page: Page, appUrl: string): Pro
   // Failure → same settings page.
   await page.goto(`${appUrl}/settings`, {waitUntil: 'domcontentloaded'})
   await page.waitForTimeout(BROWSER_TIMEOUT.short)
-  const afterText = (await page.textContent('body')) ?? ''
-  if (afterText.includes('404: Not Found')) return true
-  if (afterText.includes('500: Internal Server Error') || afterText.includes('502 Bad Gateway')) {
-    throw new Error('Server error verifying app deletion')
+  const afterStatus = getLastPageStatus(page)
+  if (afterStatus === 404) return true
+  if (afterStatus !== undefined && afterStatus >= 500) {
+    throw new Error(`Server error verifying app deletion (status ${afterStatus})`)
   }
   return false
 }

--- a/packages/e2e/setup/app.ts
+++ b/packages/e2e/setup/app.ts
@@ -19,7 +19,9 @@ import type {Page} from '@playwright/test'
 async function raceWaiters<T>(build: (signal: AbortSignal) => Promise<T>[]): Promise<T> {
   const ctrl = new AbortController()
   const promises = build(ctrl.signal)
-  promises.forEach((promise) => promise.catch(() => {}))
+  promises.forEach((promise) => {
+    promise.catch(() => {})
+  })
   try {
     return await Promise.race(promises)
   } finally {

--- a/packages/e2e/setup/app.ts
+++ b/packages/e2e/setup/app.ts
@@ -249,7 +249,7 @@ export async function configLink(
   // Short sleep so Ink's useInput hooks attach before we start writing.
   // Without this, an Enter press arrives mid-mount and a subsequent render can
   // flip the prompt state unexpectedly (e.g. turning a select into search mode).
-  const settle = (ms = 150) => new Promise<void>((resolve) => setTimeout(resolve, ms))
+  const settle = (ms = 50) => new Promise<void>((resolve) => setTimeout(resolve, ms))
 
   try {
     // The first prompt is either the multi-org selector or — when the account

--- a/packages/e2e/setup/app.ts
+++ b/packages/e2e/setup/app.ts
@@ -27,20 +27,16 @@ export async function createApp(ctx: {
   const template = ctx.template ?? 'reactRouter'
   const packageManager =
     ctx.packageManager ?? (process.env.E2E_PACKAGE_MANAGER as 'npm' | 'yarn' | 'pnpm' | 'bun') ?? 'pnpm'
+  // reactRouter/remix both require a --flavor or they'll hang on the language
+  // prompt in non-interactive runs. Default to javascript when template needs
+  // it. For `--template none` (extension-only) flavor is ignored.
+  const flavor = ctx.flavor ?? (template === 'none' ? undefined : 'javascript')
 
-  const args = [
-    '--name',
-    name,
-    '--path',
-    parentDir,
-    '--package-manager',
-    packageManager,
-    '--local',
-    '--template',
-    template,
-  ]
+  const args = ['--template', template]
+  if (flavor) args.push('--flavor', flavor)
+  args.push('--name', name, '--package-manager', packageManager, '--local')
   if (ctx.orgId) args.push('--organization-id', ctx.orgId)
-  if (ctx.flavor) args.push('--flavor', ctx.flavor)
+  args.push('--path', parentDir)
 
   const result = await cli.execCreateApp(args, {
     env: {FORCE_COLOR: '0'},
@@ -116,8 +112,9 @@ export async function generateExtension(
     flavor?: string
   },
 ): Promise<ExecResult> {
-  const args = ['app', 'generate', 'extension', '--name', ctx.name, '--path', ctx.appDir, '--template', ctx.template]
+  const args = ['app', 'generate', 'extension', '--template', ctx.template]
   if (ctx.flavor) args.push('--flavor', ctx.flavor)
+  args.push('--name', ctx.name, '--path', ctx.appDir)
   return ctx.cli.exec(args, {timeout: CLI_TIMEOUT.long})
 }
 
@@ -134,12 +131,13 @@ export async function deployApp(
     noBuild?: boolean
   },
 ): Promise<ExecResult> {
-  const args = ['app', 'deploy', '--path', ctx.appDir]
-  if (ctx.force ?? true) args.push('--force')
-  if (ctx.noBuild) args.push('--no-build')
+  const args = ['app', 'deploy']
   if (ctx.version) args.push('--version', ctx.version)
   if (ctx.message) args.push('--message', ctx.message)
   if (ctx.config) args.push('--config', ctx.config)
+  if (ctx.force ?? true) args.push('--force')
+  if (ctx.noBuild) args.push('--no-build')
+  args.push('--path', ctx.appDir)
   return ctx.cli.exec(args, {timeout: CLI_TIMEOUT.long})
 }
 
@@ -152,7 +150,7 @@ export async function appInfo(ctx: CLIContext): Promise<{
     entrySourceFilePath: string
   }[]
 }> {
-  const result = await ctx.cli.exec(['app', 'info', '--path', ctx.appDir, '--json'])
+  const result = await ctx.cli.exec(['app', 'info', '--json', '--path', ctx.appDir])
   if (result.exitCode !== 0) {
     throw new Error(`app info failed (exit ${result.exitCode}):\nstdout: ${result.stdout}\nstderr: ${result.stderr}`)
   }
@@ -168,25 +166,124 @@ export async function functionRun(
     inputPath: string
   },
 ): Promise<ExecResult> {
-  return ctx.cli.exec(['app', 'function', 'run', '--path', ctx.appDir, '--input', ctx.inputPath], {
+  return ctx.cli.exec(['app', 'function', 'run', '--input', ctx.inputPath, '--path', ctx.appDir], {
     timeout: CLI_TIMEOUT.short,
   })
 }
 
-export async function versionsList(ctx: CLIContext): Promise<ExecResult> {
-  return ctx.cli.exec(['app', 'versions', 'list', '--path', ctx.appDir, '--json'], {
-    timeout: CLI_TIMEOUT.short,
-  })
-}
-
-export async function configLink(
+export async function versionsList(
   ctx: CLIContext & {
-    clientId: string
+    config?: string
   },
 ): Promise<ExecResult> {
-  return ctx.cli.exec(['app', 'config', 'link', '--path', ctx.appDir, '--client-id', ctx.clientId], {
-    timeout: CLI_TIMEOUT.medium,
+  const args = ['app', 'versions', 'list', '--json']
+  if (ctx.config) args.push('--config', ctx.config)
+  args.push('--path', ctx.appDir)
+  return ctx.cli.exec(args, {timeout: CLI_TIMEOUT.short})
+}
+
+/**
+ * Run `app config link` to create a brand-new app on Shopify interactively.
+ * Answers the prompts:
+ *   "Which organization is this work for?" → filter by orgId → Enter
+ *   "Create this project as a new app on Shopify?" → Yes (default)
+ *   "App name" → appName
+ *   "Configuration file name" → skipped via `--config` flag
+ *
+ * Env overrides (via PTY spawn):
+ *   CI=undefined                        — drop the key so prompts render.
+ *                                         Fixture default is CI=1; Ink's `is-in-ci`
+ *                                         treats `'CI' in env` as CI even when ''.
+ *                                         In CI mode Ink suppresses prompt frames
+ *                                         (only emitted on unmount), so waitForOutput
+ *                                         hangs until the process is killed.
+ *   SHOPIFY_CLI_NEVER_USE_PARTNERS_API=1 — skip Partners client in fetchOrganizations.
+ *                                         Without this, fetchOrganizations iterates
+ *                                         AppManagement AND Partners sequentially.
+ *                                         Partners requires SHOPIFY_CLI_PARTNERS_TOKEN
+ *                                         (not set in OAuth-auth'd tests) and hangs
+ *                                         for minutes trying to authenticate. The e2e
+ *                                         test org (161686155) lives in AppManagement.
+ */
+export async function configLink(
+  ctx: CLIContext & {
+    appName: string
+    orgId: string
+    configName?: string
+  },
+): Promise<ExecResult> {
+  const args = ['app', 'config', 'link']
+  // Pass configName as --config flag. link.ts → loadConfigurationFileName skips
+  // the "Configuration file name" prompt when options.configName is set, which
+  // also side-steps a painful interactive quirk: that prompt uses
+  // `initialAnswer = remoteApp.title`, so any text we write would be appended
+  // to the app name rather than replacing it.
+  if (ctx.configName) args.push('--config', ctx.configName)
+  args.push('--path', ctx.appDir)
+
+  const proc = await ctx.cli.spawn(args, {
+    env: {
+      CI: undefined,
+      SHOPIFY_CLI_NEVER_USE_PARTNERS_API: '1',
+    },
   })
+
+  // Short sleep so Ink's useInput hooks attach before we start writing.
+  // Without this, an Enter press arrives mid-mount and a subsequent render can
+  // flip the prompt state unexpectedly (e.g. turning a select into search mode).
+  const settle = (ms = 150) => new Promise<void>((resolve) => setTimeout(resolve, ms))
+
+  try {
+    // The first prompt is either the multi-org selector or — when the account
+    // has only one org, or none of the orgs have existing apps — we jump
+    // straight to `createAsNewAppPrompt`. Race both.
+    const firstPrompt = await Promise.race([
+      proc.waitForOutput('Which organization', CLI_TIMEOUT.medium).then(() => 'org' as const),
+      proc.waitForOutput('Create this project as a new app', CLI_TIMEOUT.medium).then(() => 'create' as const),
+      proc.waitForOutput('App name', CLI_TIMEOUT.medium).then(() => 'appName' as const),
+    ])
+
+    if (firstPrompt === 'org') {
+      // Type the orgId to filter the autocomplete prompt to exactly one match.
+      // selectOrganizationPrompt's label includes `(${org.id})` when duplicate
+      // org names exist (which is true for the e2e test account), so substring
+      // matching on the numeric ID is unique. Avoids relying on MRU ordering.
+      await settle()
+      proc.ptyProcess.write(ctx.orgId)
+      await settle()
+      proc.sendKey('\r')
+      // After org selection the CLI fetches apps for the chosen org. If
+      // the org has existing apps → "Create this project" prompt. If it has
+      // zero apps → selectOrCreateApp skips straight to appNamePrompt.
+      const next = await Promise.race([
+        proc.waitForOutput('Create this project as a new app', CLI_TIMEOUT.medium).then(() => 'create' as const),
+        proc.waitForOutput('App name', CLI_TIMEOUT.medium).then(() => 'appName' as const),
+      ])
+      if (next === 'create') {
+        await settle()
+        proc.sendKey('\r')
+      }
+    } else if (firstPrompt === 'create') {
+      await settle()
+      proc.sendKey('\r')
+    }
+
+    // Wait for "App name" text prompt and submit the desired name.
+    // Important: Ink parses each PTY data event as ONE keypress. If we write
+    // "name\r" in one call, parseKeypress sees the whole string and treats
+    // it as text (not Enter), so the prompt never submits. We must write the
+    // text, wait for it to be consumed, then write \r separately.
+    await proc.waitForOutput('App name', CLI_TIMEOUT.medium)
+    await settle()
+    proc.ptyProcess.write(ctx.appName)
+    await settle()
+    proc.sendKey('\r')
+
+    const exitCode = await proc.waitForExit(CLI_TIMEOUT.long)
+    return {exitCode, stdout: proc.getOutput(), stderr: ''}
+  } finally {
+    proc.kill()
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -225,70 +322,61 @@ export async function findAppOnDevDashboard(page: Page, appName: string, orgId?:
   return null
 }
 
-/** Delete an app from its dev dashboard settings page. Returns true if deleted, false if not. */
+/**
+ * Delete an app from its dev dashboard settings page. Returns true if deleted.
+ *
+ * Single attempt — caller owns the retry loop.
+ *
+ * Fail-fast on STILL_HAS_INSTALLS: the Delete button stays disabled while
+ * installs exist, so we throw to let the caller skip instead of spinning.
+ */
 export async function deleteAppFromDevDashboard(page: Page, appUrl: string): Promise<boolean> {
-  // Step 1: Navigate to settings page
+  // Step 1: Navigate to the app's settings page. 404 → already deleted. 5xx → throw for retry.
   await page.goto(`${appUrl}/settings`, {waitUntil: 'domcontentloaded'})
   await page.waitForTimeout(BROWSER_TIMEOUT.medium)
-  await refreshIfPageError(page)
+  const bodyText = (await page.textContent('body')) ?? ''
+  if (bodyText.includes('404: Not Found')) return true
+  if (bodyText.includes('500: Internal Server Error') || bodyText.includes('502 Bad Gateway')) {
+    throw new Error('Server error loading app settings page')
+  }
 
-  // Step 2: Wait for "Delete app" button to be enabled, then click (retry with error check)
-  const deleteAppBtn = page.locator('button:has-text("Delete app")').first()
-  for (let attempt = 1; attempt <= 3; attempt++) {
-    if (await refreshIfPageError(page)) continue
-    const isDisabled = await deleteAppBtn.getAttribute('disabled').catch(() => 'true')
-    if (!isDisabled) break
+  // Step 2: Click "Delete app" to open the confirmation modal.
+  // Button can be below the fold, and takes ~1-2s to enable after uninstall (one reload covers propagation lag).
+  // If it stays disabled after reload, installs remain — fail fast for caller.
+  const deleteBtn = page.locator('button:has-text("Delete app")').first()
+  await deleteBtn.scrollIntoViewIfNeeded()
+  if (!(await deleteBtn.isEnabled())) {
     await page.reload({waitUntil: 'domcontentloaded'})
     await page.waitForTimeout(BROWSER_TIMEOUT.medium)
+    await deleteBtn.scrollIntoViewIfNeeded()
+    if (!(await deleteBtn.isEnabled())) throw new Error('STILL_HAS_INSTALLS')
   }
-
-  // Click the delete button — if it's not found, the page didn't load properly
-  const deleteClicked = await deleteAppBtn
-    .click({timeout: BROWSER_TIMEOUT.long})
-    .then(() => true)
-    .catch(() => false)
-  if (!deleteClicked) return false
+  await deleteBtn.click({timeout: 2 * BROWSER_TIMEOUT.long})
   await page.waitForTimeout(BROWSER_TIMEOUT.medium)
 
-  // Step 3: Click confirm "Delete" in the modal (retry step 2+3 if not visible)
-  // The dev dashboard modal has a submit button with class "critical" inside a form
-  const confirmAppBtn = page.locator('button.critical[type="submit"]')
-  for (let attempt = 1; attempt <= 3; attempt++) {
-    if (await confirmAppBtn.isVisible({timeout: BROWSER_TIMEOUT.medium}).catch(() => false)) break
-    if (attempt === 3) return false
-    // Retry: re-click the delete button to reopen modal
-    await page.keyboard.press('Escape')
+  // Step 3: Some confirmation modals require typing "DELETE". Fill if the input is present.
+  const confirmInput = page.locator('input[type="text"]').last()
+  if (await confirmInput.isVisible({timeout: BROWSER_TIMEOUT.medium}).catch(() => false)) {
+    await confirmInput.fill('DELETE')
     await page.waitForTimeout(BROWSER_TIMEOUT.short)
-    const retryClicked = await deleteAppBtn
-      .click({timeout: BROWSER_TIMEOUT.long})
-      .then(() => true)
-      .catch(() => false)
-    if (!retryClicked) return false
-    await page.waitForTimeout(BROWSER_TIMEOUT.medium)
   }
 
-  const urlBefore = page.url()
-  const confirmClicked = await confirmAppBtn
-    .click({timeout: BROWSER_TIMEOUT.long})
-    .then(() => true)
-    .catch(() => false)
-  if (!confirmClicked) return false
+  // Step 4: Click the confirm button (second "Delete app" button on the page, inside the modal).
+  const confirmBtn = page.locator('button:has-text("Delete app")').last()
+  await confirmBtn.click({timeout: BROWSER_TIMEOUT.long})
+  await page.waitForTimeout(BROWSER_TIMEOUT.medium)
 
-  // Wait for page to navigate away after deletion
-  try {
-    await page.waitForURL((url) => url.toString() !== urlBefore, {timeout: BROWSER_TIMEOUT.max})
-    // eslint-disable-next-line no-catch-all/no-catch-all
-  } catch (_err) {
-    // URL didn't change — check if page error occurred during redirect
-    if (await refreshIfPageError(page)) {
-      // After refresh, 404 means the app was deleted (settings page no longer exists)
-      const bodyText = (await page.textContent('body')) ?? ''
-      if (bodyText.includes('404: Not Found')) return true
-      return false
-    }
-    await page.waitForTimeout(BROWSER_TIMEOUT.medium)
+  // Step 5: Reload the settings page to confirm deletion.
+  // Success → 404.
+  // Failure → same settings page.
+  await page.goto(`${appUrl}/settings`, {waitUntil: 'domcontentloaded'})
+  await page.waitForTimeout(BROWSER_TIMEOUT.short)
+  const afterText = (await page.textContent('body')) ?? ''
+  if (afterText.includes('404: Not Found')) return true
+  if (afterText.includes('500: Internal Server Error') || afterText.includes('502 Bad Gateway')) {
+    throw new Error('Server error verifying app deletion')
   }
-  return page.url() !== urlBefore
+  return false
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/e2e/setup/browser.ts
+++ b/packages/e2e/setup/browser.ts
@@ -57,8 +57,7 @@ export const browserFixture = cliFixture.extend<{}, {browserPage: Page}>({
  */
 export async function refreshIfPageError(page: Page): Promise<boolean> {
   const pageText = (await page.textContent('body')) ?? ''
-  if (!pageText.includes('Internal Server Error') && !pageText.includes('502 Bad Gateway')) return false
-  // if (process.env.DEBUG === '1') process.stdout.write('                   page refreshing...\n')
+  if (!pageText.includes('500: Internal Server Error') && !pageText.includes('502 Bad Gateway')) return false
   await page.reload({waitUntil: 'domcontentloaded'})
   await page.waitForTimeout(BROWSER_TIMEOUT.medium)
   return true

--- a/packages/e2e/setup/browser.ts
+++ b/packages/e2e/setup/browser.ts
@@ -12,6 +12,33 @@ export interface BrowserContext {
 }
 
 // ---------------------------------------------------------------------------
+// Main-frame response status tracking
+// ---------------------------------------------------------------------------
+
+/**
+ * Records the HTTP status of the most recent main-frame document response per
+ * page. Populated by a `response` listener attached when the page is created
+ * (see fixture below). Read via `getLastPageStatus(page)`.
+ *
+ * A WeakMap lets the entry be garbage-collected with the page — no manual
+ * cleanup required.
+ */
+const lastMainFrameStatus = new WeakMap<Page, number>()
+
+export function trackMainFrameStatus(page: Page): void {
+  page.on('response', (response) => {
+    if (response.frame() !== page.mainFrame()) return
+    if (response.request().resourceType() !== 'document') return
+    lastMainFrameStatus.set(page, response.status())
+  })
+}
+
+/** Get the HTTP status of the last main-frame document response on `page`. */
+export function getLastPageStatus(page: Page): number | undefined {
+  return lastMainFrameStatus.get(page)
+}
+
+// ---------------------------------------------------------------------------
 // Fixture
 // ---------------------------------------------------------------------------
 
@@ -40,6 +67,7 @@ export const browserFixture = cliFixture.extend<{}, {browserPage: Page}>({
       context.setDefaultTimeout(BROWSER_TIMEOUT.max)
       context.setDefaultNavigationTimeout(BROWSER_TIMEOUT.max)
       const page = await context.newPage()
+      trackMainFrameStatus(page)
       await use(page)
       await browser.close()
     },
@@ -52,12 +80,16 @@ export const browserFixture = cliFixture.extend<{}, {browserPage: Page}>({
 // ---------------------------------------------------------------------------
 
 /**
- * Check if the current page shows a server error (500, 502). If so, refresh and return true.
- * Call this in retry loops when a selector isn't found — the page might be an error page.
+ * If the most recent main-frame response was a 5xx server error, reload the
+ * page and return true. Otherwise return false. Call this in retry loops when
+ * a selector isn't found — the page might be an error page.
+ *
+ * Uses the HTTP status captured by `trackMainFrameStatus` rather than scraping
+ * body text, so it works regardless of how an error page is rendered.
  */
 export async function refreshIfPageError(page: Page): Promise<boolean> {
-  const pageText = (await page.textContent('body')) ?? ''
-  if (!pageText.includes('500: Internal Server Error') && !pageText.includes('502 Bad Gateway')) return false
+  const status = getLastPageStatus(page)
+  if (status === undefined || status < 500) return false
   await page.reload({waitUntil: 'domcontentloaded'})
   await page.waitForTimeout(BROWSER_TIMEOUT.medium)
   return true

--- a/packages/e2e/setup/browser.ts
+++ b/packages/e2e/setup/browser.ts
@@ -1,6 +1,6 @@
 import {cliFixture} from './cli.js'
 import {BROWSER_TIMEOUT} from './constants.js'
-import {chromium, type Page} from '@playwright/test'
+import {chromium, type Locator, type Page} from '@playwright/test'
 import * as fs from 'fs'
 
 // ---------------------------------------------------------------------------
@@ -80,6 +80,22 @@ export const browserFixture = cliFixture.extend<{}, {browserPage: Page}>({
 // ---------------------------------------------------------------------------
 
 /**
+ * Wait up to `timeoutMs` for `locator` to become visible. Returns `true` if it
+ * appears in time, `false` on timeout or any other locator error (detached
+ * element, closed context, etc.).
+ *
+ * Use this instead of `locator.isVisible({timeout})` — that API does not
+ * actually wait in modern Playwright; it returns the current visibility state.
+ * This helper uses `waitFor({state: 'visible', timeout})` for true polling.
+ */
+export async function isVisibleWithin(locator: Locator, timeoutMs: number): Promise<boolean> {
+  return locator
+    .waitFor({state: 'visible', timeout: timeoutMs})
+    .then(() => true)
+    .catch(() => false)
+}
+
+/**
  * If the most recent main-frame response was a 5xx server error, reload the
  * page and return true. Otherwise return false. Call this in retry loops when
  * a selector isn't found — the page might be an error page.
@@ -114,7 +130,7 @@ export async function navigateToDashboard(
   // Handle account picker (skip if email not provided)
   if (ctx.email) {
     const accountButton = browserPage.locator(`text=${ctx.email}`).first()
-    if (await accountButton.isVisible({timeout: BROWSER_TIMEOUT.medium}).catch(() => false)) {
+    if (await isVisibleWithin(accountButton, BROWSER_TIMEOUT.medium)) {
       await accountButton.click()
       await browserPage.waitForTimeout(BROWSER_TIMEOUT.medium)
     }

--- a/packages/e2e/setup/cli.ts
+++ b/packages/e2e/setup/cli.ts
@@ -11,9 +11,19 @@ export interface ExecResult {
   exitCode: number
 }
 
+export interface WaitForOutputOptions {
+  timeoutMs?: number
+  /** Cancel the wait early — frees the timer and removes the waiter entry. */
+  signal?: AbortSignal
+}
+
 export interface SpawnedProcess {
-  /** Wait for a string to appear in the PTY output */
-  waitForOutput(text: string, timeoutMs?: number): Promise<void>
+  /**
+   * Wait for a string to appear in the PTY output.
+   * Pass a number for the legacy positional `timeoutMs` form, or an options
+   * object to also supply an `AbortSignal` for cancellation.
+   */
+  waitForOutput(text: string, opts?: number | WaitForOutputOptions): Promise<void>
   /** Send a single key to the PTY */
   sendKey(key: string): void
   /** Send a line of text followed by Enter */
@@ -132,13 +142,13 @@ export const cliFixture = envFixture.extend<{cli: CLIProcess}>({
             process.stdout.write(data)
           }
 
-          // Check if any waiters are satisfied (check both raw and stripped output)
+          // Check if any waiters are satisfied (check both raw and stripped
+          // output). resolve() removes the waiter from outputWaiters internally,
+          // so we iterate over a snapshot to avoid index shifting during the loop.
           const stripped = stripAnsi(output)
-          for (let idx = outputWaiters.length - 1; idx >= 0; idx--) {
-            const waiter = outputWaiters[idx]
-            if (waiter && (stripped.includes(waiter.text) || output.includes(waiter.text))) {
+          for (const waiter of [...outputWaiters]) {
+            if (stripped.includes(waiter.text) || output.includes(waiter.text)) {
               waiter.resolve()
-              outputWaiters.splice(idx, 1)
             }
           }
         })
@@ -151,26 +161,39 @@ export const cliFixture = envFixture.extend<{cli: CLIProcess}>({
           if (exitResolve) {
             exitResolve(code)
           }
-          // Reject any remaining output waiters
-          for (const waiter of outputWaiters) {
+          // Reject any remaining output waiters. reject() removes each waiter
+          // from outputWaiters, so iterate over a snapshot to avoid skipping.
+          for (const waiter of [...outputWaiters]) {
             waiter.reject(new Error(`Process exited (code ${code}) while waiting for output: "${waiter.text}"`))
           }
-          outputWaiters.length = 0
         })
 
         const spawned: SpawnedProcess = {
           ptyProcess,
 
-          waitForOutput(text: string, timeoutMs = CLI_TIMEOUT.medium) {
+          waitForOutput(text: string, opts: number | WaitForOutputOptions = {}) {
+            const {timeoutMs = CLI_TIMEOUT.medium, signal} =
+              typeof opts === 'number' ? {timeoutMs: opts, signal: undefined} : opts
+
             // Check if already in output (raw or stripped)
             if (stripAnsi(output).includes(text) || output.includes(text)) {
               return Promise.resolve()
             }
+            if (signal?.aborted) {
+              return Promise.reject(new Error(`Cancelled waiting for output: "${text}"`))
+            }
 
             return new Promise<void>((resolve, reject) => {
+              // eslint-disable-next-line prefer-const
+              let waiter: {text: string; resolve: () => void; reject: (err: Error) => void}
+
+              const removeWaiter = () => {
+                const idx = outputWaiters.indexOf(waiter)
+                if (idx >= 0) outputWaiters.splice(idx, 1)
+              }
+
               const timer = setTimeout(() => {
-                const waiterIdx = outputWaiters.findIndex((waiter) => waiter.text === text)
-                if (waiterIdx >= 0) outputWaiters.splice(waiterIdx, 1)
+                removeWaiter()
                 reject(
                   new Error(
                     `Timed out after ${timeoutMs}ms waiting for output: "${text}"\n\nCaptured output:\n${stripAnsi(
@@ -180,17 +203,32 @@ export const cliFixture = envFixture.extend<{cli: CLIProcess}>({
                 )
               }, timeoutMs)
 
-              outputWaiters.push({
+              waiter = {
                 text,
                 resolve: () => {
                   clearTimeout(timer)
+                  removeWaiter()
                   resolve()
                 },
                 reject: (err) => {
                   clearTimeout(timer)
+                  removeWaiter()
                   reject(err)
                 },
-              })
+              }
+              outputWaiters.push(waiter)
+
+              if (signal) {
+                signal.addEventListener(
+                  'abort',
+                  () => {
+                    clearTimeout(timer)
+                    removeWaiter()
+                    reject(new Error(`Cancelled waiting for output: "${text}"`))
+                  },
+                  {once: true},
+                )
+              }
             })
           },
 

--- a/packages/e2e/setup/global-auth.ts
+++ b/packages/e2e/setup/global-auth.ts
@@ -6,6 +6,7 @@
  */
 
 /* eslint-disable no-restricted-imports */
+import {isVisibleWithin} from './browser.js'
 import {directories, executables, globalLog} from './env.js'
 import {CLI_TIMEOUT, BROWSER_TIMEOUT} from './constants.js'
 import {stripAnsi} from '../helpers/strip-ansi.js'
@@ -154,7 +155,7 @@ async function visitAndHandleAccountPicker(page: Page, url: string, email: strin
   await page.waitForTimeout(BROWSER_TIMEOUT.medium)
   if (isAccountsShopifyUrl(page.url())) {
     const accountButton = page.locator(`text=${email}`).first()
-    if (await accountButton.isVisible({timeout: BROWSER_TIMEOUT.long}).catch(() => false)) {
+    if (await isVisibleWithin(accountButton, BROWSER_TIMEOUT.long)) {
       await accountButton.click()
       await page.waitForTimeout(BROWSER_TIMEOUT.medium)
     }

--- a/packages/e2e/setup/store.ts
+++ b/packages/e2e/setup/store.ts
@@ -9,7 +9,7 @@ import type {Page} from '@playwright/test'
 const log = createLogger('browser')
 
 // ---------------------------------------------------------------------------
-// Dev store management — create and delete stores via browser automation
+// Dev store provisioning — create new stores via browser automation
 // ---------------------------------------------------------------------------
 
 /** Generate a unique store name for a worker. */
@@ -122,7 +122,7 @@ export async function createDevStore(
 }
 
 // ---------------------------------------------------------------------------
-// Store admin browser actions — uninstall apps and delete stores
+// Store admin browser actions — uninstall apps, delete stores, and helpers
 // ---------------------------------------------------------------------------
 
 /** Dismiss the Dev Console panel if visible on a store admin page. */
@@ -138,49 +138,49 @@ export async function dismissDevConsole(page: Page): Promise<void> {
 }
 
 /**
- * Uninstall an app from a store's admin settings page.
- * Navigates to /settings/apps, finds the app by name, uninstalls it, and verifies removal.
- * Returns true if app is confirmed gone, false if still present.
+ * Uninstall an app from a store's admin settings/apps page. Returns true if confirmed uninstalled.
+ *
+ * Single attempt — caller owns the retry loop.
  */
 export async function uninstallAppFromStore(page: Page, storeSlug: string, appName: string): Promise<boolean> {
+  // Step 1: Navigate to the store's settings/apps page.
   await page.goto(`https://admin.shopify.com/store/${storeSlug}/settings/apps`, {
     waitUntil: 'domcontentloaded',
   })
   await page.waitForTimeout(BROWSER_TIMEOUT.long)
   await dismissDevConsole(page)
 
+  // Step 2: Find the app by name. Not visible → already uninstalled.
   const appSpan = page.locator(`span:has-text("${appName}"):not([class*="Polaris"])`).first()
   if (!(await appSpan.isVisible({timeout: BROWSER_TIMEOUT.long}).catch(() => false))) return true
 
-  // Click ⋯ menu → Uninstall → Confirm
+  // Step 3: Open the ⋯ menu and click Uninstall.
   await appSpan.locator('xpath=./following::button[1]').click()
   await page.waitForTimeout(BROWSER_TIMEOUT.short)
-
   const uninstallOpt = page.locator('text=Uninstall').last()
   if (!(await uninstallOpt.isVisible({timeout: BROWSER_TIMEOUT.medium}).catch(() => false))) return false
   await uninstallOpt.click()
   await page.waitForTimeout(BROWSER_TIMEOUT.medium)
 
+  // Step 4: Confirm the uninstall in the modal (if one appears).
   const confirmBtn = page.locator('button:has-text("Uninstall"), button:has-text("Confirm")').last()
   if (await confirmBtn.isVisible({timeout: BROWSER_TIMEOUT.medium}).catch(() => false)) {
     await confirmBtn.click()
     await page.waitForTimeout(BROWSER_TIMEOUT.medium)
   }
 
-  // Verify: check the specific app is gone
-  const check = async () =>
-    page
-      .locator(`span:has-text("${appName}"):not([class*="Polaris"])`)
-      .first()
-      .isVisible({timeout: BROWSER_TIMEOUT.medium})
-      .catch(() => false)
-
-  if (!(await check())) return true
-
-  // If still visible — reload and check again
+  // Step 5: Reload the page to confirm the app is no longer listed.
+  // Success → app is not on listed on the page.
+  // Failure → app is still listed.
   await page.reload({waitUntil: 'domcontentloaded'})
   await page.waitForTimeout(BROWSER_TIMEOUT.long)
-  return !(await check())
+  await dismissDevConsole(page)
+  const stillVisible = await page
+    .locator(`span:has-text("${appName}"):not([class*="Polaris"])`)
+    .first()
+    .isVisible({timeout: BROWSER_TIMEOUT.medium})
+    .catch(() => false)
+  return !stillVisible
 }
 
 /** Check if the current page shows the empty state (zero apps installed). Caller must navigate first. */
@@ -195,76 +195,61 @@ export async function isStoreAppsEmpty(page: Page): Promise<boolean> {
 }
 
 /**
- * Delete a store via the admin settings plan page.
- * Caller must verify no apps are installed before calling.
- * Returns true if deleted, false if not.
+ * Delete a store via the admin /settings/plan/cancel page. Returns true if deleted.
+ *
+ * Gate: store must have zero apps installed.
+ * Caller should verify via `isStoreAppsEmpty` and skip this call if apps remain,
+ * otherwise step 4 will exhaust its micro-retry (Delete button never enables) and throw.
+ *
+ * Single attempt — caller owns the retry loop.
  */
 export async function deleteStore(page: Page, storeSlug: string): Promise<boolean> {
-  // Step 1: Navigate to plan page and click delete button to open modal (retry navigation on failure)
-  const planUrl = `https://admin.shopify.com/store/${storeSlug}/settings/plan`
-  const deleteButton = page.locator('s-internal-button[tone="critical"]').locator('button')
+  // Step 1: Navigate to /settings/plan/cancel (auto-opens the "Review before deleting store" modal).
+  const cancelUrl = `https://admin.shopify.com/store/${storeSlug}/settings/plan/cancel`
+  await page.goto(cancelUrl, {waitUntil: 'domcontentloaded'})
 
-  for (let attempt = 1; attempt <= 3; attempt++) {
-    try {
-      await page.goto(planUrl, {waitUntil: 'domcontentloaded'})
-      await page.waitForTimeout(BROWSER_TIMEOUT.long)
-      // If redirected to access_account, store is already deleted
-      if (page.url().includes('access_account')) return true
-      await deleteButton.click({timeout: BROWSER_TIMEOUT.long})
-      break
-      // eslint-disable-next-line no-catch-all/no-catch-all
-    } catch (_err) {
-      if (attempt === 3) return false
-    }
-  }
-  await page.waitForTimeout(BROWSER_TIMEOUT.medium)
-
-  const modal = page.locator('.Polaris-Modal-Dialog__Modal')
-
-  // Step 2: Check the confirmation checkbox (retry step 1+2 if fails)
-  for (let attempt = 1; attempt <= 3; attempt++) {
-    const checkbox = modal.locator('input[type="checkbox"]')
-    if (await checkbox.isVisible({timeout: BROWSER_TIMEOUT.medium}).catch(() => false)) {
-      await checkbox.check({force: true})
-      await page.waitForTimeout(BROWSER_TIMEOUT.short)
-      break
-    }
-    if (attempt === 3) return false
-    // Retry: close modal and re-click delete
-    await page.keyboard.press('Escape')
-    await page.waitForTimeout(BROWSER_TIMEOUT.short)
-    await deleteButton.click({timeout: BROWSER_TIMEOUT.max})
-    await page.waitForTimeout(BROWSER_TIMEOUT.medium)
-  }
-
-  // Step 3: Click confirm (retry step 2+3 if button is still disabled)
-  const confirmButton = modal.locator('button:has-text("Delete store")')
-  for (let attempt = 1; attempt <= 3; attempt++) {
-    const isDisabled = await confirmButton
-      .evaluate((el) => el.getAttribute('aria-disabled') === 'true' || el.hasAttribute('disabled'))
-      .catch(() => true)
-    if (!isDisabled) break
-    if (attempt === 3) return false
-    // Retry: re-check the checkbox
-    const checkbox = modal.locator('input[type="checkbox"]')
-    await checkbox.check({force: true})
-    await page.waitForTimeout(BROWSER_TIMEOUT.short)
-  }
-
-  const confirmClicked = await confirmButton
-    .click({force: true})
-    .then(() => true)
-    .catch(() => false)
-  if (!confirmClicked) return false
-
-  // Verify: URL reaching access_account confirms store is deleted
+  // Step 2: Race — modal renders (normal) vs. redirect to /access_account (already deleted).
+  // The redirect can fire post-DOMContentLoaded, so a URL check right after goto is too early.
+  const modal = page.locator('.Polaris-Modal-Dialog__Modal:has-text("Review before deleting store")')
+  const checkbox = modal.locator('input[type="checkbox"]')
   try {
-    await page.waitForURL(/access_account/, {timeout: BROWSER_TIMEOUT.max})
-    return true
+    await Promise.race([
+      checkbox.waitFor({state: 'visible', timeout: BROWSER_TIMEOUT.max}),
+      page.waitForURL(/access_account/, {timeout: BROWSER_TIMEOUT.max}),
+    ])
     // eslint-disable-next-line no-catch-all/no-catch-all
-  } catch (_err) {
-    return false
+  } catch {
+    // Both branches timed out — fall through so outer retry can decide.
   }
+  if (page.url().includes('access_account')) return true
+
+  // Step 3: Check the confirmation checkbox (enables the Delete button).
+  await checkbox.check()
+
+  // Step 4: Wait for the Delete button to enable, then click.
+  // Micro-retry for flaky checkbox state — different concern from caller's retry loop.
+  const confirmButton = modal.locator('button:has-text("Delete store")')
+  for (let i = 1; i <= 3; i++) {
+    if (await confirmButton.isEnabled().catch(() => false)) break
+    if (i === 3) throw new Error('Confirm button still disabled')
+    await checkbox.check()
+    await page.waitForTimeout(BROWSER_TIMEOUT.short)
+  }
+  await confirmButton.click()
+
+  // Step 5: Wait for the delete POST to finish before reloading.
+  try {
+    await page.waitForLoadState('networkidle', {timeout: BROWSER_TIMEOUT.max})
+    // eslint-disable-next-line no-catch-all/no-catch-all
+  } catch {
+    // networkidle can miss on busy pages — fall through to reload anyway.
+  }
+
+  // Step 6: Reload /settings/plan/cancel to confirm deletion.
+  // Success → redirect to /access_account.
+  // Failure → still on /settings/plan/cancel
+  await page.reload({waitUntil: 'domcontentloaded'})
+  return page.url().includes('access_account')
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/e2e/setup/store.ts
+++ b/packages/e2e/setup/store.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-await-in-loop */
 import {appTestFixture} from './app.js'
+import {isVisibleWithin} from './browser.js'
 import {BROWSER_TIMEOUT} from './constants.js'
 import {createLogger, e2eSection} from './env.js'
 import * as fs from 'fs'
@@ -63,7 +64,7 @@ export async function createDevStore(
 
     if (browserPage.url().includes('accounts.shopify.com') && email) {
       const accountButton = browserPage.locator(`text=${email}`).first()
-      if (await accountButton.isVisible({timeout: BROWSER_TIMEOUT.long}).catch(() => false)) {
+      if (await isVisibleWithin(accountButton, BROWSER_TIMEOUT.long)) {
         await accountButton.click()
         await browserPage.waitForTimeout(BROWSER_TIMEOUT.medium)
       }
@@ -73,7 +74,7 @@ export async function createDevStore(
   // Wait for the store creation form to load — retry if page didn't render
   const nameInput = browserPage.locator('s-internal-text-field[label="Store name"]').locator('input')
   for (let attempt = 1; attempt <= 3; attempt++) {
-    if (await nameInput.isVisible({timeout: BROWSER_TIMEOUT.max}).catch(() => false)) break
+    if (await isVisibleWithin(nameInput, BROWSER_TIMEOUT.max)) break
 
     log.log(ctx, `store form not loaded (attempt ${attempt}/3), url=${browserPage.url()}`)
     await browserPage.goto(`https://admin.shopify.com/store-create/organization/${orgId}`, {
@@ -128,10 +129,10 @@ export async function createDevStore(
 /** Dismiss the Dev Console panel if visible on a store admin page. */
 export async function dismissDevConsole(page: Page): Promise<void> {
   const devConsole = page.locator('h2:has-text("Dev Console")')
-  if (!(await devConsole.isVisible({timeout: BROWSER_TIMEOUT.medium}).catch(() => false))) return
+  if (!(await isVisibleWithin(devConsole, BROWSER_TIMEOUT.medium))) return
 
   const hideBtn = page.locator('button[aria-label="hide"]').first()
-  if (await hideBtn.isVisible({timeout: BROWSER_TIMEOUT.short}).catch(() => false)) {
+  if (await isVisibleWithin(hideBtn, BROWSER_TIMEOUT.short)) {
     await hideBtn.click()
     await page.waitForTimeout(BROWSER_TIMEOUT.short)
   }
@@ -152,19 +153,19 @@ export async function uninstallAppFromStore(page: Page, storeSlug: string, appNa
 
   // Step 2: Find the app by name. Not visible → already uninstalled.
   const appSpan = page.locator(`span:has-text("${appName}"):not([class*="Polaris"])`).first()
-  if (!(await appSpan.isVisible({timeout: BROWSER_TIMEOUT.long}).catch(() => false))) return true
+  if (!(await isVisibleWithin(appSpan, BROWSER_TIMEOUT.long))) return true
 
   // Step 3: Open the ⋯ menu and click Uninstall.
   await appSpan.locator('xpath=./following::button[1]').click()
   await page.waitForTimeout(BROWSER_TIMEOUT.short)
   const uninstallOpt = page.locator('text=Uninstall').last()
-  if (!(await uninstallOpt.isVisible({timeout: BROWSER_TIMEOUT.medium}).catch(() => false))) return false
+  if (!(await isVisibleWithin(uninstallOpt, BROWSER_TIMEOUT.medium))) return false
   await uninstallOpt.click()
   await page.waitForTimeout(BROWSER_TIMEOUT.medium)
 
   // Step 4: Confirm the uninstall in the modal (if one appears).
   const confirmBtn = page.locator('button:has-text("Uninstall"), button:has-text("Confirm")').last()
-  if (await confirmBtn.isVisible({timeout: BROWSER_TIMEOUT.medium}).catch(() => false)) {
+  if (await isVisibleWithin(confirmBtn, BROWSER_TIMEOUT.medium)) {
     await confirmBtn.click()
     await page.waitForTimeout(BROWSER_TIMEOUT.medium)
   }
@@ -175,11 +176,10 @@ export async function uninstallAppFromStore(page: Page, storeSlug: string, appNa
   await page.reload({waitUntil: 'domcontentloaded'})
   await page.waitForTimeout(BROWSER_TIMEOUT.long)
   await dismissDevConsole(page)
-  const stillVisible = await page
-    .locator(`span:has-text("${appName}"):not([class*="Polaris"])`)
-    .first()
-    .isVisible({timeout: BROWSER_TIMEOUT.medium})
-    .catch(() => false)
+  const stillVisible = await isVisibleWithin(
+    page.locator(`span:has-text("${appName}"):not([class*="Polaris"])`).first(),
+    BROWSER_TIMEOUT.medium,
+  )
   return !stillVisible
 }
 
@@ -187,7 +187,7 @@ export async function uninstallAppFromStore(page: Page, storeSlug: string, appNa
 export async function isStoreAppsEmpty(page: Page): Promise<boolean> {
   // "Add apps to your store" empty state is the definitive zero-apps signal
   const emptyState = page.locator('text=Add apps to your store')
-  if (await emptyState.isVisible({timeout: BROWSER_TIMEOUT.medium}).catch(() => false)) return true
+  if (await isVisibleWithin(emptyState, BROWSER_TIMEOUT.medium)) return true
 
   // Fallback: no "More actions" menu buttons in the app list
   const menuButtons = await page.locator('.Polaris-Layout__Section button[aria-label="More actions"]').all()

--- a/packages/e2e/setup/teardown.ts
+++ b/packages/e2e/setup/teardown.ts
@@ -18,15 +18,12 @@ interface TeardownCtx {
 }
 
 /**
- * Best-effort per-test teardown with escalating retry.
- *
- * Each phase is independent — failure never prevents later phases.
- * Escalation: retry same step → go back one step and retry both.
+ * Best-effort per-test teardown. Each phase retries up to 3 times.
  *
  * App + store flow:
  *   Phase 1: uninstall app from store admin
- *   Phase 2: delete store (escalates to phase 1 on failure)
- *   Phase 3: delete app from dev dashboard (always runs)
+ *   Phase 2: delete store (skipped if phase 1 failed)
+ *   Phase 3: delete app from dev dashboard (skipped if phase 1 failed)
  *
  * App-only flow:
  *   Phase 3 only
@@ -63,66 +60,79 @@ export async function teardownAll(ctx: TeardownCtx): Promise<void> {
     // Phase 2: Delete store
     log.log(wCtx, 'deleting store')
     let storeDeleted = false
-    for (let attempt = 1; attempt <= 3; attempt++) {
-      try {
-        // Navigate to apps page to check state
-        await page.goto(`https://admin.shopify.com/store/${storeSlug}/settings/apps`, {
-          waitUntil: 'domcontentloaded',
-        })
-        await page.waitForTimeout(BROWSER_TIMEOUT.long)
+    let safeToDelete = false
 
-        // Store already deleted?
-        if (page.url().includes('access_account')) {
-          log.log(wCtx, 'store already deleted')
-          storeDeleted = true
-          break
-        }
+    // Gate: confirm the store has zero apps before attempting delete store.
+    try {
+      await page.goto(`https://admin.shopify.com/store/${storeSlug}/settings/apps`, {
+        waitUntil: 'domcontentloaded',
+      })
+      await page.waitForTimeout(BROWSER_TIMEOUT.long)
 
+      if (page.url().includes('access_account')) {
+        log.log(wCtx, 'store already deleted')
+        storeDeleted = true
+      } else {
         await dismissDevConsole(page)
-
-        // Apps still installed? Reload once in case page is stale
+        // Reload once in case the page is stale (Phase 1 just uninstalled)
         if (!(await isStoreAppsEmpty(page))) {
           await page.reload({waitUntil: 'domcontentloaded'})
           await page.waitForTimeout(BROWSER_TIMEOUT.long)
           await dismissDevConsole(page)
-          if (!(await isStoreAppsEmpty(page))) {
-            log.error(wCtx, 'store still has apps installed, skipping delete')
+        }
+        if (await isStoreAppsEmpty(page)) {
+          safeToDelete = true
+        } else {
+          log.error(wCtx, 'store has apps installed, skipping delete')
+        }
+      }
+      // eslint-disable-next-line no-catch-all/no-catch-all
+    } catch (err) {
+      log.error(wCtx, `store empty state unclear, skipping delete: ${err instanceof Error ? err.message : err}`)
+    }
+
+    if (safeToDelete) {
+      for (let attempt = 1; attempt <= 3; attempt++) {
+        try {
+          if (await deleteStore(page, storeSlug)) {
+            log.log(wCtx, 'store deleted')
+            storeDeleted = true
             break
           }
+          log.log(wCtx, `(${attempt}/3) store deletion failed`)
+          // eslint-disable-next-line no-catch-all/no-catch-all
+        } catch (err) {
+          log.log(wCtx, `(${attempt}/3) store deletion failed: ${err instanceof Error ? err.message : err}`)
         }
-
-        // Safe to delete
-        const deleted = await deleteStore(page, storeSlug)
-        if (deleted) {
-          log.log(wCtx, 'store deleted')
-          storeDeleted = true
-          break
-        }
-        log.log(wCtx, `(${attempt}/3) store deletion failed`)
-        // eslint-disable-next-line no-catch-all/no-catch-all
-      } catch (err) {
-        log.log(wCtx, `(${attempt}/3) store deletion failed: ${err instanceof Error ? err.message : err}`)
+      }
+      if (!storeDeleted) {
+        log.error(wCtx, 'store deletion failed after 3 attempts')
       }
     }
-    if (!storeDeleted) {
-      log.error(wCtx, 'store deletion failed after 3 attempts')
+
+    // Gate: confirm the store has zero apps before attempting delete app.
+    if (!uninstalled) {
+      log.log(wCtx, 'skipping app delete — uninstall failed, run `pnpm test:e2e-cleanup-apps` after')
+      return
     }
   }
 
-  // Phase 3: Delete app from dev dashboard — ALWAYS runs
+  // Phase 3: Delete app from dev dashboard
   e2eSection(wCtx, `Teardown: app ${ctx.appName}`)
   log.log(wCtx, 'deleting app')
   let appDeleted = false
+  let stillHasInstalls = false
   for (let attempt = 1; attempt <= 3; attempt++) {
     try {
       const appUrl = await findAppOnDevDashboard(page, ctx.appName, ctx.orgId)
       if (!appUrl) {
-        // Check if the page actually loaded — a 500/502 page also returns null
+        // null could mean "app not in the list" OR "pagination ended on a stuck error page"
+        // — findAppOnDevDashboard's refresh-on-error doesn't cover every iteration.
+        // Detect and retry so we don't misclassify an error page as "already deleted".
         if (await refreshIfPageError(page)) {
           log.log(wCtx, `page error, refreshing...`)
           continue
         }
-        // Page loaded correctly and app wasn't found = already deleted
         log.log(wCtx, 'app already deleted')
         appDeleted = true
         break
@@ -137,10 +147,17 @@ export async function teardownAll(ctx: TeardownCtx): Promise<void> {
       log.log(wCtx, `(${attempt}/3) app deletion failed`)
       // eslint-disable-next-line no-catch-all/no-catch-all
     } catch (err) {
+      // Fail fast: Delete button stays disabled while installs exist — retries won't help.
+      // cleanup-apps.ts reaps the orphan.
+      if (err instanceof Error && err.message === 'STILL_HAS_INSTALLS') {
+        log.log(wCtx, 'app delete skipped — still has installs, run `pnpm test:e2e-cleanup-apps` after')
+        stillHasInstalls = true
+        break
+      }
       log.log(wCtx, `(${attempt}/3) app deletion failed: ${err instanceof Error ? err.message : err}`)
     }
   }
-  if (!appDeleted) {
+  if (!appDeleted && !stillHasInstalls) {
     log.error(wCtx, 'app deletion failed after 3 attempts')
   }
 }

--- a/packages/e2e/tests/app-deploy.spec.ts
+++ b/packages/e2e/tests/app-deploy.spec.ts
@@ -41,8 +41,8 @@ test.describe('App deploy', () => {
       expect(listResult.exitCode, `versions list failed:\n${listOutput}`).toBe(0)
       expect(listOutput).toContain(versionTag)
     } finally {
-      // E2E_SKIP_CLEANUP=1 skips cleanup for debugging. Run `pnpm test:e2e-cleanup` afterward.
-      if (!process.env.E2E_SKIP_CLEANUP) {
+      // E2E_SKIP_TEARDOWN=1 skips teardown for debugging. Run cleanup scripts afterward.
+      if (!process.env.E2E_SKIP_TEARDOWN) {
         fs.rmSync(parentDir, {recursive: true, force: true})
         await teardownAll({
           browserPage,

--- a/packages/e2e/tests/app-dev-server.spec.ts
+++ b/packages/e2e/tests/app-dev-server.spec.ts
@@ -49,8 +49,8 @@ test.describe('App dev server', () => {
       const exitCode = await dev.waitForExit(CLI_TIMEOUT.short)
       expect(exitCode, `dev exited with non-zero code. Output:\n${dev.getOutput()}`).toBe(0)
     } finally {
-      // E2E_SKIP_CLEANUP=1 skips cleanup for debugging. Run `pnpm test:e2e-cleanup` afterward.
-      if (!process.env.E2E_SKIP_CLEANUP) {
+      // E2E_SKIP_TEARDOWN=1 skips teardown for debugging. Run cleanup scripts afterward.
+      if (!process.env.E2E_SKIP_TEARDOWN) {
         fs.rmSync(parentDir, {recursive: true, force: true})
         await teardownAll({
           browserPage,

--- a/packages/e2e/tests/app-scaffold.spec.ts
+++ b/packages/e2e/tests/app-scaffold.spec.ts
@@ -45,8 +45,8 @@ test.describe('App scaffold', () => {
         `buildApp failed:\nstdout: ${buildResult.stdout}\nstderr: ${buildResult.stderr}`,
       ).toBe(0)
     } finally {
-      // E2E_SKIP_CLEANUP=1 skips cleanup for debugging. Run `pnpm test:e2e-cleanup` afterward.
-      if (!process.env.E2E_SKIP_CLEANUP) {
+      // E2E_SKIP_TEARDOWN=1 skips teardown for debugging. Run cleanup scripts afterward.
+      if (!process.env.E2E_SKIP_TEARDOWN) {
         fs.rmSync(parentDir, {recursive: true, force: true})
         await teardownAll({
           browserPage,
@@ -80,8 +80,8 @@ test.describe('App scaffold', () => {
       expect(fs.existsSync(initResult.appDir)).toBe(true)
       expect(fs.existsSync(path.join(initResult.appDir, 'shopify.app.toml'))).toBe(true)
     } finally {
-      // E2E_SKIP_CLEANUP=1 skips cleanup for debugging. Run `pnpm test:e2e-cleanup` afterward.
-      if (!process.env.E2E_SKIP_CLEANUP) {
+      // E2E_SKIP_TEARDOWN=1 skips teardown for debugging. Run cleanup scripts afterward.
+      if (!process.env.E2E_SKIP_TEARDOWN) {
         fs.rmSync(parentDir, {recursive: true, force: true})
         await teardownAll({
           browserPage,
@@ -138,8 +138,8 @@ test.describe('App scaffold', () => {
         `buildApp failed:\nstdout: ${buildResult.stdout}\nstderr: ${buildResult.stderr}`,
       ).toBe(0)
     } finally {
-      // E2E_SKIP_CLEANUP=1 skips cleanup for debugging. Run `pnpm test:e2e-cleanup` afterward.
-      if (!process.env.E2E_SKIP_CLEANUP) {
+      // E2E_SKIP_TEARDOWN=1 skips teardown for debugging. Run cleanup scripts afterward.
+      if (!process.env.E2E_SKIP_TEARDOWN) {
         fs.rmSync(parentDir, {recursive: true, force: true})
         await teardownAll({
           browserPage,

--- a/packages/e2e/tests/dev-hot-reload.spec.ts
+++ b/packages/e2e/tests/dev-hot-reload.spec.ts
@@ -83,8 +83,8 @@ test.describe('Dev hot reload', () => {
         proc.kill()
       }
     } finally {
-      // E2E_SKIP_CLEANUP=1 skips cleanup for debugging. Run `pnpm test:e2e-cleanup` afterward.
-      if (!process.env.E2E_SKIP_CLEANUP) {
+      // E2E_SKIP_TEARDOWN=1 skips teardown for debugging. Run cleanup scripts afterward.
+      if (!process.env.E2E_SKIP_TEARDOWN) {
         fs.rmSync(parentDir, {recursive: true, force: true})
         await teardownAll({
           browserPage,
@@ -135,8 +135,8 @@ test.describe('Dev hot reload', () => {
         proc.kill()
       }
     } finally {
-      // E2E_SKIP_CLEANUP=1 skips cleanup for debugging. Run `pnpm test:e2e-cleanup` afterward.
-      if (!process.env.E2E_SKIP_CLEANUP) {
+      // E2E_SKIP_TEARDOWN=1 skips teardown for debugging. Run cleanup scripts afterward.
+      if (!process.env.E2E_SKIP_TEARDOWN) {
         fs.rmSync(parentDir, {recursive: true, force: true})
         await teardownAll({
           browserPage,
@@ -193,8 +193,8 @@ test.describe('Dev hot reload', () => {
         proc.kill()
       }
     } finally {
-      // E2E_SKIP_CLEANUP=1 skips cleanup for debugging. Run `pnpm test:e2e-cleanup` afterward.
-      if (!process.env.E2E_SKIP_CLEANUP) {
+      // E2E_SKIP_TEARDOWN=1 skips teardown for debugging. Run cleanup scripts afterward.
+      if (!process.env.E2E_SKIP_TEARDOWN) {
         fs.rmSync(parentDir, {recursive: true, force: true})
         await teardownAll({
           browserPage,

--- a/packages/e2e/tests/multi-config-dev.spec.ts
+++ b/packages/e2e/tests/multi-config-dev.spec.ts
@@ -84,8 +84,8 @@ include_config_on_deploy = true
         proc.kill()
       }
     } finally {
-      // E2E_SKIP_CLEANUP=1 skips cleanup for debugging. Run `pnpm test:e2e-cleanup` afterward.
-      if (!process.env.E2E_SKIP_CLEANUP) {
+      // E2E_SKIP_TEARDOWN=1 skips teardown for debugging. Run cleanup scripts afterward.
+      if (!process.env.E2E_SKIP_TEARDOWN) {
         fs.rmSync(parentDir, {recursive: true, force: true})
         await teardownAll({
           browserPage,
@@ -156,8 +156,8 @@ api_version = "2025-01"
         proc.kill()
       }
     } finally {
-      // E2E_SKIP_CLEANUP=1 skips cleanup for debugging. Run `pnpm test:e2e-cleanup` afterward.
-      if (!process.env.E2E_SKIP_CLEANUP) {
+      // E2E_SKIP_TEARDOWN=1 skips teardown for debugging. Run cleanup scripts afterward.
+      if (!process.env.E2E_SKIP_TEARDOWN) {
         fs.rmSync(parentDir, {recursive: true, force: true})
         await teardownAll({
           browserPage,

--- a/packages/e2e/tests/toml-config-invalid.spec.ts
+++ b/packages/e2e/tests/toml-config-invalid.spec.ts
@@ -36,8 +36,8 @@ test.describe('TOML config invalid', () => {
         expect(result.exitCode, `expected deploy to fail for ${label}, but it succeeded:\n${output}`).not.toBe(0)
         expect(output.toLowerCase(), `expected error output for ${label}:\n${output}`).toMatch(/error|invalid|failed/)
       } finally {
-        // E2E_SKIP_CLEANUP=1 skips cleanup for debugging. Run `pnpm test:e2e-cleanup` afterward.
-        if (!process.env.E2E_SKIP_CLEANUP) {
+        // E2E_SKIP_TEARDOWN=1 skips teardown for debugging. Run cleanup scripts afterward.
+        if (!process.env.E2E_SKIP_TEARDOWN) {
           fs.rmSync(appDir, {recursive: true, force: true})
         }
       }

--- a/packages/e2e/tests/toml-config.spec.ts
+++ b/packages/e2e/tests/toml-config.spec.ts
@@ -35,8 +35,8 @@ test.describe('TOML config regression', () => {
       const output = result.stdout + result.stderr
       expect(result.exitCode, `deploy failed:\n${output}`).toBe(0)
     } finally {
-      // E2E_SKIP_CLEANUP=1 skips cleanup for debugging. Run `pnpm test:e2e-cleanup` afterward.
-      if (!process.env.E2E_SKIP_CLEANUP) {
+      // E2E_SKIP_TEARDOWN=1 skips teardown for debugging. Run cleanup scripts afterward.
+      if (!process.env.E2E_SKIP_TEARDOWN) {
         fs.rmSync(parentDir, {recursive: true, force: true})
         await teardownAll({
           browserPage,
@@ -77,8 +77,8 @@ test.describe('TOML config regression', () => {
         proc.kill()
       }
     } finally {
-      // E2E_SKIP_CLEANUP=1 skips cleanup for debugging. Run `pnpm test:e2e-cleanup` afterward.
-      if (!process.env.E2E_SKIP_CLEANUP) {
+      // E2E_SKIP_TEARDOWN=1 skips teardown for debugging. Run cleanup scripts afterward.
+      if (!process.env.E2E_SKIP_TEARDOWN) {
         fs.rmSync(parentDir, {recursive: true, force: true})
         await teardownAll({
           browserPage,


### PR DESCRIPTION
### WHY are these changes introduced?

Improves reliability and speed of per-test teardown.

### WHAT is this pull request doing?

Refactors teardown so phases have consistent structure, fixes/optimizes browser verification, and upgrades CLI helpers.

Now a complete store + app teardown looks like this:
| Phase | Steps | Code/Logic | Retry |
| :---- | :---- | :---- | :---- |
| 1 | 1\. Uninstall app<br>`@admin/…/settings/apps` | `uninstallAppFromStore`: <br>click ⋯ → Uninstall → Confirm | Up to 3x, outer in teardown Phase 1 |
| 1 | 2\. Confirm uninstall<br>(reload `admin/…/settings/apps`) | `uninstallAppFromStore`: <br>reload `/apps`, <br>check app span gone <br>→ success | If fails, retry ↑↑↑ |
| 2 | 3\. Delete store<br>(gate: step 2 passed)<br>`@admin/…/settings/plan/cancel` | Gate verifies `isStoreAppsEmpty` <br>→ `safeToDelete = true` <br>→ `deleteStore` | Up to 3x, outer in teardown Phase 2 |
| 2 | 4\. Confirm store delete<br>(reload `admin/…/settings/plan/cancel`) | Inside new `deleteStore`:<br>reload `/cancel`, <br>check if it gets redirect to `admin/…/access_account` <br>→ success | If fails, retry ↑↑↑ |
| 3 | 5\. Delete app<br>(gate: step 2 passed)<br>`@dashboard/../app/…/settings` | Gate verifies `uninstalled = true`<br>→ proceed to delete app | Up to 3x, outer in teardown Phase 3 |
| 3 | 6\. Confirm app delete<br>(reload `dashboard/../app/…/settings`) | `deleteAppFromDevDashboard`:<br>reload `/settings`, <br>check if 404 <br>→ success |If fails, retry ↑↑↑ |

---

#### 1. Faster app deletion verification (`setup/app.ts`)

Before: `waitForURL(url !== urlBefore)` burned up to 60s for the page to navigate away (usually takes 10-20 sec).

https://github.com/user-attachments/assets/ba55e3c1-6099-4848-b72e-d530134a4e60

After: reloads `{appUrl}/settings` — `404` = deleted, other = fail/retry. Completes in seconds.

https://github.com/user-attachments/assets/6c55c4fd-2caf-4544-b65b-2b138f78ac59

Also: early 404 short-circuit on initial load, `scrollIntoViewIfNeeded` for below-fold button, `STILL_HAS_INSTALLS` fail-fast (throw instead of spinning on disabled Delete button), optional `DELETE` confirmation input.

---

#### 2. Faster store deletion verification (`setup/store.ts`)

Before: navigated to `/settings/plan`, clicked shadow DOM button, verified via `waitForURL(/access_account/)` — burned 60s on silent failure.
After: navigates to `/settings/plan/cancel` (auto-opens modal, no shadow DOM click needed), verifies via `networkidle` + reload → `access_account` redirect check.

Modal scoped by title (`.Polaris-Modal-Dialog__Modal:has-text("Review before deleting store")`) to avoid matching stale modals.

---

#### 3. Consistent uninstall verification (`setup/store.ts`)

Before: checked stale DOM first, only reloaded as fallback.
After: always reloads → dismisses Dev Console → checks. Matches cleanup-stores pattern.

---

#### 4. Teardown orchestrator cleanup (`setup/teardown.ts`)

Each helper now owns its own verification; teardown becomes the orchestrator:
- Phase 2 (delete store) **skipped if Phase 1 failed**
- Phase 3 (delete app) **skipped if Phase 1 failed** — catches `STILL_HAS_INSTALLS` and fails fast (cleanup-apps reaps orphans)
- Pre-flight gate: verifies `isStoreAppsEmpty` before attempting store delete

---

#### 5. CLI helper upgrades (`setup/app.ts`)

- **`configLink` rewritten** — from `exec` with `--client-id` to interactive PTY spawn that answers org/app prompts (needed for tests that create apps from scratch)
- **`createApp` auto-defaults `--flavor javascript`** for reactRouter/remix (prevents PTY hang)
- **`versionsList` accepts optional `config`** (needed for multi-config tests)
- **Consistent arg ordering** — `--path` always last across all helpers

---

#### 6. Minor fixes

- `E2E_SKIP_CLEANUP` → `E2E_SKIP_TEARDOWN` across 7 test specs (matches what it actually controls)
- `refreshIfPageError`: `Internal Server Error` → `500: Internal Server Error` (tighter match)

---

### How to test your changes?

Run an E2E test and confirm teardown completes cleanly:
```bash
E2E_HEADED=1 DEBUG=1 pnpm --filter e2e exec playwright test app-dev-server
```

<details>

<summary>Expand for complete log</summary>

```bash
cli % E2E_HEADED=1 DEBUG=1 pnpm --filter e2e exec playwright test app-dev-server
[e2e][auth] global setup starting

To run this command, log in to Shopify.
User verification code: QGWN-RFHK
👉 Open this link to start the auth process: https://accounts.shopify.com/activate-with-code?device_code%5Buser_code%5D=QGWN-RFHK
✔ Logged in.
✔ Current account: genghis-khan-identity-1-2025-03-31@shopify.com.
[e2e][auth] browser sessions established for admin + dev dashboard
[e2e][auth] global setup done, config at /Users/psyw/src/github.com/Shopify/cli/.e2e-tmp/global-auth/XDG_CONFIG_HOME

Running 1 test using 1 worker

     1 …ev starts, shows ready message, and quits with q

[e2e][w0] ----- TEST: dev starts, shows ready message, and quits with q ----- 
[e2e][auth] copying session from global setup

[e2e][w0] ----- Setup: store e2e-w0-1776933243084 ----- 
[e2e][w0][browser] store creating
[e2e][w0][browser] store form not loaded (attempt 1/3), url=https://admin.shopify.com/store-create/organization/161686155
[e2e][w0][browser] store plan=SHOPIFY_PLUS_APP_DEVELOPMENT
[e2e][w0][browser] store created e2e-w0-1776933243084.myshopify.com
[e2e][w0][cli] exec: node /Users/psyw/src/github.com/Shopify/cli/packages/create-app/bin/run.js
[e2e][w0][cli] app init --template none --name E2E-dev-1776933268386 --package-manager pnpm --local --organization-id 161686155 --path /Users/psyw/src/github.com/Shopify/cli/.e2e-tmp/e2e-trWnwm/app-5C8wvK
╭─ info ───────────────────────────────────────────────────────────────────────╮
│                                                                              │
│  Initializing project with `pnpm`                                            │
│  Use the `--package-manager` flag to select a different package manager.     │
│                                                                              │
╰──────────────────────────────────────────────────────────────────────────────╯


╭─ success ────────────────────────────────────────────────────────────────────╮
│                                                                              │
│  e2-e-dev-1776933268386 is ready for you to build!                           │
│                                                                              │
│  Next steps                                                                  │
│    • Run `cd e2-e-dev-1776933268386`                                         │
│    • For extensions, run `shopify app generate extension`                    │
│    • To see your app, run `shopify app dev`                                  │
│                                                                              │
│  Reference                                                                   │
│    • Shopify docs [1]                                                        │
│    • Shopify Dev MCP, [2] connect your AI assistant to development           │
│      resources                                                               │
│    • For an overview of commands, run `shopify app --help`                   │
│                                                                              │
╰──────────────────────────────────────────────────────────────────────────────╯
[1] https://shopify.dev
[2] https://shopify.dev/docs/apps/build/devmcp

[e2e][w0][cli] spawn: node /Users/psyw/src/github.com/Shopify/cli/packages/cli/bin/run.js
[e2e][w0][cli] app dev --path /Users/psyw/src/github.com/Shopify/cli/.e2e-tmp/e2e-trWnwm/app-5C8wvK/e2-e-dev-1776933268386
╭─ info ───────────────────────────────────────────────────────────────────────╮
│                                                                              │
│  Using shopify.app.toml for default values:                                  │
│                                                                              │
│    • Org:             core-build-develop-admin-web-e2e                       │
│    • App:             E2E-dev-1776933268386                                  │
│    • Dev store:       e2e-w0-1776933243084.myshopify.com                     │
│    • Update URLs:     Yes                                                    │
│                                                                              │
│   You can pass `--reset` to your command to reset your app configuration.    │
│                                                                              │
╰──────────────────────────────────────────────────────────────────────────────╯

04:34:49 │               app-preview │ Preparing dev preview on e2e-w0-1776933243084.myshopify.com
04:34:49 │                  graphiql │ GraphiQL server started on port 3457
04:34:49 │                     proxy │ Proxy server started on port 54238
04:34:51 │               app-preview │ ✅ Ready, watching for changes in your app 
04:34:51 │                app_access │ │ App has been installed
04:34:51 │                  app_home │ └ Using URL: https://shopify.dev/apps/default-app-home

╭─ info ───────────────────────────────────────────────────────────────────────╮
│                                                                              │
│  A preview of your development changes is still available on                 │
│  e2e-w0-1776933243084.myshopify.com.                                         │
│                                                                              │
│  Run `shopify app dev clean` to restore the latest released version of your  │
│   app.                                                                       │
│                                                                              │
│  Learn more about dev previews [1]                                           │
│                                                                              │
╰──────────────────────────────────────────────────────────────────────────────╯
[1] https://shopify.dev/beta/developer-dashboard/shopify-app-dev


[e2e][w0] ----- Teardown: store e2e-w0-1776933243084.myshopify.com ----- 
[e2e][w0][browser] uninstalling app from store
[e2e][w0][browser] app uninstalled
[e2e][w0][browser] deleting store
[e2e][w0][browser] store deleted

[e2e][w0] ----- Teardown: app E2E-dev-1776933268386 ----- 
[e2e][w0][browser] deleting app
[e2e][w0][browser] app found, deleting
[e2e][w0][browser] app deleted
  ✓  1 …ts, shows ready message, and quits with q (2.8m)

  1 passed (3.5m)
```

</details>


### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing, so I've added a changelog entry with `pnpm changeset add`