### PR TITLE
[Tests] Make 'refreshes extension url' test deterministic

### DIFF
--- a/packages/ui-extensions-server-kit/src/state/reducers/extensionServerReducer.test.ts
+++ b/packages/ui-extensions-server-kit/src/state/reducers/extensionServerReducer.test.ts
@@ -8,6 +8,7 @@ import {
   createFocusAction,
   createUnfocusAction,
 } from '../actions'
+import {vi} from 'vitest'
 
 import type {ExtensionServerState} from './types'
 
@@ -92,8 +93,11 @@ describe('extensionServerReducer()', () => {
     })
   })
 
-  // eslint-disable-next-line vitest/no-disabled-tests
-  test.skip('refreshes extension url', async () => {
+  test('refreshes extension url', () => {
+    vi.useFakeTimers()
+    const time1 = 1000
+    vi.setSystemTime(time1)
+
     const extension = mockExtension()
     const previousState: ExtensionServerState = {
       store: 'test-store.com',
@@ -105,20 +109,21 @@ describe('extensionServerReducer()', () => {
     const state1 = extensionServerReducer(previousState, action)
 
     const url1 = new URL(state1.extensions[0].assets.main.url)
-    const timestamp1 = url1.searchParams.get('lastUpdated') ?? ''
+    const timestamp1 = url1.searchParams.get('lastUpdated')
 
-    expect(timestamp1.length).toBeGreaterThan(0)
+    expect(timestamp1).toBe(time1.toString())
 
-    // sleep 1ms to guarantee new timestamp
-    await new Promise((resolve) => setTimeout(resolve, 1))
+    const time2 = 2000
+    vi.setSystemTime(time2)
 
     const state2 = extensionServerReducer(state1, action)
 
     const url2 = new URL(state2.extensions[0].assets.main.url)
-    const timestamp2 = url2.searchParams.get('lastUpdated') ?? ''
+    const timestamp2 = url2.searchParams.get('lastUpdated')
 
-    expect(timestamp2.length).toBeGreaterThan(0)
-    expect(timestamp1).not.toStrictEqual(timestamp2)
+    expect(timestamp2).toBe(time2.toString())
+
+    vi.useRealTimers()
   })
 
   describe('focus', () => {


### PR DESCRIPTION
### WHY are these changes introduced?

The test `refreshes extension url` in `packages/ui-extensions-server-kit/src/state/reducers/extensionServerReducer.test.ts` was skipped and relied on real-time passage (`setTimeout`) to verify timestamp changes. This is non-deterministic and can lead to flakiness.

### WHAT is this pull request doing?

- Unskips the `refreshes extension url` test.
- Refactors the test to use `vi.useFakeTimers()` and `vi.setSystemTime()`.
- Replaces loose assertions with exact timestamp checks.
- Removes the asynchronous `setTimeout` block, making the test synchronous and faster.

### How to test your changes?

Run the unit tests for the affected package:
```bash
pnpm --filter @shopify/ui-extensions-server-kit vitest run src/state/reducers/extensionServerReducer.test.ts
```

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible documentation changes
- [x] I've considered analytics changes to measure impact
- [x] The change is NOT user-facing.

---
*PR created automatically by Jules for task [8839888816816504392](https://jules.google.com/task/8839888816816504392) started by @gonzaloriestra*