### PR TITLE
Automatically unlock main branch after release publishes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -170,6 +170,41 @@ jobs:
             --latest=legacy
           echo "Created release $TAG"
 
+      - name: Unlock main branch
+        if: steps.changesets.outputs.hasChangesets == 'false' && github.ref_name == 'main'
+        env:
+          ADMIN_TOKEN: ${{ secrets.RELEASE_ADMIN_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${ADMIN_TOKEN:-}" ]; then
+            echo "::warning::RELEASE_ADMIN_TOKEN not configured; skipping main branch unlock"
+            exit 0
+          fi
+
+          RULE_ID=$(GITHUB_TOKEN="$ADMIN_TOKEN" gh api graphql \
+            -f query='query($owner: String!, $repo: String!) {
+              repository(owner: $owner, name: $repo) {
+                branchProtectionRules(first: 50) { nodes { id pattern } }
+              }
+            }' \
+            -F owner="${GITHUB_REPOSITORY%/*}" \
+            -F repo="${GITHUB_REPOSITORY#*/}" \
+            --jq '.data.repository.branchProtectionRules.nodes[] | select(.pattern == "main") | .id')
+
+          if [ -z "$RULE_ID" ]; then
+            echo "::warning::No branch protection rule found for main; skipping unlock"
+            exit 0
+          fi
+
+          GITHUB_TOKEN="$ADMIN_TOKEN" gh api graphql \
+            -f query='mutation($id: ID!) {
+              updateBranchProtectionRule(input: { branchProtectionRuleId: $id, lockBranch: false }) {
+                branchProtectionRule { lockBranch }
+              }
+            }' \
+            -f id="$RULE_ID" >/dev/null
+          echo "Unlocked main branch"
+
   # Manual/Cron release job - runs on schedule or manual trigger with tag
   manual-cron-release:
     name: Manual & Cron Release


### PR DESCRIPTION
## Summary
- Adds an "Unlock main branch" step at the end of the `changeset-release` job that flips `lockBranch` back to `false` on the `main` branch protection rule once a release publishes successfully.
- The pre-release lock is still applied manually (out of scope for this PR); only the unlock is automated for now.
- Step is gated on `hasChangesets == 'false'` (release was just published) and `github.ref_name == 'main'`, so it doesn't run on stable branches or on the version-PR creation pass.

## Token requirement
The default `GITHUB_TOKEN` cannot modify branch protection rules. The step uses a separate `RELEASE_ADMIN_TOKEN` secret (PAT or GitHub App installation token with `Administration: write` on the repo). If the secret is not configured, the step emits a `::warning::` and exits 0 without failing the workflow — meaning this is safe to merge before the secret is provisioned, and the unlock will simply remain manual until then.

Stacked on top of #7415.

## Test plan
- [ ] Provision `RELEASE_ADMIN_TOKEN` secret in the repo
- [ ] Lock `main` manually via the GitHub UI before the next release
- [ ] Confirm the step flips `lockBranch` back to `false` after the release publishes
- [ ] Verify in the Actions log that the GraphQL mutation returns `lockBranch: false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)