### PR TITLE
[Refactor] Use robust path handling in copyDirectoryContents

### DIFF
--- a/packages/cli-kit/src/public/node/fs.ts
+++ b/packages/cli-kit/src/public/node/fs.ts
@@ -728,16 +728,13 @@ export async function copyDirectoryContents(srcDir: string, destDir: string): Pr
   }
 
   // Get all files and directories in the source directory
-  const items = await glob(joinPath(srcDir, '**/*'))
+  const relativePaths = await glob('**/*', {cwd: srcDir})
 
-  const filesToCopy = []
-
-  for (const item of items) {
-    const relativePath = item.replace(srcDir, '').replace(/^[/\\]/, '')
-    const destPath = joinPath(destDir, relativePath)
-
-    filesToCopy.push(copyFile(item, destPath))
-  }
-
-  await Promise.all(filesToCopy)
+  await Promise.all(
+    relativePaths.map((relativePath) => {
+      const srcPath = joinPath(srcDir, relativePath)
+      const destPath = joinPath(destDir, relativePath)
+      return copyFile(srcPath, destPath)
+    }),
+  )
 }


### PR DESCRIPTION
### Description
Refactored `copyDirectoryContents` in `packages/cli-kit/src/public/node/fs.ts` to improve robust path handling and simplify parallel task execution.

### Changes
- Updated `copyDirectoryContents` to use the `cwd` option in `glob`.
- Replaced manual relative path calculation with direct relative path retrieval.
- Simplified the loop into a `.map()` call wrapped in `Promise.all()`.
- Added documentation of this refactoring pattern to `.jules/refactor.md`.

### How to test your changes?
Run the following command to verify that the refactored code still passes its unit tests:
`pnpm --filter @shopify/cli-kit vitest run src/public/node/fs.test.ts`


---
*PR created automatically by Jules for task [8140256861223159334](https://jules.google.com/task/8140256861223159334) started by @gonzaloriestra*