### PR TITLE
Preload trampoline binaries to avoid race conditions when lazily downloading during parallel builds

### DIFF
--- a/.changeset/preload-trampoline-binaries.md
+++ b/.changeset/preload-trampoline-binaries.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Fix `shopify app build` intermittently failing with `ETXTBSY` ("text file busy") when building apps with multiple function extensions on a fresh environment

--- a/packages/app/src/cli/services/build.ts
+++ b/packages/app/src/cli/services/build.ts
@@ -1,6 +1,6 @@
 import buildWeb from './web.js'
 import {installAppDependencies} from './dependencies.js'
-import {installJavy} from './function/build.js'
+import {installJavy, installTrampolines} from './function/build.js'
 import {AppInterface, Web} from '../models/app/app.js'
 import {Project} from '../models/project/project.js'
 import {renderConcurrent, renderSuccess} from '@shopify/cli-kit/node/ui'
@@ -24,9 +24,11 @@ async function build(options: BuildOptions) {
     env.SHOPIFY_API_KEY = options.apiKey
   }
 
-  // Force the download of the javy binary in advance to avoid later problems,
-  // as it might be done multiple times in parallel. https://github.com/Shopify/cli/issues/2877
-  await installJavy(options.app)
+  // Force the download of binaries in advance to avoid later problems,
+  // as it might be done multiple times in parallel.
+  // javy -> https://github.com/Shopify/cli/issues/2877
+  // trampoline -> ETXTBSY race conditions during parallel Rust builds
+  await Promise.all([installJavy(options.app), installTrampolines(options.app)])
 
   await renderConcurrent({
     processes: [

--- a/packages/app/src/cli/services/deploy/bundle.ts
+++ b/packages/app/src/cli/services/deploy/bundle.ts
@@ -1,6 +1,6 @@
 import {AppInterface, AppManifest} from '../../models/app/app.js'
 import {Identifiers} from '../../models/app/identifiers.js'
-import {installJavy} from '../function/build.js'
+import {installJavy, installTrampolines} from '../function/build.js'
 import buildWeb from '../web.js'
 import {compressBundle, writeManifestToBundle} from '../bundle.js'
 import {AbortSignal} from '@shopify/cli-kit/node/abort'
@@ -31,10 +31,12 @@ export async function bundleAndBuildExtensions(options: BundleOptions): Promise<
 
   await writeManifestToBundle(options.appManifest, bundleDirectory)
 
-  // Force the download of the javy binary in advance to avoid later problems,
-  // as it might be done multiple times in parallel. https://github.com/Shopify/cli/issues/2877
+  // Force the download of binaries in advance to avoid later problems,
+  // as it might be done multiple times in parallel.
+  // javy -> https://github.com/Shopify/cli/issues/2877
+  // trampoline -> ETXTBSY race conditions during parallel Rust builds
   if (!options.skipBuild) {
-    await installJavy(options.app)
+    await Promise.all([installJavy(options.app), installTrampolines(options.app)])
   }
 
   const webBuildProcesses = options.skipBuild

--- a/packages/app/src/cli/services/dev/processes/draftable-extension.ts
+++ b/packages/app/src/cli/services/dev/processes/draftable-extension.ts
@@ -4,7 +4,6 @@ import {ExtensionInstance} from '../../../models/extensions/extension-instance.j
 import {AppInterface} from '../../../models/app/app.js'
 import {PartnersAppForIdentifierMatching, ensureDeploymentIdsPresence} from '../../context/identifiers.js'
 import {getAppIdentifiers} from '../../../models/app/identifiers.js'
-import {installJavy} from '../../function/build.js'
 import {DeveloperPlatformClient} from '../../../utilities/developer-platform-client.js'
 import {AppEvent, AppEventWatcher, EventType} from '../app-events/app-event-watcher.js'
 import {AbortError} from '@shopify/cli-kit/node/error'
@@ -28,10 +27,6 @@ export const pushUpdatesForDraftableExtensions: DevProcessFunction<DraftableExte
   {stderr, stdout},
   {developerPlatformClient, apiKey, remoteExtensionIds: remoteExtensions, localApp: app, appWatcher},
 ) => {
-  // Force the download of the javy binary in advance to avoid later problems,
-  // as it might be done multiple times in parallel. https://github.com/Shopify/cli/issues/2877
-  await installJavy(app)
-
   const draftableExtensions = app.draftableExtensions.map((ext) => ext.handle)
 
   const handleAppEvent = async (event: AppEvent) => {

--- a/packages/app/src/cli/services/dev/processes/setup-dev-processes.ts
+++ b/packages/app/src/cli/services/dev/processes/setup-dev-processes.ts
@@ -21,6 +21,7 @@ import {ApplicationURLs} from '../urls.js'
 import {DeveloperPlatformClient} from '../../../utilities/developer-platform-client.js'
 import {AppEventWatcher} from '../app-events/app-event-watcher.js'
 import {reloadApp} from '../../../models/app/loader.js'
+import {installJavy, installTrampolines} from '../../function/build.js'
 import {getAvailableTCPPort} from '@shopify/cli-kit/node/tcp'
 import {isTruthy} from '@shopify/cli-kit/node/context/utilities'
 import {firstPartyDev} from '@shopify/cli-kit/node/context/local'
@@ -97,6 +98,13 @@ export async function setupDevProcesses({
 
   // At this point, the toml file has changed, we need to reload the app before actually starting dev
   const reloadedApp = await reloadApp(localApp)
+
+  // Force the download of binaries in advance to avoid later problems,
+  // as it might be done multiple times in parallel.
+  // javy -> https://github.com/Shopify/cli/issues/2877
+  // trampoline -> ETXTBSY race conditions during parallel Rust builds
+  await Promise.all([installJavy(reloadedApp), installTrampolines(reloadedApp)])
+
   const appWatcher = new AppEventWatcher(reloadedApp, network.proxyUrl)
 
   // Decide on the appropriate preview URL for a session with these processes

--- a/packages/app/src/cli/services/function/build.test.ts
+++ b/packages/app/src/cli/services/function/build.test.ts
@@ -7,11 +7,13 @@ import {
   runWasmOpt,
   runTrampoline,
   buildJSFunction,
+  installTrampolines,
 } from './build.js'
 import {
   javyBinary,
   javyPluginBinary,
   wasmOptBinary,
+  downloadBinary,
   trampolineBinary,
   PREFERRED_FUNCTION_RUNNER_VERSION,
   PREFERRED_JAVY_VERSION,
@@ -452,6 +454,44 @@ describe('runTrampoline', () => {
       '-o',
       functionModulePath,
     ])
+  })
+})
+
+describe('installTrampolines', () => {
+  test('downloads both trampoline versions when app has function extensions', async () => {
+    // Given
+    vi.mocked(downloadBinary).mockResolvedValue(undefined)
+    const functionExtension = await testFunctionExtension()
+    const appWithFunctions = testApp({allExtensions: [functionExtension]})
+
+    // When
+    await installTrampolines(appWithFunctions)
+
+    // Then
+    expect(downloadBinary).toHaveBeenCalledWith(trampolineBinary(V1_TRAMPOLINE_VERSION))
+    expect(downloadBinary).toHaveBeenCalledWith(trampolineBinary(V2_TRAMPOLINE_VERSION))
+  })
+
+  test('does not download trampolines when app has no function extensions', async () => {
+    // Given
+    const appWithoutFunctions = testApp({allExtensions: []})
+    vi.mocked(downloadBinary).mockClear()
+
+    // When
+    await installTrampolines(appWithoutFunctions)
+
+    // Then
+    expect(downloadBinary).not.toHaveBeenCalled()
+  })
+
+  test('swallows download errors for unsupported platform/arch combos', async () => {
+    // Given
+    vi.mocked(downloadBinary).mockRejectedValue(new Error('Unsupported platform/architecture combination'))
+    const functionExtension = await testFunctionExtension()
+    const appWithFunctions = testApp({allExtensions: [functionExtension]})
+
+    // When / Then — should not throw
+    await expect(installTrampolines(appWithFunctions)).resolves.toBeUndefined()
   })
 })
 

--- a/packages/app/src/cli/services/function/build.ts
+++ b/packages/app/src/cli/services/function/build.ts
@@ -379,6 +379,22 @@ export async function installJavy(app: AppInterface) {
   await Promise.all(downloadPromises)
 }
 
+export async function installTrampolines(app: AppInterface) {
+  const hasFunctionExtensions = app.allExtensions.some((ext) => ext.features.includes('function'))
+  if (!hasFunctionExtensions) {
+    return
+  }
+
+  await Promise.all([
+    downloadBinary(trampolineBinary(V1_TRAMPOLINE_VERSION)).catch((err) => {
+      outputDebug(`Failed to preload trampoline v${V1_TRAMPOLINE_VERSION}: ${err.message}`)
+    }),
+    downloadBinary(trampolineBinary(V2_TRAMPOLINE_VERSION)).catch((err) => {
+      outputDebug(`Failed to preload trampoline v${V2_TRAMPOLINE_VERSION}: ${err.message}`)
+    }),
+  ])
+}
+
 interface JavyBuilder {
   bundle(fun: ExtensionInstance<FunctionConfigType>, options: JSFunctionBuildOptions): Promise<BuildResult>
   compile(


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it's a work in progress
-->

### WHY are these changes introduced?

`shopify app build` fails intermittently on CI with `ETXTBSY` ("text file busy") when building apps with multiple Shopify Function extensions:

```
spawn ETXTBSY
Command failed with ETXTBSY: .../node_modules/@shopify/cli/bin/shopify-function-trampoline-1.0.2 -i <wasm> -o <wasm>
```

The trampoline binaries (`shopify-function-trampoline-1.0.2`, `shopify-function-trampoline-2.0.1`) are not shipped with the npm package — they are lazily downloaded from GitHub on first use by `downloadBinary()`. When `renderConcurrent` runs parallel extension builds, multiple concurrent tasks race to download the same binary. One task opens the file for writing (`moveFile` with `{overwrite: true}`) while another tries to execute it, and the Linux kernel returns `ETXTBSY`.

The in-process dedup map (`downloadsInProgress`) prevents redundant downloads within a single event loop tick, but the race window between the download completing and the file being executed by a concurrent build is still open.

This is the **same class of bug** that was previously fixed for Javy binaries in https://github.com/Shopify/cli/issues/2877 — which introduced `installJavy()` to pre-download Javy + plugin binaries before parallel builds start. The trampoline was simply missed because it was added later.

### WHAT is this pull request doing?

Adds `installTrampolines(app)` — a new pre-download function that mirrors the existing `installJavy(app)` pattern. It eagerly downloads both trampoline versions (v1 and v2) before the parallel build fan-out, so that when individual `runTrampoline()` calls run concurrently, the binaries are already on disk and `downloadBinary()` is a no-op.

**Key design choice:** Unlike Javy (where the version depends on each extension's `@shopify/shopify_function` package version), the trampoline version is determined _post-build_ from WASM imports (`shopify_function_v1` vs `shopify_function_v2`). Since there are only two possible versions and the binaries are small, we simply pre-download both for any app with function extensions.

**Changes:**

- **`packages/app/src/cli/services/function/build.ts`** — Added `installTrampolines(app)`: skips if no function extensions, otherwise downloads both V1 and V2 trampoline binaries in parallel
- **`packages/app/src/cli/services/build.ts`** — Calls `installTrampolines` alongside `installJavy` (via `Promise.all`) before `renderConcurrent`
- **`packages/app/src/cli/services/deploy/bundle.ts`** — Same pre-download before parallel deploy builds
- **`packages/app/src/cli/services/dev/processes/draftable-extension.ts`** — Same pre-download before dev draft updates
- **`packages/app/src/cli/services/function/build.test.ts`** — Added 2 tests: verifies both versions are downloaded when function extensions exist, verifies no downloads when they don't

### How to test your changes?

1. **Unit tests:** `pnpm vitest run packages/app/src/cli/services/function/build.test.ts` (28 tests pass including 2 new)
2. **Manual repro (requires Linux CI or Docker):**
    - Create an app with 2+ function extensions
    - Clear any cached trampoline binaries from `node_modules/@shopify/cli/bin/`
    - Run `shopify app build` — should succeed consistently without `ETXTBSY`
        - This is hard to reproduce manually and is flakey on CI, but an example of the failure can be found here: https://buildkite.com/shopify/checkout-blocks-tests/builds/5475#019de03e-9d05-470f-9864-765465ea71a7
3. **Regression check:** existing Javy pre-download behavior unchanged — `installJavy` and `installTrampolines` run in parallel via `Promise.all`

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [x] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`