### PR TITLE
[Security] Fix command injection in treeKill utility

### DIFF
--- a/packages/cli-kit/src/public/node/tree-kill.test.ts
+++ b/packages/cli-kit/src/public/node/tree-kill.test.ts
@@ -1,0 +1,58 @@
+/* eslint-disable no-restricted-imports */
+import {treeKill} from './tree-kill.js'
+import {vi, describe, test, expect, afterEach} from 'vitest'
+import {spawn} from 'child_process'
+
+vi.mock('child_process', async () => {
+  const actual: any = await vi.importActual('child_process')
+  return {
+    ...actual,
+    spawn: vi.fn(),
+  }
+})
+
+describe('treeKill', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  test('calls the callback with an error if the PID is not a number (string with digits)', async () => {
+    const maliciousPid = '1234; calc.exe'
+
+    await new Promise<void>((resolve) => {
+      // Correct signature for treeKill is (pid, signal, killRoot, callback)
+      treeKill(maliciousPid, 'SIGTERM', true, (err) => {
+        expect(err?.message).toBe('pid must be a number')
+        resolve()
+      })
+    })
+
+    expect(spawn).not.toHaveBeenCalled()
+  })
+
+  test('works with a valid numeric PID as string', () => {
+    const pid = '1234'
+    vi.mocked(spawn).mockReturnValue({
+      on: vi.fn(),
+      stdout: {on: vi.fn()},
+    } as any)
+    vi.stubGlobal('process', {...process, platform: 'win32'})
+
+    treeKill(pid)
+
+    expect(spawn).toHaveBeenCalledWith('taskkill', ['/pid', '1234', '/T', '/F'])
+  })
+
+  test('works with a valid numeric PID as number', () => {
+    const pid = 1234
+    vi.mocked(spawn).mockReturnValue({
+      on: vi.fn(),
+      stdout: {on: vi.fn()},
+    } as any)
+    vi.stubGlobal('process', {...process, platform: 'win32'})
+
+    treeKill(pid)
+
+    expect(spawn).toHaveBeenCalledWith('taskkill', ['/pid', '1234', '/T', '/F'])
+  })
+})

--- a/packages/cli-kit/src/public/node/tree-kill.ts
+++ b/packages/cli-kit/src/public/node/tree-kill.ts
@@ -3,7 +3,7 @@
 /* eslint-disable no-restricted-imports */
 
 import {outputDebug} from './output.js'
-import {exec, spawn} from 'child_process'
+import {spawn} from 'child_process'
 
 type ProcessTree = Record<string, string[]>
 
@@ -52,7 +52,8 @@ function adaptedTreeKill(
 ): void {
   const rootPid = typeof pid === 'number' ? pid.toString() : pid
 
-  if (Number.isNaN(rootPid)) {
+  // Security: Validate that the PID is a number to prevent command injection
+  if (!/^\d+$/.test(rootPid)) {
     if (callback) {
       callback(new Error('pid must be a number'))
       return
@@ -71,10 +72,20 @@ function adaptedTreeKill(
 
   // eslint-disable-next-line @typescript-eslint/switch-exhaustiveness-check -- default handles all Unix-like platforms
   switch (process.platform) {
-    case 'win32':
-      // @ts-ignore
-      exec(`taskkill /pid ${pid} /T /F`, callback)
+    case 'win32': {
+      // Security: Use spawn instead of exec to avoid shell injection when killing processes on Windows
+      const taskkill = spawn('taskkill', ['/pid', rootPid, '/T', '/F'])
+      taskkill.on('close', (code: number) => {
+        if (callback) {
+          if (code === 0) {
+            callback()
+          } else {
+            callback(new Error(`taskkill exited with code ${code}`))
+          }
+        }
+      })
       break
+    }
     case 'darwin':
       buildProcessTree(
         rootPid,


### PR DESCRIPTION
### WHY are these changes introduced?

`treeKill` in `@shopify/cli-kit` had a critical command injection vulnerability on Windows. The PID validation used `Number.isNaN(pid)` against a string, which always returns `false` for non-`NaN` string values, so malicious inputs like `"1234; calc.exe"` slipped through. The Windows branch then forwarded the value to `child_process.exec` via string concatenation, which spawns a shell and interprets the injected command.

### WHAT is this pull request doing?

- Replaces the broken `Number.isNaN` PID check with a strict regex (`/^\d+$/`) so only digit-only strings are accepted.
- Switches the Windows `taskkill` invocation from `child_process.exec` (shell-based) to `child_process.spawn` with arguments passed as an array, eliminating shell interpolation.
- Adds `packages/cli-kit/src/public/node/tree-kill.test.ts` with regression coverage for malicious and valid PID inputs.
- Adds short security-focused comments at the validation and spawn sites.

### How to test your changes?

`treeKill` is invoked when you quit `shopify app dev` (it tears down the dev process tree). Build the CLI, run a dev session against any sample app, and confirm a graceful shutdown:

```bash
pnpm install
pnpm shopify app dev --path <path-to-app>
# Inside the dev session, press 'q' (or Ctrl+C) and confirm the CLI exits cleanly.
# Then confirm no orphans were left behind (matches against full argv):
pgrep -fl 'app dev --path .*<path-to-app>' || echo "no orphan dev processes"
```

Then sanity-check the new PID validation directly. With a malicious PID it should refuse to spawn anything and surface the validation error. Run from the repo root against the built bundle:

```bash
pnpm nx build cli-kit
node -e "import('./packages/cli-kit/dist/public/node/tree-kill.js').then(({treeKill}) => treeKill('1234; calc.exe', 'SIGTERM', true, (err) => console.log(err?.message)))"
# Expect: pid must be a number
```

On Windows specifically, the `taskkill` invocation now uses `spawn` with array arguments instead of `exec` with string concatenation. Reviewers on Windows can confirm by running `shopify app dev` and quitting — the child tree should still terminate.

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`