### PR TITLE
[Refactor] Simplify copyDirectoryContents implementation

### DIFF
--- a/packages/cli-kit/src/public/node/fs.ts
+++ b/packages/cli-kit/src/public/node/fs.ts
@@ -717,21 +717,5 @@ export async function copyDirectoryContents(srcDir: string, destDir: string): Pr
     throw new Error(`Source directory ${srcDir} does not exist`)
   }
 
-  if (!(await fileExists(destDir))) {
-    await mkdir(destDir)
-  }
-
-  // Get all files and directories in the source directory
-  const items = await glob(joinPath(srcDir, '**/*'))
-
-  const filesToCopy = []
-
-  for (const item of items) {
-    const relativePath = item.replace(srcDir, '').replace(/^[/\\]/, '')
-    const destPath = joinPath(destDir, relativePath)
-
-    filesToCopy.push(copyFile(item, destPath))
-  }
-
-  await Promise.all(filesToCopy)
+  await fsCopy(srcDir, destDir)
 }


### PR DESCRIPTION
### WHY are these changes introduced?

`copyDirectoryContents` in `packages/cli-kit/src/public/node/fs.ts` reimplemented directory copying by hand: it created the destination, ran a `glob` over the source tree, and fanned out one `copyFile` per match through `Promise.all`. That extra logic is harder to reason about and can hit `EMFILE` ("too many open files") on large trees because every file is opened concurrently. `fs-extra`'s `fsCopy` already handles directory creation, recursion, and back-pressure correctly.

### WHAT is this pull request doing?

- Replaces the manual `glob` + `Promise.all`/`copyFile` loop in `copyDirectoryContents` with a single `fsCopy(srcDir, destDir)` call.
- Keeps the existing source-existence check so callers still get the same error message when the source directory is missing.
- Removes the redundant `mkdir` for the destination (handled by `fsCopy`).

### How to test your changes?

`copyDirectoryContents` is exercised by the `include_assets` build step for UI extensions when the `source` is a directory. Build any app whose extension declares an `include_assets` entry pointing at a directory and confirm the contents are copied recursively:

```bash
pnpm install
pnpm shopify app build --path <path-to-app>
```

After the build, verify under the extension's output directory (`<path-to-app>/dist/<extension>/...`) that:

- the target directory exists,
- all nested files and subdirectories from the source are present (counts and contents match the source),
- the build completes without `EMFILE` / `ENOENT` errors.

Negative path — make sure the original error message is preserved when the source is missing. Run from the repo root against the built bundle:

```bash
pnpm nx build cli-kit
node -e "import('./packages/cli-kit/dist/public/node/fs.js').then(({copyDirectoryContents}) => copyDirectoryContents('/tmp/does-not-exist-xyz', '/tmp/dest').catch((err) => console.log(err.message)))"
# Expect: Source directory /tmp/does-not-exist-xyz does not exist
```

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`