### PR TITLE
Fix web pixel bundle_ui step

### DIFF
--- a/packages/app/src/cli/models/extensions/specifications/web_pixel_extension.ts
+++ b/packages/app/src/cli/models/extensions/specifications/web_pixel_extension.ts
@@ -33,11 +33,11 @@ const webPixelSpec = createExtensionSpecification({
   partnersWebIdentifier: 'web_pixel',
   schema: WebPixelSchema,
   appModuleFeatures: (_) => ['esbuild', 'single_js_entry_path'],
-  getOutputRelativePath: (extension: ExtensionInstance<WebPixelConfigType>) => `dist/${extension.handle}.js`,
+  getOutputRelativePath: (extension: ExtensionInstance<WebPixelConfigType>) => `${extension.handle}.js`,
   clientSteps: [
     {
       lifecycle: 'deploy',
-      steps: [{id: 'bundle-ui', name: 'Bundle UI Extension', type: 'bundle_ui', config: {}}],
+      steps: [{id: 'bundle-ui', name: 'Bundle UI Extension', type: 'bundle_ui', config: {bundleFolder: 'dist/'}}],
     },
   ],
   deployConfig: async (config, _) => {


### PR DESCRIPTION
### WHY are these changes introduced?

The `bundle_ui` step needs to control where the bundled output is placed, rather than having the output path hardcoded into the relative path returned by `getOutputRelativePath`.



**Before** 

![image.png](https://app.graphite.com/user-attachments/assets/b0eab738-9e27-4c56-ad32-3442ed671d15.png)



**After**

![image.png](https://app.graphite.com/user-attachments/assets/dbc97ced-372e-4432-81f2-fdd977a925d1.png)





### WHAT is this pull request doing?

Moves the `dist/` folder prefix from `getOutputRelativePath` into the `bundle_ui` step configuration via a `bundleFolder` config property. This allows the bundling step to own the output directory while `getOutputRelativePath` returns just the filename (`${extension.handle}.js`).

### How to test your changes?

1. Deploy a web pixel extension and verify the bundled output is still placed in the `dist/` folder.
2. Confirm the output file is correctly referenced as `${handle}.js` without the `dist/` prefix in the relative path.

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`