### PR TITLE
[Tests] Replace filesystem mocks with real temporary directory in Notifier tests

### DIFF
--- a/packages/theme/src/cli/utilities/notifier.test.ts
+++ b/packages/theme/src/cli/utilities/notifier.test.ts
@@ -1,10 +1,9 @@
 import {Notifier} from './notifier.js'
 import {vi, describe, expect, test} from 'vitest'
 import {outputWarn} from '@shopify/cli-kit/node/output'
+import {inTemporaryDirectory, readFile} from '@shopify/cli-kit/node/fs'
+import {joinPath} from '@shopify/cli-kit/node/path'
 
-import fs from 'fs/promises'
-
-vi.mock('fs/promises')
 vi.mock('@shopify/cli-kit/node/output')
 
 describe('Notifier', () => {
@@ -26,13 +25,15 @@ describe('Notifier', () => {
   })
 
   test('updates file atime and mtime when path is not a URL', async () => {
-    const path = 'theme.update'
-    notifier = new Notifier(path)
-    const fileName = 'announcement.liquid'
+    await inTemporaryDirectory(async (tmpDir) => {
+      const path = joinPath(tmpDir, 'theme.update')
+      notifier = new Notifier(path)
+      const fileName = 'announcement.liquid'
 
-    await notifier.notify(fileName)
+      await notifier.notify(fileName)
 
-    expect(fs.writeFile).toHaveBeenCalledWith(path, fileName)
+      expect(await readFile(path)).toBe(fileName)
+    })
   })
 
   test('does not update if path is empty', async () => {
@@ -43,19 +44,20 @@ describe('Notifier', () => {
     await notifier.notify(fileName)
 
     expect(fetchSpy).not.toHaveBeenCalled()
-    expect(fs.appendFile).not.toHaveBeenCalled()
   })
 
   test('does not notify file when path is URL', async () => {
-    const url = 'https://example.com/notify'
-    const mockFetch = vi.spyOn(global, 'fetch').mockResolvedValue(new Response())
-    notifier = new Notifier(url)
-    const fileName = 'announcement.liquid'
+    await inTemporaryDirectory(async (tmpDir) => {
+      const url = 'https://example.com/notify'
+      const mockFetch = vi.spyOn(global, 'fetch').mockResolvedValue(new Response())
+      notifier = new Notifier(url)
+      const fileName = 'announcement.liquid'
+      const path = joinPath(tmpDir, 'theme.update')
 
-    await notifier.notify(fileName)
+      await notifier.notify(fileName)
 
-    expect(mockFetch).toHaveBeenCalled()
-    expect(fs.appendFile).not.toHaveBeenCalled()
+      expect(mockFetch).toHaveBeenCalled()
+    })
   })
 
   test('prints error if response is not successful', async () => {
@@ -85,15 +87,14 @@ describe('Notifier', () => {
   })
 
   test('outputs error if file update fails', async () => {
-    const invalidPath = 'dir/file:theme.update'
-    vi.spyOn(fs, 'writeFile').mockRejectedValue(new Error('No such file or directory'))
+    const invalidPath = '/non/existent/directory/theme.update'
     notifier = new Notifier(invalidPath)
     const fileName = 'announcement.liquid'
 
     await notifier.notify(fileName)
 
     expect(outputWarn).toHaveBeenCalledWith(
-      `Failed to notify filechange listener at ${invalidPath}: No such file or directory`,
+      expect.stringContaining(`Failed to notify filechange listener at ${invalidPath}`),
     )
   })
 })


### PR DESCRIPTION
This PR improves the test quality of `notifier.test.ts` by replacing filesystem mocks with real filesystem interactions using temporary directories.

Specifically:
- Removed `vi.mock('fs/promises')`.
- Integrated `inTemporaryDirectory` and `readFile` from `@shopify/cli-kit/node/fs`.
- Updated tests to verify that files are correctly written to the filesystem.
- Refactored the error handling test to use a naturally failing filesystem operation.
- Removed redundant assertions on unused `fs.appendFile`.

These changes make the tests more robust against implementation details and ensure they are testing actual behavior in a deterministic, isolated environment.

---
*PR created automatically by Jules for task [6840211217554415176](https://jules.google.com/task/6840211217554415176) started by @gonzaloriestra*