### PR TITLE
Skip 400ms search throttle for in-memory autocomplete filtering

### DIFF
--- a/.changeset/autocomplete-instant-local-search.md
+++ b/.changeset/autocomplete-instant-local-search.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': patch
+---
+
+Make the autocomplete prompt feel instant when filtering against in-memory choices. The 400ms throttle on the search callback was designed for remote/paginated backends, but it also gated the default in-memory filter used by callers that don't supply their own `search` (e.g. the theme selector), producing a noticeable lag while typing. The prompt now exposes a `searchDebounceMs` prop, and `renderAutocompletePrompt` sets it to `0` when it injects its own synchronous filter. Custom remote-search consumers keep the existing 400ms throttle unless they opt out.

--- a/.changeset/autocomplete-instant-local-search.md
+++ b/.changeset/autocomplete-instant-local-search.md
@@ -2,4 +2,4 @@
 '@shopify/cli-kit': patch
 ---
 
-Make the autocomplete prompt feel instant when filtering against in-memory choices. The 400ms throttle on the search callback was designed for remote/paginated backends, but it also gated the default in-memory filter used by callers that don't supply their own `search` (e.g. the theme selector), producing a noticeable lag while typing. The prompt now exposes a `searchDebounceMs` prop, and `renderAutocompletePrompt` sets it to `0` when it injects its own synchronous filter. Custom remote-search consumers keep the existing 400ms throttle unless they opt out.
+Make the autocomplete prompt feel instant when filtering against in-memory choices.

--- a/packages/cli-kit/src/private/node/ui/components/AutocompletePrompt.test.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/AutocompletePrompt.test.tsx
@@ -620,6 +620,34 @@ describe('AutocompletePrompt', async () => {
     `)
   })
 
+  test('searchDebounceMs: 0 invokes search on every keystroke without throttling', async () => {
+    const search = vi.fn(async (term: string) => ({
+      data: DATABASE.filter((item) => item.label.includes(term)),
+    }))
+
+    const renderInstance = render(
+      <AutocompletePrompt
+        message="Associate your project with the org Castile Ventures?"
+        choices={DATABASE}
+        onSubmit={() => {}}
+        search={search}
+        searchDebounceMs={0}
+      />,
+    )
+
+    await waitForInputsToBeReady()
+    await sendInputAndWaitForChange(renderInstance, 'f')
+    await sendInputAndWaitForChange(renderInstance, 'i')
+    await sendInputAndWaitForChange(renderInstance, 'r')
+
+    // With the default 400ms throttle, three rapid keystrokes coalesce to ~2 calls
+    // (leading + trailing edge). With searchDebounceMs=0, each keystroke fires.
+    expect(search).toHaveBeenCalledTimes(3)
+    expect(search).toHaveBeenNthCalledWith(1, 'f')
+    expect(search).toHaveBeenNthCalledWith(2, 'fi')
+    expect(search).toHaveBeenNthCalledWith(3, 'fir')
+  })
+
   test('displays an error message if the search fails', async () => {
     const search = (_term: string) => {
       return Promise.reject(new Error('Something went wrong'))

--- a/packages/cli-kit/src/private/node/ui/components/AutocompletePrompt.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/AutocompletePrompt.tsx
@@ -28,9 +28,17 @@ export interface AutocompletePromptProps<T> {
   abortSignal?: AbortSignal
   infoMessage?: InfoMessageProps['message']
   groupOrder?: string[]
+  /**
+   * Throttle window in milliseconds applied to the search callback. Defaults to 400ms,
+   * which is appropriate for remote/paginated backends. In-memory consumers (where the
+   * search callback resolves synchronously) can pass 0 for instant filtering on every
+   * keystroke.
+   */
+  searchDebounceMs?: number
 }
 
 const MIN_NUMBER_OF_ITEMS_FOR_SEARCH = 5
+const DEFAULT_SEARCH_DEBOUNCE_MS = 400
 
 function AutocompletePrompt<T>({
   message,
@@ -42,6 +50,7 @@ function AutocompletePrompt<T>({
   abortSignal,
   infoMessage,
   groupOrder,
+  searchDebounceMs = DEFAULT_SEARCH_DEBOUNCE_MS,
 }: React.PropsWithChildren<AutocompletePromptProps<T>>): ReactElement | null {
   const complete = useComplete()
   const [searchTerm, setSearchTerm] = useState('')
@@ -121,10 +130,10 @@ function AutocompletePrompt<T>({
               clearTimeout(setLoadingWhenSlow.current)
             })
         },
-        400,
+        searchDebounceMs,
         {leading: true, trailing: true},
       ),
-    [paginatedSearch, setPromptState],
+    [paginatedSearch, setPromptState, searchDebounceMs],
   )
 
   return (

--- a/packages/cli-kit/src/public/node/ui.tsx
+++ b/packages/cli-kit/src/public/node/ui.tsx
@@ -417,6 +417,11 @@ export async function renderAutocompletePrompt<T>(
 ): Promise<T> {
   throwInNonTTY({message: props.message, stdin: renderOptions?.stdin}, uiDebugOptions)
 
+  // The default search filters in-memory choices synchronously, so it doesn't need
+  // throttling. Skipping the throttle makes the keystroke-to-result latency feel
+  // instant. Callers that supply their own (typically remote/paginated) search keep
+  // the component's default throttle unless they opt out via `searchDebounceMs`.
+  const usingDefaultSearch = props.search === undefined
   const newProps = {
     search(term: string) {
       const lowerTerm = term.toLowerCase()
@@ -426,6 +431,7 @@ export async function renderAutocompletePrompt<T>(
         }),
       })
     },
+    ...(usingDefaultSearch ? {searchDebounceMs: 0} : {}),
     ...props,
   }
 


### PR DESCRIPTION
### WHY are these changes introduced?

Filtering inside `renderAutocompletePrompt` (e.g. the theme selector that appears for `shopify theme push`) feels noticeably laggy: there's a ~400ms gap between typing and seeing matching results update.

The cause is the throttle on the search callback in `AutocompletePrompt` (`packages/cli-kit/src/private/node/ui/components/AutocompletePrompt.tsx`). The 400ms window makes sense for callers that supply a remote/paginated `search` (we don't want to hammer an API on every keystroke), but it also gates the default in-memory filter that `renderAutocompletePrompt` injects when the caller doesn't pass one — and that filter is fully synchronous (`Promise.resolve(choices.filter(...))`), so there's no I/O to throttle.

### WHAT is this pull request doing?

- Adds an optional `searchDebounceMs` prop to `AutocompletePrompt`, default `400` (backward-compatible).
- `renderAutocompletePrompt` sets `searchDebounceMs: 0` only when it's injecting its own default in-memory filter; if the caller supplied their own `search`, the default 400ms throttle still applies.
- Adds a test asserting that `searchDebounceMs={0}` invokes the search callback on every keystroke (vs. coalescing to leading + trailing edges).

Net effect: prompts that filter against in-memory choices feel instant; remote/paginated consumers see no behavior change unless they opt in.

### How to test your changes?

1. Build the CLI: `pnpm nx build cli`
2. From any theme directory, run a command that opens the theme selector — e.g. `node packages/cli/bin/dev.js theme push`
3. Type into the search box; results should update on each keystroke instead of in ~400ms bursts.

Unit tests:
```
pnpm -F @shopify/cli-kit vitest run src/private/node/ui/components/AutocompletePrompt.test.tsx
```

### Post-release steps

None.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows) — pure JS timing change, platform-agnostic.
- [x] I've considered possible [documentation](https://shopify.dev) changes — JSDoc on the new prop covers it.
- [x] I've considered analytics changes to measure impact — none required.
- [x] The change is user-facing — I've added a `patch` changeset for `@shopify/cli-kit`.
