### PR TITLE
Add assets config key support for UI extension points

### DIFF
--- a/packages/app/src/cli/models/extensions/schemas.ts
+++ b/packages/app/src/cli/models/extensions/schemas.ts
@@ -75,6 +75,7 @@ const NewExtensionPointSchema = zod.object({
       chat: zod.string().optional(),
     })
     .optional(),
+  assets: zod.string().optional(),
 })
 
 export const NewExtensionPointsSchema = zod.array(NewExtensionPointSchema)

--- a/packages/app/src/cli/models/extensions/specifications/ui_extension.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/ui_extension.test.ts
@@ -151,6 +151,7 @@ describe('ui_extension', async () => {
           tools: undefined,
           instructions: undefined,
           intents: undefined,
+          assets: undefined,
           module: './src/ExtensionPointA.js',
           metafields: [{namespace: 'test', key: 'test'}],
           default_placement_reference: undefined,
@@ -219,6 +220,7 @@ describe('ui_extension', async () => {
           tools: undefined,
           instructions: undefined,
           intents: undefined,
+          assets: undefined,
           module: './src/ExtensionPointA.js',
           metafields: [],
           default_placement_reference: 'PLACEMENT_REFERENCE1',
@@ -283,6 +285,7 @@ describe('ui_extension', async () => {
           tools: undefined,
           instructions: undefined,
           intents: undefined,
+          assets: undefined,
           module: './src/ExtensionPointA.js',
           metafields: [],
           urls: {},
@@ -347,6 +350,7 @@ describe('ui_extension', async () => {
           tools: undefined,
           instructions: undefined,
           intents: undefined,
+          assets: undefined,
           module: './src/ExtensionPointA.js',
           metafields: [],
           default_placement_reference: undefined,
@@ -414,6 +418,7 @@ describe('ui_extension', async () => {
           tools: undefined,
           instructions: undefined,
           intents: undefined,
+          assets: undefined,
           module: './src/ExtensionPointA.js',
           metafields: [],
           default_placement_reference: undefined,
@@ -483,6 +488,7 @@ describe('ui_extension', async () => {
           tools: undefined,
           instructions: undefined,
           intents: undefined,
+          assets: undefined,
           module: './src/ExtensionPointA.js',
           metafields: [],
           default_placement_reference: undefined,
@@ -552,6 +558,7 @@ describe('ui_extension', async () => {
           tools: './tools.json',
           instructions: undefined,
           intents: undefined,
+          assets: undefined,
           metafields: [],
           default_placement_reference: undefined,
           capabilities: undefined,
@@ -616,6 +623,72 @@ describe('ui_extension', async () => {
           tools: undefined,
           instructions: './instructions.md',
           intents: undefined,
+          assets: undefined,
+          metafields: [],
+          default_placement_reference: undefined,
+          capabilities: undefined,
+          preloads: {},
+          build_manifest: {
+            assets: {
+              main: {
+                filepath: 'test-ui-extension.js',
+                module: './src/ExtensionPointA.js',
+              },
+            },
+          },
+          urls: {},
+        },
+      ])
+    })
+
+    test('targeting object passes through assets when configured', async () => {
+      const allSpecs = await loadLocalExtensionsSpecifications()
+      const specification = allSpecs.find((spec) => spec.identifier === 'ui_extension')!
+      const configuration = {
+        targeting: [
+          {
+            target: 'EXTENSION::POINT::A',
+            module: './src/ExtensionPointA.js',
+            assets: './assets',
+          },
+        ],
+        api_version: '2023-01' as const,
+        name: 'UI Extension',
+        description: 'This is an ordinary test extension',
+        type: 'ui_extension',
+        handle: 'test-ui-extension',
+        capabilities: {
+          block_progress: false,
+          network_access: false,
+          api_access: false,
+          collect_buyer_consent: {
+            customer_privacy: true,
+            sms_marketing: false,
+          },
+          iframe: {
+            sources: [],
+          },
+        },
+        settings: {},
+      }
+
+      // When
+      const parsed = specification.parseConfigurationObject(configuration)
+      if (parsed.state !== 'ok') {
+        throw new Error("Couldn't parse configuration")
+      }
+
+      const got = parsed.data
+
+      // Then
+      expect(got.extension_points).toStrictEqual([
+        {
+          target: 'EXTENSION::POINT::A',
+          module: './src/ExtensionPointA.js',
+          tools: undefined,
+          instructions: undefined,
+          intents: undefined,
+          assets: './assets',
           metafields: [],
           default_placement_reference: undefined,
           capabilities: undefined,
@@ -779,6 +852,7 @@ Please check the configuration in ${uiExtension.configurationPath}`),
           tools: './tools.json',
           instructions: './instructions.md',
           intents: undefined,
+          assets: undefined,
           metafields: [],
           default_placement_reference: undefined,
           capabilities: undefined,

--- a/packages/app/src/cli/models/extensions/specifications/ui_extension.ts
+++ b/packages/app/src/cli/models/extensions/specifications/ui_extension.ts
@@ -74,6 +74,7 @@ export const UIExtensionSchema = BaseSchema.extend({
         tools: targeting.tools,
         instructions: targeting.instructions,
         intents: targeting.intents,
+        assets: targeting.assets,
       }
     })
     return {...config, extension_points: extensionPoints}
@@ -118,6 +119,12 @@ const uiExtensionSpec = createExtensionSpecification({
                 anchor: 'extension_points[]',
                 groupBy: 'target',
                 key: 'extension_points[].intents[].schema',
+              },
+              {
+                type: 'configKey',
+                anchor: 'extension_points[]',
+                groupBy: 'target',
+                key: 'extension_points[].assets',
               },
             ],
           },

--- a/packages/app/src/cli/models/extensions/specifications/ui_extension.ts
+++ b/packages/app/src/cli/models/extensions/specifications/ui_extension.ts
@@ -106,6 +106,12 @@ const uiExtensionSpec = createExtensionSpecification({
                 type: 'configKey',
                 anchor: 'extension_points[]',
                 groupBy: 'target',
+                key: 'extension_points[].assets',
+              },
+              {
+                type: 'configKey',
+                anchor: 'extension_points[]',
+                groupBy: 'target',
                 key: 'extension_points[].tools',
               },
               {
@@ -119,12 +125,6 @@ const uiExtensionSpec = createExtensionSpecification({
                 anchor: 'extension_points[]',
                 groupBy: 'target',
                 key: 'extension_points[].intents[].schema',
-              },
-              {
-                type: 'configKey',
-                anchor: 'extension_points[]',
-                groupBy: 'target',
-                key: 'extension_points[].assets',
               },
             ],
           },

--- a/packages/app/src/cli/services/dev/extension/payload/models.ts
+++ b/packages/app/src/cli/services/dev/extension/payload/models.ts
@@ -39,7 +39,7 @@ interface Asset {
   lastUpdated: number
 }
 
-export interface DevNewExtensionPointSchema extends Omit<NewExtensionPointSchemaType, 'intents'> {
+export interface DevNewExtensionPointSchema extends Omit<NewExtensionPointSchemaType, 'intents' | 'assets'> {
   assets: {
     [name: string]: Asset
   }


### PR DESCRIPTION
Part of https://github.com/shop/issues-admin-extensibility/issues/2439

### WHY are these changes introduced?

Adds support for an `assets` field on UI extension points, allowing extension point configurations to declare associated assets.

### WHAT is this pull request doing?

- Adds an optional `assets` field to `NewExtensionPointSchema` in the extension schemas
- Passes the `assets` property through when transforming extension point targeting configurations in `UIExtensionSchema`
- Registers `extension_points[].assets` as a `configKey` in the UI extension specification so it is properly grouped and tracked per extension point target
- Updates `DevNewExtensionPointSchema` to omit `assets` from the base type and redefine it as a map of named `Asset` objects (with `lastUpdated`), preserving the existing dev payload structure while accommodating the new schema field

### How to test your changes?

1. Create a UI extension with extension points that include an `assets` field in the configuration
2. Run `shopify app dev` and verify the extension point payload includes the `assets` field correctly
3. Verify that the dev server payload maps `assets` to the expected `{ [name: string]: Asset }` structure

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct bump type (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](../CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`