### PR TITLE
[Refactor] Improve copyDirectoryContents efficiency and cleanup knip config

### DIFF
--- a/package.json
+++ b/package.json
@@ -199,7 +199,6 @@
           "**/graphql/**/generated/*.ts"
         ],
         "ignoreDependencies": [
-          "@graphql-typed-document-node/core",
           "@shopify/plugin-cloudflare"
         ],
         "vite": {
@@ -292,9 +291,7 @@
         "ignoreBinaries": [
           "open"
         ],
-        "ignoreDependencies": [
-          "@graphql-typed-document-node/core"
-        ],
+        "ignoreDependencies": [],
         "vite": {
           "config": [
             "vite.config.ts"

--- a/packages/cli-kit/src/public/node/fs.ts
+++ b/packages/cli-kit/src/public/node/fs.ts
@@ -727,17 +727,12 @@ export async function copyDirectoryContents(srcDir: string, destDir: string): Pr
     await mkdir(destDir)
   }
 
-  // Get all files and directories in the source directory
-  const items = await glob(joinPath(srcDir, '**/*'))
+  // Get all files in the source directory relative to srcDir
+  const items = await glob('**/*', {cwd: srcDir})
 
-  const filesToCopy = []
-
-  for (const item of items) {
-    const relativePath = item.replace(srcDir, '').replace(/^[/\\]/, '')
-    const destPath = joinPath(destDir, relativePath)
-
-    filesToCopy.push(copyFile(item, destPath))
-  }
-
-  await Promise.all(filesToCopy)
+  await Promise.all(
+    items.map((item) => {
+      return copyFile(joinPath(srcDir, item), joinPath(destDir, item))
+    }),
+  )
 }


### PR DESCRIPTION
### WHY are these changes introduced?

The current implementation of `copyDirectoryContents` was inefficiently performing manual string replacements on absolute paths to calculate relative destination paths. Additionally, the `knip` configuration contained stale `ignoreDependencies` entries.

### WHAT is this pull request doing?

1.  **Refactored `copyDirectoryContents`**: Used the `cwd` option in `glob` to directly obtain relative paths, eliminating the need for brittle manual path stripping. Simplified the copy loop using `Promise.all` with `map`.
2.  **Cleaned up `knip` configuration**: Removed unused `@graphql-typed-document-node/core` entries from `ignoreDependencies` in `package.json` for both `packages/app` and `packages/cli-kit`.
3.  **Documented Learnings**: Added key performance and refactoring insights to `.jules/refactor.md` and `.jules/bolt.md`.

### How to test your changes?

Run the unit tests for `cli-kit`'s filesystem utilities:
```bash
pnpm --filter @shopify/cli-kit vitest run src/public/node/fs.test.ts
```

Verify that `knip` no longer reports configuration hints:
```bash
pnpm knip
```

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type] and added a changeset with `pnpm changeset add`


---
*PR created automatically by Jules for task [1894134398803177433](https://jules.google.com/task/1894134398803177433) started by @gonzaloriestra*