### PR TITLE
feat/agent only command for app store requirement retrieval

### DIFF
--- a/packages/app/src/cli/commands/app/agent/get-self-review-requirements.ts
+++ b/packages/app/src/cli/commands/app/agent/get-self-review-requirements.ts
@@ -1,0 +1,20 @@
+import {getSelfReviewRequirementsMarkdown} from '../../../services/agent/self-review-requirements.js'
+import Command from '@shopify/cli-kit/node/base-command'
+import {globalFlags} from '@shopify/cli-kit/node/cli'
+import {outputResult} from '@shopify/cli-kit/node/output'
+import {CLI_KIT_VERSION} from '@shopify/cli-kit/common/version'
+
+export default class AgentGetSelfReviewRequirements extends Command {
+  static hidden = true
+
+  static description = 'Agent-only. Not for human use.'
+
+  static flags = {
+    ...globalFlags,
+  }
+
+  public async run(): Promise<void> {
+    const markdown = await getSelfReviewRequirementsMarkdown({cliVersion: CLI_KIT_VERSION})
+    outputResult(markdown)
+  }
+}

--- a/packages/app/src/cli/index.ts
+++ b/packages/app/src/cli/index.ts
@@ -1,3 +1,4 @@
+import AgentGetSelfReviewRequirements from './commands/app/agent/get-self-review-requirements.js'
 import Build from './commands/app/build.js'
 import BulkCancel from './commands/app/bulk/cancel.js'
 import BulkStatus from './commands/app/bulk/status.js'
@@ -44,6 +45,7 @@ import BaseCommand from '@shopify/cli-kit/node/base-command'
  * Organization commands extend BaseCommand directly.
  */
 export const commands: {[key: string]: typeof AppLinkedCommand | typeof AppUnlinkedCommand | typeof BaseCommand} = {
+  'app:agent:get-self-review-requirements': AgentGetSelfReviewRequirements,
   'app:build': Build,
   'app:bulk:cancel': BulkCancel,
   'app:bulk:status': BulkStatus,

--- a/packages/app/src/cli/services/agent/self-review-requirements.ts
+++ b/packages/app/src/cli/services/agent/self-review-requirements.ts
@@ -1,0 +1,36 @@
+import {shopifyFetch} from '@shopify/cli-kit/node/http'
+import {addPublicMetadata} from '@shopify/cli-kit/node/metadata'
+import {AbortError} from '@shopify/cli-kit/node/error'
+
+const REQUIREMENTS_URL = 'https://shopify.dev/docs/apps/launch/app-store-review/app-store-ai-self-review-requirements'
+
+// Sentinel comment prepended to the response so an agent can confirm it parsed the expected command's output.
+const SENTINEL = '<!-- shopify-agent: get-self-review-requirements -->'
+
+interface GetSelfReviewRequirementsInput {
+  cliVersion: string
+}
+
+export async function getSelfReviewRequirementsMarkdown({cliVersion}: GetSelfReviewRequirementsInput): Promise<string> {
+  const response = await shopifyFetch(REQUIREMENTS_URL, {
+    method: 'GET',
+    headers: {
+      Accept: 'text/markdown',
+      'User-Agent': `shopify-cli/${cliVersion}`,
+    },
+  })
+
+  if (!response.ok) {
+    await addPublicMetadata(() => ({cmd_app_agent_upstream_status: response.status}))
+    throw new AbortError(`Failed to fetch self-review requirements: HTTP ${response.status}`)
+  }
+
+  const body = await response.text()
+
+  await addPublicMetadata(() => ({
+    cmd_app_agent_upstream_status: response.status,
+    cmd_app_agent_response_bytes: body.length,
+  }))
+
+  return `${SENTINEL}\n\n${body}`
+}

--- a/packages/cli-kit/src/public/node/hooks/postrun.ts
+++ b/packages/cli-kit/src/public/node/hooks/postrun.ts
@@ -26,11 +26,14 @@ export const hook: Hook.Postrun = async ({config, Command}) => {
   deprecationsHook(Command)
 
   const {outputDebug} = await import('../output.js')
+  const isAgentCommand = Command.id.startsWith('app:agent:')
   const command = Command.id.replace(/:/g, ' ')
   outputDebug(`Completed command ${command}`)
   postRunHookCompleted = true
 
-  if (!command.includes('notifications') && !command.includes('upgrade')) await autoUpgradeIfNeeded()
+  if (!isAgentCommand && !command.includes('notifications') && !command.includes('upgrade')) {
+    await autoUpgradeIfNeeded()
+  }
 }
 
 /**

--- a/packages/cli-kit/src/public/node/monorail.ts
+++ b/packages/cli-kit/src/public/node/monorail.ts
@@ -99,6 +99,10 @@ export interface Schemas {
       cmd_app_validate_issue_count?: Optional<number>
       cmd_app_validate_file_count?: Optional<number>
 
+      // Agent (`app:agent:*`) related commands
+      cmd_app_agent_upstream_status?: Optional<number>
+      cmd_app_agent_response_bytes?: Optional<number>
+
       // Dev related commands
       cmd_dev_tunnel_type?: Optional<string>
       cmd_dev_tunnel_custom_hash?: Optional<string>

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -1,55 +1,91 @@
 {
   "commands": {
-    "app:build": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/app",
-      "description": "This command executes the build script specified in the element's TOML file. You can specify a custom script in the file. To learn about configuration files in Shopify apps, refer to \"App configuration\" (https://shopify.dev/docs/apps/tools/cli/configuration).\n\n  If you're building a \"theme app extension\" (https://shopify.dev/docs/apps/online-store/theme-app-extensions), then running the `build` command runs \"Theme Check\" (https://shopify.dev/docs/themes/tools/theme-check) against your extension to ensure that it's valid.",
-      "descriptionWithMarkdown": "This command executes the build script specified in the element's TOML file. You can specify a custom script in the file. To learn about configuration files in Shopify apps, refer to [App configuration](https://shopify.dev/docs/apps/tools/cli/configuration).\n\n  If you're building a [theme app extension](https://shopify.dev/docs/apps/online-store/theme-app-extensions), then running the `build` command runs [Theme Check](https://shopify.dev/docs/themes/tools/theme-check) against your extension to ensure that it's valid.",
+    "app:agent:get-self-review-requirements": {
+      "aliases": [],
+      "args": {},
+      "description": "Agent-only. Not for human use.",
       "flags": {
-        "client-id": {
-          "description": "The Client ID of your app.",
-          "env": "SHOPIFY_FLAG_CLIENT_ID",
-          "exclusive": [
-            "config"
-          ],
-          "hasDynamicHelp": false,
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
           "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hidden": true,
+      "hiddenAliases": [],
+      "id": "app:agent:get-self-review-requirements",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false,
+      "customPluginName": "@shopify/app"
+    },
+    "app:build": {
+      "aliases": [],
+      "args": {},
+      "description": "This command executes the build script specified in the element's TOML file. You can specify a custom script in the file. To learn about configuration files in Shopify apps, refer to \"App configuration\" (https://shopify.dev/docs/apps/tools/cli/configuration).\n\n  If you're building a \"theme app extension\" (https://shopify.dev/docs/apps/online-store/theme-app-extensions), then running the `build` command runs \"Theme Check\" (https://shopify.dev/docs/themes/tools/theme-check) against your extension to ensure that it's valid.",
+      "flags": {
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path to your app directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "name": "path",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
           "multiple": false,
-          "name": "client-id",
           "type": "option"
         },
         "config": {
           "char": "c",
           "description": "The name of the app configuration.",
           "env": "SHOPIFY_FLAG_APP_CONFIG",
-          "hasDynamicHelp": false,
           "hidden": false,
-          "multiple": false,
           "name": "config",
+          "hasDynamicHelp": false,
+          "multiple": false,
           "type": "option"
         },
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
+        "client-id": {
+          "description": "The Client ID of your app.",
+          "env": "SHOPIFY_FLAG_CLIENT_ID",
+          "exclusive": [
+            "config"
+          ],
           "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
-        "path": {
-          "description": "The path to your app directory.",
-          "env": "SHOPIFY_FLAG_PATH",
+          "name": "client-id",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "path",
-          "noCacheDefault": true,
           "type": "option"
         },
         "reset": {
-          "allowNo": false,
           "description": "Reset all your settings.",
           "env": "SHOPIFY_FLAG_RESET",
           "exclusive": [
@@ -57,93 +93,82 @@
           ],
           "hidden": false,
           "name": "reset",
+          "allowNo": false,
           "type": "boolean"
         },
         "skip-dependencies-installation": {
-          "allowNo": false,
           "description": "Skips the installation of dependencies. Deprecated, use workspaces instead.",
           "env": "SHOPIFY_FLAG_SKIP_DEPENDENCIES_INSTALLATION",
           "hidden": false,
           "name": "skip-dependencies-installation",
-          "type": "boolean"
-        },
-        "verbose": {
           "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
           "type": "boolean"
         }
       },
       "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
+      "hiddenAliases": [],
       "id": "app:build",
       "pluginAlias": "@shopify/cli",
       "pluginName": "@shopify/cli",
       "pluginType": "core",
       "strict": true,
-      "summary": "Build the app, including extensions."
+      "summary": "Build the app, including extensions.",
+      "descriptionWithMarkdown": "This command executes the build script specified in the element's TOML file. You can specify a custom script in the file. To learn about configuration files in Shopify apps, refer to [App configuration](https://shopify.dev/docs/apps/tools/cli/configuration).\n\n  If you're building a [theme app extension](https://shopify.dev/docs/apps/online-store/theme-app-extensions), then running the `build` command runs [Theme Check](https://shopify.dev/docs/themes/tools/theme-check) against your extension to ensure that it's valid.",
+      "customPluginName": "@shopify/app"
     },
     "app:bulk:cancel": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/app",
+      "aliases": [],
+      "args": {},
       "description": "Cancels a running bulk operation by ID.",
       "flags": {
-        "client-id": {
-          "description": "The Client ID of your app.",
-          "env": "SHOPIFY_FLAG_CLIENT_ID",
-          "exclusive": [
-            "config"
-          ],
-          "hasDynamicHelp": false,
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
           "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path to your app directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "name": "path",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
           "multiple": false,
-          "name": "client-id",
           "type": "option"
         },
         "config": {
           "char": "c",
           "description": "The name of the app configuration.",
           "env": "SHOPIFY_FLAG_APP_CONFIG",
-          "hasDynamicHelp": false,
           "hidden": false,
-          "multiple": false,
           "name": "config",
-          "type": "option"
-        },
-        "id": {
-          "description": "The bulk operation ID to cancel (numeric ID or full GID).",
-          "env": "SHOPIFY_FLAG_ID",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "id",
-          "required": true,
           "type": "option"
         },
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
+        "client-id": {
+          "description": "The Client ID of your app.",
+          "env": "SHOPIFY_FLAG_CLIENT_ID",
+          "exclusive": [
+            "config"
+          ],
           "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
-        "path": {
-          "description": "The path to your app directory.",
-          "env": "SHOPIFY_FLAG_PATH",
+          "name": "client-id",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "path",
-          "noCacheDefault": true,
           "type": "option"
         },
         "reset": {
-          "allowNo": false,
           "description": "Reset all your settings.",
           "env": "SHOPIFY_FLAG_RESET",
           "exclusive": [
@@ -151,115 +176,91 @@
           ],
           "hidden": false,
           "name": "reset",
+          "allowNo": false,
           "type": "boolean"
+        },
+        "id": {
+          "description": "The bulk operation ID to cancel (numeric ID or full GID).",
+          "env": "SHOPIFY_FLAG_ID",
+          "name": "id",
+          "required": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
         },
         "store": {
           "char": "s",
           "description": "The store domain. Must be an existing dev store.",
           "env": "SHOPIFY_FLAG_STORE",
+          "name": "store",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "store",
           "type": "option"
-        },
-        "verbose": {
-          "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
-          "type": "boolean"
         }
       },
       "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
+      "hiddenAliases": [],
       "id": "app:bulk:cancel",
       "pluginAlias": "@shopify/cli",
       "pluginName": "@shopify/cli",
       "pluginType": "core",
       "strict": true,
-      "summary": "Cancel a bulk operation."
+      "summary": "Cancel a bulk operation.",
+      "customPluginName": "@shopify/app"
     },
-    "app:bulk:execute": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/app",
-      "description": "Executes an Admin API GraphQL query or mutation on the specified store, as a bulk operation. Mutations are only allowed on dev stores.\n\n  Bulk operations allow you to process large amounts of data asynchronously. Learn more about \"bulk query operations\" (https://shopify.dev/docs/api/usage/bulk-operations/queries) and \"bulk mutation operations\" (https://shopify.dev/docs/api/usage/bulk-operations/imports).\n\n  Use \"`bulk status`\" (https://shopify.dev/docs/api/shopify-cli/app/app-bulk-status) to check the status of your bulk operations.",
-      "descriptionWithMarkdown": "Executes an Admin API GraphQL query or mutation on the specified store, as a bulk operation. Mutations are only allowed on dev stores.\n\n  Bulk operations allow you to process large amounts of data asynchronously. Learn more about [bulk query operations](https://shopify.dev/docs/api/usage/bulk-operations/queries) and [bulk mutation operations](https://shopify.dev/docs/api/usage/bulk-operations/imports).\n\n  Use [`bulk status`](https://shopify.dev/docs/api/shopify-cli/app/app-bulk-status) to check the status of your bulk operations.",
+    "app:bulk:status": {
+      "aliases": [],
+      "args": {},
+      "description": "Check the status of a specific bulk operation by ID, or list all bulk operations belonging to this app on this store in the last 7 days.\n\n  Bulk operations allow you to process large amounts of data asynchronously. Learn more about \"bulk query operations\" (https://shopify.dev/docs/api/usage/bulk-operations/queries) and \"bulk mutation operations\" (https://shopify.dev/docs/api/usage/bulk-operations/imports).\n\n  Use \"`bulk execute`\" (https://shopify.dev/docs/api/shopify-cli/app/app-bulk-execute) to start a new bulk operation.",
       "flags": {
-        "client-id": {
-          "description": "The Client ID of your app.",
-          "env": "SHOPIFY_FLAG_CLIENT_ID",
-          "exclusive": [
-            "config"
-          ],
-          "hasDynamicHelp": false,
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
           "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path to your app directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "name": "path",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
           "multiple": false,
-          "name": "client-id",
           "type": "option"
         },
         "config": {
           "char": "c",
           "description": "The name of the app configuration.",
           "env": "SHOPIFY_FLAG_APP_CONFIG",
-          "hasDynamicHelp": false,
           "hidden": false,
-          "multiple": false,
           "name": "config",
+          "hasDynamicHelp": false,
+          "multiple": false,
           "type": "option"
         },
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
-          "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
-        "output-file": {
-          "dependsOn": [
-            "watch"
+        "client-id": {
+          "description": "The Client ID of your app.",
+          "env": "SHOPIFY_FLAG_CLIENT_ID",
+          "exclusive": [
+            "config"
           ],
-          "description": "The file path where results should be written if --watch is specified. If not specified, results will be written to STDOUT.",
-          "env": "SHOPIFY_FLAG_OUTPUT_FILE",
+          "hidden": false,
+          "name": "client-id",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "output-file",
-          "type": "option"
-        },
-        "path": {
-          "description": "The path to your app directory.",
-          "env": "SHOPIFY_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "path",
-          "noCacheDefault": true,
-          "type": "option"
-        },
-        "query": {
-          "char": "q",
-          "description": "The GraphQL query or mutation to run as a bulk operation.",
-          "env": "SHOPIFY_FLAG_QUERY",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "query",
-          "required": false,
-          "type": "option"
-        },
-        "query-file": {
-          "description": "Path to a file containing the GraphQL query or mutation. Can't be used with --query.",
-          "env": "SHOPIFY_FLAG_QUERY_FILE",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "query-file",
           "type": "option"
         },
         "reset": {
-          "allowNo": false,
           "description": "Reset all your settings.",
           "env": "SHOPIFY_FLAG_RESET",
           "exclusive": [
@@ -267,509 +268,77 @@
           ],
           "hidden": false,
           "name": "reset",
-          "type": "boolean"
-        },
-        "store": {
-          "char": "s",
-          "description": "The store domain. Must be an existing dev store.",
-          "env": "SHOPIFY_FLAG_STORE",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "store",
-          "type": "option"
-        },
-        "variable-file": {
-          "description": "Path to a file containing GraphQL variables in JSONL format (one JSON object per line). Can't be used with --variables.",
-          "env": "SHOPIFY_FLAG_VARIABLE_FILE",
-          "exclusive": [
-            "variables"
-          ],
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "variable-file",
-          "type": "option"
-        },
-        "variables": {
-          "char": "v",
-          "description": "The values for any GraphQL variables in your mutation, in JSON format. Can be specified multiple times.",
-          "env": "SHOPIFY_FLAG_VARIABLES",
-          "exclusive": [
-            "variable-file"
-          ],
-          "hasDynamicHelp": false,
-          "multiple": true,
-          "name": "variables",
-          "type": "option"
-        },
-        "verbose": {
           "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
           "type": "boolean"
-        },
-        "version": {
-          "description": "The API version to use for the bulk operation. If not specified, uses the latest stable version.",
-          "env": "SHOPIFY_FLAG_VERSION",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "version",
-          "type": "option"
-        },
-        "watch": {
-          "allowNo": false,
-          "description": "Wait for bulk operation results before exiting. Defaults to false.",
-          "env": "SHOPIFY_FLAG_WATCH",
-          "name": "watch",
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "app:bulk:execute",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true,
-      "summary": "Execute bulk operations."
-    },
-    "app:bulk:status": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/app",
-      "description": "Check the status of a specific bulk operation by ID, or list all bulk operations belonging to this app on this store in the last 7 days.\n\n  Bulk operations allow you to process large amounts of data asynchronously. Learn more about \"bulk query operations\" (https://shopify.dev/docs/api/usage/bulk-operations/queries) and \"bulk mutation operations\" (https://shopify.dev/docs/api/usage/bulk-operations/imports).\n\n  Use \"`bulk execute`\" (https://shopify.dev/docs/api/shopify-cli/app/app-bulk-execute) to start a new bulk operation.",
-      "descriptionWithMarkdown": "Check the status of a specific bulk operation by ID, or list all bulk operations belonging to this app on this store in the last 7 days.\n\n  Bulk operations allow you to process large amounts of data asynchronously. Learn more about [bulk query operations](https://shopify.dev/docs/api/usage/bulk-operations/queries) and [bulk mutation operations](https://shopify.dev/docs/api/usage/bulk-operations/imports).\n\n  Use [`bulk execute`](https://shopify.dev/docs/api/shopify-cli/app/app-bulk-execute) to start a new bulk operation.",
-      "flags": {
-        "client-id": {
-          "description": "The Client ID of your app.",
-          "env": "SHOPIFY_FLAG_CLIENT_ID",
-          "exclusive": [
-            "config"
-          ],
-          "hasDynamicHelp": false,
-          "hidden": false,
-          "multiple": false,
-          "name": "client-id",
-          "type": "option"
-        },
-        "config": {
-          "char": "c",
-          "description": "The name of the app configuration.",
-          "env": "SHOPIFY_FLAG_APP_CONFIG",
-          "hasDynamicHelp": false,
-          "hidden": false,
-          "multiple": false,
-          "name": "config",
-          "type": "option"
         },
         "id": {
           "description": "The bulk operation ID (numeric ID or full GID). If not provided, lists all bulk operations belonging to this app on this store in the last 7 days.",
           "env": "SHOPIFY_FLAG_ID",
-          "hasDynamicHelp": false,
-          "multiple": false,
           "name": "id",
-          "type": "option"
-        },
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
-          "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
-        "path": {
-          "description": "The path to your app directory.",
-          "env": "SHOPIFY_FLAG_PATH",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "path",
-          "noCacheDefault": true,
           "type": "option"
-        },
-        "reset": {
-          "allowNo": false,
-          "description": "Reset all your settings.",
-          "env": "SHOPIFY_FLAG_RESET",
-          "exclusive": [
-            "config"
-          ],
-          "hidden": false,
-          "name": "reset",
-          "type": "boolean"
         },
         "store": {
           "char": "s",
           "description": "The store domain. Must be an existing dev store.",
           "env": "SHOPIFY_FLAG_STORE",
+          "name": "store",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "store",
           "type": "option"
-        },
-        "verbose": {
-          "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
-          "type": "boolean"
         }
       },
       "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
+      "hiddenAliases": [],
       "id": "app:bulk:status",
       "pluginAlias": "@shopify/cli",
       "pluginName": "@shopify/cli",
       "pluginType": "core",
       "strict": true,
-      "summary": "Check the status of bulk operations."
-    },
-    "app:config:link": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/app",
-      "description": "Pulls app configuration from the Developer Dashboard and creates or overwrites a configuration file. You can create a new app with this command to start with a default configuration file.\n\n  For more information on the format of the created TOML configuration file, refer to the \"App configuration\" (https://shopify.dev/docs/apps/tools/cli/configuration) page.\n  ",
-      "descriptionWithMarkdown": "Pulls app configuration from the Developer Dashboard and creates or overwrites a configuration file. You can create a new app with this command to start with a default configuration file.\n\n  For more information on the format of the created TOML configuration file, refer to the [App configuration](https://shopify.dev/docs/apps/tools/cli/configuration) page.\n  ",
-      "flags": {
-        "client-id": {
-          "description": "The Client ID of your app.",
-          "env": "SHOPIFY_FLAG_CLIENT_ID",
-          "exclusive": [
-            "config"
-          ],
-          "hasDynamicHelp": false,
-          "hidden": false,
-          "multiple": false,
-          "name": "client-id",
-          "type": "option"
-        },
-        "config": {
-          "char": "c",
-          "description": "The name of the app configuration.",
-          "env": "SHOPIFY_FLAG_APP_CONFIG",
-          "hasDynamicHelp": false,
-          "hidden": false,
-          "multiple": false,
-          "name": "config",
-          "type": "option"
-        },
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
-          "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
-        "path": {
-          "description": "The path to your app directory.",
-          "env": "SHOPIFY_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "path",
-          "noCacheDefault": true,
-          "type": "option"
-        },
-        "reset": {
-          "allowNo": false,
-          "description": "Reset all your settings.",
-          "env": "SHOPIFY_FLAG_RESET",
-          "exclusive": [
-            "config"
-          ],
-          "hidden": false,
-          "name": "reset",
-          "type": "boolean"
-        },
-        "verbose": {
-          "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "app:config:link",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true,
-      "summary": "Fetch your app configuration from the Developer Dashboard."
-    },
-    "app:config:pull": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/app",
-      "description": "Pulls the latest configuration from the already-linked Shopify app and updates the selected configuration file.\n\nThis command reuses the existing linked app and organization and skips all interactive prompts. Use `--config` to target a specific configuration file, or omit it to use the default one.",
-      "descriptionWithMarkdown": "Pulls the latest configuration from the already-linked Shopify app and updates the selected configuration file.\n\nThis command reuses the existing linked app and organization and skips all interactive prompts. Use `--config` to target a specific configuration file, or omit it to use the default one.",
-      "flags": {
-        "client-id": {
-          "description": "The Client ID of your app.",
-          "env": "SHOPIFY_FLAG_CLIENT_ID",
-          "exclusive": [
-            "config"
-          ],
-          "hasDynamicHelp": false,
-          "hidden": false,
-          "multiple": false,
-          "name": "client-id",
-          "type": "option"
-        },
-        "config": {
-          "char": "c",
-          "description": "The name of the app configuration.",
-          "env": "SHOPIFY_FLAG_APP_CONFIG",
-          "hasDynamicHelp": false,
-          "hidden": false,
-          "multiple": false,
-          "name": "config",
-          "type": "option"
-        },
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
-          "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
-        "path": {
-          "description": "The path to your app directory.",
-          "env": "SHOPIFY_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "path",
-          "noCacheDefault": true,
-          "type": "option"
-        },
-        "reset": {
-          "allowNo": false,
-          "description": "Reset all your settings.",
-          "env": "SHOPIFY_FLAG_RESET",
-          "exclusive": [
-            "config"
-          ],
-          "hidden": false,
-          "name": "reset",
-          "type": "boolean"
-        },
-        "verbose": {
-          "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "app:config:pull",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true,
-      "summary": "Refresh an already-linked app configuration without prompts."
-    },
-    "app:config:use": {
-      "aliases": [
-      ],
-      "args": {
-        "config": {
-          "description": "The name of the app configuration. Can be 'shopify.app.staging.toml' or simply 'staging'.",
-          "name": "config"
-        }
-      },
-      "customPluginName": "@shopify/app",
-      "description": "Sets default configuration when you run app-related CLI commands. If you omit the `config-name` parameter, then you'll be prompted to choose from the configuration files in your project.",
-      "descriptionWithMarkdown": "Sets default configuration when you run app-related CLI commands. If you omit the `config-name` parameter, then you'll be prompted to choose from the configuration files in your project.",
-      "flags": {
-        "client-id": {
-          "description": "The Client ID of your app.",
-          "env": "SHOPIFY_FLAG_CLIENT_ID",
-          "exclusive": [
-            "config"
-          ],
-          "hasDynamicHelp": false,
-          "hidden": false,
-          "multiple": false,
-          "name": "client-id",
-          "type": "option"
-        },
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
-          "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
-        "path": {
-          "description": "The path to your app directory.",
-          "env": "SHOPIFY_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "path",
-          "noCacheDefault": true,
-          "type": "option"
-        },
-        "reset": {
-          "allowNo": false,
-          "description": "Reset all your settings.",
-          "env": "SHOPIFY_FLAG_RESET",
-          "exclusive": [
-            "config"
-          ],
-          "hidden": false,
-          "name": "reset",
-          "type": "boolean"
-        },
-        "verbose": {
-          "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "app:config:use",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true,
-      "summary": "Activate an app configuration.",
-      "usage": "app config use [config] [flags]"
-    },
-    "app:config:validate": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/app",
-      "description": "Validates the selected app configuration file and all extension configurations against their schemas and reports any errors found.",
-      "descriptionWithMarkdown": "Validates the selected app configuration file and all extension configurations against their schemas and reports any errors found.",
-      "flags": {
-        "client-id": {
-          "description": "The Client ID of your app.",
-          "env": "SHOPIFY_FLAG_CLIENT_ID",
-          "exclusive": [
-            "config"
-          ],
-          "hasDynamicHelp": false,
-          "hidden": false,
-          "multiple": false,
-          "name": "client-id",
-          "type": "option"
-        },
-        "config": {
-          "char": "c",
-          "description": "The name of the app configuration.",
-          "env": "SHOPIFY_FLAG_APP_CONFIG",
-          "hasDynamicHelp": false,
-          "hidden": false,
-          "multiple": false,
-          "name": "config",
-          "type": "option"
-        },
-        "json": {
-          "allowNo": false,
-          "char": "j",
-          "description": "Output the result as JSON. Automatically disables color output.",
-          "env": "SHOPIFY_FLAG_JSON",
-          "hidden": false,
-          "name": "json",
-          "type": "boolean"
-        },
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
-          "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
-        "path": {
-          "description": "The path to your app directory.",
-          "env": "SHOPIFY_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "path",
-          "noCacheDefault": true,
-          "type": "option"
-        },
-        "reset": {
-          "allowNo": false,
-          "description": "Reset all your settings.",
-          "env": "SHOPIFY_FLAG_RESET",
-          "exclusive": [
-            "config"
-          ],
-          "hidden": false,
-          "name": "reset",
-          "type": "boolean"
-        },
-        "verbose": {
-          "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "app:config:validate",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true,
-      "summary": "Validate your app configuration and extensions."
+      "summary": "Check the status of bulk operations.",
+      "descriptionWithMarkdown": "Check the status of a specific bulk operation by ID, or list all bulk operations belonging to this app on this store in the last 7 days.\n\n  Bulk operations allow you to process large amounts of data asynchronously. Learn more about [bulk query operations](https://shopify.dev/docs/api/usage/bulk-operations/queries) and [bulk mutation operations](https://shopify.dev/docs/api/usage/bulk-operations/imports).\n\n  Use [`bulk execute`](https://shopify.dev/docs/api/shopify-cli/app/app-bulk-execute) to start a new bulk operation.",
+      "customPluginName": "@shopify/app"
     },
     "app:deploy": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/app",
+      "aliases": [],
+      "args": {},
       "description": "\"Builds the app\" (https://shopify.dev/docs/api/shopify-cli/app/app-build), then deploys your app configuration and extensions.\n\n  This command creates an app version, which is a snapshot of your app configuration and all extensions. This version is then released to users.\n\n  This command doesn't deploy your \"web app\" (https://shopify.dev/docs/apps/tools/cli/structure#web-components). You need to \"deploy your web app\" (https://shopify.dev/docs/apps/deployment/web) to your own hosting solution.\n  ",
-      "descriptionWithMarkdown": "[Builds the app](https://shopify.dev/docs/api/shopify-cli/app/app-build), then deploys your app configuration and extensions.\n\n  This command creates an app version, which is a snapshot of your app configuration and all extensions. This version is then released to users.\n\n  This command doesn't deploy your [web app](https://shopify.dev/docs/apps/tools/cli/structure#web-components). You need to [deploy your web app](https://shopify.dev/docs/apps/deployment/web) to your own hosting solution.\n  ",
       "flags": {
-        "allow-deletes": {
-          "allowNo": false,
-          "description": "Allows removing extensions and configuration without requiring user confirmation. For CI/CD environments, the recommended flag is --allow-updates.",
-          "env": "SHOPIFY_FLAG_ALLOW_DELETES",
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
           "hidden": false,
-          "name": "allow-deletes",
+          "name": "no-color",
+          "allowNo": false,
           "type": "boolean"
         },
-        "allow-updates": {
-          "allowNo": false,
-          "description": "Allows adding and updating extensions and configuration without requiring user confirmation. Recommended option for CI/CD environments.",
-          "env": "SHOPIFY_FLAG_ALLOW_UPDATES",
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
           "hidden": false,
-          "name": "allow-updates",
+          "name": "verbose",
+          "allowNo": false,
           "type": "boolean"
+        },
+        "path": {
+          "description": "The path to your app directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "name": "path",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "config": {
+          "char": "c",
+          "description": "The name of the app configuration.",
+          "env": "SHOPIFY_FLAG_APP_CONFIG",
+          "hidden": false,
+          "name": "config",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
         },
         "client-id": {
           "description": "The Client ID of your app.",
@@ -777,57 +346,49 @@
           "exclusive": [
             "config"
           ],
-          "hasDynamicHelp": false,
           "hidden": false,
-          "multiple": false,
           "name": "client-id",
+          "hasDynamicHelp": false,
+          "multiple": false,
           "type": "option"
         },
-        "config": {
-          "char": "c",
-          "description": "The name of the app configuration.",
-          "env": "SHOPIFY_FLAG_APP_CONFIG",
-          "hasDynamicHelp": false,
+        "reset": {
+          "description": "Reset all your settings.",
+          "env": "SHOPIFY_FLAG_RESET",
+          "exclusive": [
+            "config"
+          ],
           "hidden": false,
-          "multiple": false,
-          "name": "config",
-          "type": "option"
+          "name": "reset",
+          "allowNo": false,
+          "type": "boolean"
         },
         "force": {
-          "allowNo": false,
           "char": "f",
           "description": "[Deprecated] Deploy without asking for confirmation. Equivalent to --allow-updates --allow-deletes. Use --allow-updates for CI/CD environments instead.",
           "env": "SHOPIFY_FLAG_FORCE",
           "hidden": false,
           "name": "force",
+          "allowNo": false,
           "type": "boolean"
         },
-        "message": {
-          "description": "Optional message that will be associated with this version. This is for internal use only and won't be available externally.",
-          "env": "SHOPIFY_FLAG_MESSAGE",
-          "hasDynamicHelp": false,
+        "allow-updates": {
+          "description": "Allows adding and updating extensions and configuration without requiring user confirmation. Recommended option for CI/CD environments.",
+          "env": "SHOPIFY_FLAG_ALLOW_UPDATES",
           "hidden": false,
-          "multiple": false,
-          "name": "message",
-          "type": "option"
-        },
-        "no-build": {
+          "name": "allow-updates",
           "allowNo": false,
-          "description": "Use with caution: Skips building any elements of the app that require building. You should ensure your app has been prepared in advance, such as by running `shopify app build` or by caching build artifacts.",
-          "env": "SHOPIFY_FLAG_NO_BUILD",
-          "name": "no-build",
           "type": "boolean"
         },
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
+        "allow-deletes": {
+          "description": "Allows removing extensions and configuration without requiring user confirmation. For CI/CD environments, the recommended flag is --allow-updates.",
+          "env": "SHOPIFY_FLAG_ALLOW_DELETES",
           "hidden": false,
-          "name": "no-color",
+          "name": "allow-deletes",
+          "allowNo": false,
           "type": "boolean"
         },
         "no-release": {
-          "allowNo": false,
           "description": "Creates a version but doesn't release it - it's not made available to merchants. With this flag, a user confirmation is not required.",
           "env": "SHOPIFY_FLAG_NO_RELEASE",
           "exclusive": [
@@ -836,80 +397,93 @@
           ],
           "hidden": false,
           "name": "no-release",
+          "allowNo": false,
           "type": "boolean"
         },
-        "path": {
-          "description": "The path to your app directory.",
-          "env": "SHOPIFY_FLAG_PATH",
+        "no-build": {
+          "description": "Use with caution: Skips building any elements of the app that require building. You should ensure your app has been prepared in advance, such as by running `shopify app build` or by caching build artifacts.",
+          "env": "SHOPIFY_FLAG_NO_BUILD",
+          "name": "no-build",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "message": {
+          "description": "Optional message that will be associated with this version. This is for internal use only and won't be available externally.",
+          "env": "SHOPIFY_FLAG_MESSAGE",
+          "hidden": false,
+          "name": "message",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "path",
-          "noCacheDefault": true,
           "type": "option"
-        },
-        "reset": {
-          "allowNo": false,
-          "description": "Reset all your settings.",
-          "env": "SHOPIFY_FLAG_RESET",
-          "exclusive": [
-            "config"
-          ],
-          "hidden": false,
-          "name": "reset",
-          "type": "boolean"
-        },
-        "source-control-url": {
-          "description": "URL associated with the new app version.",
-          "env": "SHOPIFY_FLAG_SOURCE_CONTROL_URL",
-          "hasDynamicHelp": false,
-          "hidden": false,
-          "multiple": false,
-          "name": "source-control-url",
-          "type": "option"
-        },
-        "verbose": {
-          "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
-          "type": "boolean"
         },
         "version": {
           "description": "Optional version tag that will be associated with this app version. If not provided, an auto-generated identifier will be generated for this app version.",
           "env": "SHOPIFY_FLAG_VERSION",
-          "hasDynamicHelp": false,
           "hidden": false,
-          "multiple": false,
           "name": "version",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "source-control-url": {
+          "description": "URL associated with the new app version.",
+          "env": "SHOPIFY_FLAG_SOURCE_CONTROL_URL",
+          "hidden": false,
+          "name": "source-control-url",
+          "hasDynamicHelp": false,
+          "multiple": false,
           "type": "option"
         }
       },
       "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
+      "hiddenAliases": [],
       "id": "app:deploy",
       "pluginAlias": "@shopify/cli",
       "pluginName": "@shopify/cli",
       "pluginType": "core",
       "strict": true,
-      "summary": "Deploy your Shopify app."
+      "summary": "Deploy your Shopify app.",
+      "descriptionWithMarkdown": "[Builds the app](https://shopify.dev/docs/api/shopify-cli/app/app-build), then deploys your app configuration and extensions.\n\n  This command creates an app version, which is a snapshot of your app configuration and all extensions. This version is then released to users.\n\n  This command doesn't deploy your [web app](https://shopify.dev/docs/apps/tools/cli/structure#web-components). You need to [deploy your web app](https://shopify.dev/docs/apps/deployment/web) to your own hosting solution.\n  ",
+      "customPluginName": "@shopify/app"
     },
     "app:dev": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/app",
+      "aliases": [],
+      "args": {},
       "description": "Builds and previews your app on a dev store, and watches for changes. \"Read more about testing apps locally\" (https://shopify.dev/docs/apps/build/cli-for-apps/test-apps-locally).",
-      "descriptionWithMarkdown": "Builds and previews your app on a dev store, and watches for changes. [Read more about testing apps locally](https://shopify.dev/docs/apps/build/cli-for-apps/test-apps-locally).",
       "flags": {
-        "checkout-cart-url": {
-          "description": "Resource URL for checkout UI extension. Format: \"/cart/{productVariantID}:{productQuantity}\"",
-          "env": "SHOPIFY_FLAG_CHECKOUT_CART_URL",
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path to your app directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "name": "path",
+          "noCacheDefault": true,
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "checkout-cart-url",
+          "type": "option"
+        },
+        "config": {
+          "char": "c",
+          "description": "The name of the app configuration.",
+          "env": "SHOPIFY_FLAG_APP_CONFIG",
+          "hidden": false,
+          "name": "config",
+          "hasDynamicHelp": false,
+          "multiple": false,
           "type": "option"
         },
         "client-id": {
@@ -918,82 +492,13 @@
           "exclusive": [
             "config"
           ],
-          "hasDynamicHelp": false,
           "hidden": false,
-          "multiple": false,
           "name": "client-id",
-          "type": "option"
-        },
-        "config": {
-          "char": "c",
-          "description": "The name of the app configuration.",
-          "env": "SHOPIFY_FLAG_APP_CONFIG",
-          "hasDynamicHelp": false,
-          "hidden": false,
-          "multiple": false,
-          "name": "config",
-          "type": "option"
-        },
-        "graphiql-key": {
-          "description": "Key used to authenticate GraphiQL requests. By default, a key is automatically derived from the app secret. Use this flag to override with a custom key.",
-          "env": "SHOPIFY_FLAG_GRAPHIQL_KEY",
-          "hasDynamicHelp": false,
-          "hidden": true,
-          "multiple": false,
-          "name": "graphiql-key",
-          "type": "option"
-        },
-        "graphiql-port": {
-          "description": "Local port of the GraphiQL development server.",
-          "env": "SHOPIFY_FLAG_GRAPHIQL_PORT",
-          "hasDynamicHelp": false,
-          "hidden": true,
-          "multiple": false,
-          "name": "graphiql-port",
-          "type": "option"
-        },
-        "localhost-port": {
-          "description": "Port to use for localhost.",
-          "env": "SHOPIFY_FLAG_LOCALHOST_PORT",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "localhost-port",
-          "type": "option"
-        },
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
-          "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
-        "no-update": {
-          "allowNo": false,
-          "description": "Uses the app URL from the toml file instead an autogenerated URL for dev.",
-          "env": "SHOPIFY_FLAG_NO_UPDATE",
-          "name": "no-update",
-          "type": "boolean"
-        },
-        "notify": {
-          "description": "The file path or URL. The file path is to a file that you want updated on idle. The URL path is where you want a webhook posted to report on file changes.",
-          "env": "SHOPIFY_FLAG_NOTIFY",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "notify",
-          "type": "option"
-        },
-        "path": {
-          "description": "The path to your app directory.",
-          "env": "SHOPIFY_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "path",
-          "noCacheDefault": true,
           "type": "option"
         },
         "reset": {
-          "allowNo": false,
           "description": "Reset all your settings.",
           "env": "SHOPIFY_FLAG_RESET",
           "exclusive": [
@@ -1001,47 +506,46 @@
           ],
           "hidden": false,
           "name": "reset",
-          "type": "boolean"
-        },
-        "skip-dependencies-installation": {
           "allowNo": false,
-          "description": "Skips the installation of dependencies. Deprecated, use workspaces instead.",
-          "env": "SHOPIFY_FLAG_SKIP_DEPENDENCIES_INSTALLATION",
-          "name": "skip-dependencies-installation",
           "type": "boolean"
         },
         "store": {
           "char": "s",
           "description": "Store URL. Must be an existing development or Shopify Plus sandbox store.",
           "env": "SHOPIFY_FLAG_STORE",
+          "name": "store",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "store",
           "type": "option"
+        },
+        "skip-dependencies-installation": {
+          "description": "Skips the installation of dependencies. Deprecated, use workspaces instead.",
+          "env": "SHOPIFY_FLAG_SKIP_DEPENDENCIES_INSTALLATION",
+          "name": "skip-dependencies-installation",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "no-update": {
+          "description": "Uses the app URL from the toml file instead an autogenerated URL for dev.",
+          "env": "SHOPIFY_FLAG_NO_UPDATE",
+          "name": "no-update",
+          "allowNo": false,
+          "type": "boolean"
         },
         "subscription-product-url": {
           "description": "Resource URL for subscription UI extension. Format: \"/products/{productId}\"",
           "env": "SHOPIFY_FLAG_SUBSCRIPTION_PRODUCT_URL",
-          "hasDynamicHelp": false,
-          "multiple": false,
           "name": "subscription-product-url",
-          "type": "option"
-        },
-        "theme": {
-          "char": "t",
-          "description": "Theme ID or name of the theme app extension host theme.",
-          "env": "SHOPIFY_FLAG_THEME",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "theme",
           "type": "option"
         },
-        "theme-app-extension-port": {
-          "description": "Local port of the theme app extension development server.",
-          "env": "SHOPIFY_FLAG_THEME_APP_EXTENSION_PORT",
+        "checkout-cart-url": {
+          "description": "Resource URL for checkout UI extension. Format: \"/cart/{productVariantID}:{productQuantity}\"",
+          "env": "SHOPIFY_FLAG_CHECKOUT_CART_URL",
+          "name": "checkout-cart-url",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "theme-app-extension-port",
           "type": "option"
         },
         "tunnel-url": {
@@ -1050,90 +554,137 @@
           "exclusive": [
             "tunnel"
           ],
+          "name": "tunnel-url",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "tunnel-url",
           "type": "option"
         },
         "use-localhost": {
-          "allowNo": false,
           "description": "Service entry point will listen to localhost. A tunnel won't be used. Will work for testing many app features, but not those that directly invoke your app (E.g: Webhooks)",
           "env": "SHOPIFY_FLAG_USE_LOCALHOST",
           "exclusive": [
             "tunnel-url"
           ],
           "name": "use-localhost",
+          "allowNo": false,
           "type": "boolean"
         },
-        "verbose": {
-          "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
-          "type": "boolean"
+        "localhost-port": {
+          "description": "Port to use for localhost.",
+          "env": "SHOPIFY_FLAG_LOCALHOST_PORT",
+          "name": "localhost-port",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "theme": {
+          "char": "t",
+          "description": "Theme ID or name of the theme app extension host theme.",
+          "env": "SHOPIFY_FLAG_THEME",
+          "name": "theme",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "theme-app-extension-port": {
+          "description": "Local port of the theme app extension development server.",
+          "env": "SHOPIFY_FLAG_THEME_APP_EXTENSION_PORT",
+          "name": "theme-app-extension-port",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "notify": {
+          "description": "The file path or URL. The file path is to a file that you want updated on idle. The URL path is where you want a webhook posted to report on file changes.",
+          "env": "SHOPIFY_FLAG_NOTIFY",
+          "name": "notify",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "graphiql-port": {
+          "description": "Local port of the GraphiQL development server.",
+          "env": "SHOPIFY_FLAG_GRAPHIQL_PORT",
+          "hidden": true,
+          "name": "graphiql-port",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "graphiql-key": {
+          "description": "Key used to authenticate GraphiQL requests. By default, a key is automatically derived from the app secret. Use this flag to override with a custom key.",
+          "env": "SHOPIFY_FLAG_GRAPHIQL_KEY",
+          "hidden": true,
+          "name": "graphiql-key",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
         }
       },
       "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
+      "hiddenAliases": [],
       "id": "app:dev",
       "pluginAlias": "@shopify/cli",
       "pluginName": "@shopify/cli",
       "pluginType": "core",
       "strict": true,
-      "summary": "Run the app."
+      "summary": "Run the app.",
+      "descriptionWithMarkdown": "Builds and previews your app on a dev store, and watches for changes. [Read more about testing apps locally](https://shopify.dev/docs/apps/build/cli-for-apps/test-apps-locally).",
+      "customPluginName": "@shopify/app"
     },
     "app:dev:clean": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/app",
+      "aliases": [],
+      "args": {},
       "description": "Stop the dev preview that was started with `shopify app dev`.\n\n  It restores the app's active version to the selected development store.\n  ",
-      "descriptionWithMarkdown": "Stop the dev preview that was started with `shopify app dev`.\n\n  It restores the app's active version to the selected development store.\n  ",
       "flags": {
-        "client-id": {
-          "description": "The Client ID of your app.",
-          "env": "SHOPIFY_FLAG_CLIENT_ID",
-          "exclusive": [
-            "config"
-          ],
-          "hasDynamicHelp": false,
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
           "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path to your app directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "name": "path",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
           "multiple": false,
-          "name": "client-id",
           "type": "option"
         },
         "config": {
           "char": "c",
           "description": "The name of the app configuration.",
           "env": "SHOPIFY_FLAG_APP_CONFIG",
-          "hasDynamicHelp": false,
           "hidden": false,
-          "multiple": false,
           "name": "config",
+          "hasDynamicHelp": false,
+          "multiple": false,
           "type": "option"
         },
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
+        "client-id": {
+          "description": "The Client ID of your app.",
+          "env": "SHOPIFY_FLAG_CLIENT_ID",
+          "exclusive": [
+            "config"
+          ],
           "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
-        "path": {
-          "description": "The path to your app directory.",
-          "env": "SHOPIFY_FLAG_PATH",
+          "name": "client-id",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "path",
-          "noCacheDefault": true,
           "type": "option"
         },
         "reset": {
-          "allowNo": false,
           "description": "Reset all your settings.",
           "env": "SHOPIFY_FLAG_RESET",
           "exclusive": [
@@ -1141,96 +692,84 @@
           ],
           "hidden": false,
           "name": "reset",
+          "allowNo": false,
           "type": "boolean"
         },
         "store": {
           "char": "s",
           "description": "Store URL. Must be an existing development store.",
           "env": "SHOPIFY_FLAG_STORE",
-          "hasDynamicHelp": false,
           "hidden": false,
-          "multiple": false,
           "name": "store",
+          "hasDynamicHelp": false,
+          "multiple": false,
           "type": "option"
-        },
-        "verbose": {
-          "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
-          "type": "boolean"
         }
       },
       "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
+      "hiddenAliases": [],
       "id": "app:dev:clean",
       "pluginAlias": "@shopify/cli",
       "pluginName": "@shopify/cli",
       "pluginType": "core",
       "strict": true,
-      "summary": "Cleans up the dev preview from the selected store."
+      "summary": "Cleans up the dev preview from the selected store.",
+      "descriptionWithMarkdown": "Stop the dev preview that was started with `shopify app dev`.\n\n  It restores the app's active version to the selected development store.\n  ",
+      "customPluginName": "@shopify/app"
     },
-    "app:env:pull": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/app",
-      "description": "Creates or updates an `.env` files that contains app and app extension environment variables.\n\n  When an existing `.env` file is updated, changes to the variables are displayed in the terminal output. Existing variables and commented variables are preserved.",
-      "descriptionWithMarkdown": "Creates or updates an `.env` files that contains app and app extension environment variables.\n\n  When an existing `.env` file is updated, changes to the variables are displayed in the terminal output. Existing variables and commented variables are preserved.",
+    "app:logs": {
+      "aliases": [],
+      "args": {},
+      "description": "\n  Opens a real-time stream of detailed app logs from the selected app and store.\n  Use the `--source` argument to limit output to a particular log source, such as a specific Shopify Function handle. Use the `shopify app logs sources` command to view a list of sources.\n  Use the `--status` argument to filter on status, either `success` or `failure`.\n  ```\n  shopify app logs --status=success --source=extension.discount-function\n  ```\n  ",
       "flags": {
-        "client-id": {
-          "description": "The Client ID of your app.",
-          "env": "SHOPIFY_FLAG_CLIENT_ID",
-          "exclusive": [
-            "config"
-          ],
-          "hasDynamicHelp": false,
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
           "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path to your app directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "name": "path",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
           "multiple": false,
-          "name": "client-id",
           "type": "option"
         },
         "config": {
           "char": "c",
           "description": "The name of the app configuration.",
           "env": "SHOPIFY_FLAG_APP_CONFIG",
-          "hasDynamicHelp": false,
           "hidden": false,
-          "multiple": false,
           "name": "config",
-          "type": "option"
-        },
-        "env-file": {
-          "description": "Specify an environment file to update if the update flag is set",
-          "env": "SHOPIFY_FLAG_ENV_FILE",
-          "hasDynamicHelp": false,
-          "hidden": false,
-          "multiple": false,
-          "name": "env-file",
-          "type": "option"
-        },
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
-          "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
-        "path": {
-          "description": "The path to your app directory.",
-          "env": "SHOPIFY_FLAG_PATH",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "path",
-          "noCacheDefault": true,
+          "type": "option"
+        },
+        "client-id": {
+          "description": "The Client ID of your app.",
+          "env": "SHOPIFY_FLAG_CLIENT_ID",
+          "exclusive": [
+            "config"
+          ],
+          "hidden": false,
+          "name": "client-id",
+          "hasDynamicHelp": false,
+          "multiple": false,
           "type": "option"
         },
         "reset": {
-          "allowNo": false,
           "description": "Reset all your settings.",
           "env": "SHOPIFY_FLAG_RESET",
           "exclusive": [
@@ -1238,77 +777,1057 @@
           ],
           "hidden": false,
           "name": "reset",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "json": {
+          "char": "j",
+          "description": "Output the result as JSON. Automatically disables color output.",
+          "env": "SHOPIFY_FLAG_JSON",
+          "hidden": false,
+          "name": "json",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "store": {
+          "char": "s",
+          "description": "Store URL. Must be an existing development or Shopify Plus sandbox store.",
+          "env": "SHOPIFY_FLAG_STORE",
+          "name": "store",
+          "hasDynamicHelp": false,
+          "multiple": true,
+          "type": "option"
+        },
+        "source": {
+          "description": "Filters output to the specified log source.",
+          "env": "SHOPIFY_FLAG_SOURCE",
+          "name": "source",
+          "hasDynamicHelp": false,
+          "multiple": true,
+          "type": "option"
+        },
+        "status": {
+          "description": "Filters output to the specified status (success or failure).",
+          "env": "SHOPIFY_FLAG_STATUS",
+          "name": "status",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "options": [
+            "success",
+            "failure"
+          ],
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "app:logs",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "summary": "Stream detailed logs for your Shopify app.",
+      "descriptionWithMarkdown": "\n  Opens a real-time stream of detailed app logs from the selected app and store.\n  Use the `--source` argument to limit output to a particular log source, such as a specific Shopify Function handle. Use the `shopify app logs sources` command to view a list of sources.\n  Use the `--status` argument to filter on status, either `success` or `failure`.\n  ```\n  shopify app logs --status=success --source=extension.discount-function\n  ```\n  ",
+      "customPluginName": "@shopify/app"
+    },
+    "app:logs:sources": {
+      "aliases": [],
+      "args": {},
+      "description": "The output source names can be used with the `--source` argument of `shopify app logs` to filter log output. Currently only function extensions are supported as sources.",
+      "flags": {
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
           "type": "boolean"
         },
         "verbose": {
-          "allowNo": false,
           "description": "Increase the verbosity of the output.",
           "env": "SHOPIFY_FLAG_VERBOSE",
           "hidden": false,
           "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path to your app directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "name": "path",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "config": {
+          "char": "c",
+          "description": "The name of the app configuration.",
+          "env": "SHOPIFY_FLAG_APP_CONFIG",
+          "hidden": false,
+          "name": "config",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "client-id": {
+          "description": "The Client ID of your app.",
+          "env": "SHOPIFY_FLAG_CLIENT_ID",
+          "exclusive": [
+            "config"
+          ],
+          "hidden": false,
+          "name": "client-id",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "reset": {
+          "description": "Reset all your settings.",
+          "env": "SHOPIFY_FLAG_RESET",
+          "exclusive": [
+            "config"
+          ],
+          "hidden": false,
+          "name": "reset",
+          "allowNo": false,
           "type": "boolean"
         }
       },
       "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
+      "hiddenAliases": [],
+      "id": "app:logs:sources",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "summary": "Print out a list of sources that may be used with the logs command.",
+      "descriptionWithMarkdown": "The output source names can be used with the `--source` argument of `shopify app logs` to filter log output. Currently only function extensions are supported as sources.",
+      "customPluginName": "@shopify/app"
+    },
+    "app:import-custom-data-definitions": {
+      "aliases": [],
+      "args": {},
+      "description": "Import metafield and metaobject definitions from your development store. \"Read more about declarative custom data definitions\" (https://shopify.dev/docs/apps/build/custom-data/declarative-custom-data-definitions).",
+      "flags": {
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path to your app directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "name": "path",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "config": {
+          "char": "c",
+          "description": "The name of the app configuration.",
+          "env": "SHOPIFY_FLAG_APP_CONFIG",
+          "hidden": false,
+          "name": "config",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "client-id": {
+          "description": "The Client ID of your app.",
+          "env": "SHOPIFY_FLAG_CLIENT_ID",
+          "exclusive": [
+            "config"
+          ],
+          "hidden": false,
+          "name": "client-id",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "reset": {
+          "description": "Reset all your settings.",
+          "env": "SHOPIFY_FLAG_RESET",
+          "exclusive": [
+            "config"
+          ],
+          "hidden": false,
+          "name": "reset",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "store": {
+          "char": "s",
+          "description": "Store URL. Must be an existing development or Shopify Plus sandbox store.",
+          "env": "SHOPIFY_FLAG_STORE",
+          "name": "store",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "include-existing": {
+          "description": "Include existing declared definitions in the output.",
+          "env": "SHOPIFY_FLAG_INCLUDE_EXISTING",
+          "name": "include-existing",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "app:import-custom-data-definitions",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "summary": "Import metafield and metaobject definitions.",
+      "descriptionWithMarkdown": "Import metafield and metaobject definitions from your development store. [Read more about declarative custom data definitions](https://shopify.dev/docs/apps/build/custom-data/declarative-custom-data-definitions).",
+      "customPluginName": "@shopify/app"
+    },
+    "app:import-extensions": {
+      "aliases": [],
+      "args": {},
+      "description": "Import dashboard-managed extensions into your app.",
+      "flags": {
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path to your app directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "name": "path",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "config": {
+          "char": "c",
+          "description": "The name of the app configuration.",
+          "env": "SHOPIFY_FLAG_APP_CONFIG",
+          "hidden": false,
+          "name": "config",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "client-id": {
+          "description": "The Client ID of your app.",
+          "env": "SHOPIFY_FLAG_CLIENT_ID",
+          "exclusive": [
+            "config"
+          ],
+          "hidden": false,
+          "name": "client-id",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "reset": {
+          "description": "Reset all your settings.",
+          "env": "SHOPIFY_FLAG_RESET",
+          "exclusive": [
+            "config"
+          ],
+          "hidden": false,
+          "name": "reset",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "app:import-extensions",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "customPluginName": "@shopify/app"
+    },
+    "app:info": {
+      "aliases": [],
+      "args": {},
+      "description": "The information returned includes the following:\n\n  - The app and dev store that's used when you run the \"dev\" (https://shopify.dev/docs/api/shopify-cli/app/app-dev) command. You can reset these configurations using \"`dev --reset`\" (https://shopify.dev/docs/api/shopify-cli/app/app-dev#flags-propertydetail-reset).\n  - The \"structure\" (https://shopify.dev/docs/apps/tools/cli/structure) of your app project.\n  - The \"access scopes\" (https://shopify.dev/docs/api/usage) your app has requested.\n  - System information, including the package manager and version of Shopify CLI used in the project.",
+      "flags": {
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path to your app directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "name": "path",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "config": {
+          "char": "c",
+          "description": "The name of the app configuration.",
+          "env": "SHOPIFY_FLAG_APP_CONFIG",
+          "hidden": false,
+          "name": "config",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "client-id": {
+          "description": "The Client ID of your app.",
+          "env": "SHOPIFY_FLAG_CLIENT_ID",
+          "exclusive": [
+            "config"
+          ],
+          "hidden": false,
+          "name": "client-id",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "reset": {
+          "description": "Reset all your settings.",
+          "env": "SHOPIFY_FLAG_RESET",
+          "exclusive": [
+            "config"
+          ],
+          "hidden": false,
+          "name": "reset",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "json": {
+          "char": "j",
+          "description": "Output the result as JSON. Automatically disables color output.",
+          "env": "SHOPIFY_FLAG_JSON",
+          "hidden": false,
+          "name": "json",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "web-env": {
+          "description": "Outputs environment variables necessary for running and deploying web/.",
+          "env": "SHOPIFY_FLAG_OUTPUT_WEB_ENV",
+          "hidden": false,
+          "name": "web-env",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "app:info",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "summary": "Print basic information about your app and extensions.",
+      "descriptionWithMarkdown": "The information returned includes the following:\n\n  - The app and dev store that's used when you run the [dev](https://shopify.dev/docs/api/shopify-cli/app/app-dev) command. You can reset these configurations using [`dev --reset`](https://shopify.dev/docs/api/shopify-cli/app/app-dev#flags-propertydetail-reset).\n  - The [structure](https://shopify.dev/docs/apps/tools/cli/structure) of your app project.\n  - The [access scopes](https://shopify.dev/docs/api/usage) your app has requested.\n  - System information, including the package manager and version of Shopify CLI used in the project.",
+      "customPluginName": "@shopify/app"
+    },
+    "app:init": {
+      "aliases": [],
+      "args": {},
+      "flags": {
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "name": {
+          "char": "n",
+          "description": "The name for the new app. When provided, skips the app selection prompt and creates a new app with this name.",
+          "env": "SHOPIFY_FLAG_NAME",
+          "hidden": false,
+          "name": "name",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "path": {
+          "char": "p",
+          "env": "SHOPIFY_FLAG_PATH",
+          "hidden": false,
+          "name": "path",
+          "default": "/Users/brandonreid/src/github.com/Shopify/cli/packages/cli",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "template": {
+          "description": "The app template. Accepts one of the following:\n       - <reactRouter|none>\n       - Any GitHub repo with optional branch and subpath, e.g., https://github.com/Shopify/<repository>/[subpath]#[branch]",
+          "env": "SHOPIFY_FLAG_TEMPLATE",
+          "name": "template",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "flavor": {
+          "description": "Which flavor of the given template to use.",
+          "env": "SHOPIFY_FLAG_TEMPLATE_FLAVOR",
+          "name": "flavor",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "package-manager": {
+          "char": "d",
+          "env": "SHOPIFY_FLAG_PACKAGE_MANAGER",
+          "hidden": false,
+          "name": "package-manager",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "options": [
+            "npm",
+            "yarn",
+            "pnpm",
+            "bun"
+          ],
+          "type": "option"
+        },
+        "local": {
+          "char": "l",
+          "env": "SHOPIFY_FLAG_LOCAL",
+          "hidden": true,
+          "name": "local",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "client-id": {
+          "description": "The Client ID of your app. Use this to automatically link your new project to an existing app. Using this flag avoids the app selection prompt.",
+          "env": "SHOPIFY_FLAG_CLIENT_ID",
+          "exclusive": [
+            "config"
+          ],
+          "hidden": false,
+          "name": "client-id",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "organization-id": {
+          "description": "The organization ID. Your organization ID can be found in your Dev Dashboard URL: https://dev.shopify.com/dashboard/<organization-id>",
+          "env": "SHOPIFY_FLAG_ORGANIZATION_ID",
+          "exclusive": [
+            "client-id"
+          ],
+          "hidden": false,
+          "name": "organization-id",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "app:init",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "summary": "Create a new app project",
+      "customPluginName": "@shopify/app"
+    },
+    "app:config:validate": {
+      "aliases": [],
+      "args": {},
+      "description": "Validates the selected app configuration file and all extension configurations against their schemas and reports any errors found.",
+      "flags": {
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path to your app directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "name": "path",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "config": {
+          "char": "c",
+          "description": "The name of the app configuration.",
+          "env": "SHOPIFY_FLAG_APP_CONFIG",
+          "hidden": false,
+          "name": "config",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "client-id": {
+          "description": "The Client ID of your app.",
+          "env": "SHOPIFY_FLAG_CLIENT_ID",
+          "exclusive": [
+            "config"
+          ],
+          "hidden": false,
+          "name": "client-id",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "reset": {
+          "description": "Reset all your settings.",
+          "env": "SHOPIFY_FLAG_RESET",
+          "exclusive": [
+            "config"
+          ],
+          "hidden": false,
+          "name": "reset",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "json": {
+          "char": "j",
+          "description": "Output the result as JSON. Automatically disables color output.",
+          "env": "SHOPIFY_FLAG_JSON",
+          "hidden": false,
+          "name": "json",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "app:config:validate",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "summary": "Validate your app configuration and extensions.",
+      "descriptionWithMarkdown": "Validates the selected app configuration file and all extension configurations against their schemas and reports any errors found.",
+      "customPluginName": "@shopify/app"
+    },
+    "app:release": {
+      "aliases": [],
+      "args": {},
+      "description": "Releases an existing app version. Pass the name of the version that you want to release using the `--version` flag.",
+      "flags": {
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path to your app directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "name": "path",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "config": {
+          "char": "c",
+          "description": "The name of the app configuration.",
+          "env": "SHOPIFY_FLAG_APP_CONFIG",
+          "hidden": false,
+          "name": "config",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "client-id": {
+          "description": "The Client ID of your app.",
+          "env": "SHOPIFY_FLAG_CLIENT_ID",
+          "exclusive": [
+            "config"
+          ],
+          "hidden": false,
+          "name": "client-id",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "reset": {
+          "description": "Reset all your settings.",
+          "env": "SHOPIFY_FLAG_RESET",
+          "exclusive": [
+            "config"
+          ],
+          "hidden": false,
+          "name": "reset",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "force": {
+          "char": "f",
+          "description": "[Deprecated] Release without asking for confirmation. Equivalent to --allow-updates --allow-deletes. Use --allow-updates for CI/CD environments instead.",
+          "env": "SHOPIFY_FLAG_FORCE",
+          "hidden": false,
+          "name": "force",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "allow-updates": {
+          "description": "Allows adding and updating extensions and configuration without requiring user confirmation. Recommended option for CI/CD environments.",
+          "env": "SHOPIFY_FLAG_ALLOW_UPDATES",
+          "hidden": false,
+          "name": "allow-updates",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "allow-deletes": {
+          "description": "Allows removing extensions and configuration without requiring user confirmation. For CI/CD environments, the recommended flag is --allow-updates.",
+          "env": "SHOPIFY_FLAG_ALLOW_DELETES",
+          "hidden": false,
+          "name": "allow-deletes",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "version": {
+          "description": "The name of the app version to release.",
+          "env": "SHOPIFY_FLAG_VERSION",
+          "hidden": false,
+          "name": "version",
+          "required": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "app:release",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "summary": "Release an app version.",
+      "usage": "app release --version <version>",
+      "descriptionWithMarkdown": "Releases an existing app version. Pass the name of the version that you want to release using the `--version` flag.",
+      "customPluginName": "@shopify/app"
+    },
+    "app:config:link": {
+      "aliases": [],
+      "args": {},
+      "description": "Pulls app configuration from the Developer Dashboard and creates or overwrites a configuration file. You can create a new app with this command to start with a default configuration file.\n\n  For more information on the format of the created TOML configuration file, refer to the \"App configuration\" (https://shopify.dev/docs/apps/tools/cli/configuration) page.\n  ",
+      "flags": {
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path to your app directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "name": "path",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "config": {
+          "char": "c",
+          "description": "The name of the app configuration.",
+          "env": "SHOPIFY_FLAG_APP_CONFIG",
+          "hidden": false,
+          "name": "config",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "client-id": {
+          "description": "The Client ID of your app.",
+          "env": "SHOPIFY_FLAG_CLIENT_ID",
+          "exclusive": [
+            "config"
+          ],
+          "hidden": false,
+          "name": "client-id",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "reset": {
+          "description": "Reset all your settings.",
+          "env": "SHOPIFY_FLAG_RESET",
+          "exclusive": [
+            "config"
+          ],
+          "hidden": false,
+          "name": "reset",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "app:config:link",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "summary": "Fetch your app configuration from the Developer Dashboard.",
+      "descriptionWithMarkdown": "Pulls app configuration from the Developer Dashboard and creates or overwrites a configuration file. You can create a new app with this command to start with a default configuration file.\n\n  For more information on the format of the created TOML configuration file, refer to the [App configuration](https://shopify.dev/docs/apps/tools/cli/configuration) page.\n  ",
+      "customPluginName": "@shopify/app"
+    },
+    "app:config:use": {
+      "aliases": [],
+      "args": {
+        "config": {
+          "description": "The name of the app configuration. Can be 'shopify.app.staging.toml' or simply 'staging'.",
+          "name": "config"
+        }
+      },
+      "description": "Sets default configuration when you run app-related CLI commands. If you omit the `config-name` parameter, then you'll be prompted to choose from the configuration files in your project.",
+      "flags": {
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path to your app directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "name": "path",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "client-id": {
+          "description": "The Client ID of your app.",
+          "env": "SHOPIFY_FLAG_CLIENT_ID",
+          "exclusive": [
+            "config"
+          ],
+          "hidden": false,
+          "name": "client-id",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "reset": {
+          "description": "Reset all your settings.",
+          "env": "SHOPIFY_FLAG_RESET",
+          "exclusive": [
+            "config"
+          ],
+          "hidden": false,
+          "name": "reset",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "app:config:use",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "summary": "Activate an app configuration.",
+      "usage": "app config use [config] [flags]",
+      "descriptionWithMarkdown": "Sets default configuration when you run app-related CLI commands. If you omit the `config-name` parameter, then you'll be prompted to choose from the configuration files in your project.",
+      "customPluginName": "@shopify/app"
+    },
+    "app:config:pull": {
+      "aliases": [],
+      "args": {},
+      "description": "Pulls the latest configuration from the already-linked Shopify app and updates the selected configuration file.\n\nThis command reuses the existing linked app and organization and skips all interactive prompts. Use `--config` to target a specific configuration file, or omit it to use the default one.",
+      "flags": {
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path to your app directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "name": "path",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "config": {
+          "char": "c",
+          "description": "The name of the app configuration.",
+          "env": "SHOPIFY_FLAG_APP_CONFIG",
+          "hidden": false,
+          "name": "config",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "client-id": {
+          "description": "The Client ID of your app.",
+          "env": "SHOPIFY_FLAG_CLIENT_ID",
+          "exclusive": [
+            "config"
+          ],
+          "hidden": false,
+          "name": "client-id",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "reset": {
+          "description": "Reset all your settings.",
+          "env": "SHOPIFY_FLAG_RESET",
+          "exclusive": [
+            "config"
+          ],
+          "hidden": false,
+          "name": "reset",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "app:config:pull",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "summary": "Refresh an already-linked app configuration without prompts.",
+      "descriptionWithMarkdown": "Pulls the latest configuration from the already-linked Shopify app and updates the selected configuration file.\n\nThis command reuses the existing linked app and organization and skips all interactive prompts. Use `--config` to target a specific configuration file, or omit it to use the default one.",
+      "customPluginName": "@shopify/app"
+    },
+    "app:env:pull": {
+      "aliases": [],
+      "args": {},
+      "description": "Creates or updates an `.env` files that contains app and app extension environment variables.\n\n  When an existing `.env` file is updated, changes to the variables are displayed in the terminal output. Existing variables and commented variables are preserved.",
+      "flags": {
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path to your app directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "name": "path",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "config": {
+          "char": "c",
+          "description": "The name of the app configuration.",
+          "env": "SHOPIFY_FLAG_APP_CONFIG",
+          "hidden": false,
+          "name": "config",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "client-id": {
+          "description": "The Client ID of your app.",
+          "env": "SHOPIFY_FLAG_CLIENT_ID",
+          "exclusive": [
+            "config"
+          ],
+          "hidden": false,
+          "name": "client-id",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "reset": {
+          "description": "Reset all your settings.",
+          "env": "SHOPIFY_FLAG_RESET",
+          "exclusive": [
+            "config"
+          ],
+          "hidden": false,
+          "name": "reset",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "env-file": {
+          "description": "Specify an environment file to update if the update flag is set",
+          "env": "SHOPIFY_FLAG_ENV_FILE",
+          "hidden": false,
+          "name": "env-file",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
       "id": "app:env:pull",
       "pluginAlias": "@shopify/cli",
       "pluginName": "@shopify/cli",
       "pluginType": "core",
       "strict": true,
-      "summary": "Pull app and extensions environment variables."
+      "summary": "Pull app and extensions environment variables.",
+      "descriptionWithMarkdown": "Creates or updates an `.env` files that contains app and app extension environment variables.\n\n  When an existing `.env` file is updated, changes to the variables are displayed in the terminal output. Existing variables and commented variables are preserved.",
+      "customPluginName": "@shopify/app"
     },
     "app:env:show": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/app",
+      "aliases": [],
+      "args": {},
       "description": "Displays environment variables that can be used to deploy apps and app extensions.",
-      "descriptionWithMarkdown": "Displays environment variables that can be used to deploy apps and app extensions.",
       "flags": {
-        "client-id": {
-          "description": "The Client ID of your app.",
-          "env": "SHOPIFY_FLAG_CLIENT_ID",
-          "exclusive": [
-            "config"
-          ],
-          "hasDynamicHelp": false,
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
           "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path to your app directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "name": "path",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
           "multiple": false,
-          "name": "client-id",
           "type": "option"
         },
         "config": {
           "char": "c",
           "description": "The name of the app configuration.",
           "env": "SHOPIFY_FLAG_APP_CONFIG",
-          "hasDynamicHelp": false,
           "hidden": false,
-          "multiple": false,
           "name": "config",
+          "hasDynamicHelp": false,
+          "multiple": false,
           "type": "option"
         },
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
+        "client-id": {
+          "description": "The Client ID of your app.",
+          "env": "SHOPIFY_FLAG_CLIENT_ID",
+          "exclusive": [
+            "config"
+          ],
           "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
-        "path": {
-          "description": "The path to your app directory.",
-          "env": "SHOPIFY_FLAG_PATH",
+          "name": "client-id",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "path",
-          "noCacheDefault": true,
           "type": "option"
         },
         "reset": {
-          "allowNo": false,
           "description": "Reset all your settings.",
           "env": "SHOPIFY_FLAG_RESET",
           "exclusive": [
@@ -1316,103 +1835,74 @@
           ],
           "hidden": false,
           "name": "reset",
-          "type": "boolean"
-        },
-        "verbose": {
           "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
           "type": "boolean"
         }
       },
       "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
+      "hiddenAliases": [],
       "id": "app:env:show",
       "pluginAlias": "@shopify/cli",
       "pluginName": "@shopify/cli",
       "pluginType": "core",
       "strict": true,
-      "summary": "Display app and extensions environment variables."
+      "summary": "Display app and extensions environment variables.",
+      "descriptionWithMarkdown": "Displays environment variables that can be used to deploy apps and app extensions.",
+      "customPluginName": "@shopify/app"
     },
     "app:execute": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/app",
+      "aliases": [],
+      "args": {},
       "description": "Executes an Admin API GraphQL query or mutation on the specified store. Mutations are only allowed on dev stores.\n\n  For operations that process large amounts of data, use \"`bulk execute`\" (https://shopify.dev/docs/api/shopify-cli/app/app-bulk-execute) instead.",
-      "descriptionWithMarkdown": "Executes an Admin API GraphQL query or mutation on the specified store. Mutations are only allowed on dev stores.\n\n  For operations that process large amounts of data, use [`bulk execute`](https://shopify.dev/docs/api/shopify-cli/app/app-bulk-execute) instead.",
       "flags": {
-        "client-id": {
-          "description": "The Client ID of your app.",
-          "env": "SHOPIFY_FLAG_CLIENT_ID",
-          "exclusive": [
-            "config"
-          ],
-          "hasDynamicHelp": false,
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
           "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path to your app directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "name": "path",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
           "multiple": false,
-          "name": "client-id",
           "type": "option"
         },
         "config": {
           "char": "c",
           "description": "The name of the app configuration.",
           "env": "SHOPIFY_FLAG_APP_CONFIG",
-          "hasDynamicHelp": false,
           "hidden": false,
-          "multiple": false,
           "name": "config",
+          "hasDynamicHelp": false,
+          "multiple": false,
           "type": "option"
         },
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
+        "client-id": {
+          "description": "The Client ID of your app.",
+          "env": "SHOPIFY_FLAG_CLIENT_ID",
+          "exclusive": [
+            "config"
+          ],
           "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
-        "output-file": {
-          "description": "The file name where results should be written, instead of STDOUT.",
-          "env": "SHOPIFY_FLAG_OUTPUT_FILE",
+          "name": "client-id",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "output-file",
-          "type": "option"
-        },
-        "path": {
-          "description": "The path to your app directory.",
-          "env": "SHOPIFY_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "path",
-          "noCacheDefault": true,
-          "type": "option"
-        },
-        "query": {
-          "char": "q",
-          "description": "The GraphQL query or mutation, as a string.",
-          "env": "SHOPIFY_FLAG_QUERY",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "query",
-          "required": false,
-          "type": "option"
-        },
-        "query-file": {
-          "description": "Path to a file containing the GraphQL query or mutation. Can't be used with --query.",
-          "env": "SHOPIFY_FLAG_QUERY_FILE",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "query-file",
           "type": "option"
         },
         "reset": {
-          "allowNo": false,
           "description": "Reset all your settings.",
           "env": "SHOPIFY_FLAG_RESET",
           "exclusive": [
@@ -1420,26 +1910,25 @@
           ],
           "hidden": false,
           "name": "reset",
+          "allowNo": false,
           "type": "boolean"
         },
-        "store": {
-          "char": "s",
-          "description": "The myshopify.com domain of the store to execute against. The app must be installed on the store. If not specified, you will be prompted to select a store.",
-          "env": "SHOPIFY_FLAG_STORE",
+        "query": {
+          "char": "q",
+          "description": "The GraphQL query or mutation, as a string.",
+          "env": "SHOPIFY_FLAG_QUERY",
+          "name": "query",
+          "required": false,
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "store",
           "type": "option"
         },
-        "variable-file": {
-          "description": "Path to a file containing GraphQL variables in JSON format. Can't be used with --variables.",
-          "env": "SHOPIFY_FLAG_VARIABLE_FILE",
-          "exclusive": [
-            "variables"
-          ],
+        "query-file": {
+          "description": "Path to a file containing the GraphQL query or mutation. Can't be used with --query.",
+          "env": "SHOPIFY_FLAG_QUERY_FILE",
+          "name": "query-file",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "variable-file",
           "type": "option"
         },
         "variables": {
@@ -1449,89 +1938,112 @@
           "exclusive": [
             "variable-file"
           ],
+          "name": "variables",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "variables",
           "type": "option"
         },
-        "verbose": {
-          "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
-          "type": "boolean"
+        "variable-file": {
+          "description": "Path to a file containing GraphQL variables in JSON format. Can't be used with --variables.",
+          "env": "SHOPIFY_FLAG_VARIABLE_FILE",
+          "exclusive": [
+            "variables"
+          ],
+          "name": "variable-file",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "store": {
+          "char": "s",
+          "description": "The myshopify.com domain of the store to execute against. The app must be installed on the store. If not specified, you will be prompted to select a store.",
+          "env": "SHOPIFY_FLAG_STORE",
+          "name": "store",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
         },
         "version": {
           "description": "The API version to use for the query or mutation. Defaults to the latest stable version.",
           "env": "SHOPIFY_FLAG_VERSION",
+          "name": "version",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "version",
+          "type": "option"
+        },
+        "output-file": {
+          "description": "The file name where results should be written, instead of STDOUT.",
+          "env": "SHOPIFY_FLAG_OUTPUT_FILE",
+          "name": "output-file",
+          "hasDynamicHelp": false,
+          "multiple": false,
           "type": "option"
         }
       },
       "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
+      "hiddenAliases": [],
       "id": "app:execute",
       "pluginAlias": "@shopify/cli",
       "pluginName": "@shopify/cli",
       "pluginType": "core",
       "strict": true,
-      "summary": "Execute GraphQL queries and mutations."
+      "summary": "Execute GraphQL queries and mutations.",
+      "descriptionWithMarkdown": "Executes an Admin API GraphQL query or mutation on the specified store. Mutations are only allowed on dev stores.\n\n  For operations that process large amounts of data, use [`bulk execute`](https://shopify.dev/docs/api/shopify-cli/app/app-bulk-execute) instead.",
+      "customPluginName": "@shopify/app"
     },
-    "app:function:build": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/app",
-      "description": "Compiles the function in your current directory to WebAssembly (Wasm) for testing purposes.",
-      "descriptionWithMarkdown": "Compiles the function in your current directory to WebAssembly (Wasm) for testing purposes.",
+    "app:bulk:execute": {
+      "aliases": [],
+      "args": {},
+      "description": "Executes an Admin API GraphQL query or mutation on the specified store, as a bulk operation. Mutations are only allowed on dev stores.\n\n  Bulk operations allow you to process large amounts of data asynchronously. Learn more about \"bulk query operations\" (https://shopify.dev/docs/api/usage/bulk-operations/queries) and \"bulk mutation operations\" (https://shopify.dev/docs/api/usage/bulk-operations/imports).\n\n  Use \"`bulk status`\" (https://shopify.dev/docs/api/shopify-cli/app/app-bulk-status) to check the status of your bulk operations.",
       "flags": {
-        "client-id": {
-          "description": "The Client ID of your app.",
-          "env": "SHOPIFY_FLAG_CLIENT_ID",
-          "exclusive": [
-            "config"
-          ],
-          "hasDynamicHelp": false,
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
           "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path to your app directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "name": "path",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
           "multiple": false,
-          "name": "client-id",
           "type": "option"
         },
         "config": {
           "char": "c",
           "description": "The name of the app configuration.",
           "env": "SHOPIFY_FLAG_APP_CONFIG",
-          "hasDynamicHelp": false,
           "hidden": false,
-          "multiple": false,
           "name": "config",
+          "hasDynamicHelp": false,
+          "multiple": false,
           "type": "option"
         },
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
+        "client-id": {
+          "description": "The Client ID of your app.",
+          "env": "SHOPIFY_FLAG_CLIENT_ID",
+          "exclusive": [
+            "config"
+          ],
           "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
-        "path": {
-          "description": "The path to your function directory.",
-          "env": "SHOPIFY_FLAG_PATH",
+          "name": "client-id",
           "hasDynamicHelp": false,
-          "hidden": false,
           "multiple": false,
-          "name": "path",
-          "noCacheDefault": true,
           "type": "option"
         },
         "reset": {
-          "allowNo": false,
           "description": "Reset all your settings.",
           "env": "SHOPIFY_FLAG_RESET",
           "exclusive": [
@@ -1539,87 +2051,311 @@
           ],
           "hidden": false,
           "name": "reset",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "query": {
+          "char": "q",
+          "description": "The GraphQL query or mutation to run as a bulk operation.",
+          "env": "SHOPIFY_FLAG_QUERY",
+          "name": "query",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "query-file": {
+          "description": "Path to a file containing the GraphQL query or mutation. Can't be used with --query.",
+          "env": "SHOPIFY_FLAG_QUERY_FILE",
+          "name": "query-file",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "variables": {
+          "char": "v",
+          "description": "The values for any GraphQL variables in your mutation, in JSON format. Can be specified multiple times.",
+          "env": "SHOPIFY_FLAG_VARIABLES",
+          "exclusive": [
+            "variable-file"
+          ],
+          "name": "variables",
+          "hasDynamicHelp": false,
+          "multiple": true,
+          "type": "option"
+        },
+        "variable-file": {
+          "description": "Path to a file containing GraphQL variables in JSONL format (one JSON object per line). Can't be used with --variables.",
+          "env": "SHOPIFY_FLAG_VARIABLE_FILE",
+          "exclusive": [
+            "variables"
+          ],
+          "name": "variable-file",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "store": {
+          "char": "s",
+          "description": "The store domain. Must be an existing dev store.",
+          "env": "SHOPIFY_FLAG_STORE",
+          "name": "store",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "watch": {
+          "description": "Wait for bulk operation results before exiting. Defaults to false.",
+          "env": "SHOPIFY_FLAG_WATCH",
+          "name": "watch",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "output-file": {
+          "dependsOn": [
+            "watch"
+          ],
+          "description": "The file path where results should be written if --watch is specified. If not specified, results will be written to STDOUT.",
+          "env": "SHOPIFY_FLAG_OUTPUT_FILE",
+          "name": "output-file",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "version": {
+          "description": "The API version to use for the bulk operation. If not specified, uses the latest stable version.",
+          "env": "SHOPIFY_FLAG_VERSION",
+          "name": "version",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "app:bulk:execute",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "summary": "Execute bulk operations.",
+      "descriptionWithMarkdown": "Executes an Admin API GraphQL query or mutation on the specified store, as a bulk operation. Mutations are only allowed on dev stores.\n\n  Bulk operations allow you to process large amounts of data asynchronously. Learn more about [bulk query operations](https://shopify.dev/docs/api/usage/bulk-operations/queries) and [bulk mutation operations](https://shopify.dev/docs/api/usage/bulk-operations/imports).\n\n  Use [`bulk status`](https://shopify.dev/docs/api/shopify-cli/app/app-bulk-status) to check the status of your bulk operations.",
+      "customPluginName": "@shopify/app"
+    },
+    "app:generate:schema": {
+      "aliases": [],
+      "args": {},
+      "description": "\"DEPRECATED, use `app function schema`] Generates the latest [GraphQL schema\" (https://shopify.dev/docs/apps/functions/input-output#graphql-schema) for a function in your app. Run this command from the function directory.\n\n  This command uses the API type and version of your function, as defined in your extension TOML file, to generate the latest GraphQL schema. The schema is written to the `schema.graphql` file.",
+      "flags": {
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
           "type": "boolean"
         },
         "verbose": {
-          "allowNo": false,
           "description": "Increase the verbosity of the output.",
           "env": "SHOPIFY_FLAG_VERBOSE",
           "hidden": false,
           "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path to your function directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "hidden": false,
+          "name": "path",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "config": {
+          "char": "c",
+          "description": "The name of the app configuration.",
+          "env": "SHOPIFY_FLAG_APP_CONFIG",
+          "hidden": false,
+          "name": "config",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "client-id": {
+          "description": "The Client ID of your app.",
+          "env": "SHOPIFY_FLAG_CLIENT_ID",
+          "exclusive": [
+            "config"
+          ],
+          "hidden": false,
+          "name": "client-id",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "reset": {
+          "description": "Reset all your settings.",
+          "env": "SHOPIFY_FLAG_RESET",
+          "exclusive": [
+            "config"
+          ],
+          "hidden": false,
+          "name": "reset",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "stdout": {
+          "description": "Output the schema to stdout instead of writing to a file.",
+          "env": "SHOPIFY_FLAG_STDOUT",
+          "name": "stdout",
+          "required": false,
+          "allowNo": false,
           "type": "boolean"
         }
       },
       "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
+      "hidden": true,
+      "hiddenAliases": [],
+      "id": "app:generate:schema",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "summary": "Fetch the latest GraphQL schema for a function.",
+      "descriptionWithMarkdown": "[DEPRECATED, use `app function schema`] Generates the latest [GraphQL schema](https://shopify.dev/docs/apps/functions/input-output#graphql-schema) for a function in your app. Run this command from the function directory.\n\n  This command uses the API type and version of your function, as defined in your extension TOML file, to generate the latest GraphQL schema. The schema is written to the `schema.graphql` file.",
+      "customPluginName": "@shopify/app"
+    },
+    "app:function:build": {
+      "aliases": [],
+      "args": {},
+      "description": "Compiles the function in your current directory to WebAssembly (Wasm) for testing purposes.",
+      "flags": {
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path to your function directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "hidden": false,
+          "name": "path",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "config": {
+          "char": "c",
+          "description": "The name of the app configuration.",
+          "env": "SHOPIFY_FLAG_APP_CONFIG",
+          "hidden": false,
+          "name": "config",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "client-id": {
+          "description": "The Client ID of your app.",
+          "env": "SHOPIFY_FLAG_CLIENT_ID",
+          "exclusive": [
+            "config"
+          ],
+          "hidden": false,
+          "name": "client-id",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "reset": {
+          "description": "Reset all your settings.",
+          "env": "SHOPIFY_FLAG_RESET",
+          "exclusive": [
+            "config"
+          ],
+          "hidden": false,
+          "name": "reset",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
       "id": "app:function:build",
       "pluginAlias": "@shopify/cli",
       "pluginName": "@shopify/cli",
       "pluginType": "core",
       "strict": true,
-      "summary": "Compile a function to wasm."
+      "summary": "Compile a function to wasm.",
+      "descriptionWithMarkdown": "Compiles the function in your current directory to WebAssembly (Wasm) for testing purposes.",
+      "customPluginName": "@shopify/app"
     },
-    "app:function:info": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/app",
-      "description": "The information returned includes the following:\n\n  - The function handle\n  - The function name\n  - The function API version\n  - The targeting configuration\n  - The schema path\n  - The WASM path\n  - The function runner path",
-      "descriptionWithMarkdown": "The information returned includes the following:\n\n  - The function handle\n  - The function name\n  - The function API version\n  - The targeting configuration\n  - The schema path\n  - The WASM path\n  - The function runner path",
+    "app:function:replay": {
+      "aliases": [],
+      "args": {},
+      "description": "Runs the function from your current directory for \"testing purposes\" (https://shopify.dev/docs/apps/functions/testing-and-debugging). To learn how you can monitor and debug functions when errors occur, refer to \"Shopify Functions error handling\" (https://shopify.dev/docs/api/functions/errors).",
       "flags": {
-        "client-id": {
-          "description": "The Client ID of your app.",
-          "env": "SHOPIFY_FLAG_CLIENT_ID",
-          "exclusive": [
-            "config"
-          ],
-          "hasDynamicHelp": false,
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
           "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path to your function directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "hidden": false,
+          "name": "path",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
           "multiple": false,
-          "name": "client-id",
           "type": "option"
         },
         "config": {
           "char": "c",
           "description": "The name of the app configuration.",
           "env": "SHOPIFY_FLAG_APP_CONFIG",
-          "hasDynamicHelp": false,
           "hidden": false,
-          "multiple": false,
           "name": "config",
+          "hasDynamicHelp": false,
+          "multiple": false,
           "type": "option"
         },
-        "json": {
-          "allowNo": false,
-          "char": "j",
-          "description": "Output the result as JSON. Automatically disables color output.",
-          "env": "SHOPIFY_FLAG_JSON",
+        "client-id": {
+          "description": "The Client ID of your app.",
+          "env": "SHOPIFY_FLAG_CLIENT_ID",
+          "exclusive": [
+            "config"
+          ],
           "hidden": false,
-          "name": "json",
-          "type": "boolean"
-        },
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
-          "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
-        "path": {
-          "description": "The path to your function directory.",
-          "env": "SHOPIFY_FLAG_PATH",
+          "name": "client-id",
           "hasDynamicHelp": false,
-          "hidden": false,
           "multiple": false,
-          "name": "path",
-          "noCacheDefault": true,
           "type": "option"
         },
         "reset": {
-          "allowNo": false,
           "description": "Reset all your settings.",
           "env": "SHOPIFY_FLAG_RESET",
           "exclusive": [
@@ -1627,96 +2363,102 @@
           ],
           "hidden": false,
           "name": "reset",
-          "type": "boolean"
-        },
-        "verbose": {
           "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
           "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "app:function:info",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true,
-      "summary": "Print basic information about your function."
-    },
-    "app:function:replay": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/app",
-      "description": "Runs the function from your current directory for \"testing purposes\" (https://shopify.dev/docs/apps/functions/testing-and-debugging). To learn how you can monitor and debug functions when errors occur, refer to \"Shopify Functions error handling\" (https://shopify.dev/docs/api/functions/errors).",
-      "descriptionWithMarkdown": "Runs the function from your current directory for [testing purposes](https://shopify.dev/docs/apps/functions/testing-and-debugging). To learn how you can monitor and debug functions when errors occur, refer to [Shopify Functions error handling](https://shopify.dev/docs/api/functions/errors).",
-      "flags": {
-        "client-id": {
-          "description": "The Client ID of your app.",
-          "env": "SHOPIFY_FLAG_CLIENT_ID",
-          "exclusive": [
-            "config"
-          ],
-          "hasDynamicHelp": false,
-          "hidden": false,
-          "multiple": false,
-          "name": "client-id",
-          "type": "option"
-        },
-        "config": {
-          "char": "c",
-          "description": "The name of the app configuration.",
-          "env": "SHOPIFY_FLAG_APP_CONFIG",
-          "hasDynamicHelp": false,
-          "hidden": false,
-          "multiple": false,
-          "name": "config",
-          "type": "option"
         },
         "json": {
-          "allowNo": false,
           "char": "j",
           "description": "Output the result as JSON. Automatically disables color output.",
           "env": "SHOPIFY_FLAG_JSON",
           "hidden": false,
           "name": "json",
+          "allowNo": false,
           "type": "boolean"
         },
         "log": {
           "char": "l",
           "description": "Specifies a log identifier to replay instead of selecting from a list. The identifier is provided in the output of `shopify app dev` and is the suffix of the log file name.",
           "env": "SHOPIFY_FLAG_LOG",
+          "name": "log",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "log",
           "type": "option"
         },
+        "watch": {
+          "char": "w",
+          "description": "Re-run the function when the source code changes.",
+          "env": "SHOPIFY_FLAG_WATCH",
+          "hidden": false,
+          "name": "watch",
+          "allowNo": true,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "app:function:replay",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "summary": "Replays a function run from an app log.",
+      "descriptionWithMarkdown": "Runs the function from your current directory for [testing purposes](https://shopify.dev/docs/apps/functions/testing-and-debugging). To learn how you can monitor and debug functions when errors occur, refer to [Shopify Functions error handling](https://shopify.dev/docs/api/functions/errors).",
+      "customPluginName": "@shopify/app"
+    },
+    "app:function:run": {
+      "aliases": [],
+      "args": {},
+      "description": "Runs the function from your current directory for \"testing purposes\" (https://shopify.dev/docs/apps/functions/testing-and-debugging). To learn how you can monitor and debug functions when errors occur, refer to \"Shopify Functions error handling\" (https://shopify.dev/docs/api/functions/errors).",
+      "flags": {
         "no-color": {
-          "allowNo": false,
           "description": "Disable color output.",
           "env": "SHOPIFY_FLAG_NO_COLOR",
           "hidden": false,
           "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
           "type": "boolean"
         },
         "path": {
           "description": "The path to your function directory.",
           "env": "SHOPIFY_FLAG_PATH",
-          "hasDynamicHelp": false,
           "hidden": false,
-          "multiple": false,
           "name": "path",
           "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "config": {
+          "char": "c",
+          "description": "The name of the app configuration.",
+          "env": "SHOPIFY_FLAG_APP_CONFIG",
+          "hidden": false,
+          "name": "config",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "client-id": {
+          "description": "The Client ID of your app.",
+          "env": "SHOPIFY_FLAG_CLIENT_ID",
+          "exclusive": [
+            "config"
+          ],
+          "hidden": false,
+          "name": "client-id",
+          "hasDynamicHelp": false,
+          "multiple": false,
           "type": "option"
         },
         "reset": {
-          "allowNo": false,
           "description": "Reset all your settings.",
           "env": "SHOPIFY_FLAG_RESET",
           "exclusive": [
@@ -1724,194 +2466,103 @@
           ],
           "hidden": false,
           "name": "reset",
-          "type": "boolean"
-        },
-        "verbose": {
           "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
           "type": "boolean"
         },
-        "watch": {
-          "allowNo": true,
-          "char": "w",
-          "description": "Re-run the function when the source code changes.",
-          "env": "SHOPIFY_FLAG_WATCH",
+        "json": {
+          "char": "j",
+          "description": "Output the result as JSON. Automatically disables color output.",
+          "env": "SHOPIFY_FLAG_JSON",
           "hidden": false,
-          "name": "watch",
+          "name": "json",
+          "allowNo": false,
           "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "app:function:replay",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true,
-      "summary": "Replays a function run from an app log."
-    },
-    "app:function:run": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/app",
-      "description": "Runs the function from your current directory for \"testing purposes\" (https://shopify.dev/docs/apps/functions/testing-and-debugging). To learn how you can monitor and debug functions when errors occur, refer to \"Shopify Functions error handling\" (https://shopify.dev/docs/api/functions/errors).",
-      "descriptionWithMarkdown": "Runs the function from your current directory for [testing purposes](https://shopify.dev/docs/apps/functions/testing-and-debugging). To learn how you can monitor and debug functions when errors occur, refer to [Shopify Functions error handling](https://shopify.dev/docs/api/functions/errors).",
-      "flags": {
-        "client-id": {
-          "description": "The Client ID of your app.",
-          "env": "SHOPIFY_FLAG_CLIENT_ID",
-          "exclusive": [
-            "config"
-          ],
-          "hasDynamicHelp": false,
-          "hidden": false,
-          "multiple": false,
-          "name": "client-id",
-          "type": "option"
         },
-        "config": {
-          "char": "c",
-          "description": "The name of the app configuration.",
-          "env": "SHOPIFY_FLAG_APP_CONFIG",
+        "input": {
+          "char": "i",
+          "description": "The input JSON to pass to the function. If omitted, standard input is used.",
+          "env": "SHOPIFY_FLAG_INPUT",
+          "name": "input",
           "hasDynamicHelp": false,
-          "hidden": false,
           "multiple": false,
-          "name": "config",
           "type": "option"
         },
         "export": {
           "char": "e",
           "description": "Name of the WebAssembly export to invoke.",
           "env": "SHOPIFY_FLAG_EXPORT",
-          "hasDynamicHelp": false,
           "hidden": false,
-          "multiple": false,
           "name": "export",
-          "type": "option"
-        },
-        "input": {
-          "char": "i",
-          "description": "The input JSON to pass to the function. If omitted, standard input is used.",
-          "env": "SHOPIFY_FLAG_INPUT",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "input",
           "type": "option"
-        },
-        "json": {
-          "allowNo": false,
-          "char": "j",
-          "description": "Output the result as JSON. Automatically disables color output.",
-          "env": "SHOPIFY_FLAG_JSON",
-          "hidden": false,
-          "name": "json",
-          "type": "boolean"
-        },
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
-          "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
-        "path": {
-          "description": "The path to your function directory.",
-          "env": "SHOPIFY_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "hidden": false,
-          "multiple": false,
-          "name": "path",
-          "noCacheDefault": true,
-          "type": "option"
-        },
-        "reset": {
-          "allowNo": false,
-          "description": "Reset all your settings.",
-          "env": "SHOPIFY_FLAG_RESET",
-          "exclusive": [
-            "config"
-          ],
-          "hidden": false,
-          "name": "reset",
-          "type": "boolean"
-        },
-        "verbose": {
-          "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
-          "type": "boolean"
         }
       },
       "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
+      "hiddenAliases": [],
       "id": "app:function:run",
       "pluginAlias": "@shopify/cli",
       "pluginName": "@shopify/cli",
       "pluginType": "core",
       "strict": true,
-      "summary": "Run a function locally for testing."
+      "summary": "Run a function locally for testing.",
+      "descriptionWithMarkdown": "Runs the function from your current directory for [testing purposes](https://shopify.dev/docs/apps/functions/testing-and-debugging). To learn how you can monitor and debug functions when errors occur, refer to [Shopify Functions error handling](https://shopify.dev/docs/api/functions/errors).",
+      "customPluginName": "@shopify/app"
     },
-    "app:function:schema": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/app",
-      "description": "Generates the latest \"GraphQL schema\" (https://shopify.dev/docs/apps/functions/input-output#graphql-schema) for a function in your app. Run this command from the function directory.\n\n  This command uses the API type and version of your function, as defined in your extension TOML file, to generate the latest GraphQL schema. The schema is written to the `schema.graphql` file.",
-      "descriptionWithMarkdown": "Generates the latest [GraphQL schema](https://shopify.dev/docs/apps/functions/input-output#graphql-schema) for a function in your app. Run this command from the function directory.\n\n  This command uses the API type and version of your function, as defined in your extension TOML file, to generate the latest GraphQL schema. The schema is written to the `schema.graphql` file.",
+    "app:function:info": {
+      "aliases": [],
+      "args": {},
+      "description": "The information returned includes the following:\n\n  - The function handle\n  - The function name\n  - The function API version\n  - The targeting configuration\n  - The schema path\n  - The WASM path\n  - The function runner path",
       "flags": {
-        "client-id": {
-          "description": "The Client ID of your app.",
-          "env": "SHOPIFY_FLAG_CLIENT_ID",
-          "exclusive": [
-            "config"
-          ],
-          "hasDynamicHelp": false,
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
           "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path to your function directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "hidden": false,
+          "name": "path",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
           "multiple": false,
-          "name": "client-id",
           "type": "option"
         },
         "config": {
           "char": "c",
           "description": "The name of the app configuration.",
           "env": "SHOPIFY_FLAG_APP_CONFIG",
-          "hasDynamicHelp": false,
           "hidden": false,
-          "multiple": false,
           "name": "config",
+          "hasDynamicHelp": false,
+          "multiple": false,
           "type": "option"
         },
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
+        "client-id": {
+          "description": "The Client ID of your app.",
+          "env": "SHOPIFY_FLAG_CLIENT_ID",
+          "exclusive": [
+            "config"
+          ],
           "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
-        "path": {
-          "description": "The path to your function directory.",
-          "env": "SHOPIFY_FLAG_PATH",
+          "name": "client-id",
           "hasDynamicHelp": false,
-          "hidden": false,
           "multiple": false,
-          "name": "path",
-          "noCacheDefault": true,
           "type": "option"
         },
         "reset": {
-          "allowNo": false,
           "description": "Reset all your settings.",
           "env": "SHOPIFY_FLAG_RESET",
           "exclusive": [
@@ -1919,86 +2570,168 @@
           ],
           "hidden": false,
           "name": "reset",
+          "allowNo": false,
           "type": "boolean"
         },
-        "stdout": {
-          "allowNo": false,
-          "description": "Output the schema to stdout instead of writing to a file.",
-          "env": "SHOPIFY_FLAG_STDOUT",
-          "name": "stdout",
-          "required": false,
-          "type": "boolean"
-        },
-        "verbose": {
-          "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
+        "json": {
+          "char": "j",
+          "description": "Output the result as JSON. Automatically disables color output.",
+          "env": "SHOPIFY_FLAG_JSON",
           "hidden": false,
-          "name": "verbose",
+          "name": "json",
+          "allowNo": false,
           "type": "boolean"
         }
       },
       "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
+      "hiddenAliases": [],
+      "id": "app:function:info",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "summary": "Print basic information about your function.",
+      "descriptionWithMarkdown": "The information returned includes the following:\n\n  - The function handle\n  - The function name\n  - The function API version\n  - The targeting configuration\n  - The schema path\n  - The WASM path\n  - The function runner path",
+      "customPluginName": "@shopify/app"
+    },
+    "app:function:schema": {
+      "aliases": [],
+      "args": {},
+      "description": "Generates the latest \"GraphQL schema\" (https://shopify.dev/docs/apps/functions/input-output#graphql-schema) for a function in your app. Run this command from the function directory.\n\n  This command uses the API type and version of your function, as defined in your extension TOML file, to generate the latest GraphQL schema. The schema is written to the `schema.graphql` file.",
+      "flags": {
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path to your function directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "hidden": false,
+          "name": "path",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "config": {
+          "char": "c",
+          "description": "The name of the app configuration.",
+          "env": "SHOPIFY_FLAG_APP_CONFIG",
+          "hidden": false,
+          "name": "config",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "client-id": {
+          "description": "The Client ID of your app.",
+          "env": "SHOPIFY_FLAG_CLIENT_ID",
+          "exclusive": [
+            "config"
+          ],
+          "hidden": false,
+          "name": "client-id",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "reset": {
+          "description": "Reset all your settings.",
+          "env": "SHOPIFY_FLAG_RESET",
+          "exclusive": [
+            "config"
+          ],
+          "hidden": false,
+          "name": "reset",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "stdout": {
+          "description": "Output the schema to stdout instead of writing to a file.",
+          "env": "SHOPIFY_FLAG_STDOUT",
+          "name": "stdout",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
       "id": "app:function:schema",
       "pluginAlias": "@shopify/cli",
       "pluginName": "@shopify/cli",
       "pluginType": "core",
       "strict": true,
-      "summary": "Fetch the latest GraphQL schema for a function."
+      "summary": "Fetch the latest GraphQL schema for a function.",
+      "descriptionWithMarkdown": "Generates the latest [GraphQL schema](https://shopify.dev/docs/apps/functions/input-output#graphql-schema) for a function in your app. Run this command from the function directory.\n\n  This command uses the API type and version of your function, as defined in your extension TOML file, to generate the latest GraphQL schema. The schema is written to the `schema.graphql` file.",
+      "customPluginName": "@shopify/app"
     },
     "app:function:typegen": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/app",
+      "aliases": [],
+      "args": {},
       "description": "Creates GraphQL types based on your \"input query\" (https://shopify.dev/docs/apps/functions/input-output#input) for a function. Supports JavaScript functions out of the box, or any language via the `build.typegen_command` configuration.",
-      "descriptionWithMarkdown": "Creates GraphQL types based on your [input query](https://shopify.dev/docs/apps/functions/input-output#input) for a function. Supports JavaScript functions out of the box, or any language via the `build.typegen_command` configuration.",
       "flags": {
-        "client-id": {
-          "description": "The Client ID of your app.",
-          "env": "SHOPIFY_FLAG_CLIENT_ID",
-          "exclusive": [
-            "config"
-          ],
-          "hasDynamicHelp": false,
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
           "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path to your function directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "hidden": false,
+          "name": "path",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
           "multiple": false,
-          "name": "client-id",
           "type": "option"
         },
         "config": {
           "char": "c",
           "description": "The name of the app configuration.",
           "env": "SHOPIFY_FLAG_APP_CONFIG",
-          "hasDynamicHelp": false,
           "hidden": false,
-          "multiple": false,
           "name": "config",
+          "hasDynamicHelp": false,
+          "multiple": false,
           "type": "option"
         },
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
+        "client-id": {
+          "description": "The Client ID of your app.",
+          "env": "SHOPIFY_FLAG_CLIENT_ID",
+          "exclusive": [
+            "config"
+          ],
           "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
-        "path": {
-          "description": "The path to your function directory.",
-          "env": "SHOPIFY_FLAG_PATH",
+          "name": "client-id",
           "hasDynamicHelp": false,
-          "hidden": false,
           "multiple": false,
-          "name": "path",
-          "noCacheDefault": true,
           "type": "option"
         },
         "reset": {
-          "allowNo": false,
           "description": "Reset all your settings.",
           "env": "SHOPIFY_FLAG_RESET",
           "exclusive": [
@@ -2006,75 +2739,131 @@
           ],
           "hidden": false,
           "name": "reset",
-          "type": "boolean"
-        },
-        "verbose": {
           "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
           "type": "boolean"
         }
       },
       "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
+      "hiddenAliases": [],
       "id": "app:function:typegen",
       "pluginAlias": "@shopify/cli",
       "pluginName": "@shopify/cli",
       "pluginType": "core",
       "strict": true,
-      "summary": "Generate GraphQL types for a function."
+      "summary": "Generate GraphQL types for a function.",
+      "descriptionWithMarkdown": "Creates GraphQL types based on your [input query](https://shopify.dev/docs/apps/functions/input-output#input) for a function. Supports JavaScript functions out of the box, or any language via the `build.typegen_command` configuration.",
+      "customPluginName": "@shopify/app"
     },
     "app:generate:extension": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/app",
+      "aliases": [],
+      "args": {},
       "description": "Generates a new \"app extension\" (https://shopify.dev/docs/apps/build/app-extensions). For a list of app extensions that you can generate using this command, refer to \"Supported extensions\" (https://shopify.dev/docs/apps/build/app-extensions/list-of-app-extensions).\n\n  Each new app extension is created in a folder under `extensions/`. To learn more about the extensions file structure, refer to \"App structure\" (https://shopify.dev/docs/apps/build/cli-for-apps/app-structure) and the documentation for your extension.\n  ",
-      "descriptionWithMarkdown": "Generates a new [app extension](https://shopify.dev/docs/apps/build/app-extensions). For a list of app extensions that you can generate using this command, refer to [Supported extensions](https://shopify.dev/docs/apps/build/app-extensions/list-of-app-extensions).\n\n  Each new app extension is created in a folder under `extensions/`. To learn more about the extensions file structure, refer to [App structure](https://shopify.dev/docs/apps/build/cli-for-apps/app-structure) and the documentation for your extension.\n  ",
       "flags": {
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path to your app directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "name": "path",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "config": {
+          "char": "c",
+          "description": "The name of the app configuration.",
+          "env": "SHOPIFY_FLAG_APP_CONFIG",
+          "hidden": false,
+          "name": "config",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
         "client-id": {
           "description": "The Client ID of your app.",
           "env": "SHOPIFY_FLAG_CLIENT_ID",
           "exclusive": [
             "config"
           ],
-          "hasDynamicHelp": false,
           "hidden": false,
-          "multiple": false,
           "name": "client-id",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "reset": {
+          "description": "Reset all your settings.",
+          "env": "SHOPIFY_FLAG_RESET",
+          "exclusive": [
+            "config"
+          ],
+          "hidden": false,
+          "name": "reset",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "type": {
+          "char": "t",
+          "description": "Deprecated. Please use --template",
+          "env": "SHOPIFY_FLAG_EXTENSION_TYPE",
+          "hidden": false,
+          "name": "type",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "template": {
+          "char": "t",
+          "description": "Extension template",
+          "env": "SHOPIFY_FLAG_EXTENSION_TEMPLATE",
+          "hidden": false,
+          "name": "template",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "name": {
+          "char": "n",
+          "description": "name of your Extension",
+          "env": "SHOPIFY_FLAG_NAME",
+          "hidden": false,
+          "name": "name",
+          "hasDynamicHelp": false,
+          "multiple": false,
           "type": "option"
         },
         "clone-url": {
           "char": "u",
           "description": "The Git URL to clone the function extensions templates from. Defaults to: https://github.com/Shopify/function-examples",
           "env": "SHOPIFY_FLAG_CLONE_URL",
-          "hasDynamicHelp": false,
           "hidden": true,
-          "multiple": false,
           "name": "clone-url",
-          "type": "option"
-        },
-        "config": {
-          "char": "c",
-          "description": "The name of the app configuration.",
-          "env": "SHOPIFY_FLAG_APP_CONFIG",
           "hasDynamicHelp": false,
-          "hidden": false,
           "multiple": false,
-          "name": "config",
           "type": "option"
         },
         "flavor": {
           "description": "Choose a starting template for your extension, where applicable",
           "env": "SHOPIFY_FLAG_FLAVOR",
-          "hasDynamicHelp": false,
           "hidden": false,
-          "multiple": false,
           "name": "flavor",
+          "hasDynamicHelp": false,
+          "multiple": false,
           "options": [
             "vanilla-js",
             "react",
@@ -2084,920 +2873,72 @@
             "rust"
           ],
           "type": "option"
-        },
-        "name": {
-          "char": "n",
-          "description": "name of your Extension",
-          "env": "SHOPIFY_FLAG_NAME",
-          "hasDynamicHelp": false,
-          "hidden": false,
-          "multiple": false,
-          "name": "name",
-          "type": "option"
-        },
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
-          "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
-        "path": {
-          "description": "The path to your app directory.",
-          "env": "SHOPIFY_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "path",
-          "noCacheDefault": true,
-          "type": "option"
-        },
-        "reset": {
-          "allowNo": false,
-          "description": "Reset all your settings.",
-          "env": "SHOPIFY_FLAG_RESET",
-          "exclusive": [
-            "config"
-          ],
-          "hidden": false,
-          "name": "reset",
-          "type": "boolean"
-        },
-        "template": {
-          "char": "t",
-          "description": "Extension template",
-          "env": "SHOPIFY_FLAG_EXTENSION_TEMPLATE",
-          "hasDynamicHelp": false,
-          "hidden": false,
-          "multiple": false,
-          "name": "template",
-          "type": "option"
-        },
-        "type": {
-          "char": "t",
-          "description": "Deprecated. Please use --template",
-          "env": "SHOPIFY_FLAG_EXTENSION_TYPE",
-          "hasDynamicHelp": false,
-          "hidden": false,
-          "multiple": false,
-          "name": "type",
-          "type": "option"
-        },
-        "verbose": {
-          "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
-          "type": "boolean"
         }
       },
       "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
+      "hiddenAliases": [],
       "id": "app:generate:extension",
       "pluginAlias": "@shopify/cli",
       "pluginName": "@shopify/cli",
       "pluginType": "core",
       "strict": true,
-      "summary": "Generate a new app Extension."
-    },
-    "app:generate:schema": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/app",
-      "description": "\"DEPRECATED, use `app function schema`] Generates the latest [GraphQL schema\" (https://shopify.dev/docs/apps/functions/input-output#graphql-schema) for a function in your app. Run this command from the function directory.\n\n  This command uses the API type and version of your function, as defined in your extension TOML file, to generate the latest GraphQL schema. The schema is written to the `schema.graphql` file.",
-      "descriptionWithMarkdown": "[DEPRECATED, use `app function schema`] Generates the latest [GraphQL schema](https://shopify.dev/docs/apps/functions/input-output#graphql-schema) for a function in your app. Run this command from the function directory.\n\n  This command uses the API type and version of your function, as defined in your extension TOML file, to generate the latest GraphQL schema. The schema is written to the `schema.graphql` file.",
-      "flags": {
-        "client-id": {
-          "description": "The Client ID of your app.",
-          "env": "SHOPIFY_FLAG_CLIENT_ID",
-          "exclusive": [
-            "config"
-          ],
-          "hasDynamicHelp": false,
-          "hidden": false,
-          "multiple": false,
-          "name": "client-id",
-          "type": "option"
-        },
-        "config": {
-          "char": "c",
-          "description": "The name of the app configuration.",
-          "env": "SHOPIFY_FLAG_APP_CONFIG",
-          "hasDynamicHelp": false,
-          "hidden": false,
-          "multiple": false,
-          "name": "config",
-          "type": "option"
-        },
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
-          "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
-        "path": {
-          "description": "The path to your function directory.",
-          "env": "SHOPIFY_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "hidden": false,
-          "multiple": false,
-          "name": "path",
-          "noCacheDefault": true,
-          "type": "option"
-        },
-        "reset": {
-          "allowNo": false,
-          "description": "Reset all your settings.",
-          "env": "SHOPIFY_FLAG_RESET",
-          "exclusive": [
-            "config"
-          ],
-          "hidden": false,
-          "name": "reset",
-          "type": "boolean"
-        },
-        "stdout": {
-          "allowNo": false,
-          "description": "Output the schema to stdout instead of writing to a file.",
-          "env": "SHOPIFY_FLAG_STDOUT",
-          "name": "stdout",
-          "required": false,
-          "type": "boolean"
-        },
-        "verbose": {
-          "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hidden": true,
-      "hiddenAliases": [
-      ],
-      "id": "app:generate:schema",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "summary": "Fetch the latest GraphQL schema for a function."
-    },
-    "app:import-custom-data-definitions": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/app",
-      "description": "Import metafield and metaobject definitions from your development store. \"Read more about declarative custom data definitions\" (https://shopify.dev/docs/apps/build/custom-data/declarative-custom-data-definitions).",
-      "descriptionWithMarkdown": "Import metafield and metaobject definitions from your development store. [Read more about declarative custom data definitions](https://shopify.dev/docs/apps/build/custom-data/declarative-custom-data-definitions).",
-      "flags": {
-        "client-id": {
-          "description": "The Client ID of your app.",
-          "env": "SHOPIFY_FLAG_CLIENT_ID",
-          "exclusive": [
-            "config"
-          ],
-          "hasDynamicHelp": false,
-          "hidden": false,
-          "multiple": false,
-          "name": "client-id",
-          "type": "option"
-        },
-        "config": {
-          "char": "c",
-          "description": "The name of the app configuration.",
-          "env": "SHOPIFY_FLAG_APP_CONFIG",
-          "hasDynamicHelp": false,
-          "hidden": false,
-          "multiple": false,
-          "name": "config",
-          "type": "option"
-        },
-        "include-existing": {
-          "allowNo": false,
-          "description": "Include existing declared definitions in the output.",
-          "env": "SHOPIFY_FLAG_INCLUDE_EXISTING",
-          "name": "include-existing",
-          "type": "boolean"
-        },
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
-          "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
-        "path": {
-          "description": "The path to your app directory.",
-          "env": "SHOPIFY_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "path",
-          "noCacheDefault": true,
-          "type": "option"
-        },
-        "reset": {
-          "allowNo": false,
-          "description": "Reset all your settings.",
-          "env": "SHOPIFY_FLAG_RESET",
-          "exclusive": [
-            "config"
-          ],
-          "hidden": false,
-          "name": "reset",
-          "type": "boolean"
-        },
-        "store": {
-          "char": "s",
-          "description": "Store URL. Must be an existing development or Shopify Plus sandbox store.",
-          "env": "SHOPIFY_FLAG_STORE",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "store",
-          "type": "option"
-        },
-        "verbose": {
-          "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "app:import-custom-data-definitions",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true,
-      "summary": "Import metafield and metaobject definitions."
-    },
-    "app:import-extensions": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/app",
-      "description": "Import dashboard-managed extensions into your app.",
-      "flags": {
-        "client-id": {
-          "description": "The Client ID of your app.",
-          "env": "SHOPIFY_FLAG_CLIENT_ID",
-          "exclusive": [
-            "config"
-          ],
-          "hasDynamicHelp": false,
-          "hidden": false,
-          "multiple": false,
-          "name": "client-id",
-          "type": "option"
-        },
-        "config": {
-          "char": "c",
-          "description": "The name of the app configuration.",
-          "env": "SHOPIFY_FLAG_APP_CONFIG",
-          "hasDynamicHelp": false,
-          "hidden": false,
-          "multiple": false,
-          "name": "config",
-          "type": "option"
-        },
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
-          "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
-        "path": {
-          "description": "The path to your app directory.",
-          "env": "SHOPIFY_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "path",
-          "noCacheDefault": true,
-          "type": "option"
-        },
-        "reset": {
-          "allowNo": false,
-          "description": "Reset all your settings.",
-          "env": "SHOPIFY_FLAG_RESET",
-          "exclusive": [
-            "config"
-          ],
-          "hidden": false,
-          "name": "reset",
-          "type": "boolean"
-        },
-        "verbose": {
-          "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "app:import-extensions",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true
-    },
-    "app:info": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/app",
-      "description": "The information returned includes the following:\n\n  - The app and dev store that's used when you run the \"dev\" (https://shopify.dev/docs/api/shopify-cli/app/app-dev) command. You can reset these configurations using \"`dev --reset`\" (https://shopify.dev/docs/api/shopify-cli/app/app-dev#flags-propertydetail-reset).\n  - The \"structure\" (https://shopify.dev/docs/apps/tools/cli/structure) of your app project.\n  - The \"access scopes\" (https://shopify.dev/docs/api/usage) your app has requested.\n  - System information, including the package manager and version of Shopify CLI used in the project.",
-      "descriptionWithMarkdown": "The information returned includes the following:\n\n  - The app and dev store that's used when you run the [dev](https://shopify.dev/docs/api/shopify-cli/app/app-dev) command. You can reset these configurations using [`dev --reset`](https://shopify.dev/docs/api/shopify-cli/app/app-dev#flags-propertydetail-reset).\n  - The [structure](https://shopify.dev/docs/apps/tools/cli/structure) of your app project.\n  - The [access scopes](https://shopify.dev/docs/api/usage) your app has requested.\n  - System information, including the package manager and version of Shopify CLI used in the project.",
-      "flags": {
-        "client-id": {
-          "description": "The Client ID of your app.",
-          "env": "SHOPIFY_FLAG_CLIENT_ID",
-          "exclusive": [
-            "config"
-          ],
-          "hasDynamicHelp": false,
-          "hidden": false,
-          "multiple": false,
-          "name": "client-id",
-          "type": "option"
-        },
-        "config": {
-          "char": "c",
-          "description": "The name of the app configuration.",
-          "env": "SHOPIFY_FLAG_APP_CONFIG",
-          "hasDynamicHelp": false,
-          "hidden": false,
-          "multiple": false,
-          "name": "config",
-          "type": "option"
-        },
-        "json": {
-          "allowNo": false,
-          "char": "j",
-          "description": "Output the result as JSON. Automatically disables color output.",
-          "env": "SHOPIFY_FLAG_JSON",
-          "hidden": false,
-          "name": "json",
-          "type": "boolean"
-        },
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
-          "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
-        "path": {
-          "description": "The path to your app directory.",
-          "env": "SHOPIFY_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "path",
-          "noCacheDefault": true,
-          "type": "option"
-        },
-        "reset": {
-          "allowNo": false,
-          "description": "Reset all your settings.",
-          "env": "SHOPIFY_FLAG_RESET",
-          "exclusive": [
-            "config"
-          ],
-          "hidden": false,
-          "name": "reset",
-          "type": "boolean"
-        },
-        "verbose": {
-          "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
-          "type": "boolean"
-        },
-        "web-env": {
-          "allowNo": false,
-          "description": "Outputs environment variables necessary for running and deploying web/.",
-          "env": "SHOPIFY_FLAG_OUTPUT_WEB_ENV",
-          "hidden": false,
-          "name": "web-env",
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "app:info",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true,
-      "summary": "Print basic information about your app and extensions."
-    },
-    "app:init": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/app",
-      "flags": {
-        "client-id": {
-          "description": "The Client ID of your app. Use this to automatically link your new project to an existing app. Using this flag avoids the app selection prompt.",
-          "env": "SHOPIFY_FLAG_CLIENT_ID",
-          "exclusive": [
-            "config"
-          ],
-          "hasDynamicHelp": false,
-          "hidden": false,
-          "multiple": false,
-          "name": "client-id",
-          "type": "option"
-        },
-        "flavor": {
-          "description": "Which flavor of the given template to use.",
-          "env": "SHOPIFY_FLAG_TEMPLATE_FLAVOR",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "flavor",
-          "type": "option"
-        },
-        "local": {
-          "allowNo": false,
-          "char": "l",
-          "env": "SHOPIFY_FLAG_LOCAL",
-          "hidden": true,
-          "name": "local",
-          "type": "boolean"
-        },
-        "name": {
-          "char": "n",
-          "description": "The name for the new app. When provided, skips the app selection prompt and creates a new app with this name.",
-          "env": "SHOPIFY_FLAG_NAME",
-          "hasDynamicHelp": false,
-          "hidden": false,
-          "multiple": false,
-          "name": "name",
-          "type": "option"
-        },
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
-          "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
-        "organization-id": {
-          "description": "The organization ID. Your organization ID can be found in your Dev Dashboard URL: https://dev.shopify.com/dashboard/<organization-id>",
-          "env": "SHOPIFY_FLAG_ORGANIZATION_ID",
-          "exclusive": [
-            "client-id"
-          ],
-          "hasDynamicHelp": false,
-          "hidden": false,
-          "multiple": false,
-          "name": "organization-id",
-          "type": "option"
-        },
-        "package-manager": {
-          "char": "d",
-          "env": "SHOPIFY_FLAG_PACKAGE_MANAGER",
-          "hasDynamicHelp": false,
-          "hidden": false,
-          "multiple": false,
-          "name": "package-manager",
-          "options": [
-            "npm",
-            "yarn",
-            "pnpm",
-            "bun"
-          ],
-          "type": "option"
-        },
-        "path": {
-          "char": "p",
-          "default": ".",
-          "env": "SHOPIFY_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "hidden": false,
-          "multiple": false,
-          "name": "path",
-          "type": "option"
-        },
-        "template": {
-          "description": "The app template. Accepts one of the following:\n       - <reactRouter|none>\n       - Any GitHub repo with optional branch and subpath, e.g., https://github.com/Shopify/<repository>/[subpath]#[branch]",
-          "env": "SHOPIFY_FLAG_TEMPLATE",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "template",
-          "type": "option"
-        },
-        "verbose": {
-          "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "app:init",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true,
-      "summary": "Create a new app project"
-    },
-    "app:logs": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/app",
-      "description": "\n  Opens a real-time stream of detailed app logs from the selected app and store.\n  Use the `--source` argument to limit output to a particular log source, such as a specific Shopify Function handle. Use the `shopify app logs sources` command to view a list of sources.\n  Use the `--status` argument to filter on status, either `success` or `failure`.\n  ```\n  shopify app logs --status=success --source=extension.discount-function\n  ```\n  ",
-      "descriptionWithMarkdown": "\n  Opens a real-time stream of detailed app logs from the selected app and store.\n  Use the `--source` argument to limit output to a particular log source, such as a specific Shopify Function handle. Use the `shopify app logs sources` command to view a list of sources.\n  Use the `--status` argument to filter on status, either `success` or `failure`.\n  ```\n  shopify app logs --status=success --source=extension.discount-function\n  ```\n  ",
-      "flags": {
-        "client-id": {
-          "description": "The Client ID of your app.",
-          "env": "SHOPIFY_FLAG_CLIENT_ID",
-          "exclusive": [
-            "config"
-          ],
-          "hasDynamicHelp": false,
-          "hidden": false,
-          "multiple": false,
-          "name": "client-id",
-          "type": "option"
-        },
-        "config": {
-          "char": "c",
-          "description": "The name of the app configuration.",
-          "env": "SHOPIFY_FLAG_APP_CONFIG",
-          "hasDynamicHelp": false,
-          "hidden": false,
-          "multiple": false,
-          "name": "config",
-          "type": "option"
-        },
-        "json": {
-          "allowNo": false,
-          "char": "j",
-          "description": "Output the result as JSON. Automatically disables color output.",
-          "env": "SHOPIFY_FLAG_JSON",
-          "hidden": false,
-          "name": "json",
-          "type": "boolean"
-        },
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
-          "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
-        "path": {
-          "description": "The path to your app directory.",
-          "env": "SHOPIFY_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "path",
-          "noCacheDefault": true,
-          "type": "option"
-        },
-        "reset": {
-          "allowNo": false,
-          "description": "Reset all your settings.",
-          "env": "SHOPIFY_FLAG_RESET",
-          "exclusive": [
-            "config"
-          ],
-          "hidden": false,
-          "name": "reset",
-          "type": "boolean"
-        },
-        "source": {
-          "description": "Filters output to the specified log source.",
-          "env": "SHOPIFY_FLAG_SOURCE",
-          "hasDynamicHelp": false,
-          "multiple": true,
-          "name": "source",
-          "type": "option"
-        },
-        "status": {
-          "description": "Filters output to the specified status (success or failure).",
-          "env": "SHOPIFY_FLAG_STATUS",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "status",
-          "options": [
-            "success",
-            "failure"
-          ],
-          "type": "option"
-        },
-        "store": {
-          "char": "s",
-          "description": "Store URL. Must be an existing development or Shopify Plus sandbox store.",
-          "env": "SHOPIFY_FLAG_STORE",
-          "hasDynamicHelp": false,
-          "multiple": true,
-          "name": "store",
-          "type": "option"
-        },
-        "verbose": {
-          "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "app:logs",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true,
-      "summary": "Stream detailed logs for your Shopify app."
-    },
-    "app:logs:sources": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/app",
-      "description": "The output source names can be used with the `--source` argument of `shopify app logs` to filter log output. Currently only function extensions are supported as sources.",
-      "descriptionWithMarkdown": "The output source names can be used with the `--source` argument of `shopify app logs` to filter log output. Currently only function extensions are supported as sources.",
-      "flags": {
-        "client-id": {
-          "description": "The Client ID of your app.",
-          "env": "SHOPIFY_FLAG_CLIENT_ID",
-          "exclusive": [
-            "config"
-          ],
-          "hasDynamicHelp": false,
-          "hidden": false,
-          "multiple": false,
-          "name": "client-id",
-          "type": "option"
-        },
-        "config": {
-          "char": "c",
-          "description": "The name of the app configuration.",
-          "env": "SHOPIFY_FLAG_APP_CONFIG",
-          "hasDynamicHelp": false,
-          "hidden": false,
-          "multiple": false,
-          "name": "config",
-          "type": "option"
-        },
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
-          "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
-        "path": {
-          "description": "The path to your app directory.",
-          "env": "SHOPIFY_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "path",
-          "noCacheDefault": true,
-          "type": "option"
-        },
-        "reset": {
-          "allowNo": false,
-          "description": "Reset all your settings.",
-          "env": "SHOPIFY_FLAG_RESET",
-          "exclusive": [
-            "config"
-          ],
-          "hidden": false,
-          "name": "reset",
-          "type": "boolean"
-        },
-        "verbose": {
-          "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "app:logs:sources",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true,
-      "summary": "Print out a list of sources that may be used with the logs command."
-    },
-    "app:release": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/app",
-      "description": "Releases an existing app version. Pass the name of the version that you want to release using the `--version` flag.",
-      "descriptionWithMarkdown": "Releases an existing app version. Pass the name of the version that you want to release using the `--version` flag.",
-      "flags": {
-        "allow-deletes": {
-          "allowNo": false,
-          "description": "Allows removing extensions and configuration without requiring user confirmation. For CI/CD environments, the recommended flag is --allow-updates.",
-          "env": "SHOPIFY_FLAG_ALLOW_DELETES",
-          "hidden": false,
-          "name": "allow-deletes",
-          "type": "boolean"
-        },
-        "allow-updates": {
-          "allowNo": false,
-          "description": "Allows adding and updating extensions and configuration without requiring user confirmation. Recommended option for CI/CD environments.",
-          "env": "SHOPIFY_FLAG_ALLOW_UPDATES",
-          "hidden": false,
-          "name": "allow-updates",
-          "type": "boolean"
-        },
-        "client-id": {
-          "description": "The Client ID of your app.",
-          "env": "SHOPIFY_FLAG_CLIENT_ID",
-          "exclusive": [
-            "config"
-          ],
-          "hasDynamicHelp": false,
-          "hidden": false,
-          "multiple": false,
-          "name": "client-id",
-          "type": "option"
-        },
-        "config": {
-          "char": "c",
-          "description": "The name of the app configuration.",
-          "env": "SHOPIFY_FLAG_APP_CONFIG",
-          "hasDynamicHelp": false,
-          "hidden": false,
-          "multiple": false,
-          "name": "config",
-          "type": "option"
-        },
-        "force": {
-          "allowNo": false,
-          "char": "f",
-          "description": "[Deprecated] Release without asking for confirmation. Equivalent to --allow-updates --allow-deletes. Use --allow-updates for CI/CD environments instead.",
-          "env": "SHOPIFY_FLAG_FORCE",
-          "hidden": false,
-          "name": "force",
-          "type": "boolean"
-        },
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
-          "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
-        "path": {
-          "description": "The path to your app directory.",
-          "env": "SHOPIFY_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "path",
-          "noCacheDefault": true,
-          "type": "option"
-        },
-        "reset": {
-          "allowNo": false,
-          "description": "Reset all your settings.",
-          "env": "SHOPIFY_FLAG_RESET",
-          "exclusive": [
-            "config"
-          ],
-          "hidden": false,
-          "name": "reset",
-          "type": "boolean"
-        },
-        "verbose": {
-          "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
-          "type": "boolean"
-        },
-        "version": {
-          "description": "The name of the app version to release.",
-          "env": "SHOPIFY_FLAG_VERSION",
-          "hasDynamicHelp": false,
-          "hidden": false,
-          "multiple": false,
-          "name": "version",
-          "required": true,
-          "type": "option"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "app:release",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true,
-      "summary": "Release an app version.",
-      "usage": "app release --version <version>"
+      "summary": "Generate a new app Extension.",
+      "descriptionWithMarkdown": "Generates a new [app extension](https://shopify.dev/docs/apps/build/app-extensions). For a list of app extensions that you can generate using this command, refer to [Supported extensions](https://shopify.dev/docs/apps/build/app-extensions/list-of-app-extensions).\n\n  Each new app extension is created in a folder under `extensions/`. To learn more about the extensions file structure, refer to [App structure](https://shopify.dev/docs/apps/build/cli-for-apps/app-structure) and the documentation for your extension.\n  ",
+      "customPluginName": "@shopify/app"
     },
     "app:versions:list": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/app",
+      "aliases": [],
+      "args": {},
       "description": "Lists the deployed app versions. An app version is a snapshot of your app extensions.",
-      "descriptionWithMarkdown": "Lists the deployed app versions. An app version is a snapshot of your app extensions.",
       "flags": {
-        "client-id": {
-          "description": "The Client ID of your app.",
-          "env": "SHOPIFY_FLAG_CLIENT_ID",
-          "exclusive": [
-            "config"
-          ],
-          "hasDynamicHelp": false,
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
           "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path to your app directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "name": "path",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
           "multiple": false,
-          "name": "client-id",
           "type": "option"
         },
         "config": {
           "char": "c",
           "description": "The name of the app configuration.",
           "env": "SHOPIFY_FLAG_APP_CONFIG",
-          "hasDynamicHelp": false,
           "hidden": false,
-          "multiple": false,
           "name": "config",
+          "hasDynamicHelp": false,
+          "multiple": false,
           "type": "option"
         },
-        "json": {
-          "allowNo": false,
-          "char": "j",
-          "description": "Output the result as JSON. Automatically disables color output.",
-          "env": "SHOPIFY_FLAG_JSON",
+        "client-id": {
+          "description": "The Client ID of your app.",
+          "env": "SHOPIFY_FLAG_CLIENT_ID",
+          "exclusive": [
+            "config"
+          ],
           "hidden": false,
-          "name": "json",
-          "type": "boolean"
-        },
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
-          "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
-        "path": {
-          "description": "The path to your app directory.",
-          "env": "SHOPIFY_FLAG_PATH",
+          "name": "client-id",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "path",
-          "noCacheDefault": true,
           "type": "option"
         },
         "reset": {
-          "allowNo": false,
           "description": "Reset all your settings.",
           "env": "SHOPIFY_FLAG_RESET",
           "exclusive": [
@@ -3005,54 +2946,52 @@
           ],
           "hidden": false,
           "name": "reset",
+          "allowNo": false,
           "type": "boolean"
         },
-        "verbose": {
-          "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
+        "json": {
+          "char": "j",
+          "description": "Output the result as JSON. Automatically disables color output.",
+          "env": "SHOPIFY_FLAG_JSON",
           "hidden": false,
-          "name": "verbose",
+          "name": "json",
+          "allowNo": false,
           "type": "boolean"
         }
       },
       "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
+      "hiddenAliases": [],
       "id": "app:versions:list",
       "pluginAlias": "@shopify/cli",
       "pluginName": "@shopify/cli",
       "pluginType": "core",
       "strict": true,
-      "summary": "List deployed versions of your app."
+      "summary": "List deployed versions of your app.",
+      "descriptionWithMarkdown": "Lists the deployed app versions. An app version is a snapshot of your app extensions.",
+      "customPluginName": "@shopify/app"
     },
     "app:webhook:trigger": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/app",
+      "aliases": [],
+      "args": {},
       "description": "\n  Triggers the delivery of a sample Admin API event topic payload to a designated address.\n\n  You should use this command to experiment with webhooks, to initially test your webhook configuration, or for unit testing. However, to test your webhook configuration from end to end, you should always trigger webhooks by performing the related action in Shopify.\n\n  Because most webhook deliveries use remote endpoints, you can trigger the command from any directory where you can use Shopify CLI, and send the webhook to any of the supported endpoint types. For example, you can run the command from your app's local directory, but send the webhook to a staging environment endpoint.\n\n  To learn more about using webhooks in a Shopify app, refer to \"Webhooks overview\" (https://shopify.dev/docs/apps/webhooks).\n\n  ### Limitations\n\n  - Webhooks triggered using this method always have the same payload, so they can't be used to test scenarios that differ based on the payload contents.\n  - Webhooks triggered using this method aren't retried when they fail.\n  - Trigger requests are rate-limited using the \"Partner API rate limit\" (https://shopify.dev/docs/api/partner#rate_limits).\n  - You can't use this method to validate your API webhook subscriptions.\n  ",
-      "descriptionWithMarkdown": "\n  Triggers the delivery of a sample Admin API event topic payload to a designated address.\n\n  You should use this command to experiment with webhooks, to initially test your webhook configuration, or for unit testing. However, to test your webhook configuration from end to end, you should always trigger webhooks by performing the related action in Shopify.\n\n  Because most webhook deliveries use remote endpoints, you can trigger the command from any directory where you can use Shopify CLI, and send the webhook to any of the supported endpoint types. For example, you can run the command from your app's local directory, but send the webhook to a staging environment endpoint.\n\n  To learn more about using webhooks in a Shopify app, refer to [Webhooks overview](https://shopify.dev/docs/apps/webhooks).\n\n  ### Limitations\n\n  - Webhooks triggered using this method always have the same payload, so they can't be used to test scenarios that differ based on the payload contents.\n  - Webhooks triggered using this method aren't retried when they fail.\n  - Trigger requests are rate-limited using the [Partner API rate limit](https://shopify.dev/docs/api/partner#rate_limits).\n  - You can't use this method to validate your API webhook subscriptions.\n  ",
       "flags": {
-        "address": {
-          "description": "The URL where the webhook payload should be sent.\n                    You will need a different address type for each delivery-method:\n                          · For remote HTTP testing, use a URL that starts with https://\n      · For local HTTP testing, use http://localhost:{port}/{url-path}\n                          · For Google Pub/Sub, use pubsub://{project-id}:{topic-id}\n                          · For Amazon EventBridge, use an Amazon Resource Name (ARN) starting with arn:aws:events:",
-          "env": "SHOPIFY_FLAG_ADDRESS",
+        "path": {
+          "description": "The path to your app directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "name": "path",
+          "noCacheDefault": true,
           "hasDynamicHelp": false,
-          "hidden": false,
           "multiple": false,
-          "name": "address",
-          "required": false,
           "type": "option"
         },
-        "api-version": {
-          "description": "The API Version of the webhook topic.",
-          "env": "SHOPIFY_FLAG_API_VERSION",
-          "hasDynamicHelp": false,
+        "config": {
+          "char": "c",
+          "description": "The name of the app configuration.",
+          "env": "SHOPIFY_FLAG_APP_CONFIG",
           "hidden": false,
+          "name": "config",
+          "hasDynamicHelp": false,
           "multiple": false,
-          "name": "api-version",
-          "required": false,
           "type": "option"
         },
         "client-id": {
@@ -3061,67 +3000,13 @@
           "exclusive": [
             "config"
           ],
-          "hasDynamicHelp": false,
           "hidden": false,
-          "multiple": false,
           "name": "client-id",
-          "type": "option"
-        },
-        "client-secret": {
-          "description": "Your app's client secret. This secret allows us to return the X-Shopify-Hmac-SHA256 header that lets you validate the origin of the response that you receive.",
-          "env": "SHOPIFY_FLAG_CLIENT_SECRET",
-          "hasDynamicHelp": false,
-          "hidden": false,
-          "multiple": false,
-          "name": "client-secret",
-          "required": false,
-          "type": "option"
-        },
-        "config": {
-          "char": "c",
-          "description": "The name of the app configuration.",
-          "env": "SHOPIFY_FLAG_APP_CONFIG",
-          "hasDynamicHelp": false,
-          "hidden": false,
-          "multiple": false,
-          "name": "config",
-          "type": "option"
-        },
-        "delivery-method": {
-          "description": "Method chosen to deliver the topic payload. If not passed, it's inferred from the address.",
-          "env": "SHOPIFY_FLAG_DELIVERY_METHOD",
-          "hasDynamicHelp": false,
-          "hidden": false,
-          "multiple": false,
-          "name": "delivery-method",
-          "options": [
-            "http",
-            "google-pub-sub",
-            "event-bridge"
-          ],
-          "required": false,
-          "type": "option"
-        },
-        "help": {
-          "allowNo": false,
-          "description": "This help. When you run the trigger command the CLI will prompt you for any information that isn't passed using flags.",
-          "env": "SHOPIFY_FLAG_HELP",
-          "hidden": false,
-          "name": "help",
-          "required": false,
-          "type": "boolean"
-        },
-        "path": {
-          "description": "The path to your app directory.",
-          "env": "SHOPIFY_FLAG_PATH",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "path",
-          "noCacheDefault": true,
           "type": "option"
         },
         "reset": {
-          "allowNo": false,
           "description": "Reset all your settings.",
           "env": "SHOPIFY_FLAG_RESET",
           "exclusive": [
@@ -3129,121 +3014,2966 @@
           ],
           "hidden": false,
           "name": "reset",
+          "allowNo": false,
           "type": "boolean"
         },
-        "shared-secret": {
-          "description": "Deprecated. Please use client-secret.",
-          "env": "SHOPIFY_FLAG_SHARED_SECRET",
-          "hasDynamicHelp": false,
+        "help": {
+          "description": "This help. When you run the trigger command the CLI will prompt you for any information that isn't passed using flags.",
+          "env": "SHOPIFY_FLAG_HELP",
           "hidden": false,
-          "multiple": false,
-          "name": "shared-secret",
+          "name": "help",
           "required": false,
-          "type": "option"
+          "allowNo": false,
+          "type": "boolean"
         },
         "topic": {
           "description": "The requested webhook topic.",
           "env": "SHOPIFY_FLAG_TOPIC",
-          "hasDynamicHelp": false,
           "hidden": false,
-          "multiple": false,
           "name": "topic",
           "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "api-version": {
+          "description": "The API Version of the webhook topic.",
+          "env": "SHOPIFY_FLAG_API_VERSION",
+          "hidden": false,
+          "name": "api-version",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "delivery-method": {
+          "description": "Method chosen to deliver the topic payload. If not passed, it's inferred from the address.",
+          "env": "SHOPIFY_FLAG_DELIVERY_METHOD",
+          "hidden": false,
+          "name": "delivery-method",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "options": [
+            "http",
+            "google-pub-sub",
+            "event-bridge"
+          ],
+          "type": "option"
+        },
+        "shared-secret": {
+          "description": "Deprecated. Please use client-secret.",
+          "env": "SHOPIFY_FLAG_SHARED_SECRET",
+          "hidden": false,
+          "name": "shared-secret",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "client-secret": {
+          "description": "Your app's client secret. This secret allows us to return the X-Shopify-Hmac-SHA256 header that lets you validate the origin of the response that you receive.",
+          "env": "SHOPIFY_FLAG_CLIENT_SECRET",
+          "hidden": false,
+          "name": "client-secret",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "address": {
+          "description": "The URL where the webhook payload should be sent.\n                    You will need a different address type for each delivery-method:\n                          · For remote HTTP testing, use a URL that starts with https://\n      · For local HTTP testing, use http://localhost:{port}/{url-path}\n                          · For Google Pub/Sub, use pubsub://{project-id}:{topic-id}\n                          · For Amazon EventBridge, use an Amazon Resource Name (ARN) starting with arn:aws:events:",
+          "env": "SHOPIFY_FLAG_ADDRESS",
+          "hidden": false,
+          "name": "address",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
           "type": "option"
         }
       },
       "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
+      "hiddenAliases": [],
       "id": "app:webhook:trigger",
       "pluginAlias": "@shopify/cli",
       "pluginName": "@shopify/cli",
       "pluginType": "core",
       "strict": true,
-      "summary": "Trigger delivery of a sample webhook topic payload to a designated address."
+      "summary": "Trigger delivery of a sample webhook topic payload to a designated address.",
+      "descriptionWithMarkdown": "\n  Triggers the delivery of a sample Admin API event topic payload to a designated address.\n\n  You should use this command to experiment with webhooks, to initially test your webhook configuration, or for unit testing. However, to test your webhook configuration from end to end, you should always trigger webhooks by performing the related action in Shopify.\n\n  Because most webhook deliveries use remote endpoints, you can trigger the command from any directory where you can use Shopify CLI, and send the webhook to any of the supported endpoint types. For example, you can run the command from your app's local directory, but send the webhook to a staging environment endpoint.\n\n  To learn more about using webhooks in a Shopify app, refer to [Webhooks overview](https://shopify.dev/docs/apps/webhooks).\n\n  ### Limitations\n\n  - Webhooks triggered using this method always have the same payload, so they can't be used to test scenarios that differ based on the payload contents.\n  - Webhooks triggered using this method aren't retried when they fail.\n  - Trigger requests are rate-limited using the [Partner API rate limit](https://shopify.dev/docs/api/partner#rate_limits).\n  - You can't use this method to validate your API webhook subscriptions.\n  ",
+      "customPluginName": "@shopify/app"
     },
-    "auth:login": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "description": "Logs you in to your Shopify account.",
-      "enableJsonFlag": false,
+    "webhook:trigger": {
+      "aliases": [],
+      "args": {},
+      "description": "\n  Triggers the delivery of a sample Admin API event topic payload to a designated address.\n\n  You should use this command to experiment with webhooks, to initially test your webhook configuration, or for unit testing. However, to test your webhook configuration from end to end, you should always trigger webhooks by performing the related action in Shopify.\n\n  Because most webhook deliveries use remote endpoints, you can trigger the command from any directory where you can use Shopify CLI, and send the webhook to any of the supported endpoint types. For example, you can run the command from your app's local directory, but send the webhook to a staging environment endpoint.\n\n  To learn more about using webhooks in a Shopify app, refer to \"Webhooks overview\" (https://shopify.dev/docs/apps/webhooks).\n\n  ### Limitations\n\n  - Webhooks triggered using this method always have the same payload, so they can't be used to test scenarios that differ based on the payload contents.\n  - Webhooks triggered using this method aren't retried when they fail.\n  - Trigger requests are rate-limited using the \"Partner API rate limit\" (https://shopify.dev/docs/api/partner#rate_limits).\n  - You can't use this method to validate your API webhook subscriptions.\n  ",
       "flags": {
-        "alias": {
-          "description": "Alias of the session you want to login to.",
-          "env": "SHOPIFY_FLAG_AUTH_ALIAS",
+        "path": {
+          "description": "The path to your app directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "name": "path",
+          "noCacheDefault": true,
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "alias",
+          "type": "option"
+        },
+        "config": {
+          "char": "c",
+          "description": "The name of the app configuration.",
+          "env": "SHOPIFY_FLAG_APP_CONFIG",
+          "hidden": false,
+          "name": "config",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "client-id": {
+          "description": "The Client ID of your app.",
+          "env": "SHOPIFY_FLAG_CLIENT_ID",
+          "exclusive": [
+            "config"
+          ],
+          "hidden": false,
+          "name": "client-id",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "reset": {
+          "description": "Reset all your settings.",
+          "env": "SHOPIFY_FLAG_RESET",
+          "exclusive": [
+            "config"
+          ],
+          "hidden": false,
+          "name": "reset",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "help": {
+          "description": "This help. When you run the trigger command the CLI will prompt you for any information that isn't passed using flags.",
+          "env": "SHOPIFY_FLAG_HELP",
+          "hidden": false,
+          "name": "help",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "topic": {
+          "description": "The requested webhook topic.",
+          "env": "SHOPIFY_FLAG_TOPIC",
+          "hidden": false,
+          "name": "topic",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "api-version": {
+          "description": "The API Version of the webhook topic.",
+          "env": "SHOPIFY_FLAG_API_VERSION",
+          "hidden": false,
+          "name": "api-version",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "delivery-method": {
+          "description": "Method chosen to deliver the topic payload. If not passed, it's inferred from the address.",
+          "env": "SHOPIFY_FLAG_DELIVERY_METHOD",
+          "hidden": false,
+          "name": "delivery-method",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "options": [
+            "http",
+            "google-pub-sub",
+            "event-bridge"
+          ],
+          "type": "option"
+        },
+        "shared-secret": {
+          "description": "Deprecated. Please use client-secret.",
+          "env": "SHOPIFY_FLAG_SHARED_SECRET",
+          "hidden": false,
+          "name": "shared-secret",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "client-secret": {
+          "description": "Your app's client secret. This secret allows us to return the X-Shopify-Hmac-SHA256 header that lets you validate the origin of the response that you receive.",
+          "env": "SHOPIFY_FLAG_CLIENT_SECRET",
+          "hidden": false,
+          "name": "client-secret",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "address": {
+          "description": "The URL where the webhook payload should be sent.\n                    You will need a different address type for each delivery-method:\n                          · For remote HTTP testing, use a URL that starts with https://\n      · For local HTTP testing, use http://localhost:{port}/{url-path}\n                          · For Google Pub/Sub, use pubsub://{project-id}:{topic-id}\n                          · For Amazon EventBridge, use an Amazon Resource Name (ARN) starting with arn:aws:events:",
+          "env": "SHOPIFY_FLAG_ADDRESS",
+          "hidden": false,
+          "name": "address",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
           "type": "option"
         }
       },
       "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "auth:login",
+      "hidden": true,
+      "hiddenAliases": [],
+      "id": "webhook:trigger",
       "pluginAlias": "@shopify/cli",
       "pluginName": "@shopify/cli",
       "pluginType": "core",
-      "strict": true
+      "summary": "Trigger delivery of a sample webhook topic payload to a designated address.",
+      "descriptionWithMarkdown": "\n  Triggers the delivery of a sample Admin API event topic payload to a designated address.\n\n  You should use this command to experiment with webhooks, to initially test your webhook configuration, or for unit testing. However, to test your webhook configuration from end to end, you should always trigger webhooks by performing the related action in Shopify.\n\n  Because most webhook deliveries use remote endpoints, you can trigger the command from any directory where you can use Shopify CLI, and send the webhook to any of the supported endpoint types. For example, you can run the command from your app's local directory, but send the webhook to a staging environment endpoint.\n\n  To learn more about using webhooks in a Shopify app, refer to [Webhooks overview](https://shopify.dev/docs/apps/webhooks).\n\n  ### Limitations\n\n  - Webhooks triggered using this method always have the same payload, so they can't be used to test scenarios that differ based on the payload contents.\n  - Webhooks triggered using this method aren't retried when they fail.\n  - Trigger requests are rate-limited using the [Partner API rate limit](https://shopify.dev/docs/api/partner#rate_limits).\n  - You can't use this method to validate your API webhook subscriptions.\n  ",
+      "customPluginName": "@shopify/app"
     },
-    "auth:logout": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "description": "Logs you out of the Shopify account or Partner account and store.",
-      "enableJsonFlag": false,
+    "demo:watcher": {
+      "aliases": [],
+      "args": {},
       "flags": {
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "auth:logout",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true
-    },
-    "cache:clear": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "description": "Clear the CLI cache, used to store some API responses and handle notifications status",
-      "enableJsonFlag": false,
-      "flags": {
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path to your app directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "name": "path",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "config": {
+          "char": "c",
+          "description": "The name of the app configuration.",
+          "env": "SHOPIFY_FLAG_APP_CONFIG",
+          "hidden": false,
+          "name": "config",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "client-id": {
+          "description": "The Client ID of your app.",
+          "env": "SHOPIFY_FLAG_CLIENT_ID",
+          "exclusive": [
+            "config"
+          ],
+          "hidden": false,
+          "name": "client-id",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "reset": {
+          "description": "Reset all your settings.",
+          "env": "SHOPIFY_FLAG_RESET",
+          "exclusive": [
+            "config"
+          ],
+          "hidden": false,
+          "name": "reset",
+          "allowNo": false,
+          "type": "boolean"
+        }
       },
       "hasDynamicHelp": false,
       "hidden": true,
-      "hiddenAliases": [
-      ],
-      "id": "cache:clear",
+      "hiddenAliases": [],
+      "id": "demo:watcher",
       "pluginAlias": "@shopify/cli",
       "pluginName": "@shopify/cli",
       "pluginType": "core",
-      "strict": true
+      "strict": true,
+      "summary": "Watch and prints out changes to an app.",
+      "customPluginName": "@shopify/app"
     },
-    "commands": {
+    "organization:list": {
+      "aliases": [],
+      "args": {},
+      "description": "Lists the Shopify organizations that you have access to, along with their organization IDs.",
+      "flags": {
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "json": {
+          "char": "j",
+          "description": "Output the result as JSON. Automatically disables color output.",
+          "env": "SHOPIFY_FLAG_JSON",
+          "hidden": false,
+          "name": "json",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "organization:list",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "summary": "List Shopify organizations you have access to.",
+      "enableJsonFlag": false,
+      "descriptionWithMarkdown": "Lists the Shopify organizations that you have access to, along with their organization IDs.",
+      "customPluginName": "@shopify/app"
+    },
+    "theme:init": {
+      "aliases": [],
+      "args": {
+        "name": {
+          "description": "Name of the new theme",
+          "name": "name",
+          "required": false
+        }
+      },
+      "description": "Clones a Git repository to your local machine to use as the starting point for building a theme.\n\n  If no Git repository is specified, then this command creates a copy of Shopify's \"Skeleton theme\" (https://github.com/Shopify/skeleton-theme.git), with the specified name in the current folder. If no name is provided, then you're prompted to enter one.\n\n  > Caution: If you're building a theme for the Shopify Theme Store, then you can use our example theme as a starting point. However, the theme that you submit needs to be \"substantively different from existing themes\" (https://shopify.dev/docs/themes/store/requirements#uniqueness) so that it provides added value for users.\n  ",
+      "flags": {
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path where you want to run the command. Defaults to the current working directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "name": "path",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "clone-url": {
+          "char": "u",
+          "description": "The Git URL to clone from. Defaults to Shopify's Skeleton theme.",
+          "env": "SHOPIFY_FLAG_CLONE_URL",
+          "name": "clone-url",
+          "default": "https://github.com/Shopify/skeleton-theme.git",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "latest": {
+          "char": "l",
+          "description": "Downloads the latest release of the `clone-url`",
+          "env": "SHOPIFY_FLAG_LATEST",
+          "name": "latest",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "theme:init",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "summary": "Clones a Git repository to use as a starting point for building a new theme.",
+      "usage": "theme init [name] [flags]",
+      "descriptionWithMarkdown": "Clones a Git repository to your local machine to use as the starting point for building a theme.\n\n  If no Git repository is specified, then this command creates a copy of Shopify's [Skeleton theme](https://github.com/Shopify/skeleton-theme.git), with the specified name in the current folder. If no name is provided, then you're prompted to enter one.\n\n  > Caution: If you're building a theme for the Shopify Theme Store, then you can use our example theme as a starting point. However, the theme that you submit needs to be [substantively different from existing themes](https://shopify.dev/docs/themes/store/requirements#uniqueness) so that it provides added value for users.\n  ",
+      "multiEnvironmentsFlags": null,
+      "customPluginName": "@shopify/theme"
+    },
+    "theme:check": {
+      "aliases": [],
+      "args": {},
+      "description": "Calls and runs \"Theme Check\" (https://shopify.dev/docs/themes/tools/theme-check) to analyze your theme code for errors and to ensure that it follows theme and Liquid best practices. \"Learn more about the checks that Theme Check runs.\" (https://shopify.dev/docs/themes/tools/theme-check/checks)",
+      "flags": {
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path where you want to run the command. Defaults to the current working directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "name": "path",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "auto-correct": {
+          "char": "a",
+          "description": "Automatically fix offenses",
+          "env": "SHOPIFY_FLAG_AUTO_CORRECT",
+          "name": "auto-correct",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "config": {
+          "char": "C",
+          "description": "Use the config provided, overriding .theme-check.yml if present\n      Supports all theme-check: config values, e.g., theme-check:theme-app-extension,\n      theme-check:recommended, theme-check:all\n      For backwards compatibility, :theme_app_extension is also supported ",
+          "env": "SHOPIFY_FLAG_CONFIG",
+          "name": "config",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "fail-level": {
+          "description": "Minimum severity for exit with error code",
+          "env": "SHOPIFY_FLAG_FAIL_LEVEL",
+          "name": "fail-level",
+          "required": false,
+          "default": "error",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "options": [
+            "crash",
+            "error",
+            "suggestion",
+            "style",
+            "warning",
+            "info"
+          ],
+          "type": "option"
+        },
+        "init": {
+          "description": "Generate a .theme-check.yml file",
+          "env": "SHOPIFY_FLAG_INIT",
+          "name": "init",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "list": {
+          "description": "List enabled checks",
+          "env": "SHOPIFY_FLAG_LIST",
+          "name": "list",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "output": {
+          "char": "o",
+          "description": "The output format to use",
+          "env": "SHOPIFY_FLAG_OUTPUT",
+          "name": "output",
+          "required": false,
+          "default": "text",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "options": [
+            "text",
+            "json"
+          ],
+          "type": "option"
+        },
+        "print": {
+          "description": "Output active config to STDOUT",
+          "env": "SHOPIFY_FLAG_PRINT",
+          "name": "print",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "version": {
+          "char": "v",
+          "description": "Print Theme Check version",
+          "env": "SHOPIFY_FLAG_VERSION",
+          "name": "version",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "environment": {
+          "char": "e",
+          "description": "The environment to apply to the current command.",
+          "env": "SHOPIFY_FLAG_ENVIRONMENT",
+          "name": "environment",
+          "hasDynamicHelp": false,
+          "multiple": true,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "theme:check",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "summary": "Validate the theme.",
+      "descriptionWithMarkdown": "Calls and runs [Theme Check](https://shopify.dev/docs/themes/tools/theme-check) to analyze your theme code for errors and to ensure that it follows theme and Liquid best practices. [Learn more about the checks that Theme Check runs.](https://shopify.dev/docs/themes/tools/theme-check/checks)",
+      "multiEnvironmentsFlags": [
+        "path"
+      ],
+      "customPluginName": "@shopify/theme"
+    },
+    "theme:console": {
+      "aliases": [],
+      "args": {},
+      "description": "Starts the Shopify Liquid REPL (read-eval-print loop) tool. This tool provides an interactive terminal interface for evaluating Liquid code and exploring Liquid objects, filters, and tags using real store data.\n\n  You can also provide context to the console using a URL, as some Liquid objects are context-specific",
+      "flags": {
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path where you want to run the command. Defaults to the current working directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "name": "path",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "password": {
+          "description": "Password generated from the Theme Access app or an Admin API token.",
+          "env": "SHOPIFY_CLI_THEME_TOKEN",
+          "name": "password",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "store": {
+          "char": "s",
+          "description": "Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).",
+          "env": "SHOPIFY_FLAG_STORE",
+          "name": "store",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "environment": {
+          "char": "e",
+          "description": "The environment to apply to the current command.",
+          "env": "SHOPIFY_FLAG_ENVIRONMENT",
+          "name": "environment",
+          "hasDynamicHelp": false,
+          "multiple": true,
+          "type": "option"
+        },
+        "url": {
+          "description": "The url to be used as context",
+          "env": "SHOPIFY_FLAG_URL",
+          "name": "url",
+          "default": "/",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "store-password": {
+          "description": "The password for storefronts with password protection.",
+          "env": "SHOPIFY_FLAG_STORE_PASSWORD",
+          "name": "store-password",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "theme:console",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "summary": "Shopify Liquid REPL (read-eval-print loop) tool",
+      "usage": [
+        "theme console",
+        "theme console --url /products/classic-leather-jacket"
+      ],
+      "descriptionWithMarkdown": "Starts the Shopify Liquid REPL (read-eval-print loop) tool. This tool provides an interactive terminal interface for evaluating Liquid code and exploring Liquid objects, filters, and tags using real store data.\n\n  You can also provide context to the console using a URL, as some Liquid objects are context-specific",
+      "multiEnvironmentsFlags": null,
+      "customPluginName": "@shopify/theme"
+    },
+    "theme:delete": {
+      "aliases": [],
+      "args": {},
+      "description": "Deletes a theme from your store.\n\n  You can specify multiple themes by ID. If no theme is specified, then you're prompted to select the theme that you want to delete from the list of themes in your store.\n\n  You're asked to confirm that you want to delete the specified themes before they are deleted. You can skip this confirmation using the `--force` flag.",
+      "flags": {
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path where you want to run the command. Defaults to the current working directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "name": "path",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "password": {
+          "description": "Password generated from the Theme Access app or an Admin API token.",
+          "env": "SHOPIFY_CLI_THEME_TOKEN",
+          "name": "password",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "store": {
+          "char": "s",
+          "description": "Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).",
+          "env": "SHOPIFY_FLAG_STORE",
+          "name": "store",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "environment": {
+          "char": "e",
+          "description": "The environment to apply to the current command.",
+          "env": "SHOPIFY_FLAG_ENVIRONMENT",
+          "name": "environment",
+          "hasDynamicHelp": false,
+          "multiple": true,
+          "type": "option"
+        },
+        "development": {
+          "char": "d",
+          "description": "Delete your development theme.",
+          "env": "SHOPIFY_FLAG_DEVELOPMENT",
+          "name": "development",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "show-all": {
+          "char": "a",
+          "description": "Include others development themes in theme list.",
+          "env": "SHOPIFY_FLAG_SHOW_ALL",
+          "name": "show-all",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "force": {
+          "char": "f",
+          "description": "Skip confirmation.",
+          "env": "SHOPIFY_FLAG_FORCE",
+          "name": "force",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "theme": {
+          "char": "t",
+          "description": "Theme ID or name of the remote theme.",
+          "env": "SHOPIFY_FLAG_THEME_ID",
+          "name": "theme",
+          "hasDynamicHelp": false,
+          "multiple": true,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "theme:delete",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "summary": "Delete remote themes from the connected store. This command can't be undone.",
+      "descriptionWithMarkdown": "Deletes a theme from your store.\n\n  You can specify multiple themes by ID. If no theme is specified, then you're prompted to select the theme that you want to delete from the list of themes in your store.\n\n  You're asked to confirm that you want to delete the specified themes before they are deleted. You can skip this confirmation using the `--force` flag.",
+      "multiEnvironmentsFlags": [
+        "store",
+        "password",
+        [
+          "development",
+          "theme"
+        ]
+      ],
+      "customPluginName": "@shopify/theme"
+    },
+    "theme:dev": {
+      "aliases": [],
+      "args": {},
+      "description": "\n  Uploads the current theme as the specified theme, or a \"development theme\" (https://shopify.dev/docs/themes/tools/cli#development-themes), to a store so you can preview it.\n\nThis command returns the following information:\n\n- A link to your development theme at http://127.0.0.1:9292. This URL can hot reload local changes to CSS and sections, or refresh the entire page when a file changes, enabling you to preview changes in real time using the store's data.\n\n  You can specify a different network interface and port using `--host` and `--port`.\n\n- A link to the \"editor\" (https://shopify.dev/docs/themes/tools/online-editor) for the theme in the Shopify admin.\n\n- A \"preview link\" (https://help.shopify.com/manual/online-store/themes/adding-themes#share-a-theme-preview-with-others) that you can share with other developers.\n\nIf you already have a development theme for your current environment, then this command replaces the development theme with your local theme. You can override this using the `--theme-editor-sync` flag.\n\n> Note: You can't preview checkout customizations using http://127.0.0.1:9292.\n\nDevelopment themes are deleted when you run `shopify auth logout`. If you need a preview link that can be used after you log out, then you should \"share\" (https://shopify.dev/docs/api/shopify-cli/theme/theme-share) your theme or \"push\" (https://shopify.dev/docs/api/shopify-cli/theme/theme-push) to an unpublished theme on your store.\n\nYou can run this command only in a directory that matches the \"default Shopify theme folder structure\" (https://shopify.dev/docs/themes/tools/cli#directory-structure).",
+      "flags": {
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path where you want to run the command. Defaults to the current working directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "name": "path",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "password": {
+          "description": "Password generated from the Theme Access app or an Admin API token.",
+          "env": "SHOPIFY_CLI_THEME_TOKEN",
+          "name": "password",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "store": {
+          "char": "s",
+          "description": "Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).",
+          "env": "SHOPIFY_FLAG_STORE",
+          "name": "store",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "environment": {
+          "char": "e",
+          "description": "The environment to apply to the current command.",
+          "env": "SHOPIFY_FLAG_ENVIRONMENT",
+          "name": "environment",
+          "hasDynamicHelp": false,
+          "multiple": true,
+          "type": "option"
+        },
+        "host": {
+          "description": "Set which network interface the web server listens on. The default value is 127.0.0.1.",
+          "env": "SHOPIFY_FLAG_HOST",
+          "name": "host",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "live-reload": {
+          "description": "The live reload mode switches the server behavior when a file is modified:\n- hot-reload Hot reloads local changes to CSS and sections (default)\n- full-page  Always refreshes the entire page\n- off        Deactivate live reload",
+          "env": "SHOPIFY_FLAG_LIVE_RELOAD",
+          "name": "live-reload",
+          "default": "hot-reload",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "options": [
+            "hot-reload",
+            "full-page",
+            "off"
+          ],
+          "type": "option"
+        },
+        "error-overlay": {
+          "description": "Controls the visibility of the error overlay when an theme asset upload fails:\n- silent Prevents the error overlay from appearing.\n- default Displays the error overlay.\n      ",
+          "env": "SHOPIFY_FLAG_ERROR_OVERLAY",
+          "name": "error-overlay",
+          "default": "default",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "options": [
+            "silent",
+            "default"
+          ],
+          "type": "option"
+        },
+        "poll": {
+          "description": "Force polling to detect file changes.",
+          "env": "SHOPIFY_FLAG_POLL",
+          "hidden": true,
+          "name": "poll",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "theme-editor-sync": {
+          "description": "Synchronize Theme Editor updates in the local theme files.",
+          "env": "SHOPIFY_FLAG_THEME_EDITOR_SYNC",
+          "name": "theme-editor-sync",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "port": {
+          "description": "Local port to serve theme preview from.",
+          "env": "SHOPIFY_FLAG_PORT",
+          "name": "port",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "theme": {
+          "char": "t",
+          "description": "Theme ID or name of the remote theme.",
+          "env": "SHOPIFY_FLAG_THEME_ID",
+          "name": "theme",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "listing": {
+          "description": "The listing preset to use for multi-preset themes. Applies preset files from listings/[preset-name] directory.",
+          "env": "SHOPIFY_FLAG_LISTING",
+          "name": "listing",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "nodelete": {
+          "char": "n",
+          "description": "Prevents files from being deleted in the remote theme when a file has been deleted locally. This applies to files that are deleted while the command is running, and files that have been deleted locally before the command is run.",
+          "env": "SHOPIFY_FLAG_NODELETE",
+          "name": "nodelete",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "only": {
+          "char": "o",
+          "description": "Hot reload only files that match the specified pattern.",
+          "env": "SHOPIFY_FLAG_ONLY",
+          "name": "only",
+          "hasDynamicHelp": false,
+          "multiple": true,
+          "type": "option"
+        },
+        "ignore": {
+          "char": "x",
+          "description": "Skip hot reloading any files that match the specified pattern.",
+          "env": "SHOPIFY_FLAG_IGNORE",
+          "name": "ignore",
+          "hasDynamicHelp": false,
+          "multiple": true,
+          "type": "option"
+        },
+        "force": {
+          "char": "f",
+          "description": "Proceed without confirmation, if current directory does not seem to be theme directory.",
+          "env": "SHOPIFY_FLAG_FORCE",
+          "hidden": true,
+          "name": "force",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "notify": {
+          "description": "The file path or URL. The file path is to a file that you want updated on idle. The URL path is where you want a webhook posted to report on file changes.",
+          "env": "SHOPIFY_FLAG_NOTIFY",
+          "name": "notify",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "open": {
+          "description": "Automatically launch the theme preview in your default web browser.",
+          "env": "SHOPIFY_FLAG_OPEN",
+          "name": "open",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "store-password": {
+          "description": "The password for storefronts with password protection.",
+          "env": "SHOPIFY_FLAG_STORE_PASSWORD",
+          "name": "store-password",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "allow-live": {
+          "char": "a",
+          "description": "Allow development on a live theme.",
+          "env": "SHOPIFY_FLAG_ALLOW_LIVE",
+          "name": "allow-live",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "theme:dev",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "summary": "Uploads the current theme as a development theme to the connected store, then prints theme editor and preview URLs to your terminal. While running, changes will push to the store in real time.",
+      "descriptionWithMarkdown": "\n  Uploads the current theme as the specified theme, or a [development theme](https://shopify.dev/docs/themes/tools/cli#development-themes), to a store so you can preview it.\n\nThis command returns the following information:\n\n- A link to your development theme at http://127.0.0.1:9292. This URL can hot reload local changes to CSS and sections, or refresh the entire page when a file changes, enabling you to preview changes in real time using the store's data.\n\n  You can specify a different network interface and port using `--host` and `--port`.\n\n- A link to the [editor](https://shopify.dev/docs/themes/tools/online-editor) for the theme in the Shopify admin.\n\n- A [preview link](https://help.shopify.com/manual/online-store/themes/adding-themes#share-a-theme-preview-with-others) that you can share with other developers.\n\nIf you already have a development theme for your current environment, then this command replaces the development theme with your local theme. You can override this using the `--theme-editor-sync` flag.\n\n> Note: You can't preview checkout customizations using http://127.0.0.1:9292.\n\nDevelopment themes are deleted when you run `shopify auth logout`. If you need a preview link that can be used after you log out, then you should [share](https://shopify.dev/docs/api/shopify-cli/theme/theme-share) your theme or [push](https://shopify.dev/docs/api/shopify-cli/theme/theme-push) to an unpublished theme on your store.\n\nYou can run this command only in a directory that matches the [default Shopify theme folder structure](https://shopify.dev/docs/themes/tools/cli#directory-structure).",
+      "multiEnvironmentsFlags": null,
+      "customPluginName": "@shopify/theme"
+    },
+    "theme:duplicate": {
+      "aliases": [],
+      "args": {},
+      "description": "If you want to duplicate your local theme, you need to run `shopify theme push` first.\n\nIf no theme ID is specified, you're prompted to select the theme that you want to duplicate from the list of themes in your store. You're asked to confirm that you want to duplicate the specified theme.\n\nPrompts and confirmations are not shown when duplicate is run in a CI environment or the `--force` flag is used, therefore you must specify a theme ID using the `--theme` flag.\n\nYou can optionally name the duplicated theme using the `--name` flag.\n\nIf you use the `--json` flag, then theme information is returned in JSON format, which can be used as a machine-readable input for scripts or continuous integration.\n\nSample JSON output:\n\n```json\n{\n  \"theme\": {\n    \"id\": 108267175958,\n    \"name\": \"A Duplicated Theme\",\n    \"role\": \"unpublished\",\n    \"shop\": \"mystore.myshopify.com\"\n  }\n}\n```\n\n```json\n{\n  \"message\": \"The theme 'Summer Edition' could not be duplicated due to errors\",\n  \"errors\": [\"Maximum number of themes reached\"],\n  \"requestId\": \"12345-abcde-67890\"\n}\n```",
+      "flags": {
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "json": {
+          "char": "j",
+          "description": "Output the result as JSON. Automatically disables color output.",
+          "env": "SHOPIFY_FLAG_JSON",
+          "hidden": false,
+          "name": "json",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "password": {
+          "description": "Password generated from the Theme Access app or an Admin API token.",
+          "env": "SHOPIFY_CLI_THEME_TOKEN",
+          "name": "password",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "theme": {
+          "char": "t",
+          "description": "Theme ID or name of the remote theme.",
+          "env": "SHOPIFY_FLAG_THEME_ID",
+          "name": "theme",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "name": {
+          "char": "n",
+          "description": "Name of the newly duplicated theme.",
+          "env": "SHOPIFY_FLAG_NAME",
+          "name": "name",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "store": {
+          "char": "s",
+          "description": "Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).",
+          "env": "SHOPIFY_FLAG_STORE",
+          "name": "store",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "environment": {
+          "char": "e",
+          "description": "The environment to apply to the current command.",
+          "env": "SHOPIFY_FLAG_ENVIRONMENT",
+          "name": "environment",
+          "hasDynamicHelp": false,
+          "multiple": true,
+          "type": "option"
+        },
+        "force": {
+          "char": "f",
+          "description": "Force the duplicate operation to run without prompts or confirmations.",
+          "env": "SHOPIFY_FLAG_FORCE",
+          "name": "force",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "theme:duplicate",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "summary": "Duplicates a theme from your theme library.",
+      "usage": [
+        "theme duplicate",
+        "theme duplicate --theme 10 --name 'New Theme'"
+      ],
+      "descriptionWithMarkdown": "If you want to duplicate your local theme, you need to run `shopify theme push` first.\n\nIf no theme ID is specified, you're prompted to select the theme that you want to duplicate from the list of themes in your store. You're asked to confirm that you want to duplicate the specified theme.\n\nPrompts and confirmations are not shown when duplicate is run in a CI environment or the `--force` flag is used, therefore you must specify a theme ID using the `--theme` flag.\n\nYou can optionally name the duplicated theme using the `--name` flag.\n\nIf you use the `--json` flag, then theme information is returned in JSON format, which can be used as a machine-readable input for scripts or continuous integration.\n\nSample JSON output:\n\n```json\n{\n  \"theme\": {\n    \"id\": 108267175958,\n    \"name\": \"A Duplicated Theme\",\n    \"role\": \"unpublished\",\n    \"shop\": \"mystore.myshopify.com\"\n  }\n}\n```\n\n```json\n{\n  \"message\": \"The theme 'Summer Edition' could not be duplicated due to errors\",\n  \"errors\": [\"Maximum number of themes reached\"],\n  \"requestId\": \"12345-abcde-67890\"\n}\n```",
+      "customPluginName": "@shopify/theme"
+    },
+    "theme:info": {
+      "aliases": [],
+      "args": {},
+      "description": "Displays information about your theme environment, including your current store. Can also retrieve information about a specific theme.",
+      "flags": {
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "json": {
+          "char": "j",
+          "description": "Output the result as JSON. Automatically disables color output.",
+          "env": "SHOPIFY_FLAG_JSON",
+          "hidden": false,
+          "name": "json",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path where you want to run the command. Defaults to the current working directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "name": "path",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "password": {
+          "description": "Password generated from the Theme Access app or an Admin API token.",
+          "env": "SHOPIFY_CLI_THEME_TOKEN",
+          "name": "password",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "store": {
+          "char": "s",
+          "description": "Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).",
+          "env": "SHOPIFY_FLAG_STORE",
+          "name": "store",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "environment": {
+          "char": "e",
+          "description": "The environment to apply to the current command.",
+          "env": "SHOPIFY_FLAG_ENVIRONMENT",
+          "name": "environment",
+          "hasDynamicHelp": false,
+          "multiple": true,
+          "type": "option"
+        },
+        "development": {
+          "char": "d",
+          "description": "Retrieve info from your development theme.",
+          "env": "SHOPIFY_FLAG_DEVELOPMENT",
+          "name": "development",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "theme": {
+          "char": "t",
+          "description": "Theme ID or name of the remote theme.",
+          "env": "SHOPIFY_FLAG_THEME_ID",
+          "name": "theme",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "theme:info",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "multiEnvironmentsFlags": [
+        "store",
+        "password"
+      ],
+      "customPluginName": "@shopify/theme"
+    },
+    "theme:language-server": {
+      "aliases": [],
+      "args": {},
+      "description": "Starts the \"Language Server\" (https://shopify.dev/docs/themes/tools/cli/language-server).",
+      "flags": {
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "theme:language-server",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "summary": "Start a Language Server Protocol server.",
+      "descriptionWithMarkdown": "Starts the [Language Server](https://shopify.dev/docs/themes/tools/cli/language-server).",
+      "multiEnvironmentsFlags": null,
+      "customPluginName": "@shopify/theme"
+    },
+    "theme:list": {
+      "aliases": [],
+      "args": {},
+      "description": "Lists the themes in your store, along with their IDs and statuses.",
+      "flags": {
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "json": {
+          "char": "j",
+          "description": "Output the result as JSON. Automatically disables color output.",
+          "env": "SHOPIFY_FLAG_JSON",
+          "hidden": false,
+          "name": "json",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path where you want to run the command. Defaults to the current working directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "name": "path",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "password": {
+          "description": "Password generated from the Theme Access app or an Admin API token.",
+          "env": "SHOPIFY_CLI_THEME_TOKEN",
+          "name": "password",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "store": {
+          "char": "s",
+          "description": "Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).",
+          "env": "SHOPIFY_FLAG_STORE",
+          "name": "store",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "environment": {
+          "char": "e",
+          "description": "The environment to apply to the current command.",
+          "env": "SHOPIFY_FLAG_ENVIRONMENT",
+          "name": "environment",
+          "hasDynamicHelp": false,
+          "multiple": true,
+          "type": "option"
+        },
+        "role": {
+          "description": "Only list themes with the given role.",
+          "env": "SHOPIFY_FLAG_ROLE",
+          "name": "role",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "options": [
+            "live",
+            "unpublished",
+            "development"
+          ],
+          "type": "option"
+        },
+        "name": {
+          "description": "Only list themes that contain the given name.",
+          "env": "SHOPIFY_FLAG_NAME",
+          "name": "name",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "id": {
+          "description": "Only list theme with the given ID.",
+          "env": "SHOPIFY_FLAG_ID",
+          "name": "id",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "theme:list",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "multiEnvironmentsFlags": [
+        "store",
+        "password"
+      ],
+      "customPluginName": "@shopify/theme"
+    },
+    "theme:metafields:pull": {
+      "aliases": [],
+      "args": {},
+      "description": "Retrieves metafields from Shopify Admin.\n\nIf the metafields file already exists, it will be overwritten.",
+      "flags": {
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path where you want to run the command. Defaults to the current working directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "name": "path",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "password": {
+          "description": "Password generated from the Theme Access app or an Admin API token.",
+          "env": "SHOPIFY_CLI_THEME_TOKEN",
+          "name": "password",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "store": {
+          "char": "s",
+          "description": "Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).",
+          "env": "SHOPIFY_FLAG_STORE",
+          "name": "store",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "environment": {
+          "char": "e",
+          "description": "The environment to apply to the current command.",
+          "env": "SHOPIFY_FLAG_ENVIRONMENT",
+          "name": "environment",
+          "hasDynamicHelp": false,
+          "multiple": true,
+          "type": "option"
+        },
+        "force": {
+          "char": "f",
+          "description": "Proceed without confirmation, if current directory does not seem to be theme directory.",
+          "env": "SHOPIFY_FLAG_FORCE",
+          "hidden": true,
+          "name": "force",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "theme:metafields:pull",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "summary": "Download metafields definitions from your shop into a local file.",
+      "descriptionWithMarkdown": "Retrieves metafields from Shopify Admin.\n\nIf the metafields file already exists, it will be overwritten.",
+      "multiEnvironmentsFlags": null,
+      "customPluginName": "@shopify/theme"
+    },
+    "theme:open": {
+      "aliases": [],
+      "args": {},
+      "description": "Returns links that let you preview the specified theme. The following links are returned:\n\n  - A link to the \"editor\" (https://shopify.dev/docs/themes/tools/online-editor) for the theme in the Shopify admin.\n  - A \"preview link\" (https://help.shopify.com/manual/online-store/themes/adding-themes#share-a-theme-preview-with-others) that you can share with other developers.\n\n  If you don't specify a theme, then you're prompted to select the theme to open from the list of the themes in your store.",
+      "flags": {
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path where you want to run the command. Defaults to the current working directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "name": "path",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "password": {
+          "description": "Password generated from the Theme Access app or an Admin API token.",
+          "env": "SHOPIFY_CLI_THEME_TOKEN",
+          "name": "password",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "store": {
+          "char": "s",
+          "description": "Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).",
+          "env": "SHOPIFY_FLAG_STORE",
+          "name": "store",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "environment": {
+          "char": "e",
+          "description": "The environment to apply to the current command.",
+          "env": "SHOPIFY_FLAG_ENVIRONMENT",
+          "name": "environment",
+          "hasDynamicHelp": false,
+          "multiple": true,
+          "type": "option"
+        },
+        "development": {
+          "char": "d",
+          "description": "Open your development theme.",
+          "env": "SHOPIFY_FLAG_DEVELOPMENT",
+          "name": "development",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "editor": {
+          "char": "E",
+          "description": "Open the theme editor for the specified theme in the browser.",
+          "env": "SHOPIFY_FLAG_EDITOR",
+          "name": "editor",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "live": {
+          "char": "l",
+          "description": "Open your live (published) theme.",
+          "env": "SHOPIFY_FLAG_LIVE",
+          "name": "live",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "theme": {
+          "char": "t",
+          "description": "Theme ID or name of the remote theme.",
+          "env": "SHOPIFY_FLAG_THEME_ID",
+          "name": "theme",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "theme:open",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "summary": "Opens the preview of your remote theme.",
+      "descriptionWithMarkdown": "Returns links that let you preview the specified theme. The following links are returned:\n\n  - A link to the [editor](https://shopify.dev/docs/themes/tools/online-editor) for the theme in the Shopify admin.\n  - A [preview link](https://help.shopify.com/manual/online-store/themes/adding-themes#share-a-theme-preview-with-others) that you can share with other developers.\n\n  If you don't specify a theme, then you're prompted to select the theme to open from the list of the themes in your store.",
+      "multiEnvironmentsFlags": null,
+      "customPluginName": "@shopify/theme"
+    },
+    "theme:package": {
+      "aliases": [],
+      "args": {},
+      "description": "Packages your local theme files into a ZIP file that can be uploaded to Shopify.\n\n  Only folders that match the \"default Shopify theme folder structure\" (https://shopify.dev/docs/storefronts/themes/tools/cli#directory-structure) are included in the package.\n\n  The package includes the `listings` directory if present (required for multi-preset themes per \"Theme Store requirements\" (https://shopify.dev/docs/storefronts/themes/store/requirements#adding-presets-to-your-theme-zip-submission)).\n\n  The ZIP file uses the name `theme_name-theme_version.zip`, based on parameters in your \"settings_schema.json\" (https://shopify.dev/docs/storefronts/themes/architecture/config/settings-schema-json) file.",
+      "flags": {
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path where you want to run the command. Defaults to the current working directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "name": "path",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "theme:package",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "summary": "Package your theme into a .zip file, ready to upload to the Online Store.",
+      "descriptionWithMarkdown": "Packages your local theme files into a ZIP file that can be uploaded to Shopify.\n\n  Only folders that match the [default Shopify theme folder structure](https://shopify.dev/docs/storefronts/themes/tools/cli#directory-structure) are included in the package.\n\n  The package includes the `listings` directory if present (required for multi-preset themes per [Theme Store requirements](https://shopify.dev/docs/storefronts/themes/store/requirements#adding-presets-to-your-theme-zip-submission)).\n\n  The ZIP file uses the name `theme_name-theme_version.zip`, based on parameters in your [settings_schema.json](https://shopify.dev/docs/storefronts/themes/architecture/config/settings-schema-json) file.",
+      "multiEnvironmentsFlags": null,
+      "customPluginName": "@shopify/theme"
+    },
+    "theme:profile": {
+      "aliases": [],
+      "args": {},
+      "description": "Profile the Shopify Liquid on a given page.\n\n  This command will open a web page with the Speedscope profiler detailing the time spent executing Liquid on the given page.",
+      "flags": {
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path where you want to run the command. Defaults to the current working directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "name": "path",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "password": {
+          "description": "Password generated from the Theme Access app or an Admin API token.",
+          "env": "SHOPIFY_CLI_THEME_TOKEN",
+          "name": "password",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "store": {
+          "char": "s",
+          "description": "Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).",
+          "env": "SHOPIFY_FLAG_STORE",
+          "name": "store",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "environment": {
+          "char": "e",
+          "description": "The environment to apply to the current command.",
+          "env": "SHOPIFY_FLAG_ENVIRONMENT",
+          "name": "environment",
+          "hasDynamicHelp": false,
+          "multiple": true,
+          "type": "option"
+        },
+        "theme": {
+          "char": "t",
+          "description": "Theme ID or name of the remote theme.",
+          "env": "SHOPIFY_FLAG_THEME_ID",
+          "name": "theme",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "url": {
+          "description": "The url to be used as context",
+          "env": "SHOPIFY_FLAG_URL",
+          "name": "url",
+          "default": "/",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "store-password": {
+          "description": "The password for storefronts with password protection.",
+          "env": "SHOPIFY_FLAG_STORE_PASSWORD",
+          "name": "store-password",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "json": {
+          "char": "j",
+          "description": "Output the result as JSON. Automatically disables color output.",
+          "env": "SHOPIFY_FLAG_JSON",
+          "hidden": false,
+          "name": "json",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "theme:profile",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "summary": "Profile the Liquid rendering of a theme page.",
+      "usage": [
+        "theme profile",
+        "theme profile --url /products/classic-leather-jacket"
+      ],
+      "descriptionWithMarkdown": "Profile the Shopify Liquid on a given page.\n\n  This command will open a web page with the Speedscope profiler detailing the time spent executing Liquid on the given page.",
+      "multiEnvironmentsFlags": null,
+      "customPluginName": "@shopify/theme"
+    },
+    "theme:publish": {
+      "aliases": [],
+      "args": {},
+      "description": "Publishes an unpublished theme from your theme library.\n\nIf no theme ID is specified, then you're prompted to select the theme that you want to publish from the list of themes in your store.\n\nYou can run this command only in a directory that matches the \"default Shopify theme folder structure\" (https://shopify.dev/docs/themes/tools/cli#directory-structure).\n\nIf you want to publish your local theme, then you need to run `shopify theme push` first. You're asked to confirm that you want to publish the specified theme. You can skip this confirmation using the `--force` flag.",
+      "flags": {
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path where you want to run the command. Defaults to the current working directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "name": "path",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "password": {
+          "description": "Password generated from the Theme Access app or an Admin API token.",
+          "env": "SHOPIFY_CLI_THEME_TOKEN",
+          "name": "password",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "store": {
+          "char": "s",
+          "description": "Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).",
+          "env": "SHOPIFY_FLAG_STORE",
+          "name": "store",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "environment": {
+          "char": "e",
+          "description": "The environment to apply to the current command.",
+          "env": "SHOPIFY_FLAG_ENVIRONMENT",
+          "name": "environment",
+          "hasDynamicHelp": false,
+          "multiple": true,
+          "type": "option"
+        },
+        "force": {
+          "char": "f",
+          "description": "Skip confirmation.",
+          "env": "SHOPIFY_FLAG_FORCE",
+          "name": "force",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "theme": {
+          "char": "t",
+          "description": "Theme ID or name of the remote theme.",
+          "env": "SHOPIFY_FLAG_THEME_ID",
+          "name": "theme",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "theme:publish",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "summary": "Set a remote theme as the live theme.",
+      "descriptionWithMarkdown": "Publishes an unpublished theme from your theme library.\n\nIf no theme ID is specified, then you're prompted to select the theme that you want to publish from the list of themes in your store.\n\nYou can run this command only in a directory that matches the [default Shopify theme folder structure](https://shopify.dev/docs/themes/tools/cli#directory-structure).\n\nIf you want to publish your local theme, then you need to run `shopify theme push` first. You're asked to confirm that you want to publish the specified theme. You can skip this confirmation using the `--force` flag.",
+      "multiEnvironmentsFlags": [
+        "store",
+        "password",
+        "theme"
+      ],
+      "customPluginName": "@shopify/theme"
+    },
+    "theme:preview": {
+      "aliases": [],
+      "args": {},
+      "description": "Applies a JSON overrides file to a theme and creates or updates a preview. This lets you quickly preview changes.\n\n  The command returns a preview URL and a preview identifier. You can reuse the preview identifier with `--preview-id` to update an existing preview instead of creating a new one.",
+      "flags": {
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path where you want to run the command. Defaults to the current working directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "name": "path",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "password": {
+          "description": "Password generated from the Theme Access app or an Admin API token.",
+          "env": "SHOPIFY_CLI_THEME_TOKEN",
+          "name": "password",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "store": {
+          "char": "s",
+          "description": "Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).",
+          "env": "SHOPIFY_FLAG_STORE",
+          "name": "store",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "environment": {
+          "char": "e",
+          "description": "The environment to apply to the current command.",
+          "env": "SHOPIFY_FLAG_ENVIRONMENT",
+          "name": "environment",
+          "hasDynamicHelp": false,
+          "multiple": true,
+          "type": "option"
+        },
+        "theme": {
+          "char": "t",
+          "description": "Theme ID or name of the remote theme.",
+          "env": "SHOPIFY_FLAG_THEME_ID",
+          "name": "theme",
+          "required": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "overrides": {
+          "description": "Path to a JSON overrides file.",
+          "env": "SHOPIFY_FLAG_OVERRIDES",
+          "name": "overrides",
+          "required": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "preview-id": {
+          "description": "An existing preview identifier to update instead of creating a new preview.",
+          "env": "SHOPIFY_FLAG_PREVIEW_ID",
+          "name": "preview-id",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "open": {
+          "description": "Automatically launch the theme preview in your default web browser.",
+          "env": "SHOPIFY_FLAG_OPEN",
+          "name": "open",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "json": {
+          "description": "Output the preview URL and identifier as JSON.",
+          "env": "SHOPIFY_FLAG_JSON",
+          "name": "json",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "theme:preview",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "summary": "Applies JSON overrides to a theme and returns a preview URL.",
+      "descriptionWithMarkdown": "Applies a JSON overrides file to a theme and creates or updates a preview. This lets you quickly preview changes.\n\n  The command returns a preview URL and a preview identifier. You can reuse the preview identifier with `--preview-id` to update an existing preview instead of creating a new one.",
+      "multiEnvironmentsFlags": null,
+      "customPluginName": "@shopify/theme"
+    },
+    "theme:pull": {
+      "aliases": [],
+      "args": {},
+      "description": "Retrieves theme files from Shopify.\n\nIf no theme is specified, then you're prompted to select the theme to pull from the list of the themes in your store.",
+      "flags": {
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path where you want to run the command. Defaults to the current working directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "name": "path",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "password": {
+          "description": "Password generated from the Theme Access app or an Admin API token.",
+          "env": "SHOPIFY_CLI_THEME_TOKEN",
+          "name": "password",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "store": {
+          "char": "s",
+          "description": "Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).",
+          "env": "SHOPIFY_FLAG_STORE",
+          "name": "store",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "environment": {
+          "char": "e",
+          "description": "The environment to apply to the current command.",
+          "env": "SHOPIFY_FLAG_ENVIRONMENT",
+          "name": "environment",
+          "hasDynamicHelp": false,
+          "multiple": true,
+          "type": "option"
+        },
+        "only": {
+          "char": "o",
+          "description": "Download only the specified files (Multiple flags allowed). Wrap the value in double quotes if you're using wildcards.",
+          "env": "SHOPIFY_FLAG_ONLY",
+          "name": "only",
+          "hasDynamicHelp": false,
+          "multiple": true,
+          "type": "option"
+        },
+        "ignore": {
+          "char": "x",
+          "description": "Skip downloading the specified files (Multiple flags allowed). Wrap the value in double quotes if you're using wildcards.",
+          "env": "SHOPIFY_FLAG_IGNORE",
+          "name": "ignore",
+          "hasDynamicHelp": false,
+          "multiple": true,
+          "type": "option"
+        },
+        "theme": {
+          "char": "t",
+          "description": "Theme ID or name of the remote theme.",
+          "env": "SHOPIFY_FLAG_THEME_ID",
+          "name": "theme",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "development": {
+          "char": "d",
+          "description": "Pull theme files from your remote development theme.",
+          "env": "SHOPIFY_FLAG_DEVELOPMENT",
+          "name": "development",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "live": {
+          "char": "l",
+          "description": "Pull theme files from your remote live theme.",
+          "env": "SHOPIFY_FLAG_LIVE",
+          "name": "live",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "nodelete": {
+          "char": "n",
+          "description": "Prevent deleting local files that don't exist remotely.",
+          "env": "SHOPIFY_FLAG_NODELETE",
+          "name": "nodelete",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "force": {
+          "char": "f",
+          "description": "Proceed without confirmation, if current directory does not seem to be theme directory.",
+          "env": "SHOPIFY_FLAG_FORCE",
+          "hidden": true,
+          "name": "force",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "theme:pull",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "summary": "Download your remote theme files locally.",
+      "descriptionWithMarkdown": "Retrieves theme files from Shopify.\n\nIf no theme is specified, then you're prompted to select the theme to pull from the list of the themes in your store.",
+      "multiEnvironmentsFlags": [
+        "store",
+        "password",
+        "path",
+        [
+          "live",
+          "development",
+          "theme"
+        ]
+      ],
+      "customPluginName": "@shopify/theme"
+    },
+    "theme:push": {
+      "aliases": [],
+      "args": {},
+      "description": "Uploads your local theme files to Shopify, overwriting the remote version if specified.\n\n  If no theme is specified, then you're prompted to select the theme to overwrite from the list of the themes in your store.\n\n  You can run this command only in a directory that matches the \"default Shopify theme folder structure\" (https://shopify.dev/docs/themes/tools/cli#directory-structure).\n\n  This command returns the following information:\n\n  - A link to the \"editor\" (https://shopify.dev/docs/themes/tools/online-editor) for the theme in the Shopify admin.\n  - A \"preview link\" (https://help.shopify.com/manual/online-store/themes/adding-themes#share-a-theme-preview-with-others) that you can share with others.\n\n  If you use the `--json` flag, then theme information is returned in JSON format, which can be used as a machine-readable input for scripts or continuous integration.\n\n  Sample output:\n\n  ```json\n  {\n    \"theme\": {\n      \"id\": 108267175958,\n      \"name\": \"MyTheme\",\n      \"role\": \"unpublished\",\n      \"shop\": \"mystore.myshopify.com\",\n      \"editor_url\": \"https://mystore.myshopify.com/admin/themes/108267175958/editor\",\n      \"preview_url\": \"https://mystore.myshopify.com/?preview_theme_id=108267175958\"\n    }\n  }\n  ```\n    ",
+      "flags": {
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path where you want to run the command. Defaults to the current working directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "name": "path",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "password": {
+          "description": "Password generated from the Theme Access app or an Admin API token.",
+          "env": "SHOPIFY_CLI_THEME_TOKEN",
+          "name": "password",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "store": {
+          "char": "s",
+          "description": "Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).",
+          "env": "SHOPIFY_FLAG_STORE",
+          "name": "store",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "environment": {
+          "char": "e",
+          "description": "The environment to apply to the current command.",
+          "env": "SHOPIFY_FLAG_ENVIRONMENT",
+          "name": "environment",
+          "hasDynamicHelp": false,
+          "multiple": true,
+          "type": "option"
+        },
+        "only": {
+          "char": "o",
+          "description": "Upload only the specified files (Multiple flags allowed). Wrap the value in double quotes if you're using wildcards.",
+          "env": "SHOPIFY_FLAG_ONLY",
+          "name": "only",
+          "hasDynamicHelp": false,
+          "multiple": true,
+          "type": "option"
+        },
+        "ignore": {
+          "char": "x",
+          "description": "Skip uploading the specified files (Multiple flags allowed). Wrap the value in double quotes if you're using wildcards.",
+          "env": "SHOPIFY_FLAG_IGNORE",
+          "name": "ignore",
+          "hasDynamicHelp": false,
+          "multiple": true,
+          "type": "option"
+        },
+        "json": {
+          "char": "j",
+          "description": "Output the result as JSON. Automatically disables color output.",
+          "env": "SHOPIFY_FLAG_JSON",
+          "hidden": false,
+          "name": "json",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "theme": {
+          "char": "t",
+          "description": "Theme ID or name of the remote theme.",
+          "env": "SHOPIFY_FLAG_THEME_ID",
+          "name": "theme",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "development": {
+          "char": "d",
+          "description": "Push theme files from your remote development theme.",
+          "env": "SHOPIFY_FLAG_DEVELOPMENT",
+          "name": "development",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "development-context": {
+          "char": "c",
+          "dependsOn": [
+            "development"
+          ],
+          "description": "Unique identifier for a development theme context (e.g., PR number, branch name). Reuses an existing development theme with this context name, or creates one if none exists.",
+          "env": "SHOPIFY_FLAG_DEVELOPMENT_CONTEXT",
+          "exclusive": [
+            "theme"
+          ],
+          "name": "development-context",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "live": {
+          "char": "l",
+          "description": "Push theme files from your remote live theme.",
+          "env": "SHOPIFY_FLAG_LIVE",
+          "name": "live",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "unpublished": {
+          "char": "u",
+          "description": "Create a new unpublished theme and push to it.",
+          "env": "SHOPIFY_FLAG_UNPUBLISHED",
+          "name": "unpublished",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "nodelete": {
+          "char": "n",
+          "description": "Prevent deleting remote files that don't exist locally.",
+          "env": "SHOPIFY_FLAG_NODELETE",
+          "name": "nodelete",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "allow-live": {
+          "char": "a",
+          "description": "Allow push to a live theme.",
+          "env": "SHOPIFY_FLAG_ALLOW_LIVE",
+          "name": "allow-live",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "publish": {
+          "char": "p",
+          "description": "Publish as the live theme after uploading.",
+          "env": "SHOPIFY_FLAG_PUBLISH",
+          "name": "publish",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "force": {
+          "char": "f",
+          "description": "Proceed without confirmation, if current directory does not seem to be theme directory.",
+          "env": "SHOPIFY_FLAG_FORCE",
+          "hidden": true,
+          "name": "force",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "strict": {
+          "description": "Require theme check to pass without errors before pushing. Warnings are allowed.",
+          "env": "SHOPIFY_FLAG_STRICT_PUSH",
+          "name": "strict",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "listing": {
+          "description": "The listing preset to use for multi-preset themes. Applies preset files from listings/[preset-name] directory.",
+          "env": "SHOPIFY_FLAG_LISTING",
+          "name": "listing",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "theme:push",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "summary": "Uploads your local theme files to the connected store, overwriting the remote version if specified.",
+      "usage": [
+        "theme push",
+        "theme push --unpublished --json"
+      ],
+      "descriptionWithMarkdown": "Uploads your local theme files to Shopify, overwriting the remote version if specified.\n\n  If no theme is specified, then you're prompted to select the theme to overwrite from the list of the themes in your store.\n\n  You can run this command only in a directory that matches the [default Shopify theme folder structure](https://shopify.dev/docs/themes/tools/cli#directory-structure).\n\n  This command returns the following information:\n\n  - A link to the [editor](https://shopify.dev/docs/themes/tools/online-editor) for the theme in the Shopify admin.\n  - A [preview link](https://help.shopify.com/manual/online-store/themes/adding-themes#share-a-theme-preview-with-others) that you can share with others.\n\n  If you use the `--json` flag, then theme information is returned in JSON format, which can be used as a machine-readable input for scripts or continuous integration.\n\n  Sample output:\n\n  ```json\n  {\n    \"theme\": {\n      \"id\": 108267175958,\n      \"name\": \"MyTheme\",\n      \"role\": \"unpublished\",\n      \"shop\": \"mystore.myshopify.com\",\n      \"editor_url\": \"https://mystore.myshopify.com/admin/themes/108267175958/editor\",\n      \"preview_url\": \"https://mystore.myshopify.com/?preview_theme_id=108267175958\"\n    }\n  }\n  ```\n    ",
+      "multiEnvironmentsFlags": [
+        "store",
+        "password",
+        "path",
+        [
+          "live",
+          "development",
+          "theme"
+        ]
+      ],
+      "customPluginName": "@shopify/theme"
+    },
+    "theme:rename": {
+      "aliases": [],
+      "args": {},
+      "description": "Renames a theme in your store.\n\n  If no theme is specified, then you're prompted to select the theme that you want to rename from the list of themes in your store.\n  ",
+      "flags": {
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path where you want to run the command. Defaults to the current working directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "name": "path",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "password": {
+          "description": "Password generated from the Theme Access app or an Admin API token.",
+          "env": "SHOPIFY_CLI_THEME_TOKEN",
+          "name": "password",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "store": {
+          "char": "s",
+          "description": "Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).",
+          "env": "SHOPIFY_FLAG_STORE",
+          "name": "store",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "environment": {
+          "char": "e",
+          "description": "The environment to apply to the current command.",
+          "env": "SHOPIFY_FLAG_ENVIRONMENT",
+          "name": "environment",
+          "hasDynamicHelp": false,
+          "multiple": true,
+          "type": "option"
+        },
+        "name": {
+          "char": "n",
+          "description": "The new name for the theme.",
+          "env": "SHOPIFY_FLAG_NEW_NAME",
+          "name": "name",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "development": {
+          "char": "d",
+          "description": "Rename your development theme.",
+          "env": "SHOPIFY_FLAG_DEVELOPMENT",
+          "name": "development",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "theme": {
+          "char": "t",
+          "description": "Theme ID or name of the remote theme.",
+          "env": "SHOPIFY_FLAG_THEME_ID",
+          "name": "theme",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "live": {
+          "char": "l",
+          "description": "Rename your remote live theme.",
+          "env": "SHOPIFY_FLAG_LIVE",
+          "name": "live",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "theme:rename",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "summary": "Renames an existing theme.",
+      "descriptionWithMarkdown": "Renames a theme in your store.\n\n  If no theme is specified, then you're prompted to select the theme that you want to rename from the list of themes in your store.\n  ",
+      "multiEnvironmentsFlags": [
+        "store",
+        "password",
+        "name",
+        [
+          "live",
+          "development",
+          "theme"
+        ]
+      ],
+      "customPluginName": "@shopify/theme"
+    },
+    "theme:serve": {
+      "aliases": [],
+      "args": {},
+      "description": "\n  Uploads the current theme as the specified theme, or a \"development theme\" (https://shopify.dev/docs/themes/tools/cli#development-themes), to a store so you can preview it.\n\nThis command returns the following information:\n\n- A link to your development theme at http://127.0.0.1:9292. This URL can hot reload local changes to CSS and sections, or refresh the entire page when a file changes, enabling you to preview changes in real time using the store's data.\n\n  You can specify a different network interface and port using `--host` and `--port`.\n\n- A link to the \"editor\" (https://shopify.dev/docs/themes/tools/online-editor) for the theme in the Shopify admin.\n\n- A \"preview link\" (https://help.shopify.com/manual/online-store/themes/adding-themes#share-a-theme-preview-with-others) that you can share with other developers.\n\nIf you already have a development theme for your current environment, then this command replaces the development theme with your local theme. You can override this using the `--theme-editor-sync` flag.\n\n> Note: You can't preview checkout customizations using http://127.0.0.1:9292.\n\nDevelopment themes are deleted when you run `shopify auth logout`. If you need a preview link that can be used after you log out, then you should \"share\" (https://shopify.dev/docs/api/shopify-cli/theme/theme-share) your theme or \"push\" (https://shopify.dev/docs/api/shopify-cli/theme/theme-push) to an unpublished theme on your store.\n\nYou can run this command only in a directory that matches the \"default Shopify theme folder structure\" (https://shopify.dev/docs/themes/tools/cli#directory-structure).",
+      "flags": {
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path where you want to run the command. Defaults to the current working directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "name": "path",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "password": {
+          "description": "Password generated from the Theme Access app or an Admin API token.",
+          "env": "SHOPIFY_CLI_THEME_TOKEN",
+          "name": "password",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "store": {
+          "char": "s",
+          "description": "Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).",
+          "env": "SHOPIFY_FLAG_STORE",
+          "name": "store",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "environment": {
+          "char": "e",
+          "description": "The environment to apply to the current command.",
+          "env": "SHOPIFY_FLAG_ENVIRONMENT",
+          "name": "environment",
+          "hasDynamicHelp": false,
+          "multiple": true,
+          "type": "option"
+        },
+        "host": {
+          "description": "Set which network interface the web server listens on. The default value is 127.0.0.1.",
+          "env": "SHOPIFY_FLAG_HOST",
+          "name": "host",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "live-reload": {
+          "description": "The live reload mode switches the server behavior when a file is modified:\n- hot-reload Hot reloads local changes to CSS and sections (default)\n- full-page  Always refreshes the entire page\n- off        Deactivate live reload",
+          "env": "SHOPIFY_FLAG_LIVE_RELOAD",
+          "name": "live-reload",
+          "default": "hot-reload",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "options": [
+            "hot-reload",
+            "full-page",
+            "off"
+          ],
+          "type": "option"
+        },
+        "error-overlay": {
+          "description": "Controls the visibility of the error overlay when an theme asset upload fails:\n- silent Prevents the error overlay from appearing.\n- default Displays the error overlay.\n      ",
+          "env": "SHOPIFY_FLAG_ERROR_OVERLAY",
+          "name": "error-overlay",
+          "default": "default",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "options": [
+            "silent",
+            "default"
+          ],
+          "type": "option"
+        },
+        "poll": {
+          "description": "Force polling to detect file changes.",
+          "env": "SHOPIFY_FLAG_POLL",
+          "hidden": true,
+          "name": "poll",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "theme-editor-sync": {
+          "description": "Synchronize Theme Editor updates in the local theme files.",
+          "env": "SHOPIFY_FLAG_THEME_EDITOR_SYNC",
+          "name": "theme-editor-sync",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "port": {
+          "description": "Local port to serve theme preview from.",
+          "env": "SHOPIFY_FLAG_PORT",
+          "name": "port",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "theme": {
+          "char": "t",
+          "description": "Theme ID or name of the remote theme.",
+          "env": "SHOPIFY_FLAG_THEME_ID",
+          "name": "theme",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "listing": {
+          "description": "The listing preset to use for multi-preset themes. Applies preset files from listings/[preset-name] directory.",
+          "env": "SHOPIFY_FLAG_LISTING",
+          "name": "listing",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "nodelete": {
+          "char": "n",
+          "description": "Prevents files from being deleted in the remote theme when a file has been deleted locally. This applies to files that are deleted while the command is running, and files that have been deleted locally before the command is run.",
+          "env": "SHOPIFY_FLAG_NODELETE",
+          "name": "nodelete",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "only": {
+          "char": "o",
+          "description": "Hot reload only files that match the specified pattern.",
+          "env": "SHOPIFY_FLAG_ONLY",
+          "name": "only",
+          "hasDynamicHelp": false,
+          "multiple": true,
+          "type": "option"
+        },
+        "ignore": {
+          "char": "x",
+          "description": "Skip hot reloading any files that match the specified pattern.",
+          "env": "SHOPIFY_FLAG_IGNORE",
+          "name": "ignore",
+          "hasDynamicHelp": false,
+          "multiple": true,
+          "type": "option"
+        },
+        "force": {
+          "char": "f",
+          "description": "Proceed without confirmation, if current directory does not seem to be theme directory.",
+          "env": "SHOPIFY_FLAG_FORCE",
+          "hidden": true,
+          "name": "force",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "notify": {
+          "description": "The file path or URL. The file path is to a file that you want updated on idle. The URL path is where you want a webhook posted to report on file changes.",
+          "env": "SHOPIFY_FLAG_NOTIFY",
+          "name": "notify",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "open": {
+          "description": "Automatically launch the theme preview in your default web browser.",
+          "env": "SHOPIFY_FLAG_OPEN",
+          "name": "open",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "store-password": {
+          "description": "The password for storefronts with password protection.",
+          "env": "SHOPIFY_FLAG_STORE_PASSWORD",
+          "name": "store-password",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "allow-live": {
+          "char": "a",
+          "description": "Allow development on a live theme.",
+          "env": "SHOPIFY_FLAG_ALLOW_LIVE",
+          "name": "allow-live",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hidden": true,
+      "hiddenAliases": [],
+      "id": "theme:serve",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "summary": "Uploads the current theme as a development theme to the connected store, then prints theme editor and preview URLs to your terminal. While running, changes will push to the store in real time.",
+      "descriptionWithMarkdown": "\n  Uploads the current theme as the specified theme, or a [development theme](https://shopify.dev/docs/themes/tools/cli#development-themes), to a store so you can preview it.\n\nThis command returns the following information:\n\n- A link to your development theme at http://127.0.0.1:9292. This URL can hot reload local changes to CSS and sections, or refresh the entire page when a file changes, enabling you to preview changes in real time using the store's data.\n\n  You can specify a different network interface and port using `--host` and `--port`.\n\n- A link to the [editor](https://shopify.dev/docs/themes/tools/online-editor) for the theme in the Shopify admin.\n\n- A [preview link](https://help.shopify.com/manual/online-store/themes/adding-themes#share-a-theme-preview-with-others) that you can share with other developers.\n\nIf you already have a development theme for your current environment, then this command replaces the development theme with your local theme. You can override this using the `--theme-editor-sync` flag.\n\n> Note: You can't preview checkout customizations using http://127.0.0.1:9292.\n\nDevelopment themes are deleted when you run `shopify auth logout`. If you need a preview link that can be used after you log out, then you should [share](https://shopify.dev/docs/api/shopify-cli/theme/theme-share) your theme or [push](https://shopify.dev/docs/api/shopify-cli/theme/theme-push) to an unpublished theme on your store.\n\nYou can run this command only in a directory that matches the [default Shopify theme folder structure](https://shopify.dev/docs/themes/tools/cli#directory-structure).",
+      "multiEnvironmentsFlags": null,
+      "customPluginName": "@shopify/theme"
+    },
+    "theme:share": {
+      "aliases": [],
+      "args": {},
+      "description": "Uploads your theme as a new, unpublished theme in your theme library. The theme is given a randomized name.\n\n  This command returns a \"preview link\" (https://help.shopify.com/manual/online-store/themes/adding-themes#share-a-theme-preview-with-others) that you can share with others.",
+      "flags": {
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path where you want to run the command. Defaults to the current working directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "name": "path",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "password": {
+          "description": "Password generated from the Theme Access app or an Admin API token.",
+          "env": "SHOPIFY_CLI_THEME_TOKEN",
+          "name": "password",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "store": {
+          "char": "s",
+          "description": "Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).",
+          "env": "SHOPIFY_FLAG_STORE",
+          "name": "store",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "environment": {
+          "char": "e",
+          "description": "The environment to apply to the current command.",
+          "env": "SHOPIFY_FLAG_ENVIRONMENT",
+          "name": "environment",
+          "hasDynamicHelp": false,
+          "multiple": true,
+          "type": "option"
+        },
+        "force": {
+          "char": "f",
+          "description": "Proceed without confirmation, if current directory does not seem to be theme directory.",
+          "env": "SHOPIFY_FLAG_FORCE",
+          "hidden": true,
+          "name": "force",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "listing": {
+          "description": "The listing preset to use for multi-preset themes. Applies preset files from listings/[preset-name] directory.",
+          "env": "SHOPIFY_FLAG_LISTING",
+          "name": "listing",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "theme:share",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "summary": "Creates a shareable, unpublished, and new theme on your theme library with a randomized name.",
+      "descriptionWithMarkdown": "Uploads your theme as a new, unpublished theme in your theme library. The theme is given a randomized name.\n\n  This command returns a [preview link](https://help.shopify.com/manual/online-store/themes/adding-themes#share-a-theme-preview-with-others) that you can share with others.",
+      "multiEnvironmentsFlags": [
+        "store",
+        "password",
+        "path"
+      ],
+      "customPluginName": "@shopify/theme"
+    },
+    "plugins": {
+      "aliases": [],
+      "args": {},
+      "description": "List installed plugins.",
+      "examples": [
+        "<%= config.bin %> <%= command.id %>"
+      ],
+      "flags": {
+        "json": {
+          "description": "Format output as json.",
+          "helpGroup": "GLOBAL",
+          "name": "json",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "core": {
+          "description": "Show core plugins.",
+          "name": "core",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hidden": true,
+      "hiddenAliases": [],
+      "id": "plugins",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": true,
+      "customPluginName": "@oclif/plugin-plugins"
+    },
+    "plugins:inspect": {
+      "aliases": [],
+      "args": {
+        "plugin": {
+          "default": ".",
+          "description": "Plugin to inspect.",
+          "name": "plugin",
+          "required": true
+        }
+      },
+      "description": "Displays installation properties of a plugin.",
+      "examples": [
+        "<%= config.bin %> <%= command.id %> <%- config.pjson.oclif.examplePlugin || \"myplugin\" %> "
+      ],
+      "flags": {
+        "json": {
+          "description": "Format output as json.",
+          "helpGroup": "GLOBAL",
+          "name": "json",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "help": {
+          "char": "h",
+          "description": "Show CLI help.",
+          "name": "help",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "char": "v",
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "plugins:inspect",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": false,
+      "usage": "plugins:inspect PLUGIN...",
+      "enableJsonFlag": true,
+      "customPluginName": "@oclif/plugin-plugins"
+    },
+    "plugins:install": {
       "aliases": [
+        "plugins:add"
       ],
       "args": {
+        "plugin": {
+          "description": "Plugin to install.",
+          "name": "plugin",
+          "required": true
+        }
       },
-      "customPluginName": "@oclif/plugin-commands",
-      "description": "List all <%= config.bin %> commands.",
-      "enableJsonFlag": true,
+      "description": "",
+      "examples": [
+        {
+          "command": "<%= config.bin %> <%= command.id %> <%- config.pjson.oclif.examplePlugin || \"myplugin\" %> ",
+          "description": "Install a plugin from npm registry."
+        },
+        {
+          "command": "<%= config.bin %> <%= command.id %> https://github.com/someuser/someplugin",
+          "description": "Install a plugin from a github url."
+        },
+        {
+          "command": "<%= config.bin %> <%= command.id %> someuser/someplugin",
+          "description": "Install a plugin from a github slug."
+        }
+      ],
       "flags": {
+        "json": {
+          "description": "Format output as json.",
+          "helpGroup": "GLOBAL",
+          "name": "json",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "force": {
+          "char": "f",
+          "description": "Force npm to fetch remote resources even if a local copy exists on disk.",
+          "name": "force",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "help": {
+          "char": "h",
+          "description": "Show CLI help.",
+          "name": "help",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "jit": {
+          "hidden": true,
+          "name": "jit",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "silent": {
+          "char": "s",
+          "description": "Silences npm output.",
+          "exclusive": [
+            "verbose"
+          ],
+          "name": "silent",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "char": "v",
+          "description": "Show verbose npm output.",
+          "exclusive": [
+            "silent"
+          ],
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "plugins:install",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": false,
+      "summary": "Installs a plugin into <%= config.bin %>.",
+      "enableJsonFlag": true,
+      "customPluginName": "@oclif/plugin-plugins"
+    },
+    "plugins:link": {
+      "aliases": [],
+      "args": {
+        "path": {
+          "default": ".",
+          "description": "path to plugin",
+          "name": "path",
+          "required": true
+        }
+      },
+      "description": "Installation of a linked plugin will override a user-installed or core plugin.\n\ne.g. If you have a user-installed or core plugin that has a 'hello' command, installing a linked plugin with a 'hello' command will override the user-installed or core plugin implementation. This is useful for development work.\n",
+      "examples": [
+        "<%= config.bin %> <%= command.id %> <%- config.pjson.oclif.examplePlugin || \"myplugin\" %> "
+      ],
+      "flags": {
+        "help": {
+          "char": "h",
+          "description": "Show CLI help.",
+          "name": "help",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "install": {
+          "description": "Install dependencies after linking the plugin.",
+          "name": "install",
+          "allowNo": true,
+          "type": "boolean"
+        },
+        "verbose": {
+          "char": "v",
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "plugins:link",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "summary": "Links a plugin into the CLI for development.",
+      "enableJsonFlag": false,
+      "customPluginName": "@oclif/plugin-plugins"
+    },
+    "plugins:reset": {
+      "aliases": [],
+      "args": {},
+      "flags": {
+        "hard": {
+          "name": "hard",
+          "summary": "Delete node_modules and package manager related files in addition to uninstalling plugins.",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "reinstall": {
+          "name": "reinstall",
+          "summary": "Reinstall all plugins after uninstalling.",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "plugins:reset",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "summary": "Remove all user-installed and linked plugins.",
+      "enableJsonFlag": false,
+      "customPluginName": "@oclif/plugin-plugins"
+    },
+    "plugins:uninstall": {
+      "aliases": [
+        "plugins:unlink",
+        "plugins:remove"
+      ],
+      "args": {
+        "plugin": {
+          "description": "plugin to uninstall",
+          "name": "plugin"
+        }
+      },
+      "description": "Removes a plugin from the CLI.",
+      "examples": [
+        "<%= config.bin %> <%= command.id %> <%- config.pjson.oclif.examplePlugin || \"myplugin\" %>"
+      ],
+      "flags": {
+        "help": {
+          "char": "h",
+          "description": "Show CLI help.",
+          "name": "help",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "char": "v",
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "plugins:uninstall",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": false,
+      "enableJsonFlag": false,
+      "customPluginName": "@oclif/plugin-plugins"
+    },
+    "plugins:update": {
+      "aliases": [],
+      "args": {},
+      "description": "Update installed plugins.",
+      "flags": {
+        "help": {
+          "char": "h",
+          "description": "Show CLI help.",
+          "name": "help",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "char": "v",
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "plugins:update",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false,
+      "customPluginName": "@oclif/plugin-plugins"
+    },
+    "config:autocorrect:off": {
+      "aliases": [],
+      "args": {},
+      "description": "Disable autocorrect. Off by default.\n\n  When autocorrection is enabled, Shopify CLI automatically runs a corrected version of your command if a correction is available.\n\n  When autocorrection is disabled, you need to confirm that you want to run corrections for mistyped commands.\n",
+      "flags": {},
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "config:autocorrect:off",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "summary": "Disable autocorrect. Off by default.",
+      "enableJsonFlag": false,
+      "descriptionWithMarkdown": "Disable autocorrect. Off by default.\n\n  When autocorrection is enabled, Shopify CLI automatically runs a corrected version of your command if a correction is available.\n\n  When autocorrection is disabled, you need to confirm that you want to run corrections for mistyped commands.\n",
+      "customPluginName": "@shopify/plugin-did-you-mean"
+    },
+    "config:autocorrect:status": {
+      "aliases": [],
+      "args": {},
+      "description": "Check whether autocorrect is enabled or disabled. On by default.\n\n  When autocorrection is enabled, Shopify CLI automatically runs a corrected version of your command if a correction is available.\n\n  When autocorrection is disabled, you need to confirm that you want to run corrections for mistyped commands.\n",
+      "flags": {},
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "config:autocorrect:status",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "summary": "Check whether autocorrect is enabled or disabled. On by default.",
+      "enableJsonFlag": false,
+      "descriptionWithMarkdown": "Check whether autocorrect is enabled or disabled. On by default.\n\n  When autocorrection is enabled, Shopify CLI automatically runs a corrected version of your command if a correction is available.\n\n  When autocorrection is disabled, you need to confirm that you want to run corrections for mistyped commands.\n",
+      "customPluginName": "@shopify/plugin-did-you-mean"
+    },
+    "config:autocorrect:on": {
+      "aliases": [],
+      "args": {},
+      "description": "Enable autocorrect. Off by default.\n\n  When autocorrection is enabled, Shopify CLI automatically runs a corrected version of your command if a correction is available.\n\n  When autocorrection is disabled, you need to confirm that you want to run corrections for mistyped commands.\n",
+      "flags": {},
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "config:autocorrect:on",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "summary": "Enable autocorrect. Off by default.",
+      "enableJsonFlag": false,
+      "descriptionWithMarkdown": "Enable autocorrect. Off by default.\n\n  When autocorrection is enabled, Shopify CLI automatically runs a corrected version of your command if a correction is available.\n\n  When autocorrection is disabled, you need to confirm that you want to run corrections for mistyped commands.\n",
+      "customPluginName": "@shopify/plugin-did-you-mean"
+    },
+    "commands": {
+      "aliases": [],
+      "args": {},
+      "description": "List all <%= config.bin %> commands.",
+      "flags": {
+        "json": {
+          "description": "Format output as json.",
+          "helpGroup": "GLOBAL",
+          "name": "json",
+          "allowNo": false,
+          "type": "boolean"
+        },
         "columns": {
           "char": "c",
-          "delimiter": ",",
           "description": "Only show provided columns (comma-separated).",
           "exclusive": [
             "tree"
           ],
+          "name": "columns",
+          "delimiter": ",",
           "hasDynamicHelp": false,
           "multiple": true,
-          "name": "columns",
           "options": [
             "id",
             "plugin",
@@ -3253,52 +5983,45 @@
           "type": "option"
         },
         "deprecated": {
-          "allowNo": false,
           "description": "Show deprecated commands.",
           "name": "deprecated",
+          "allowNo": false,
           "type": "boolean"
         },
         "extended": {
-          "allowNo": false,
           "char": "x",
           "description": "Show extra columns.",
           "exclusive": [
             "tree"
           ],
           "name": "extended",
+          "allowNo": false,
           "type": "boolean"
         },
         "hidden": {
-          "allowNo": false,
           "description": "Show hidden commands.",
           "name": "hidden",
-          "type": "boolean"
-        },
-        "json": {
           "allowNo": false,
-          "description": "Format output as json.",
-          "helpGroup": "GLOBAL",
-          "name": "json",
           "type": "boolean"
         },
         "no-truncate": {
-          "allowNo": false,
           "description": "Do not truncate output.",
           "exclusive": [
             "tree"
           ],
           "name": "no-truncate",
+          "allowNo": false,
           "type": "boolean"
         },
         "sort": {
-          "default": "id",
           "description": "Property to sort by.",
           "exclusive": [
             "tree"
           ],
+          "name": "sort",
+          "default": "id",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "sort",
           "options": [
             "id",
             "plugin",
@@ -3308,410 +6031,57 @@
           "type": "option"
         },
         "tree": {
-          "allowNo": false,
           "description": "Show tree of commands.",
           "name": "tree",
+          "allowNo": false,
           "type": "boolean"
         }
       },
       "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
+      "hiddenAliases": [],
       "id": "commands",
       "pluginAlias": "@shopify/cli",
       "pluginName": "@shopify/cli",
       "pluginType": "core",
-      "strict": true
-    },
-    "config:autocorrect:off": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/plugin-did-you-mean",
-      "description": "Disable autocorrect. Off by default.\n\n  When autocorrection is enabled, Shopify CLI automatically runs a corrected version of your command if a correction is available.\n\n  When autocorrection is disabled, you need to confirm that you want to run corrections for mistyped commands.\n",
-      "descriptionWithMarkdown": "Disable autocorrect. Off by default.\n\n  When autocorrection is enabled, Shopify CLI automatically runs a corrected version of your command if a correction is available.\n\n  When autocorrection is disabled, you need to confirm that you want to run corrections for mistyped commands.\n",
-      "enableJsonFlag": false,
-      "flags": {
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "config:autocorrect:off",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
       "strict": true,
-      "summary": "Disable autocorrect. Off by default."
+      "enableJsonFlag": true,
+      "customPluginName": "@oclif/plugin-commands"
     },
-    "config:autocorrect:on": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/plugin-did-you-mean",
-      "description": "Enable autocorrect. Off by default.\n\n  When autocorrection is enabled, Shopify CLI automatically runs a corrected version of your command if a correction is available.\n\n  When autocorrection is disabled, you need to confirm that you want to run corrections for mistyped commands.\n",
-      "descriptionWithMarkdown": "Enable autocorrect. Off by default.\n\n  When autocorrection is enabled, Shopify CLI automatically runs a corrected version of your command if a correction is available.\n\n  When autocorrection is disabled, you need to confirm that you want to run corrections for mistyped commands.\n",
-      "enableJsonFlag": false,
+    "hydrogen:dev": {
+      "aliases": [],
+      "args": {},
+      "description": "Runs Hydrogen storefront in an Oxygen worker for development.",
       "flags": {
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "config:autocorrect:on",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true,
-      "summary": "Enable autocorrect. Off by default."
-    },
-    "config:autocorrect:status": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/plugin-did-you-mean",
-      "description": "Check whether autocorrect is enabled or disabled. On by default.\n\n  When autocorrection is enabled, Shopify CLI automatically runs a corrected version of your command if a correction is available.\n\n  When autocorrection is disabled, you need to confirm that you want to run corrections for mistyped commands.\n",
-      "descriptionWithMarkdown": "Check whether autocorrect is enabled or disabled. On by default.\n\n  When autocorrection is enabled, Shopify CLI automatically runs a corrected version of your command if a correction is available.\n\n  When autocorrection is disabled, you need to confirm that you want to run corrections for mistyped commands.\n",
-      "enableJsonFlag": false,
-      "flags": {
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "config:autocorrect:status",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true,
-      "summary": "Check whether autocorrect is enabled or disabled. On by default."
-    },
-    "config:autoupgrade:off": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "description": "Disable automatic upgrades for Shopify CLI.\n\n  When auto-upgrade is disabled, Shopify CLI won't automatically update. Run `shopify upgrade` to update manually.\n\n  To enable auto-upgrade, run `shopify config autoupgrade on`.\n",
-      "descriptionWithMarkdown": "Disable automatic upgrades for Shopify CLI.\n\n  When auto-upgrade is disabled, Shopify CLI won't automatically update. Run `shopify upgrade` to update manually.\n\n  To enable auto-upgrade, run `shopify config autoupgrade on`.\n",
-      "enableJsonFlag": false,
-      "flags": {
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "config:autoupgrade:off",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true,
-      "summary": "Disable automatic upgrades for Shopify CLI."
-    },
-    "config:autoupgrade:on": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "description": "Enable automatic upgrades for Shopify CLI.\n\n  When auto-upgrade is enabled, Shopify CLI automatically updates to the latest version once per day. Major version upgrades are skipped and must be done manually.\n\n  To disable auto-upgrade, run `shopify config autoupgrade off`.\n",
-      "descriptionWithMarkdown": "Enable automatic upgrades for Shopify CLI.\n\n  When auto-upgrade is enabled, Shopify CLI automatically updates to the latest version once per day. Major version upgrades are skipped and must be done manually.\n\n  To disable auto-upgrade, run `shopify config autoupgrade off`.\n",
-      "enableJsonFlag": false,
-      "flags": {
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "config:autoupgrade:on",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true,
-      "summary": "Enable automatic upgrades for Shopify CLI."
-    },
-    "config:autoupgrade:status": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "description": "Check whether auto-upgrade is enabled, disabled, or not yet configured.\n\n  When auto-upgrade is enabled, Shopify CLI automatically updates to the latest version after each command.\n\n  Run `shopify config autoupgrade on` or `shopify config autoupgrade off` to configure it.\n",
-      "descriptionWithMarkdown": "Check whether auto-upgrade is enabled, disabled, or not yet configured.\n\n  When auto-upgrade is enabled, Shopify CLI automatically updates to the latest version after each command.\n\n  Run `shopify config autoupgrade on` or `shopify config autoupgrade off` to configure it.\n",
-      "enableJsonFlag": false,
-      "flags": {
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "config:autoupgrade:status",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true,
-      "summary": "Check whether auto-upgrade is enabled, disabled, or not yet configured."
-    },
-    "debug:command-flags": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "description": "View all the available command flags",
-      "enableJsonFlag": false,
-      "flags": {
-        "csv": {
-          "allowNo": false,
-          "description": "Output as CSV",
-          "env": "SHOPIFY_FLAG_OUTPUT_CSV",
-          "name": "csv",
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hidden": true,
-      "hiddenAliases": [
-      ],
-      "id": "debug:command-flags",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true
-    },
-    "demo:watcher": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/app",
-      "flags": {
-        "client-id": {
-          "description": "The Client ID of your app.",
-          "env": "SHOPIFY_FLAG_CLIENT_ID",
-          "exclusive": [
-            "config"
-          ],
-          "hasDynamicHelp": false,
-          "hidden": false,
-          "multiple": false,
-          "name": "client-id",
-          "type": "option"
-        },
-        "config": {
-          "char": "c",
-          "description": "The name of the app configuration.",
-          "env": "SHOPIFY_FLAG_APP_CONFIG",
-          "hasDynamicHelp": false,
-          "hidden": false,
-          "multiple": false,
-          "name": "config",
-          "type": "option"
-        },
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
-          "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
         "path": {
-          "description": "The path to your app directory.",
-          "env": "SHOPIFY_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "multiple": false,
+          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
           "name": "path",
-          "noCacheDefault": true,
-          "type": "option"
-        },
-        "reset": {
-          "allowNo": false,
-          "description": "Reset all your settings.",
-          "env": "SHOPIFY_FLAG_RESET",
-          "exclusive": [
-            "config"
-          ],
-          "hidden": false,
-          "name": "reset",
-          "type": "boolean"
-        },
-        "verbose": {
-          "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hidden": true,
-      "hiddenAliases": [
-      ],
-      "id": "demo:watcher",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true,
-      "summary": "Watch and prints out changes to an app."
-    },
-    "docs:generate": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "description": "Generate CLI commands documentation",
-      "enableJsonFlag": false,
-      "flags": {
-      },
-      "hasDynamicHelp": false,
-      "hidden": true,
-      "hiddenAliases": [
-      ],
-      "id": "docs:generate",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true
-    },
-    "doctor-release": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "description": "Run CLI doctor-release tests",
-      "enableJsonFlag": false,
-      "flags": {
-      },
-      "hasDynamicHelp": false,
-      "hidden": true,
-      "hiddenAliases": [
-      ],
-      "id": "doctor-release",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true
-    },
-    "doctor-release:theme": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "description": "Run all theme command doctor-release tests",
-      "enableJsonFlag": false,
-      "flags": {
-        "environment": {
-          "char": "e",
-          "description": "The environment to use from shopify.theme.toml (required for store-connected tests).",
-          "env": "SHOPIFY_FLAG_ENVIRONMENT",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "environment",
-          "required": true,
           "type": "option"
         },
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
-          "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
-        "password": {
-          "description": "Password from Theme Access app (overrides environment).",
-          "env": "SHOPIFY_FLAG_PASSWORD",
+        "entry": {
+          "description": "Entry file for the worker. Defaults to `./server`.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_ENTRY",
+          "name": "entry",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "password",
           "type": "option"
         },
-        "path": {
-          "char": "p",
-          "default": ".",
-          "description": "The path to run tests in. Defaults to current directory.",
-          "env": "SHOPIFY_FLAG_PATH",
+        "port": {
+          "description": "The port to run the server on. Defaults to 3000.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_PORT",
+          "name": "port",
+          "required": false,
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "path",
           "type": "option"
-        },
-        "store": {
-          "char": "s",
-          "description": "Store URL (overrides environment).",
-          "env": "SHOPIFY_FLAG_STORE",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "store",
-          "type": "option"
-        },
-        "verbose": {
-          "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hidden": true,
-      "hiddenAliases": [
-      ],
-      "id": "doctor-release:theme",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true
-    },
-    "help": {
-      "aliases": [
-      ],
-      "args": {
-        "command": {
-          "description": "Command to show help for.",
-          "name": "command",
-          "required": false
-        }
-      },
-      "description": "Display help for Shopify CLI",
-      "enableJsonFlag": false,
-      "flags": {
-        "nested-commands": {
-          "allowNo": false,
-          "char": "n",
-          "description": "Include all nested commands in the output.",
-          "env": "SHOPIFY_FLAG_CLI_NESTED_COMMANDS",
-          "name": "nested-commands",
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "help",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": false,
-      "usage": "help [command] [flags]"
-    },
-    "hydrogen:build": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/cli-hydrogen",
-      "description": "Builds a Hydrogen storefront for production.",
-      "descriptionWithMarkdown": "Builds a Hydrogen storefront for production. The client and app worker files are compiled to a `/dist` folder in your Hydrogen project directory.",
-      "enableJsonFlag": false,
-      "flags": {
-        "bundle-stats": {
-          "allowNo": true,
-          "description": "Show a bundle size summary after building. Defaults to true, use `--no-bundle-stats` to disable.",
-          "name": "bundle-stats",
-          "type": "boolean"
         },
         "codegen": {
-          "allowNo": false,
           "description": "Automatically generates GraphQL types for your project’s Storefront API queries.",
           "name": "codegen",
           "required": false,
+          "allowNo": false,
           "type": "boolean"
         },
         "codegen-config-path": {
@@ -3719,76 +6089,208 @@
             "codegen"
           ],
           "description": "Specifies a path to a codegen configuration file. Defaults to `<root>/codegen.ts` if this file exists.",
-          "hasDynamicHelp": false,
-          "multiple": false,
           "name": "codegen-config-path",
           "required": false,
-          "type": "option"
-        },
-        "disable-route-warning": {
-          "allowNo": false,
-          "description": "Disables any warnings about missing standard routes.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_DISABLE_ROUTE_WARNING",
-          "name": "disable-route-warning",
-          "type": "boolean"
-        },
-        "entry": {
-          "description": "Entry file for the worker. Defaults to `./server`.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_ENTRY",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "entry",
           "type": "option"
         },
-        "force-client-sourcemap": {
+        "disable-virtual-routes": {
+          "description": "Disable rendering fallback routes when a route file doesn't exist.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_DISABLE_VIRTUAL_ROUTES",
+          "name": "disable-virtual-routes",
           "allowNo": false,
-          "description": "Client sourcemapping is avoided by default because it makes backend code visible in the browser. Use this flag to force enabling it.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_FORCE_CLIENT_SOURCEMAP",
-          "name": "force-client-sourcemap",
           "type": "boolean"
         },
-        "lockfile-check": {
-          "allowNo": true,
-          "description": "Checks that there is exactly one valid lockfile in the project. Defaults to `true`. Deactivate with `--no-lockfile-check`.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_LOCKFILE_CHECK",
-          "name": "lockfile-check",
+        "debug": {
+          "description": "Enables inspector connections to the server with a debugger such as Visual Studio Code or Chrome DevTools.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_DEBUG",
+          "name": "debug",
+          "allowNo": false,
           "type": "boolean"
         },
-        "path": {
-          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
+        "inspector-port": {
+          "description": "The port where the inspector is available. Defaults to 9229.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_INSPECTOR_PORT",
+          "name": "inspector-port",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "path",
           "type": "option"
         },
-        "sourcemap": {
-          "allowNo": true,
-          "description": "Controls whether server sourcemaps are generated. Default to `true`. Deactivate `--no-sourcemaps`.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_SOURCEMAP",
-          "name": "sourcemap",
+        "env": {
+          "description": "Specifies the environment to perform the operation using its handle. Fetch the handle using the `env list` command.",
+          "exclusive": [
+            "env-branch"
+          ],
+          "name": "env",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "env-branch": {
+          "deprecated": {
+            "to": "env",
+            "message": "--env-branch is deprecated. Use --env instead."
+          },
+          "description": "Specifies the environment to perform the operation using its Git branch name.",
+          "env": "SHOPIFY_HYDROGEN_ENVIRONMENT_BRANCH",
+          "name": "env-branch",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "env-file": {
+          "description": "Path to an environment file to override existing environment variables. Defaults to the '.env' located in your project path `--path`.",
+          "name": "env-file",
+          "required": false,
+          "default": ".env",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "disable-version-check": {
+          "description": "Skip the version check when running `hydrogen dev`",
+          "name": "disable-version-check",
+          "required": false,
+          "allowNo": false,
           "type": "boolean"
         },
-        "watch": {
+        "customer-account-push": {
+          "description": "Use tunneling for local development and push the tunneling domain to admin. Required to use Customer Account API's OAuth flow",
+          "env": "SHOPIFY_HYDROGEN_FLAG_CUSTOMER_ACCOUNT_PUSH",
+          "name": "customer-account-push",
+          "required": false,
           "allowNo": false,
-          "description": "Watches for changes and rebuilds the project writing output to disk.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_WATCH",
-          "name": "watch",
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Outputs more information about the command's execution.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_VERBOSE",
+          "name": "verbose",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "host": {
+          "description": "Expose the server to the local network",
+          "name": "host",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "disable-deps-optimizer": {
+          "description": "Disable adding dependencies to Vite's `ssr.optimizeDeps.include` automatically",
+          "env": "SHOPIFY_HYDROGEN_FLAG_DISABLE_DEPS_OPTIMIZER",
+          "name": "disable-deps-optimizer",
+          "allowNo": false,
           "type": "boolean"
         }
       },
       "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
+      "hiddenAliases": [],
+      "id": "hydrogen:dev",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false,
+      "descriptionWithMarkdown": "Runs a Hydrogen storefront in a local runtime that emulates an Oxygen worker for development.\n\n  If your project is [linked](https://shopify.dev/docs/api/shopify-cli/hydrogen/hydrogen-link) to a Hydrogen storefront, then its environment variables will be loaded with the runtime.",
+      "customPluginName": "@shopify/cli-hydrogen"
+    },
+    "hydrogen:build": {
+      "aliases": [],
+      "args": {},
+      "description": "Builds a Hydrogen storefront for production.",
+      "flags": {
+        "path": {
+          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
+          "name": "path",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "entry": {
+          "description": "Entry file for the worker. Defaults to `./server`.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_ENTRY",
+          "name": "entry",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "sourcemap": {
+          "description": "Controls whether server sourcemaps are generated. Default to `true`. Deactivate `--no-sourcemaps`.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_SOURCEMAP",
+          "name": "sourcemap",
+          "allowNo": true,
+          "type": "boolean"
+        },
+        "lockfile-check": {
+          "description": "Checks that there is exactly one valid lockfile in the project. Defaults to `true`. Deactivate with `--no-lockfile-check`.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_LOCKFILE_CHECK",
+          "name": "lockfile-check",
+          "allowNo": true,
+          "type": "boolean"
+        },
+        "disable-route-warning": {
+          "description": "Disables any warnings about missing standard routes.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_DISABLE_ROUTE_WARNING",
+          "name": "disable-route-warning",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "codegen": {
+          "description": "Automatically generates GraphQL types for your project’s Storefront API queries.",
+          "name": "codegen",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "codegen-config-path": {
+          "dependsOn": [
+            "codegen"
+          ],
+          "description": "Specifies a path to a codegen configuration file. Defaults to `<root>/codegen.ts` if this file exists.",
+          "name": "codegen-config-path",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "watch": {
+          "description": "Watches for changes and rebuilds the project writing output to disk.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_WATCH",
+          "name": "watch",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "bundle-stats": {
+          "description": "Show a bundle size summary after building. Defaults to true, use `--no-bundle-stats` to disable.",
+          "name": "bundle-stats",
+          "allowNo": true,
+          "type": "boolean"
+        },
+        "force-client-sourcemap": {
+          "description": "Client sourcemapping is avoided by default because it makes backend code visible in the browser. Use this flag to force enabling it.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_FORCE_CLIENT_SOURCEMAP",
+          "name": "force-client-sourcemap",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
       "id": "hydrogen:build",
       "pluginAlias": "@shopify/cli",
       "pluginName": "@shopify/cli",
       "pluginType": "core",
-      "strict": true
+      "strict": true,
+      "enableJsonFlag": false,
+      "descriptionWithMarkdown": "Builds a Hydrogen storefront for production. The client and app worker files are compiled to a `/dist` folder in your Hydrogen project directory.",
+      "customPluginName": "@shopify/cli-hydrogen"
     },
     "hydrogen:check": {
-      "aliases": [
-      ],
+      "aliases": [],
       "args": {
         "resource": {
           "description": "The resource to check. Currently only 'routes' is supported.",
@@ -3799,197 +6301,148 @@
           "required": true
         }
       },
-      "customPluginName": "@shopify/cli-hydrogen",
       "description": "Returns diagnostic information about a Hydrogen storefront.",
-      "descriptionWithMarkdown": "Checks whether your Hydrogen app includes a set of standard Shopify routes.",
-      "enableJsonFlag": false,
       "flags": {
         "path": {
           "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
           "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
+          "name": "path",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "path",
           "type": "option"
         }
       },
       "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
+      "hiddenAliases": [],
       "id": "hydrogen:check",
       "pluginAlias": "@shopify/cli",
       "pluginName": "@shopify/cli",
       "pluginType": "core",
-      "strict": true
+      "strict": true,
+      "enableJsonFlag": false,
+      "descriptionWithMarkdown": "Checks whether your Hydrogen app includes a set of standard Shopify routes.",
+      "customPluginName": "@shopify/cli-hydrogen"
     },
     "hydrogen:codegen": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/cli-hydrogen",
+      "aliases": [],
+      "args": {},
       "description": "Generate types for the Storefront API queries found in your project.",
-      "descriptionWithMarkdown": "Automatically generates GraphQL types for your project’s Storefront API queries.",
-      "enableJsonFlag": false,
       "flags": {
-        "codegen-config-path": {
-          "description": "Specify a path to a codegen configuration file. Defaults to `<root>/codegen.ts` if it exists.",
+        "path": {
+          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
+          "name": "path",
           "hasDynamicHelp": false,
           "multiple": false,
+          "type": "option"
+        },
+        "codegen-config-path": {
+          "description": "Specify a path to a codegen configuration file. Defaults to `<root>/codegen.ts` if it exists.",
           "name": "codegen-config-path",
           "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
           "type": "option"
         },
         "force-sfapi-version": {
           "description": "Force generating Storefront API types for a specific version instead of using the one provided in Hydrogen. A token can also be provided with this format: `<version>:<token>`.",
-          "hasDynamicHelp": false,
           "hidden": true,
-          "multiple": false,
           "name": "force-sfapi-version",
-          "type": "option"
-        },
-        "path": {
-          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "path",
           "type": "option"
         },
         "watch": {
-          "allowNo": false,
           "description": "Watch the project for changes to update types on file save.",
           "name": "watch",
           "required": false,
+          "allowNo": false,
           "type": "boolean"
         }
       },
       "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
+      "hiddenAliases": [],
       "id": "hydrogen:codegen",
       "pluginAlias": "@shopify/cli",
       "pluginName": "@shopify/cli",
       "pluginType": "core",
-      "strict": true
-    },
-    "hydrogen:customer-account-push": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/cli-hydrogen",
-      "description": "Push project configuration to admin",
+      "strict": true,
       "enableJsonFlag": false,
-      "flags": {
-        "dev-origin": {
-          "description": "The development domain of your application.",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "dev-origin",
-          "required": true,
-          "type": "option"
-        },
-        "path": {
-          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "path",
-          "type": "option"
-        },
-        "relative-logout-uri": {
-          "description": "The relative url of allowed url that will be redirected to post-logout for Customer Account API OAuth flow. Default to nothing.",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "relative-logout-uri",
-          "type": "option"
-        },
-        "relative-redirect-uri": {
-          "description": "The relative url of allowed callback url for Customer Account API OAuth flow. Default is '/account/authorize'",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "relative-redirect-uri",
-          "type": "option"
-        },
-        "storefront-id": {
-          "description": "The id of the storefront the configuration should be pushed to. Must start with 'gid://shopify/HydrogenStorefront/'",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "storefront-id",
-          "type": "option"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "hydrogen:customer-account-push",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true
+      "descriptionWithMarkdown": "Automatically generates GraphQL types for your project’s Storefront API queries.",
+      "customPluginName": "@shopify/cli-hydrogen"
     },
-    "hydrogen:debug:cpu": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/cli-hydrogen",
-      "description": "Builds and profiles the server startup time the app.",
-      "descriptionWithMarkdown": "Builds the app and runs the resulting code to profile the server startup time, watching for changes. This command can be used to [debug slow app startup times](https://shopify.dev/docs/custom-storefronts/hydrogen/debugging/cpu-startup) that cause failed deployments in Oxygen.\n\n  The profiling results are written to a `.cpuprofile` file that can be viewed with certain tools such as [Flame Chart Visualizer for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=ms-vscode.vscode-js-profile-flame).",
-      "enableJsonFlag": false,
+    "hydrogen:deploy": {
+      "aliases": [],
+      "args": {},
+      "description": "Builds and deploys a Hydrogen storefront to Oxygen.",
       "flags": {
         "entry": {
           "description": "Entry file for the worker. Defaults to `./server`.",
           "env": "SHOPIFY_HYDROGEN_FLAG_ENTRY",
-          "hasDynamicHelp": false,
-          "multiple": false,
           "name": "entry",
-          "type": "option"
-        },
-        "output": {
-          "default": "startup.cpuprofile",
-          "description": "Specify a path to generate the profile file. Defaults to \"startup.cpuprofile\".",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "output",
+          "type": "option"
+        },
+        "env": {
+          "description": "Specifies the environment to perform the operation using its handle. Fetch the handle using the `env list` command.",
+          "exclusive": [
+            "env-branch"
+          ],
+          "name": "env",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "env-branch": {
+          "deprecated": {
+            "to": "env",
+            "message": "--env-branch is deprecated. Use --env instead."
+          },
+          "description": "Specifies the environment to perform the operation using its Git branch name.",
+          "env": "SHOPIFY_HYDROGEN_ENVIRONMENT_BRANCH",
+          "name": "env-branch",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "env-file": {
+          "description": "Path to an environment file to override existing environment variables for the deployment.",
+          "name": "env-file",
           "required": false,
-          "type": "option"
-        },
-        "path": {
-          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "path",
           "type": "option"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "hydrogen:debug:cpu",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true
-    },
-    "hydrogen:deploy": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/cli-hydrogen",
-      "description": "Builds and deploys a Hydrogen storefront to Oxygen.",
-      "descriptionWithMarkdown": "Builds and deploys your Hydrogen storefront to Oxygen. Requires an Oxygen deployment token to be set with the `--token` flag or an environment variable (`SHOPIFY_HYDROGEN_DEPLOYMENT_TOKEN`). If the storefront is [linked](https://shopify.dev/docs/api/shopify-cli/hydrogen/hydrogen-link) then the Oxygen deployment token for the linked storefront will be used automatically.",
-      "enableJsonFlag": false,
-      "flags": {
-        "auth-bypass-token": {
+        },
+        "preview": {
+          "description": "Deploys to the Preview environment.",
+          "name": "preview",
+          "required": false,
           "allowNo": false,
+          "type": "boolean"
+        },
+        "force": {
+          "char": "f",
+          "description": "Forces a deployment to proceed if there are uncommited changes in its Git repository.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_FORCE",
+          "name": "force",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "no-verify": {
+          "description": "Skip the routability verification step after deployment.",
+          "name": "no-verify",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "auth-bypass-token": {
           "description": "Generate an authentication bypass token, which can be used to perform end-to-end tests against the deployment.",
           "env": "AUTH_BYPASS_TOKEN",
           "name": "auth-bypass-token",
           "required": false,
+          "allowNo": false,
           "type": "boolean"
         },
         "auth-bypass-token-duration": {
@@ -3998,26 +6451,390 @@
           ],
           "description": "Specify the duration (in hours) up to 12 hours for the authentication bypass token. Defaults to `2`",
           "env": "AUTH_BYPASS_TOKEN_DURATION",
-          "hasDynamicHelp": false,
-          "multiple": false,
           "name": "auth-bypass-token-duration",
           "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
           "type": "option"
         },
         "build-command": {
           "description": "Specify a build command to run before deploying. If not specified, `shopify hydrogen build` will be used.",
-          "hasDynamicHelp": false,
-          "multiple": false,
           "name": "build-command",
           "required": false,
-          "type": "option"
-        },
-        "entry": {
-          "description": "Entry file for the worker. Defaults to `./server`.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_ENTRY",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "entry",
+          "type": "option"
+        },
+        "lockfile-check": {
+          "description": "Checks that there is exactly one valid lockfile in the project. Defaults to `true`. Deactivate with `--no-lockfile-check`.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_LOCKFILE_CHECK",
+          "name": "lockfile-check",
+          "allowNo": true,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
+          "name": "path",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "shop": {
+          "char": "s",
+          "description": "Shop URL. It can be the shop prefix (janes-apparel) or the full myshopify.com URL (janes-apparel.myshopify.com, https://janes-apparel.myshopify.com).",
+          "env": "SHOPIFY_SHOP",
+          "name": "shop",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "json-output": {
+          "description": "Create a JSON file containing the deployment details in CI environments. Defaults to true, use `--no-json-output` to disable.",
+          "name": "json-output",
+          "required": false,
+          "allowNo": true,
+          "type": "boolean"
+        },
+        "token": {
+          "char": "t",
+          "description": "Oxygen deployment token. Defaults to the linked storefront's token if available.",
+          "env": "SHOPIFY_HYDROGEN_DEPLOYMENT_TOKEN",
+          "name": "token",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "metadata-description": {
+          "description": "Description of the changes in the deployment. Defaults to the commit message of the latest commit if there are no uncommited changes.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_METADATA_DESCRIPTION",
+          "name": "metadata-description",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "metadata-url": {
+          "env": "SHOPIFY_HYDROGEN_FLAG_METADATA_URL",
+          "hidden": true,
+          "name": "metadata-url",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "metadata-user": {
+          "description": "User that initiated the deployment. Will be saved and displayed in the Shopify admin",
+          "env": "SHOPIFY_HYDROGEN_FLAG_METADATA_USER",
+          "name": "metadata-user",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "metadata-version": {
+          "env": "SHOPIFY_HYDROGEN_FLAG_METADATA_VERSION",
+          "hidden": true,
+          "name": "metadata-version",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "force-client-sourcemap": {
+          "description": "Client sourcemapping is avoided by default because it makes backend code visible in the browser. Use this flag to force enabling it.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_FORCE_CLIENT_SOURCEMAP",
+          "name": "force-client-sourcemap",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "hydrogen:deploy",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false,
+      "descriptionWithMarkdown": "Builds and deploys your Hydrogen storefront to Oxygen. Requires an Oxygen deployment token to be set with the `--token` flag or an environment variable (`SHOPIFY_HYDROGEN_DEPLOYMENT_TOKEN`). If the storefront is [linked](https://shopify.dev/docs/api/shopify-cli/hydrogen/hydrogen-link) then the Oxygen deployment token for the linked storefront will be used automatically.",
+      "customPluginName": "@shopify/cli-hydrogen"
+    },
+    "hydrogen:g": {
+      "aliases": [],
+      "args": {},
+      "description": "Shortcut for `hydrogen generate`. See `hydrogen generate --help` for more information.",
+      "flags": {},
+      "hasDynamicHelp": false,
+      "hidden": true,
+      "hiddenAliases": [],
+      "id": "hydrogen:g",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": false,
+      "enableJsonFlag": false,
+      "customPluginName": "@shopify/cli-hydrogen"
+    },
+    "hydrogen:init": {
+      "aliases": [],
+      "args": {},
+      "description": "Creates a new Hydrogen storefront.",
+      "flags": {
+        "force": {
+          "char": "f",
+          "description": "Overwrites the destination directory and files if they already exist.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_FORCE",
+          "name": "force",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path to the directory of the new Hydrogen storefront.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
+          "name": "path",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "language": {
+          "description": "Sets the template language to use. One of `js` or `ts`.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_LANGUAGE",
+          "name": "language",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "template": {
+          "description": "Scaffolds project based on an existing template or example from the Hydrogen repository.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_TEMPLATE",
+          "name": "template",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "install-deps": {
+          "description": "Auto installs dependencies using the active package manager.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_INSTALL_DEPS",
+          "name": "install-deps",
+          "allowNo": true,
+          "type": "boolean"
+        },
+        "mock-shop": {
+          "description": "Use mock.shop as the data source for the storefront.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_MOCK_DATA",
+          "name": "mock-shop",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "styling": {
+          "description": "Sets the styling strategy to use. One of `tailwind`, `vanilla-extract`, `css-modules`, `postcss`, `none`.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_STYLING",
+          "name": "styling",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "markets": {
+          "description": "Sets the URL structure to support multiple markets. Must be one of: `subfolders`, `domains`, `subdomains`, `none`. Example: `--markets subfolders`.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_I18N",
+          "name": "markets",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "shortcut": {
+          "description": "Creates a global h2 shortcut for Shopify CLI using shell aliases. Deactivate with `--no-shortcut`.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_SHORTCUT",
+          "name": "shortcut",
+          "allowNo": true,
+          "type": "boolean"
+        },
+        "git": {
+          "description": "Init Git and create initial commits.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_GIT",
+          "name": "git",
+          "allowNo": true,
+          "type": "boolean"
+        },
+        "quickstart": {
+          "description": "Scaffolds a new Hydrogen project with a set of sensible defaults. Equivalent to `shopify hydrogen init --path hydrogen-quickstart --mock-shop --language js --shortcut --markets none`",
+          "env": "SHOPIFY_HYDROGEN_FLAG_QUICKSTART",
+          "name": "quickstart",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "package-manager": {
+          "env": "SHOPIFY_HYDROGEN_FLAG_PACKAGE_MANAGER",
+          "hidden": true,
+          "name": "package-manager",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "options": [
+            "npm",
+            "yarn",
+            "pnpm",
+            "unknown"
+          ],
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "hydrogen:init",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false,
+      "descriptionWithMarkdown": "Creates a new Hydrogen storefront.",
+      "customPluginName": "@shopify/cli-hydrogen"
+    },
+    "hydrogen:link": {
+      "aliases": [],
+      "args": {},
+      "description": "Link a local project to one of your shop's Hydrogen storefronts.",
+      "flags": {
+        "force": {
+          "char": "f",
+          "description": "Overwrites the destination directory and files if they already exist.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_FORCE",
+          "name": "force",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
+          "name": "path",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "storefront": {
+          "description": "The name of a Hydrogen Storefront (e.g. \"Jane's Apparel\")",
+          "env": "SHOPIFY_HYDROGEN_STOREFRONT",
+          "name": "storefront",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "hydrogen:link",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false,
+      "descriptionWithMarkdown": "Links your local development environment to a remote Hydrogen storefront. You can link an unlimited number of development environments to a single Hydrogen storefront.\n\n  Linking to a Hydrogen storefront enables you to run [dev](https://shopify.dev/docs/api/shopify-cli/hydrogen/hydrogen-dev) and automatically inject your linked Hydrogen storefront's environment variables directly into the server runtime.\n\n  After you run the `link` command, you can access the [env list](https://shopify.dev/docs/api/shopify-cli/hydrogen/hydrogen-env-list), [env pull](https://shopify.dev/docs/api/shopify-cli/hydrogen/hydrogen-env-pull), and [unlink](https://shopify.dev/docs/api/shopify-cli/hydrogen/hydrogen-unlink) commands.",
+      "customPluginName": "@shopify/cli-hydrogen"
+    },
+    "hydrogen:list": {
+      "aliases": [],
+      "args": {},
+      "description": "Returns a list of Hydrogen storefronts available on a given shop.",
+      "flags": {
+        "path": {
+          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
+          "name": "path",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "hydrogen:list",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false,
+      "descriptionWithMarkdown": "Lists all remote Hydrogen storefronts available to link to your local development environment.",
+      "customPluginName": "@shopify/cli-hydrogen"
+    },
+    "hydrogen:login": {
+      "aliases": [],
+      "args": {},
+      "description": "Login to your Shopify account.",
+      "flags": {
+        "path": {
+          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
+          "name": "path",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "shop": {
+          "char": "s",
+          "description": "Shop URL. It can be the shop prefix (janes-apparel) or the full myshopify.com URL (janes-apparel.myshopify.com, https://janes-apparel.myshopify.com).",
+          "env": "SHOPIFY_SHOP",
+          "name": "shop",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "hydrogen:login",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false,
+      "descriptionWithMarkdown": "Logs in to the specified shop and saves the shop domain to the project.",
+      "customPluginName": "@shopify/cli-hydrogen"
+    },
+    "hydrogen:logout": {
+      "aliases": [],
+      "args": {},
+      "description": "Logout of your local session.",
+      "flags": {
+        "path": {
+          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
+          "name": "path",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "hydrogen:logout",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false,
+      "descriptionWithMarkdown": "Log out from the current shop.",
+      "customPluginName": "@shopify/cli-hydrogen"
+    },
+    "hydrogen:preview": {
+      "aliases": [],
+      "args": {},
+      "description": "Runs a Hydrogen storefront in an Oxygen worker for production.",
+      "flags": {
+        "path": {
+          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
+          "name": "path",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "port": {
+          "description": "The port to run the server on. Defaults to 3000.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_PORT",
+          "name": "port",
+          "hasDynamicHelp": false,
+          "multiple": false,
           "type": "option"
         },
         "env": {
@@ -4025,163 +6842,89 @@
           "exclusive": [
             "env-branch"
           ],
+          "name": "env",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "env",
           "type": "option"
         },
         "env-branch": {
           "deprecated": {
-            "message": "--env-branch is deprecated. Use --env instead.",
-            "to": "env"
+            "to": "env",
+            "message": "--env-branch is deprecated. Use --env instead."
           },
           "description": "Specifies the environment to perform the operation using its Git branch name.",
           "env": "SHOPIFY_HYDROGEN_ENVIRONMENT_BRANCH",
+          "name": "env-branch",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "env-branch",
           "type": "option"
         },
         "env-file": {
-          "description": "Path to an environment file to override existing environment variables for the deployment.",
-          "hasDynamicHelp": false,
-          "multiple": false,
+          "description": "Path to an environment file to override existing environment variables. Defaults to the '.env' located in your project path `--path`.",
           "name": "env-file",
           "required": false,
+          "default": ".env",
+          "hasDynamicHelp": false,
+          "multiple": false,
           "type": "option"
         },
-        "force": {
+        "inspector-port": {
+          "description": "The port where the inspector is available. Defaults to 9229.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_INSPECTOR_PORT",
+          "name": "inspector-port",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "debug": {
+          "description": "Enables inspector connections to the server with a debugger such as Visual Studio Code or Chrome DevTools.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_DEBUG",
+          "name": "debug",
           "allowNo": false,
-          "char": "f",
-          "description": "Forces a deployment to proceed if there are uncommited changes in its Git repository.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_FORCE",
-          "name": "force",
-          "required": false,
           "type": "boolean"
         },
-        "force-client-sourcemap": {
+        "verbose": {
+          "description": "Outputs more information about the command's execution.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_VERBOSE",
+          "name": "verbose",
+          "required": false,
           "allowNo": false,
-          "description": "Client sourcemapping is avoided by default because it makes backend code visible in the browser. Use this flag to force enabling it.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_FORCE_CLIENT_SOURCEMAP",
-          "name": "force-client-sourcemap",
           "type": "boolean"
         },
-        "json-output": {
-          "allowNo": true,
-          "description": "Create a JSON file containing the deployment details in CI environments. Defaults to true, use `--no-json-output` to disable.",
-          "name": "json-output",
-          "required": false,
-          "type": "boolean"
-        },
-        "lockfile-check": {
-          "allowNo": true,
-          "description": "Checks that there is exactly one valid lockfile in the project. Defaults to `true`. Deactivate with `--no-lockfile-check`.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_LOCKFILE_CHECK",
-          "name": "lockfile-check",
-          "type": "boolean"
-        },
-        "metadata-description": {
-          "description": "Description of the changes in the deployment. Defaults to the commit message of the latest commit if there are no uncommited changes.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_METADATA_DESCRIPTION",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "metadata-description",
-          "required": false,
-          "type": "option"
-        },
-        "metadata-url": {
-          "env": "SHOPIFY_HYDROGEN_FLAG_METADATA_URL",
-          "hasDynamicHelp": false,
-          "hidden": true,
-          "multiple": false,
-          "name": "metadata-url",
-          "required": false,
-          "type": "option"
-        },
-        "metadata-user": {
-          "description": "User that initiated the deployment. Will be saved and displayed in the Shopify admin",
-          "env": "SHOPIFY_HYDROGEN_FLAG_METADATA_USER",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "metadata-user",
-          "required": false,
-          "type": "option"
-        },
-        "metadata-version": {
-          "env": "SHOPIFY_HYDROGEN_FLAG_METADATA_VERSION",
-          "hasDynamicHelp": false,
-          "hidden": true,
-          "multiple": false,
-          "name": "metadata-version",
-          "required": false,
-          "type": "option"
-        },
-        "no-verify": {
+        "build": {
+          "description": "Builds the app before starting the preview server.",
+          "name": "build",
           "allowNo": false,
-          "description": "Skip the routability verification step after deployment.",
-          "name": "no-verify",
-          "required": false,
           "type": "boolean"
         },
-        "path": {
-          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "path",
-          "type": "option"
-        },
-        "preview": {
+        "watch": {
+          "dependsOn": [
+            "build"
+          ],
+          "description": "Watches for changes and rebuilds the project.",
+          "name": "watch",
           "allowNo": false,
-          "description": "Deploys to the Preview environment.",
-          "name": "preview",
-          "required": false,
           "type": "boolean"
         },
-        "shop": {
-          "char": "s",
-          "description": "Shop URL. It can be the shop prefix (janes-apparel) or the full myshopify.com URL (janes-apparel.myshopify.com, https://janes-apparel.myshopify.com).",
-          "env": "SHOPIFY_SHOP",
+        "entry": {
+          "dependsOn": [
+            "build"
+          ],
+          "description": "Entry file for the worker. Defaults to `./server`.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_ENTRY",
+          "name": "entry",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "shop",
           "type": "option"
         },
-        "token": {
-          "char": "t",
-          "description": "Oxygen deployment token. Defaults to the linked storefront's token if available.",
-          "env": "SHOPIFY_HYDROGEN_DEPLOYMENT_TOKEN",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "token",
-          "required": false,
-          "type": "option"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "hydrogen:deploy",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true
-    },
-    "hydrogen:dev": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/cli-hydrogen",
-      "description": "Runs Hydrogen storefront in an Oxygen worker for development.",
-      "descriptionWithMarkdown": "Runs a Hydrogen storefront in a local runtime that emulates an Oxygen worker for development.\n\n  If your project is [linked](https://shopify.dev/docs/api/shopify-cli/hydrogen/hydrogen-link) to a Hydrogen storefront, then its environment variables will be loaded with the runtime.",
-      "enableJsonFlag": false,
-      "flags": {
         "codegen": {
-          "allowNo": false,
+          "dependsOn": [
+            "build"
+          ],
           "description": "Automatically generates GraphQL types for your project’s Storefront API queries.",
           "name": "codegen",
           "required": false,
+          "allowNo": false,
           "type": "boolean"
         },
         "codegen-config-path": {
@@ -4189,301 +6932,390 @@
             "codegen"
           ],
           "description": "Specifies a path to a codegen configuration file. Defaults to `<root>/codegen.ts` if this file exists.",
-          "hasDynamicHelp": false,
-          "multiple": false,
           "name": "codegen-config-path",
           "required": false,
-          "type": "option"
-        },
-        "customer-account-push": {
-          "allowNo": false,
-          "description": "Use tunneling for local development and push the tunneling domain to admin. Required to use Customer Account API's OAuth flow",
-          "env": "SHOPIFY_HYDROGEN_FLAG_CUSTOMER_ACCOUNT_PUSH",
-          "name": "customer-account-push",
-          "required": false,
-          "type": "boolean"
-        },
-        "debug": {
-          "allowNo": false,
-          "description": "Enables inspector connections to the server with a debugger such as Visual Studio Code or Chrome DevTools.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_DEBUG",
-          "name": "debug",
-          "type": "boolean"
-        },
-        "disable-deps-optimizer": {
-          "allowNo": false,
-          "description": "Disable adding dependencies to Vite's `ssr.optimizeDeps.include` automatically",
-          "env": "SHOPIFY_HYDROGEN_FLAG_DISABLE_DEPS_OPTIMIZER",
-          "name": "disable-deps-optimizer",
-          "type": "boolean"
-        },
-        "disable-version-check": {
-          "allowNo": false,
-          "description": "Skip the version check when running `hydrogen dev`",
-          "name": "disable-version-check",
-          "required": false,
-          "type": "boolean"
-        },
-        "disable-virtual-routes": {
-          "allowNo": false,
-          "description": "Disable rendering fallback routes when a route file doesn't exist.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_DISABLE_VIRTUAL_ROUTES",
-          "name": "disable-virtual-routes",
-          "type": "boolean"
-        },
-        "entry": {
-          "description": "Entry file for the worker. Defaults to `./server`.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_ENTRY",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "entry",
-          "type": "option"
-        },
-        "env": {
-          "description": "Specifies the environment to perform the operation using its handle. Fetch the handle using the `env list` command.",
-          "exclusive": [
-            "env-branch"
-          ],
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "env",
-          "type": "option"
-        },
-        "env-branch": {
-          "deprecated": {
-            "message": "--env-branch is deprecated. Use --env instead.",
-            "to": "env"
-          },
-          "description": "Specifies the environment to perform the operation using its Git branch name.",
-          "env": "SHOPIFY_HYDROGEN_ENVIRONMENT_BRANCH",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "env-branch",
-          "type": "option"
-        },
-        "env-file": {
-          "default": ".env",
-          "description": "Path to an environment file to override existing environment variables. Defaults to the '.env' located in your project path `--path`.",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "env-file",
-          "required": false,
-          "type": "option"
-        },
-        "host": {
-          "allowNo": false,
-          "description": "Expose the server to the local network",
-          "name": "host",
-          "required": false,
-          "type": "boolean"
-        },
-        "inspector-port": {
-          "description": "The port where the inspector is available. Defaults to 9229.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_INSPECTOR_PORT",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "inspector-port",
-          "type": "option"
-        },
-        "path": {
-          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "path",
-          "type": "option"
-        },
-        "port": {
-          "description": "The port to run the server on. Defaults to 3000.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_PORT",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "port",
-          "required": false,
-          "type": "option"
-        },
-        "verbose": {
-          "allowNo": false,
-          "description": "Outputs more information about the command's execution.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_VERBOSE",
-          "name": "verbose",
-          "required": false,
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "hydrogen:dev",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true
-    },
-    "hydrogen:env:list": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/cli-hydrogen",
-      "description": "List the environments on your linked Hydrogen storefront.",
-      "descriptionWithMarkdown": "Lists all environments available on the linked Hydrogen storefront.",
-      "enableJsonFlag": false,
-      "flags": {
-        "path": {
-          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "path",
           "type": "option"
         }
       },
       "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "hydrogen:env:list",
+      "hiddenAliases": [],
+      "id": "hydrogen:preview",
       "pluginAlias": "@shopify/cli",
       "pluginName": "@shopify/cli",
       "pluginType": "core",
-      "strict": true
-    },
-    "hydrogen:env:pull": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/cli-hydrogen",
-      "description": "Populate your .env with variables from your Hydrogen storefront.",
-      "descriptionWithMarkdown": "Pulls environment variables from the linked Hydrogen storefront and writes them to an `.env` file.",
+      "strict": true,
       "enableJsonFlag": false,
+      "descriptionWithMarkdown": "Runs a server in your local development environment that serves your Hydrogen app's production build. Requires running the [build](https://shopify.dev/docs/api/shopify-cli/hydrogen/hydrogen-build) command first.",
+      "customPluginName": "@shopify/cli-hydrogen"
+    },
+    "hydrogen:setup": {
+      "aliases": [],
+      "args": {},
+      "description": "Scaffold routes and core functionality.",
       "flags": {
-        "env": {
-          "description": "Specifies the environment to perform the operation using its handle. Fetch the handle using the `env list` command.",
-          "exclusive": [
-            "env-branch"
-          ],
+        "path": {
+          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
+          "name": "path",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "env",
-          "type": "option"
-        },
-        "env-branch": {
-          "deprecated": {
-            "message": "--env-branch is deprecated. Use --env instead.",
-            "to": "env"
-          },
-          "description": "Specifies the environment to perform the operation using its Git branch name.",
-          "env": "SHOPIFY_HYDROGEN_ENVIRONMENT_BRANCH",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "env-branch",
-          "type": "option"
-        },
-        "env-file": {
-          "default": ".env",
-          "description": "Path to an environment file to override existing environment variables. Defaults to the '.env' located in your project path `--path`.",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "env-file",
-          "required": false,
           "type": "option"
         },
         "force": {
-          "allowNo": false,
           "char": "f",
           "description": "Overwrites the destination directory and files if they already exist.",
           "env": "SHOPIFY_HYDROGEN_FLAG_FORCE",
           "name": "force",
+          "allowNo": false,
           "type": "boolean"
         },
+        "markets": {
+          "description": "Sets the URL structure to support multiple markets. Must be one of: `subfolders`, `domains`, `subdomains`, `none`. Example: `--markets subfolders`.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_I18N",
+          "name": "markets",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "shortcut": {
+          "description": "Creates a global h2 shortcut for Shopify CLI using shell aliases. Deactivate with `--no-shortcut`.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_SHORTCUT",
+          "name": "shortcut",
+          "allowNo": true,
+          "type": "boolean"
+        },
+        "install-deps": {
+          "description": "Auto installs dependencies using the active package manager.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_INSTALL_DEPS",
+          "name": "install-deps",
+          "allowNo": true,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "hydrogen:setup",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false,
+      "customPluginName": "@shopify/cli-hydrogen"
+    },
+    "hydrogen:shortcut": {
+      "aliases": [],
+      "args": {},
+      "description": "Creates a global `h2` shortcut for the Hydrogen CLI",
+      "flags": {},
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "hydrogen:shortcut",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false,
+      "descriptionWithMarkdown": "Creates a global h2 shortcut for Shopify CLI using shell aliases.\n\n  The following shells are supported:\n\n  - Bash (using `~/.bashrc`)\n  - ZSH (using `~/.zshrc`)\n  - Fish (using `~/.config/fish/functions`)\n  - PowerShell (added to `$PROFILE`)\n\n  After the alias is created, you can call Shopify CLI from anywhere in your project using `h2 <command>`.",
+      "customPluginName": "@shopify/cli-hydrogen"
+    },
+    "hydrogen:unlink": {
+      "aliases": [],
+      "args": {},
+      "description": "Unlink a local project from a Hydrogen storefront.",
+      "flags": {
         "path": {
           "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
           "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
+          "name": "path",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "path",
           "type": "option"
         }
       },
       "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "hydrogen:env:pull",
+      "hiddenAliases": [],
+      "id": "hydrogen:unlink",
       "pluginAlias": "@shopify/cli",
       "pluginName": "@shopify/cli",
       "pluginType": "core",
-      "strict": true
-    },
-    "hydrogen:env:push": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/cli-hydrogen",
-      "description": "Push environment variables from the local .env file to your linked Hydrogen storefront.",
+      "strict": true,
       "enableJsonFlag": false,
+      "descriptionWithMarkdown": "Unlinks your local development environment from a remote Hydrogen storefront.",
+      "customPluginName": "@shopify/cli-hydrogen"
+    },
+    "hydrogen:upgrade": {
+      "aliases": [],
+      "args": {},
+      "description": "Upgrade Remix and Hydrogen npm dependencies.",
+      "flags": {
+        "path": {
+          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
+          "name": "path",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "version": {
+          "char": "v",
+          "description": "A target hydrogen version to update to",
+          "name": "version",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "force": {
+          "char": "f",
+          "description": "Ignore warnings and force the upgrade to the target version",
+          "env": "SHOPIFY_HYDROGEN_FLAG_FORCE",
+          "name": "force",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "hydrogen:upgrade",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false,
+      "descriptionWithMarkdown": "Upgrade Hydrogen project dependencies, preview features, fixes and breaking changes. The command also generates an instruction file for each upgrade.",
+      "customPluginName": "@shopify/cli-hydrogen"
+    },
+    "hydrogen:customer-account-push": {
+      "aliases": [],
+      "args": {},
+      "description": "Push project configuration to admin",
+      "flags": {
+        "path": {
+          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
+          "name": "path",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "storefront-id": {
+          "description": "The id of the storefront the configuration should be pushed to. Must start with 'gid://shopify/HydrogenStorefront/'",
+          "name": "storefront-id",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "dev-origin": {
+          "description": "The development domain of your application.",
+          "name": "dev-origin",
+          "required": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "relative-redirect-uri": {
+          "description": "The relative url of allowed callback url for Customer Account API OAuth flow. Default is '/account/authorize'",
+          "name": "relative-redirect-uri",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "relative-logout-uri": {
+          "description": "The relative url of allowed url that will be redirected to post-logout for Customer Account API OAuth flow. Default to nothing.",
+          "name": "relative-logout-uri",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "hydrogen:customer-account-push",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false,
+      "customPluginName": "@shopify/cli-hydrogen"
+    },
+    "hydrogen:debug:cpu": {
+      "aliases": [],
+      "args": {},
+      "description": "Builds and profiles the server startup time the app.",
+      "flags": {
+        "path": {
+          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
+          "name": "path",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "entry": {
+          "description": "Entry file for the worker. Defaults to `./server`.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_ENTRY",
+          "name": "entry",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "output": {
+          "description": "Specify a path to generate the profile file. Defaults to \"startup.cpuprofile\".",
+          "name": "output",
+          "required": false,
+          "default": "startup.cpuprofile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "hydrogen:debug:cpu",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false,
+      "descriptionWithMarkdown": "Builds the app and runs the resulting code to profile the server startup time, watching for changes. This command can be used to [debug slow app startup times](https://shopify.dev/docs/custom-storefronts/hydrogen/debugging/cpu-startup) that cause failed deployments in Oxygen.\n\n  The profiling results are written to a `.cpuprofile` file that can be viewed with certain tools such as [Flame Chart Visualizer for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=ms-vscode.vscode-js-profile-flame).",
+      "customPluginName": "@shopify/cli-hydrogen"
+    },
+    "hydrogen:env:list": {
+      "aliases": [],
+      "args": {},
+      "description": "List the environments on your linked Hydrogen storefront.",
+      "flags": {
+        "path": {
+          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
+          "name": "path",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "hydrogen:env:list",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false,
+      "descriptionWithMarkdown": "Lists all environments available on the linked Hydrogen storefront.",
+      "customPluginName": "@shopify/cli-hydrogen"
+    },
+    "hydrogen:env:pull": {
+      "aliases": [],
+      "args": {},
+      "description": "Populate your .env with variables from your Hydrogen storefront.",
       "flags": {
         "env": {
           "description": "Specifies the environment to perform the operation using its handle. Fetch the handle using the `env list` command.",
           "exclusive": [
             "env-branch"
           ],
+          "name": "env",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "env",
+          "type": "option"
+        },
+        "env-branch": {
+          "deprecated": {
+            "to": "env",
+            "message": "--env-branch is deprecated. Use --env instead."
+          },
+          "description": "Specifies the environment to perform the operation using its Git branch name.",
+          "env": "SHOPIFY_HYDROGEN_ENVIRONMENT_BRANCH",
+          "name": "env-branch",
+          "hasDynamicHelp": false,
+          "multiple": false,
           "type": "option"
         },
         "env-file": {
-          "default": ".env",
           "description": "Path to an environment file to override existing environment variables. Defaults to the '.env' located in your project path `--path`.",
-          "hasDynamicHelp": false,
-          "multiple": false,
           "name": "env-file",
           "required": false,
+          "default": ".env",
+          "hasDynamicHelp": false,
+          "multiple": false,
           "type": "option"
         },
         "path": {
           "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
           "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
+          "name": "path",
           "hasDynamicHelp": false,
           "multiple": false,
+          "type": "option"
+        },
+        "force": {
+          "char": "f",
+          "description": "Overwrites the destination directory and files if they already exist.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_FORCE",
+          "name": "force",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "hydrogen:env:pull",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false,
+      "descriptionWithMarkdown": "Pulls environment variables from the linked Hydrogen storefront and writes them to an `.env` file.",
+      "customPluginName": "@shopify/cli-hydrogen"
+    },
+    "hydrogen:env:push": {
+      "aliases": [],
+      "args": {},
+      "description": "Push environment variables from the local .env file to your linked Hydrogen storefront.",
+      "flags": {
+        "env": {
+          "description": "Specifies the environment to perform the operation using its handle. Fetch the handle using the `env list` command.",
+          "exclusive": [
+            "env-branch"
+          ],
+          "name": "env",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "env-file": {
+          "description": "Path to an environment file to override existing environment variables. Defaults to the '.env' located in your project path `--path`.",
+          "name": "env-file",
+          "required": false,
+          "default": ".env",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "path": {
+          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
           "name": "path",
+          "hasDynamicHelp": false,
+          "multiple": false,
           "type": "option"
         }
       },
       "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
+      "hiddenAliases": [],
       "id": "hydrogen:env:push",
       "pluginAlias": "@shopify/cli",
       "pluginName": "@shopify/cli",
       "pluginType": "core",
-      "strict": true
-    },
-    "hydrogen:g": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/cli-hydrogen",
-      "description": "Shortcut for `hydrogen generate`. See `hydrogen generate --help` for more information.",
+      "strict": true,
       "enableJsonFlag": false,
-      "flags": {
-      },
-      "hasDynamicHelp": false,
-      "hidden": true,
-      "hiddenAliases": [
-      ],
-      "id": "hydrogen:g",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": false
+      "customPluginName": "@shopify/cli-hydrogen"
     },
     "hydrogen:generate:route": {
-      "aliases": [
-      ],
+      "aliases": [],
       "args": {
         "routeName": {
           "description": "The route to generate. One of home,page,cart,products,collections,policies,blogs,account,search,robots,sitemap,tokenlessApi,all.",
@@ -4506,569 +7338,116 @@
           "required": true
         }
       },
-      "customPluginName": "@shopify/cli-hydrogen",
       "description": "Generates a standard Shopify route.",
-      "descriptionWithMarkdown": "Generates a set of default routes from the starter template.",
-      "enableJsonFlag": false,
       "flags": {
         "adapter": {
           "description": "Remix adapter used in the route. The default is `@shopify/remix-oxygen`.",
           "env": "SHOPIFY_HYDROGEN_FLAG_ADAPTER",
+          "name": "adapter",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "adapter",
           "type": "option"
         },
-        "force": {
+        "typescript": {
+          "description": "Generate TypeScript files",
+          "env": "SHOPIFY_HYDROGEN_FLAG_TYPESCRIPT",
+          "name": "typescript",
           "allowNo": false,
-          "char": "f",
-          "description": "Overwrites the destination directory and files if they already exist.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_FORCE",
-          "name": "force",
           "type": "boolean"
         },
         "locale-param": {
           "description": "The param name in Remix routes for the i18n locale, if any. Example: `locale` becomes ($locale).",
           "env": "SHOPIFY_HYDROGEN_FLAG_ADAPTER",
+          "name": "locale-param",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "locale-param",
           "type": "option"
+        },
+        "force": {
+          "char": "f",
+          "description": "Overwrites the destination directory and files if they already exist.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_FORCE",
+          "name": "force",
+          "allowNo": false,
+          "type": "boolean"
         },
         "path": {
           "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
           "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
+          "name": "path",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "path",
           "type": "option"
-        },
-        "typescript": {
-          "allowNo": false,
-          "description": "Generate TypeScript files",
-          "env": "SHOPIFY_HYDROGEN_FLAG_TYPESCRIPT",
-          "name": "typescript",
-          "type": "boolean"
         }
       },
       "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
+      "hiddenAliases": [],
       "id": "hydrogen:generate:route",
       "pluginAlias": "@shopify/cli",
       "pluginName": "@shopify/cli",
       "pluginType": "core",
-      "strict": true
+      "strict": true,
+      "enableJsonFlag": false,
+      "descriptionWithMarkdown": "Generates a set of default routes from the starter template.",
+      "customPluginName": "@shopify/cli-hydrogen"
     },
     "hydrogen:generate:routes": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/cli-hydrogen",
+      "aliases": [],
+      "args": {},
       "description": "Generates all supported standard shopify routes.",
-      "enableJsonFlag": false,
       "flags": {
         "adapter": {
           "description": "Remix adapter used in the route. The default is `@shopify/remix-oxygen`.",
           "env": "SHOPIFY_HYDROGEN_FLAG_ADAPTER",
+          "name": "adapter",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "adapter",
           "type": "option"
         },
-        "force": {
+        "typescript": {
+          "description": "Generate TypeScript files",
+          "env": "SHOPIFY_HYDROGEN_FLAG_TYPESCRIPT",
+          "name": "typescript",
           "allowNo": false,
-          "char": "f",
-          "description": "Overwrites the destination directory and files if they already exist.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_FORCE",
-          "name": "force",
           "type": "boolean"
         },
         "locale-param": {
           "description": "The param name in Remix routes for the i18n locale, if any. Example: `locale` becomes ($locale).",
           "env": "SHOPIFY_HYDROGEN_FLAG_ADAPTER",
+          "name": "locale-param",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "locale-param",
           "type": "option"
+        },
+        "force": {
+          "char": "f",
+          "description": "Overwrites the destination directory and files if they already exist.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_FORCE",
+          "name": "force",
+          "allowNo": false,
+          "type": "boolean"
         },
         "path": {
           "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
           "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
+          "name": "path",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "path",
           "type": "option"
-        },
-        "typescript": {
-          "allowNo": false,
-          "description": "Generate TypeScript files",
-          "env": "SHOPIFY_HYDROGEN_FLAG_TYPESCRIPT",
-          "name": "typescript",
-          "type": "boolean"
         }
       },
       "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
+      "hiddenAliases": [],
       "id": "hydrogen:generate:routes",
       "pluginAlias": "@shopify/cli",
       "pluginName": "@shopify/cli",
       "pluginType": "core",
-      "strict": true
-    },
-    "hydrogen:init": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/cli-hydrogen",
-      "description": "Creates a new Hydrogen storefront.",
-      "descriptionWithMarkdown": "Creates a new Hydrogen storefront.",
+      "strict": true,
       "enableJsonFlag": false,
-      "flags": {
-        "force": {
-          "allowNo": false,
-          "char": "f",
-          "description": "Overwrites the destination directory and files if they already exist.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_FORCE",
-          "name": "force",
-          "type": "boolean"
-        },
-        "git": {
-          "allowNo": true,
-          "description": "Init Git and create initial commits.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_GIT",
-          "name": "git",
-          "type": "boolean"
-        },
-        "install-deps": {
-          "allowNo": true,
-          "description": "Auto installs dependencies using the active package manager.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_INSTALL_DEPS",
-          "name": "install-deps",
-          "type": "boolean"
-        },
-        "language": {
-          "description": "Sets the template language to use. One of `js` or `ts`.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_LANGUAGE",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "language",
-          "type": "option"
-        },
-        "markets": {
-          "description": "Sets the URL structure to support multiple markets. Must be one of: `subfolders`, `domains`, `subdomains`, `none`. Example: `--markets subfolders`.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_I18N",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "markets",
-          "type": "option"
-        },
-        "mock-shop": {
-          "allowNo": false,
-          "description": "Use mock.shop as the data source for the storefront.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_MOCK_DATA",
-          "name": "mock-shop",
-          "type": "boolean"
-        },
-        "package-manager": {
-          "env": "SHOPIFY_HYDROGEN_FLAG_PACKAGE_MANAGER",
-          "hasDynamicHelp": false,
-          "hidden": true,
-          "multiple": false,
-          "name": "package-manager",
-          "options": [
-            "npm",
-            "yarn",
-            "pnpm",
-            "unknown"
-          ],
-          "type": "option"
-        },
-        "path": {
-          "description": "The path to the directory of the new Hydrogen storefront.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "path",
-          "type": "option"
-        },
-        "quickstart": {
-          "allowNo": false,
-          "description": "Scaffolds a new Hydrogen project with a set of sensible defaults. Equivalent to `shopify hydrogen init --path hydrogen-quickstart --mock-shop --language js --shortcut --markets none`",
-          "env": "SHOPIFY_HYDROGEN_FLAG_QUICKSTART",
-          "name": "quickstart",
-          "type": "boolean"
-        },
-        "shortcut": {
-          "allowNo": true,
-          "description": "Creates a global h2 shortcut for Shopify CLI using shell aliases. Deactivate with `--no-shortcut`.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_SHORTCUT",
-          "name": "shortcut",
-          "type": "boolean"
-        },
-        "styling": {
-          "description": "Sets the styling strategy to use. One of `tailwind`, `vanilla-extract`, `css-modules`, `postcss`, `none`.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_STYLING",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "styling",
-          "type": "option"
-        },
-        "template": {
-          "description": "Scaffolds project based on an existing template or example from the Hydrogen repository.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_TEMPLATE",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "template",
-          "type": "option"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "hydrogen:init",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true
-    },
-    "hydrogen:link": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/cli-hydrogen",
-      "description": "Link a local project to one of your shop's Hydrogen storefronts.",
-      "descriptionWithMarkdown": "Links your local development environment to a remote Hydrogen storefront. You can link an unlimited number of development environments to a single Hydrogen storefront.\n\n  Linking to a Hydrogen storefront enables you to run [dev](https://shopify.dev/docs/api/shopify-cli/hydrogen/hydrogen-dev) and automatically inject your linked Hydrogen storefront's environment variables directly into the server runtime.\n\n  After you run the `link` command, you can access the [env list](https://shopify.dev/docs/api/shopify-cli/hydrogen/hydrogen-env-list), [env pull](https://shopify.dev/docs/api/shopify-cli/hydrogen/hydrogen-env-pull), and [unlink](https://shopify.dev/docs/api/shopify-cli/hydrogen/hydrogen-unlink) commands.",
-      "enableJsonFlag": false,
-      "flags": {
-        "force": {
-          "allowNo": false,
-          "char": "f",
-          "description": "Overwrites the destination directory and files if they already exist.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_FORCE",
-          "name": "force",
-          "type": "boolean"
-        },
-        "path": {
-          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "path",
-          "type": "option"
-        },
-        "storefront": {
-          "description": "The name of a Hydrogen Storefront (e.g. \"Jane's Apparel\")",
-          "env": "SHOPIFY_HYDROGEN_STOREFRONT",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "storefront",
-          "type": "option"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "hydrogen:link",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true
-    },
-    "hydrogen:list": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/cli-hydrogen",
-      "description": "Returns a list of Hydrogen storefronts available on a given shop.",
-      "descriptionWithMarkdown": "Lists all remote Hydrogen storefronts available to link to your local development environment.",
-      "enableJsonFlag": false,
-      "flags": {
-        "path": {
-          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "path",
-          "type": "option"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "hydrogen:list",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true
-    },
-    "hydrogen:login": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/cli-hydrogen",
-      "description": "Login to your Shopify account.",
-      "descriptionWithMarkdown": "Logs in to the specified shop and saves the shop domain to the project.",
-      "enableJsonFlag": false,
-      "flags": {
-        "path": {
-          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "path",
-          "type": "option"
-        },
-        "shop": {
-          "char": "s",
-          "description": "Shop URL. It can be the shop prefix (janes-apparel) or the full myshopify.com URL (janes-apparel.myshopify.com, https://janes-apparel.myshopify.com).",
-          "env": "SHOPIFY_SHOP",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "shop",
-          "type": "option"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "hydrogen:login",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true
-    },
-    "hydrogen:logout": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/cli-hydrogen",
-      "description": "Logout of your local session.",
-      "descriptionWithMarkdown": "Log out from the current shop.",
-      "enableJsonFlag": false,
-      "flags": {
-        "path": {
-          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "path",
-          "type": "option"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "hydrogen:logout",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true
-    },
-    "hydrogen:preview": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/cli-hydrogen",
-      "description": "Runs a Hydrogen storefront in an Oxygen worker for production.",
-      "descriptionWithMarkdown": "Runs a server in your local development environment that serves your Hydrogen app's production build. Requires running the [build](https://shopify.dev/docs/api/shopify-cli/hydrogen/hydrogen-build) command first.",
-      "enableJsonFlag": false,
-      "flags": {
-        "build": {
-          "allowNo": false,
-          "description": "Builds the app before starting the preview server.",
-          "name": "build",
-          "type": "boolean"
-        },
-        "codegen": {
-          "allowNo": false,
-          "dependsOn": [
-            "build"
-          ],
-          "description": "Automatically generates GraphQL types for your project’s Storefront API queries.",
-          "name": "codegen",
-          "required": false,
-          "type": "boolean"
-        },
-        "codegen-config-path": {
-          "dependsOn": [
-            "codegen"
-          ],
-          "description": "Specifies a path to a codegen configuration file. Defaults to `<root>/codegen.ts` if this file exists.",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "codegen-config-path",
-          "required": false,
-          "type": "option"
-        },
-        "debug": {
-          "allowNo": false,
-          "description": "Enables inspector connections to the server with a debugger such as Visual Studio Code or Chrome DevTools.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_DEBUG",
-          "name": "debug",
-          "type": "boolean"
-        },
-        "entry": {
-          "dependsOn": [
-            "build"
-          ],
-          "description": "Entry file for the worker. Defaults to `./server`.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_ENTRY",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "entry",
-          "type": "option"
-        },
-        "env": {
-          "description": "Specifies the environment to perform the operation using its handle. Fetch the handle using the `env list` command.",
-          "exclusive": [
-            "env-branch"
-          ],
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "env",
-          "type": "option"
-        },
-        "env-branch": {
-          "deprecated": {
-            "message": "--env-branch is deprecated. Use --env instead.",
-            "to": "env"
-          },
-          "description": "Specifies the environment to perform the operation using its Git branch name.",
-          "env": "SHOPIFY_HYDROGEN_ENVIRONMENT_BRANCH",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "env-branch",
-          "type": "option"
-        },
-        "env-file": {
-          "default": ".env",
-          "description": "Path to an environment file to override existing environment variables. Defaults to the '.env' located in your project path `--path`.",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "env-file",
-          "required": false,
-          "type": "option"
-        },
-        "inspector-port": {
-          "description": "The port where the inspector is available. Defaults to 9229.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_INSPECTOR_PORT",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "inspector-port",
-          "type": "option"
-        },
-        "path": {
-          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "path",
-          "type": "option"
-        },
-        "port": {
-          "description": "The port to run the server on. Defaults to 3000.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_PORT",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "port",
-          "type": "option"
-        },
-        "verbose": {
-          "allowNo": false,
-          "description": "Outputs more information about the command's execution.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_VERBOSE",
-          "name": "verbose",
-          "required": false,
-          "type": "boolean"
-        },
-        "watch": {
-          "allowNo": false,
-          "dependsOn": [
-            "build"
-          ],
-          "description": "Watches for changes and rebuilds the project.",
-          "name": "watch",
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "hydrogen:preview",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true
-    },
-    "hydrogen:setup": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/cli-hydrogen",
-      "description": "Scaffold routes and core functionality.",
-      "enableJsonFlag": false,
-      "flags": {
-        "force": {
-          "allowNo": false,
-          "char": "f",
-          "description": "Overwrites the destination directory and files if they already exist.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_FORCE",
-          "name": "force",
-          "type": "boolean"
-        },
-        "install-deps": {
-          "allowNo": true,
-          "description": "Auto installs dependencies using the active package manager.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_INSTALL_DEPS",
-          "name": "install-deps",
-          "type": "boolean"
-        },
-        "markets": {
-          "description": "Sets the URL structure to support multiple markets. Must be one of: `subfolders`, `domains`, `subdomains`, `none`. Example: `--markets subfolders`.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_I18N",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "markets",
-          "type": "option"
-        },
-        "path": {
-          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "path",
-          "type": "option"
-        },
-        "shortcut": {
-          "allowNo": true,
-          "description": "Creates a global h2 shortcut for Shopify CLI using shell aliases. Deactivate with `--no-shortcut`.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_SHORTCUT",
-          "name": "shortcut",
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "hydrogen:setup",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true
+      "customPluginName": "@shopify/cli-hydrogen"
     },
     "hydrogen:setup:css": {
-      "aliases": [
-      ],
+      "aliases": [],
       "args": {
         "strategy": {
           "description": "The CSS strategy to setup. One of tailwind,vanilla-extract,css-modules,postcss",
@@ -5081,47 +7460,45 @@
           ]
         }
       },
-      "customPluginName": "@shopify/cli-hydrogen",
       "description": "Setup CSS strategies for your project.",
-      "descriptionWithMarkdown": "Adds support for certain CSS strategies to your project.",
-      "enableJsonFlag": false,
       "flags": {
+        "path": {
+          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
+          "name": "path",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
         "force": {
-          "allowNo": false,
           "char": "f",
           "description": "Overwrites the destination directory and files if they already exist.",
           "env": "SHOPIFY_HYDROGEN_FLAG_FORCE",
           "name": "force",
+          "allowNo": false,
           "type": "boolean"
         },
         "install-deps": {
-          "allowNo": true,
           "description": "Auto installs dependencies using the active package manager.",
           "env": "SHOPIFY_HYDROGEN_FLAG_INSTALL_DEPS",
           "name": "install-deps",
+          "allowNo": true,
           "type": "boolean"
-        },
-        "path": {
-          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "path",
-          "type": "option"
         }
       },
       "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
+      "hiddenAliases": [],
       "id": "hydrogen:setup:css",
       "pluginAlias": "@shopify/cli",
       "pluginName": "@shopify/cli",
       "pluginType": "core",
-      "strict": true
+      "strict": true,
+      "enableJsonFlag": false,
+      "descriptionWithMarkdown": "Adds support for certain CSS strategies to your project.",
+      "customPluginName": "@shopify/cli-hydrogen"
     },
     "hydrogen:setup:markets": {
-      "aliases": [
-      ],
+      "aliases": [],
       "args": {
         "strategy": {
           "description": "The URL structure strategy to setup multiple markets. One of subfolders,domains,subdomains",
@@ -5133,743 +7510,121 @@
           ]
         }
       },
-      "customPluginName": "@shopify/cli-hydrogen",
       "description": "Setup support for multiple markets in your project.",
-      "descriptionWithMarkdown": "Adds support for multiple [markets](https://shopify.dev/docs/custom-storefronts/hydrogen/markets) to your project by using the URL structure.",
-      "enableJsonFlag": false,
       "flags": {
         "path": {
           "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
           "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
+          "name": "path",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "path",
           "type": "option"
         }
       },
       "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
+      "hiddenAliases": [],
       "id": "hydrogen:setup:markets",
       "pluginAlias": "@shopify/cli",
       "pluginName": "@shopify/cli",
       "pluginType": "core",
-      "strict": true
+      "strict": true,
+      "enableJsonFlag": false,
+      "descriptionWithMarkdown": "Adds support for multiple [markets](https://shopify.dev/docs/custom-storefronts/hydrogen/markets) to your project by using the URL structure.",
+      "customPluginName": "@shopify/cli-hydrogen"
     },
     "hydrogen:setup:vite": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/cli-hydrogen",
+      "aliases": [],
+      "args": {},
       "description": "EXPERIMENTAL: Upgrades the project to use Vite.",
-      "enableJsonFlag": false,
       "flags": {
         "path": {
           "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
           "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
+          "name": "path",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "path",
           "type": "option"
         }
       },
       "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
+      "hiddenAliases": [],
       "id": "hydrogen:setup:vite",
       "pluginAlias": "@shopify/cli",
       "pluginName": "@shopify/cli",
       "pluginType": "core",
-      "strict": true
-    },
-    "hydrogen:shortcut": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/cli-hydrogen",
-      "description": "Creates a global `h2` shortcut for the Hydrogen CLI",
-      "descriptionWithMarkdown": "Creates a global h2 shortcut for Shopify CLI using shell aliases.\n\n  The following shells are supported:\n\n  - Bash (using `~/.bashrc`)\n  - ZSH (using `~/.zshrc`)\n  - Fish (using `~/.config/fish/functions`)\n  - PowerShell (added to `$PROFILE`)\n\n  After the alias is created, you can call Shopify CLI from anywhere in your project using `h2 <command>`.",
-      "enableJsonFlag": false,
-      "flags": {
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "hydrogen:shortcut",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true
-    },
-    "hydrogen:unlink": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/cli-hydrogen",
-      "description": "Unlink a local project from a Hydrogen storefront.",
-      "descriptionWithMarkdown": "Unlinks your local development environment from a remote Hydrogen storefront.",
-      "enableJsonFlag": false,
-      "flags": {
-        "path": {
-          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "path",
-          "type": "option"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "hydrogen:unlink",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true
-    },
-    "hydrogen:upgrade": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/cli-hydrogen",
-      "description": "Upgrade Remix and Hydrogen npm dependencies.",
-      "descriptionWithMarkdown": "Upgrade Hydrogen project dependencies, preview features, fixes and breaking changes. The command also generates an instruction file for each upgrade.",
-      "enableJsonFlag": false,
-      "flags": {
-        "force": {
-          "allowNo": false,
-          "char": "f",
-          "description": "Ignore warnings and force the upgrade to the target version",
-          "env": "SHOPIFY_HYDROGEN_FLAG_FORCE",
-          "name": "force",
-          "type": "boolean"
-        },
-        "path": {
-          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "path",
-          "type": "option"
-        },
-        "version": {
-          "char": "v",
-          "description": "A target hydrogen version to update to",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "version",
-          "required": false,
-          "type": "option"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "hydrogen:upgrade",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true
-    },
-    "kitchen-sink": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "description": "View all the available UI kit components",
-      "enableJsonFlag": false,
-      "flags": {
-      },
-      "hasDynamicHelp": false,
-      "hidden": true,
-      "hiddenAliases": [
-        "kitchen-sink all"
-      ],
-      "id": "kitchen-sink",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true
-    },
-    "kitchen-sink:async": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "description": "View the UI kit components that process async tasks",
-      "enableJsonFlag": false,
-      "flags": {
-      },
-      "hasDynamicHelp": false,
-      "hidden": true,
-      "hiddenAliases": [
-      ],
-      "id": "kitchen-sink:async",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true
-    },
-    "kitchen-sink:prompts": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "description": "View the UI kit components prompts",
-      "enableJsonFlag": false,
-      "flags": {
-      },
-      "hasDynamicHelp": false,
-      "hidden": true,
-      "hiddenAliases": [
-      ],
-      "id": "kitchen-sink:prompts",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true
-    },
-    "kitchen-sink:static": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "description": "View the UI kit components that display static output",
-      "enableJsonFlag": false,
-      "flags": {
-      },
-      "hasDynamicHelp": false,
-      "hidden": true,
-      "hiddenAliases": [
-      ],
-      "id": "kitchen-sink:static",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true
-    },
-    "notifications:generate": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "description": "Generate a notifications.json file for the the CLI, appending a new notification to the current file.",
-      "enableJsonFlag": false,
-      "flags": {
-      },
-      "hasDynamicHelp": false,
-      "hidden": true,
-      "hiddenAliases": [
-      ],
-      "id": "notifications:generate",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true
-    },
-    "notifications:list": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "description": "List current notifications configured for the CLI.",
-      "enableJsonFlag": false,
-      "flags": {
-        "ignore-errors": {
-          "allowNo": false,
-          "description": "Don't fail if an error occurs.",
-          "env": "SHOPIFY_FLAG_IGNORE_ERRORS",
-          "hidden": false,
-          "name": "ignore-errors",
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hidden": true,
-      "hiddenAliases": [
-      ],
-      "id": "notifications:list",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true
-    },
-    "organization:list": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/app",
-      "description": "Lists the Shopify organizations that you have access to, along with their organization IDs.",
-      "descriptionWithMarkdown": "Lists the Shopify organizations that you have access to, along with their organization IDs.",
-      "enableJsonFlag": false,
-      "flags": {
-        "json": {
-          "allowNo": false,
-          "char": "j",
-          "description": "Output the result as JSON. Automatically disables color output.",
-          "env": "SHOPIFY_FLAG_JSON",
-          "hidden": false,
-          "name": "json",
-          "type": "boolean"
-        },
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
-          "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
-        "verbose": {
-          "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "organization:list",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
       "strict": true,
-      "summary": "List Shopify organizations you have access to."
-    },
-    "plugins": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@oclif/plugin-plugins",
-      "description": "List installed plugins.",
-      "enableJsonFlag": true,
-      "examples": [
-        "<%= config.bin %> <%= command.id %>"
-      ],
-      "flags": {
-        "core": {
-          "allowNo": false,
-          "description": "Show core plugins.",
-          "name": "core",
-          "type": "boolean"
-        },
-        "json": {
-          "allowNo": false,
-          "description": "Format output as json.",
-          "helpGroup": "GLOBAL",
-          "name": "json",
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hidden": true,
-      "hiddenAliases": [
-      ],
-      "id": "plugins",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true
-    },
-    "plugins:inspect": {
-      "aliases": [
-      ],
-      "args": {
-        "plugin": {
-          "default": ".",
-          "description": "Plugin to inspect.",
-          "name": "plugin",
-          "required": true
-        }
-      },
-      "customPluginName": "@oclif/plugin-plugins",
-      "description": "Displays installation properties of a plugin.",
-      "enableJsonFlag": true,
-      "examples": [
-        "<%= config.bin %> <%= command.id %> <%- config.pjson.oclif.examplePlugin || \"myplugin\" %> "
-      ],
-      "flags": {
-        "help": {
-          "allowNo": false,
-          "char": "h",
-          "description": "Show CLI help.",
-          "name": "help",
-          "type": "boolean"
-        },
-        "json": {
-          "allowNo": false,
-          "description": "Format output as json.",
-          "helpGroup": "GLOBAL",
-          "name": "json",
-          "type": "boolean"
-        },
-        "verbose": {
-          "allowNo": false,
-          "char": "v",
-          "name": "verbose",
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "plugins:inspect",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": false,
-      "usage": "plugins:inspect PLUGIN..."
-    },
-    "plugins:install": {
-      "aliases": [
-        "plugins:add"
-      ],
-      "args": {
-        "plugin": {
-          "description": "Plugin to install.",
-          "name": "plugin",
-          "required": true
-        }
-      },
-      "customPluginName": "@oclif/plugin-plugins",
-      "description": "",
-      "enableJsonFlag": true,
-      "examples": [
-        {
-          "command": "<%= config.bin %> <%= command.id %> <%- config.pjson.oclif.examplePlugin || \"myplugin\" %> ",
-          "description": "Install a plugin from npm registry."
-        },
-        {
-          "command": "<%= config.bin %> <%= command.id %> https://github.com/someuser/someplugin",
-          "description": "Install a plugin from a github url."
-        },
-        {
-          "command": "<%= config.bin %> <%= command.id %> someuser/someplugin",
-          "description": "Install a plugin from a github slug."
-        }
-      ],
-      "flags": {
-        "force": {
-          "allowNo": false,
-          "char": "f",
-          "description": "Force npm to fetch remote resources even if a local copy exists on disk.",
-          "name": "force",
-          "type": "boolean"
-        },
-        "help": {
-          "allowNo": false,
-          "char": "h",
-          "description": "Show CLI help.",
-          "name": "help",
-          "type": "boolean"
-        },
-        "jit": {
-          "allowNo": false,
-          "hidden": true,
-          "name": "jit",
-          "type": "boolean"
-        },
-        "json": {
-          "allowNo": false,
-          "description": "Format output as json.",
-          "helpGroup": "GLOBAL",
-          "name": "json",
-          "type": "boolean"
-        },
-        "silent": {
-          "allowNo": false,
-          "char": "s",
-          "description": "Silences npm output.",
-          "exclusive": [
-            "verbose"
-          ],
-          "name": "silent",
-          "type": "boolean"
-        },
-        "verbose": {
-          "allowNo": false,
-          "char": "v",
-          "description": "Show verbose npm output.",
-          "exclusive": [
-            "silent"
-          ],
-          "name": "verbose",
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "plugins:install",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": false,
-      "summary": "Installs a plugin into <%= config.bin %>."
-    },
-    "plugins:link": {
-      "aliases": [
-      ],
-      "args": {
-        "path": {
-          "default": ".",
-          "description": "path to plugin",
-          "name": "path",
-          "required": true
-        }
-      },
-      "customPluginName": "@oclif/plugin-plugins",
-      "description": "Installation of a linked plugin will override a user-installed or core plugin.\n\ne.g. If you have a user-installed or core plugin that has a 'hello' command, installing a linked plugin with a 'hello' command will override the user-installed or core plugin implementation. This is useful for development work.\n",
       "enableJsonFlag": false,
-      "examples": [
-        "<%= config.bin %> <%= command.id %> <%- config.pjson.oclif.examplePlugin || \"myplugin\" %> "
-      ],
-      "flags": {
-        "help": {
-          "allowNo": false,
-          "char": "h",
-          "description": "Show CLI help.",
-          "name": "help",
-          "type": "boolean"
-        },
-        "install": {
-          "allowNo": true,
-          "description": "Install dependencies after linking the plugin.",
-          "name": "install",
-          "type": "boolean"
-        },
-        "verbose": {
-          "allowNo": false,
-          "char": "v",
-          "name": "verbose",
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "plugins:link",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true,
-      "summary": "Links a plugin into the CLI for development."
-    },
-    "plugins:reset": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@oclif/plugin-plugins",
-      "enableJsonFlag": false,
-      "flags": {
-        "hard": {
-          "allowNo": false,
-          "name": "hard",
-          "summary": "Delete node_modules and package manager related files in addition to uninstalling plugins.",
-          "type": "boolean"
-        },
-        "reinstall": {
-          "allowNo": false,
-          "name": "reinstall",
-          "summary": "Reinstall all plugins after uninstalling.",
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "plugins:reset",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true,
-      "summary": "Remove all user-installed and linked plugins."
-    },
-    "plugins:uninstall": {
-      "aliases": [
-        "plugins:unlink",
-        "plugins:remove"
-      ],
-      "args": {
-        "plugin": {
-          "description": "plugin to uninstall",
-          "name": "plugin"
-        }
-      },
-      "customPluginName": "@oclif/plugin-plugins",
-      "description": "Removes a plugin from the CLI.",
-      "enableJsonFlag": false,
-      "examples": [
-        "<%= config.bin %> <%= command.id %> <%- config.pjson.oclif.examplePlugin || \"myplugin\" %>"
-      ],
-      "flags": {
-        "help": {
-          "allowNo": false,
-          "char": "h",
-          "description": "Show CLI help.",
-          "name": "help",
-          "type": "boolean"
-        },
-        "verbose": {
-          "allowNo": false,
-          "char": "v",
-          "name": "verbose",
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "plugins:uninstall",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": false
-    },
-    "plugins:update": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@oclif/plugin-plugins",
-      "description": "Update installed plugins.",
-      "enableJsonFlag": false,
-      "flags": {
-        "help": {
-          "allowNo": false,
-          "char": "h",
-          "description": "Show CLI help.",
-          "name": "help",
-          "type": "boolean"
-        },
-        "verbose": {
-          "allowNo": false,
-          "char": "v",
-          "name": "verbose",
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "plugins:update",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true
-    },
-    "search": {
-      "aliases": [
-      ],
-      "args": {
-        "query": {
-          "name": "query"
-        }
-      },
-      "description": "Starts a search on shopify.dev.",
-      "enableJsonFlag": false,
-      "examples": [
-        "# open the search modal on Shopify.dev\n    shopify search\n\n    # search for a term on Shopify.dev\n    shopify search <query>\n\n    # search for a phrase on Shopify.dev\n    shopify search \"<a search query separated by spaces>\"\n    "
-      ],
-      "flags": {
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "search",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true,
-      "usage": "search [query]"
+      "customPluginName": "@shopify/cli-hydrogen"
     },
     "store:auth": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/store",
+      "aliases": [],
+      "args": {},
       "description": "Authenticates the app against the specified store for store commands and stores an online access token for later reuse.\n\nRe-run this command if the stored token is missing, expires, or no longer has the scopes you need.",
-      "descriptionWithMarkdown": "Authenticates the app against the specified store for store commands and stores an online access token for later reuse.\n\nRe-run this command if the stored token is missing, expires, or no longer has the scopes you need.",
       "examples": [
         "<%= config.bin %> <%= command.id %> --store shop.myshopify.com --scopes read_products,write_products",
         "<%= config.bin %> <%= command.id %> --store shop.myshopify.com --scopes read_products,write_products --json"
       ],
       "flags": {
-        "json": {
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
           "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "json": {
           "char": "j",
           "description": "Output the result as JSON. Automatically disables color output.",
           "env": "SHOPIFY_FLAG_JSON",
           "hidden": false,
           "name": "json",
-          "type": "boolean"
-        },
-        "no-color": {
           "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
-          "hidden": false,
-          "name": "no-color",
           "type": "boolean"
-        },
-        "scopes": {
-          "description": "Comma-separated Admin API scopes to request for the app.",
-          "env": "SHOPIFY_FLAG_SCOPES",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "scopes",
-          "required": true,
-          "type": "option"
         },
         "store": {
           "char": "s",
           "description": "The myshopify.com domain of the store to authenticate against.",
           "env": "SHOPIFY_FLAG_STORE",
-          "hasDynamicHelp": false,
-          "multiple": false,
           "name": "store",
           "required": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
           "type": "option"
         },
-        "verbose": {
-          "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
-          "type": "boolean"
+        "scopes": {
+          "description": "Comma-separated Admin API scopes to request for the app.",
+          "env": "SHOPIFY_FLAG_SCOPES",
+          "name": "scopes",
+          "required": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
         }
       },
       "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
+      "hiddenAliases": [],
       "id": "store:auth",
       "pluginAlias": "@shopify/cli",
       "pluginName": "@shopify/cli",
       "pluginType": "core",
       "strict": true,
-      "summary": "Authenticate an app against a store for store commands."
+      "summary": "Authenticate an app against a store for store commands.",
+      "descriptionWithMarkdown": "Authenticates the app against the specified store for store commands and stores an online access token for later reuse.\n\nRe-run this command if the stored token is missing, expires, or no longer has the scopes you need.",
+      "customPluginName": "@shopify/store"
     },
     "store:execute": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/store",
+      "aliases": [],
+      "args": {},
       "description": "Executes an Admin API GraphQL query or mutation on the specified store using previously stored app authentication.\n\nRun `shopify store auth` first to create stored auth for the store.\n\nMutations are disabled by default. Re-run with `--allow-mutations` if you intend to modify store data.",
-      "descriptionWithMarkdown": "Executes an Admin API GraphQL query or mutation on the specified store using previously stored app authentication.\n\nRun `shopify store auth` first to create stored auth for the store.\n\nMutations are disabled by default. Re-run with `--allow-mutations` if you intend to modify store data.",
       "examples": [
         "<%= config.bin %> <%= command.id %> --store shop.myshopify.com --query \"query { shop { name } }\"",
         "<%= config.bin %> <%= command.id %> --store shop.myshopify.com --query-file ./operation.graphql --variables '{\"id\":\"gid://shopify/Product/1\"}'",
@@ -5877,75 +7632,47 @@
         "<%= config.bin %> <%= command.id %> --store shop.myshopify.com --query \"query { shop { name } }\" --json"
       ],
       "flags": {
-        "allow-mutations": {
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
           "allowNo": false,
-          "description": "Allow GraphQL mutations to run against the target store.",
-          "env": "SHOPIFY_FLAG_ALLOW_MUTATIONS",
-          "name": "allow-mutations",
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
           "type": "boolean"
         },
         "json": {
-          "allowNo": false,
           "char": "j",
           "description": "Output the result as JSON. Automatically disables color output.",
           "env": "SHOPIFY_FLAG_JSON",
           "hidden": false,
           "name": "json",
-          "type": "boolean"
-        },
-        "no-color": {
           "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
-          "hidden": false,
-          "name": "no-color",
           "type": "boolean"
-        },
-        "output-file": {
-          "description": "The file name where results should be written, instead of STDOUT.",
-          "env": "SHOPIFY_FLAG_OUTPUT_FILE",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "output-file",
-          "type": "option"
         },
         "query": {
           "char": "q",
           "description": "The GraphQL query or mutation, as a string.",
           "env": "SHOPIFY_FLAG_QUERY",
-          "hasDynamicHelp": false,
-          "multiple": false,
           "name": "query",
           "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
           "type": "option"
         },
         "query-file": {
           "description": "Path to a file containing the GraphQL query or mutation. Can't be used with --query.",
           "env": "SHOPIFY_FLAG_QUERY_FILE",
-          "hasDynamicHelp": false,
-          "multiple": false,
           "name": "query-file",
-          "type": "option"
-        },
-        "store": {
-          "char": "s",
-          "description": "The myshopify.com domain of the store to execute against.",
-          "env": "SHOPIFY_FLAG_STORE",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "store",
-          "required": true,
-          "type": "option"
-        },
-        "variable-file": {
-          "description": "Path to a file containing GraphQL variables in JSON format. Can't be used with --variables.",
-          "env": "SHOPIFY_FLAG_VARIABLE_FILE",
-          "exclusive": [
-            "variables"
-          ],
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "variable-file",
           "type": "option"
         },
         "variables": {
@@ -5955,2509 +7682,471 @@
           "exclusive": [
             "variable-file"
           ],
+          "name": "variables",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "variables",
           "type": "option"
         },
-        "verbose": {
-          "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
-          "type": "boolean"
+        "variable-file": {
+          "description": "Path to a file containing GraphQL variables in JSON format. Can't be used with --variables.",
+          "env": "SHOPIFY_FLAG_VARIABLE_FILE",
+          "exclusive": [
+            "variables"
+          ],
+          "name": "variable-file",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "store": {
+          "char": "s",
+          "description": "The myshopify.com domain of the store to execute against.",
+          "env": "SHOPIFY_FLAG_STORE",
+          "name": "store",
+          "required": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
         },
         "version": {
           "description": "The API version to use for the query or mutation. Defaults to the latest stable version.",
           "env": "SHOPIFY_FLAG_VERSION",
+          "name": "version",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "version",
           "type": "option"
+        },
+        "output-file": {
+          "description": "The file name where results should be written, instead of STDOUT.",
+          "env": "SHOPIFY_FLAG_OUTPUT_FILE",
+          "name": "output-file",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "allow-mutations": {
+          "description": "Allow GraphQL mutations to run against the target store.",
+          "env": "SHOPIFY_FLAG_ALLOW_MUTATIONS",
+          "name": "allow-mutations",
+          "allowNo": false,
+          "type": "boolean"
         }
       },
       "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
+      "hiddenAliases": [],
       "id": "store:execute",
       "pluginAlias": "@shopify/cli",
       "pluginName": "@shopify/cli",
       "pluginType": "core",
       "strict": true,
-      "summary": "Execute GraphQL queries and mutations on a store."
+      "summary": "Execute GraphQL queries and mutations on a store.",
+      "descriptionWithMarkdown": "Executes an Admin API GraphQL query or mutation on the specified store using previously stored app authentication.\n\nRun `shopify store auth` first to create stored auth for the store.\n\nMutations are disabled by default. Re-run with `--allow-mutations` if you intend to modify store data.",
+      "customPluginName": "@shopify/store"
     },
-    "theme:check": {
-      "aliases": [
-      ],
+    "search": {
+      "aliases": [],
       "args": {
-      },
-      "customPluginName": "@shopify/theme",
-      "description": "Calls and runs \"Theme Check\" (https://shopify.dev/docs/themes/tools/theme-check) to analyze your theme code for errors and to ensure that it follows theme and Liquid best practices. \"Learn more about the checks that Theme Check runs.\" (https://shopify.dev/docs/themes/tools/theme-check/checks)",
-      "descriptionWithMarkdown": "Calls and runs [Theme Check](https://shopify.dev/docs/themes/tools/theme-check) to analyze your theme code for errors and to ensure that it follows theme and Liquid best practices. [Learn more about the checks that Theme Check runs.](https://shopify.dev/docs/themes/tools/theme-check/checks)",
-      "flags": {
-        "auto-correct": {
-          "allowNo": false,
-          "char": "a",
-          "description": "Automatically fix offenses",
-          "env": "SHOPIFY_FLAG_AUTO_CORRECT",
-          "name": "auto-correct",
-          "required": false,
-          "type": "boolean"
-        },
-        "config": {
-          "char": "C",
-          "description": "Use the config provided, overriding .theme-check.yml if present\n      Supports all theme-check: config values, e.g., theme-check:theme-app-extension,\n      theme-check:recommended, theme-check:all\n      For backwards compatibility, :theme_app_extension is also supported ",
-          "env": "SHOPIFY_FLAG_CONFIG",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "config",
-          "required": false,
-          "type": "option"
-        },
-        "environment": {
-          "char": "e",
-          "description": "The environment to apply to the current command.",
-          "env": "SHOPIFY_FLAG_ENVIRONMENT",
-          "hasDynamicHelp": false,
-          "multiple": true,
-          "name": "environment",
-          "type": "option"
-        },
-        "fail-level": {
-          "default": "error",
-          "description": "Minimum severity for exit with error code",
-          "env": "SHOPIFY_FLAG_FAIL_LEVEL",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "fail-level",
-          "options": [
-            "crash",
-            "error",
-            "suggestion",
-            "style",
-            "warning",
-            "info"
-          ],
-          "required": false,
-          "type": "option"
-        },
-        "init": {
-          "allowNo": false,
-          "description": "Generate a .theme-check.yml file",
-          "env": "SHOPIFY_FLAG_INIT",
-          "name": "init",
-          "required": false,
-          "type": "boolean"
-        },
-        "list": {
-          "allowNo": false,
-          "description": "List enabled checks",
-          "env": "SHOPIFY_FLAG_LIST",
-          "name": "list",
-          "required": false,
-          "type": "boolean"
-        },
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
-          "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
-        "output": {
-          "char": "o",
-          "default": "text",
-          "description": "The output format to use",
-          "env": "SHOPIFY_FLAG_OUTPUT",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "output",
-          "options": [
-            "text",
-            "json"
-          ],
-          "required": false,
-          "type": "option"
-        },
-        "path": {
-          "description": "The path where you want to run the command. Defaults to the current working directory.",
-          "env": "SHOPIFY_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "path",
-          "noCacheDefault": true,
-          "type": "option"
-        },
-        "print": {
-          "allowNo": false,
-          "description": "Output active config to STDOUT",
-          "env": "SHOPIFY_FLAG_PRINT",
-          "name": "print",
-          "required": false,
-          "type": "boolean"
-        },
-        "verbose": {
-          "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
-          "type": "boolean"
-        },
-        "version": {
-          "allowNo": false,
-          "char": "v",
-          "description": "Print Theme Check version",
-          "env": "SHOPIFY_FLAG_VERSION",
-          "name": "version",
-          "required": false,
-          "type": "boolean"
+        "query": {
+          "name": "query"
         }
       },
+      "description": "Starts a search on shopify.dev.",
+      "examples": [
+        "# open the search modal on Shopify.dev\n    shopify search\n\n    # search for a term on Shopify.dev\n    shopify search <query>\n\n    # search for a phrase on Shopify.dev\n    shopify search \"<a search query separated by spaces>\"\n    "
+      ],
+      "flags": {},
       "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "theme:check",
-      "multiEnvironmentsFlags": [
-        "path"
-      ],
+      "hiddenAliases": [],
+      "id": "search",
       "pluginAlias": "@shopify/cli",
       "pluginName": "@shopify/cli",
       "pluginType": "core",
       "strict": true,
-      "summary": "Validate the theme."
-    },
-    "theme:console": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/theme",
-      "description": "Starts the Shopify Liquid REPL (read-eval-print loop) tool. This tool provides an interactive terminal interface for evaluating Liquid code and exploring Liquid objects, filters, and tags using real store data.\n\n  You can also provide context to the console using a URL, as some Liquid objects are context-specific",
-      "descriptionWithMarkdown": "Starts the Shopify Liquid REPL (read-eval-print loop) tool. This tool provides an interactive terminal interface for evaluating Liquid code and exploring Liquid objects, filters, and tags using real store data.\n\n  You can also provide context to the console using a URL, as some Liquid objects are context-specific",
-      "flags": {
-        "environment": {
-          "char": "e",
-          "description": "The environment to apply to the current command.",
-          "env": "SHOPIFY_FLAG_ENVIRONMENT",
-          "hasDynamicHelp": false,
-          "multiple": true,
-          "name": "environment",
-          "type": "option"
-        },
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
-          "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
-        "password": {
-          "description": "Password generated from the Theme Access app or an Admin API token.",
-          "env": "SHOPIFY_CLI_THEME_TOKEN",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "password",
-          "type": "option"
-        },
-        "path": {
-          "description": "The path where you want to run the command. Defaults to the current working directory.",
-          "env": "SHOPIFY_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "path",
-          "noCacheDefault": true,
-          "type": "option"
-        },
-        "store": {
-          "char": "s",
-          "description": "Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).",
-          "env": "SHOPIFY_FLAG_STORE",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "store",
-          "type": "option"
-        },
-        "store-password": {
-          "description": "The password for storefronts with password protection.",
-          "env": "SHOPIFY_FLAG_STORE_PASSWORD",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "store-password",
-          "type": "option"
-        },
-        "url": {
-          "default": "/",
-          "description": "The url to be used as context",
-          "env": "SHOPIFY_FLAG_URL",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "url",
-          "type": "option"
-        },
-        "verbose": {
-          "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "theme:console",
-      "multiEnvironmentsFlags": null,
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true,
-      "summary": "Shopify Liquid REPL (read-eval-print loop) tool",
-      "usage": [
-        "theme console",
-        "theme console --url /products/classic-leather-jacket"
-      ]
-    },
-    "theme:delete": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/theme",
-      "description": "Deletes a theme from your store.\n\n  You can specify multiple themes by ID. If no theme is specified, then you're prompted to select the theme that you want to delete from the list of themes in your store.\n\n  You're asked to confirm that you want to delete the specified themes before they are deleted. You can skip this confirmation using the `--force` flag.",
-      "descriptionWithMarkdown": "Deletes a theme from your store.\n\n  You can specify multiple themes by ID. If no theme is specified, then you're prompted to select the theme that you want to delete from the list of themes in your store.\n\n  You're asked to confirm that you want to delete the specified themes before they are deleted. You can skip this confirmation using the `--force` flag.",
-      "flags": {
-        "development": {
-          "allowNo": false,
-          "char": "d",
-          "description": "Delete your development theme.",
-          "env": "SHOPIFY_FLAG_DEVELOPMENT",
-          "name": "development",
-          "type": "boolean"
-        },
-        "environment": {
-          "char": "e",
-          "description": "The environment to apply to the current command.",
-          "env": "SHOPIFY_FLAG_ENVIRONMENT",
-          "hasDynamicHelp": false,
-          "multiple": true,
-          "name": "environment",
-          "type": "option"
-        },
-        "force": {
-          "allowNo": false,
-          "char": "f",
-          "description": "Skip confirmation.",
-          "env": "SHOPIFY_FLAG_FORCE",
-          "name": "force",
-          "type": "boolean"
-        },
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
-          "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
-        "password": {
-          "description": "Password generated from the Theme Access app or an Admin API token.",
-          "env": "SHOPIFY_CLI_THEME_TOKEN",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "password",
-          "type": "option"
-        },
-        "path": {
-          "description": "The path where you want to run the command. Defaults to the current working directory.",
-          "env": "SHOPIFY_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "path",
-          "noCacheDefault": true,
-          "type": "option"
-        },
-        "show-all": {
-          "allowNo": false,
-          "char": "a",
-          "description": "Include others development themes in theme list.",
-          "env": "SHOPIFY_FLAG_SHOW_ALL",
-          "name": "show-all",
-          "type": "boolean"
-        },
-        "store": {
-          "char": "s",
-          "description": "Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).",
-          "env": "SHOPIFY_FLAG_STORE",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "store",
-          "type": "option"
-        },
-        "theme": {
-          "char": "t",
-          "description": "Theme ID or name of the remote theme.",
-          "env": "SHOPIFY_FLAG_THEME_ID",
-          "hasDynamicHelp": false,
-          "multiple": true,
-          "name": "theme",
-          "type": "option"
-        },
-        "verbose": {
-          "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "theme:delete",
-      "multiEnvironmentsFlags": [
-        "store",
-        "password",
-        [
-          "development",
-          "theme"
-        ]
-      ],
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true,
-      "summary": "Delete remote themes from the connected store. This command can't be undone."
-    },
-    "theme:dev": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/theme",
-      "description": "\n  Uploads the current theme as the specified theme, or a \"development theme\" (https://shopify.dev/docs/themes/tools/cli#development-themes), to a store so you can preview it.\n\nThis command returns the following information:\n\n- A link to your development theme at http://127.0.0.1:9292. This URL can hot reload local changes to CSS and sections, or refresh the entire page when a file changes, enabling you to preview changes in real time using the store's data.\n\n  You can specify a different network interface and port using `--host` and `--port`.\n\n- A link to the \"editor\" (https://shopify.dev/docs/themes/tools/online-editor) for the theme in the Shopify admin.\n\n- A \"preview link\" (https://help.shopify.com/manual/online-store/themes/adding-themes#share-a-theme-preview-with-others) that you can share with other developers.\n\nIf you already have a development theme for your current environment, then this command replaces the development theme with your local theme. You can override this using the `--theme-editor-sync` flag.\n\n> Note: You can't preview checkout customizations using http://127.0.0.1:9292.\n\nDevelopment themes are deleted when you run `shopify auth logout`. If you need a preview link that can be used after you log out, then you should \"share\" (https://shopify.dev/docs/api/shopify-cli/theme/theme-share) your theme or \"push\" (https://shopify.dev/docs/api/shopify-cli/theme/theme-push) to an unpublished theme on your store.\n\nYou can run this command only in a directory that matches the \"default Shopify theme folder structure\" (https://shopify.dev/docs/themes/tools/cli#directory-structure).",
-      "descriptionWithMarkdown": "\n  Uploads the current theme as the specified theme, or a [development theme](https://shopify.dev/docs/themes/tools/cli#development-themes), to a store so you can preview it.\n\nThis command returns the following information:\n\n- A link to your development theme at http://127.0.0.1:9292. This URL can hot reload local changes to CSS and sections, or refresh the entire page when a file changes, enabling you to preview changes in real time using the store's data.\n\n  You can specify a different network interface and port using `--host` and `--port`.\n\n- A link to the [editor](https://shopify.dev/docs/themes/tools/online-editor) for the theme in the Shopify admin.\n\n- A [preview link](https://help.shopify.com/manual/online-store/themes/adding-themes#share-a-theme-preview-with-others) that you can share with other developers.\n\nIf you already have a development theme for your current environment, then this command replaces the development theme with your local theme. You can override this using the `--theme-editor-sync` flag.\n\n> Note: You can't preview checkout customizations using http://127.0.0.1:9292.\n\nDevelopment themes are deleted when you run `shopify auth logout`. If you need a preview link that can be used after you log out, then you should [share](https://shopify.dev/docs/api/shopify-cli/theme/theme-share) your theme or [push](https://shopify.dev/docs/api/shopify-cli/theme/theme-push) to an unpublished theme on your store.\n\nYou can run this command only in a directory that matches the [default Shopify theme folder structure](https://shopify.dev/docs/themes/tools/cli#directory-structure).",
-      "flags": {
-        "allow-live": {
-          "allowNo": false,
-          "char": "a",
-          "description": "Allow development on a live theme.",
-          "env": "SHOPIFY_FLAG_ALLOW_LIVE",
-          "name": "allow-live",
-          "type": "boolean"
-        },
-        "environment": {
-          "char": "e",
-          "description": "The environment to apply to the current command.",
-          "env": "SHOPIFY_FLAG_ENVIRONMENT",
-          "hasDynamicHelp": false,
-          "multiple": true,
-          "name": "environment",
-          "type": "option"
-        },
-        "error-overlay": {
-          "default": "default",
-          "description": "Controls the visibility of the error overlay when an theme asset upload fails:\n- silent Prevents the error overlay from appearing.\n- default Displays the error overlay.\n      ",
-          "env": "SHOPIFY_FLAG_ERROR_OVERLAY",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "error-overlay",
-          "options": [
-            "silent",
-            "default"
-          ],
-          "type": "option"
-        },
-        "force": {
-          "allowNo": false,
-          "char": "f",
-          "description": "Proceed without confirmation, if current directory does not seem to be theme directory.",
-          "env": "SHOPIFY_FLAG_FORCE",
-          "hidden": true,
-          "name": "force",
-          "type": "boolean"
-        },
-        "host": {
-          "description": "Set which network interface the web server listens on. The default value is 127.0.0.1.",
-          "env": "SHOPIFY_FLAG_HOST",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "host",
-          "type": "option"
-        },
-        "ignore": {
-          "char": "x",
-          "description": "Skip hot reloading any files that match the specified pattern.",
-          "env": "SHOPIFY_FLAG_IGNORE",
-          "hasDynamicHelp": false,
-          "multiple": true,
-          "name": "ignore",
-          "type": "option"
-        },
-        "listing": {
-          "description": "The listing preset to use for multi-preset themes. Applies preset files from listings/[preset-name] directory.",
-          "env": "SHOPIFY_FLAG_LISTING",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "listing",
-          "type": "option"
-        },
-        "live-reload": {
-          "default": "hot-reload",
-          "description": "The live reload mode switches the server behavior when a file is modified:\n- hot-reload Hot reloads local changes to CSS and sections (default)\n- full-page  Always refreshes the entire page\n- off        Deactivate live reload",
-          "env": "SHOPIFY_FLAG_LIVE_RELOAD",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "live-reload",
-          "options": [
-            "hot-reload",
-            "full-page",
-            "off"
-          ],
-          "type": "option"
-        },
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
-          "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
-        "nodelete": {
-          "allowNo": false,
-          "char": "n",
-          "description": "Prevents files from being deleted in the remote theme when a file has been deleted locally. This applies to files that are deleted while the command is running, and files that have been deleted locally before the command is run.",
-          "env": "SHOPIFY_FLAG_NODELETE",
-          "name": "nodelete",
-          "type": "boolean"
-        },
-        "notify": {
-          "description": "The file path or URL. The file path is to a file that you want updated on idle. The URL path is where you want a webhook posted to report on file changes.",
-          "env": "SHOPIFY_FLAG_NOTIFY",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "notify",
-          "type": "option"
-        },
-        "only": {
-          "char": "o",
-          "description": "Hot reload only files that match the specified pattern.",
-          "env": "SHOPIFY_FLAG_ONLY",
-          "hasDynamicHelp": false,
-          "multiple": true,
-          "name": "only",
-          "type": "option"
-        },
-        "open": {
-          "allowNo": false,
-          "description": "Automatically launch the theme preview in your default web browser.",
-          "env": "SHOPIFY_FLAG_OPEN",
-          "name": "open",
-          "type": "boolean"
-        },
-        "password": {
-          "description": "Password generated from the Theme Access app or an Admin API token.",
-          "env": "SHOPIFY_CLI_THEME_TOKEN",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "password",
-          "type": "option"
-        },
-        "path": {
-          "description": "The path where you want to run the command. Defaults to the current working directory.",
-          "env": "SHOPIFY_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "path",
-          "noCacheDefault": true,
-          "type": "option"
-        },
-        "poll": {
-          "allowNo": false,
-          "description": "Force polling to detect file changes.",
-          "env": "SHOPIFY_FLAG_POLL",
-          "hidden": true,
-          "name": "poll",
-          "type": "boolean"
-        },
-        "port": {
-          "description": "Local port to serve theme preview from.",
-          "env": "SHOPIFY_FLAG_PORT",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "port",
-          "type": "option"
-        },
-        "store": {
-          "char": "s",
-          "description": "Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).",
-          "env": "SHOPIFY_FLAG_STORE",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "store",
-          "type": "option"
-        },
-        "store-password": {
-          "description": "The password for storefronts with password protection.",
-          "env": "SHOPIFY_FLAG_STORE_PASSWORD",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "store-password",
-          "type": "option"
-        },
-        "theme": {
-          "char": "t",
-          "description": "Theme ID or name of the remote theme.",
-          "env": "SHOPIFY_FLAG_THEME_ID",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "theme",
-          "type": "option"
-        },
-        "theme-editor-sync": {
-          "allowNo": false,
-          "description": "Synchronize Theme Editor updates in the local theme files.",
-          "env": "SHOPIFY_FLAG_THEME_EDITOR_SYNC",
-          "name": "theme-editor-sync",
-          "type": "boolean"
-        },
-        "verbose": {
-          "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "theme:dev",
-      "multiEnvironmentsFlags": null,
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true,
-      "summary": "Uploads the current theme as a development theme to the connected store, then prints theme editor and preview URLs to your terminal. While running, changes will push to the store in real time."
-    },
-    "theme:duplicate": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/theme",
-      "description": "If you want to duplicate your local theme, you need to run `shopify theme push` first.\n\nIf no theme ID is specified, you're prompted to select the theme that you want to duplicate from the list of themes in your store. You're asked to confirm that you want to duplicate the specified theme.\n\nPrompts and confirmations are not shown when duplicate is run in a CI environment or the `--force` flag is used, therefore you must specify a theme ID using the `--theme` flag.\n\nYou can optionally name the duplicated theme using the `--name` flag.\n\nIf you use the `--json` flag, then theme information is returned in JSON format, which can be used as a machine-readable input for scripts or continuous integration.\n\nSample JSON output:\n\n```json\n{\n  \"theme\": {\n    \"id\": 108267175958,\n    \"name\": \"A Duplicated Theme\",\n    \"role\": \"unpublished\",\n    \"shop\": \"mystore.myshopify.com\"\n  }\n}\n```\n\n```json\n{\n  \"message\": \"The theme 'Summer Edition' could not be duplicated due to errors\",\n  \"errors\": [\"Maximum number of themes reached\"],\n  \"requestId\": \"12345-abcde-67890\"\n}\n```",
-      "descriptionWithMarkdown": "If you want to duplicate your local theme, you need to run `shopify theme push` first.\n\nIf no theme ID is specified, you're prompted to select the theme that you want to duplicate from the list of themes in your store. You're asked to confirm that you want to duplicate the specified theme.\n\nPrompts and confirmations are not shown when duplicate is run in a CI environment or the `--force` flag is used, therefore you must specify a theme ID using the `--theme` flag.\n\nYou can optionally name the duplicated theme using the `--name` flag.\n\nIf you use the `--json` flag, then theme information is returned in JSON format, which can be used as a machine-readable input for scripts or continuous integration.\n\nSample JSON output:\n\n```json\n{\n  \"theme\": {\n    \"id\": 108267175958,\n    \"name\": \"A Duplicated Theme\",\n    \"role\": \"unpublished\",\n    \"shop\": \"mystore.myshopify.com\"\n  }\n}\n```\n\n```json\n{\n  \"message\": \"The theme 'Summer Edition' could not be duplicated due to errors\",\n  \"errors\": [\"Maximum number of themes reached\"],\n  \"requestId\": \"12345-abcde-67890\"\n}\n```",
-      "flags": {
-        "environment": {
-          "char": "e",
-          "description": "The environment to apply to the current command.",
-          "env": "SHOPIFY_FLAG_ENVIRONMENT",
-          "hasDynamicHelp": false,
-          "multiple": true,
-          "name": "environment",
-          "type": "option"
-        },
-        "force": {
-          "allowNo": false,
-          "char": "f",
-          "description": "Force the duplicate operation to run without prompts or confirmations.",
-          "env": "SHOPIFY_FLAG_FORCE",
-          "name": "force",
-          "type": "boolean"
-        },
-        "json": {
-          "allowNo": false,
-          "char": "j",
-          "description": "Output the result as JSON. Automatically disables color output.",
-          "env": "SHOPIFY_FLAG_JSON",
-          "hidden": false,
-          "name": "json",
-          "type": "boolean"
-        },
-        "name": {
-          "char": "n",
-          "description": "Name of the newly duplicated theme.",
-          "env": "SHOPIFY_FLAG_NAME",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "name",
-          "type": "option"
-        },
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
-          "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
-        "password": {
-          "description": "Password generated from the Theme Access app or an Admin API token.",
-          "env": "SHOPIFY_CLI_THEME_TOKEN",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "password",
-          "type": "option"
-        },
-        "store": {
-          "char": "s",
-          "description": "Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).",
-          "env": "SHOPIFY_FLAG_STORE",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "store",
-          "type": "option"
-        },
-        "theme": {
-          "char": "t",
-          "description": "Theme ID or name of the remote theme.",
-          "env": "SHOPIFY_FLAG_THEME_ID",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "theme",
-          "type": "option"
-        },
-        "verbose": {
-          "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "theme:duplicate",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true,
-      "summary": "Duplicates a theme from your theme library.",
-      "usage": [
-        "theme duplicate",
-        "theme duplicate --theme 10 --name 'New Theme'"
-      ]
-    },
-    "theme:info": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/theme",
-      "description": "Displays information about your theme environment, including your current store. Can also retrieve information about a specific theme.",
-      "flags": {
-        "development": {
-          "allowNo": false,
-          "char": "d",
-          "description": "Retrieve info from your development theme.",
-          "env": "SHOPIFY_FLAG_DEVELOPMENT",
-          "name": "development",
-          "type": "boolean"
-        },
-        "environment": {
-          "char": "e",
-          "description": "The environment to apply to the current command.",
-          "env": "SHOPIFY_FLAG_ENVIRONMENT",
-          "hasDynamicHelp": false,
-          "multiple": true,
-          "name": "environment",
-          "type": "option"
-        },
-        "json": {
-          "allowNo": false,
-          "char": "j",
-          "description": "Output the result as JSON. Automatically disables color output.",
-          "env": "SHOPIFY_FLAG_JSON",
-          "hidden": false,
-          "name": "json",
-          "type": "boolean"
-        },
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
-          "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
-        "password": {
-          "description": "Password generated from the Theme Access app or an Admin API token.",
-          "env": "SHOPIFY_CLI_THEME_TOKEN",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "password",
-          "type": "option"
-        },
-        "path": {
-          "description": "The path where you want to run the command. Defaults to the current working directory.",
-          "env": "SHOPIFY_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "path",
-          "noCacheDefault": true,
-          "type": "option"
-        },
-        "store": {
-          "char": "s",
-          "description": "Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).",
-          "env": "SHOPIFY_FLAG_STORE",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "store",
-          "type": "option"
-        },
-        "theme": {
-          "char": "t",
-          "description": "Theme ID or name of the remote theme.",
-          "env": "SHOPIFY_FLAG_THEME_ID",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "theme",
-          "type": "option"
-        },
-        "verbose": {
-          "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "theme:info",
-      "multiEnvironmentsFlags": [
-        "store",
-        "password"
-      ],
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true
-    },
-    "theme:init": {
-      "aliases": [
-      ],
-      "args": {
-        "name": {
-          "description": "Name of the new theme",
-          "name": "name",
-          "required": false
-        }
-      },
-      "customPluginName": "@shopify/theme",
-      "description": "Clones a Git repository to your local machine to use as the starting point for building a theme.\n\n  If no Git repository is specified, then this command creates a copy of Shopify's \"Skeleton theme\" (https://github.com/Shopify/skeleton-theme.git), with the specified name in the current folder. If no name is provided, then you're prompted to enter one.\n\n  > Caution: If you're building a theme for the Shopify Theme Store, then you can use our example theme as a starting point. However, the theme that you submit needs to be \"substantively different from existing themes\" (https://shopify.dev/docs/themes/store/requirements#uniqueness) so that it provides added value for users.\n  ",
-      "descriptionWithMarkdown": "Clones a Git repository to your local machine to use as the starting point for building a theme.\n\n  If no Git repository is specified, then this command creates a copy of Shopify's [Skeleton theme](https://github.com/Shopify/skeleton-theme.git), with the specified name in the current folder. If no name is provided, then you're prompted to enter one.\n\n  > Caution: If you're building a theme for the Shopify Theme Store, then you can use our example theme as a starting point. However, the theme that you submit needs to be [substantively different from existing themes](https://shopify.dev/docs/themes/store/requirements#uniqueness) so that it provides added value for users.\n  ",
-      "flags": {
-        "clone-url": {
-          "char": "u",
-          "default": "https://github.com/Shopify/skeleton-theme.git",
-          "description": "The Git URL to clone from. Defaults to Shopify's Skeleton theme.",
-          "env": "SHOPIFY_FLAG_CLONE_URL",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "clone-url",
-          "type": "option"
-        },
-        "latest": {
-          "allowNo": false,
-          "char": "l",
-          "description": "Downloads the latest release of the `clone-url`",
-          "env": "SHOPIFY_FLAG_LATEST",
-          "name": "latest",
-          "type": "boolean"
-        },
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
-          "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
-        "path": {
-          "description": "The path where you want to run the command. Defaults to the current working directory.",
-          "env": "SHOPIFY_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "path",
-          "noCacheDefault": true,
-          "type": "option"
-        },
-        "verbose": {
-          "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "theme:init",
-      "multiEnvironmentsFlags": null,
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true,
-      "summary": "Clones a Git repository to use as a starting point for building a new theme.",
-      "usage": "theme init [name] [flags]"
-    },
-    "theme:language-server": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/theme",
-      "description": "Starts the \"Language Server\" (https://shopify.dev/docs/themes/tools/cli/language-server).",
-      "descriptionWithMarkdown": "Starts the [Language Server](https://shopify.dev/docs/themes/tools/cli/language-server).",
-      "flags": {
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
-          "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
-        "verbose": {
-          "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "theme:language-server",
-      "multiEnvironmentsFlags": null,
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true,
-      "summary": "Start a Language Server Protocol server."
-    },
-    "theme:list": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/theme",
-      "description": "Lists the themes in your store, along with their IDs and statuses.",
-      "flags": {
-        "environment": {
-          "char": "e",
-          "description": "The environment to apply to the current command.",
-          "env": "SHOPIFY_FLAG_ENVIRONMENT",
-          "hasDynamicHelp": false,
-          "multiple": true,
-          "name": "environment",
-          "type": "option"
-        },
-        "id": {
-          "description": "Only list theme with the given ID.",
-          "env": "SHOPIFY_FLAG_ID",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "id",
-          "type": "option"
-        },
-        "json": {
-          "allowNo": false,
-          "char": "j",
-          "description": "Output the result as JSON. Automatically disables color output.",
-          "env": "SHOPIFY_FLAG_JSON",
-          "hidden": false,
-          "name": "json",
-          "type": "boolean"
-        },
-        "name": {
-          "description": "Only list themes that contain the given name.",
-          "env": "SHOPIFY_FLAG_NAME",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "name",
-          "type": "option"
-        },
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
-          "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
-        "password": {
-          "description": "Password generated from the Theme Access app or an Admin API token.",
-          "env": "SHOPIFY_CLI_THEME_TOKEN",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "password",
-          "type": "option"
-        },
-        "path": {
-          "description": "The path where you want to run the command. Defaults to the current working directory.",
-          "env": "SHOPIFY_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "path",
-          "noCacheDefault": true,
-          "type": "option"
-        },
-        "role": {
-          "description": "Only list themes with the given role.",
-          "env": "SHOPIFY_FLAG_ROLE",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "role",
-          "options": [
-            "live",
-            "unpublished",
-            "development"
-          ],
-          "type": "option"
-        },
-        "store": {
-          "char": "s",
-          "description": "Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).",
-          "env": "SHOPIFY_FLAG_STORE",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "store",
-          "type": "option"
-        },
-        "verbose": {
-          "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "theme:list",
-      "multiEnvironmentsFlags": [
-        "store",
-        "password"
-      ],
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true
-    },
-    "theme:metafields:pull": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/theme",
-      "description": "Retrieves metafields from Shopify Admin.\n\nIf the metafields file already exists, it will be overwritten.",
-      "descriptionWithMarkdown": "Retrieves metafields from Shopify Admin.\n\nIf the metafields file already exists, it will be overwritten.",
-      "flags": {
-        "environment": {
-          "char": "e",
-          "description": "The environment to apply to the current command.",
-          "env": "SHOPIFY_FLAG_ENVIRONMENT",
-          "hasDynamicHelp": false,
-          "multiple": true,
-          "name": "environment",
-          "type": "option"
-        },
-        "force": {
-          "allowNo": false,
-          "char": "f",
-          "description": "Proceed without confirmation, if current directory does not seem to be theme directory.",
-          "env": "SHOPIFY_FLAG_FORCE",
-          "hidden": true,
-          "name": "force",
-          "type": "boolean"
-        },
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
-          "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
-        "password": {
-          "description": "Password generated from the Theme Access app or an Admin API token.",
-          "env": "SHOPIFY_CLI_THEME_TOKEN",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "password",
-          "type": "option"
-        },
-        "path": {
-          "description": "The path where you want to run the command. Defaults to the current working directory.",
-          "env": "SHOPIFY_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "path",
-          "noCacheDefault": true,
-          "type": "option"
-        },
-        "store": {
-          "char": "s",
-          "description": "Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).",
-          "env": "SHOPIFY_FLAG_STORE",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "store",
-          "type": "option"
-        },
-        "verbose": {
-          "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "theme:metafields:pull",
-      "multiEnvironmentsFlags": null,
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true,
-      "summary": "Download metafields definitions from your shop into a local file."
-    },
-    "theme:open": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/theme",
-      "description": "Returns links that let you preview the specified theme. The following links are returned:\n\n  - A link to the \"editor\" (https://shopify.dev/docs/themes/tools/online-editor) for the theme in the Shopify admin.\n  - A \"preview link\" (https://help.shopify.com/manual/online-store/themes/adding-themes#share-a-theme-preview-with-others) that you can share with other developers.\n\n  If you don't specify a theme, then you're prompted to select the theme to open from the list of the themes in your store.",
-      "descriptionWithMarkdown": "Returns links that let you preview the specified theme. The following links are returned:\n\n  - A link to the [editor](https://shopify.dev/docs/themes/tools/online-editor) for the theme in the Shopify admin.\n  - A [preview link](https://help.shopify.com/manual/online-store/themes/adding-themes#share-a-theme-preview-with-others) that you can share with other developers.\n\n  If you don't specify a theme, then you're prompted to select the theme to open from the list of the themes in your store.",
-      "flags": {
-        "development": {
-          "allowNo": false,
-          "char": "d",
-          "description": "Open your development theme.",
-          "env": "SHOPIFY_FLAG_DEVELOPMENT",
-          "name": "development",
-          "type": "boolean"
-        },
-        "editor": {
-          "allowNo": false,
-          "char": "E",
-          "description": "Open the theme editor for the specified theme in the browser.",
-          "env": "SHOPIFY_FLAG_EDITOR",
-          "name": "editor",
-          "type": "boolean"
-        },
-        "environment": {
-          "char": "e",
-          "description": "The environment to apply to the current command.",
-          "env": "SHOPIFY_FLAG_ENVIRONMENT",
-          "hasDynamicHelp": false,
-          "multiple": true,
-          "name": "environment",
-          "type": "option"
-        },
-        "live": {
-          "allowNo": false,
-          "char": "l",
-          "description": "Open your live (published) theme.",
-          "env": "SHOPIFY_FLAG_LIVE",
-          "name": "live",
-          "type": "boolean"
-        },
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
-          "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
-        "password": {
-          "description": "Password generated from the Theme Access app or an Admin API token.",
-          "env": "SHOPIFY_CLI_THEME_TOKEN",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "password",
-          "type": "option"
-        },
-        "path": {
-          "description": "The path where you want to run the command. Defaults to the current working directory.",
-          "env": "SHOPIFY_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "path",
-          "noCacheDefault": true,
-          "type": "option"
-        },
-        "store": {
-          "char": "s",
-          "description": "Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).",
-          "env": "SHOPIFY_FLAG_STORE",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "store",
-          "type": "option"
-        },
-        "theme": {
-          "char": "t",
-          "description": "Theme ID or name of the remote theme.",
-          "env": "SHOPIFY_FLAG_THEME_ID",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "theme",
-          "type": "option"
-        },
-        "verbose": {
-          "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "theme:open",
-      "multiEnvironmentsFlags": null,
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true,
-      "summary": "Opens the preview of your remote theme."
-    },
-    "theme:package": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/theme",
-      "description": "Packages your local theme files into a ZIP file that can be uploaded to Shopify.\n\n  Only folders that match the \"default Shopify theme folder structure\" (https://shopify.dev/docs/storefronts/themes/tools/cli#directory-structure) are included in the package.\n\n  The package includes the `listings` directory if present (required for multi-preset themes per \"Theme Store requirements\" (https://shopify.dev/docs/storefronts/themes/store/requirements#adding-presets-to-your-theme-zip-submission)).\n\n  The ZIP file uses the name `theme_name-theme_version.zip`, based on parameters in your \"settings_schema.json\" (https://shopify.dev/docs/storefronts/themes/architecture/config/settings-schema-json) file.",
-      "descriptionWithMarkdown": "Packages your local theme files into a ZIP file that can be uploaded to Shopify.\n\n  Only folders that match the [default Shopify theme folder structure](https://shopify.dev/docs/storefronts/themes/tools/cli#directory-structure) are included in the package.\n\n  The package includes the `listings` directory if present (required for multi-preset themes per [Theme Store requirements](https://shopify.dev/docs/storefronts/themes/store/requirements#adding-presets-to-your-theme-zip-submission)).\n\n  The ZIP file uses the name `theme_name-theme_version.zip`, based on parameters in your [settings_schema.json](https://shopify.dev/docs/storefronts/themes/architecture/config/settings-schema-json) file.",
-      "flags": {
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
-          "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
-        "path": {
-          "description": "The path where you want to run the command. Defaults to the current working directory.",
-          "env": "SHOPIFY_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "path",
-          "noCacheDefault": true,
-          "type": "option"
-        },
-        "verbose": {
-          "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "theme:package",
-      "multiEnvironmentsFlags": null,
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true,
-      "summary": "Package your theme into a .zip file, ready to upload to the Online Store."
-    },
-    "theme:preview": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/theme",
-      "description": "Applies a JSON overrides file to a theme and creates or updates a preview. This lets you quickly preview changes.\n\n  The command returns a preview URL and a preview identifier. You can reuse the preview identifier with `--preview-id` to update an existing preview instead of creating a new one.",
-      "descriptionWithMarkdown": "Applies a JSON overrides file to a theme and creates or updates a preview. This lets you quickly preview changes.\n\n  The command returns a preview URL and a preview identifier. You can reuse the preview identifier with `--preview-id` to update an existing preview instead of creating a new one.",
-      "flags": {
-        "environment": {
-          "char": "e",
-          "description": "The environment to apply to the current command.",
-          "env": "SHOPIFY_FLAG_ENVIRONMENT",
-          "hasDynamicHelp": false,
-          "multiple": true,
-          "name": "environment",
-          "type": "option"
-        },
-        "json": {
-          "allowNo": false,
-          "description": "Output the preview URL and identifier as JSON.",
-          "env": "SHOPIFY_FLAG_JSON",
-          "name": "json",
-          "type": "boolean"
-        },
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
-          "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
-        "open": {
-          "allowNo": false,
-          "description": "Automatically launch the theme preview in your default web browser.",
-          "env": "SHOPIFY_FLAG_OPEN",
-          "name": "open",
-          "type": "boolean"
-        },
-        "overrides": {
-          "description": "Path to a JSON overrides file.",
-          "env": "SHOPIFY_FLAG_OVERRIDES",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "overrides",
-          "required": true,
-          "type": "option"
-        },
-        "password": {
-          "description": "Password generated from the Theme Access app or an Admin API token.",
-          "env": "SHOPIFY_CLI_THEME_TOKEN",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "password",
-          "type": "option"
-        },
-        "path": {
-          "description": "The path where you want to run the command. Defaults to the current working directory.",
-          "env": "SHOPIFY_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "path",
-          "noCacheDefault": true,
-          "type": "option"
-        },
-        "preview-id": {
-          "description": "An existing preview identifier to update instead of creating a new preview.",
-          "env": "SHOPIFY_FLAG_PREVIEW_ID",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "preview-id",
-          "type": "option"
-        },
-        "store": {
-          "char": "s",
-          "description": "Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).",
-          "env": "SHOPIFY_FLAG_STORE",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "store",
-          "type": "option"
-        },
-        "theme": {
-          "char": "t",
-          "description": "Theme ID or name of the remote theme.",
-          "env": "SHOPIFY_FLAG_THEME_ID",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "theme",
-          "required": true,
-          "type": "option"
-        },
-        "verbose": {
-          "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "theme:preview",
-      "multiEnvironmentsFlags": null,
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true,
-      "summary": "Applies JSON overrides to a theme and returns a preview URL."
-    },
-    "theme:profile": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/theme",
-      "description": "Profile the Shopify Liquid on a given page.\n\n  This command will open a web page with the Speedscope profiler detailing the time spent executing Liquid on the given page.",
-      "descriptionWithMarkdown": "Profile the Shopify Liquid on a given page.\n\n  This command will open a web page with the Speedscope profiler detailing the time spent executing Liquid on the given page.",
-      "flags": {
-        "environment": {
-          "char": "e",
-          "description": "The environment to apply to the current command.",
-          "env": "SHOPIFY_FLAG_ENVIRONMENT",
-          "hasDynamicHelp": false,
-          "multiple": true,
-          "name": "environment",
-          "type": "option"
-        },
-        "json": {
-          "allowNo": false,
-          "char": "j",
-          "description": "Output the result as JSON. Automatically disables color output.",
-          "env": "SHOPIFY_FLAG_JSON",
-          "hidden": false,
-          "name": "json",
-          "type": "boolean"
-        },
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
-          "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
-        "password": {
-          "description": "Password generated from the Theme Access app or an Admin API token.",
-          "env": "SHOPIFY_CLI_THEME_TOKEN",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "password",
-          "type": "option"
-        },
-        "path": {
-          "description": "The path where you want to run the command. Defaults to the current working directory.",
-          "env": "SHOPIFY_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "path",
-          "noCacheDefault": true,
-          "type": "option"
-        },
-        "store": {
-          "char": "s",
-          "description": "Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).",
-          "env": "SHOPIFY_FLAG_STORE",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "store",
-          "type": "option"
-        },
-        "store-password": {
-          "description": "The password for storefronts with password protection.",
-          "env": "SHOPIFY_FLAG_STORE_PASSWORD",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "store-password",
-          "type": "option"
-        },
-        "theme": {
-          "char": "t",
-          "description": "Theme ID or name of the remote theme.",
-          "env": "SHOPIFY_FLAG_THEME_ID",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "theme",
-          "type": "option"
-        },
-        "url": {
-          "default": "/",
-          "description": "The url to be used as context",
-          "env": "SHOPIFY_FLAG_URL",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "url",
-          "type": "option"
-        },
-        "verbose": {
-          "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "theme:profile",
-      "multiEnvironmentsFlags": null,
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true,
-      "summary": "Profile the Liquid rendering of a theme page.",
-      "usage": [
-        "theme profile",
-        "theme profile --url /products/classic-leather-jacket"
-      ]
-    },
-    "theme:publish": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/theme",
-      "description": "Publishes an unpublished theme from your theme library.\n\nIf no theme ID is specified, then you're prompted to select the theme that you want to publish from the list of themes in your store.\n\nYou can run this command only in a directory that matches the \"default Shopify theme folder structure\" (https://shopify.dev/docs/themes/tools/cli#directory-structure).\n\nIf you want to publish your local theme, then you need to run `shopify theme push` first. You're asked to confirm that you want to publish the specified theme. You can skip this confirmation using the `--force` flag.",
-      "descriptionWithMarkdown": "Publishes an unpublished theme from your theme library.\n\nIf no theme ID is specified, then you're prompted to select the theme that you want to publish from the list of themes in your store.\n\nYou can run this command only in a directory that matches the [default Shopify theme folder structure](https://shopify.dev/docs/themes/tools/cli#directory-structure).\n\nIf you want to publish your local theme, then you need to run `shopify theme push` first. You're asked to confirm that you want to publish the specified theme. You can skip this confirmation using the `--force` flag.",
-      "flags": {
-        "environment": {
-          "char": "e",
-          "description": "The environment to apply to the current command.",
-          "env": "SHOPIFY_FLAG_ENVIRONMENT",
-          "hasDynamicHelp": false,
-          "multiple": true,
-          "name": "environment",
-          "type": "option"
-        },
-        "force": {
-          "allowNo": false,
-          "char": "f",
-          "description": "Skip confirmation.",
-          "env": "SHOPIFY_FLAG_FORCE",
-          "name": "force",
-          "type": "boolean"
-        },
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
-          "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
-        "password": {
-          "description": "Password generated from the Theme Access app or an Admin API token.",
-          "env": "SHOPIFY_CLI_THEME_TOKEN",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "password",
-          "type": "option"
-        },
-        "path": {
-          "description": "The path where you want to run the command. Defaults to the current working directory.",
-          "env": "SHOPIFY_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "path",
-          "noCacheDefault": true,
-          "type": "option"
-        },
-        "store": {
-          "char": "s",
-          "description": "Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).",
-          "env": "SHOPIFY_FLAG_STORE",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "store",
-          "type": "option"
-        },
-        "theme": {
-          "char": "t",
-          "description": "Theme ID or name of the remote theme.",
-          "env": "SHOPIFY_FLAG_THEME_ID",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "theme",
-          "type": "option"
-        },
-        "verbose": {
-          "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "theme:publish",
-      "multiEnvironmentsFlags": [
-        "store",
-        "password",
-        "theme"
-      ],
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true,
-      "summary": "Set a remote theme as the live theme."
-    },
-    "theme:pull": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/theme",
-      "description": "Retrieves theme files from Shopify.\n\nIf no theme is specified, then you're prompted to select the theme to pull from the list of the themes in your store.",
-      "descriptionWithMarkdown": "Retrieves theme files from Shopify.\n\nIf no theme is specified, then you're prompted to select the theme to pull from the list of the themes in your store.",
-      "flags": {
-        "development": {
-          "allowNo": false,
-          "char": "d",
-          "description": "Pull theme files from your remote development theme.",
-          "env": "SHOPIFY_FLAG_DEVELOPMENT",
-          "name": "development",
-          "type": "boolean"
-        },
-        "environment": {
-          "char": "e",
-          "description": "The environment to apply to the current command.",
-          "env": "SHOPIFY_FLAG_ENVIRONMENT",
-          "hasDynamicHelp": false,
-          "multiple": true,
-          "name": "environment",
-          "type": "option"
-        },
-        "force": {
-          "allowNo": false,
-          "char": "f",
-          "description": "Proceed without confirmation, if current directory does not seem to be theme directory.",
-          "env": "SHOPIFY_FLAG_FORCE",
-          "hidden": true,
-          "name": "force",
-          "type": "boolean"
-        },
-        "ignore": {
-          "char": "x",
-          "description": "Skip downloading the specified files (Multiple flags allowed). Wrap the value in double quotes if you're using wildcards.",
-          "env": "SHOPIFY_FLAG_IGNORE",
-          "hasDynamicHelp": false,
-          "multiple": true,
-          "name": "ignore",
-          "type": "option"
-        },
-        "live": {
-          "allowNo": false,
-          "char": "l",
-          "description": "Pull theme files from your remote live theme.",
-          "env": "SHOPIFY_FLAG_LIVE",
-          "name": "live",
-          "type": "boolean"
-        },
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
-          "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
-        "nodelete": {
-          "allowNo": false,
-          "char": "n",
-          "description": "Prevent deleting local files that don't exist remotely.",
-          "env": "SHOPIFY_FLAG_NODELETE",
-          "name": "nodelete",
-          "type": "boolean"
-        },
-        "only": {
-          "char": "o",
-          "description": "Download only the specified files (Multiple flags allowed). Wrap the value in double quotes if you're using wildcards.",
-          "env": "SHOPIFY_FLAG_ONLY",
-          "hasDynamicHelp": false,
-          "multiple": true,
-          "name": "only",
-          "type": "option"
-        },
-        "password": {
-          "description": "Password generated from the Theme Access app or an Admin API token.",
-          "env": "SHOPIFY_CLI_THEME_TOKEN",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "password",
-          "type": "option"
-        },
-        "path": {
-          "description": "The path where you want to run the command. Defaults to the current working directory.",
-          "env": "SHOPIFY_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "path",
-          "noCacheDefault": true,
-          "type": "option"
-        },
-        "store": {
-          "char": "s",
-          "description": "Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).",
-          "env": "SHOPIFY_FLAG_STORE",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "store",
-          "type": "option"
-        },
-        "theme": {
-          "char": "t",
-          "description": "Theme ID or name of the remote theme.",
-          "env": "SHOPIFY_FLAG_THEME_ID",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "theme",
-          "type": "option"
-        },
-        "verbose": {
-          "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "theme:pull",
-      "multiEnvironmentsFlags": [
-        "store",
-        "password",
-        "path",
-        [
-          "live",
-          "development",
-          "theme"
-        ]
-      ],
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true,
-      "summary": "Download your remote theme files locally."
-    },
-    "theme:push": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/theme",
-      "description": "Uploads your local theme files to Shopify, overwriting the remote version if specified.\n\n  If no theme is specified, then you're prompted to select the theme to overwrite from the list of the themes in your store.\n\n  You can run this command only in a directory that matches the \"default Shopify theme folder structure\" (https://shopify.dev/docs/themes/tools/cli#directory-structure).\n\n  This command returns the following information:\n\n  - A link to the \"editor\" (https://shopify.dev/docs/themes/tools/online-editor) for the theme in the Shopify admin.\n  - A \"preview link\" (https://help.shopify.com/manual/online-store/themes/adding-themes#share-a-theme-preview-with-others) that you can share with others.\n\n  If you use the `--json` flag, then theme information is returned in JSON format, which can be used as a machine-readable input for scripts or continuous integration.\n\n  Sample output:\n\n  ```json\n  {\n    \"theme\": {\n      \"id\": 108267175958,\n      \"name\": \"MyTheme\",\n      \"role\": \"unpublished\",\n      \"shop\": \"mystore.myshopify.com\",\n      \"editor_url\": \"https://mystore.myshopify.com/admin/themes/108267175958/editor\",\n      \"preview_url\": \"https://mystore.myshopify.com/?preview_theme_id=108267175958\"\n    }\n  }\n  ```\n    ",
-      "descriptionWithMarkdown": "Uploads your local theme files to Shopify, overwriting the remote version if specified.\n\n  If no theme is specified, then you're prompted to select the theme to overwrite from the list of the themes in your store.\n\n  You can run this command only in a directory that matches the [default Shopify theme folder structure](https://shopify.dev/docs/themes/tools/cli#directory-structure).\n\n  This command returns the following information:\n\n  - A link to the [editor](https://shopify.dev/docs/themes/tools/online-editor) for the theme in the Shopify admin.\n  - A [preview link](https://help.shopify.com/manual/online-store/themes/adding-themes#share-a-theme-preview-with-others) that you can share with others.\n\n  If you use the `--json` flag, then theme information is returned in JSON format, which can be used as a machine-readable input for scripts or continuous integration.\n\n  Sample output:\n\n  ```json\n  {\n    \"theme\": {\n      \"id\": 108267175958,\n      \"name\": \"MyTheme\",\n      \"role\": \"unpublished\",\n      \"shop\": \"mystore.myshopify.com\",\n      \"editor_url\": \"https://mystore.myshopify.com/admin/themes/108267175958/editor\",\n      \"preview_url\": \"https://mystore.myshopify.com/?preview_theme_id=108267175958\"\n    }\n  }\n  ```\n    ",
-      "flags": {
-        "allow-live": {
-          "allowNo": false,
-          "char": "a",
-          "description": "Allow push to a live theme.",
-          "env": "SHOPIFY_FLAG_ALLOW_LIVE",
-          "name": "allow-live",
-          "type": "boolean"
-        },
-        "development": {
-          "allowNo": false,
-          "char": "d",
-          "description": "Push theme files from your remote development theme.",
-          "env": "SHOPIFY_FLAG_DEVELOPMENT",
-          "name": "development",
-          "type": "boolean"
-        },
-        "development-context": {
-          "char": "c",
-          "dependsOn": [
-            "development"
-          ],
-          "description": "Unique identifier for a development theme context (e.g., PR number, branch name). Reuses an existing development theme with this context name, or creates one if none exists.",
-          "env": "SHOPIFY_FLAG_DEVELOPMENT_CONTEXT",
-          "exclusive": [
-            "theme"
-          ],
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "development-context",
-          "type": "option"
-        },
-        "environment": {
-          "char": "e",
-          "description": "The environment to apply to the current command.",
-          "env": "SHOPIFY_FLAG_ENVIRONMENT",
-          "hasDynamicHelp": false,
-          "multiple": true,
-          "name": "environment",
-          "type": "option"
-        },
-        "force": {
-          "allowNo": false,
-          "char": "f",
-          "description": "Proceed without confirmation, if current directory does not seem to be theme directory.",
-          "env": "SHOPIFY_FLAG_FORCE",
-          "hidden": true,
-          "name": "force",
-          "type": "boolean"
-        },
-        "ignore": {
-          "char": "x",
-          "description": "Skip uploading the specified files (Multiple flags allowed). Wrap the value in double quotes if you're using wildcards.",
-          "env": "SHOPIFY_FLAG_IGNORE",
-          "hasDynamicHelp": false,
-          "multiple": true,
-          "name": "ignore",
-          "type": "option"
-        },
-        "json": {
-          "allowNo": false,
-          "char": "j",
-          "description": "Output the result as JSON. Automatically disables color output.",
-          "env": "SHOPIFY_FLAG_JSON",
-          "hidden": false,
-          "name": "json",
-          "type": "boolean"
-        },
-        "listing": {
-          "description": "The listing preset to use for multi-preset themes. Applies preset files from listings/[preset-name] directory.",
-          "env": "SHOPIFY_FLAG_LISTING",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "listing",
-          "type": "option"
-        },
-        "live": {
-          "allowNo": false,
-          "char": "l",
-          "description": "Push theme files from your remote live theme.",
-          "env": "SHOPIFY_FLAG_LIVE",
-          "name": "live",
-          "type": "boolean"
-        },
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
-          "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
-        "nodelete": {
-          "allowNo": false,
-          "char": "n",
-          "description": "Prevent deleting remote files that don't exist locally.",
-          "env": "SHOPIFY_FLAG_NODELETE",
-          "name": "nodelete",
-          "type": "boolean"
-        },
-        "only": {
-          "char": "o",
-          "description": "Upload only the specified files (Multiple flags allowed). Wrap the value in double quotes if you're using wildcards.",
-          "env": "SHOPIFY_FLAG_ONLY",
-          "hasDynamicHelp": false,
-          "multiple": true,
-          "name": "only",
-          "type": "option"
-        },
-        "password": {
-          "description": "Password generated from the Theme Access app or an Admin API token.",
-          "env": "SHOPIFY_CLI_THEME_TOKEN",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "password",
-          "type": "option"
-        },
-        "path": {
-          "description": "The path where you want to run the command. Defaults to the current working directory.",
-          "env": "SHOPIFY_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "path",
-          "noCacheDefault": true,
-          "type": "option"
-        },
-        "publish": {
-          "allowNo": false,
-          "char": "p",
-          "description": "Publish as the live theme after uploading.",
-          "env": "SHOPIFY_FLAG_PUBLISH",
-          "name": "publish",
-          "type": "boolean"
-        },
-        "store": {
-          "char": "s",
-          "description": "Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).",
-          "env": "SHOPIFY_FLAG_STORE",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "store",
-          "type": "option"
-        },
-        "strict": {
-          "allowNo": false,
-          "description": "Require theme check to pass without errors before pushing. Warnings are allowed.",
-          "env": "SHOPIFY_FLAG_STRICT_PUSH",
-          "name": "strict",
-          "type": "boolean"
-        },
-        "theme": {
-          "char": "t",
-          "description": "Theme ID or name of the remote theme.",
-          "env": "SHOPIFY_FLAG_THEME_ID",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "theme",
-          "type": "option"
-        },
-        "unpublished": {
-          "allowNo": false,
-          "char": "u",
-          "description": "Create a new unpublished theme and push to it.",
-          "env": "SHOPIFY_FLAG_UNPUBLISHED",
-          "name": "unpublished",
-          "type": "boolean"
-        },
-        "verbose": {
-          "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "theme:push",
-      "multiEnvironmentsFlags": [
-        "store",
-        "password",
-        "path",
-        [
-          "live",
-          "development",
-          "theme"
-        ]
-      ],
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true,
-      "summary": "Uploads your local theme files to the connected store, overwriting the remote version if specified.",
-      "usage": [
-        "theme push",
-        "theme push --unpublished --json"
-      ]
-    },
-    "theme:rename": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/theme",
-      "description": "Renames a theme in your store.\n\n  If no theme is specified, then you're prompted to select the theme that you want to rename from the list of themes in your store.\n  ",
-      "descriptionWithMarkdown": "Renames a theme in your store.\n\n  If no theme is specified, then you're prompted to select the theme that you want to rename from the list of themes in your store.\n  ",
-      "flags": {
-        "development": {
-          "allowNo": false,
-          "char": "d",
-          "description": "Rename your development theme.",
-          "env": "SHOPIFY_FLAG_DEVELOPMENT",
-          "name": "development",
-          "type": "boolean"
-        },
-        "environment": {
-          "char": "e",
-          "description": "The environment to apply to the current command.",
-          "env": "SHOPIFY_FLAG_ENVIRONMENT",
-          "hasDynamicHelp": false,
-          "multiple": true,
-          "name": "environment",
-          "type": "option"
-        },
-        "live": {
-          "allowNo": false,
-          "char": "l",
-          "description": "Rename your remote live theme.",
-          "env": "SHOPIFY_FLAG_LIVE",
-          "name": "live",
-          "type": "boolean"
-        },
-        "name": {
-          "char": "n",
-          "description": "The new name for the theme.",
-          "env": "SHOPIFY_FLAG_NEW_NAME",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "name",
-          "required": false,
-          "type": "option"
-        },
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
-          "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
-        "password": {
-          "description": "Password generated from the Theme Access app or an Admin API token.",
-          "env": "SHOPIFY_CLI_THEME_TOKEN",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "password",
-          "type": "option"
-        },
-        "path": {
-          "description": "The path where you want to run the command. Defaults to the current working directory.",
-          "env": "SHOPIFY_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "path",
-          "noCacheDefault": true,
-          "type": "option"
-        },
-        "store": {
-          "char": "s",
-          "description": "Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).",
-          "env": "SHOPIFY_FLAG_STORE",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "store",
-          "type": "option"
-        },
-        "theme": {
-          "char": "t",
-          "description": "Theme ID or name of the remote theme.",
-          "env": "SHOPIFY_FLAG_THEME_ID",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "theme",
-          "type": "option"
-        },
-        "verbose": {
-          "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "theme:rename",
-      "multiEnvironmentsFlags": [
-        "store",
-        "password",
-        "name",
-        [
-          "live",
-          "development",
-          "theme"
-        ]
-      ],
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true,
-      "summary": "Renames an existing theme."
-    },
-    "theme:serve": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/theme",
-      "description": "\n  Uploads the current theme as the specified theme, or a \"development theme\" (https://shopify.dev/docs/themes/tools/cli#development-themes), to a store so you can preview it.\n\nThis command returns the following information:\n\n- A link to your development theme at http://127.0.0.1:9292. This URL can hot reload local changes to CSS and sections, or refresh the entire page when a file changes, enabling you to preview changes in real time using the store's data.\n\n  You can specify a different network interface and port using `--host` and `--port`.\n\n- A link to the \"editor\" (https://shopify.dev/docs/themes/tools/online-editor) for the theme in the Shopify admin.\n\n- A \"preview link\" (https://help.shopify.com/manual/online-store/themes/adding-themes#share-a-theme-preview-with-others) that you can share with other developers.\n\nIf you already have a development theme for your current environment, then this command replaces the development theme with your local theme. You can override this using the `--theme-editor-sync` flag.\n\n> Note: You can't preview checkout customizations using http://127.0.0.1:9292.\n\nDevelopment themes are deleted when you run `shopify auth logout`. If you need a preview link that can be used after you log out, then you should \"share\" (https://shopify.dev/docs/api/shopify-cli/theme/theme-share) your theme or \"push\" (https://shopify.dev/docs/api/shopify-cli/theme/theme-push) to an unpublished theme on your store.\n\nYou can run this command only in a directory that matches the \"default Shopify theme folder structure\" (https://shopify.dev/docs/themes/tools/cli#directory-structure).",
-      "descriptionWithMarkdown": "\n  Uploads the current theme as the specified theme, or a [development theme](https://shopify.dev/docs/themes/tools/cli#development-themes), to a store so you can preview it.\n\nThis command returns the following information:\n\n- A link to your development theme at http://127.0.0.1:9292. This URL can hot reload local changes to CSS and sections, or refresh the entire page when a file changes, enabling you to preview changes in real time using the store's data.\n\n  You can specify a different network interface and port using `--host` and `--port`.\n\n- A link to the [editor](https://shopify.dev/docs/themes/tools/online-editor) for the theme in the Shopify admin.\n\n- A [preview link](https://help.shopify.com/manual/online-store/themes/adding-themes#share-a-theme-preview-with-others) that you can share with other developers.\n\nIf you already have a development theme for your current environment, then this command replaces the development theme with your local theme. You can override this using the `--theme-editor-sync` flag.\n\n> Note: You can't preview checkout customizations using http://127.0.0.1:9292.\n\nDevelopment themes are deleted when you run `shopify auth logout`. If you need a preview link that can be used after you log out, then you should [share](https://shopify.dev/docs/api/shopify-cli/theme/theme-share) your theme or [push](https://shopify.dev/docs/api/shopify-cli/theme/theme-push) to an unpublished theme on your store.\n\nYou can run this command only in a directory that matches the [default Shopify theme folder structure](https://shopify.dev/docs/themes/tools/cli#directory-structure).",
-      "flags": {
-        "allow-live": {
-          "allowNo": false,
-          "char": "a",
-          "description": "Allow development on a live theme.",
-          "env": "SHOPIFY_FLAG_ALLOW_LIVE",
-          "name": "allow-live",
-          "type": "boolean"
-        },
-        "environment": {
-          "char": "e",
-          "description": "The environment to apply to the current command.",
-          "env": "SHOPIFY_FLAG_ENVIRONMENT",
-          "hasDynamicHelp": false,
-          "multiple": true,
-          "name": "environment",
-          "type": "option"
-        },
-        "error-overlay": {
-          "default": "default",
-          "description": "Controls the visibility of the error overlay when an theme asset upload fails:\n- silent Prevents the error overlay from appearing.\n- default Displays the error overlay.\n      ",
-          "env": "SHOPIFY_FLAG_ERROR_OVERLAY",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "error-overlay",
-          "options": [
-            "silent",
-            "default"
-          ],
-          "type": "option"
-        },
-        "force": {
-          "allowNo": false,
-          "char": "f",
-          "description": "Proceed without confirmation, if current directory does not seem to be theme directory.",
-          "env": "SHOPIFY_FLAG_FORCE",
-          "hidden": true,
-          "name": "force",
-          "type": "boolean"
-        },
-        "host": {
-          "description": "Set which network interface the web server listens on. The default value is 127.0.0.1.",
-          "env": "SHOPIFY_FLAG_HOST",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "host",
-          "type": "option"
-        },
-        "ignore": {
-          "char": "x",
-          "description": "Skip hot reloading any files that match the specified pattern.",
-          "env": "SHOPIFY_FLAG_IGNORE",
-          "hasDynamicHelp": false,
-          "multiple": true,
-          "name": "ignore",
-          "type": "option"
-        },
-        "listing": {
-          "description": "The listing preset to use for multi-preset themes. Applies preset files from listings/[preset-name] directory.",
-          "env": "SHOPIFY_FLAG_LISTING",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "listing",
-          "type": "option"
-        },
-        "live-reload": {
-          "default": "hot-reload",
-          "description": "The live reload mode switches the server behavior when a file is modified:\n- hot-reload Hot reloads local changes to CSS and sections (default)\n- full-page  Always refreshes the entire page\n- off        Deactivate live reload",
-          "env": "SHOPIFY_FLAG_LIVE_RELOAD",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "live-reload",
-          "options": [
-            "hot-reload",
-            "full-page",
-            "off"
-          ],
-          "type": "option"
-        },
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
-          "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
-        "nodelete": {
-          "allowNo": false,
-          "char": "n",
-          "description": "Prevents files from being deleted in the remote theme when a file has been deleted locally. This applies to files that are deleted while the command is running, and files that have been deleted locally before the command is run.",
-          "env": "SHOPIFY_FLAG_NODELETE",
-          "name": "nodelete",
-          "type": "boolean"
-        },
-        "notify": {
-          "description": "The file path or URL. The file path is to a file that you want updated on idle. The URL path is where you want a webhook posted to report on file changes.",
-          "env": "SHOPIFY_FLAG_NOTIFY",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "notify",
-          "type": "option"
-        },
-        "only": {
-          "char": "o",
-          "description": "Hot reload only files that match the specified pattern.",
-          "env": "SHOPIFY_FLAG_ONLY",
-          "hasDynamicHelp": false,
-          "multiple": true,
-          "name": "only",
-          "type": "option"
-        },
-        "open": {
-          "allowNo": false,
-          "description": "Automatically launch the theme preview in your default web browser.",
-          "env": "SHOPIFY_FLAG_OPEN",
-          "name": "open",
-          "type": "boolean"
-        },
-        "password": {
-          "description": "Password generated from the Theme Access app or an Admin API token.",
-          "env": "SHOPIFY_CLI_THEME_TOKEN",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "password",
-          "type": "option"
-        },
-        "path": {
-          "description": "The path where you want to run the command. Defaults to the current working directory.",
-          "env": "SHOPIFY_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "path",
-          "noCacheDefault": true,
-          "type": "option"
-        },
-        "poll": {
-          "allowNo": false,
-          "description": "Force polling to detect file changes.",
-          "env": "SHOPIFY_FLAG_POLL",
-          "hidden": true,
-          "name": "poll",
-          "type": "boolean"
-        },
-        "port": {
-          "description": "Local port to serve theme preview from.",
-          "env": "SHOPIFY_FLAG_PORT",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "port",
-          "type": "option"
-        },
-        "store": {
-          "char": "s",
-          "description": "Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).",
-          "env": "SHOPIFY_FLAG_STORE",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "store",
-          "type": "option"
-        },
-        "store-password": {
-          "description": "The password for storefronts with password protection.",
-          "env": "SHOPIFY_FLAG_STORE_PASSWORD",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "store-password",
-          "type": "option"
-        },
-        "theme": {
-          "char": "t",
-          "description": "Theme ID or name of the remote theme.",
-          "env": "SHOPIFY_FLAG_THEME_ID",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "theme",
-          "type": "option"
-        },
-        "theme-editor-sync": {
-          "allowNo": false,
-          "description": "Synchronize Theme Editor updates in the local theme files.",
-          "env": "SHOPIFY_FLAG_THEME_EDITOR_SYNC",
-          "name": "theme-editor-sync",
-          "type": "boolean"
-        },
-        "verbose": {
-          "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hidden": true,
-      "hiddenAliases": [
-      ],
-      "id": "theme:serve",
-      "multiEnvironmentsFlags": null,
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "summary": "Uploads the current theme as a development theme to the connected store, then prints theme editor and preview URLs to your terminal. While running, changes will push to the store in real time."
-    },
-    "theme:share": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/theme",
-      "description": "Uploads your theme as a new, unpublished theme in your theme library. The theme is given a randomized name.\n\n  This command returns a \"preview link\" (https://help.shopify.com/manual/online-store/themes/adding-themes#share-a-theme-preview-with-others) that you can share with others.",
-      "descriptionWithMarkdown": "Uploads your theme as a new, unpublished theme in your theme library. The theme is given a randomized name.\n\n  This command returns a [preview link](https://help.shopify.com/manual/online-store/themes/adding-themes#share-a-theme-preview-with-others) that you can share with others.",
-      "flags": {
-        "environment": {
-          "char": "e",
-          "description": "The environment to apply to the current command.",
-          "env": "SHOPIFY_FLAG_ENVIRONMENT",
-          "hasDynamicHelp": false,
-          "multiple": true,
-          "name": "environment",
-          "type": "option"
-        },
-        "force": {
-          "allowNo": false,
-          "char": "f",
-          "description": "Proceed without confirmation, if current directory does not seem to be theme directory.",
-          "env": "SHOPIFY_FLAG_FORCE",
-          "hidden": true,
-          "name": "force",
-          "type": "boolean"
-        },
-        "listing": {
-          "description": "The listing preset to use for multi-preset themes. Applies preset files from listings/[preset-name] directory.",
-          "env": "SHOPIFY_FLAG_LISTING",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "listing",
-          "type": "option"
-        },
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
-          "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
-        "password": {
-          "description": "Password generated from the Theme Access app or an Admin API token.",
-          "env": "SHOPIFY_CLI_THEME_TOKEN",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "password",
-          "type": "option"
-        },
-        "path": {
-          "description": "The path where you want to run the command. Defaults to the current working directory.",
-          "env": "SHOPIFY_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "path",
-          "noCacheDefault": true,
-          "type": "option"
-        },
-        "store": {
-          "char": "s",
-          "description": "Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).",
-          "env": "SHOPIFY_FLAG_STORE",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "store",
-          "type": "option"
-        },
-        "verbose": {
-          "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "theme:share",
-      "multiEnvironmentsFlags": [
-        "store",
-        "password",
-        "path"
-      ],
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true,
-      "summary": "Creates a shareable, unpublished, and new theme on your theme library with a randomized name."
+      "usage": "search [query]",
+      "enableJsonFlag": false
     },
     "upgrade": {
-      "aliases": [
-      ],
-      "args": {
-      },
+      "aliases": [],
+      "args": {},
       "description": "Upgrades Shopify CLI using your package manager.",
-      "descriptionWithMarkdown": "Upgrades Shopify CLI using your package manager.",
-      "enableJsonFlag": false,
-      "flags": {
-      },
+      "flags": {},
       "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
+      "hiddenAliases": [],
       "id": "upgrade",
       "pluginAlias": "@shopify/cli",
       "pluginName": "@shopify/cli",
       "pluginType": "core",
       "strict": true,
-      "summary": "Upgrades Shopify CLI."
+      "summary": "Upgrades Shopify CLI.",
+      "enableJsonFlag": false,
+      "descriptionWithMarkdown": "Upgrades Shopify CLI using your package manager."
     },
     "version": {
-      "aliases": [
-      ],
-      "args": {
-      },
+      "aliases": [],
+      "args": {},
       "description": "Shopify CLI version currently installed.",
-      "enableJsonFlag": false,
-      "flags": {
-      },
+      "flags": {},
       "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
+      "hiddenAliases": [],
       "id": "version",
       "pluginAlias": "@shopify/cli",
       "pluginName": "@shopify/cli",
       "pluginType": "core",
-      "strict": true
+      "strict": true,
+      "enableJsonFlag": false
     },
-    "webhook:trigger": {
-      "aliases": [
-      ],
+    "help": {
+      "aliases": [],
       "args": {
+        "command": {
+          "description": "Command to show help for.",
+          "name": "command",
+          "required": false
+        }
       },
-      "customPluginName": "@shopify/app",
-      "description": "\n  Triggers the delivery of a sample Admin API event topic payload to a designated address.\n\n  You should use this command to experiment with webhooks, to initially test your webhook configuration, or for unit testing. However, to test your webhook configuration from end to end, you should always trigger webhooks by performing the related action in Shopify.\n\n  Because most webhook deliveries use remote endpoints, you can trigger the command from any directory where you can use Shopify CLI, and send the webhook to any of the supported endpoint types. For example, you can run the command from your app's local directory, but send the webhook to a staging environment endpoint.\n\n  To learn more about using webhooks in a Shopify app, refer to \"Webhooks overview\" (https://shopify.dev/docs/apps/webhooks).\n\n  ### Limitations\n\n  - Webhooks triggered using this method always have the same payload, so they can't be used to test scenarios that differ based on the payload contents.\n  - Webhooks triggered using this method aren't retried when they fail.\n  - Trigger requests are rate-limited using the \"Partner API rate limit\" (https://shopify.dev/docs/api/partner#rate_limits).\n  - You can't use this method to validate your API webhook subscriptions.\n  ",
-      "descriptionWithMarkdown": "\n  Triggers the delivery of a sample Admin API event topic payload to a designated address.\n\n  You should use this command to experiment with webhooks, to initially test your webhook configuration, or for unit testing. However, to test your webhook configuration from end to end, you should always trigger webhooks by performing the related action in Shopify.\n\n  Because most webhook deliveries use remote endpoints, you can trigger the command from any directory where you can use Shopify CLI, and send the webhook to any of the supported endpoint types. For example, you can run the command from your app's local directory, but send the webhook to a staging environment endpoint.\n\n  To learn more about using webhooks in a Shopify app, refer to [Webhooks overview](https://shopify.dev/docs/apps/webhooks).\n\n  ### Limitations\n\n  - Webhooks triggered using this method always have the same payload, so they can't be used to test scenarios that differ based on the payload contents.\n  - Webhooks triggered using this method aren't retried when they fail.\n  - Trigger requests are rate-limited using the [Partner API rate limit](https://shopify.dev/docs/api/partner#rate_limits).\n  - You can't use this method to validate your API webhook subscriptions.\n  ",
+      "description": "Display help for Shopify CLI",
       "flags": {
-        "address": {
-          "description": "The URL where the webhook payload should be sent.\n                    You will need a different address type for each delivery-method:\n                          · For remote HTTP testing, use a URL that starts with https://\n      · For local HTTP testing, use http://localhost:{port}/{url-path}\n                          · For Google Pub/Sub, use pubsub://{project-id}:{topic-id}\n                          · For Amazon EventBridge, use an Amazon Resource Name (ARN) starting with arn:aws:events:",
-          "env": "SHOPIFY_FLAG_ADDRESS",
-          "hasDynamicHelp": false,
-          "hidden": false,
-          "multiple": false,
-          "name": "address",
-          "required": false,
-          "type": "option"
-        },
-        "api-version": {
-          "description": "The API Version of the webhook topic.",
-          "env": "SHOPIFY_FLAG_API_VERSION",
-          "hasDynamicHelp": false,
-          "hidden": false,
-          "multiple": false,
-          "name": "api-version",
-          "required": false,
-          "type": "option"
-        },
-        "client-id": {
-          "description": "The Client ID of your app.",
-          "env": "SHOPIFY_FLAG_CLIENT_ID",
-          "exclusive": [
-            "config"
-          ],
-          "hasDynamicHelp": false,
-          "hidden": false,
-          "multiple": false,
-          "name": "client-id",
-          "type": "option"
-        },
-        "client-secret": {
-          "description": "Your app's client secret. This secret allows us to return the X-Shopify-Hmac-SHA256 header that lets you validate the origin of the response that you receive.",
-          "env": "SHOPIFY_FLAG_CLIENT_SECRET",
-          "hasDynamicHelp": false,
-          "hidden": false,
-          "multiple": false,
-          "name": "client-secret",
-          "required": false,
-          "type": "option"
-        },
-        "config": {
-          "char": "c",
-          "description": "The name of the app configuration.",
-          "env": "SHOPIFY_FLAG_APP_CONFIG",
-          "hasDynamicHelp": false,
-          "hidden": false,
-          "multiple": false,
-          "name": "config",
-          "type": "option"
-        },
-        "delivery-method": {
-          "description": "Method chosen to deliver the topic payload. If not passed, it's inferred from the address.",
-          "env": "SHOPIFY_FLAG_DELIVERY_METHOD",
-          "hasDynamicHelp": false,
-          "hidden": false,
-          "multiple": false,
-          "name": "delivery-method",
-          "options": [
-            "http",
-            "google-pub-sub",
-            "event-bridge"
-          ],
-          "required": false,
-          "type": "option"
-        },
-        "help": {
+        "nested-commands": {
+          "char": "n",
+          "description": "Include all nested commands in the output.",
+          "env": "SHOPIFY_FLAG_CLI_NESTED_COMMANDS",
+          "name": "nested-commands",
           "allowNo": false,
-          "description": "This help. When you run the trigger command the CLI will prompt you for any information that isn't passed using flags.",
-          "env": "SHOPIFY_FLAG_HELP",
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "help",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": false,
+      "usage": "help [command] [flags]",
+      "enableJsonFlag": false
+    },
+    "auth:logout": {
+      "aliases": [],
+      "args": {},
+      "description": "Logs you out of the Shopify account or Partner account and store.",
+      "flags": {},
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "auth:logout",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "auth:login": {
+      "aliases": [],
+      "args": {},
+      "description": "Logs you in to your Shopify account.",
+      "flags": {
+        "alias": {
+          "description": "Alias of the session you want to login to.",
+          "env": "SHOPIFY_FLAG_AUTH_ALIAS",
+          "name": "alias",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "auth:login",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "debug:command-flags": {
+      "aliases": [],
+      "args": {},
+      "description": "View all the available command flags",
+      "flags": {
+        "csv": {
+          "description": "Output as CSV",
+          "env": "SHOPIFY_FLAG_OUTPUT_CSV",
+          "name": "csv",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hidden": true,
+      "hiddenAliases": [],
+      "id": "debug:command-flags",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "kitchen-sink": {
+      "aliases": [],
+      "args": {},
+      "description": "View all the available UI kit components",
+      "flags": {},
+      "hasDynamicHelp": false,
+      "hidden": true,
+      "hiddenAliases": [
+        "kitchen-sink all"
+      ],
+      "id": "kitchen-sink",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "kitchen-sink:async": {
+      "aliases": [],
+      "args": {},
+      "description": "View the UI kit components that process async tasks",
+      "flags": {},
+      "hasDynamicHelp": false,
+      "hidden": true,
+      "hiddenAliases": [],
+      "id": "kitchen-sink:async",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "kitchen-sink:prompts": {
+      "aliases": [],
+      "args": {},
+      "description": "View the UI kit components prompts",
+      "flags": {},
+      "hasDynamicHelp": false,
+      "hidden": true,
+      "hiddenAliases": [],
+      "id": "kitchen-sink:prompts",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "kitchen-sink:static": {
+      "aliases": [],
+      "args": {},
+      "description": "View the UI kit components that display static output",
+      "flags": {},
+      "hasDynamicHelp": false,
+      "hidden": true,
+      "hiddenAliases": [],
+      "id": "kitchen-sink:static",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "doctor-release": {
+      "aliases": [],
+      "args": {},
+      "description": "Run CLI doctor-release tests",
+      "flags": {},
+      "hasDynamicHelp": false,
+      "hidden": true,
+      "hiddenAliases": [],
+      "id": "doctor-release",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "doctor-release:theme": {
+      "aliases": [],
+      "args": {},
+      "description": "Run all theme command doctor-release tests",
+      "flags": {
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
           "hidden": false,
-          "name": "help",
-          "required": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
           "type": "boolean"
         },
         "path": {
-          "description": "The path to your app directory.",
+          "char": "p",
+          "description": "The path to run tests in. Defaults to current directory.",
           "env": "SHOPIFY_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "multiple": false,
           "name": "path",
-          "noCacheDefault": true,
+          "default": "/Users/brandonreid/src/github.com/Shopify/cli/packages/cli",
+          "hasDynamicHelp": false,
+          "multiple": false,
           "type": "option"
         },
-        "reset": {
-          "allowNo": false,
-          "description": "Reset all your settings.",
-          "env": "SHOPIFY_FLAG_RESET",
-          "exclusive": [
-            "config"
-          ],
-          "hidden": false,
-          "name": "reset",
-          "type": "boolean"
-        },
-        "shared-secret": {
-          "description": "Deprecated. Please use client-secret.",
-          "env": "SHOPIFY_FLAG_SHARED_SECRET",
+        "environment": {
+          "char": "e",
+          "description": "The environment to use from shopify.theme.toml (required for store-connected tests).",
+          "env": "SHOPIFY_FLAG_ENVIRONMENT",
+          "name": "environment",
+          "required": true,
           "hasDynamicHelp": false,
-          "hidden": false,
           "multiple": false,
-          "name": "shared-secret",
-          "required": false,
           "type": "option"
         },
-        "topic": {
-          "description": "The requested webhook topic.",
-          "env": "SHOPIFY_FLAG_TOPIC",
+        "store": {
+          "char": "s",
+          "description": "Store URL (overrides environment).",
+          "env": "SHOPIFY_FLAG_STORE",
+          "name": "store",
           "hasDynamicHelp": false,
-          "hidden": false,
           "multiple": false,
-          "name": "topic",
-          "required": false,
+          "type": "option"
+        },
+        "password": {
+          "description": "Password from Theme Access app (overrides environment).",
+          "env": "SHOPIFY_FLAG_PASSWORD",
+          "name": "password",
+          "hasDynamicHelp": false,
+          "multiple": false,
           "type": "option"
         }
       },
       "hasDynamicHelp": false,
       "hidden": true,
-      "hiddenAliases": [
-      ],
-      "id": "webhook:trigger",
+      "hiddenAliases": [],
+      "id": "doctor-release:theme",
       "pluginAlias": "@shopify/cli",
       "pluginName": "@shopify/cli",
       "pluginType": "core",
-      "summary": "Trigger delivery of a sample webhook topic payload to a designated address."
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "docs:generate": {
+      "aliases": [],
+      "args": {},
+      "description": "Generate CLI commands documentation",
+      "flags": {},
+      "hasDynamicHelp": false,
+      "hidden": true,
+      "hiddenAliases": [],
+      "id": "docs:generate",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "notifications:list": {
+      "aliases": [],
+      "args": {},
+      "description": "List current notifications configured for the CLI.",
+      "flags": {
+        "ignore-errors": {
+          "description": "Don't fail if an error occurs.",
+          "env": "SHOPIFY_FLAG_IGNORE_ERRORS",
+          "hidden": false,
+          "name": "ignore-errors",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hidden": true,
+      "hiddenAliases": [],
+      "id": "notifications:list",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "notifications:generate": {
+      "aliases": [],
+      "args": {},
+      "description": "Generate a notifications.json file for the the CLI, appending a new notification to the current file.",
+      "flags": {},
+      "hasDynamicHelp": false,
+      "hidden": true,
+      "hiddenAliases": [],
+      "id": "notifications:generate",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "cache:clear": {
+      "aliases": [],
+      "args": {},
+      "description": "Clear the CLI cache, used to store some API responses and handle notifications status",
+      "flags": {},
+      "hasDynamicHelp": false,
+      "hidden": true,
+      "hiddenAliases": [],
+      "id": "cache:clear",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "config:autoupgrade:off": {
+      "aliases": [],
+      "args": {},
+      "description": "Disable automatic upgrades for Shopify CLI.\n\n  When auto-upgrade is disabled, Shopify CLI won't automatically update. Run `shopify upgrade` to update manually.\n\n  To enable auto-upgrade, run `shopify config autoupgrade on`.\n",
+      "flags": {},
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "config:autoupgrade:off",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "summary": "Disable automatic upgrades for Shopify CLI.",
+      "enableJsonFlag": false,
+      "descriptionWithMarkdown": "Disable automatic upgrades for Shopify CLI.\n\n  When auto-upgrade is disabled, Shopify CLI won't automatically update. Run `shopify upgrade` to update manually.\n\n  To enable auto-upgrade, run `shopify config autoupgrade on`.\n"
+    },
+    "config:autoupgrade:on": {
+      "aliases": [],
+      "args": {},
+      "description": "Enable automatic upgrades for Shopify CLI.\n\n  When auto-upgrade is enabled, Shopify CLI automatically updates to the latest version once per day. Major version upgrades are skipped and must be done manually.\n\n  To disable auto-upgrade, run `shopify config autoupgrade off`.\n",
+      "flags": {},
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "config:autoupgrade:on",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "summary": "Enable automatic upgrades for Shopify CLI.",
+      "enableJsonFlag": false,
+      "descriptionWithMarkdown": "Enable automatic upgrades for Shopify CLI.\n\n  When auto-upgrade is enabled, Shopify CLI automatically updates to the latest version once per day. Major version upgrades are skipped and must be done manually.\n\n  To disable auto-upgrade, run `shopify config autoupgrade off`.\n"
+    },
+    "config:autoupgrade:status": {
+      "aliases": [],
+      "args": {},
+      "description": "Check whether auto-upgrade is enabled, disabled, or not yet configured.\n\n  When auto-upgrade is enabled, Shopify CLI automatically updates to the latest version after each command.\n\n  Run `shopify config autoupgrade on` or `shopify config autoupgrade off` to configure it.\n",
+      "flags": {},
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "config:autoupgrade:status",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "summary": "Check whether auto-upgrade is enabled, disabled, or not yet configured.",
+      "enableJsonFlag": false,
+      "descriptionWithMarkdown": "Check whether auto-upgrade is enabled, disabled, or not yet configured.\n\n  When auto-upgrade is enabled, Shopify CLI automatically updates to the latest version after each command.\n\n  Run `shopify config autoupgrade on` or `shopify config autoupgrade off` to configure it.\n"
     }
   },
   "version": "3.94.0"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -112,6 +112,10 @@
       "app:env": {
         "description": "Manage environment variables."
       },
+      "app:agent": {
+        "description": "Commands intended to be invoked by AI agents in tandem with the Shopify AI Toolkit. Not for direct human use.",
+        "hidden": true
+      },
       "app:function": {
         "description": "Manage Shopify Functions."
       },


### PR DESCRIPTION
## WHY are these changes introduced?

We're introducing a new pattern for **agent-only commands** in the Shopify CLI: commands that are hidden from `--help` and "did you mean" suggestions, intended to be invoked by AI coding agents when prompted by the Shopify AI Toolkit.

The first command in this pattern, `app agentget-self-review-requirements`, returns an AI agent a filtered set of the Shopify App Store requirements that are checkable against a developer's codebase and come with tailored agent verification guidance. The agent uses the verification guidance in each requirement to inspect the developer's codebase and report back which requirements are likely passing, likely failing, or need review, helping the developer catch issues before submitting for review.

This initial implementation is simple, it requests the requirements from a [dedicated page in dev docs](https://shopify.dev/docs/apps/launch/app-store-review/app-store-ai-self-review-requirements). This is temporary. The next iteration will be retrieving the requirements directly from app store, where the authenticated request can track which app has made the request (useful as a trust signal) and filter the requirements for direct relevancy to the app's selected category (if they have declared one).

## WHAT is this pull request doing?

**New hidden topic + command**

- Registers `app:agent` as a hidden oclif topic in `packages/cli/package.json`. Both the topic and individual commands set `hidden: true`, so nothing under it appears in `shopify --help`, topic listings, or "did you mean" suggestions, but the command remains directly invokable when called by name.
- Adds `shopify app agent get-app-store-requirements`, which fetches the App Store self-review requirements from [dev docs](https://shopify.dev/docs/apps/launch/app-store-review/app-store-ai-self-review-requirements) (already served as `Content-Type: text/markdown`, no auth required) and writes the result to stdout via `outputResult`.

**Establishes the agent-only contract**

- Sentinel header on stdout: `<!-- shopify-agent: <command-id> -->` so agents can verify they parsed the expected payload.
- Errors go to stderr as a single `shopify-agent-error: <message>` line.
- Stable exit codes: `0` success, `1` generic failure, `2` not linked, `3` auth failure, `4` server unavailable.
- The command extends plain `Command` (not `AppLinkedCommand`) — the requirements page is universal, and forcing an app link would trigger a prompt that breaks agent invocation. Future agent commands should only opt into app context if their response actually depends on it.

**Postrun hook adjustment**

- Excludes `app:agent:*` commands from `autoUpgradeIfNeeded()` in `packages/cli-kit/src/public/node/hooks/postrun.ts`, alongside the existing `notifications` and `upgrade` exclusions. This is mainly to prevent an agent invocation of a fast metadata command from triggering a global `npm install -g @shopify/cli@latest` as a side effect, which would slow the call down by 10–30s and write spawn output to stdout/stderr.

## How to test your changes?

```bash
# Build the affected packages
pnpm nx run-many --target=build --projects=cli-kit,app,cli

# Run the command
pnpm shopify app agent get-app-store-requirements
```

Expected: ~60KB of markdown to stdout starting with `<!-- shopify-agent: get-app-store-requirements v1 -->`, followed by the live requirements from shopify.dev.

**Verify the agent contract**

```bash
pnpm shopify app agent get-app-store-requirements > /tmp/out.md 2> /tmp/err.txt
wc -c /tmp/out.md /tmp/err.txt
head -1 /tmp/out.md
```

Expect: stdout ~60KB, **stderr 0 bytes**, first line is the sentinel.

**Verify the command is hidden**

```bash
pnpm shopify --help | grep -i agent          # should print nothing
pnpm shopify app --help | grep -i agent      # should print nothing
pnpm shopify app aget-app-store-requirements 2>&1 | grep -i "did you mean"  # should NOT suggest the agent command
pnpm shopify app agent get-app-store-requirements --help  # works (direct path)
```

**Verify the error path** — temporarily edit `REQUIREMENTS_URL` in `packages/app/src/cli/services/agent/app-store-requirements.ts` to a 404 path on `shopify.dev`, rebuild `app`, and rerun:

```bash
pnpm shopify app agent get-app-store-requirements 2>/tmp/err.txt; echo "exit=$?"
cat /tmp/err.txt
```

Expect: `exit=4`, stderr starts with `shopify-agent-error:`, stdout empty. Revert the URL when done.

**Verify the postrun guard didn't over-match** — on a setup where the upgrade nudge would normally fire, confirm a non-agent command still emits it on stderr:

```bash
pnpm shopify version 2>/tmp/err.txt; cat /tmp/err.txt
```

## Post-release steps

None for this PR. The command is hidden and the new namespace is unused outside of it. Once the upstream "copy-paste prompt for your agent" UI surface lands (separately, likely in the Partner Dashboard / [dev.shopify.com](http://dev.shopify.com)), it will reference this command by name.

## Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows) — pure Node, no platform-specific APIs; uses `shopifyFetch` from `cli-kit` which is already cross-platform.
- [x] I've considered possible documentation changes — intentionally not adding public docs. The command is hidden from `docs:generate` (which excludes `hidden: true` commands) and from the `packages/cli/README.md` regen. The agent-facing "documentation" is the markdown output itself.
- [x] I've considered analytics changes to measure impact — the existing `reportAnalyticsEvent` in the postrun hook still runs for agent commands (only the auto-upgrade leg is skipped), so usage of `app:agent:*` commands will show up in standard CLI analytics like any other command.
- [ ] The change is user-facing — **no changeset.** The new command is hidden from end users and has no impact on existing public commands. The postrun hook change is additive and only affects the new hidden [namespace.is](http://namespace.is) simple,the 