### PR TITLE
E2E - QA: init, deploy, versions list, config link, 2nd deploy

### DIFF
--- a/packages/e2e/tests/app-deploy.spec.ts
+++ b/packages/e2e/tests/app-deploy.spec.ts
@@ -1,10 +1,10 @@
-/* eslint-disable no-restricted-imports */
 import {appTestFixture as test, createApp, deployApp, versionsList, configLink} from '../setup/app.js'
 import {teardownAll} from '../setup/teardown.js'
 import {TEST_TIMEOUT} from '../setup/constants.js'
 import {requireEnv} from '../setup/env.js'
 import {expect} from '@playwright/test'
 import * as fs from 'fs'
+// eslint-disable-next-line no-restricted-imports
 import * as path from 'path'
 
 /**
@@ -106,7 +106,9 @@ test.describe('App deploy', () => {
       })
       const linkOutput = linkResult.stdout + linkResult.stderr
       expect(linkResult.exitCode, `Step 4 - config link failed:\n${linkOutput}`).toBe(0)
-      expect(linkOutput, 'Step 4 - missing "is now linked to"').toContain('is now linked to')
+      expect(linkOutput, `Step 4 - missing "is now linked to \\"${secondaryAppName}\\""`).toContain(
+        `is now linked to "${secondaryAppName}"`,
+      )
       const secondaryTomlPath = path.join(appDir, `shopify.app.${secondaryConfig}.toml`)
       expect(
         fs.existsSync(secondaryTomlPath),

--- a/packages/e2e/tests/app-deploy.spec.ts
+++ b/packages/e2e/tests/app-deploy.spec.ts
@@ -1,52 +1,154 @@
-import {appTestFixture as test, createApp, deployApp, versionsList} from '../setup/app.js'
+/* eslint-disable no-restricted-imports */
+import {appTestFixture as test, createApp, deployApp, versionsList, configLink} from '../setup/app.js'
 import {teardownAll} from '../setup/teardown.js'
 import {TEST_TIMEOUT} from '../setup/constants.js'
 import {requireEnv} from '../setup/env.js'
 import {expect} from '@playwright/test'
 import * as fs from 'fs'
-import * as path from 'path' // eslint-disable-line no-restricted-imports
+import * as path from 'path'
+
+/**
+ * Test A — full deploy lifecycle (QA checklist: Apps section, deploy flow).
+ *
+ *   1. `app init` Create primary app (React Router + JavaScript)
+ *   2. `app deploy --version v1` Deploy with a version tag
+ *   3. `app versions list` Verify the primary tag is active and no other
+ *      version is stuck active
+ *   4. `app config link` from primary dir → creates a brand-new secondary app
+ *      interactively (answers org → "Create new?" → app name; config name
+ *      prompt is skipped via `--config secondary`)
+ *   5. `app deploy --config secondary` Deploy from primary dir to secondary app
+ *   6. `app versions list --config secondary` Verify the secondary deploy hit
+ *      the secondary app (not a silent fallback to primary) and the primary
+ *      tag does not leak into secondary's list
+ *
+ * Test body is pure CLI; teardown uses the dev dashboard to delete both apps.
+ */
+
+interface VersionLine {
+  versionTag?: string | null
+  status: string
+}
+
+/**
+ * Asserts a `versions list --json` result shows:
+ *   - `expectedTag` is present and `active`
+ *   - no other version is stuck `active`
+ *   - (if `forbiddenTag` provided) `forbiddenTag` does not appear at all
+ *
+ * The last check guards cross-app leakage: a version we expect to live on one
+ * app should never appear in another app's version list.
+ */
+function assertActiveVersion(opts: {
+  result: {stdout: string; stderr: string; exitCode: number}
+  expectedTag: string
+  step: string
+  forbiddenTag?: string
+}) {
+  const {result, expectedTag, step, forbiddenTag} = opts
+  const output = result.stdout + result.stderr
+  expect(result.exitCode, `${step} - versions list failed:\n${output}`).toBe(0)
+  const versions = JSON.parse(result.stdout) as VersionLine[]
+  const entry = versions.find((version) => version.versionTag === expectedTag)
+  expect(entry, `${step} - version tag "${expectedTag}" not found in:\n${result.stdout}`).toBeDefined()
+  expect(entry?.status, `${step} - expected "${expectedTag}" to be active, got "${entry?.status}"`).toBe('active')
+  const otherActive = versions.filter((version) => version.versionTag !== expectedTag && version.status === 'active')
+  expect(otherActive, `${step} - unexpected other active versions: ${JSON.stringify(otherActive)}`).toHaveLength(0)
+  if (forbiddenTag) {
+    const tags = versions.map((version) => version.versionTag)
+    expect(tags, `${step} - tag "${forbiddenTag}" unexpectedly found in list`).not.toContain(forbiddenTag)
+  }
+}
 
 test.describe('App deploy', () => {
-  test('deploy and verify version exists', async ({cli, env, browserPage}) => {
+  test('init, deploy, versions list, config link, deploy to secondary', async ({cli, env, browserPage}) => {
     test.setTimeout(TEST_TIMEOUT.long)
     requireEnv(env, 'orgId')
 
     const parentDir = fs.mkdtempSync(path.join(env.tempDir, 'app-'))
-    const appName = `E2E-deploy-${Date.now()}`
+    const appName = `E2E-deploy1-${Date.now()}`
+    const secondaryAppName = `E2E-deploy2-${Date.now()}`
 
     try {
-      // Step 1: Create an extension-only app (no scopes needed for deploy)
+      // Step 1: Create primary app (React Router template)
       const initResult = await createApp({
         cli,
         parentDir,
         name: appName,
-        template: 'none',
+        template: 'reactRouter',
+        flavor: 'javascript',
         packageManager: 'pnpm',
         orgId: env.orgId,
       })
-      expect(initResult.exitCode, `createApp failed:\nstdout: ${initResult.stdout}\nstderr: ${initResult.stderr}`).toBe(
-        0,
-      )
+      expect(initResult.exitCode, `Step 1 - primary app init failed:\n${initResult.stderr}`).toBe(0)
       const appDir = initResult.appDir
 
       // Step 2: Deploy with a tagged version
-      const versionTag = `e2e-v-${Date.now()}`
-      const deployResult = await deployApp({cli, appDir, version: versionTag, message: 'E2E test deployment'})
+      const versionTag = `E2E-v1-${Date.now()}`
+      const deployResult = await deployApp({cli, appDir, version: versionTag, message: 'E2E A primary deployment'})
       const deployOutput = deployResult.stdout + deployResult.stderr
-      expect(deployResult.exitCode, `deploy failed:\n${deployOutput}`).toBe(0)
+      expect(deployResult.exitCode, `Step 2 - deploy failed:\n${deployOutput}`).toBe(0)
 
-      // Step 3: Verify the version exists via versions list
+      // Step 3: Verify the primary tag is active and no other version is stuck active.
       const listResult = await versionsList({cli, appDir})
-      const listOutput = listResult.stdout + listResult.stderr
-      expect(listResult.exitCode, `versions list failed:\n${listOutput}`).toBe(0)
-      expect(listOutput).toContain(versionTag)
+      assertActiveVersion({result: listResult, expectedTag: versionTag, step: 'Step 3'})
+
+      // Step 4: Config link from primary dir → creates a brand-new secondary app
+      // interactively (org → "Create new?" → "App name"). The "Configuration file
+      // name" prompt is skipped via `--config secondary`.
+      const secondaryConfig = 'secondary'
+      const linkResult = await configLink({
+        cli,
+        appDir,
+        appName: secondaryAppName,
+        orgId: env.orgId,
+        configName: secondaryConfig,
+      })
+      const linkOutput = linkResult.stdout + linkResult.stderr
+      expect(linkResult.exitCode, `Step 4 - config link failed:\n${linkOutput}`).toBe(0)
+      expect(linkOutput, 'Step 4 - missing "is now linked to"').toContain('is now linked to')
+      const secondaryTomlPath = path.join(appDir, `shopify.app.${secondaryConfig}.toml`)
+      expect(
+        fs.existsSync(secondaryTomlPath),
+        `Step 4 - expected ${secondaryTomlPath} to exist after config link`,
+      ).toBe(true)
+
+      // Step 5: Deploy from primary dir to secondary app via --config secondary
+      const secondaryVersionTag = `E2E-v2-${Date.now()}`
+      const secondaryDeployResult = await deployApp({
+        cli,
+        appDir,
+        config: secondaryConfig,
+        version: secondaryVersionTag,
+        message: 'E2E A secondary deployment',
+      })
+      const secondaryDeployOutput = secondaryDeployResult.stdout + secondaryDeployResult.stderr
+      expect(secondaryDeployResult.exitCode, `Step 5 - secondary deploy failed:\n${secondaryDeployOutput}`).toBe(0)
+
+      // Step 6: Verify the secondary deploy hit the secondary app (not a silent
+      // fallback to primary). Checks the secondary tag is active, no other
+      // version is stuck active, and the primary tag doesn't leak into secondary.
+      const secondaryListResult = await versionsList({cli, appDir, config: secondaryConfig})
+      assertActiveVersion({
+        result: secondaryListResult,
+        expectedTag: secondaryVersionTag,
+        step: 'Step 6',
+        forbiddenTag: versionTag,
+      })
     } finally {
       // E2E_SKIP_TEARDOWN=1 skips teardown for debugging. Run cleanup scripts afterward.
       if (!process.env.E2E_SKIP_TEARDOWN) {
         fs.rmSync(parentDir, {recursive: true, force: true})
+        // Neither app was installed on a store — delete the apps only (no uninstall)
         await teardownAll({
           browserPage,
           appName,
+          orgId: env.orgId,
+          workerIndex: env.workerIndex,
+        })
+        await teardownAll({
+          browserPage,
+          appName: secondaryAppName,
           orgId: env.orgId,
           workerIndex: env.workerIndex,
         })


### PR DESCRIPTION
### WHY are these changes introduced?

Automates test A of the manual [QA flow](https://docs.google.com/document/d/1XX6QnS6kKZTT1shcCZVcso74VWn-Ui4V2IASenHHi1E/edit?tab=t.0) (tracked in #7368 / sub-issue #7369). The existing `app-deploy.spec.ts` only covered a single init→deploy→versions-list cycle. Test A extends it to the full manual flow, adding coverage for:

- Version-tagged deploy + message persistence
- `app config link` creating a second app (interactive PTY prompts)
- Deploying against the linked secondary config
- Verifying each app's active version is correctly isolated

This closes the gap for the `config link`-to-new-app codepath, which previously had no E2E coverage.

### WHAT is this pull request doing?

Expands `tests/app-deploy.spec.ts` to the full A scope:

1. `shopify app init --template reactRouter` (primary app)
2. `shopify app deploy --version v1` + assert active on primary
3. `shopify app versions list --json` + assert `versionTag` matches
4. `shopify app config link --config secondary` (via PTY) → creates a new app within the primary app's organization
5. `shopify app deploy --config secondary --version v2` + assert active on secondary
6. `shopify app versions list --config secondary --json` + assert isolation from primary

Also adds helpers in `setup/app.ts` (config-link PTY driver, JSON-mode versions list, shared assertion for active-version checks) reused across this and future A–F tests.

### How to test your changes?

```bash
# One-shot
pnpm --filter e2e exec playwright test app-deploy

# With live CLI output
DEBUG=1 pnpm --filter e2e exec playwright test app-deploy
```

Requires `.env` with `E2E_ACCOUNT_EMAIL`, `E2E_ACCOUNT_PASSWORD`, `E2E_ORG_ID`.

Runtime ~2 min. Resources created during the test are the two apps (primary + secondary) — teardown deletes both automatically.

#### Example
```bash
DEBUG=1 pnpm --filter e2e exec playwright test app-deploy
```

<details>

<summary>Expand for complete log</summary>

```bash
cli % DEBUG=1 pnpm --filter e2e exec playwright test app-deploy
[e2e][auth] global setup starting

To run this command, log in to Shopify.
User verification code: LLTN-KJVC
👉 Open this link to start the auth process: https://accounts.shopify.com/activate-with-code?device_code%5Buser_code%5D=LLTN-KJVC
✔ Logged in.
✔ Current account: genghis-khan-identity-1-2025-03-31@shopify.com.
[e2e][auth] browser sessions established for admin + dev dashboard
[e2e][auth] global setup done, config at /Users/psyw/src/github.com/Shopify/cli/.e2e-tmp/global-auth/XDG_CONFIG_HOME

Running 1 test using 1 worker

     1 tests/app-deploy.spec.ts:64:3 › App deploy › init, deploy, versions list, config link, deploy to secondary

[e2e][w0] ----- TEST: init, deploy, versions list, config link, deploy to secondary ----- 
[e2e][auth] copying session from global setup
[e2e][w0][cli] exec: node /Users/psyw/src/github.com/Shopify/cli/packages/create-app/bin/run.js
[e2e][w0][cli] app init --template reactRouter --flavor javascript --name E2E-deploy1-1776876378681 --package-manager pnpm --local --organization-id 161686155 --path /Users/psyw/src/github.com/Shopify/cli/.e2e-tmp/e2e-IM5lTV/app-OvgU1X
╭─ info ───────────────────────────────────────────────────────────────────────╮
│                                                                              │
│  Initializing project with `pnpm`                                            │
│  Use the `--package-manager` flag to select a different package manager.     │
│                                                                              │
╰──────────────────────────────────────────────────────────────────────────────╯


╭─ success ────────────────────────────────────────────────────────────────────╮
│                                                                              │
│  e2-e-deploy1-1776876378681 is ready for you to build!                       │
│                                                                              │
│  Next steps                                                                  │
│    • Run `cd e2-e-deploy1-1776876378681`                                     │
│    • For extensions, run `shopify app generate extension`                    │
│    • To see your app, run `shopify app dev`                                  │
│                                                                              │
│  Reference                                                                   │
│    • Shopify docs [1]                                                        │
│    • Shopify Dev MCP, [2] connect your AI assistant to development           │
│      resources                                                               │
│    • For an overview of commands, run `shopify app --help`                   │
│                                                                              │
╰──────────────────────────────────────────────────────────────────────────────╯
[1] https://shopify.dev
[2] https://shopify.dev/docs/apps/build/devmcp

[e2e][w0][cli] exec: node /Users/psyw/src/github.com/Shopify/cli/packages/cli/bin/run.js
[e2e][w0][cli] app deploy --version E2E-v1-1776876395516 --message E2E A primary deployment --force --path /Users/psyw/src/github.com/Shopify/cli/.e2e-tmp/e2e-IM5lTV/app-OvgU1X/e2-e-deploy1-1776876378681
╭─ warning ────────────────────────────────────────────────────────────────────╮
│                                                                              │
│  The `--force` flag is deprecated and will be removed in the next major      │
│  release.                                                                    │
│                                                                              │
│  Use `--allow-updates` for CI/CD environments, or `--allow-updates           │
│  --allow-deletes` if you also want to allow removals.                        │
│                                                                              │
╰──────────────────────────────────────────────────────────────────────────────╯

╭─ info ───────────────────────────────────────────────────────────────────────╮
│                                                                              │
│  Your configuration file has been modified                                   │
│                                                                              │
│  The `include_config_on_deploy` field is no longer supported, since all      │
│  apps must now include configuration on deploy. It has been removed from     │
│  your configuration file.                                                    │
│                                                                              │
│  See Shopify CLI documentation. [1]                                          │
│                                                                              │
╰──────────────────────────────────────────────────────────────────────────────╯
[1] https://shopify.dev/docs/apps/build/cli-for-apps/app-configuration#build

╭─ info ───────────────────────────────────────────────────────────────────────╮
│                                                                              │
│  Using shopify.app.toml for default values:                                  │
│                                                                              │
│    • Org:             core-build-develop-admin-web-e2e                       │
│    • App:             E2E-deploy1-1776876378681                              │
│                                                                              │
│   You can pass `--reset` to your command to reset your app configuration.    │
│                                                                              │
╰──────────────────────────────────────────────────────────────────────────────╯


Releasing a new app version as part of E2E-deploy1-1776876378681



╭─ success ────────────────────────────────────────────────────────────────────╮
│                                                                              │
│  New version released to users.                                              │
│                                                                              │
│  E2E-v1-1776876395516 [1]                                                    │
│  E2E A primary deployment                                                    │
│                                                                              │
╰──────────────────────────────────────────────────────────────────────────────╯
[1] https://dev.shopify.com/dashboard/161686155/apps/351353143297/versions/93525
3475329

[e2e][w0][cli] exec: node /Users/psyw/src/github.com/Shopify/cli/packages/cli/bin/run.js
[e2e][w0][cli] app versions list --json --path /Users/psyw/src/github.com/Shopify/cli/.e2e-tmp/e2e-IM5lTV/app-OvgU1X/e2-e-deploy1-1776876378681
[
  {
    "createdAt": "2026-04-22 16:46:39",
    "createdBy": "gid://shopify/User/187591014",
    "versionTag": "E2E-v1-1776876395516",
    "status": "active",
    "versionId": "gid://shopify/Version/935253475329",
    "message": "E2E A primary deployment"
  },
  {
    "createdAt": "2026-04-22 16:46:33",
    "createdBy": "gid://shopify/User/187591014",
    "versionTag": "e2e-deploy1-1776876378681-1",
    "status": "inactive",
    "versionId": "gid://shopify/Version/935253278721",
    "message": ""
  }
]
[e2e][w0][cli] spawn: node /Users/psyw/src/github.com/Shopify/cli/packages/cli/bin/run.js
[e2e][w0][cli] app config link --config secondary --path /Users/psyw/src/github.com/Shopify/cli/.e2e-tmp/e2e-IM5lTV/app-OvgU1X/e2-e-deploy1-1776876378681
?  Which organization is this work for?
✔  core-build-develop-admin-web-e2e (161686155)

?  Create this project as a new app on Shopify?
✔  Yes, create it as a new app

?  App name:
✔  E2E-deploy2-1776876378681

╭─ success ────────────────────────────────────────────────────────────────────╮
│                                                                              │
│  shopify.app.secondary.toml is now linked to "E2E-deploy2-1776876378681" on  │
│   Shopify                                                                    │
│                                                                              │
│  Using shopify.app.secondary.toml as your default config.                    │
│                                                                              │
│  Next steps                                                                  │
│    • Make updates to shopify.app.secondary.toml in your local project        │
│    • To upload your config, run `shopify app deploy`                         │
│                                                                              │
│  Reference                                                                   │
│    • App configuration [1]                                                   │
│                                                                              │
╰──────────────────────────────────────────────────────────────────────────────╯
[1] https://shopify.dev/docs/apps/tools/cli/configuration

[e2e][w0][cli] exec: node /Users/psyw/src/github.com/Shopify/cli/packages/cli/bin/run.js
[e2e][w0][cli] app deploy --version E2E-v2-1776876408185 --message E2E A secondary deployment --config secondary --force --path /Users/psyw/src/github.com/Shopify/cli/.e2e-tmp/e2e-IM5lTV/app-OvgU1X/e2-e-deploy1-1776876378681
╭─ warning ────────────────────────────────────────────────────────────────────╮
│                                                                              │
│  The `--force` flag is deprecated and will be removed in the next major      │
│  release.                                                                    │
│                                                                              │
│  Use `--allow-updates` for CI/CD environments, or `--allow-updates           │
│  --allow-deletes` if you also want to allow removals.                        │
│                                                                              │
╰──────────────────────────────────────────────────────────────────────────────╯

╭─ info ───────────────────────────────────────────────────────────────────────╮
│                                                                              │
│  Your configuration file has been modified                                   │
│                                                                              │
│  The `include_config_on_deploy` field is no longer supported, since all      │
│  apps must now include configuration on deploy. It has been removed from     │
│  your configuration file.                                                    │
│                                                                              │
│  See Shopify CLI documentation. [1]                                          │
│                                                                              │
╰──────────────────────────────────────────────────────────────────────────────╯
[1] https://shopify.dev/docs/apps/build/cli-for-apps/app-configuration#build

╭─ info ───────────────────────────────────────────────────────────────────────╮
│                                                                              │
│  Using shopify.app.secondary.toml for default values:                        │
│                                                                              │
│    • Org:             core-build-develop-admin-web-e2e                       │
│    • App:             E2E-deploy2-1776876378681                              │
│                                                                              │
│   You can pass `--reset` to your command to reset your app configuration.    │
│                                                                              │
╰──────────────────────────────────────────────────────────────────────────────╯


Releasing a new app version as part of E2E-deploy2-1776876378681



╭─ success ────────────────────────────────────────────────────────────────────╮
│                                                                              │
│  New version released to users.                                              │
│                                                                              │
│  E2E-v2-1776876408185 [1]                                                    │
│  E2E A secondary deployment                                                  │
│                                                                              │
╰──────────────────────────────────────────────────────────────────────────────╯
[1] https://dev.shopify.com/dashboard/161686155/apps/351353241601/versions/93525
3737473

[e2e][w0][cli] exec: node /Users/psyw/src/github.com/Shopify/cli/packages/cli/bin/run.js
[e2e][w0][cli] app versions list --json --config secondary --path /Users/psyw/src/github.com/Shopify/cli/.e2e-tmp/e2e-IM5lTV/app-OvgU1X/e2-e-deploy1-1776876378681
[
  {
    "createdAt": "2026-04-22 16:46:51",
    "createdBy": "gid://shopify/User/187591014",
    "versionTag": "E2E-v2-1776876408185",
    "status": "active",
    "versionId": "gid://shopify/Version/935253737473",
    "message": "E2E A secondary deployment"
  },
  {
    "createdAt": "2026-04-22 16:46:46",
    "createdBy": "gid://shopify/User/187591014",
    "versionTag": "e2e-deploy2-1776876378681-1",
    "status": "inactive",
    "versionId": "gid://shopify/Version/935253573633",
    "message": ""
  }
]

[e2e][w0] ----- Teardown: app E2E-deploy1-1776876378681 ----- 
[e2e][w0][browser] deleting app
[e2e][w0][browser] app found, deleting
[e2e][w0][browser] app deleted

[e2e][w0] ----- Teardown: app E2E-deploy2-1776876378681 ----- 
[e2e][w0][browser] deleting app
[e2e][w0][browser] app found, deleting
[e2e][w0][browser] app deleted
  ✓  1 tests/app-deploy.spec.ts:64:3 › App deploy › init, deploy, versions list, config link, deploy to secondary (1.5m)

  1 passed (2.2m)
```

</details>


### Post-release steps

N/A

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows) — E2E tests run on macOS/Linux in CI
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — no user-facing changes (test infrastructure only), no changeset needed
