### PR TITLE
Check JSON response for knip to avoid false positives

### DIFF
--- a/.github/workflows/tests-pr.yml
+++ b/.github/workflows/tests-pr.yml
@@ -87,7 +87,7 @@ jobs:
         with:
           node-version: ${{ env.DEFAULT_NODE_VERSION }}
       - name: Run knip
-        run: pnpm knip
+        run: node bin/run-knip-ci.js
 
   graphql-schema:
     if: ${{ github.event.pull_request.user.login != 'dependabot[bot]' }}

--- a/bin/run-knip-ci.js
+++ b/bin/run-knip-ci.js
@@ -1,0 +1,41 @@
+import {spawnSync} from 'node:child_process'
+
+// Run knip with the JSON reporter so a successful run still emits structured
+// output (e.g. {"files":[],"issues":[]}). An empty stdout therefore indicates
+// knip did not actually analyze the codebase — a silent-pass mode previously
+// observed — and must be treated as a failure to avoid false-green builds.
+const knip = spawnSync('pnpm', ['--silent', 'knip', '--reporter', 'json'], {
+  encoding: 'utf8',
+})
+
+if (knip.error) {
+  console.error(`::error::failed to spawn knip: ${knip.error.message}`)
+  process.exit(1)
+}
+
+let report
+try {
+  report = JSON.parse(knip.stdout)
+} catch {
+  console.error(
+    `::error::knip exited ${knip.status} but produced no parseable JSON output. Failing CI to avoid a false green.`,
+  )
+  console.error('Raw stdout:')
+  console.error(knip.stdout)
+  console.error('Raw stderr:')
+  console.error(knip.stderr)
+  process.exit(1)
+}
+
+if (!Array.isArray(report.files) || !Array.isArray(report.issues)) {
+  console.error('::error::knip output had unexpected shape')
+  console.error(JSON.stringify(report))
+  process.exit(1)
+}
+
+if (knip.status !== 0) {
+  // Findings: re-run with the default reporter so the log is human-readable.
+  spawnSync('pnpm', ['knip'], {stdio: 'inherit'})
+}
+
+process.exit(knip.status ?? 1)


### PR DESCRIPTION
### WHY are these changes introduced?

The `Knip (unused code check)` job can pass silently in CI even when knip never actually analyzes the codebase. We hit this in [PR #7463](https://github.com/Shopify/cli/pull/7463): the job exited 0 with no output and was reported as green, even though running `pnpm knip` locally on the exact same SHA reproducibly fails with two unused dependencies. A false-green knip job lets real findings slip into `main`.

### WHAT is this pull request doing?

- Adds `bin/run-knip-ci.js`, a small Node script that runs knip with `--reporter json` and validates the output before trusting the exit code.
  - Knip with `--reporter json` always emits a structured object on success (`{"files":[],"issues":[]}`), so an empty / unparseable stdout is a reliable signal that knip didn't actually run — in which case the script fails the job with a `::error::` annotation.
  - When knip reports findings, the script re-runs it with the default reporter so the human-readable report still appears in the build log.
- Simplifies the `Run knip` step in `.github/workflows/tests-pr.yml` to a single line: `node bin/run-knip-ci.js`.

### How to test your changes?

I verified all three relevant scenarios locally against the real workspace:

1. **Clean run** (current `main`): `node bin/run-knip-ci.js` exits 0 with no output.
2. **Findings**: temporarily remove `@graphql-typed-document-node/core` from `knip.workspaces["packages/app"].ignoreDependencies` in `package.json` → script re-runs knip in default reporter mode, prints `Unused dependencies (1) ...`, and exits 1.
3. **Silent-pass bug** (the regression we're guarding against): temporarily replace the root `scripts.knip` with `node -e ""` so `pnpm knip` exits 0 with empty stdout → script prints `::error::knip exited N but produced no parseable JSON output. Failing CI to avoid a false green.` and exits 1.

You can reproduce 2 and 3 by editing `package.json` as described above, running `node bin/run-knip-ci.js`, and reverting the edit.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing, so I've added a changelog entry with `pnpm changeset add`