### PR TITLE
Normalize paths in bundle-ui-step same-path guard

### DIFF
--- a/.changeset/fix-bundle-ui-step-path-normalization.md
+++ b/.changeset/fix-bundle-ui-step-path-normalization.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Fix `shopify app build` intermittently failing with "Source and destination must not be the same" on UI extensions when the local esbuild output directory and the bundle output directory resolve to the same path but differ as strings (e.g. due to `.` segments, trailing slashes, or path joining quirks). The same-path guard now normalizes both paths via `resolvePath` before comparison.

--- a/packages/app/src/cli/services/build/steps/bundle-ui-step.test.ts
+++ b/packages/app/src/cli/services/build/steps/bundle-ui-step.test.ts
@@ -57,4 +57,13 @@ describe('executeBundleUIStep', () => {
     // Then
     expect(fs.copyFile).toHaveBeenCalledWith('/test/extension/dist', '/bundle/handle')
   })
+
+  test('skips the copy when local and bundle output directories resolve to the same path but differ as strings', async () => {
+    mockContext.extension.outputPath = '/test/./extension/dist/handle.js'
+    vi.mocked(buildExtension.buildUIExtension).mockResolvedValue('/test/extension/dist/handle.js')
+
+    await executeBundleUIStep(step, mockContext)
+
+    expect(fs.copyFile).not.toHaveBeenCalled()
+  })
 })

--- a/packages/app/src/cli/services/build/steps/bundle-ui-step.ts
+++ b/packages/app/src/cli/services/build/steps/bundle-ui-step.ts
@@ -2,7 +2,7 @@ import {createOrUpdateManifestFile} from './include-assets/generate-manifest.js'
 import {buildUIExtension} from '../extension.js'
 import {BuildManifest} from '../../../models/extensions/specifications/ui_extension.js'
 import {copyFile} from '@shopify/cli-kit/node/fs'
-import {dirname, joinPath} from '@shopify/cli-kit/node/path'
+import {dirname, joinPath, resolvePath} from '@shopify/cli-kit/node/path'
 import type {BundleUIStep, BuildContext} from '../client-steps.js'
 
 interface ExtensionPointWithBuildManifest {
@@ -27,7 +27,7 @@ export async function executeBundleUIStep(step: BundleUIStep, context: BuildCont
   const bundleOutputDir = step.config?.bundleFolder
     ? joinPath(dirname(context.extension.outputPath), step.config.bundleFolder)
     : dirname(context.extension.outputPath)
-  if (localOutputDir !== bundleOutputDir) {
+  if (resolvePath(localOutputDir) !== resolvePath(bundleOutputDir)) {
     await copyFile(localOutputDir, bundleOutputDir)
   }
 


### PR DESCRIPTION
Resolves https://github.com/shop/issues-retail/issues/28335

Companion [ui-extension PR](https://github.com/Shopify/ui-extensions/pull/4123)

## Summary

`shopify app build` intermittently fails on UI extensions with:

![image.png](https://app.graphite.com/user-attachments/assets/80aa5364-ee00-4ef1-8b18-2574a7075ec0.png)



The same-path guard in [bundle-ui-step.ts](packages/app/src/cli/services/build/steps/bundle-ui-step.ts) compared `localOutputDir` and `bundleOutputDir` as raw strings. These are computed along different code paths:

- `localOutputDir = dirname(buildUIExtension(...))` — where esbuild writes
- `bundleOutputDir = dirname(extension.outputPath)` or `joinPath(dirname(extension.outputPath), bundleFolder)` — copy destination

When both resolve to the same directory on disk but differ as strings (a `.` segment, a trailing slash, a path that went through a different `joinPath` path and came out non-canonical), the `!==` check slips through and fs-extra rejects the copy.

## Fix

Normalize both sides with `resolvePath` before comparing:

```diff
-if (localOutputDir !== bundleOutputDir) {
+if (resolvePath(localOutputDir) !== resolvePath(bundleOutputDir)) {
   await copyFile(localOutputDir, bundleOutputDir)
 }
```

Two-line change. Same code path that the existing test at [bundle-ui-step.test.ts:38-47](packages/app/src/cli/services/build/steps/bundle-ui-step.test.ts#L38-L47) was already asserting skips the copy — the guard just wasn't robust to non-canonical path shapes.

## Scope

- Pure guard normalization. `copyFile` is only invoked in the "different directories" case (unchanged).
- No behavior change when the two directories are genuinely different — `resolvePath` is idempotent on canonical paths.
- No runtime-resolution of symlinks (keeps current semantics — we rely on string equality of resolved paths, not `realpathSync`).

## How to reproduce on main

Any local setup where `extension.outputPath` and `buildUIExtension`'s return value compute to the same directory via different string shapes will hit this. It surfaced for me while running `pnpm shopify app build --path <sibling-app>` against a test extension that links `@shopify/ui-extensions` via a `pnpm.overrides` `link:` path — the esbuild output path came back in a different normalization from the extension output path, and the existing guard missed it.

## Test plan

- [x] Existing `bundle-ui-step.test.ts` still passes (unit test mocks `fs.copyFile`; the behavior asserted — "skips the copy when local and bundle output directories are identical" — is preserved and now more robust).
- [x] Full `shopify app build` on an affected extension completes end-to-end (previously failed at the bundle step).
- [ ] Reviewer: any path shape that was previously distinct-by-string-comparison but `resolvePath`\-equal would now skip the copy. Confirm no intended code path relied on that (I could not find one — the branch is explicitly guarding against fs-extra's same-path rejection, and every caller I traced expects a no-op when the dirs collapse).

## Rollback

Revert the two-line change. No migration required.