### PR TITLE
[Refactor] Optimize copyDirectoryContents and clean up knip config

### DIFF
--- a/package.json
+++ b/package.json
@@ -199,7 +199,6 @@
           "**/graphql/**/generated/*.ts"
         ],
         "ignoreDependencies": [
-          "@graphql-typed-document-node/core",
           "@shopify/plugin-cloudflare"
         ],
         "vite": {
@@ -292,9 +291,7 @@
         "ignoreBinaries": [
           "open"
         ],
-        "ignoreDependencies": [
-          "@graphql-typed-document-node/core"
-        ],
+        "ignoreDependencies": [],
         "vite": {
           "config": [
             "vite.config.ts"

--- a/packages/cli-kit/src/public/node/fs.ts
+++ b/packages/cli-kit/src/public/node/fs.ts
@@ -728,16 +728,12 @@ export async function copyDirectoryContents(srcDir: string, destDir: string): Pr
   }
 
   // Get all files and directories in the source directory
-  const items = await glob(joinPath(srcDir, '**/*'))
+  const items = await glob('**/*', {cwd: srcDir})
 
-  const filesToCopy = []
-
-  for (const item of items) {
-    const relativePath = item.replace(srcDir, '').replace(/^[/\\]/, '')
-    const destPath = joinPath(destDir, relativePath)
-
-    filesToCopy.push(copyFile(item, destPath))
-  }
+  const filesToCopy = items.map((item) => {
+    const destPath = joinPath(destDir, item)
+    return copyFile(joinPath(srcDir, item), destPath)
+  })
 
   await Promise.all(filesToCopy)
 }


### PR DESCRIPTION
Refactored `copyDirectoryContents` in `packages/cli-kit/src/public/node/fs.ts` to use the `cwd` option in `glob` for better robustness and readability. Also removed unused `ignoreDependencies` from the `knip` configuration in the root `package.json` as flagged by `knip`. verified with tests and linting.

---
*PR created automatically by Jules for task [9802385123648497733](https://jules.google.com/task/9802385123648497733) started by @gonzaloriestra*