### PR TITLE
Auto-label PRs and use native release notes generation

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,17 @@
+changelog:
+  exclude:
+    labels:
+      - no-changelog
+  categories:
+    - title: App
+      labels:
+        - "Area: @shopify/app"
+    - title: Theme
+      labels:
+        - "Area: @shopify/theme"
+    - title: CLI
+      labels:
+        - "Area: @shopify/cli"
+    - title: Other
+      labels:
+        - "*"

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -1,0 +1,70 @@
+name: Label PR
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+jobs:
+  label:
+    name: Apply labels from changesets
+    # Skip fork PRs — GITHUB_TOKEN is read-only there and the labeling would fail.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Determine and apply label
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUM: ${{ github.event.pull_request.number }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+
+          CHANGESETS=$(git diff --name-only --diff-filter=A "$BASE_SHA" HEAD -- '.changeset/*.md' | grep -v 'README\.md$' || true)
+
+          if [ -z "$CHANGESETS" ]; then
+            TARGET="no-changelog"
+          else
+            HAS_APP=0
+            HAS_THEME=0
+            HAS_OTHER=0
+            while IFS= read -r FILE; do
+              [ -z "$FILE" ] && continue
+              FRONTMATTER=$(awk '/^---$/{c++; if (c==2) exit; next} c==1' "$FILE")
+              while IFS= read -r PKG; do
+                case "$PKG" in
+                  @shopify/app|@shopify/create-app) HAS_APP=1 ;;
+                  @shopify/theme) HAS_THEME=1 ;;
+                  @shopify/*) HAS_OTHER=1 ;;
+                esac
+              done < <(echo "$FRONTMATTER" | grep -oE "'@shopify/[a-z-]+'" | tr -d "'")
+            done <<< "$CHANGESETS"
+
+            AREA_COUNT=$((HAS_APP + HAS_THEME + HAS_OTHER))
+            if [ "$AREA_COUNT" -eq 1 ] && [ "$HAS_APP" -eq 1 ]; then
+              TARGET="Area: @shopify/app"
+            elif [ "$AREA_COUNT" -eq 1 ] && [ "$HAS_THEME" -eq 1 ]; then
+              TARGET="Area: @shopify/theme"
+            else
+              TARGET="Area: @shopify/cli"
+            fi
+          fi
+
+          echo "Target label: $TARGET"
+
+          # Idempotently keep only the target label from the managed set.
+          for L in "no-changelog" "Area: @shopify/app" "Area: @shopify/theme" "Area: @shopify/cli"; do
+            if [ "$L" = "$TARGET" ]; then
+              gh pr edit "$PR_NUM" --add-label "$L"
+            else
+              gh pr edit "$PR_NUM" --remove-label "$L" 2>/dev/null || true
+            fi
+          done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -166,7 +166,7 @@ jobs:
           fi
           gh release create "$TAG" \
             --title "$TAG" \
-            --notes "" \
+            --generate-notes \
             --latest=legacy
           echo "Created release $TAG"
 


### PR DESCRIPTION
## Summary

Replaces the empty release body (from #7415) with GitHub's native `--generate-notes` output, made useful by two new pieces of automation:

- **`.github/workflows/label-pr.yml`** runs on PR open/sync/reopen and inspects any changeset files added in the PR:
  - PRs with no changeset → `no-changelog` label
  - PRs with a changeset → `Area: @shopify/<area>` label, derived from the packages in the changeset frontmatter
  - Multi-package changesets fold to `Area: @shopify/cli` (per discussion: "anything mixed counts as CLI")
  - Idempotent: cycles labels correctly when changesets are added/removed during PR review
- **`.github/release.yml`** configures `--generate-notes` to exclude `no-changelog` PRs and bucket the rest into App / Theme / CLI / Other categories.

The `Create GitHub release` step in `release.yml` now passes `--generate-notes` instead of `--notes ""`.

## Notes

- Fork PRs are skipped by the labeler (`GITHUB_TOKEN` is read-only on forks). They land in "Other" in release notes until manually labeled.
- Pre-existing open PRs and recently merged PRs won't be auto-labeled until they're updated. The first release after this lands will have unlabeled merges show up under "Other"; cleans up over time.
- The `no-changelog`, `Area: @shopify/cli`, `Area: @shopify/theme`, `Area: @shopify/app` labels already exist in the repo.

## Test plan

- [ ] Verify the labeler runs on a fresh PR with no changeset → `no-changelog` is applied
- [ ] Verify on a PR with an `@shopify/app` changeset → `Area: @shopify/app` is applied
- [ ] Verify on a PR touching multiple packages → `Area: @shopify/cli` is applied
- [ ] Verify on a PR where a changeset is added later → `no-changelog` is removed and the area label is added
- [ ] After the next release, eyeball the auto-generated notes and confirm category bucketing works

🤖 Generated with [Claude Code](https://claude.com/claude-code)