### PR TITLE
Fix App Management API app-not-found error message (shop/issues-develop#226)

### DIFF
--- a/.changeset/handle-app-management-app-not-found.md
+++ b/.changeset/handle-app-management-app-not-found.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Display a friendly error message instead of a stack trace when running `shopify app config link --client-id=<id>` against a Dev Dashboard app and the client ID does not exist.

--- a/packages/app/src/cli/utilities/developer-platform-client/app-management-client.test.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/app-management-client.test.ts
@@ -1388,6 +1388,64 @@ describe('AppManagementClient', () => {
       expect(client.bundleFormat).toBe('br')
     })
   })
+
+  describe('appFromIdentifiers', () => {
+    test('returns undefined when the app is not found', async () => {
+      // Given
+      const client = AppManagementClient.getInstance()
+      client.token = () => Promise.resolve('token')
+      vi.mocked(appManagementRequestDoc).mockResolvedValueOnce({app: null})
+
+      // When
+      const got = await client.appFromIdentifiers('non-existent-api-key')
+
+      // Then
+      expect(got).toBeUndefined()
+    })
+
+    test('returns the app when the app is found', async () => {
+      // Given
+      const client = AppManagementClient.getInstance()
+      client.token = () => Promise.resolve('token')
+      const apiKey = 'existing-api-key'
+      const mockedResponse = {
+        app: {
+          id: 'gid://shopify/App/1',
+          key: apiKey,
+          organizationId: 'gid://shopify/Organization/2',
+          activeRoot: {
+            grantedShopifyApprovalScopes: ['read_products'],
+            clientCredentials: {secrets: [{key: 'secret-1'}]},
+          },
+          activeRelease: {
+            id: 'gid://shopify/Release/1',
+            version: {
+              name: 'My App',
+              appModules: [],
+            },
+          },
+        },
+      }
+      vi.mocked(appManagementRequestDoc).mockResolvedValueOnce(mockedResponse)
+
+      // When
+      const got = await client.appFromIdentifiers(apiKey)
+
+      // Then
+      expect(got).toEqual({
+        id: 'gid://shopify/App/1',
+        title: 'My App',
+        apiKey,
+        apiSecretKeys: [{secret: 'secret-1'}],
+        organizationId: '2',
+        grantedScopes: ['read_products'],
+        applicationUrl: undefined,
+        embedded: undefined,
+        flags: [],
+        developerPlatformClient: client,
+      })
+    })
+  })
 })
 
 describe('ensureUserAccessToStore', () => {

--- a/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
@@ -356,6 +356,7 @@ export class AppManagementClient implements DeveloperPlatformClient {
 
   async appFromIdentifiers(apiKey: string): Promise<OrganizationApp | undefined> {
     const {app} = await this.activeAppVersionRawResult(apiKey)
+    if (!app) return undefined
     const {name, appModules} = app.activeRelease.version
     const appHomeModule = appModules.find((mod) => mod.specification.externalIdentifier === 'app_home')
     const apiSecretKeys = app.activeRoot.clientCredentials.secrets.map((secret) => ({secret: secret.key}))


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes [shop/issues-develop#226](https://github.com/shop/issues-develop/issues/226)

When `shopify app config link --client-id=<unknown>` is run against a Dev Dashboard (App Management) app, the CLI crashed with a `TypeError: Cannot read properties of null (reading 'activeRelease')` stack trace, instead of the friendly *"No app with client ID … found"* abort that Partners apps already surface. The underlying GraphQL `appByKey` query returns `null` (HTTP 200) when the client ID does not exist, but `AppManagementClient.appFromIdentifiers` was destructuring the result unconditionally.

### WHAT is this pull request doing?

- `packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts`: return `undefined` when `appByKey` resolves to `null`, mirroring `PartnersClient`. The caller in `services/context.ts` then renders the existing abort error.
- Added two unit tests covering the null-app and happy-path branches of `appFromIdentifiers`.
- Patch changeset for `@shopify/app`.

### How to test your changes?

1. Check out this branch and `pnpm build` it.
2. From any app directory, run:
   ```
   shopify app config link --client-id=does-not-exist
   ```
   against a Dev Dashboard organization (App Management).
3. Expect a clean *"No app with client ID …"* abort message — no stack trace.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [x] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`