### PR TITLE
E2E: .env.example cleanup after test isolation

### DIFF
--- a/packages/e2e/.env.example
+++ b/packages/e2e/.env.example
@@ -6,9 +6,6 @@ E2E_ACCOUNT_EMAIL=
 # CI secret: E2E_ACCOUNT_PASSWORD
 E2E_ACCOUNT_PASSWORD=
 
-# Required: Dev store FQDN for dev server / deploy tests (e.g. my-store.myshopify.com)
-# CI secret: E2E_STORE_FQDN
-E2E_STORE_FQDN=
-
 # Required: dedicated e2e org ID
+# CI secret: E2E_ORG_ID
 E2E_ORG_ID=


### PR DESCRIPTION
### WHY are these changes introduced?

The `E2E_STORE_FQDN` environment variable is no longer required for e2e tests and should be removed from the e2e configuration. Additionally, the `E2E_ORG_ID` variable was missing its CI secret annotation comment.

### WHAT is this pull request doing?

Removes the `E2E_STORE_FQDN` environment variable from the e2e `.env.example` file and adds the missing `# CI secret: E2E_ORG_ID` comment to the `E2E_ORG_ID` variable, bringing it in line with the documentation style used for other secrets.

### How to test your changes?

Verify that e2e tests run successfully without the `E2E_STORE_FQDN` variable set in the environment.

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct bump type (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](../CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`