### PR TITLE
Respect user .theme-check.yml in theme app extension builds

### DIFF
--- a/.changeset/theme-check-respect-user-config.md
+++ b/.changeset/theme-check-respect-user-config.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+`runThemeCheck` now respects a user's `.theme-check.yml` in the theme app extension root. When present, theme-check-node auto-discovery is used; otherwise the bundled `theme-check:theme-app-extension` config is applied as before. This lets extensions ignore source directories (e.g. a `src/` folder containing uncompiled Liquid templates) without forking the CLI.

--- a/packages/app/src/cli/services/build/theme-check.ts
+++ b/packages/app/src/cli/services/build/theme-check.ts
@@ -1,4 +1,5 @@
-import {readFileSync} from '@shopify/cli-kit/node/fs'
+import {fileExists, readFileSync} from '@shopify/cli-kit/node/fs'
+import {joinPath} from '@shopify/cli-kit/node/path'
 import {itemToString} from '@shopify/cli-kit/node/output'
 import {TokenItem} from '@shopify/cli-kit/node/ui'
 import {Severity, type Offense, check, path as pathUtils} from '@shopify/theme-check-node'
@@ -60,7 +61,11 @@ function formatOffenses(offenses: Offense[]): TokenItem {
 }
 
 export async function runThemeCheck(directory: string): Promise<string> {
-  const configPath = 'theme-check:theme-app-extension'
+  // Respect a user's `.theme-check.yml` in the extension root when present.
+  // Falling through to `undefined` lets theme-check-node auto-discover the
+  // user config; otherwise use the bundled theme-app-extension defaults.
+  const hasUserConfig = await fileExists(joinPath(directory, '.theme-check.yml'))
+  const configPath = hasUserConfig ? undefined : 'theme-check:theme-app-extension'
   const offenses = await check(directory, configPath)
   const formattedOffenses = formatOffenses(offenses)
   return itemToString(formattedOffenses)


### PR DESCRIPTION
## Summary

`runThemeCheck` in `packages/app/src/cli/services/build/theme-check.ts` hardcodes the config identifier `'theme-check:theme-app-extension'`, which bypasses theme-check-node's user-config discovery (`findConfigPath`). As a result, a `.theme-check.yml` placed in the theme app extension root is ignored during `shopify app dev` and `shopify app deploy`, even though the standalone `shopify theme check` command respects it.

This PR makes `runThemeCheck` check for `.theme-check.yml` in the extension directory and pass `undefined` to `check()` when present, letting theme-check-node auto-discover the user config. When absent, the existing bundled `theme-check:theme-app-extension` defaults are applied exactly as before — no behavior change for extensions without a user config.

## Motivation

Theme app extensions only allow a fixed set of top-level directories (`assets/`, `blocks/`, `snippets/`, `locales/`, `config/`). Authors who want a separate source directory (e.g. uncompiled Liquid / TS / Tailwind that gets built into `blocks/` + `assets/`) currently have two options:

1. Dot-prefix the source dir (`.src/`) so theme-check's `**/*.{liquid,json}` glob skips it.
2. Fork the CLI.

Option 1 works but is surprising and fragile. Option 2 is heavy. With this change, a plain `src/` source directory works as expected:

```yaml
# extensions/my-extension/.theme-check.yml
extends: theme-check:theme-app-extension
ignore:
  - "src/**"
  - "node_modules/**"
```

## Changes

- `packages/app/src/cli/services/build/theme-check.ts`: check for `.theme-check.yml` and fall through to user-config discovery when present.
- Added a changeset (`@shopify/app` patch).

## Test plan

- [ ] Theme app extension without `.theme-check.yml` — `shopify app dev` and `shopify app deploy` produce identical theme-check output to before (uses bundled `theme-app-extension` defaults).
- [ ] Theme app extension with `.theme-check.yml` extending `theme-check:theme-app-extension` and adding `ignore: ['src/**']` — `shopify app dev` skips `src/**` offenses.
- [ ] Same `.theme-check.yml` with a custom check severity override — `shopify app dev` reflects the override.
