### PR TITLE
address png encoding bug, path changes

### DIFF
--- a/packages/app/src/cli/services/dev/extension/server/middlewares.test.ts
+++ b/packages/app/src/cli/services/dev/extension/server/middlewares.test.ts
@@ -133,7 +133,7 @@ describe('fileServerMiddleware()', async () => {
       })
 
       expect(event.node.res.setHeader).toHaveBeenCalledWith('Content-Type', 'text/html')
-      expect(result).toBe('<html></html>')
+      expect(String(result)).toBe('<html></html>')
     })
   })
 
@@ -166,7 +166,24 @@ describe('fileServerMiddleware()', async () => {
       })
 
       expect(event.node.res.setHeader).toHaveBeenCalledWith('Content-Type', contentType)
-      expect(result).toBe(fileContent)
+      expect(String(result)).toBe(fileContent)
+    })
+  })
+
+  test('serves binary files as a Buffer without UTF-8 corruption', async () => {
+    await inTemporaryDirectory(async (tmpDir: string) => {
+      // Bytes that are invalid as UTF-8 input (0x89, 0xFF, 0xFE) — if the
+      // middleware decoded these as UTF-8 they'd collapse to U+FFFD and the
+      // image would be corrupt. Includes the real PNG magic header.
+      const pngBytes = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0xff, 0xfe, 0x00, 0x42])
+      await mkdir(joinPath(tmpDir, 'img'))
+      await writeFile(joinPath(tmpDir, 'img', 'logo.png'), pngBytes)
+
+      const event = getMockEvent()
+      const result = await fileServerMiddleware(event, {filePath: joinPath(tmpDir, 'img', 'logo.png')})
+
+      expect(event.node.res.setHeader).toHaveBeenCalledWith('Content-Type', 'image/png')
+      expect(Buffer.isBuffer(result)).toBe(true)
     })
   })
 
@@ -183,7 +200,7 @@ describe('fileServerMiddleware()', async () => {
       })
 
       expect(event.node.res.setHeader).toHaveBeenCalledWith('Content-Type', 'text/plain')
-      expect(result).toBe('Content for bar.foo')
+      expect(String(result)).toBe('Content for bar.foo')
     })
   })
 })
@@ -244,7 +261,7 @@ describe('getExtensionAssetMiddleware()', () => {
       const result = await getExtensionAssetMiddleware(options)(event)
 
       expect(event.node.res.setHeader).toHaveBeenCalledWith('Content-Type', 'application/json')
-      expect(result).toBe('{"tools": []}')
+      expect(String(result)).toBe('{"tools": []}')
     })
   })
 
@@ -275,7 +292,7 @@ describe('getExtensionAssetMiddleware()', () => {
       const result = await getExtensionAssetMiddleware(options)(event)
 
       expect(event.node.res.setHeader).toHaveBeenCalledWith('Content-Type', 'text/javascript')
-      expect(result).toBe('compiled bundle content')
+      expect(String(result)).toBe('compiled bundle content')
     })
   })
 
@@ -306,7 +323,7 @@ describe('getExtensionAssetMiddleware()', () => {
       const result = await getExtensionAssetMiddleware(options)(event)
 
       // Built asset takes priority
-      expect(result).toBe('built content')
+      expect(String(result)).toBe('built content')
     })
   })
 })

--- a/packages/app/src/cli/services/dev/extension/server/middlewares.ts
+++ b/packages/app/src/cli/services/dev/extension/server/middlewares.ts
@@ -41,7 +41,11 @@ export async function fileServerMiddleware(event: H3Event, options: {filePath: s
     return sendError(event, {statusCode: 404, statusMessage: `Not Found: ${filePath}`})
   }
 
-  const fileContent = await readFile(filePath)
+  // Pass `{}` to opt out of cli-kit's `{encoding: 'utf8'}` default — binary
+  // files (png, jpeg, pdf, wasm, …) must come back as a Buffer or their bytes
+  // get mangled into U+FFFD replacement chars by the UTF-8 decode. h3 sends
+  // Buffers as-is and the browser decodes per Content-Type for text types.
+  const fileContent = await readFile(filePath, {})
   const extensionToContent = {
     '.ico': 'image/x-icon',
     '.html': 'text/html',


### PR DESCRIPTION
Closes https://github.com/shop/issues-admin-extensibility/issues/2452

### WHY are these changes introduced?

When serving static assets for UI extensions during development, the dev server only looked in the build output directory and the extension's root source directory. Extensions that declare a per-extension-point `assets` folder (via the `assets` config key) had no way to serve those static files through the dev server, leaving assets like images inaccessible at runtime.

### WHAT is this pull request doing?

Adds a third candidate lookup path when resolving extension assets: the per-extension-point `assets` directory declared in the extension configuration. The resolution order is now:

1. Build output directory (e.g. `dist/handle.js`)
2. Extension source root (e.g. `tools`, `instructions`)
3. Per-extension-point static asset folders declared via the `assets` config key (e.g. `./assets/logo.png`)

This mirrors how the admin spec's `static_root` serves a whole directory of static files.

Additionally, `readFile` is called with an explicit options argument (`{}`) so that it returns a `Buffer` rather than a `string`, and test assertions are updated to use `.toString()` accordingly.

A new test covers the fallback to the extension-point `assets` folder, verifying that a static asset (e.g. `logo.png`) is correctly resolved and served with the appropriate `Content-Type`.

### How to test your changes?

1. Create a UI extension with an `extension_points` entry that includes an `assets` key pointing to a local directory (e.g. `assets: './assets'`).
2. Place a static file (e.g. `logo.png`) in that directory.
3. Run `shopify app dev` and request the asset via the extension dev server URL.
4. Confirm the asset is served correctly with the right `Content-Type` header.

Alternatively, run the existing test suite:
```
pnpm test packages/app/src/cli/services/dev/extension/server/middlewares.test.ts
```

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct bump type (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](../CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`