### PR TITLE
Support [build].watch for theme app extensions

### DIFF
--- a/.changeset/theme-extension-build-watch.md
+++ b/.changeset/theme-extension-build-watch.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Theme app extensions now support `[build].watch` in `shopify.extension.toml` to restrict which files trigger bundle rebuilds during `shopify app dev`. This mirrors the behavior already available for function extensions. When `build.watch` is specified, the CLI only reacts to changes in those paths (plus `locales/**.json` and `**.toml`) instead of the entire extension directory, preventing redundant bundle cycles when an external build tool (e.g. Vite) writes multiple output files.

--- a/packages/app/src/cli/models/extensions/specifications/theme.ts
+++ b/packages/app/src/cli/models/extensions/specifications/theme.ts
@@ -3,13 +3,24 @@ import {BaseSchema} from '../schemas.js'
 import {themeExtensionFiles} from '../../../utilities/extensions/theme.js'
 import {ExtensionInstance} from '../extension-instance.js'
 import {fileSize} from '@shopify/cli-kit/node/fs'
-import {dirname, relativePath} from '@shopify/cli-kit/node/path'
+import {dirname, joinPath, relativePath} from '@shopify/cli-kit/node/path'
 import {AbortError} from '@shopify/cli-kit/node/error'
 import {outputContent, outputToken} from '@shopify/cli-kit/node/output'
+import {zod} from '@shopify/cli-kit/node/schema'
+
+const ThemeExtensionSchema = BaseSchema.extend({
+  build: zod
+    .object({
+      watch: zod.union([zod.string(), zod.string().array()]).optional(),
+    })
+    .optional(),
+})
+
+type ThemeExtensionConfigType = zod.infer<typeof ThemeExtensionSchema>
 
 const themeSpec = createExtensionSpecification({
   identifier: 'theme',
-  schema: BaseSchema,
+  schema: ThemeExtensionSchema,
   partnersWebIdentifier: 'theme_app_extension',
   graphQLType: 'theme_app_extension',
   clientSteps: [
@@ -23,6 +34,17 @@ const themeSpec = createExtensionSpecification({
   ],
   appModuleFeatures: (_) => {
     return ['theme']
+  },
+  devSessionWatchConfig: (extension: ExtensionInstance<ThemeExtensionConfigType>) => {
+    const config = extension.configuration
+    if (!config.build || !config.build.watch) return undefined
+
+    const paths = [config.build.watch].flat().map((path) => joinPath(extension.directory, path))
+
+    paths.push(joinPath(extension.directory, 'locales', '**.json'))
+    paths.push(joinPath(extension.directory, '**.toml'))
+
+    return {paths}
   },
   deployConfig: async () => {
     return {theme_extension: {files: {}}}


### PR DESCRIPTION
## Summary

Theme app extensions currently use the base `BaseSchema` (which has no `build` field) and don't implement `devSessionWatchConfig`. As a result, any `[build]` block in `shopify.extension.toml` is silently stripped by zod, and the CLI's dev watcher falls back to globbing `**/*` under the extension directory.

This is painful when an external build tool (Vite, esbuild, `tsc --watch`) writes multiple output files per build — each write fires an "Extension changed" event, triggering redundant theme-check and bundle cycles. A single manual `bun run theme-extension:build` during `shopify app dev` can produce 8+ "Extension changed" events and 2 full bundle cycles.

This PR makes the theme spec support `[build].watch` the same way function extensions already do:

- Extend `BaseSchema` into `ThemeExtensionSchema` with `build: { watch: string | string[] }`.
- Add `devSessionWatchConfig` to the theme spec that restricts watched paths to `build.watch` + `locales/**.json` + `**.toml`.

## Motivation

Authors who use a separate source directory + build tool (common when writing Tailwind, TypeScript, or templated Liquid that compiles into `blocks/`) have no way to tell the CLI "only rebundle when the build is fully done." With this change, they can point the CLI at a sentinel file written last by their build tool:

```toml
name = "my-theme-extension"
type = "theme"
uid = "..."

[build]
watch = [".build-stamp"]
```

and get exactly one bundle cycle per build.

## Changes

- `packages/app/src/cli/models/extensions/specifications/theme.ts`: extend schema with `build.watch`, add `devSessionWatchConfig`.
- Added a changeset (`@shopify/app` patch).

## Test plan

- [ ] Theme app extension without `[build]` in its toml — dev watcher behaves exactly as before (watches whole extension dir).
- [ ] Theme app extension with `[build] watch = [".build-stamp"]` and an external build tool that touches `.build-stamp` last — `shopify app dev` only triggers one bundle cycle per build, instead of one per file write.
- [ ] Theme app extension with `[build] watch = ["src/**"]` — only changes under `src/` trigger the watcher.
- [ ] `locales/**.json` and `**.toml` still trigger bundle cycles when `build.watch` is set (parity with function extensions).
