### PR TITLE
[Refactor] Use relativePath utility in copyDirectoryContents

### DIFF
--- a/packages/cli-kit/src/public/node/fs.ts
+++ b/packages/cli-kit/src/public/node/fs.ts
@@ -1,5 +1,5 @@
 import {outputContent, outputToken, outputDebug} from './output.js'
-import {joinPath, normalizePath, resolvePath} from './path.js'
+import {joinPath, normalizePath, resolvePath, relativePath} from './path.js'
 import {OverloadParameters} from '../../private/common/ts/overloaded-parameters.js'
 import {getRandomName, RandomNameFamily} from '../common/string.js'
 import {systemTempDir} from '../../private/node/temp-dir.js'
@@ -730,14 +730,11 @@ export async function copyDirectoryContents(srcDir: string, destDir: string): Pr
   // Get all files and directories in the source directory
   const items = await glob(joinPath(srcDir, '**/*'))
 
-  const filesToCopy = []
-
-  for (const item of items) {
-    const relativePath = item.replace(srcDir, '').replace(/^[/\\]/, '')
-    const destPath = joinPath(destDir, relativePath)
-
-    filesToCopy.push(copyFile(item, destPath))
-  }
+  const filesToCopy = items.map((item) => {
+    const relPath = relativePath(srcDir, item)
+    const destPath = joinPath(destDir, relPath)
+    return copyFile(item, destPath)
+  })
 
   await Promise.all(filesToCopy)
 }


### PR DESCRIPTION
This PR refactors the `copyDirectoryContents` function in the `cli-kit` package to improve its readability and robustness.

- Replaced manual `.replace()` calls with the `relativePath` utility for consistent path calculation.
- Switched from an imperative loop with an array push to a more idiomatic `.map()` for collecting file-copy promises.
- Avoided variable shadowing by using `relPath` as the local variable name.

Verified with existing tests in `packages/cli-kit/src/public/node/fs.test.ts`.

---
*PR created automatically by Jules for task [12107833890165445825](https://jules.google.com/task/12107833890165445825) started by @gonzaloriestra*