### PR TITLE
Fix Spawn ETXTBSY bug

### DIFF
--- a/.changeset/common-jokes-hide.md
+++ b/.changeset/common-jokes-hide.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Fix Spawn ETXTBSY bug with multiple Functions using trampoline binaries

--- a/packages/app/src/cli/services/function/binaries.test.ts
+++ b/packages/app/src/cli/services/function/binaries.test.ts
@@ -11,7 +11,7 @@ import {
   V2_TRAMPOLINE_VERSION,
 } from './binaries.js'
 import {fetch, Response} from '@shopify/cli-kit/node/http'
-import {fileExists, removeFile} from '@shopify/cli-kit/node/fs'
+import {fileExists, removeFile, writeFile} from '@shopify/cli-kit/node/fs'
 import {describe, expect, test, vi} from 'vitest'
 import {gzipSync} from 'zlib'
 
@@ -172,6 +172,52 @@ describe('javy', () => {
 
     // Then
     expect(fetch).toHaveBeenCalledOnce()
+    await expect(fileExists(javy.path)).resolves.toBeTruthy()
+  })
+
+  test('does not return early when file exists but rename is in progress', async () => {
+    // Given
+    await removeFile(javy.path)
+    await expect(fileExists(javy.path)).resolves.toBeFalsy()
+
+    let resolveDownload!: () => void
+    const blockDownload = new Promise<void>((resolve) => {
+      resolveDownload = resolve
+    })
+
+    vi.mocked(fetch).mockImplementation(async () => {
+      await blockDownload
+      return new Response(gzipSync('javy binary'))
+    })
+
+    // When
+    // Start first download — will block at fetch
+    const firstDownload = downloadBinary(javy)
+
+    // Allow first download to reach fetch and register in downloadsInProgress
+    await new Promise((resolve) => setTimeout(resolve, 1))
+
+    // Simulate file appearing on disk (e.g., non-atomic moveFile creating the destination
+    // while the download is still tracked as in-progress)
+    await writeFile(javy.path, 'incomplete binary')
+
+    // Start second download — should wait for first, not return early
+    let secondResolved = false
+    const secondDownload = downloadBinary(javy).then(() => {
+      secondResolved = true
+    })
+    await new Promise((resolve) => setTimeout(resolve, 1))
+
+    // Then — second download should be blocked waiting for first
+    expect(secondResolved).toBe(false)
+
+    // Complete the first download
+    resolveDownload()
+    await Promise.all([firstDownload, secondDownload])
+
+    // Only one fetch should have been made
+    expect(fetch).toHaveBeenCalledOnce()
+    expect(secondResolved).toBe(true)
     await expect(fileExists(javy.path)).resolves.toBeTruthy()
   })
 })

--- a/packages/app/src/cli/services/function/binaries.ts
+++ b/packages/app/src/cli/services/function/binaries.ts
@@ -230,7 +230,11 @@ export function trampolineBinary(version: string) {
 const downloadsInProgress = new Map<string, Promise<void>>()
 
 export async function downloadBinary(bin: DownloadableBinary) {
-  const isDownloaded = await fileExists(bin.path)
+  // If the file exists but its download is still in progress, the file cannot be used yet and we
+  // must wait for the download process to finish first.
+  // The `downloadsInProgress` check must happen after the async operation so the next `get` check
+  // runs in the same microtask.
+  const isDownloaded = (await fileExists(bin.path)) && !downloadsInProgress.has(bin.path)
   if (isDownloaded) {
     return
   }


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it's a work in progress
-->

### WHY are these changes introduced?

#7438 mentioned seeing the following in Linux CI environments:

```
spawn ETXTBSY
Command failed with ETXTBSY: .../node_modules/@shopify/cli/bin/shopify-function-trampoline-1.0.2 -i <wasm> -o <wasm>
```

I think the source of the bug is that `moveFile` is making a directory entry visible to `fs` but with a kernel lock so we need to account for that in `downloadBinary`.

### WHAT is this pull request doing?

I've updated the `isDownloaded` check to ensure the download process for that file isn't still in progress before we return that the download process is complete. If the file exists but the download process is still in progress, we immediately get the promise for the download in progress and await on it.

When `moveFile` is resolved in the promise performing the download, the kernel lock that was triggering the `ETXTBSY` on spawn should be released, and then that will resolve the `downloadPromise` for anyone awaiting on it. So that _should_ clear up any `ETXTBSY` errors.

I've also added a test case. 

### How to test your changes?

1. Clear out any cached binaries in `node_modules/@shopify/cli/bin/`.
1. `pnpm shopify app build --path <path>` where `<path>` is a path to a project with multiple Function extensions using one of the trampolines.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [x] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`
