### PR TITLE
 Fix modern Bun lockfile cleanup in app templates

### DIFF
--- a/.changeset/fix-bun-lockfile-cleanup.md
+++ b/.changeset/fix-bun-lockfile-cleanup.md
@@ -1,0 +1,6 @@
+---
+'@shopify/app': patch
+'@shopify/cli-kit': patch
+---
+
+Handle modern Bun `bun.lock` files when cleaning up app templates so non-Bun projects do not keep stale Bun lockfiles or `.gitignore` entries.

--- a/packages/app/src/cli/services/init/template/cleanup.test.ts
+++ b/packages/app/src/cli/services/init/template/cleanup.test.ts
@@ -68,6 +68,7 @@ describe('cleanup', () => {
       await writeFile(joinPath(tmpDir, 'package-lock.json'), '{}')
       await writeFile(joinPath(tmpDir, 'yarn.lock'), '{}')
       await writeFile(joinPath(tmpDir, 'pnpm-lock.yaml'), '{}')
+      await writeFile(joinPath(tmpDir, 'bun.lock'), '{}')
       await writeFile(joinPath(tmpDir, 'bun.lockb'), '{}')
 
       // When
@@ -77,6 +78,7 @@ describe('cleanup', () => {
       await expect(fileExists(joinPath(tmpDir, 'package-lock.json'))).resolves.toBe(packageManager === 'npm')
       await expect(fileExists(joinPath(tmpDir, 'yarn.lock'))).resolves.toBe(packageManager === 'yarn')
       await expect(fileExists(joinPath(tmpDir, 'pnpm-lock.yaml'))).resolves.toBe(packageManager === 'pnpm')
+      await expect(fileExists(joinPath(tmpDir, 'bun.lock'))).resolves.toBe(packageManager === 'bun')
       await expect(fileExists(joinPath(tmpDir, 'bun.lockb'))).resolves.toBe(packageManager === 'bun')
     })
   })
@@ -87,6 +89,7 @@ describe('cleanup', () => {
       await writeFile(joinPath(tmpDir, 'package-lock.json'), '{}')
       await writeFile(joinPath(tmpDir, 'yarn.lock'), '{}')
       await writeFile(joinPath(tmpDir, 'pnpm-lock.yaml'), '{}')
+      await writeFile(joinPath(tmpDir, 'bun.lock'), '{}')
       await writeFile(joinPath(tmpDir, 'bun.lockb'), '{}')
 
       // When
@@ -96,6 +99,7 @@ describe('cleanup', () => {
       await expect(fileExists(joinPath(tmpDir, 'package-lock.json'))).resolves.toBe(false)
       await expect(fileExists(joinPath(tmpDir, 'yarn.lock'))).resolves.toBe(false)
       await expect(fileExists(joinPath(tmpDir, 'pnpm-lock.yaml'))).resolves.toBe(false)
+      await expect(fileExists(joinPath(tmpDir, 'bun.lock'))).resolves.toBe(false)
       await expect(fileExists(joinPath(tmpDir, 'bun.lockb'))).resolves.toBe(false)
     })
   })

--- a/packages/app/src/cli/services/init/template/cleanup.ts
+++ b/packages/app/src/cli/services/init/template/cleanup.ts
@@ -1,5 +1,5 @@
 import {rmdir, glob, fileExistsSync, unlinkFile} from '@shopify/cli-kit/node/fs'
-import {lockfiles, lockfilesForPackageManager, PackageManager} from '@shopify/cli-kit/node/node-package-manager'
+import {lockfiles, lockfilesByManager, PackageManager} from '@shopify/cli-kit/node/node-package-manager'
 import {joinPath} from '@shopify/cli-kit/node/path'
 
 export default async function cleanup(webOutputDirectory: string, packageManager: PackageManager) {
@@ -23,7 +23,7 @@ export default async function cleanup(webOutputDirectory: string, packageManager
 
   const gitPathPromises = gitPaths.map((path) => rmdir(path, {force: true}))
 
-  const lockfilesToKeep = new Set(lockfilesForPackageManager(packageManager))
+  const lockfilesToKeep = new Set(lockfilesByManager[packageManager])
   const lockfilePromises = lockfiles
     .filter((lockfile) => !lockfilesToKeep.has(lockfile))
     .map((lockfile) => {

--- a/packages/app/src/cli/services/init/template/cleanup.ts
+++ b/packages/app/src/cli/services/init/template/cleanup.ts
@@ -1,5 +1,5 @@
 import {rmdir, glob, fileExistsSync, unlinkFile} from '@shopify/cli-kit/node/fs'
-import {Lockfile, lockfilesByManager, PackageManager} from '@shopify/cli-kit/node/node-package-manager'
+import {lockfiles, lockfilesForPackageManager, PackageManager} from '@shopify/cli-kit/node/node-package-manager'
 import {joinPath} from '@shopify/cli-kit/node/path'
 
 export default async function cleanup(webOutputDirectory: string, packageManager: PackageManager) {
@@ -23,12 +23,13 @@ export default async function cleanup(webOutputDirectory: string, packageManager
 
   const gitPathPromises = gitPaths.map((path) => rmdir(path, {force: true}))
 
-  const lockfilePromises = Object.entries(lockfilesByManager)
-    .filter(([manager, lockfile]) => manager !== packageManager && lockfile)
-    .map(([_, lockfile]) => {
-      const path = joinPath(webOutputDirectory, lockfile as Lockfile)
+  const lockfilesToKeep = new Set(lockfilesForPackageManager(packageManager))
+  const lockfilePromises = lockfiles
+    .filter((lockfile) => !lockfilesToKeep.has(lockfile))
+    .map((lockfile) => {
+      const path = joinPath(webOutputDirectory, lockfile)
       if (fileExistsSync(path)) return unlinkFile(path)
-    }, [])
+    })
 
   return Promise.all([...gitPathPromises, ...lockfilePromises])
 }

--- a/packages/cli-kit/src/public/node/node-package-manager.test.ts
+++ b/packages/cli-kit/src/public/node/node-package-manager.test.ts
@@ -22,7 +22,7 @@ import {
   inferPackageManager,
   PackageManager,
   npmLockfile,
-  lockfilesForPackageManager,
+  lockfilesByManager,
 } from './node-package-manager.js'
 import {captureOutput, exec} from './system.js'
 import {inTemporaryDirectory, mkdir, touchFile, writeFile} from './fs.js'
@@ -133,9 +133,9 @@ describe('install', () => {
   })
 })
 
-describe('lockfilesForPackageManager', () => {
-  test('returns both Bun lockfile names', () => {
-    expect(lockfilesForPackageManager('bun')).toEqual(['bun.lockb', 'bun.lock'])
+describe('lockfilesByManager', () => {
+  test('maps Bun to both lockfile names', () => {
+    expect(lockfilesByManager.bun).toEqual(['bun.lockb', 'bun.lock'])
   })
 })
 

--- a/packages/cli-kit/src/public/node/node-package-manager.test.ts
+++ b/packages/cli-kit/src/public/node/node-package-manager.test.ts
@@ -22,6 +22,7 @@ import {
   inferPackageManager,
   PackageManager,
   npmLockfile,
+  lockfilesForPackageManager,
 } from './node-package-manager.js'
 import {captureOutput, exec} from './system.js'
 import {inTemporaryDirectory, mkdir, touchFile, writeFile} from './fs.js'
@@ -129,6 +130,12 @@ describe('install', () => {
     expect(mockedExec).toHaveBeenCalledWith(packageManager, ['install', 'arg1'], {
       cwd: directory,
     })
+  })
+})
+
+describe('lockfilesForPackageManager', () => {
+  test('returns both Bun lockfile names', () => {
+    expect(lockfilesForPackageManager('bun')).toEqual(['bun.lockb', 'bun.lock'])
   })
 })
 

--- a/packages/cli-kit/src/public/node/node-package-manager.ts
+++ b/packages/cli-kit/src/public/node/node-package-manager.ts
@@ -29,7 +29,7 @@ const modernBunLockfile = 'bun.lock'
 export const pnpmWorkspaceFile = 'pnpm-workspace.yaml'
 
 /** An array containing the lockfiles from all the package managers */
-export const lockfiles: Lockfile[] = [yarnLockfile, pnpmLockfile, npmLockfile, bunLockfile]
+export const lockfiles: Lockfile[] = [yarnLockfile, pnpmLockfile, npmLockfile, bunLockfile, modernBunLockfile]
 export const lockfilesByManager: Record<PackageManager, Lockfile | undefined> = {
   yarn: yarnLockfile,
   npm: npmLockfile,
@@ -38,7 +38,7 @@ export const lockfilesByManager: Record<PackageManager, Lockfile | undefined> = 
   homebrew: undefined,
   unknown: undefined,
 }
-export type Lockfile = 'yarn.lock' | 'package-lock.json' | 'pnpm-lock.yaml' | 'bun.lockb'
+export type Lockfile = 'yarn.lock' | 'package-lock.json' | 'pnpm-lock.yaml' | 'bun.lockb' | 'bun.lock'
 
 /**
  * A union type that represents the type of dependencies in the package.json
@@ -54,6 +54,13 @@ export type DependencyType = 'dev' | 'prod' | 'peer'
 export const packageManager = ['yarn', 'npm', 'pnpm', 'bun', 'homebrew', 'unknown'] as const
 export type PackageManager = (typeof packageManager)[number]
 type ProjectPackageManager = Extract<PackageManager, 'yarn' | 'npm' | 'pnpm' | 'bun'>
+
+export function lockfilesForPackageManager(packageManager: PackageManager): Lockfile[] {
+  if (packageManager === 'bun') return [bunLockfile, modernBunLockfile]
+
+  const lockfile = lockfilesByManager[packageManager]
+  return lockfile ? [lockfile] : []
+}
 
 /**
  * Returns an abort error that's thrown when the package manager can't be determined.

--- a/packages/cli-kit/src/public/node/node-package-manager.ts
+++ b/packages/cli-kit/src/public/node/node-package-manager.ts
@@ -30,13 +30,13 @@ export const pnpmWorkspaceFile = 'pnpm-workspace.yaml'
 
 /** An array containing the lockfiles from all the package managers */
 export const lockfiles: Lockfile[] = [yarnLockfile, pnpmLockfile, npmLockfile, bunLockfile, modernBunLockfile]
-export const lockfilesByManager: Record<PackageManager, Lockfile | undefined> = {
-  yarn: yarnLockfile,
-  npm: npmLockfile,
-  pnpm: pnpmLockfile,
-  bun: bunLockfile,
-  homebrew: undefined,
-  unknown: undefined,
+export const lockfilesByManager: Record<PackageManager, Lockfile[]> = {
+  yarn: [yarnLockfile],
+  npm: [npmLockfile],
+  pnpm: [pnpmLockfile],
+  bun: [bunLockfile, modernBunLockfile],
+  homebrew: [],
+  unknown: [],
 }
 export type Lockfile = 'yarn.lock' | 'package-lock.json' | 'pnpm-lock.yaml' | 'bun.lockb' | 'bun.lock'
 
@@ -54,13 +54,6 @@ export type DependencyType = 'dev' | 'prod' | 'peer'
 export const packageManager = ['yarn', 'npm', 'pnpm', 'bun', 'homebrew', 'unknown'] as const
 export type PackageManager = (typeof packageManager)[number]
 type ProjectPackageManager = Extract<PackageManager, 'yarn' | 'npm' | 'pnpm' | 'bun'>
-
-export function lockfilesForPackageManager(packageManager: PackageManager): Lockfile[] {
-  if (packageManager === 'bun') return [bunLockfile, modernBunLockfile]
-
-  const lockfile = lockfilesByManager[packageManager]
-  return lockfile ? [lockfile] : []
-}
 
 /**
  * Returns an abort error that's thrown when the package manager can't be determined.


### PR DESCRIPTION
### WHY are these changes introduced?

No linked issue.

Shopify CLI already detects Bun projects from both `bun.lockb` and modern `bun.lock`, but app template cleanup only treated `bun.lockb` as Bun's lockfile. This could leave stale `bun.lock` files or `.gitignore` entries behind when initializing non-Bun app projects.

### WHAT is this pull request doing?

- Adds modern `bun.lock` to the shared lockfile list.
- Adds `lockfilesForPackageManager()` so Bun keeps both valid Bun lockfile names.
- Updates app template cleanup to remove unused modern Bun lockfiles for non-Bun projects.
- Adds focused regression coverage and a patch changeset.

### How to test your changes?

```bash
pnpm test packages/app/src/cli/services/init/template/cleanup.test.ts packages/cli-kit/src/public/node/node-package-manager.test.ts
pnpm --filter @shopify/cli-kit type-check
pnpm --filter @shopify/app type-check
pnpm --filter @shopify/cli-kit lint
pnpm --filter @shopify/app lint
```

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [x] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`
