### PR TITLE
Gardener: require manual label, keep Dependabot auto-label

### DIFF
--- a/.github/workflows/gardener-notify-event.yml
+++ b/.github/workflows/gardener-notify-event.yml
@@ -2,18 +2,22 @@ name: Gardener - Notify Event
 # Tiny event capturer: stashes the triggering issue/PR payload as an artifact
 # for `gardener-notify-slack.yml` to pick up via workflow_run.
 #
+# Fires when `devtools-gardener` is applied manually, or automatically for
+# Dependabot-opened PRs (which we always want in Slack). Other `opened`
+# events are ignored — auto-labeling everything turned out too noisy.
+#
 # Why two workflows? When Dependabot triggers a workflow, GitHub forces
 # GITHUB_TOKEN to read-only and hides Actions secrets — so labeling and
-# Slack posting from this workflow would fail on every Dependabot PR. A
+# Slack posting from this workflow would fail on Dependabot PRs. A
 # workflow_run-triggered follow-up runs in the default-branch context with
 # full permissions and secret access, regardless of the upstream actor.
 #
-# Uses pull_request_target so fork-opened PRs still produce an artifact.
-# No code is checked out here; this workflow only reads the pre-parsed
-# event payload, so there is no pwn-request surface.
+# Uses pull_request_target so fork PRs still produce an artifact when
+# labeled. No code is checked out here; this workflow only reads the
+# pre-parsed event payload, so there is no pwn-request surface.
 on:
   issues:
-    types: [opened, labeled]
+    types: [labeled]
   pull_request_target:
     types: [opened, labeled]
 
@@ -22,7 +26,9 @@ permissions:
 
 jobs:
   capture:
-    if: github.event.action == 'opened' || github.event.label.name == 'devtools-gardener'
+    if: >-
+      github.event.label.name == 'devtools-gardener' ||
+      (github.event.action == 'opened' && github.event.pull_request.user.login == 'dependabot[bot]')
     runs-on: ubuntu-latest
     steps:
       - name: Stash event payload

--- a/.github/workflows/gardener-notify-slack.yml
+++ b/.github/workflows/gardener-notify-slack.yml
@@ -1,11 +1,15 @@
 name: Gardener - Notify Slack
-# Runs after `Gardener - Notify Event` completes and does the real work:
-# applies the devtools-gardener label and posts a summary to Slack.
+# Runs after `Gardener - Notify Event` completes. Posts a summary to Slack,
+# and for Dependabot-opened PRs also applies the `devtools-gardener` label
+# (so Dependabot PRs show up in the gardener flow without a human having
+# to label them).
 #
 # The workflow_run trigger runs this job in the default-branch context with
 # full GITHUB_TOKEN permissions and Actions secret access — this is what
 # lets it succeed for Dependabot-opened PRs, where the upstream event
-# workflow can't label or reach secrets directly.
+# workflow can't label or reach secrets directly. Labels applied here via
+# GITHUB_TOKEN do not trigger another `labeled` run (loop prevention), so
+# Slack only gets one post per PR.
 on:
   workflow_run:
     workflows: ['Gardener - Notify Event']
@@ -34,23 +38,21 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Add devtools-gardener label
+      - name: Add devtools-gardener label to Dependabot PR
         if: steps.download.outcome == 'success'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
         run: |
           ACTION=$(jq -r '.action' event.json)
-          # On `labeled` events the label is already there — skip.
-          if [ "$ACTION" != "opened" ]; then
+          LOGIN=$(jq -r '.pull_request.user.login // ""' event.json)
+          # Only the Dependabot-opened path needs labeling here. On manual
+          # `labeled` events the label is already on the PR/issue.
+          if [ "$ACTION" != "opened" ] || [ "$LOGIN" != "dependabot[bot]" ]; then
             exit 0
           fi
-          NUMBER=$(jq -r '(.issue // .pull_request).number' event.json)
-          if jq -e 'has("pull_request")' event.json > /dev/null; then
-            gh pr edit "$NUMBER" --add-label devtools-gardener
-          else
-            gh issue edit "$NUMBER" --add-label devtools-gardener
-          fi
+          NUMBER=$(jq -r '.pull_request.number' event.json)
+          gh pr edit "$NUMBER" --add-label devtools-gardener
 
       - name: Post to Slack
         if: steps.download.outcome == 'success'


### PR DESCRIPTION
## Summary

Changes the gardener Slack notifier so that the `devtools-gardener` label (which gates Slack posting) must be applied manually for human-opened issues and PRs. Dependabot-opened PRs are still auto-labeled.

## Why

The previous flow applied `devtools-gardener` to every newly opened issue and PR. This repo gets a lot of PR's, many of which don't need to be reviewed by this team. So it was too noisy.

Dependabot PRs are kept auto-labeled because we always want dependency updates to surface for triage, and there's no human to apply the label.

## Behavior matrix

| Event | Before | After |
|---|---|---|
| Human opens issue/PR | Label applied, Slack post | Nothing |
| Human applies `devtools-gardener` | Slack post | Slack post |
| Dependabot opens PR | Label applied, Slack post | Label applied, Slack post |

## How it works

`gardener-notify-event.yml` (capture):
- Dropped `opened` from `issues:` types — issues now only capture on `labeled`.
- Kept `opened` on `pull_request_target:` but the job `if` only admits it when the opener is `dependabot[bot]`.
- `labeled` events still pass through when the label is `devtools-gardener`.

`gardener-notify-slack.yml` (downstream workflow_run):
- The auto-label step is scoped to the Dependabot-opened path (`action == opened && login == dependabot[bot]`) instead of every `opened` event.
- No duplicate Slack posts: labels applied here via `GITHUB_TOKEN` don't trigger another `labeled` run (GitHub's loop-prevention).

The two-workflow pattern is still needed: Dependabot-triggered workflows have read-only `GITHUB_TOKEN` and no Actions secret access, so labeling and Slack posting happen in the `workflow_run` follow-up which runs in the default-branch context.