### PR TITLE
Explicitly set identifier and uiStrategy for admin_link so the build command will work

### DIFF
--- a/packages/app/src/cli/models/extensions/specifications/admin_link.ts
+++ b/packages/app/src/cli/models/extensions/specifications/admin_link.ts
@@ -2,6 +2,8 @@ import {createContractBasedModuleSpecification} from '../specification.js'
 
 const adminLinkSpec = createContractBasedModuleSpecification({
   identifier: 'admin_link',
+  uidStrategy: 'uuid',
+  experience: 'extension',
   clientSteps: [
     {
       lifecycle: 'deploy',


### PR DESCRIPTION
### WHY are these changes introduced?

The `admin_link` specification was missing required fields to work with the `build`command which does not pull remote specs

### WHAT is this pull request doing?

Adds `uidStrategy: 'uuid'` and `experience: 'extension'` to the `admin_link` contract-based module specification, ensuring it is correctly identified and categorized as an extension with a UUID-based UID strategy.

### How to test your changes?

1. Deploy an app with an `admin_link` extension.
2. Verify the extension is correctly identified with a UUID and treated as an `extension` experience type during the deploy lifecycle.

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct bump type (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](../CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`