### PR TITLE
Fix dependabot pnpm-lock.yaml updates in workspaces

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,6 @@ updates:
     versioning-strategy: increase
     directories:
       - "/"
-      - "packages/*"
     schedule:
       interval: "weekly"
     labels:


### PR DESCRIPTION
### WHY are these changes introduced?

Recent Dependabot PRs ([#7166](https://github.com/Shopify/cli/pull/7166), the prior liquidjs bump on the cli-kit/liquidjs branch, and others) bump a workspace package's `package.json` but leave `pnpm-lock.yaml` untouched, forcing maintainers to push a manual "update lock" commit before CI is happy and the PR can land.

Root cause is in our `.github/dependabot.yml`:

```yaml
directories:
  - "/"
  - "packages/*"
```

This is a pnpm workspace — there is one `pnpm-lock.yaml` at the root and `pnpm-workspace.yaml` declares the member packages. When Dependabot runs the update from a subdirectory like `/packages/cli-kit`, pnpm needs the workspace root to resolve and rewrite the lockfile, but the lockfile is one level up, so the subdir job edits `package.json` and produces no lockfile diff.

This is a known dependabot-core limitation: see [dependabot/dependabot-core#11135](https://github.com/dependabot/dependabot-core/issues/11135) and the follow-up [#11487 (merged Feb 2025)](https://github.com/dependabot/dependabot-core/pull/11487), where the team explicitly states *"all dependencies should be updated from the root directory, where `pnpm-workspace.yaml` and `pnpm-lock.yaml` exist"* and now raises a `MisconfiguredTooling` error for pure subdirectory pnpm runs.

### WHAT is this pull request doing?

Drops `"packages/*"` from `directories:` so Dependabot only runs from the workspace root. From the root, it walks `pnpm-workspace.yaml`, picks up dependencies declared in any `packages/*/package.json`, and writes both `package.json` *and* `pnpm-lock.yaml` in the same PR.

### Possible issues and tradeoffs

- **Reverses [ba794ba](https://github.com/Shopify/cli/commit/ba794ba47a) ("Include the packages subdirectories", Nov 2024).** That commit was added because root-only runs at the time weren't picking up dependencies declared inside `packages/*/package.json`. Dependabot's pnpm-workspace handling has improved since (notably #11487), so root-only should now cover sub-package deps via `pnpm-workspace.yaml` — but I cannot fully prove that without watching the next weekly run. **Concrete risk:** if root-only still misses sub-package deps, we'll silently stop getting bump PRs for those packages until someone notices.
- **PR title format changes.** Today titles look like `Bump lodash from X to Y in /packages/cli-kit`. After this change they'll lose the `in /packages/cli-kit` qualifier when the dep lives in a workspace package. Cosmetic, but worth knowing if any tooling/automation parses the title.
- **Existing open Dependabot PRs may be re-created.** Dependabot can supersede or rebase open PRs when the schedule's directory set changes. Expect some churn on the next run after this merges.
- **Existing duplicate PRs disappear.** When the same dep is declared in `/package.json` and one of `packages/*/package.json`, the current config can produce two PRs (one per `directories` entry). After this we get one. That's an improvement, but if anyone was relying on per-package PRs landing independently, they won't anymore.
- **Verification gap.** There's no unit test for Dependabot config; the only real signal is the next scheduled run. If sub-package deps stop being bumped, the rollback is to re-add `packages/*` and accept the manual-lockfile workaround until dependabot-core supports per-subdir lockfile rewrites — but that's the broken state we just left.

### How to test your changes?

Wait for the next Dependabot weekly run after merge and confirm that:
1. A bump PR that touches `packages/*/package.json` *also* updates `pnpm-lock.yaml`.
2. PRs are still being opened for dependencies declared in workspace packages (i.e. coverage didn't regress).

If neither happens within ~a week, re-add `"packages/*"` and re-open the conversation.

### Post-release steps

None.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [x] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add` — _N/A: CI/Dependabot config only, no shipped code change_