### PR TITLE
Fix unhelpful error when extension locale file has invalid UTF-8 (shop/issues-develop#21558)

### DIFF
--- a/.changeset/validate-locale-utf8.md
+++ b/.changeset/validate-locale-utf8.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Fail UI extension `dev` and `deploy` early with a clear error pointing at the offending locale file when a `locales/*.json` file contains invalid UTF-8 byte sequences, instead of letting the upload reach the server and abort with a generic `INTERNAL_SERVER_ERROR`.

--- a/.changeset/validate-locale-utf8.md
+++ b/.changeset/validate-locale-utf8.md
@@ -2,4 +2,4 @@
 '@shopify/app': patch
 ---
 
-Fail UI extension `dev` and `deploy` early with a clear error pointing at the offending locale file when a `locales/*.json` file contains invalid UTF-8 byte sequences, instead of letting the upload reach the server and abort with a generic `INTERNAL_SERVER_ERROR`.
+Fix unhelpful error when extension locale file has invalid UTF-8

--- a/packages/app/src/cli/utilities/extensions/locales-configuration.test.ts
+++ b/packages/app/src/cli/utilities/extensions/locales-configuration.test.ts
@@ -2,6 +2,7 @@ import {loadLocalesConfig} from './locales-configuration.js'
 import {describe, expect, test} from 'vitest'
 import {inTemporaryDirectory, mkdir, writeFile} from '@shopify/cli-kit/node/fs'
 import {joinPath} from '@shopify/cli-kit/node/path'
+import fs from 'fs'
 
 describe('loadLocalesConfig', () => {
   test('Works if all locales are correct', async () => {
@@ -72,6 +73,36 @@ describe('loadLocalesConfig', () => {
       // When
       const got = loadLocalesConfig(tmpDir, 'checkout_ui')
       await expect(got).rejects.toThrow(/Error loading checkout_ui/)
+    })
+  })
+
+  test('Throws with a helpful message if a locale file contains invalid UTF-8 bytes', async () => {
+    await inTemporaryDirectory(async (tmpDir: string) => {
+      // Given
+      const localesPath = joinPath(tmpDir, 'locales')
+      const enDefault = joinPath(localesPath, 'en.default.json')
+      const it = joinPath(localesPath, 'it.json')
+
+      await mkdir(localesPath)
+      await writeFile(enDefault, JSON.stringify({hello: 'Hello'}))
+      // 0xE0 starts a 3-byte UTF-8 sequence but is followed by an ASCII space,
+      // mirroring the Latin-1 encoded "sarà" (`sar\xE0`) reported in shop/issues-develop#21558.
+      const invalidBytes = Buffer.concat([
+        Buffer.from('{"hello":"sar', 'utf8'),
+        Buffer.from([0xe0]),
+        Buffer.from(' "}', 'utf8'),
+      ])
+      fs.writeFileSync(it, invalidBytes)
+
+      // When
+      const got = loadLocalesConfig(tmpDir, 'checkout_ui')
+      await expect(got).rejects.toThrow(/Error loading checkout_ui/)
+      await expect(got).rejects.toMatchObject({
+        tryMessage: expect.stringMatching(/invalid UTF-8 byte sequences/),
+      })
+      await expect(got).rejects.toMatchObject({
+        tryMessage: expect.stringMatching(/it\.json/),
+      })
     })
   })
 })

--- a/packages/app/src/cli/utilities/extensions/locales-configuration.ts
+++ b/packages/app/src/cli/utilities/extensions/locales-configuration.ts
@@ -1,6 +1,7 @@
 import {joinPath, basename} from '@shopify/cli-kit/node/path'
 import {glob} from '@shopify/cli-kit/node/fs'
 import {AbortError, BugError} from '@shopify/cli-kit/node/error'
+import {isUtf8} from 'node:buffer'
 import fs from 'fs'
 
 export async function loadLocalesConfig(extensionPath: string, extensionIdentifier: string) {
@@ -30,7 +31,7 @@ export async function loadLocalesConfig(extensionPath: string, extensionIdentifi
 
   return {
     default_locale: defaultLanguageCode[0],
-    translations: getAllLocales(localesPaths),
+    translations: getAllLocales(localesPaths, extensionIdentifier),
   }
 }
 
@@ -39,12 +40,20 @@ function findDefaultLocale(filePaths: string[]) {
   return defaultLocale.map((locale) => basename(locale).split('.')[0])
 }
 
-function getAllLocales(localesPath: string[]) {
+function getAllLocales(localesPath: string[], extensionIdentifier: string) {
   const all: {[key: string]: string} = {}
   for (const localePath of localesPath) {
     const localeCode = failIfUnset(basename(localePath).split('.')[0], 'Locale code is unset')
-    const locale = fs.readFileSync(localePath, 'base64')
-    all[localeCode] = locale
+    const localeBuffer = fs.readFileSync(localePath)
+    // Validate UTF-8 client-side: the server decodes these as UTF-8 strings and a
+    // single invalid byte sequence aborts the upload with an unhelpful error.
+    if (!isUtf8(localeBuffer)) {
+      throw new AbortError(
+        `Error loading ${extensionIdentifier}`,
+        `Locale file ${localePath} contains invalid UTF-8 byte sequences. Re-save the file using UTF-8 encoding.`,
+      )
+    }
+    all[localeCode] = localeBuffer.toString('base64')
   }
   return all
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes [shop/issues-develop#21558](https://github.com/shop/issues-develop/issues/21558)

When an extension's `locales/*.json` file contains invalid UTF-8 (for example, a stray Latin-1 `à` left in an Italian translation), `shopify app dev` and `shopify app deploy` aborted with a generic `INTERNAL_SERVER_ERROR` raised server-side from `String#strip` in the framework's `LocalizationUpdate#decode_dictionary`. The error gave no hint about which locale file was wrong, leaving users to bisect their translations by hand.

### WHAT is this pull request doing?

- `packages/app/src/cli/utilities/extensions/locales-configuration.ts`: read each locale as a raw `Buffer`, run `Buffer.isUtf8` (Node ≥ 18.14, well within the package's `>=20.10.0` engine range) before base64-encoding, and throw an `AbortError` naming the offending file with an actionable hint to re-save it as UTF-8.
- Added a regression test that writes a stray `0xE0` byte mirroring the example from the issue and asserts on the title and `tryMessage`.
- Patch changeset for `@shopify/app`.

### How to test your changes?

1. In any extension that supports locales (e.g. `checkout_ui_extension`), write a locale file with invalid UTF-8:
   ```bash
   printf '{"hello":"sar\xE0"}' > extensions/<name>/locales/it.json
   ```
2. Run `shopify app deploy` (or `dev`).
3. Expect a CLI-side abort identifying `locales/it.json` and suggesting UTF-8 re-save — no `INTERNAL_SERVER_ERROR`.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [x] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`