### PR TITLE
Make GraphiQL server auth-agnostic

### DIFF
--- a/packages/app/src/cli/services/dev/processes/graphiql-token-provider.test.ts
+++ b/packages/app/src/cli/services/dev/processes/graphiql-token-provider.test.ts
@@ -1,0 +1,113 @@
+import {createClientCredentialsTokenProvider} from './graphiql-token-provider.js'
+import {fetch} from '@shopify/cli-kit/node/http'
+import {beforeEach, describe, expect, test, vi} from 'vitest'
+
+vi.mock('@shopify/cli-kit/node/http')
+
+const mockedFetch = vi.mocked(fetch)
+
+function mockTokenResponse(token: string) {
+  mockedFetch.mockResolvedValueOnce({
+    ok: true,
+    status: 200,
+    json: async () => ({access_token: token}),
+  } as unknown as Awaited<ReturnType<typeof fetch>>)
+}
+
+function mockFailedTokenResponse(status: number, body: object = {}) {
+  mockedFetch.mockResolvedValueOnce({
+    ok: false,
+    status,
+    json: async () => body,
+  } as unknown as Awaited<ReturnType<typeof fetch>>)
+}
+
+describe('createClientCredentialsTokenProvider', () => {
+  beforeEach(() => {
+    mockedFetch.mockReset()
+  })
+
+  test('mints a token on first getToken call and caches it', async () => {
+    mockTokenResponse('first-token')
+
+    const provider = createClientCredentialsTokenProvider({
+      apiKey: 'api-key',
+      apiSecret: 'api-secret',
+      storeFqdn: 'store.myshopify.com',
+    })
+
+    await expect(provider.getToken()).resolves.toBe('first-token')
+    await expect(provider.getToken()).resolves.toBe('first-token')
+    expect(mockedFetch).toHaveBeenCalledTimes(1)
+  })
+
+  test('refreshToken always re-mints, even when a cached token exists', async () => {
+    mockTokenResponse('first-token')
+    mockTokenResponse('second-token')
+
+    const provider = createClientCredentialsTokenProvider({
+      apiKey: 'api-key',
+      apiSecret: 'api-secret',
+      storeFqdn: 'store.myshopify.com',
+    })
+
+    await expect(provider.getToken()).resolves.toBe('first-token')
+    await expect(provider.refreshToken!()).resolves.toBe('second-token')
+    await expect(provider.getToken()).resolves.toBe('second-token')
+    expect(mockedFetch).toHaveBeenCalledTimes(2)
+  })
+
+  test('posts the OAuth client_credentials body to the store admin endpoint', async () => {
+    mockTokenResponse('token')
+
+    const provider = createClientCredentialsTokenProvider({
+      apiKey: 'api-key',
+      apiSecret: 'api-secret',
+      storeFqdn: 'store.myshopify.com',
+    })
+    await provider.getToken()
+
+    expect(mockedFetch).toHaveBeenCalledWith(
+      'https://store.myshopify.com/admin/oauth/access_token',
+      expect.objectContaining({
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({
+          client_id: 'api-key',
+          client_secret: 'api-secret',
+          grant_type: 'client_credentials',
+        }),
+      }),
+    )
+  })
+
+  test('throws when the token response is not successful', async () => {
+    mockFailedTokenResponse(401)
+
+    const provider = createClientCredentialsTokenProvider({
+      apiKey: 'api-key',
+      apiSecret: 'api-secret',
+      storeFqdn: 'store.myshopify.com',
+    })
+
+    await expect(provider.getToken()).rejects.toThrow('Token request failed with status 401')
+    expect(mockedFetch).toHaveBeenCalledTimes(1)
+  })
+
+  test('throws when a successful token response does not include an access token', async () => {
+    mockedFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({}),
+    } as unknown as Awaited<ReturnType<typeof fetch>>)
+
+    const provider = createClientCredentialsTokenProvider({
+      apiKey: 'api-key',
+      apiSecret: 'api-secret',
+      storeFqdn: 'store.myshopify.com',
+    })
+
+    await expect(provider.getToken()).rejects.toThrow('Token request failed with status 200')
+    expect(mockedFetch).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/app/src/cli/services/dev/processes/graphiql-token-provider.ts
+++ b/packages/app/src/cli/services/dev/processes/graphiql-token-provider.ts
@@ -1,0 +1,52 @@
+import {TokenProvider} from '@shopify/cli-kit/node/graphiql/server'
+import {fetch} from '@shopify/cli-kit/node/http'
+
+interface ClientCredentialsTokenProviderOptions {
+  apiKey: string
+  apiSecret: string
+  storeFqdn: string
+}
+
+/**
+ * Returns a `TokenProvider` that mints Admin API tokens via OAuth `client_credentials`
+ * using a Partners app's `apiKey` + `apiSecret`. Tokens are cached in-memory and
+ * re-minted on demand when `refreshToken` is called (e.g. on a 401 from upstream).
+ *
+ * This is the strategy used by `shopify app dev`'s GraphiQL server. It assumes the app
+ * is installed on the target store and that the app secret can mint a fresh token at any time.
+ */
+export function createClientCredentialsTokenProvider({
+  apiKey,
+  apiSecret,
+  storeFqdn,
+}: ClientCredentialsTokenProviderOptions): TokenProvider {
+  let cachedToken: string | undefined
+
+  const mint = async (): Promise<string> => {
+    const tokenResponse = await fetch(`https://${storeFqdn}/admin/oauth/access_token`, {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({
+        client_id: apiKey,
+        client_secret: apiSecret,
+        grant_type: 'client_credentials',
+      }),
+    })
+
+    const tokenJson = (await tokenResponse.json()) as {access_token?: string}
+    if (!tokenResponse.ok || !tokenJson.access_token) {
+      throw new Error(`Token request failed with status ${tokenResponse.status}`)
+    }
+
+    cachedToken = tokenJson.access_token
+    return cachedToken
+  }
+
+  return {
+    getToken: async () => cachedToken ?? mint(),
+    refreshToken: async () => {
+      cachedToken = undefined
+      return mint()
+    },
+  }
+}

--- a/packages/app/src/cli/services/dev/processes/graphiql.ts
+++ b/packages/app/src/cli/services/dev/processes/graphiql.ts
@@ -1,5 +1,6 @@
 import {BaseProcess, DevProcessFunction} from './types.js'
-import {setupGraphiQLServer} from '@shopify/cli-kit/node/graphiql/server'
+import {setupGraphiQLServer, TokenProvider} from '@shopify/cli-kit/node/graphiql/server'
+import {fetch} from '@shopify/cli-kit/node/http'
 
 interface GraphiQLServerProcessOptions {
   appName: string
@@ -30,8 +31,60 @@ export const launchGraphiQLServer: DevProcessFunction<GraphiQLServerProcessOptio
   {stdout, abortSignal},
   options: GraphiQLServerProcessOptions,
 ) => {
-  const httpServer = setupGraphiQLServer({...options, stdout})
+  const tokenProvider = createClientCredentialsTokenProvider({
+    apiKey: options.apiKey,
+    apiSecret: options.apiSecret,
+    storeFqdn: options.storeFqdn,
+  })
+  const httpServer = setupGraphiQLServer({
+    stdout,
+    port: options.port,
+    storeFqdn: options.storeFqdn,
+    key: options.key,
+    tokenProvider,
+    appContext: {
+      appName: options.appName,
+      appUrl: options.appUrl,
+      apiSecret: options.apiSecret,
+    },
+  })
   abortSignal.addEventListener('abort', async () => {
     httpServer.close()
   })
+}
+
+/**
+ * In-memory token provider that mints Admin API tokens via OAuth `client_credentials`
+ * using the Partners app's `apiKey` + `apiSecret`. Refreshes lazily and re-mints on demand.
+ */
+function createClientCredentialsTokenProvider(options: {
+  apiKey: string
+  apiSecret: string
+  storeFqdn: string
+}): TokenProvider {
+  let cachedToken: string | undefined
+
+  const mint = async (): Promise<string> => {
+    const tokenResponse = await fetch(`https://${options.storeFqdn}/admin/oauth/access_token`, {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({
+        client_id: options.apiKey,
+        client_secret: options.apiSecret,
+        grant_type: 'client_credentials',
+      }),
+    })
+
+    const tokenJson = (await tokenResponse.json()) as {access_token: string}
+    cachedToken = tokenJson.access_token
+    return cachedToken
+  }
+
+  return {
+    getToken: async () => cachedToken ?? mint(),
+    refreshToken: async () => {
+      cachedToken = undefined
+      return mint()
+    },
+  }
 }

--- a/packages/app/src/cli/services/dev/processes/graphiql.ts
+++ b/packages/app/src/cli/services/dev/processes/graphiql.ts
@@ -1,4 +1,5 @@
 import {BaseProcess, DevProcessFunction} from './types.js'
+import {createClientCredentialsTokenProvider} from './graphiql-token-provider.js'
 import {setupGraphiQLServer} from '@shopify/cli-kit/node/graphiql/server'
 
 interface GraphiQLServerProcessOptions {
@@ -30,7 +31,23 @@ export const launchGraphiQLServer: DevProcessFunction<GraphiQLServerProcessOptio
   {stdout, abortSignal},
   options: GraphiQLServerProcessOptions,
 ) => {
-  const httpServer = setupGraphiQLServer({...options, stdout})
+  const tokenProvider = createClientCredentialsTokenProvider({
+    apiKey: options.apiKey,
+    apiSecret: options.apiSecret,
+    storeFqdn: options.storeFqdn,
+  })
+  const httpServer = setupGraphiQLServer({
+    stdout,
+    port: options.port,
+    storeFqdn: options.storeFqdn,
+    key: options.key,
+    tokenProvider,
+    appContext: {
+      appName: options.appName,
+      appUrl: options.appUrl,
+      apiSecret: options.apiSecret,
+    },
+  })
   abortSignal.addEventListener('abort', async () => {
     httpServer.close()
   })

--- a/packages/cli-kit/src/public/node/graphiql/server.test.ts
+++ b/packages/cli-kit/src/public/node/graphiql/server.test.ts
@@ -1,5 +1,8 @@
-import {deriveGraphiQLKey, resolveGraphiQLKey} from './server.js'
-import {describe, expect, test} from 'vitest'
+import {deriveGraphiQLKey, resolveGraphiQLKey, setupGraphiQLServer, TokenProvider} from './server.js'
+import {getAvailableTCPPort} from '../tcp.js'
+import {afterEach, describe, expect, test, vi} from 'vitest'
+import {Server} from 'http'
+import {Writable} from 'stream'
 
 describe('deriveGraphiQLKey', () => {
   test('returns a 64-character hex string', () => {
@@ -45,5 +48,138 @@ describe('resolveGraphiQLKey', () => {
   test('derives key when provided key is whitespace-only', () => {
     const key = resolveGraphiQLKey('   ', 'secret', 'store.myshopify.com')
     expect(key).toBe(deriveGraphiQLKey('secret', 'store.myshopify.com'))
+  })
+})
+
+describe('setupGraphiQLServer', () => {
+  const servers: Server[] = []
+
+  afterEach(() => {
+    for (const server of servers) server.close()
+    servers.length = 0
+  })
+
+  /**
+   * Starts the GraphiQL server with the given options on an available port and
+   * returns its base URL. Server is auto-closed by the afterEach hook.
+   */
+  async function startServer(options: {
+    tokenProvider: TokenProvider
+    storeFqdn?: string
+    key?: string
+    protectMutations?: boolean
+    appContext?: {appName: string; appUrl: string; apiSecret: string}
+  }) {
+    const port = await getAvailableTCPPort()
+    const noopStdout = new Writable({write: (_chunk, _enc, cb) => cb()})
+    const server = setupGraphiQLServer({
+      stdout: noopStdout,
+      port,
+      storeFqdn: options.storeFqdn ?? 'store.myshopify.com',
+      tokenProvider: options.tokenProvider,
+      key: options.key,
+      protectMutations: options.protectMutations,
+      appContext: options.appContext,
+    })
+    servers.push(server)
+    await new Promise<void>((resolve) => server.on('listening', () => resolve()))
+    return {url: `http://localhost:${port}`}
+  }
+
+  test('rejects mutations with HTTP 400 when protectMutations is true', async () => {
+    const tokenProvider: TokenProvider = {getToken: vi.fn(async () => 'access-token')}
+    const {url} = await startServer({tokenProvider, key: 'k', protectMutations: true})
+
+    const response = await fetch(`${url}/graphiql/graphql.json?key=k&api_version=2024-10`, {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({query: 'mutation M { shopUpdate(input: {}) { id } }'}),
+    })
+
+    expect(response.status).toBe(400)
+    const body = (await response.json()) as {errors: {message: string}[]}
+    expect(body.errors[0]?.message).toMatch(/mutations are disabled/i)
+    expect(tokenProvider.getToken).not.toHaveBeenCalled()
+  })
+
+  test('does not invoke the token provider for blocked mutations', async () => {
+    const tokenProvider: TokenProvider = {
+      getToken: vi.fn(async () => 'access-token'),
+      refreshToken: vi.fn(async () => 'refreshed-token'),
+    }
+    const {url} = await startServer({tokenProvider, key: 'k', protectMutations: true})
+
+    await fetch(`${url}/graphiql/graphql.json?key=k&api_version=2024-10`, {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({query: 'mutation M { shopUpdate(input: {}) { id } }'}),
+    })
+
+    expect(tokenProvider.getToken).not.toHaveBeenCalled()
+    expect(tokenProvider.refreshToken).not.toHaveBeenCalled()
+  })
+
+  test('lets queries through to the upstream call when protectMutations is true', async () => {
+    const tokenProvider: TokenProvider = {getToken: vi.fn(async () => 'access-token')}
+    const {url} = await startServer({tokenProvider, key: 'k', protectMutations: true})
+
+    const response = await fetch(`${url}/graphiql/graphql.json?key=k&api_version=2024-10`, {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({query: 'query Q { shop { name } }'}),
+    })
+
+    expect(response.status).not.toBe(400)
+    expect(tokenProvider.getToken).toHaveBeenCalled()
+  })
+
+  test('returns 404 when the request key does not match', async () => {
+    const tokenProvider: TokenProvider = {getToken: async () => 'access-token'}
+    const {url} = await startServer({tokenProvider, key: 'expected-key'})
+
+    const response = await fetch(`${url}/graphiql/graphql.json?key=wrong-key&api_version=2024-10`, {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({query: '{ shop { name } }'}),
+    })
+
+    expect(response.status).toBe(404)
+  })
+
+  test('uses the deterministic derived key when appContext is provided and no key is set', async () => {
+    const tokenProvider: TokenProvider = {getToken: async () => 'access-token'}
+    const derived = deriveGraphiQLKey('app-secret', 'store.myshopify.com')
+    const {url} = await startServer({
+      tokenProvider,
+      appContext: {appName: 'My App', appUrl: 'https://example.com', apiSecret: 'app-secret'},
+    })
+
+    const valid = await fetch(`${url}/graphiql/graphql.json?key=${derived}&api_version=2024-10`, {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({query: 'mutation M { x { id } }'}),
+    })
+    expect(valid.status).not.toBe(404)
+
+    const invalid = await fetch(`${url}/graphiql/graphql.json?key=wrong&api_version=2024-10`, {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({query: 'mutation M { x { id } }'}),
+    })
+    expect(invalid.status).toBe(404)
+  })
+
+  test('generates a random per-process key when no appContext and no key are provided', async () => {
+    const tokenProvider: TokenProvider = {getToken: async () => 'access-token'}
+    const {url} = await startServer({tokenProvider})
+
+    const response = await fetch(`${url}/graphiql/graphql.json?key=anything&api_version=2024-10`, {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({query: '{ shop { name } }'}),
+    })
+
+    // We don't know the key; hitting the endpoint with an arbitrary key should 404.
+    expect(response.status).toBe(404)
   })
 })

--- a/packages/cli-kit/src/public/node/graphiql/server.test.ts
+++ b/packages/cli-kit/src/public/node/graphiql/server.test.ts
@@ -1,5 +1,8 @@
-import {deriveGraphiQLKey, resolveGraphiQLKey} from './server.js'
-import {describe, expect, test} from 'vitest'
+import {deriveGraphiQLKey, resolveGraphiQLKey, setupGraphiQLServer, TokenProvider} from './server.js'
+import {getAvailableTCPPort} from '../tcp.js'
+import {afterEach, describe, expect, test, vi} from 'vitest'
+import {Server} from 'http'
+import {Writable} from 'stream'
 
 describe('deriveGraphiQLKey', () => {
   test('returns a 64-character hex string', () => {
@@ -45,5 +48,172 @@ describe('resolveGraphiQLKey', () => {
   test('derives key when provided key is whitespace-only', () => {
     const key = resolveGraphiQLKey('   ', 'secret', 'store.myshopify.com')
     expect(key).toBe(deriveGraphiQLKey('secret', 'store.myshopify.com'))
+  })
+})
+
+describe('setupGraphiQLServer', () => {
+  const servers: Server[] = []
+
+  afterEach(() => {
+    for (const server of servers) server.close()
+    servers.length = 0
+  })
+
+  /**
+   * Starts the GraphiQL server with the given options on an available port and
+   * returns its base URL. Server is auto-closed by the afterEach hook.
+   */
+  async function startServer(options: {
+    tokenProvider: TokenProvider
+    storeFqdn?: string
+    key?: string
+    protectMutations?: boolean
+    appContext?: {appName: string; appUrl: string; apiSecret: string}
+  }) {
+    const port = await getAvailableTCPPort()
+    const noopStdout = new Writable({write: (_chunk, _enc, cb) => cb()})
+    const server = setupGraphiQLServer({
+      stdout: noopStdout,
+      port,
+      storeFqdn: options.storeFqdn ?? 'store.myshopify.com',
+      tokenProvider: options.tokenProvider,
+      key: options.key,
+      protectMutations: options.protectMutations,
+      appContext: options.appContext,
+    })
+    servers.push(server)
+    await new Promise<void>((resolve) => server.on('listening', () => resolve()))
+    return {url: `http://localhost:${port}`}
+  }
+
+  test('rejects mutations with HTTP 400 when protectMutations is true', async () => {
+    const tokenProvider: TokenProvider = {getToken: vi.fn(async () => 'access-token')}
+    const {url} = await startServer({tokenProvider, key: 'k', protectMutations: true})
+
+    const response = await fetch(`${url}/graphiql/graphql.json?key=k&api_version=2024-10`, {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({query: 'mutation M { shopUpdate(input: {}) { id } }'}),
+    })
+
+    expect(response.status).toBe(400)
+    const body = (await response.json()) as {errors: {message: string}[]}
+    expect(body.errors[0]?.message).toMatch(/mutations are disabled/i)
+    expect(tokenProvider.getToken).not.toHaveBeenCalled()
+  })
+
+  test('does not invoke the token provider for blocked mutations', async () => {
+    const tokenProvider: TokenProvider = {
+      getToken: vi.fn(async () => 'access-token'),
+      refreshToken: vi.fn(async () => 'refreshed-token'),
+    }
+    const {url} = await startServer({tokenProvider, key: 'k', protectMutations: true})
+
+    await fetch(`${url}/graphiql/graphql.json?key=k&api_version=2024-10`, {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({query: 'mutation M { shopUpdate(input: {}) { id } }'}),
+    })
+
+    expect(tokenProvider.getToken).not.toHaveBeenCalled()
+    expect(tokenProvider.refreshToken).not.toHaveBeenCalled()
+  })
+
+  test('lets queries through to the upstream call when protectMutations is true', async () => {
+    const tokenProvider: TokenProvider = {getToken: vi.fn(async () => 'access-token')}
+    const {url} = await startServer({tokenProvider, key: 'k', protectMutations: true})
+
+    const response = await fetch(`${url}/graphiql/graphql.json?key=k&api_version=2024-10`, {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({query: 'query Q { shop { name } }'}),
+    })
+
+    expect(response.status).not.toBe(400)
+    expect(tokenProvider.getToken).toHaveBeenCalled()
+  })
+
+  test('returns 404 when the request key does not match', async () => {
+    const tokenProvider: TokenProvider = {getToken: async () => 'access-token'}
+    const {url} = await startServer({tokenProvider, key: 'expected-key'})
+
+    const response = await fetch(`${url}/graphiql/graphql.json?key=wrong-key&api_version=2024-10`, {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({query: '{ shop { name } }'}),
+    })
+
+    expect(response.status).toBe(404)
+  })
+
+  test('uses the deterministic derived key when appContext is provided and no key is set', async () => {
+    const tokenProvider: TokenProvider = {getToken: async () => 'access-token'}
+    const derived = deriveGraphiQLKey('app-secret', 'store.myshopify.com')
+    const {url} = await startServer({
+      tokenProvider,
+      protectMutations: true,
+      appContext: {appName: 'My App', appUrl: 'https://example.com', apiSecret: 'app-secret'},
+    })
+
+    const valid = await fetch(`${url}/graphiql/graphql.json?key=${derived}&api_version=2024-10`, {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({query: 'mutation M { x { id } }'}),
+    })
+    expect(valid.status).toBe(400)
+    const validBody = (await valid.json()) as {errors: {message: string}[]}
+    expect(validBody.errors[0]?.message).toMatch(/mutations are disabled/i)
+
+    const invalid = await fetch(`${url}/graphiql/graphql.json?key=wrong&api_version=2024-10`, {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({query: 'mutation M { x { id } }'}),
+    })
+    expect(invalid.status).toBe(404)
+  })
+
+  test('generates a random per-process key when no appContext and no key are provided', async () => {
+    const tokenProvider: TokenProvider = {getToken: async () => 'access-token'}
+    const {url} = await startServer({tokenProvider})
+
+    const response = await fetch(`${url}/graphiql/graphql.json?key=anything&api_version=2024-10`, {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({query: '{ shop { name } }'}),
+    })
+
+    // We don't know the key; hitting the endpoint with an arbitrary key should 404.
+    expect(response.status).toBe(404)
+  })
+
+  test('renders app install guidance for unauthorized app GraphiQL sessions', async () => {
+    const tokenProvider: TokenProvider = {getToken: async () => Promise.reject(new Error('No token'))}
+    const {url} = await startServer({
+      tokenProvider,
+      appContext: {appName: 'My App', appUrl: 'https://example.com', apiSecret: 'app-secret'},
+    })
+    const derived = deriveGraphiQLKey('app-secret', 'store.myshopify.com')
+
+    const response = await fetch(`${url}/graphiql?key=${derived}`)
+    const body = await response.text()
+
+    expect(body).toContain('Install your app to access GraphiQL')
+    expect(body).toContain('Install your app')
+    expect(body).not.toContain('shopify store auth --store store.myshopify.com')
+  })
+
+  test('renders store auth guidance for unauthorized app-less GraphiQL sessions', async () => {
+    const tokenProvider: TokenProvider = {getToken: async () => Promise.reject(new Error('No token'))}
+    const {url} = await startServer({tokenProvider, key: 'k'})
+
+    const response = await fetch(`${url}/graphiql?key=k`)
+    const body = await response.text()
+
+    expect(body).toContain('Reconnect store authentication to access GraphiQL')
+    expect(body).toContain('The GraphiQL Explorer couldn&#x27;t access this store with the stored authentication.')
+    expect(body).toContain('shopify store auth --store store.myshopify.com')
+    expect(body).toContain('GraphiQL Explorer - Authentication Required')
+    expect(body).not.toContain('Install your app to access GraphiQL')
+    expect(body).not.toContain('id="app-install-button"')
   })
 })

--- a/packages/cli-kit/src/public/node/graphiql/server.ts
+++ b/packages/cli-kit/src/public/node/graphiql/server.ts
@@ -8,6 +8,7 @@ import {adminUrl, supportedApiVersions} from '../api/admin.js'
 import {fetch} from '../http.js'
 import {renderLiquidTemplate} from '../liquid.js'
 import {outputDebug} from '../output.js'
+import {containsMutation} from '../graphql.js'
 import {
   createApp,
   createRouter,
@@ -20,7 +21,7 @@ import {
   setResponseStatus,
   toNodeListener,
 } from 'h3'
-import {createHmac} from 'crypto'
+import {createHmac, randomBytes} from 'crypto'
 import {createServer, Server} from 'http'
 import {readFileSync} from 'fs'
 import {Writable} from 'stream'
@@ -61,64 +62,87 @@ class TokenRefreshError extends AbortError {
   }
 }
 
-interface SetupGraphiQLServerOptions {
-  stdout: Writable
-  port: number
-  appName: string
-  appUrl: string
-  apiKey: string
-  apiSecret: string
-  key?: string
-  storeFqdn: string
+/**
+ * Pluggable strategy for obtaining and refreshing the Admin API access token
+ * that the GraphiQL proxy injects into every request.
+ *
+ * - `getToken` may return a cached token; the proxy calls it for every request.
+ * - `refreshToken` (optional) is invoked when the upstream Admin API returns 401.
+ * When omitted, the proxy falls back to calling `getToken` again on 401.
+ *
+ * Implementations must throw `TokenRefreshError` (or any thrown error) when the
+ * token cannot be obtained; the proxy renders the unauthorized template in that case.
+ */
+export interface TokenProvider {
+  getToken: () => Promise<string>
+  refreshToken?: () => Promise<string>
 }
 
 /**
+ * Optional app-specific context, used to render the app pill and scopes note in the
+ * GraphiQL header and to drive the deterministic key derivation. Pass when the GraphiQL
+ * server is hosted as part of `shopify app dev`; omit for app-less use cases such as
+ * `shopify store execute`.
+ */
+export interface GraphiQLAppContext {
+  appName: string
+  appUrl: string
+  apiSecret: string
+}
+
+export interface SetupGraphiQLServerOptions {
+  stdout: Writable
+  port: number
+  storeFqdn: string
+  tokenProvider: TokenProvider
+  /**
+   * Authentication key required as a `?key=` query string on every request. When omitted:
+   * - if `appContext` is provided, derived deterministically from `apiSecret` + `storeFqdn`
+   * so browser tabs survive dev server restarts.
+   * - otherwise, generated randomly per process.
+   */
+  key?: string
+  appContext?: GraphiQLAppContext
+  /**
+   * When true, the proxy rejects mutation operations with HTTP 400 before forwarding
+   * them to the Admin API. Use this to mirror non-interactive safety guarantees in the
+   * interactive UI.
+   */
+  protectMutations?: boolean
+}
+
+const MUTATIONS_BLOCKED_MESSAGE = 'Mutations are disabled. Re-run with --allow-mutations to enable mutations.'
+
+/**
  * Starts a local HTTP server that hosts the GraphiQL UI and proxies requests to the
- * Admin API for the configured store. The server uses the OAuth `client_credentials`
- * grant with the supplied `apiKey` / `apiSecret` to mint and refresh access tokens
- * on the fly.
+ * Admin API for the configured store. Authentication is delegated to the supplied
+ * `tokenProvider`, so the same server can serve both `shopify app dev` and stored-session
+ * use cases.
  *
  * @param options - Configuration for the server, including the target store, the
- * Partners app credentials, and the local port to bind to.
+ * pluggable token provider, and the local port to bind to.
  * @returns The underlying Node `http.Server` instance, already listening on `options.port`.
  */
 export function setupGraphiQLServer(options: SetupGraphiQLServerOptions): Server {
-  const {stdout, port, appName, appUrl, apiKey, apiSecret, key: providedKey, storeFqdn} = options
-  // Always require an authentication key. If not explicitly provided, derive one
-  // deterministically from apiSecret + storeFqdn so the key is stable across restarts
-  // (browser tabs survive dev server restarts) but not guessable without the app secret.
-  const key = resolveGraphiQLKey(providedKey, apiSecret, storeFqdn)
+  const {stdout, port, storeFqdn, tokenProvider, key: providedKey, appContext, protectMutations = false} = options
+  const key = resolveGraphiQLServerKey(providedKey, appContext, storeFqdn)
   outputDebug(`Setting up GraphiQL HTTP server on port ${port}...`, stdout)
 
   const app = createApp()
   const router = createRouter()
 
-  let _token: string | undefined
-  async function token(): Promise<string> {
-    // eslint-disable-next-line require-atomic-updates
-    _token ??= await refreshToken()
-    return _token
-  }
-
-  async function refreshToken(): Promise<string> {
+  const refreshUpstreamToken = async (): Promise<string> => {
     try {
       outputDebug('refreshing token', stdout)
-      _token = undefined
-      const bodyData = {
-        client_id: apiKey,
-        client_secret: apiSecret,
-        grant_type: 'client_credentials',
-      }
-      const tokenResponse = await fetch(`https://${storeFqdn}/admin/oauth/access_token`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify(bodyData),
-      })
+      return await (tokenProvider.refreshToken ?? tokenProvider.getToken)()
+    } catch (_error) {
+      throw new TokenRefreshError()
+    }
+  }
 
-      const tokenJson = (await tokenResponse.json()) as {access_token: string}
-      return tokenJson.access_token
+  const currentToken = async (): Promise<string> => {
+    try {
+      return await tokenProvider.getToken()
     } catch (_error) {
       throw new TokenRefreshError()
     }
@@ -126,8 +150,8 @@ export function setupGraphiQLServer(options: SetupGraphiQLServerOptions): Server
 
   async function fetchApiVersionsWithTokenRefresh(): Promise<string[]> {
     return performActionWithRetryAfterRecovery(
-      async () => supportedApiVersions({storeFqdn, token: await token()}),
-      refreshToken,
+      async () => supportedApiVersions({storeFqdn, token: await currentToken()}),
+      refreshUpstreamToken,
     )
   }
 
@@ -174,7 +198,7 @@ export function setupGraphiQLServer(options: SetupGraphiQLServerOptions): Server
     defineEventHandler(async () => {
       try {
         await fetchApiVersionsWithTokenRefresh()
-        return {status: 'OK', storeFqdn, appName, appUrl}
+        return {status: 'OK', storeFqdn, appName: appContext?.appName, appUrl: appContext?.appUrl}
         // eslint-disable-next-line no-catch-all/no-catch-all
       } catch {
         return {status: 'UNAUTHENTICATED'}
@@ -205,7 +229,7 @@ export function setupGraphiQLServer(options: SetupGraphiQLServerOptions): Server
       } catch (err) {
         if (err instanceof TokenRefreshError) {
           return renderLiquidTemplate(unauthorizedTemplate, {
-            previewUrl: appUrl,
+            previewUrl: appContext?.appUrl ?? '',
             url,
           })
         }
@@ -225,10 +249,11 @@ export function setupGraphiQLServer(options: SetupGraphiQLServerOptions): Server
         graphiqlTemplate({
           apiVersion,
           apiVersions: [...apiVersions, 'unstable'],
-          appName,
-          appUrl,
+          appName: appContext?.appName,
+          appUrl: appContext?.appUrl,
           key,
           storeFqdn,
+          protectMutations,
         }),
         {
           url,
@@ -255,17 +280,23 @@ export function setupGraphiQLServer(options: SetupGraphiQLServerOptions): Server
       const graphqlUrl = adminUrl(storeFqdn, query.api_version as string)
       try {
         const body = await readBody(event)
+
+        if (protectMutations && isMutationRequestBody(body)) {
+          setResponseStatus(event, 400)
+          return {errors: [{message: MUTATIONS_BLOCKED_MESSAGE}]}
+        }
+
         const reqBody = JSON.stringify(body)
 
         const reqHeaders = getRequestHeaders(event)
         const customHeaders = filterCustomHeaders(reqHeaders)
 
-        const runRequest = async () => {
+        const runRequest = async (token: string) => {
           const headers = {
             ...customHeaders,
             Accept: 'application/json',
             'Content-Type': 'application/json',
-            'X-Shopify-Access-Token': await token(),
+            'X-Shopify-Access-Token': token,
             'User-Agent': `ShopifyCLIGraphiQL/${CLI_KIT_VERSION}`,
           }
 
@@ -276,11 +307,10 @@ export function setupGraphiQLServer(options: SetupGraphiQLServerOptions): Server
           })
         }
 
-        let result = await runRequest()
+        let result = await runRequest(await currentToken())
         if (result.status === 401) {
           outputDebug('Token expired, fetching new token', stdout)
-          await refreshToken()
-          result = await runRequest()
+          result = await runRequest(await refreshUpstreamToken())
         }
 
         setResponseHeader(event, 'Content-Type', 'application/json')
@@ -302,4 +332,27 @@ export function setupGraphiQLServer(options: SetupGraphiQLServerOptions): Server
   const server = createServer(toNodeListener(app))
   server.listen(port, 'localhost', () => stdout.write(`GraphiQL server started on port ${port}`))
   return server
+}
+
+// Picks the right key based on what the caller supplied:
+// - explicit non-empty key → use it
+// - app context with apiSecret → derive deterministically (stable across restarts)
+// - otherwise → random per-process key (browser tabs won't survive restarts, which is
+//   the right tradeoff when there's no stable secret to derive from).
+function resolveGraphiQLServerKey(
+  providedKey: string | undefined,
+  appContext: GraphiQLAppContext | undefined,
+  storeFqdn: string,
+): string {
+  const trimmed = providedKey?.trim()
+  if (trimmed) return trimmed
+  if (appContext) return deriveGraphiQLKey(appContext.apiSecret, storeFqdn)
+  return randomBytes(32).toString('hex')
+}
+
+function isMutationRequestBody(body: unknown): boolean {
+  if (typeof body !== 'object' || body === null) return false
+  const {query, operationName} = body as {query?: unknown; operationName?: unknown}
+  if (typeof query !== 'string') return false
+  return containsMutation(query, typeof operationName === 'string' ? operationName : undefined)
 }

--- a/packages/cli-kit/src/public/node/graphiql/server.ts
+++ b/packages/cli-kit/src/public/node/graphiql/server.ts
@@ -8,6 +8,7 @@ import {adminUrl, supportedApiVersions} from '../api/admin.js'
 import {fetch} from '../http.js'
 import {renderLiquidTemplate} from '../liquid.js'
 import {outputDebug} from '../output.js'
+import {containsMutation} from '../graphql.js'
 import {
   createApp,
   createRouter,
@@ -20,7 +21,7 @@ import {
   setResponseStatus,
   toNodeListener,
 } from 'h3'
-import {createHmac} from 'crypto'
+import {createHmac, randomBytes} from 'crypto'
 import {createServer, Server} from 'http'
 import {readFileSync} from 'fs'
 import {Writable} from 'stream'
@@ -61,64 +62,87 @@ class TokenRefreshError extends AbortError {
   }
 }
 
-interface SetupGraphiQLServerOptions {
-  stdout: Writable
-  port: number
-  appName: string
-  appUrl: string
-  apiKey: string
-  apiSecret: string
-  key?: string
-  storeFqdn: string
+/**
+ * Pluggable strategy for obtaining and refreshing the Admin API access token
+ * that the GraphiQL proxy injects into every request.
+ *
+ * - `getToken` may return a cached token; the proxy calls it for every request.
+ * - `refreshToken` (optional) is invoked when the upstream Admin API returns 401.
+ * When omitted, the proxy falls back to calling `getToken` again on 401.
+ *
+ * Implementations must throw `TokenRefreshError` (or any thrown error) when the
+ * token cannot be obtained; the proxy renders the unauthorized template in that case.
+ */
+export interface TokenProvider {
+  getToken: () => Promise<string>
+  refreshToken?: () => Promise<string>
 }
 
 /**
+ * Optional app-specific context, used to render the app pill and scopes note in the
+ * GraphiQL header and to drive the deterministic key derivation. Pass when the GraphiQL
+ * server is hosted as part of `shopify app dev`; omit for app-less use cases such as
+ * `shopify store execute`.
+ */
+export interface GraphiQLAppContext {
+  appName: string
+  appUrl: string
+  apiSecret: string
+}
+
+export interface SetupGraphiQLServerOptions {
+  stdout: Writable
+  port: number
+  storeFqdn: string
+  tokenProvider: TokenProvider
+  /**
+   * Authentication key required as a `?key=` query string on every request. When omitted:
+   * - if `appContext` is provided, derived deterministically from `apiSecret` + `storeFqdn`
+   * so browser tabs survive dev server restarts.
+   * - otherwise, generated randomly per process.
+   */
+  key?: string
+  appContext?: GraphiQLAppContext
+  /**
+   * When true, the proxy rejects mutation operations with HTTP 400 before forwarding
+   * them to the Admin API. Use this to mirror non-interactive safety guarantees in the
+   * interactive UI.
+   */
+  protectMutations?: boolean
+}
+
+export const MUTATIONS_BLOCKED_MESSAGE = 'Mutations are disabled. Re-run with --allow-mutations to enable mutations.'
+
+/**
  * Starts a local HTTP server that hosts the GraphiQL UI and proxies requests to the
- * Admin API for the configured store. The server uses the OAuth `client_credentials`
- * grant with the supplied `apiKey` / `apiSecret` to mint and refresh access tokens
- * on the fly.
+ * Admin API for the configured store. Authentication is delegated to the supplied
+ * `tokenProvider`, so the same server can serve both `shopify app dev` and stored-session
+ * use cases.
  *
  * @param options - Configuration for the server, including the target store, the
- * Partners app credentials, and the local port to bind to.
+ * pluggable token provider, and the local port to bind to.
  * @returns The underlying Node `http.Server` instance, already listening on `options.port`.
  */
 export function setupGraphiQLServer(options: SetupGraphiQLServerOptions): Server {
-  const {stdout, port, appName, appUrl, apiKey, apiSecret, key: providedKey, storeFqdn} = options
-  // Always require an authentication key. If not explicitly provided, derive one
-  // deterministically from apiSecret + storeFqdn so the key is stable across restarts
-  // (browser tabs survive dev server restarts) but not guessable without the app secret.
-  const key = resolveGraphiQLKey(providedKey, apiSecret, storeFqdn)
+  const {stdout, port, storeFqdn, tokenProvider, key: providedKey, appContext, protectMutations = false} = options
+  const key = resolveGraphiQLServerKey(providedKey, appContext, storeFqdn)
   outputDebug(`Setting up GraphiQL HTTP server on port ${port}...`, stdout)
 
   const app = createApp()
   const router = createRouter()
 
-  let _token: string | undefined
-  async function token(): Promise<string> {
-    // eslint-disable-next-line require-atomic-updates
-    _token ??= await refreshToken()
-    return _token
-  }
-
-  async function refreshToken(): Promise<string> {
+  const refreshUpstreamToken = async (): Promise<string> => {
     try {
       outputDebug('refreshing token', stdout)
-      _token = undefined
-      const bodyData = {
-        client_id: apiKey,
-        client_secret: apiSecret,
-        grant_type: 'client_credentials',
-      }
-      const tokenResponse = await fetch(`https://${storeFqdn}/admin/oauth/access_token`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify(bodyData),
-      })
+      return await (tokenProvider.refreshToken ?? tokenProvider.getToken)()
+    } catch (_error) {
+      throw new TokenRefreshError()
+    }
+  }
 
-      const tokenJson = (await tokenResponse.json()) as {access_token: string}
-      return tokenJson.access_token
+  const currentToken = async (): Promise<string> => {
+    try {
+      return await tokenProvider.getToken()
     } catch (_error) {
       throw new TokenRefreshError()
     }
@@ -126,8 +150,8 @@ export function setupGraphiQLServer(options: SetupGraphiQLServerOptions): Server
 
   async function fetchApiVersionsWithTokenRefresh(): Promise<string[]> {
     return performActionWithRetryAfterRecovery(
-      async () => supportedApiVersions({storeFqdn, token: await token()}),
-      refreshToken,
+      async () => supportedApiVersions({storeFqdn, token: await currentToken()}),
+      refreshUpstreamToken,
     )
   }
 
@@ -174,7 +198,7 @@ export function setupGraphiQLServer(options: SetupGraphiQLServerOptions): Server
     defineEventHandler(async () => {
       try {
         await fetchApiVersionsWithTokenRefresh()
-        return {status: 'OK', storeFqdn, appName, appUrl}
+        return {status: 'OK', storeFqdn, appName: appContext?.appName, appUrl: appContext?.appUrl}
         // eslint-disable-next-line no-catch-all/no-catch-all
       } catch {
         return {status: 'UNAUTHENTICATED'}
@@ -204,8 +228,9 @@ export function setupGraphiQLServer(options: SetupGraphiQLServerOptions): Server
         apiVersions = await fetchApiVersionsWithTokenRefresh()
       } catch (err) {
         if (err instanceof TokenRefreshError) {
-          return renderLiquidTemplate(unauthorizedTemplate, {
-            previewUrl: appUrl,
+          return renderLiquidTemplate(unauthorizedTemplate({hasAppContext: Boolean(appContext)}), {
+            previewUrl: appContext?.appUrl ?? '',
+            storeFqdn,
             url,
           })
         }
@@ -225,10 +250,11 @@ export function setupGraphiQLServer(options: SetupGraphiQLServerOptions): Server
         graphiqlTemplate({
           apiVersion,
           apiVersions: [...apiVersions, 'unstable'],
-          appName,
-          appUrl,
+          appName: appContext?.appName,
+          appUrl: appContext?.appUrl,
           key,
           storeFqdn,
+          protectMutations,
         }),
         {
           url,
@@ -255,17 +281,23 @@ export function setupGraphiQLServer(options: SetupGraphiQLServerOptions): Server
       const graphqlUrl = adminUrl(storeFqdn, query.api_version as string)
       try {
         const body = await readBody(event)
+
+        if (protectMutations && isMutationRequestBody(body)) {
+          setResponseStatus(event, 400)
+          return {errors: [{message: MUTATIONS_BLOCKED_MESSAGE}]}
+        }
+
         const reqBody = JSON.stringify(body)
 
         const reqHeaders = getRequestHeaders(event)
         const customHeaders = filterCustomHeaders(reqHeaders)
 
-        const runRequest = async () => {
+        const runRequest = async (token: string) => {
           const headers = {
             ...customHeaders,
             Accept: 'application/json',
             'Content-Type': 'application/json',
-            'X-Shopify-Access-Token': await token(),
+            'X-Shopify-Access-Token': token,
             'User-Agent': `ShopifyCLIGraphiQL/${CLI_KIT_VERSION}`,
           }
 
@@ -276,11 +308,10 @@ export function setupGraphiQLServer(options: SetupGraphiQLServerOptions): Server
           })
         }
 
-        let result = await runRequest()
+        let result = await runRequest(await currentToken())
         if (result.status === 401) {
           outputDebug('Token expired, fetching new token', stdout)
-          await refreshToken()
-          result = await runRequest()
+          result = await runRequest(await refreshUpstreamToken())
         }
 
         setResponseHeader(event, 'Content-Type', 'application/json')
@@ -302,4 +333,27 @@ export function setupGraphiQLServer(options: SetupGraphiQLServerOptions): Server
   const server = createServer(toNodeListener(app))
   server.listen(port, 'localhost', () => stdout.write(`GraphiQL server started on port ${port}`))
   return server
+}
+
+// Picks the right key based on what the caller supplied:
+// - explicit non-empty key → use it
+// - app context with apiSecret → derive deterministically (stable across restarts)
+// - otherwise → random per-process key (browser tabs won't survive restarts, which is
+//   the right tradeoff when there's no stable secret to derive from).
+function resolveGraphiQLServerKey(
+  providedKey: string | undefined,
+  appContext: GraphiQLAppContext | undefined,
+  storeFqdn: string,
+): string {
+  const trimmed = providedKey?.trim()
+  if (trimmed) return trimmed
+  if (appContext) return deriveGraphiQLKey(appContext.apiSecret, storeFqdn)
+  return randomBytes(32).toString('hex')
+}
+
+function isMutationRequestBody(body: unknown): boolean {
+  if (typeof body !== 'object' || body === null) return false
+  const {query, operationName} = body as {query?: unknown; operationName?: unknown}
+  if (typeof query !== 'string') return false
+  return containsMutation(query, typeof operationName === 'string' ? operationName : undefined)
 }

--- a/packages/cli-kit/src/public/node/graphiql/templates/graphiql.tsx
+++ b/packages/cli-kit/src/public/node/graphiql/templates/graphiql.tsx
@@ -49,10 +49,11 @@ export const defaultQuery = `query shopInfo {
 interface GraphiQLTemplateOptions {
   apiVersion: string
   apiVersions: string[]
-  appName: string
-  appUrl: string
+  appName?: string
+  appUrl?: string
   key: string
   storeFqdn: string
+  protectMutations?: boolean
 }
 
 export function graphiqlTemplate({
@@ -62,7 +63,10 @@ export function graphiqlTemplate({
   appUrl,
   key,
   storeFqdn,
+  protectMutations = false,
 }: GraphiQLTemplateOptions): string {
+  const hasAppContext = Boolean(appName && appUrl)
+  const unauthorizedLabel = hasAppContext ? 'App uninstalled' : 'Auth invalid'
   return `<!DOCTYPE html>
 <html lang="en">
   <head>
@@ -193,7 +197,7 @@ export function graphiqlTemplate({
                         <div className="status-badge-option with-shrunk-icon" id="status-badge-unauthorized">
                           <span className="top-bar-section-title">Status: </span>
                           <Badge tone="attention" icon={AlertCircleIcon}>
-                            App uninstalled
+                            {unauthorizedLabel}
                           </Badge>
                         </div>
                         <div className="status-badge-option with-shrunk-icon" id="status-badge-disconnected">
@@ -219,7 +223,7 @@ export function graphiqlTemplate({
                   <Grid.Cell columnSpan={{xs: 3, sm: 3, md: 3, lg: 5, xl: 5}}>
                     <div id="scopes-note" className="top-bar-section">
                       <Text as="span" tone="subdued">
-                        GraphiQL runs on the same access scopes you've defined in the TOML file for your app.
+                        {scopesNoteText({hasAppContext, protectMutations})}
                       </Text>
                     </div>
                   </Grid.Cell>
@@ -325,15 +329,25 @@ export function graphiqlTemplate({
             const {status, storeFqdn, appName, appUrl} = await response.json()
             appIsInstalled = status === 'OK'
             if (storeFqdn) {
-              document.getElementById('outbound-links').innerHTML = \`${renderToStaticMarkup(
-                // Create HTML string with substitutions included
-                <AppProvider i18n={{}}>
-                  {
-                    // eslint-disable-next-line no-template-curly-in-string
-                    linkPills({storeFqdn: '${storeFqdn}', appName: '${appName}', appUrl: '${appUrl}'})
-                  }
-                </AppProvider>,
-              )}\`
+              ${
+                hasAppContext
+                  ? `document.getElementById('outbound-links').innerHTML = \`${renderToStaticMarkup(
+                      <AppProvider i18n={{}}>
+                        {
+                          // eslint-disable-next-line no-template-curly-in-string
+                          linkPills({storeFqdn: '${storeFqdn}', appName: '${appName}', appUrl: '${appUrl}'})
+                        }
+                      </AppProvider>,
+                    )}\``
+                  : `document.getElementById('outbound-links').innerHTML = \`${renderToStaticMarkup(
+                      <AppProvider i18n={{}}>
+                        {
+                          // eslint-disable-next-line no-template-curly-in-string
+                          linkPills({storeFqdn: '${storeFqdn}'})
+                        }
+                      </AppProvider>,
+                    )}\``
+              }
             }
           })
       }, 5000)
@@ -345,8 +359,8 @@ export function graphiqlTemplate({
 
 interface LinkPillOptions {
   storeFqdn: string
-  appName: string
-  appUrl: string
+  appName?: string
+  appUrl?: string
 }
 
 function linkPills({storeFqdn, appName, appUrl}: LinkPillOptions) {
@@ -356,10 +370,30 @@ function linkPills({storeFqdn, appName, appUrl}: LinkPillOptions) {
       <Link url={`https://${storeFqdn}/admin`} target="_blank">
         <Badge tone="info" icon={LinkIcon} children={storeFqdn} />
       </Link>
-      <span className="top-bar-section-title">App: </span>
-      <Link url={appUrl} target="_blank">
-        <Badge tone="info" icon={LinkIcon} children={appName} />
-      </Link>
+      {appName && appUrl ? (
+        <>
+          <span className="top-bar-section-title">App: </span>
+          <Link url={appUrl} target="_blank">
+            <Badge tone="info" icon={LinkIcon} children={appName} />
+          </Link>
+        </>
+      ) : null}
     </div>
   )
+}
+
+function scopesNoteText({
+  hasAppContext,
+  protectMutations,
+}: {
+  hasAppContext: boolean
+  protectMutations: boolean
+}): string {
+  if (protectMutations) {
+    return 'Mutations are disabled. Re-run with --allow-mutations to enable mutations.'
+  }
+  if (hasAppContext) {
+    return "GraphiQL runs on the same access scopes you've defined in the TOML file for your app."
+  }
+  return 'GraphiQL runs with the access scopes granted to the stored app authentication for this store.'
 }

--- a/packages/cli-kit/src/public/node/graphiql/templates/graphiql.tsx
+++ b/packages/cli-kit/src/public/node/graphiql/templates/graphiql.tsx
@@ -1,4 +1,5 @@
 import {platformAndArch} from '../../os.js'
+import {MUTATIONS_BLOCKED_MESSAGE} from '../server.js'
 import React from 'react'
 import {renderToStaticMarkup} from 'react-dom/server'
 import {AppProvider, Badge, Banner, BlockStack, Box, Grid, InlineStack, Link, Select, Text} from '@shopify/polaris'
@@ -49,10 +50,11 @@ export const defaultQuery = `query shopInfo {
 interface GraphiQLTemplateOptions {
   apiVersion: string
   apiVersions: string[]
-  appName: string
-  appUrl: string
+  appName?: string
+  appUrl?: string
   key: string
   storeFqdn: string
+  protectMutations?: boolean
 }
 
 export function graphiqlTemplate({
@@ -62,7 +64,10 @@ export function graphiqlTemplate({
   appUrl,
   key,
   storeFqdn,
+  protectMutations = false,
 }: GraphiQLTemplateOptions): string {
+  const hasAppContext = Boolean(appName && appUrl)
+  const unauthorizedLabel = hasAppContext ? 'App uninstalled' : 'Auth invalid'
   return `<!DOCTYPE html>
 <html lang="en">
   <head>
@@ -193,7 +198,7 @@ export function graphiqlTemplate({
                         <div className="status-badge-option with-shrunk-icon" id="status-badge-unauthorized">
                           <span className="top-bar-section-title">Status: </span>
                           <Badge tone="attention" icon={AlertCircleIcon}>
-                            App uninstalled
+                            {unauthorizedLabel}
                           </Badge>
                         </div>
                         <div className="status-badge-option with-shrunk-icon" id="status-badge-disconnected">
@@ -219,7 +224,7 @@ export function graphiqlTemplate({
                   <Grid.Cell columnSpan={{xs: 3, sm: 3, md: 3, lg: 5, xl: 5}}>
                     <div id="scopes-note" className="top-bar-section">
                       <Text as="span" tone="subdued">
-                        GraphiQL runs on the same access scopes you've defined in the TOML file for your app.
+                        {scopesNoteText({hasAppContext, protectMutations})}
                       </Text>
                     </div>
                   </Grid.Cell>
@@ -325,15 +330,25 @@ export function graphiqlTemplate({
             const {status, storeFqdn, appName, appUrl} = await response.json()
             appIsInstalled = status === 'OK'
             if (storeFqdn) {
-              document.getElementById('outbound-links').innerHTML = \`${renderToStaticMarkup(
-                // Create HTML string with substitutions included
-                <AppProvider i18n={{}}>
-                  {
-                    // eslint-disable-next-line no-template-curly-in-string
-                    linkPills({storeFqdn: '${storeFqdn}', appName: '${appName}', appUrl: '${appUrl}'})
-                  }
-                </AppProvider>,
-              )}\`
+              ${
+                hasAppContext
+                  ? `document.getElementById('outbound-links').innerHTML = \`${renderToStaticMarkup(
+                      <AppProvider i18n={{}}>
+                        {
+                          // eslint-disable-next-line no-template-curly-in-string
+                          linkPills({storeFqdn: '${storeFqdn}', appName: '${appName}', appUrl: '${appUrl}'})
+                        }
+                      </AppProvider>,
+                    )}\``
+                  : `document.getElementById('outbound-links').innerHTML = \`${renderToStaticMarkup(
+                      <AppProvider i18n={{}}>
+                        {
+                          // eslint-disable-next-line no-template-curly-in-string
+                          linkPills({storeFqdn: '${storeFqdn}'})
+                        }
+                      </AppProvider>,
+                    )}\``
+              }
             }
           })
       }, 5000)
@@ -345,8 +360,8 @@ export function graphiqlTemplate({
 
 interface LinkPillOptions {
   storeFqdn: string
-  appName: string
-  appUrl: string
+  appName?: string
+  appUrl?: string
 }
 
 function linkPills({storeFqdn, appName, appUrl}: LinkPillOptions) {
@@ -356,10 +371,30 @@ function linkPills({storeFqdn, appName, appUrl}: LinkPillOptions) {
       <Link url={`https://${storeFqdn}/admin`} target="_blank">
         <Badge tone="info" icon={LinkIcon} children={storeFqdn} />
       </Link>
-      <span className="top-bar-section-title">App: </span>
-      <Link url={appUrl} target="_blank">
-        <Badge tone="info" icon={LinkIcon} children={appName} />
-      </Link>
+      {appName && appUrl ? (
+        <>
+          <span className="top-bar-section-title">App: </span>
+          <Link url={appUrl} target="_blank">
+            <Badge tone="info" icon={LinkIcon} children={appName} />
+          </Link>
+        </>
+      ) : null}
     </div>
   )
+}
+
+function scopesNoteText({
+  hasAppContext,
+  protectMutations,
+}: {
+  hasAppContext: boolean
+  protectMutations: boolean
+}): string {
+  if (protectMutations) {
+    return MUTATIONS_BLOCKED_MESSAGE
+  }
+  if (hasAppContext) {
+    return "GraphiQL runs on the same access scopes you've defined in the TOML file for your app."
+  }
+  return 'GraphiQL runs with the access scopes granted to the stored app authentication for this store.'
 }

--- a/packages/cli-kit/src/public/node/graphiql/templates/unauthorized.tsx
+++ b/packages/cli-kit/src/public/node/graphiql/templates/unauthorized.tsx
@@ -48,47 +48,72 @@ const shopifySvg = (
   </svg>
 )
 
-const polarisUnauthorizedContent = renderToStaticMarkup(
-  <AppProvider i18n={{}}>
-    <Page narrowWidth>
-      <div className="card-wrapper">
-        <Card padding="600">
-          <BlockStack gap="500">
-            {shopifySvg}
-            <div id="pre-install">
-              <BlockStack gap="200">
-                <Text variant="headingMd" as="h2">
-                  Install your app to access GraphiQL
-                </Text>
-                <p>The GraphiQL Explorer relies on your app being installed on your dev store to access its data.</p>
-                <p id="card-cta">
-                  <Button id="app-install-button">Install your app</Button>
-                </p>
-              </BlockStack>
-            </div>
+interface UnauthorizedTemplateOptions {
+  hasAppContext: boolean
+}
 
-            <div id="post-install">
-              <BlockStack gap="200">
-                <Text variant="headingMd" as="h2">
-                  Loading GraphiQL...
-                </Text>
-                <p>
-                  If you're not redirected automatically, <Link url="{{url}}/graphiql">click here</Link>.
-                </p>
-              </BlockStack>
-            </div>
-          </BlockStack>
-        </Card>
-      </div>
-    </Page>
-  </AppProvider>,
-)
+function polarisUnauthorizedContent({hasAppContext}: UnauthorizedTemplateOptions) {
+  return renderToStaticMarkup(
+    <AppProvider i18n={{}}>
+      <Page narrowWidth>
+        <div className="card-wrapper">
+          <Card padding="600">
+            <BlockStack gap="500">
+              {shopifySvg}
+              <div id="pre-install">{hasAppContext ? <AppUnauthorizedContent /> : <StoreUnauthorizedContent />}</div>
 
-export const unauthorizedTemplate = `
+              <div id="post-install">
+                <BlockStack gap="200">
+                  <Text variant="headingMd" as="h2">
+                    Loading GraphiQL...
+                  </Text>
+                  <p>
+                    If you're not redirected automatically, <Link url="{{url}}/graphiql">click here</Link>.
+                  </p>
+                </BlockStack>
+              </div>
+            </BlockStack>
+          </Card>
+        </div>
+      </Page>
+    </AppProvider>,
+  )
+}
+
+function AppUnauthorizedContent() {
+  return (
+    <BlockStack gap="200">
+      <Text variant="headingMd" as="h2">
+        Install your app to access GraphiQL
+      </Text>
+      <p>The GraphiQL Explorer relies on your app being installed on your dev store to access its data.</p>
+      <p id="card-cta">
+        <Button id="app-install-button">Install your app</Button>
+      </p>
+    </BlockStack>
+  )
+}
+
+function StoreUnauthorizedContent() {
+  return (
+    <BlockStack gap="200">
+      <Text variant="headingMd" as="h2">
+        Reconnect store authentication to access GraphiQL
+      </Text>
+      <p>The GraphiQL Explorer couldn't access this store with the stored authentication.</p>
+      <p>
+        Run <code>{'shopify store auth --store {{storeFqdn}}'}</code>, then refresh this page.
+      </p>
+    </BlockStack>
+  )
+}
+
+export function unauthorizedTemplate({hasAppContext}: UnauthorizedTemplateOptions): string {
+  return `
 <!DOCTYPE html>
 <html>
   <head>
-    <title>GraphiQL Explorer - App Not Installed</title>
+    <title>GraphiQL Explorer - Authentication Required</title>
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
 
@@ -133,14 +158,16 @@ export const unauthorizedTemplate = `
       }
 
       document.addEventListener("DOMContentLoaded", function() {
-        document.getElementById('app-install-button').onclick = openAppInstallTab
+        const installButton = document.getElementById('app-install-button')
+        if (installButton) installButton.onclick = openAppInstallTab
       })
     </script>
   </head>
   <body>
     <div class="vertical-center">
-      ${polarisUnauthorizedContent}
+      ${polarisUnauthorizedContent({hasAppContext})}
     </div>
   </body>
 </html>
 `
+}

--- a/packages/cli-kit/src/public/node/graphql.test.ts
+++ b/packages/cli-kit/src/public/node/graphql.test.ts
@@ -1,0 +1,64 @@
+import {containsMutation} from './graphql.js'
+import {describe, expect, test} from 'vitest'
+
+describe('containsMutation', () => {
+  test('returns false for a query', () => {
+    expect(containsMutation('query Shop { shop { name } }')).toBe(false)
+  })
+
+  test('returns false for an anonymous query', () => {
+    expect(containsMutation('{ shop { name } }')).toBe(false)
+  })
+
+  test('returns true for a mutation', () => {
+    expect(containsMutation('mutation UpdateShop { shopUpdate(input: {}) { id } }')).toBe(true)
+  })
+
+  test('returns false for a subscription', () => {
+    expect(containsMutation('subscription Foo { foo { id } }')).toBe(false)
+  })
+
+  test('returns false for invalid GraphQL', () => {
+    expect(containsMutation('this is not graphql')).toBe(false)
+  })
+
+  test('returns false for an empty string', () => {
+    expect(containsMutation('')).toBe(false)
+  })
+
+  test('returns false for a fragment-only document', () => {
+    expect(containsMutation('fragment Foo on Shop { name }')).toBe(false)
+  })
+
+  test('with operationName, only checks the named operation', () => {
+    // eslint-disable-next-line @shopify/cli/no-inline-graphql
+    const document = `
+      query Q { shop { name } }
+      mutation M { shopUpdate(input: {}) { id } }
+    `
+    expect(containsMutation(document, 'Q')).toBe(false)
+    expect(containsMutation(document, 'M')).toBe(true)
+  })
+
+  test('with operationName not in document, returns false', () => {
+    const document = 'query Q { shop { name } }'
+    expect(containsMutation(document, 'DoesNotExist')).toBe(false)
+  })
+
+  test('without operationName but multiple operations, returns true if any is a mutation', () => {
+    // eslint-disable-next-line @shopify/cli/no-inline-graphql
+    const document = `
+      query Q { shop { name } }
+      mutation M { shopUpdate(input: {}) { id } }
+    `
+    expect(containsMutation(document)).toBe(true)
+  })
+
+  test('without operationName but multiple queries, returns false', () => {
+    const document = `
+      query Q1 { shop { name } }
+      query Q2 { shop { id } }
+    `
+    expect(containsMutation(document)).toBe(false)
+  })
+})

--- a/packages/cli-kit/src/public/node/graphql.ts
+++ b/packages/cli-kit/src/public/node/graphql.ts
@@ -1,0 +1,46 @@
+import {OperationDefinitionNode, parse} from 'graphql'
+
+/**
+ * Returns true if the GraphQL document contains a mutation operation that
+ * would actually be executed for the given (optional) operation name.
+ *
+ * - When `operationName` is provided, only the matching operation is checked.
+ * - When `operationName` is omitted and the document has a single operation,
+ * that operation is checked.
+ * - When the document has multiple operations and no operation name is given,
+ * any mutation in the document is treated as a mutation request (the GraphQL
+ * server would reject the ambiguous request anyway).
+ *
+ * Returns false for queries, subscriptions, fragment-only documents, and any
+ * input that fails to parse as GraphQL.
+ *
+ * @param query - The GraphQL document to inspect.
+ * @param operationName - Optional name of the operation to check; when set, only that operation is considered.
+ * @returns True if the relevant operation is a mutation; false otherwise.
+ */
+export function containsMutation(query: string, operationName?: string): boolean {
+  let document
+  try {
+    document = parse(query)
+    // eslint-disable-next-line no-catch-all/no-catch-all -- swallowing parse errors is the entire purpose
+  } catch {
+    return false
+  }
+
+  const operations = document.definitions.filter(
+    (definition): definition is OperationDefinitionNode => definition.kind === 'OperationDefinition',
+  )
+
+  if (operations.length === 0) return false
+
+  if (operationName) {
+    const target = operations.find((operation) => operation.name?.value === operationName)
+    return target?.operation === 'mutation'
+  }
+
+  if (operations.length === 1) {
+    return operations[0]!.operation === 'mutation'
+  }
+
+  return operations.some((operation) => operation.operation === 'mutation')
+}


### PR DESCRIPTION
### WHY are these changes introduced?

Store GraphiQL needs the shared server to work with tokens that do not come from app dev client credentials.

### WHAT is this pull request doing?

Makes the cli-kit GraphiQL server accept a token provider, adds shared Admin API GraphQL helpers, keeps app dev wired to its existing auth flow, and extracts the app dev client-credentials token provider into a focused module with tests.

### How to test your changes?

Open GraphiQL from `shopify app dev`

### Checklist

- [x] I have considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I have considered possible [documentation](https://shopify.dev) changes
- [x] I have considered analytics changes to measure impact
- [ ] The change is user-facing — I have identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`