### PR TITLE
Detect ShopifyGlobal re-export, emit intersection in shopify.d.ts

### DIFF
--- a/.changeset/shopify-global-type-detection.md
+++ b/.changeset/shopify-global-type-detection.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+The CLI-generated `shopify.d.ts` now types the `shopify` binding as `Api & ShopifyGlobal` (intersection) for UI extension targets whose `.d.ts` re-exports a `ShopifyGlobal` type. Existing consumers who access the target API via `shopify.*` are unaffected; new host-level APIs like `shopify.addEventListener` now type-check automatically for opt-in targets (e.g. POS background extensions). Targets that do not re-export `ShopifyGlobal` emit the same output as before.

--- a/packages/app/src/cli/models/extensions/specifications/type-generation.ts
+++ b/packages/app/src/cli/models/extensions/specifications/type-generation.ts
@@ -166,23 +166,75 @@ interface CreateTypeDefinitionOptions {
 }
 
 /**
- * Builds the shopify API type based on targets and optional tools type.
+ * Returns true when the resolved target declaration file re-exports a
+ * `ShopifyGlobal` type. Used to decide whether the `shopify` binding should be
+ * typed as `Api & ShopifyGlobal` or just `Api`.
+ *
+ * Uses the TS compiler API to avoid false positives from comments or string
+ * literals that happen to contain the word "ShopifyGlobal".
+ */
+function targetExportsShopifyGlobal(targetDtsPath: string): boolean {
+  let content: string
+  try {
+    content = readFileSync(targetDtsPath).toString()
+    // eslint-disable-next-line no-catch-all/no-catch-all
+  } catch {
+    return false
+  }
+
+  const sourceFile = ts.createSourceFile(targetDtsPath, content, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS)
+
+  let found = false
+  const visit = (node: ts.Node): void => {
+    if (found) return
+    if (ts.isExportDeclaration(node) && node.exportClause && ts.isNamedExports(node.exportClause)) {
+      for (const specifier of node.exportClause.elements) {
+        // Match on the exported (public) name. For `export {ShopifyGlobal}`,
+        // that's specifier.name. For `export {Foo as ShopifyGlobal}`,
+        // specifier.name is still 'ShopifyGlobal' (the public alias); the
+        // internal/local name 'Foo' lives on specifier.propertyName.
+        if (specifier.name.text === 'ShopifyGlobal') {
+          found = true
+          return
+        }
+      }
+    }
+    ts.forEachChild(node, visit)
+  }
+  visit(sourceFile)
+  return found
+}
+
+/**
+ * Builds the shopify API type based on targets, their resolved .d.ts paths,
+ * and optional tools type.
+ *
+ * If a target re-exports `ShopifyGlobal`, the emitted type is
+ * `import('<target>').Api & import('<target>').ShopifyGlobal` so consumers
+ * retain access to both the target's data surface and host-level APIs
+ * (e.g. `shopify.addEventListener`). Otherwise emits just `.Api`.
+ *
  * Returns null if no targets are provided.
  */
-function buildShopifyType(targets: string[], toolsTypeDefinition?: string): string | null {
+function buildShopifyType(
+  targets: string[],
+  resolvedTargetPaths: Map<string, string>,
+  toolsTypeDefinition?: string,
+): string | null {
   const toolsSuffix = toolsTypeDefinition ? ' & { tools: ShopifyTools }' : ''
 
-  if (targets.length === 1) {
-    const target = targets[0] ?? ''
-    return `import('@shopify/ui-extensions/${target}').Api${toolsSuffix}`
+  const typeForTarget = (target: string): string => {
+    const base = `import('@shopify/ui-extensions/${target}').Api`
+    const dtsPath = resolvedTargetPaths.get(target)
+    if (dtsPath && targetExportsShopifyGlobal(dtsPath)) {
+      return `${base} & import('@shopify/ui-extensions/${target}').ShopifyGlobal`
+    }
+    return base
   }
 
-  if (targets.length > 1) {
-    const unionType = targets.map((target) => `import('@shopify/ui-extensions/${target}').Api`).join(' | ')
-    return `(${unionType})${toolsSuffix}`
-  }
-
-  return null
+  if (targets.length === 0) return null
+  if (targets.length === 1) return `${typeForTarget(targets[0] ?? '')}${toolsSuffix}`
+  return `(${targets.map(typeForTarget).join(' | ')})${toolsSuffix}`
 }
 
 export function createTypeDefinition({
@@ -193,13 +245,18 @@ export function createTypeDefinition({
   toolsTypeDefinition,
 }: CreateTypeDefinitionOptions): string | null {
   try {
-    // Validate that all targets can be resolved
+    const resolvedTargetPaths = new Map<string, string>()
+
+    // Validate that all targets can be resolved, and capture the resolved .d.ts
+    // path so buildShopifyType can inspect it for ShopifyGlobal exports.
     for (const target of targets) {
       try {
-        require.resolve(`@shopify/ui-extensions/${target}`, {paths: [fullPath, typeFilePath]})
+        const resolved = require.resolve(`@shopify/ui-extensions/${target}`, {
+          paths: [fullPath, typeFilePath],
+        })
+        resolvedTargetPaths.set(target, resolved)
       } catch (_) {
         const {year, month} = parseApiVersion(apiVersion) ?? {year: 2025, month: 10}
-        // Throw specific error for the target that failed, matching the original getSharedTypeDefinition behavior
         throw new AbortError(
           `Type reference for ${target} could not be found. You might be using the wrong @shopify/ui-extensions version.`,
           `Fix the error by ensuring you have the correct version of @shopify/ui-extensions, for example ~${year}.${month}.0, in your dependencies.`,
@@ -209,7 +266,7 @@ export function createTypeDefinition({
 
     const relativePath = relativizePath(fullPath, dirname(typeFilePath))
 
-    const shopifyType = buildShopifyType(targets, toolsTypeDefinition)
+    const shopifyType = buildShopifyType(targets, resolvedTargetPaths, toolsTypeDefinition)
     if (!shopifyType) return null
 
     const lines = [
@@ -224,7 +281,6 @@ export function createTypeDefinition({
 
     return lines.join('\n')
   } catch (error) {
-    // Re-throw AbortError as-is, wrap other errors
     if (error instanceof AbortError) {
       throw error
     }

--- a/packages/app/src/cli/models/extensions/specifications/ui_extension.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/ui_extension.test.ts
@@ -1177,12 +1177,14 @@ Please check the configuration in ${uiExtension.configurationPath}`),
     shouldRenderFileContent,
     apiVersion,
     target = 'admin.product-details.action.render',
+    targetDtsContent,
   }: {
     tmpDir: string
     fileContent: string
     shouldRenderFileContent?: string
     apiVersion: string
     target?: string
+    targetDtsContent?: string
   }) {
     // Create extension files
     const srcDir = joinPath(tmpDir, 'src')
@@ -1197,7 +1199,11 @@ Please check the configuration in ${uiExtension.configurationPath}`),
 
     const targetPath = joinPath(nodeModulesPath, target)
     await mkdir(targetPath)
-    await writeFile(joinPath(targetPath, 'index.js'), '// Mock UI extension target')
+    // `require.resolve('@shopify/ui-extensions/<target>')` resolves to this file,
+    // and the CLI's ShopifyGlobal detector reads whatever path require.resolve
+    // returned. Injecting `targetDtsContent` here lets tests exercise the
+    // detection branch; defaults preserve the original placeholder.
+    await writeFile(joinPath(targetPath, 'index.js'), targetDtsContent ?? '// Mock UI extension target')
 
     let shouldRenderFilePath
     if (shouldRenderFileContent) {
@@ -1358,6 +1364,88 @@ Please check the configuration in ${uiExtension.configurationPath}`),
               new Set([
                 `//@ts-ignore\ndeclare module './should-render.js' {
   const shopify: import('@shopify/ui-extensions/admin.product-details.action.should-render').Api;
+  const globalThis: { shopify: typeof shopify };
+}\n`,
+              ]),
+            ],
+          ]),
+        )
+      })
+    })
+
+    test('emits Api & ShopifyGlobal intersection when target re-exports ShopifyGlobal', async () => {
+      const typeDefinitionsByFile = new Map<string, Set<string>>()
+
+      await inTemporaryDirectory(async (tmpDir) => {
+        const {extension} = await setupUIExtensionWithNodeModules({
+          tmpDir,
+          fileContent: '// JSX code',
+          // Remote DOM supported version
+          apiVersion: '2025-10',
+          // Mirrors the POS ui-extensions pattern: the target re-exports
+          // `ShopifyGlobal` via a named export specifier, which is the shape
+          // the AST helper detects.
+          targetDtsContent: `
+            interface _ShopifyGlobalInternal { addEventListener(type: string, listener: (event: unknown) => void): void }
+            export type {_ShopifyGlobalInternal as ShopifyGlobal}
+            export type Api = {placeholder: true}
+          `,
+        })
+
+        // Create tsconfig.json
+        const tsconfigPath = joinPath(tmpDir, 'tsconfig.json')
+        await writeFile(tsconfigPath, '// TypeScript config')
+
+        // When
+        await extension.contributeToSharedTypeFile?.(typeDefinitionsByFile)
+
+        const shopifyDtsPath = joinPath(tmpDir, 'shopify.d.ts')
+
+        // Then — prettier wraps the long intersection onto two lines.
+        expect(typeDefinitionsByFile).toStrictEqual(
+          new Map([
+            [
+              shopifyDtsPath,
+              new Set([
+                `//@ts-ignore\ndeclare module './src/index.jsx' {
+  const shopify: import('@shopify/ui-extensions/admin.product-details.action.render').Api &
+    import('@shopify/ui-extensions/admin.product-details.action.render').ShopifyGlobal;
+  const globalThis: { shopify: typeof shopify };
+}\n`,
+              ]),
+            ],
+          ]),
+        )
+      })
+    })
+
+    test('emits plain Api when target does not re-export ShopifyGlobal', async () => {
+      const typeDefinitionsByFile = new Map<string, Set<string>>()
+
+      await inTemporaryDirectory(async (tmpDir) => {
+        // No `targetDtsContent` — the helper writes the default placeholder,
+        // which contains no `ShopifyGlobal` export. This guards against the
+        // detection helper accidentally tripping on targets that don't opt in.
+        const {extension} = await setupUIExtensionWithNodeModules({
+          tmpDir,
+          fileContent: '// JSX code',
+          apiVersion: '2025-10',
+        })
+
+        const tsconfigPath = joinPath(tmpDir, 'tsconfig.json')
+        await writeFile(tsconfigPath, '// TypeScript config')
+
+        await extension.contributeToSharedTypeFile?.(typeDefinitionsByFile)
+
+        const shopifyDtsPath = joinPath(tmpDir, 'shopify.d.ts')
+
+        expect(typeDefinitionsByFile).toStrictEqual(
+          new Map([
+            [
+              shopifyDtsPath,
+              new Set([
+                `//@ts-ignore\ndeclare module './src/index.jsx' {
+  const shopify: import('@shopify/ui-extensions/admin.product-details.action.render').Api;
   const globalThis: { shopify: typeof shopify };
 }\n`,
               ]),

--- a/packages/app/src/cli/models/extensions/specifications/ui_extension.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/ui_extension.test.ts
@@ -1382,9 +1382,9 @@ Please check the configuration in ${uiExtension.configurationPath}`),
           fileContent: '// JSX code',
           // Remote DOM supported version
           apiVersion: '2025-10',
-          // Mirrors the POS ui-extensions pattern: the target re-exports
-          // `ShopifyGlobal` via a named export specifier, which is the shape
-          // the AST helper detects.
+          // The target re-exports `ShopifyGlobal` via a named export specifier,
+          // which is the shape the AST helper detects. Any surface can opt in
+          // by emitting this shape from its target `.d.ts`.
           targetDtsContent: `
             interface _ShopifyGlobalInternal { addEventListener(type: string, listener: (event: unknown) => void): void }
             export type {_ShopifyGlobalInternal as ShopifyGlobal}
@@ -1410,6 +1410,52 @@ Please check the configuration in ${uiExtension.configurationPath}`),
                 `//@ts-ignore\ndeclare module './src/index.jsx' {
   const shopify: import('@shopify/ui-extensions/admin.product-details.action.render').Api &
     import('@shopify/ui-extensions/admin.product-details.action.render').ShopifyGlobal;
+  const globalThis: { shopify: typeof shopify };
+}\n`,
+              ]),
+            ],
+          ]),
+        )
+      })
+    })
+
+    test('ShopifyGlobal detection is target-agnostic — any target with the re-export opts in', async () => {
+      const typeDefinitionsByFile = new Map<string, Set<string>>()
+
+      await inTemporaryDirectory(async (tmpDir) => {
+        // A fabricated target name belonging to no real surface. The detector
+        // is purely name-based on the public `ShopifyGlobal` export, so any
+        // surface's target can opt in by shipping this shape — there is no
+        // allowlist or hard-coded target in the CLI.
+        const genericTarget = 'fake-surface.any-target.render'
+
+        const {extension} = await setupUIExtensionWithNodeModules({
+          tmpDir,
+          fileContent: '// JSX code',
+          apiVersion: '2025-10',
+          target: genericTarget,
+          targetDtsContent: `
+            interface _FakeShopifyGlobal { someHostApi(): void }
+            export type {_FakeShopifyGlobal as ShopifyGlobal}
+            export type Api = {placeholder: true}
+          `,
+        })
+
+        const tsconfigPath = joinPath(tmpDir, 'tsconfig.json')
+        await writeFile(tsconfigPath, '// TypeScript config')
+
+        await extension.contributeToSharedTypeFile?.(typeDefinitionsByFile)
+
+        const shopifyDtsPath = joinPath(tmpDir, 'shopify.d.ts')
+
+        expect(typeDefinitionsByFile).toStrictEqual(
+          new Map([
+            [
+              shopifyDtsPath,
+              new Set([
+                `//@ts-ignore\ndeclare module './src/index.jsx' {
+  const shopify: import('@shopify/ui-extensions/${genericTarget}').Api &
+    import('@shopify/ui-extensions/${genericTarget}').ShopifyGlobal;
   const globalThis: { shopify: typeof shopify };
 }\n`,
               ]),


### PR DESCRIPTION
Closes https://github.com/shop/issues-retail/issues/28334

Companion [ui-extension PR](https://github.com/Shopify/ui-extensions/pull/4123)

## Summary

When a `@shopify/ui-extensions` target `.d.ts` re-exports a `ShopifyGlobal` type, the CLI-generated `shopify.d.ts` now types the `shopify` binding as `Api & ShopifyGlobal` instead of just `Api`. Targets that do not re-export `ShopifyGlobal` are unchanged.

This unblocks POS background extensions, where the runtime `shopify` object exposes both the target's data surface (`shopify.cart`, `shopify.products`, etc.) and host-level event APIs (`shopify.addEventListener`). Existing consumers are unaffected — the `.Api` half of the intersection preserves their current typing.

## [Screen Recording 2026-04-23 at 3.47.17 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/051c1d7d-f7de-4831-966e-92a3be3bea63.mov" />](https://app.graphite.com/user-attachments/video/051c1d7d-f7de-4831-966e-92a3be3bea63.mov)

## Detection

- AST-based, via the `typescript` compiler API (already a dependency of this file).
- Scans for a named export specifier whose public name is `ShopifyGlobal` (matches `export type {ShopifyGlobal} from '../globals'`, `export {ShopifyGlobal}`, and `export {Foo as ShopifyGlobal}`).
- No surface name is hard-coded anywhere in the CLI.

## Scope — who's affected

| Surface | Defines `ShopifyGlobal` in `globals.ts` today? | Re-exports from target `.d.ts` after companion PR? | Output change from this CLI PR? |
| --- | --- | --- | --- |
| admin | no | no | none |
| checkout | yes | no | none |
| customer-account | yes | no | none |
| point-of-sale | yes | yes (opt-in on certain target) | `Api` → `Api & ShopifyGlobal` |

**Other surfaces:** nothing breaks; no action required. The regression test added in this PR asserts that targets without a `ShopifyGlobal` re-export emit the exact same output as before.

**Why POS is the first adopter:** POS background extensions are the first pattern that writes code accessing both the target `Api` (via e.g. `shopify.cart.current`) **and** host-level APIs (via `shopify.addEventListener`) through the same `shopify` identifier in an entry file that also imports from `@shopify/ui-extensions/<target>`. That combination exposes a module-shadowing issue in the CLI-generated `shopify.d.ts` that other surfaces haven't hit yet. Any surface that later needs the same pattern can opt in with a one-line change to their branch of `buildTargetDts.ts` in ui-extensions — no CLI release required.

## Backwards compatibility

- Targets without a `ShopifyGlobal` re-export: output byte-identical to main.
- Older `@shopify/ui-extensions` versions (no `ShopifyGlobal` export on any target): graceful fallback to plain `.Api` for every target.
- Existing consumers with in-flight `shopify.<target-api-field>` usage: unchanged — intersection, not replacement

## How to test

**Before / after in generated** **`shopify.d.ts`** — this is the only behavior change:

```diff
 declare module './src/BackgroundExtension.ts' {
-  const shopify: import('@shopify/ui-extensions/pos.app.ready.data').Api;
+  const shopify: import('@shopify/ui-extensions/pos.app.ready.data').Api &
+    import('@shopify/ui-extensions/pos.app.ready.data').ShopifyGlobal;
   const globalThis: { shopify: typeof shopify };
 }
```

For a live regeneration: link a POS extension to the local ui-extensions companion branch (pnpm `overrides.@shopify/ui-extensions: link:...`), run `pnpm shopify app build --path <app>` from inside the CLI repo, and inspect `shopify.d.ts`. Full CLI setup per [vault BKMy](https://vault.shopify.io/page/BKMy).

## Test plan

- [x] Unit test — intersection emitted when target re-exports `ShopifyGlobal`.
- [x] Unit test — plain `Api` emitted when target does not re-export `ShopifyGlobal` (regression guard).
- [x] Full `ui_extension.test.ts` suite passes (45/45).
- [x] Typecheck + lint clean.
- [x] End-to-end validated against a POS background extension — `shopify.addEventListener` and `shopify.cart.current.value` both type-check against the same generated `shopify.d.ts`.

## Rollback

Revert this PR. No migration required — targets without the companion ui-extensions change are byte-identical to main, and targets with it fall back to the pre-PR output shape on the prior CLI version.t use a certa