### PR TITLE
Skip manifest generation when bundle dir matches local output

### DIFF
--- a/packages/app/src/cli/services/build/steps/bundle-ui-step.test.ts
+++ b/packages/app/src/cli/services/build/steps/bundle-ui-step.test.ts
@@ -1,4 +1,5 @@
 import {executeBundleUIStep} from './bundle-ui-step.js'
+import * as generateManifest from './include-assets/generate-manifest.js'
 import * as buildExtension from '../extension.js'
 import {BundleUIStep, BuildContext} from '../client-steps.js'
 import {ExtensionInstance} from '../../../models/extensions/extension-instance.js'
@@ -7,6 +8,7 @@ import * as fs from '@shopify/cli-kit/node/fs'
 
 vi.mock('@shopify/cli-kit/node/fs')
 vi.mock('../extension.js')
+vi.mock('./include-assets/generate-manifest.js')
 
 describe('executeBundleUIStep', () => {
   let mockContext: BuildContext
@@ -54,5 +56,26 @@ describe('executeBundleUIStep', () => {
     await executeBundleUIStep(step, mockContext)
 
     expect(fs.copyFile).not.toHaveBeenCalled()
+  })
+
+  test('skips manifest generation when local and bundle output directories resolve to the same path', async () => {
+    const stepWithManifest: BundleUIStep = {
+      id: 'bundle-ui',
+      name: 'Bundle UI Extension',
+      type: 'bundle_ui',
+      config: {generatesAssetsManifest: true},
+    }
+    mockContext.extension.outputPath = '/test/./extension/dist/handle.js'
+    mockContext.extension.configuration = {
+      extension_points: [
+        {target: 'admin.product-details.action.render', build_manifest: {assets: {main: {filepath: 'main.js'}}}},
+      ],
+    } as ExtensionInstance['configuration']
+    vi.mocked(buildExtension.buildUIExtension).mockResolvedValue('/test/extension/dist/handle.js')
+
+    await executeBundleUIStep(stepWithManifest, mockContext)
+
+    expect(fs.copyFile).not.toHaveBeenCalled()
+    expect(generateManifest.createOrUpdateManifestFile).not.toHaveBeenCalled()
   })
 })

--- a/packages/app/src/cli/services/build/steps/bundle-ui-step.ts
+++ b/packages/app/src/cli/services/build/steps/bundle-ui-step.ts
@@ -26,9 +26,11 @@ export async function executeBundleUIStep(step: BundleUIStep, context: BuildCont
   const bundleOutputDir = step.config?.bundleFolder
     ? joinPath(dirname(context.extension.outputPath), step.config.bundleFolder)
     : dirname(context.extension.outputPath)
-  if (resolvePath(localOutputDir) !== resolvePath(bundleOutputDir)) {
-    await copyFile(localOutputDir, bundleOutputDir)
-  }
+
+  // If the final output path is the same as the local one: don't copy the results and don't generate manifests.
+  if (resolvePath(localOutputDir) === resolvePath(bundleOutputDir)) return
+
+  await copyFile(localOutputDir, bundleOutputDir)
 
   if (!step.config?.generatesAssetsManifest) return
 


### PR DESCRIPTION
### WHY are these changes introduced?

When the local output directory and the bundle output directory resolve to the same path, there is no need to copy files or generate an assets manifest. Previously, the early return only skipped the file copy but still allowed manifest generation to proceed in some code paths.

### WHAT is this pull request doing?

When the resolved local and bundle output directories are identical, the function now returns early before both the file copy and any manifest generation. This ensures that manifest generation is also skipped in this case, not just the file copy.

A test has been added to verify that neither `copyFile` nor `createOrUpdateManifestFile` is called when the two paths resolve to the same location.

### How to test your changes?

1. Run the updated test suite for `bundle-ui-step`:
   ```
   pnpm test packages/app/src/cli/services/build/steps/bundle-ui-step.test.ts
   ```
2. Verify the new test case passes, confirming that both `copyFile` and `createOrUpdateManifestFile` are skipped when the local and bundle output directories resolve to the same path.

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`