### PR TITLE
[Security] Fix ineffective PID validation in treeKill

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,12 @@
+# Sentinel Security Learnings
+
+## 2025-05-22 - Ineffective Numeric Validation in `treeKill`
+
+**Vulnerability:**
+The `treeKill` utility used `Number.isNaN()` on a PID that had been converted to a string. `Number.isNaN()` does not perform type coercion and returns `false` for any non-number type, including strings that are not numeric. This meant that invalid PIDs, such as those containing shell injection characters, would bypass the check and be passed to `exec()` on Windows.
+
+**Learning:**
+Never use `Number.isNaN()` for validating that a string is a number. It is intended only for checking if a value of type `number` is `NaN`. For string numeric validation, a regular expression or a combination of `isNaN(Number(val))` is required.
+
+**Prevention:**
+Use `/^\d+$/` to validate that a string contains only digits before using it in security-sensitive operations like process management or shell commands.

--- a/packages/cli-kit/src/public/node/tree-kill.test.ts
+++ b/packages/cli-kit/src/public/node/tree-kill.test.ts
@@ -1,0 +1,59 @@
+import {treeKill} from './tree-kill.js'
+import {describe, expect, test, vi} from 'vitest'
+
+describe('treeKill', () => {
+  test('rejects non-numeric string PID', () => {
+    // Given
+    const pid = '123; echo "hello"'
+    const callback = vi.fn()
+
+    // When
+    treeKill(pid, 'SIGTERM', true, callback)
+
+    // Then
+    expect(callback).toHaveBeenCalledWith(expect.any(Error))
+    expect((callback.mock.calls[0]![0] as Error).message).toBe('pid must be a number')
+  })
+
+  test('accepts numeric string PID', () => {
+    // Given
+    const pid = '12345'
+    const callback = vi.fn()
+
+    // When
+    // We expect it to proceed to actual process killing, which we didn't mock yet
+    // so it might fail with ESRCH or similar if PID doesn't exist, but it shouldn't
+    // fail the initial validation.
+    try {
+      treeKill(pid, 'SIGTERM', true, callback)
+      // eslint-disable-next-line no-catch-all/no-catch-all
+    } catch (error) {
+      // ignore
+    }
+
+    // Then
+    // If it passed validation, it would not have called callback with 'pid must be a number'
+    if (callback.mock.calls.length > 0) {
+      expect((callback.mock.calls[0]![0] as Error).message).not.toBe('pid must be a number')
+    }
+  })
+
+  test('accepts numeric PID', () => {
+    // Given
+    const pid = 12345
+    const callback = vi.fn()
+
+    // When
+    try {
+      treeKill(pid, 'SIGTERM', true, callback)
+      // eslint-disable-next-line no-catch-all/no-catch-all
+    } catch (error) {
+      // ignore
+    }
+
+    // Then
+    if (callback.mock.calls.length > 0) {
+      expect((callback.mock.calls[0]![0] as Error).message).not.toBe('pid must be a number')
+    }
+  })
+})

--- a/packages/cli-kit/src/public/node/tree-kill.ts
+++ b/packages/cli-kit/src/public/node/tree-kill.ts
@@ -52,7 +52,7 @@ function adaptedTreeKill(
 ): void {
   const rootPid = typeof pid === 'number' ? pid.toString() : pid
 
-  if (Number.isNaN(rootPid)) {
+  if (!/^\d+$/.test(rootPid)) {
     if (callback) {
       callback(new Error('pid must be a number'))
       return


### PR DESCRIPTION
The `treeKill` utility used `Number.isNaN()` on a string variable, which is ineffective for numeric validation as it returns `false` for non-numeric strings. This created a potential command injection risk on Windows where the PID is passed to `exec()`.

This PR replaces the flawed check with a robust regex validation `/^\d+$/` to ensure the PID is a valid numeric string.

How to test your changes?
Run the newly added tests:
`pnpm --filter cli-kit vitest run tree-kill`

---
*PR created automatically by Jules for task [2778250173359050246](https://jules.google.com/task/2778250173359050246) started by @gonzaloriestra*