### PR TITLE
[Performance] Optimize copyDirectoryContents using glob cwd

### DIFF
--- a/packages/cli-kit/src/public/node/fs.ts
+++ b/packages/cli-kit/src/public/node/fs.ts
@@ -728,15 +728,16 @@ export async function copyDirectoryContents(srcDir: string, destDir: string): Pr
   }
 
   // Get all files and directories in the source directory
-  const items = await glob(joinPath(srcDir, '**/*'))
+  // Optimization: Using the `cwd` option in `glob` is more efficient than passing an absolute path
+  // and then manually stripping the source directory string to calculate relative destination paths.
+  const items = await glob('**/*', {cwd: srcDir})
 
   const filesToCopy = []
 
   for (const item of items) {
-    const relativePath = item.replace(srcDir, '').replace(/^[/\\]/, '')
-    const destPath = joinPath(destDir, relativePath)
+    const destPath = joinPath(destDir, item)
 
-    filesToCopy.push(copyFile(item, destPath))
+    filesToCopy.push(copyFile(joinPath(srcDir, item), destPath))
   }
 
   await Promise.all(filesToCopy)


### PR DESCRIPTION
### WHY are these changes introduced?

The `copyDirectoryContents` function used an absolute path with `glob`, followed by manual string replacement to calculate relative paths for the destination. This is less efficient and more error-prone than using the built-in `cwd` option in `glob`.

### WHAT is this pull request doing?

- Updates `copyDirectoryContents` to use the `cwd` option in the `glob` call.
- Simplifies the relative path calculation by removing manual string stripping.
- Reduces memory overhead by working with relative paths during the globbing process.

### How to test your changes?

Run the unit tests for `cli-kit`:
`pnpm --filter @shopify/cli-kit vitest run src/public/node/fs.test.ts`

Verification command:
`pnpm nx lint cli-kit && pnpm nx type-check cli-kit`

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [15242362493404967590](https://jules.google.com/task/15242362493404967590) started by @gonzaloriestra*