### PR TITLE
Automate tag, stable branch, and GitHub release after changeset publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,6 +116,60 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SHOPIFY_CLI_BUILD_REPO: ${{ github.repository }}
 
+      - name: Get version
+        id: version
+        if: steps.changesets.outputs.hasChangesets == 'false'
+        run: |
+          VERSION=$(node -p "require('./packages/cli/package.json').version")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Version: $VERSION"
+
+      - name: Create tag
+        if: steps.changesets.outputs.hasChangesets == 'false'
+        env:
+          TAG: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          if git ls-remote --exit-code --tags origin "$TAG" >/dev/null 2>&1; then
+            echo "Tag $TAG already exists, skipping"
+            exit 0
+          fi
+          git tag "$TAG"
+          git push origin "$TAG"
+          echo "Created tag $TAG"
+
+      - name: Create stable branch
+        if: steps.changesets.outputs.hasChangesets == 'false' && github.ref_name == 'main' && endsWith(steps.version.outputs.version, '.0')
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          MINOR=${VERSION%.0}
+          BRANCH="stable/$MINOR"
+          if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+            echo "Branch $BRANCH already exists, skipping"
+            exit 0
+          fi
+          git push origin "HEAD:refs/heads/$BRANCH"
+          echo "Created branch $BRANCH"
+
+      - name: Create GitHub release
+        if: steps.changesets.outputs.hasChangesets == 'false'
+        env:
+          TAG: ${{ steps.version.outputs.version }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Release $TAG already exists, skipping"
+            exit 0
+          fi
+          gh release create "$TAG" \
+            --title "$TAG" \
+            --notes "" \
+            --latest=legacy
+          echo "Created release $TAG"
+
   # Manual/Cron release job - runs on schedule or manual trigger with tag
   manual-cron-release:
     name: Manual & Cron Release


### PR DESCRIPTION
## Summary

Automates the post-merge steps that currently happen by hand after a "Version Packages" PR merges. After `pnpm release latest` succeeds, the new steps:

- Create the git tag (`X.Y.Z`)
- On `main` with a minor/major bump (`X.Y.0`), create the `stable/X.Y` branch
- Create the GitHub release with an empty body. Curated, grouped notes still come from `/write_release_descriptions`, which overwrites the body afterwards.

Each operation checks remote state first and skips if already done, so re-running the workflow recovers cleanly from partial failures. The `--latest=legacy` flag lets GitHub assign the latest badge via semver comparison, so a patch on the current stable still gets it.

Follow-ups (separate PRs):
- Auto-label PRs based on changeset presence/content + add `.github/release.yml` to make `--generate-notes` produce useful flat notes by default.
- Automate unlocking `main` after release (#7416).
- Out of scope: `bin/post-release` (homebrew/docs/notification PRs) — needs extra auth.

## Test plan

- [ ] Confirm no tag protection rules block `GITHUB_TOKEN` from pushing tags
- [ ] Confirm no branch protection rules block creating `stable/*` branches
- [ ] On the next minor cut, watch the workflow run and verify the tag, branch, and (empty-body) release are created with the expected names

🤖 Generated with [Claude Code](https://claude.com/claude-code)