### PR TITLE
Fix tests-pr workflow skipping in merge queue

### DIFF
--- a/.github/workflows/tests-pr.yml
+++ b/.github/workflows/tests-pr.yml
@@ -217,7 +217,7 @@ jobs:
 
   e2e-tests:
     name: "E2E tests (shard ${{ matrix.shard }})"
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event_name == 'merge_group' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 20
     continue-on-error: true


### PR DESCRIPTION
### WHY are these changes introduced?

The `e2e-tests` job in `tests-pr.yml` is gated by `github.event.pull_request.head.repo.full_name == github.repository`. In `merge_group` events the `pull_request` object doesn't exist, so that expression evaluates to an empty string and the job is silently skipped — which makes it unsuitable as a required check for the merge queue.

### WHAT is this pull request doing?

Updates the guard on `e2e-tests` to:

```yaml
if: github.event_name == 'merge_group' || github.event.pull_request.head.repo.full_name == github.repository
```

This allows the job to run in the merge queue while still skipping fork PRs (which can't access the E2E secrets). `type-diff` is intentionally left as-is — it's not needed in the merge queue.

### How to test your changes?

- Open this PR and confirm `E2E tests` runs.
- Once merged, confirm the job runs on `merge_group` events from the queue.
