### PR TITLE
E2E: improve CLI log format

### DIFF
--- a/packages/e2e/setup/cli.ts
+++ b/packages/e2e/setup/cli.ts
@@ -46,6 +46,18 @@ export const cliFixture = envFixture.extend<{cli: CLIProcess}>({
     const spawnedProcesses: SpawnedProcess[] = []
     const cliLog = createLogger('cli')
 
+    // When DEBUG=1, tee the subprocess streams to the parent so the CLI's
+    // info/success boxes and progress messages appear live, while still
+    // letting execa buffer and return the captured output.
+    const runExeca = (bin: string, args: string[], execaOpts: ExecaOptions) => {
+      const subprocess = execa('node', [bin, ...args], execaOpts)
+      if (process.env.DEBUG === '1') {
+        subprocess.stdout?.pipe(process.stdout, {end: false})
+        subprocess.stderr?.pipe(process.stderr, {end: false})
+      }
+      return subprocess
+    }
+
     const cli: CLIProcess = {
       async exec(args, opts = {}) {
         const timeout = opts.timeout ?? CLI_TIMEOUT.medium
@@ -56,9 +68,10 @@ export const cliFixture = envFixture.extend<{cli: CLIProcess}>({
           reject: false,
         }
 
-        cliLog.log(env, `exec: node ${executables.cli} ${args.join(' ')}`)
+        cliLog.log(env, `exec: node ${executables.cli}`)
+        cliLog.log(env, args.join(' '))
 
-        const result = await execa('node', [executables.cli, ...args], execaOpts)
+        const result = await runExeca(executables.cli, args, execaOpts)
 
         return {
           stdout: result.stdout ?? '',
@@ -76,9 +89,10 @@ export const cliFixture = envFixture.extend<{cli: CLIProcess}>({
           reject: false,
         }
 
-        cliLog.log(env, `exec: node ${executables.createApp} ${args.join(' ')}`)
+        cliLog.log(env, `exec: node ${executables.createApp}`)
+        cliLog.log(env, `app init ${args.join(' ')}`)
 
-        const result = await execa('node', [executables.createApp, ...args], execaOpts)
+        const result = await runExeca(executables.createApp, args, execaOpts)
 
         return {
           stdout: result.stdout ?? '',
@@ -98,7 +112,8 @@ export const cliFixture = envFixture.extend<{cli: CLIProcess}>({
           }
         }
 
-        cliLog.log(env, `spawn: node ${executables.cli} ${args.join(' ')}`)
+        cliLog.log(env, `spawn: node ${executables.cli}`)
+        cliLog.log(env, args.join(' '))
 
         const ptyProcess = nodePty.spawn('node', [executables.cli, ...args], {
           name: 'xterm-color',


### PR DESCRIPTION
### WHY are these changes introduced?

E2E debug output was hard to read and didn't match what you see when running a CLI command manually:

- **Commands were buried.** The binary path and the full arg list were logged on a single line, so for anything with a long `--path` (e.g. a temp-dir app) you'd have to scroll horizontally to find the actual subcommand.
   ```bash
   [e2e][w0][cli] exec: node /Users/psyw/src/github.com/Shopify/cli/packages/create-app/bin/run.js --name E2E-deploy-1776837816876 --path /Users/psyw/src/github.com/Shopify/cli/.e2e-tmp/e2e-bksuZC/app-c1uMa8 --package-manager pnpm --local --template none --organization-id 161686155
   ```
- **No live CLI output.** With `DEBUG=1`, `execa` buffered stdout/stderr and only surfaced them after the subprocess finished. You couldn't watch CLI info boxes, success panels, or progress messages as the test ran — only a wall of text after each command completed.

### WHAT is this pull request doing?

1. **Two-line log format.** Every `exec:` / `spawn:` entry is now split onto two lines — binary path on one, args on the next. The subcommand is the first thing you see on the args line:
   ```bash
   [e2e][w0][cli] exec: node /Users/psyw/src/github.com/Shopify/cli/packages/create-app/bin/run.js
   [e2e][w0][cli] app init --name E2E-deploy-1776837689829 --path /Users/psyw/src/github.com/Shopify/cli/.e2e-tmp/e2e-Hbb1z7/app-9Pbsml --package-manager pnpm --local --template none --organization-id 161686155
   ```
2. **Live subprocess output under `DEBUG=1`.** New `runExeca` helper pipes subprocess `stdout`/`stderr` to the parent with `{end: false}` (so the parent's streams aren't closed when the subprocess exits). execa still buffers internally, so captured `result.stdout` / `result.stderr` for assertions is unchanged. Applied to both `exec` and `execCreateApp`.

Net effect: running E2E tests with `DEBUG=1` now streams the same info boxes, success panels, and progress messages you'd see running \`shopify app deploy ...\` manually, rather than a silent wait followed by a dump.

### How to test your changes?

```bash
DEBUG=1 pnpm --filter e2e exec playwright test app-deploy
```

Expect to see:
- Each CLI invocation logged on two lines (binary → args)
- CLI info/success boxes and progress messages appearing **live** as the subprocess runs, not only after it exits

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows) — only affects stdout/stderr piping, platform-agnostic
- [x] I've considered possible [documentation](https://shopify.dev) changes — none, E2E infra only
- [x] I've considered analytics changes to measure impact — none
- [x] The change is user-facing — not user-facing; E2E test infrastructure only, no changeset needed