### PR TITLE
Normalize paths in bundle-ui-step same-path guard

### DIFF
--- a/.changeset/fix-bundle-ui-step-path-normalization.md
+++ b/.changeset/fix-bundle-ui-step-path-normalization.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Fix `shopify app build` intermittently failing with "Source and destination must not be the same" on UI extensions when the local esbuild output directory and the bundle output directory resolve to the same path but differ as strings (e.g. due to `.` segments, trailing slashes, or path joining quirks). The same-path guard now normalizes both paths via `resolvePath` before comparison.

--- a/packages/app/src/cli/services/build/steps/bundle-ui-step.ts
+++ b/packages/app/src/cli/services/build/steps/bundle-ui-step.ts
@@ -2,7 +2,7 @@ import {createOrUpdateManifestFile} from './include-assets/generate-manifest.js'
 import {buildUIExtension} from '../extension.js'
 import {BuildManifest} from '../../../models/extensions/specifications/ui_extension.js'
 import {copyFile} from '@shopify/cli-kit/node/fs'
-import {dirname, joinPath} from '@shopify/cli-kit/node/path'
+import {dirname, joinPath, resolvePath} from '@shopify/cli-kit/node/path'
 import type {BundleUIStep, BuildContext} from '../client-steps.js'
 
 interface ExtensionPointWithBuildManifest {
@@ -27,7 +27,7 @@ export async function executeBundleUIStep(step: BundleUIStep, context: BuildCont
   const bundleOutputDir = step.config?.bundleFolder
     ? joinPath(dirname(context.extension.outputPath), step.config.bundleFolder)
     : dirname(context.extension.outputPath)
-  if (localOutputDir !== bundleOutputDir) {
+  if (resolvePath(localOutputDir) !== resolvePath(bundleOutputDir)) {
     await copyFile(localOutputDir, bundleOutputDir)
   }
 


### PR DESCRIPTION
The same-path guard at bundle-ui-step.ts compared `localOutputDir` and `bundleOutputDir` as raw strings. In practice these two values are computed along different code paths (`dirname(buildUIExtension())` vs `dirname(extension.outputPath)` or `joinPath(..., bundleFolder)`) and can resolve to the same filesystem directory while differing as strings — e.g. when one path has a `.` segment, a trailing slash, or otherwise non-canonical shape. When that happens, the guard slips through and fs-extra rejects the copy with "Source and destination must not be the same".

Normalize both sides via `resolvePath` before comparing so the guard catches any string variant that maps to the same directory.

<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it's a work in progress
-->

### WHY are these changes introduced?

Fixes #0000 <!-- link to issue if one exists -->

<!--
  Context about the problem that's being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
  You can post a comment with `/snapit` to generate a snapshot of the changes to be tested.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`
