### PR TITLE
[Refactor] Remove redundant Knip ignoreDependencies entries

### DIFF
--- a/package.json
+++ b/package.json
@@ -199,7 +199,6 @@
           "**/graphql/**/generated/*.ts"
         ],
         "ignoreDependencies": [
-          "@graphql-typed-document-node/core",
           "@shopify/plugin-cloudflare"
         ],
         "vite": {
@@ -292,9 +291,7 @@
         "ignoreBinaries": [
           "open"
         ],
-        "ignoreDependencies": [
-          "@graphql-typed-document-node/core"
-        ],
+        "ignoreDependencies": [],
         "vite": {
           "config": [
             "vite.config.ts"


### PR DESCRIPTION
### WHY are these changes introduced?

`pnpm knip` reported configuration hints about unused items in `ignoreDependencies`. Specifically, `@graphql-typed-document-node/core` was being ignored for `packages/app` and `packages/cli-kit` even though it is correctly detected by the tool.

### WHAT is this pull request doing?

This PR removes the redundant `@graphql-typed-document-node/core` entries from the `knip` configuration in the root `package.json`.

### How to test your changes?

Run the following command to verify that Knip no longer reports configuration hints:

```bash
pnpm knip
```

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [x] The change is user-facing — No.

Jules label applied.

---
*PR created automatically by Jules for task [4053997740607565272](https://jules.google.com/task/4053997740607565272) started by @gonzaloriestra*