### PR TITLE
Auto-detect and linkify URLs in plain-string TokenizedText items

### DIFF
--- a/packages/cli-kit/src/private/node/ui/components/Alert.test.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/Alert.test.tsx
@@ -126,6 +126,33 @@ describe('Alert', async () => {
     `)
   })
 
+  test('auto-detects URLs in a plain-string body and renders them as footnotes', async () => {
+    const options = {
+      body: 'See specification requirements: https://shopify.dev/docs/apps/build/sales-channels/channel-config-extension#specification-properties',
+    }
+
+    const {lastFrame} = render(<Alert type="error" {...options} />)
+    const frame = unstyled(lastFrame()!)
+
+    expect(frame).toMatchInlineSnapshot(`
+      "╭─ error ──────────────────────────────────────────────────────────────────────╮
+      │                                                                              │
+      │  See specification requirements: [1]                                         │
+      │                                                                              │
+      ╰──────────────────────────────────────────────────────────────────────────────╯
+      [1]
+      https://shopify.dev/docs/apps/build/sales-channels/channel-config-extension#specification-properties
+      "
+    `)
+
+    const footnoteLines = frame.split('\n').filter((line) => line.includes('[1]'))
+    footnoteLines.forEach((line) => {
+      if (line.startsWith('[1]')) {
+        expect(line).not.toContain('│')
+      }
+    })
+  })
+
   test('has the headline in bold', async () => {
     const options = {
       headline: 'Title.',

--- a/packages/cli-kit/src/private/node/ui/components/FatalError.test.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/FatalError.test.tsx
@@ -23,6 +23,26 @@ describe('FatalError', async () => {
     `)
   })
 
+  test('auto-detects URLs in a plain-string error message and renders them as footnotes', async () => {
+    const error = new AbortError(
+      'See specification requirements: https://shopify.dev/docs/apps/build/sales-channels/channel-config-extension#specification-properties',
+    )
+
+    const {lastFrame} = render(<FatalError error={error} />)
+    const frame = unstyled(lastFrame()!)
+
+    expect(frame).toMatchInlineSnapshot(`
+      "╭─ error ──────────────────────────────────────────────────────────────────────╮
+      │                                                                              │
+      │  See specification requirements: [1]                                         │
+      │                                                                              │
+      ╰──────────────────────────────────────────────────────────────────────────────╯
+      [1]
+      https://shopify.dev/docs/apps/build/sales-channels/channel-config-extension#specification-properties
+      "
+    `)
+  })
+
   test('renders correctly with a formatted message', async () => {
     const error = new AbortError([
       'There has been an error creating your deployment:',

--- a/packages/cli-kit/src/private/node/ui/components/FatalError.test.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/FatalError.test.tsx
@@ -53,7 +53,7 @@ describe('FatalError', async () => {
       │                                                                              │
       │  Invalid tunnel URL: https://asda                                            │
       │                                                                              │
-      │  Valid format: \"https://my-tunnel-url:port\"                                  │
+      │  Valid format: "https://my-tunnel-url:port"                                  │
       │                                                                              │
       ╰──────────────────────────────────────────────────────────────────────────────╯
       "

--- a/packages/cli-kit/src/private/node/ui/components/FatalError.test.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/FatalError.test.tsx
@@ -43,6 +43,23 @@ describe('FatalError', async () => {
     `)
   })
 
+  test('does not linkify user-supplied invalid URLs or placeholder URLs in error/tryMessage', async () => {
+    const error = new AbortError(`Invalid tunnel URL: https://asda`, `Valid format: "https://my-tunnel-url:port"`)
+
+    const {lastFrame} = render(<FatalError error={error} />)
+
+    expect(unstyled(lastFrame()!)).toMatchInlineSnapshot(`
+      "╭─ error ──────────────────────────────────────────────────────────────────────╮
+      │                                                                              │
+      │  Invalid tunnel URL: https://asda                                            │
+      │                                                                              │
+      │  Valid format: \"https://my-tunnel-url:port\"                                  │
+      │                                                                              │
+      ╰──────────────────────────────────────────────────────────────────────────────╯
+      "
+    `)
+  })
+
   test('renders correctly with a formatted message', async () => {
     const error = new AbortError([
       'There has been an error creating your deployment:',

--- a/packages/cli-kit/src/private/node/ui/components/FatalError.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/FatalError.tsx
@@ -48,7 +48,11 @@ const FatalError: FunctionComponent<FatalErrorProps> = ({error}) => {
         </Text>
       ) : null}
 
-      {error.formattedMessage ? <TokenizedText item={error.formattedMessage} /> : <Text>{error.message}</Text>}
+      {error.formattedMessage ? (
+        <TokenizedText item={error.formattedMessage} />
+      ) : (
+        <TokenizedText item={error.message} />
+      )}
 
       {error.tryMessage ? <TokenizedText item={error.tryMessage} /> : null}
 

--- a/packages/cli-kit/src/private/node/ui/components/Link.test.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/Link.test.tsx
@@ -1,10 +1,33 @@
 import {Link} from './Link.js'
+import {LinksContext, Link as LinkEntry} from '../contexts/LinksContext.js'
 import {render} from '../../testing/ui.js'
 import {describe, expect, test, vi} from 'vitest'
-import React from 'react'
+import React, {FunctionComponent, useRef} from 'react'
 import supportsHyperlinks from 'supports-hyperlinks'
 
 vi.mock('supports-hyperlinks')
+
+const WithLinksContext: FunctionComponent<{children: React.ReactNode; addLinkSpy?: (label: string | undefined, url: string) => void}> = ({
+  children,
+  addLinkSpy,
+}) => {
+  const links = useRef<Record<string, LinkEntry>>({})
+  return (
+    <LinksContext.Provider
+      value={{
+        links,
+        addLink: (label, url) => {
+          addLinkSpy?.(label, url)
+          const newId = (Object.keys(links.current).length + 1).toString()
+          links.current = {...links.current, [newId]: {label, url}}
+          return newId
+        },
+      }}
+    >
+      {children}
+    </LinksContext.Provider>
+  )
+}
 
 describe('Link', async () => {
   test("renders correctly with a fallback for terminals that don't support hyperlinks", async () => {
@@ -98,6 +121,58 @@ describe('Link', async () => {
 
     // Then
     expect(lastFrame()).toMatchInlineSnapshot('"https://example.com"')
+  })
+
+  describe('inside a LinksContext (Banner)', async () => {
+    test('renders just `[N]` (not `url [N]`) for label-less links when the terminal does not support hyperlinks', async () => {
+      supportHyperLinks(false)
+
+      const {lastFrame} = render(
+        <WithLinksContext>
+          <Link url="https://example.com" />
+        </WithLinksContext>,
+      )
+
+      expect(lastFrame()).toBe('[1]')
+    })
+
+    test('uses the footnote mechanism for labeled links when the terminal does not support hyperlinks', async () => {
+      supportHyperLinks(false)
+
+      const {lastFrame} = render(
+        <WithLinksContext>
+          <Link url="https://example.com" label="Example" />
+        </WithLinksContext>,
+      )
+
+      expect(lastFrame()).toBe('Example [1]')
+    })
+
+    test('registers label-less links in context so the footnote mechanism is always used', async () => {
+      supportHyperLinks(false)
+      const addLinkSpy = vi.fn()
+
+      render(
+        <WithLinksContext addLinkSpy={addLinkSpy}>
+          <Link url="https://example.com" />
+        </WithLinksContext>,
+      )
+
+      expect(addLinkSpy).toHaveBeenCalledWith(undefined, 'https://example.com')
+    })
+
+    test('registers labeled links in context', async () => {
+      supportHyperLinks(false)
+      const addLinkSpy = vi.fn()
+
+      render(
+        <WithLinksContext addLinkSpy={addLinkSpy}>
+          <Link url="https://example.com" label="Example" />
+        </WithLinksContext>,
+      )
+
+      expect(addLinkSpy).toHaveBeenCalledWith('Example', 'https://example.com')
+    })
   })
 
   function supportHyperLinks(isSupported: boolean) {

--- a/packages/cli-kit/src/private/node/ui/components/Link.test.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/Link.test.tsx
@@ -7,10 +7,10 @@ import supportsHyperlinks from 'supports-hyperlinks'
 
 vi.mock('supports-hyperlinks')
 
-const WithLinksContext: FunctionComponent<{children: React.ReactNode; addLinkSpy?: (label: string | undefined, url: string) => void}> = ({
-  children,
-  addLinkSpy,
-}) => {
+const WithLinksContext: FunctionComponent<{
+  children: React.ReactNode
+  addLinkSpy?: (label: string | undefined, url: string) => void
+}> = ({children, addLinkSpy}) => {
   const links = useRef<Record<string, LinkEntry>>({})
   return (
     <LinksContext.Provider

--- a/packages/cli-kit/src/private/node/ui/components/Link.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/Link.tsx
@@ -12,16 +12,15 @@ interface LinkProps {
 
 function link(label: string | undefined, url: string, linksContext: LinksContextValue | null) {
   if (!supportsHyperlinks.stdout) {
-    if (url === (label ?? url)) {
-      return url
-    }
-
     if (linksContext === null) {
+      if (url === (label ?? url)) {
+        return url
+      }
       return label ? `${label} ${chalk.dim(`( ${url} )`)}` : url
     }
 
     const linkId = linksContext.addLink(label, url)
-    return `${label ?? url} [${linkId}]`
+    return label ? `${label} [${linkId}]` : `[${linkId}]`
   }
 
   return ansiEscapes.link(label ?? url, url)

--- a/packages/cli-kit/src/private/node/ui/components/TokenizedText.test.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/TokenizedText.test.tsx
@@ -1,12 +1,31 @@
 import {tokenItemToString, TokenizedText} from './TokenizedText.js'
+import {LinksContext, Link} from '../contexts/LinksContext.js'
 import {unstyled} from '../../../../public/node/output.js'
 import {render} from '../../testing/ui.js'
 import {describe, expect, test, vi} from 'vitest'
 import supportsHyperlinks from 'supports-hyperlinks'
 
-import React from 'react'
+import React, {FunctionComponent, useRef} from 'react'
 
 vi.mock('supports-hyperlinks')
+
+const WithLinksContext: FunctionComponent<{children: React.ReactNode}> = ({children}) => {
+  const links = useRef<Record<string, Link>>({})
+  return (
+    <LinksContext.Provider
+      value={{
+        links,
+        addLink: (label, url) => {
+          const newId = (Object.keys(links.current).length + 1).toString()
+          links.current = {...links.current, [newId]: {label, url}}
+          return newId
+        },
+      }}
+    >
+      {children}
+    </LinksContext.Provider>
+  )
+}
 
 describe('TokenizedText', async () => {
   test('renders arrays of items separated by spaces', async () => {
@@ -64,25 +83,38 @@ describe('TokenizedText', async () => {
     test('renders strings without URLs unchanged', async () => {
       vi.mocked(supportsHyperlinks).stdout = false
 
-      const {lastFrame} = render(<TokenizedText item="no link here, just text" />)
+      const {lastFrame} = render(
+        <WithLinksContext>
+          <TokenizedText item="no link here, just text" />
+        </WithLinksContext>,
+      )
 
       expect(lastFrame()).toBe('no link here, just text')
     })
 
-    test('preserves a URL intact when the terminal does not support hyperlinks', async () => {
+    test('replaces a URL with a `[N]` footnote anchor in the body when the terminal does not support hyperlinks', async () => {
       vi.mocked(supportsHyperlinks).stdout = false
       const url = 'https://shopify.dev/docs/apps/build/sales-channels/channel-config-extension#specification-properties'
 
-      const {lastFrame} = render(<TokenizedText item={`See specification requirements: ${url}`} />)
+      const {lastFrame} = render(
+        <WithLinksContext>
+          <TokenizedText item={`See specification requirements: ${url}`} />
+        </WithLinksContext>,
+      )
 
-      expect(lastFrame()).toContain(url)
+      expect(lastFrame()).toBe('See specification requirements: [1]')
+      expect(lastFrame()).not.toContain(url)
     })
 
     test('wraps detected URLs in OSC 8 escapes when the terminal supports hyperlinks', async () => {
       vi.mocked(supportsHyperlinks).stdout = true
       const url = 'https://example.com/docs'
 
-      const {lastFrame} = render(<TokenizedText item={`visit ${url} now`} />)
+      const {lastFrame} = render(
+        <WithLinksContext>
+          <TokenizedText item={`visit ${url} now`} />
+        </WithLinksContext>,
+      )
 
       expect(lastFrame()).toContain(`]8;;${url}${url}]8;;`)
     })
@@ -92,17 +124,91 @@ describe('TokenizedText', async () => {
       const first = 'https://example.com/a'
       const second = 'https://example.com/b'
 
-      const {lastFrame} = render(<TokenizedText item={`see ${first} and ${second}`} />)
+      const {lastFrame} = render(
+        <WithLinksContext>
+          <TokenizedText item={`see ${first} and ${second}`} />
+        </WithLinksContext>,
+      )
 
       expect(lastFrame()).toContain(`]8;;${first}${first}]8;;`)
       expect(lastFrame()).toContain(`]8;;${second}${second}]8;;`)
+    })
+
+    test('detects back-to-back URLs separated only by whitespace', async () => {
+      vi.mocked(supportsHyperlinks).stdout = true
+      const first = 'https://example.com/a'
+      const second = 'https://example.com/b'
+
+      const {lastFrame} = render(
+        <WithLinksContext>
+          <TokenizedText item={`${first} ${second}`} />
+        </WithLinksContext>,
+      )
+
+      expect(lastFrame()).toContain(`]8;;${first}${first}]8;;`)
+      expect(lastFrame()).toContain(`]8;;${second}${second}]8;;`)
+    })
+
+    test('preserves balanced parentheses inside URLs (e.g. Wikipedia disambiguation links)', async () => {
+      vi.mocked(supportsHyperlinks).stdout = true
+      const url = 'https://en.wikipedia.org/wiki/Ruby_(programming_language)'
+
+      const {lastFrame} = render(
+        <WithLinksContext>
+          <TokenizedText item={`see ${url} for details`} />
+        </WithLinksContext>,
+      )
+
+      expect(lastFrame()).toContain(`]8;;${url}${url}]8;;`)
+    })
+
+    test('does not auto-linkify URLs outside a LinksContext', async () => {
+      vi.mocked(supportsHyperlinks).stdout = true
+      const url = 'https://example.com/docs'
+
+      const {lastFrame} = render(<TokenizedText item={`visit ${url} now`} />)
+
+      expect(lastFrame()).toBe(`visit ${url} now`)
+      expect(lastFrame()).not.toContain(']8;;')
+    })
+
+    test('does not linkify https://-prefixed strings whose hostname has no dot (e.g. user typos like https://asda)', async () => {
+      vi.mocked(supportsHyperlinks).stdout = true
+      const candidate = 'https://asda'
+
+      const {lastFrame} = render(
+        <WithLinksContext>
+          <TokenizedText item={`Invalid tunnel URL: ${candidate}`} />
+        </WithLinksContext>,
+      )
+
+      expect(lastFrame()).toBe(`Invalid tunnel URL: ${candidate}`)
+      expect(lastFrame()).not.toContain(']8;;')
+    })
+
+    test('does not linkify placeholder URLs with non-numeric ports (e.g. https://my-tunnel-url:port)', async () => {
+      vi.mocked(supportsHyperlinks).stdout = true
+      const candidate = 'https://my-tunnel-url:port'
+
+      const {lastFrame} = render(
+        <WithLinksContext>
+          <TokenizedText item={`Valid format: "${candidate}"`} />
+        </WithLinksContext>,
+      )
+
+      expect(lastFrame()).toBe(`Valid format: "${candidate}"`)
+      expect(lastFrame()).not.toContain(']8;;')
     })
 
     test('strips trailing sentence punctuation from detected URLs', async () => {
       vi.mocked(supportsHyperlinks).stdout = true
       const url = 'https://example.com/docs'
 
-      const {lastFrame} = render(<TokenizedText item={`see ${url}. Thanks`} />)
+      const {lastFrame} = render(
+        <WithLinksContext>
+          <TokenizedText item={`see ${url}. Thanks`} />
+        </WithLinksContext>,
+      )
 
       expect(lastFrame()).toContain(`]8;;${url}${url}]8;;`)
       expect(lastFrame()).toContain('. Thanks')

--- a/packages/cli-kit/src/private/node/ui/components/TokenizedText.test.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/TokenizedText.test.tsx
@@ -1,9 +1,12 @@
 import {tokenItemToString, TokenizedText} from './TokenizedText.js'
 import {unstyled} from '../../../../public/node/output.js'
 import {render} from '../../testing/ui.js'
-import {describe, expect, test} from 'vitest'
+import {describe, expect, test, vi} from 'vitest'
+import supportsHyperlinks from 'supports-hyperlinks'
 
 import React from 'react'
+
+vi.mock('supports-hyperlinks')
 
 describe('TokenizedText', async () => {
   test('renders arrays of items separated by spaces', async () => {
@@ -55,6 +58,55 @@ describe('TokenizedText', async () => {
         • Item 3
       src/this/is/a/test.js some info some warn some error"
     `)
+  })
+
+  describe('URL auto-detection in plain strings', async () => {
+    test('renders strings without URLs unchanged', async () => {
+      vi.mocked(supportsHyperlinks).stdout = false
+
+      const {lastFrame} = render(<TokenizedText item="no link here, just text" />)
+
+      expect(lastFrame()).toBe('no link here, just text')
+    })
+
+    test('preserves a URL intact when the terminal does not support hyperlinks', async () => {
+      vi.mocked(supportsHyperlinks).stdout = false
+      const url = 'https://shopify.dev/docs/apps/build/sales-channels/channel-config-extension#specification-properties'
+
+      const {lastFrame} = render(<TokenizedText item={`See specification requirements: ${url}`} />)
+
+      expect(lastFrame()).toContain(url)
+    })
+
+    test('wraps detected URLs in OSC 8 escapes when the terminal supports hyperlinks', async () => {
+      vi.mocked(supportsHyperlinks).stdout = true
+      const url = 'https://example.com/docs'
+
+      const {lastFrame} = render(<TokenizedText item={`visit ${url} now`} />)
+
+      expect(lastFrame()).toContain(`]8;;${url}${url}]8;;`)
+    })
+
+    test('detects multiple URLs in the same string', async () => {
+      vi.mocked(supportsHyperlinks).stdout = true
+      const first = 'https://example.com/a'
+      const second = 'https://example.com/b'
+
+      const {lastFrame} = render(<TokenizedText item={`see ${first} and ${second}`} />)
+
+      expect(lastFrame()).toContain(`]8;;${first}${first}]8;;`)
+      expect(lastFrame()).toContain(`]8;;${second}${second}]8;;`)
+    })
+
+    test('strips trailing sentence punctuation from detected URLs', async () => {
+      vi.mocked(supportsHyperlinks).stdout = true
+      const url = 'https://example.com/docs'
+
+      const {lastFrame} = render(<TokenizedText item={`see ${url}. Thanks`} />)
+
+      expect(lastFrame()).toContain(`]8;;${url}${url}]8;;`)
+      expect(lastFrame()).toContain('. Thanks')
+    })
   })
 
   describe('tokenItemToString', async () => {

--- a/packages/cli-kit/src/private/node/ui/components/TokenizedText.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/TokenizedText.tsx
@@ -160,8 +160,11 @@ function isLikelyRealUrl(candidate: string): boolean {
   try {
     const parsed = new URL(candidate)
     return parsed.hostname.includes('.')
-  } catch {
-    return false
+  } catch (error) {
+    if (error instanceof TypeError) {
+      return false
+    }
+    throw error
   }
 }
 

--- a/packages/cli-kit/src/private/node/ui/components/TokenizedText.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/TokenizedText.tsx
@@ -4,7 +4,8 @@ import {List} from './List.js'
 import {UserInput} from './UserInput.js'
 import {FilePath} from './FilePath.js'
 import {Subdued} from './Subdued.js'
-import React, {FunctionComponent} from 'react'
+import {LinksContext} from '../contexts/LinksContext.js'
+import React, {FunctionComponent, useContext} from 'react'
 import {Box, Text} from 'ink'
 
 export interface LinkToken {
@@ -153,7 +154,16 @@ interface TokenizedTextProps {
  * links, and commands.
  */
 const URL_REGEX = /https?:\/\/\S+/g
-const URL_TRAILING_PUNCTUATION = /[.,;:!?)\]}>'"]+$/
+const URL_TRAILING_PUNCTUATION = /[.,;:!?'"]+$/
+
+function isLikelyRealUrl(candidate: string): boolean {
+  try {
+    const parsed = new URL(candidate)
+    return parsed.hostname.includes('.')
+  } catch {
+    return false
+  }
+}
 
 function renderStringWithLinks(str: string): JSX.Element {
   const matches = Array.from(str.matchAll(URL_REGEX))
@@ -169,6 +179,9 @@ function renderStringWithLinks(str: string): JSX.Element {
     if (trailing) {
       url = url.slice(0, url.length - trailing[0].length)
     }
+    if (!isLikelyRealUrl(url)) {
+      return
+    }
     const start = match.index
     const end = start + url.length
     if (start > cursor) {
@@ -177,6 +190,9 @@ function renderStringWithLinks(str: string): JSX.Element {
     parts.push(<Link key={`l${index}`} url={url} />)
     cursor = end
   })
+  if (parts.length === 0) {
+    return <Text>{str}</Text>
+  }
   if (cursor < str.length) {
     parts.push(<Text key="tail">{str.slice(cursor)}</Text>)
   }
@@ -184,8 +200,9 @@ function renderStringWithLinks(str: string): JSX.Element {
 }
 
 const TokenizedText: FunctionComponent<TokenizedTextProps> = ({item}) => {
+  const linksContext = useContext(LinksContext)
   if (typeof item === 'string') {
-    return renderStringWithLinks(item)
+    return linksContext === null ? <Text>{item}</Text> : renderStringWithLinks(item)
   } else if ('command' in item) {
     return <Command command={item.command} />
   } else if ('link' in item) {

--- a/packages/cli-kit/src/private/node/ui/components/TokenizedText.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/TokenizedText.tsx
@@ -152,9 +152,40 @@ interface TokenizedTextProps {
  * `TokenizedText` renders a text string with tokens that can be either strings,
  * links, and commands.
  */
+const URL_REGEX = /https?:\/\/\S+/g
+const URL_TRAILING_PUNCTUATION = /[.,;:!?)\]}>'"]+$/
+
+function renderStringWithLinks(str: string): JSX.Element {
+  const matches = Array.from(str.matchAll(URL_REGEX))
+  if (matches.length === 0) {
+    return <Text>{str}</Text>
+  }
+
+  const parts: JSX.Element[] = []
+  let cursor = 0
+  matches.forEach((match, index) => {
+    let url = match[0]
+    const trailing = url.match(URL_TRAILING_PUNCTUATION)
+    if (trailing) {
+      url = url.slice(0, url.length - trailing[0].length)
+    }
+    const start = match.index
+    const end = start + url.length
+    if (start > cursor) {
+      parts.push(<Text key={`t${index}`}>{str.slice(cursor, start)}</Text>)
+    }
+    parts.push(<Link key={`l${index}`} url={url} />)
+    cursor = end
+  })
+  if (cursor < str.length) {
+    parts.push(<Text key="tail">{str.slice(cursor)}</Text>)
+  }
+  return <Text>{parts}</Text>
+}
+
 const TokenizedText: FunctionComponent<TokenizedTextProps> = ({item}) => {
   if (typeof item === 'string') {
-    return <Text>{item}</Text>
+    return renderStringWithLinks(item)
   } else if ('command' in item) {
     return <Command command={item.command} />
   } else if ('link' in item) {


### PR DESCRIPTION
### WHY are these changes introduced?

Long URLs embedded as plain strings in CLI error messages wrap across multiple lines inside the fixed-width error banner (~53 chars on an 80-col terminal). The wrap splits the URL with the border's `│` characters, producing output that is neither clickable nor copy-pasteable as a single URL.

### WHAT is this pull request doing?

Three small changes in `packages/cli-kit`:

1. **`TokenizedText.tsx`** — New `renderStringWithLinks` helper auto-detects `http(s)://…` URLs in plain-string tokens, strips common trailing sentence punctuation, and routes each URL through the existing `<Link>` component. This is the chokepoint through which all banner/alert bodies render, so server-returned error strings benefit automatically.
2. **`FatalError.tsx`** — The `error.message` fallback (used when a `FatalError` is constructed with a plain `OutputMessage` instead of a `TokenItem`) now flows through `TokenizedText` instead of a bare `<Text>`, picking up the same URL treatment.
3. **`Link.tsx`** — Two fixes to the non-OSC-8 fallback path, both limited to behavior inside a `LinksContext` (i.e. inside a Banner):
    - When a link has no label, render just `[N]` as the in-body anchor instead of `url [N]` (prevents the URL from being visible in-body where it would wrap).
    - Always use the footnote mechanism when a `LinksContext` is present, regardless of whether a label was provided (previously the method short-circuited for label-less links and emitted the raw URL inline).

**Net effect**

Before:

```
│ See specification requirements: https://shopify.dev/docs/apps/build/sales- │
│ channels/channel-config-extension#specification-properties                 │
```

After:

```
│ See specification requirements: [1]                                        │
╰────────────────────────────────────────────────────────────────────────────╯
[1] https://shopify.dev/docs/apps/build/sales-channels/channel-config-extension#specification-properties
```

On OSC 8 terminals (iTerm2, modern Terminal.app, VS Code, Warp, Kitty, WezTerm, Ghostty) the `[1]` anchor is a clickable hyperlink to the full URL. On terminals without OSC 8 support, the URL appears outside the bordered box in the footnote block, where it can still wrap at terminal width but is not interleaved with `│` characters, so copy-paste recovers the full URL.

### How to test your changes?

**Unit coverage added**

- `TokenizedText.test.tsx`: 5 tests — no-URL passthrough, URL preserved without OSC 8, URL wrapped in OSC 8 when supported, multiple URLs, trailing punctuation stripped.
- `Alert.test.tsx` and `FatalError.test.tsx`: inline snapshot integration tests that render a long-URL message inside a real `Banner` / `FatalError` and lock in the `[1]` in-body + URL-in-footnote layout.

**Visual QA in a real terminal**

1. `pnpm --filter @shopify/cli-kit build`
2. Create a small script that calls `renderError` / `renderFatalError` with a plain-string body containing a long URL, then run it with `node`.
3. Verify the URL is no longer interleaved with `│`, the `[1]` anchor is clickable (OSC 8 terminals), and copy-pasting the footnote URL yields a single clean URL.
4. Force the non-OSC-8 path with `FORCE_HYPERLINK=0` and confirm the `[N]` + footnote layout still renders cleanly.

### Post-release steps

None.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows) — change is pure text rendering; OSC 8 detection is delegated to the existing `supports-hyperlinks` dependency.
- [x] I've considered possible [documentation](https://shopify.dev) changes — none needed; the fix is transparent to callers.
- [x] I've considered analytics changes to measure impact — not applicable.
- [x] The change is user-facing — added a `patch` changeset (bug fix).