### PR TITLE
[Tests] Refactor replay tests to use real filesystem

### DIFF
--- a/packages/app/src/cli/services/function/replay.test.ts
+++ b/packages/app/src/cli/services/function/replay.test.ts
@@ -2,20 +2,17 @@ import {FunctionRunData, replay} from './replay.js'
 import {renderReplay} from './ui.js'
 import {runFunction} from './runner.js'
 import {testAppLinked, testFunctionExtension} from '../../models/app/app.test-data.js'
+import {AppLinkedInterface} from '../../models/app/app.js'
 import {ExtensionInstance} from '../../models/extensions/extension-instance.js'
 import {FunctionConfigType} from '../../models/extensions/specifications/function.js'
 import {selectFunctionRunPrompt} from '../../prompts/function/replay.js'
 import {randomUUID} from '@shopify/cli-kit/node/crypto'
-import {readFile} from '@shopify/cli-kit/node/fs'
-import {describe, expect, beforeAll, test, vi} from 'vitest'
+import {inTemporaryDirectory, mkdir, writeFile} from '@shopify/cli-kit/node/fs'
+import {joinPath} from '@shopify/cli-kit/node/path'
+import {describe, expect, test, vi} from 'vitest'
 import {AbortError} from '@shopify/cli-kit/node/error'
 import {outputInfo} from '@shopify/cli-kit/node/output'
-import {getLogsDir} from '@shopify/cli-kit/node/logs'
 
-import {existsSync, readdirSync} from 'fs'
-
-vi.mock('fs')
-vi.mock('@shopify/cli-kit/node/fs')
 vi.mock('../generate-schema.js')
 vi.mock('../../prompts/function/replay.js')
 vi.mock('../dev/extension/bundler.js')
@@ -39,228 +36,269 @@ describe('replay', () => {
     handle: 'function-handle',
   }
 
-  let extension: ExtensionInstance<FunctionConfigType>
+  async function runTest(
+    callback: (args: {
+      extension: ExtensionInstance<FunctionConfigType>
+      app: AppLinkedInterface
+      functionRunsDir: string
+    }) => Promise<void>,
+  ) {
+    fileCounter = 0
+    await inTemporaryDirectory(async (tmpDir) => {
+      const extension = await testFunctionExtension({
+        config: defaultConfig,
+        dir: joinPath(tmpDir, 'extensions', 'my-function'),
+      })
+      const app = testAppLinked({directory: tmpDir})
+      const functionRunsDir = app.getLogsDir()
+      await mkdir(functionRunsDir)
 
-  beforeAll(async () => {
-    extension = await testFunctionExtension({config: defaultConfig})
-  })
+      await callback({extension, app, functionRunsDir})
+    })
+  }
 
   test('runs selected function', async () => {
-    // Given
-    const file1 = createFunctionRunFile({handle: extension.handle})
-    const file2 = createFunctionRunFile({handle: extension.handle})
-    mockFileOperations([file1, file2])
+    await runTest(async ({extension, app, functionRunsDir}) => {
+      // Given
+      const file1 = createFunctionRunFile({handle: extension.handle})
+      const file2 = createFunctionRunFile({handle: extension.handle})
+      await writeFiles(functionRunsDir, [file1, file2])
 
-    vi.mocked(selectFunctionRunPrompt).mockResolvedValue(file1.run)
+      vi.mocked(selectFunctionRunPrompt).mockResolvedValue(file1.run)
 
-    // When
-    await replay({
-      app: testAppLinked(),
-      extension,
-      stdout: false,
-      path: 'test-path',
-      json: true,
-      watch: false,
+      // When
+      await replay({
+        app,
+        extension,
+        stdout: false,
+        path: 'test-path',
+        json: true,
+        watch: false,
+      })
+
+      // Then
+      expect(selectFunctionRunPrompt).toHaveBeenCalledWith(normalizeRuns([file1.run, file2.run]))
+      expectFunctionRun(extension, file1.run.payload.input)
+      expect(outputInfo).not.toHaveBeenCalled()
     })
-
-    // Then
-    expect(selectFunctionRunPrompt).toHaveBeenCalledWith([file1.run, file2.run])
-    expectFunctionRun(extension, file1.run.payload.input)
-    expect(outputInfo).not.toHaveBeenCalled()
   })
 
   test('only allows selection of the most recent 100 runs', async () => {
-    // Given
-    const files = new Array(101).fill(undefined).map((_) => createFunctionRunFile({handle: extension.handle}))
-    mockFileOperations(files)
-    vi.mocked(selectFunctionRunPrompt).mockResolvedValue(files[100]!.run)
+    await runTest(async ({extension, app, functionRunsDir}) => {
+      // Given
+      const files = new Array(101).fill(undefined).map((_) => createFunctionRunFile({handle: extension.handle}))
+      await writeFiles(functionRunsDir, files)
+      vi.mocked(selectFunctionRunPrompt).mockResolvedValue(files[100]!.run)
 
-    // When
-    await replay({
-      app: testAppLinked(),
-      extension,
-      stdout: false,
-      path: 'test-path',
-      json: true,
-      watch: false,
+      // When
+      await replay({
+        app,
+        extension,
+        stdout: false,
+        path: 'test-path',
+        json: true,
+        watch: false,
+      })
+
+      // Then
+      expect(selectFunctionRunPrompt).toHaveBeenCalledWith(normalizeRuns(files.map(({run}) => run).slice(0, 100)))
     })
-
-    // Then
-    expect(selectFunctionRunPrompt).toHaveBeenCalledWith(files.map(({run}) => run).slice(0, 100))
   })
 
   test('does not allow selection of runs for other functions', async () => {
-    // Given
-    const file1 = createFunctionRunFile({handle: extension.handle})
-    const file2 = createFunctionRunFile({handle: 'another-function-handle'})
-    mockFileOperations([file1, file2])
+    await runTest(async ({extension, app, functionRunsDir}) => {
+      // Given
+      const file1 = createFunctionRunFile({handle: extension.handle})
+      const file2 = createFunctionRunFile({handle: 'another-function-handle'})
+      await writeFiles(functionRunsDir, [file1, file2])
 
-    vi.mocked(selectFunctionRunPrompt).mockResolvedValue(file1.run)
+      vi.mocked(selectFunctionRunPrompt).mockResolvedValue(file1.run)
 
-    // When
-    await replay({
-      app: testAppLinked(),
-      extension,
-      stdout: false,
-      path: 'test-path',
-      json: true,
-      watch: false,
+      // When
+      await replay({
+        app,
+        extension,
+        stdout: false,
+        path: 'test-path',
+        json: true,
+        watch: false,
+      })
+
+      // Then
+      expect(selectFunctionRunPrompt).toHaveBeenCalledWith(normalizeRuns([file1.run]))
     })
-
-    // Then
-    expect(selectFunctionRunPrompt).toHaveBeenCalledWith([file1.run])
   })
 
   test('throws error if no logs available', async () => {
-    // Given
-    mockFileOperations([])
-
-    // When/Then
-    await expect(async () => {
-      await replay({
-        app: testAppLinked(),
-        extension,
-        stdout: false,
-        path: 'test-path',
-        json: true,
-        watch: false,
-      })
-    }).rejects.toThrow(new AbortError(`No logs found in ${getLogsDir()}`))
+    await runTest(async ({extension, app, functionRunsDir}) => {
+      // When/Then
+      await expect(async () => {
+        await replay({
+          app,
+          extension,
+          stdout: false,
+          path: 'test-path',
+          json: true,
+          watch: false,
+        })
+      }).rejects.toThrow(new AbortError(`No logs found in ${functionRunsDir}`))
+    })
   })
 
   test('throws error if log directory does not exist', async () => {
-    // Given
-    vi.mocked(existsSync).mockReturnValue(false)
+    await inTemporaryDirectory(async (tmpDir) => {
+      const extension = await testFunctionExtension({config: defaultConfig})
+      const app = testAppLinked({directory: tmpDir})
+      const functionRunsDir = app.getLogsDir()
 
-    // When/Then
-    await expect(async () => {
-      await replay({
-        app: testAppLinked(),
-        extension,
-        stdout: false,
-        path: 'test-path',
-        json: true,
-        watch: false,
-      })
-    }).rejects.toThrow(new AbortError(`No logs found in ${getLogsDir()}`))
+      // When/Then
+      await expect(async () => {
+        await replay({
+          app,
+          extension,
+          stdout: false,
+          path: 'test-path',
+          json: true,
+          watch: false,
+        })
+      }).rejects.toThrow(new AbortError(`No logs found in ${functionRunsDir}`))
+    })
   })
 
   test('delegates to renderReplay when watch is true', async () => {
-    // Given
-    const file = createFunctionRunFile({handle: extension.handle})
-    mockFileOperations([file])
-    vi.mocked(selectFunctionRunPrompt).mockResolvedValue(file.run)
+    await runTest(async ({extension, app, functionRunsDir}) => {
+      // Given
+      const file = createFunctionRunFile({handle: extension.handle})
+      await writeFiles(functionRunsDir, [file])
+      vi.mocked(selectFunctionRunPrompt).mockResolvedValue(file.run)
 
-    vi.mocked(renderReplay)
+      vi.mocked(renderReplay)
 
-    // When
-    await replay({
-      app: testAppLinked(),
-      extension,
-      stdout: false,
-      path: 'test-path',
-      json: true,
-      watch: true,
-    })
-
-    expect(renderReplay).toHaveBeenCalledOnce()
-  })
-
-  test('aborts on error', async () => {
-    // Given
-    const file = createFunctionRunFile({handle: extension.handle})
-    mockFileOperations([file])
-
-    vi.mocked(selectFunctionRunPrompt).mockResolvedValue(file.run)
-    vi.mocked(renderReplay).mockRejectedValueOnce('failure')
-
-    // When
-    await expect(async () =>
-      replay({
-        app: testAppLinked(),
+      // When
+      await replay({
+        app,
         extension,
         stdout: false,
         path: 'test-path',
         json: true,
         watch: true,
-      }),
-    ).rejects.toThrow()
+      })
 
-    const abortSignal = vi.mocked(renderReplay).mock.calls[0]![0].abortController.signal
+      expect(renderReplay).toHaveBeenCalledOnce()
+    })
+  })
 
-    // Then
-    expect(abortSignal.aborted).toBeTruthy()
+  test('aborts on error', async () => {
+    await runTest(async ({extension, app, functionRunsDir}) => {
+      // Given
+      const file = createFunctionRunFile({handle: extension.handle})
+      await writeFiles(functionRunsDir, [file])
+
+      vi.mocked(selectFunctionRunPrompt).mockResolvedValue(file.run)
+      vi.mocked(renderReplay).mockRejectedValueOnce('failure')
+
+      // When
+      await expect(async () =>
+        replay({
+          app,
+          extension,
+          stdout: false,
+          path: 'test-path',
+          json: true,
+          watch: true,
+        }),
+      ).rejects.toThrow()
+
+      const abortSignal = vi.mocked(renderReplay).mock.calls[0]![0].abortController.signal
+
+      // Then
+      expect(abortSignal.aborted).toBeTruthy()
+    })
   })
 
   test('runs the log specified by the --log flag for the current function', async () => {
-    // Given
-    const identifier = '000000'
-    const file1 = createFunctionRunFile({handle: extension.handle})
-    const file2 = createFunctionRunFile({handle: extension.handle, identifier})
-    const file3 = createFunctionRunFile({handle: extension.handle})
-    const file4 = createFunctionRunFile({handle: 'another-extension', identifier})
-    mockFileOperations([file1, file2, file3, file4])
+    await runTest(async ({extension, app, functionRunsDir}) => {
+      // Given
+      const identifier = '000000'
+      const file1 = createFunctionRunFile({handle: extension.handle})
+      const file2 = createFunctionRunFile({handle: extension.handle, identifier})
+      const file3 = createFunctionRunFile({handle: extension.handle})
+      const file4 = createFunctionRunFile({handle: 'another-extension', identifier})
+      await writeFiles(functionRunsDir, [file1, file2, file3, file4])
 
-    // When
-    await replay({
-      app: testAppLinked(),
-      extension,
-      stdout: false,
-      path: 'test-path',
-      json: true,
-      watch: false,
-      log: identifier,
-    })
-
-    // Then
-    expectFunctionRun(extension, file2.run.payload.input)
-  })
-
-  test('throws error if the log specified by the --log flag is not found', async () => {
-    // Given
-    const identifier = '000000'
-    const file1 = createFunctionRunFile({handle: extension.handle})
-    const file2 = createFunctionRunFile({handle: extension.handle})
-    mockFileOperations([file1, file2])
-
-    // When
-    await expect(async () =>
-      replay({
-        app: testAppLinked(),
+      // When
+      await replay({
+        app,
         extension,
         stdout: false,
         path: 'test-path',
         json: true,
         watch: false,
         log: identifier,
-      }),
-    ).rejects.toThrow()
+      })
+
+      // Then
+      expectFunctionRun(extension, file2.run.payload.input)
+    })
+  })
+
+  test('throws error if the log specified by the --log flag is not found', async () => {
+    await runTest(async ({extension, app, functionRunsDir}) => {
+      // Given
+      const identifier = '000000'
+      const file1 = createFunctionRunFile({handle: extension.handle})
+      const file2 = createFunctionRunFile({handle: extension.handle})
+      await writeFiles(functionRunsDir, [file1, file2])
+
+      // When
+      await expect(async () =>
+        replay({
+          app,
+          extension,
+          stdout: false,
+          path: 'test-path',
+          json: true,
+          watch: false,
+          log: identifier,
+        }),
+      ).rejects.toThrow()
+    })
   })
 
   test('ignores runs with no input and keeps reading chunks until past the threshold', async () => {
-    // Given
-    const filesWithInput = new Array(99).fill(undefined).map((_) => createFunctionRunFile({handle: extension.handle}))
-    const fileWithoutInput = createFunctionRunFile({handle: extension.handle, partialPayload: {input: null}})
-    const additionalFiles = new Array(199).fill(undefined).map((_) => createFunctionRunFile({handle: extension.handle}))
+    await runTest(async ({extension, app, functionRunsDir}) => {
+      // Given
+      // To ensure we test the chunking and filtering, we need the file without input
+      // to be in the first chunk of 100 newest files.
+      // readdirSync().reverse() will return them in descending order of their names (timestamps).
+      const additionalFiles = new Array(199)
+        .fill(undefined)
+        .map((_) => createFunctionRunFile({handle: extension.handle}))
+      const fileWithoutInput = createFunctionRunFile({handle: extension.handle, partialPayload: {input: null}})
+      const filesWithInput = new Array(99).fill(undefined).map((_) => createFunctionRunFile({handle: extension.handle}))
 
-    mockFileOperations([...filesWithInput, fileWithoutInput, ...additionalFiles])
+      await writeFiles(functionRunsDir, [...additionalFiles, fileWithoutInput, ...filesWithInput])
 
-    vi.mocked(selectFunctionRunPrompt).mockResolvedValue(filesWithInput[0]!.run)
+      vi.mocked(selectFunctionRunPrompt).mockResolvedValue(filesWithInput[0]!.run)
 
-    // When
-    await replay({
-      app: testAppLinked(),
-      extension,
-      stdout: false,
-      path: 'test-path',
-      json: true,
-      watch: true,
+      // When
+      await replay({
+        app,
+        extension,
+        stdout: false,
+        path: 'test-path',
+        json: true,
+        watch: true,
+      })
+
+      // Then
+      // Chunk 1 will be the 99 newest files (filesWithInput) and the file without input.
+      // Since functionRunData.length will be 99 (< 100), it will read Chunk 2.
+      // Chunk 2 will have the next 100 newest files (the first 100 of additionalFiles).
+      expect(selectFunctionRunPrompt).toHaveBeenCalledWith(
+        normalizeRuns([...filesWithInput.reverse(), ...additionalFiles.reverse().slice(0, 100)].map(({run}) => run)),
+      )
     })
-
-    // Then
-    expect(selectFunctionRunPrompt).toHaveBeenCalledWith(
-      [...filesWithInput, ...additionalFiles.slice(0, 100)].map(({run}) => run),
-    )
   })
 })
 
@@ -269,11 +307,14 @@ interface FunctionRunFileOptions {
   identifier?: string
   partialPayload?: object
 }
+let fileCounter = 0
 function createFunctionRunFile(options: FunctionRunFileOptions) {
   const handle = options.handle
   const identifier = options.identifier ?? randomUUID().substring(0, 6)
   const partialPayload = options.partialPayload ?? {}
-  const path = `20240522_150641_827Z_extensions_${handle}_${identifier}.json`
+  const counter = (fileCounter++).toString().padStart(4, '0')
+  const timestamp = `20240522_150641_${counter}Z`
+  const path = `${timestamp}_extensions_${handle}_${identifier}.json`
   const run: FunctionRunData = {
     identifier,
     shopId: 1,
@@ -281,7 +322,7 @@ function createFunctionRunFile(options: FunctionRunFileOptions) {
     logType: 'function_run',
     source: handle,
     sourceNamespace: 'extensions',
-    logTimestamp: '2024-06-12T20:38:18.796Z',
+    logTimestamp: timestamp,
     cursor: '2024-06-12T20:38:18.796Z',
     status: 'success',
     payload: {
@@ -304,14 +345,26 @@ function expectFunctionRun(functionExtension: ExtensionInstance<FunctionConfigTy
   expect(runFunction).toHaveBeenCalledWith({functionExtension, json: true, export: 'run', input: JSON.stringify(input)})
 }
 
-function mockFileOperations(data: {run: FunctionRunData; path: string}[]) {
-  vi.mocked(existsSync).mockReturnValue(true)
-  vi.mocked(readdirSync).mockReturnValue([...data].reverse().map(({path}) => path) as any)
-  vi.mocked(readFile).mockImplementation((path) => {
-    const run = data.find((file) => path.endsWith(file.path))
-    if (!run) {
-      throw new AbortError(`Mock file not found: ${path}`)
-    }
-    return Promise.resolve(Buffer.from(JSON.stringify(run.run), 'utf8'))
-  })
+async function writeFiles(dir: string, data: {run: FunctionRunData; path: string}[]) {
+  for (const {run, path} of data) {
+    // eslint-disable-next-line no-await-in-loop
+    await writeFile(joinPath(dir, path), JSON.stringify(run))
+  }
+}
+
+function normalizeRuns(runs: FunctionRunData[]) {
+  return runs.map((run) => ({
+    ...run,
+    identifier: expect.any(String),
+    logTimestamp: expect.any(String),
+    payload: {
+      ...run.payload,
+      input:
+        run.payload.input === null
+          ? null
+          : expect.objectContaining({
+              identifier: expect.any(String),
+            }),
+    },
+  }))
 }


### PR DESCRIPTION
### WHY are these changes introduced?

`packages/app/src/cli/services/function/replay.test.ts` mocked the filesystem (`vi.mock('fs')` and `vi.mock('@shopify/cli-kit/node/fs')`) and shared mutable state across tests via `beforeAll`. Filesystem mocks drift from the real implementation, and shared state makes tests order-dependent and harder to reason about. The CLI testing strategy prefers real files in temporary directories with isolated state per test.

### WHAT is this pull request doing?

- Removes the `fs` and `@shopify/cli-kit/node/fs` mocks.
- Adds a `runTest` helper that uses `inTemporaryDirectory` to give every test its own isolated workspace, function extension, and logs directory.
- Writes real function-run JSON files to disk instead of stubbing readers.
- Normalizes assertions so they tolerate deterministic order and generated identifiers.
- Replaces the `beforeAll` setup with the per-test helper, eliminating shared mutable state.

### How to test your changes?

CI

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`