### PR TITLE
[Performance] Optimize copyDirectoryContents with glob cwd

### DIFF
--- a/packages/cli-kit/src/public/node/fs.ts
+++ b/packages/cli-kit/src/public/node/fs.ts
@@ -728,15 +728,16 @@ export async function copyDirectoryContents(srcDir: string, destDir: string): Pr
   }
 
   // Get all files and directories in the source directory
-  const items = await glob(joinPath(srcDir, '**/*'))
+  // Optimization: Use `cwd` to get relative paths directly from glob.
+  // This avoids expensive absolute path manipulation and prefix stripping.
+  const items = await glob('**/*', {cwd: srcDir})
 
   const filesToCopy = []
 
   for (const item of items) {
-    const relativePath = item.replace(srcDir, '').replace(/^[/\\]/, '')
-    const destPath = joinPath(destDir, relativePath)
+    const destPath = joinPath(destDir, item)
 
-    filesToCopy.push(copyFile(item, destPath))
+    filesToCopy.push(copyFile(joinPath(srcDir, item), destPath))
   }
 
   await Promise.all(filesToCopy)


### PR DESCRIPTION
### What was improved
Optimized the `copyDirectoryContents` function in `@shopify/cli-kit` to be faster and more robust by using the `cwd` option in `glob`.

### Why it was improved
The previous implementation fetched absolute paths and then used string replacement and regex to strip the source directory prefix for every item found. This is inefficient, especially for directories with many files, and can be brittle due to path separator differences. Using `cwd` allows the globbing engine to provide relative paths directly, which is faster and more reliable.

### How to test your changes?
You can verify that directory copying still works correctly by running the existing unit tests:
```bash
cd packages/cli-kit
pnpm vitest run src/public/node/fs.test.ts
```
The tests `copyDirectoryContents > copies the contents of source directory to destination directory` and its variations confirm that files and nested directories are still copied as expected.


---
*PR created automatically by Jules for task [3559203706858836990](https://jules.google.com/task/3559203706858836990) started by @gonzaloriestra*