### PR TITLE
Link bump type documentation in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -41,4 +41,4 @@ Fixes #0000 <!-- link to issue if one exists -->
 - [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
 - [ ] I've considered possible [documentation](https://shopify.dev) changes
 - [ ] I've considered analytics changes to measure impact
-- [ ] The change is user-facing — I've identified the correct bump type (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](../CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`
+- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it's a work in progress
-->

### WHY are these changes introduced?

The PR checklist mentions "bump type" (`patch`, `minor`, `major`) but only links to the breaking changes section of `CONTRIBUTING.md`. Contributors unfamiliar with our versioning policy have no quick path to the full guide that explains when to use each bump type.

### WHAT is this pull request doing?

Adds a hyperlink from "bump type" in the PR template checklist to [`CONTRIBUTING.md#choosing-the-right-bump-type`](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type), so both the general versioning guide and the specific [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change) section are one click away.

### How to test your changes?

Open a new PR draft in this repo and confirm the checklist renders two links:

- **bump type** → [`CONTRIBUTING.md#choosing-the-right-bump-type`](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type)
- **breaking changes** → [`CONTRIBUTING.md#what-counts-as-a-breaking-change`](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`