### PR TITLE
Fix label-pr workflow checking out merge ref instead of PR head

### DIFF
--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -20,6 +20,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Determine and apply label
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

The Label PR workflow was assigning incorrect labels (e.g. `Area: @shopify/cli` instead of `no-changelog`) on PRs that don't include a changeset.

## Root cause

`actions/checkout@v4` defaults to checking out the merge ref (`refs/pull/N/merge`) for `pull_request` events. That ref is the PR head merged into the latest base branch, so `git diff $BASE_SHA HEAD` includes any changesets that landed on `main` after `BASE_SHA` — even though the PR didn't add them.

Example: PR #7384 (no changeset) was labeled `Area: @shopify/cli` because the merge ref contained 5 unrelated changesets that had merged into main between `base.sha` and now.

## Fix

Pin the checkout ref to `pull_request.head.sha` so `HEAD` is the actual PR tip, not the merge ref.

## Test plan
- [x] Reproduce locally on PR #7384's `base.sha` and merge ref — confirms 5 phantom changesets appear with the merge ref and 0 with the head SHA.
- [ ] After merge, verify the next `pull_request` event on a no-changeset PR receives `no-changelog`.