### PR TITLE
Fix release workflow by removing oclif manifest generation for some packages

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -41,15 +41,14 @@
   "files": [
     "/dist",
     "/assets",
-    "/templates",
-    "/oclif.manifest.json"
+    "/templates"
   ],
   "scripts": {
     "build": "nx build",
     "clean": "nx clean",
     "lint": "nx lint",
     "lint:fix": "nx lint:fix",
-    "prepack": "NODE_ENV=production pnpm nx build && pnpm oclif manifest && cp ../../README.md README.md",
+    "prepack": "NODE_ENV=production pnpm nx build && cp ../../README.md README.md",
     "vitest": "vitest",
     "type-check": "nx type-check"
   },

--- a/packages/plugin-cloudflare/package.json
+++ b/packages/plugin-cloudflare/package.json
@@ -22,8 +22,7 @@
   "module": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
-    "/dist",
-    "/oclif.manifest.json"
+    "/dist"
   ],
   "exports": {
     "./hooks/*": {
@@ -36,7 +35,7 @@
     "clean": "nx clean",
     "lint": "nx lint",
     "lint:fix": "nx lint:fix",
-    "prepack": "NODE_ENV=production pnpm nx build && pnpm oclif manifest && cp ../../README.md README.md",
+    "prepack": "NODE_ENV=production pnpm nx build && cp ../../README.md README.md",
     "vitest": "vitest",
     "type-check": "nx type-check"
   },

--- a/packages/plugin-did-you-mean/package.json
+++ b/packages/plugin-did-you-mean/package.json
@@ -17,8 +17,7 @@
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
-    "/dist",
-    "/oclif.manifest.json"
+    "/dist"
   ],
   "exports": {
     ".": {
@@ -31,7 +30,7 @@
     "clean": "nx clean",
     "lint": "nx lint",
     "lint:fix": "nx lint:fix",
-    "prepack": "NODE_ENV=production pnpm nx build && pnpm oclif manifest && cp ../../README.md README.md",
+    "prepack": "NODE_ENV=production pnpm nx build && cp ../../README.md README.md",
     "vitest": "vitest",
     "type-check": "nx type-check"
   },

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -22,15 +22,14 @@
     }
   },
   "files": [
-    "/dist",
-    "/oclif.manifest.json"
+    "/dist"
   ],
   "scripts": {
     "build": "nx build",
     "clean": "nx clean",
     "lint": "nx lint",
     "lint:fix": "nx lint:fix",
-    "prepack": "NODE_ENV=production pnpm nx build && pnpm oclif manifest && cp ../../README.md README.md",
+    "prepack": "NODE_ENV=production pnpm nx build && cp ../../README.md README.md",
     "vitest": "vitest",
     "type-check": "nx type-check"
   },

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -22,8 +22,7 @@
     }
   },
   "files": [
-    "/dist",
-    "/oclif.manifest.json"
+    "/dist"
   ],
   "scripts": {
     "build": "nx build",
@@ -31,7 +30,7 @@
     "clean": "nx clean",
     "lint": "nx lint",
     "lint:fix": "nx lint:fix",
-    "prepack": "NODE_ENV=production pnpm nx build && pnpm oclif manifest && cp ../../README.md README.md",
+    "prepack": "NODE_ENV=production pnpm nx build && cp ../../README.md README.md",
     "vitest": "vitest",
     "type-check": "nx type-check"
   },


### PR DESCRIPTION
### WHY are these changes introduced?

The releases started failing when publishing `@shopify/plugin-cloudflare` with `Cannot find package '@oclif/plugin-legacy' imported from .../oclif/lib/commands/manifest.js`. [Example](https://github.com/Shopify/cli/actions/runs/25305749488/job/74181222825).

Root cause: #7159 added `pnpm oclif manifest` to the `prepack` of every package listing `oclif.manifest.json`. But some of them don't declare an `oclif` config block and the command fails. They don't need the manifest.

### WHAT is this pull request doing?

For the five packages without an `oclif` config block, drops `pnpm oclif manifest` from their `prepack` script and removes the dead `"/oclif.manifest.json"` entry from their `files` array

### How to test your changes?

https://github.com/Shopify/cli/pull/7455#issuecomment-4369252306

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing, so I've added a changelog entry with `pnpm changeset add`