### PR TITLE
Skip graphql schema check in forks

### DIFF
--- a/.github/workflows/tests-pr.yml
+++ b/.github/workflows/tests-pr.yml
@@ -90,7 +90,10 @@ jobs:
         run: pnpm knip
 
   graphql-schema:
-    if: ${{ github.event.pull_request.user.login != 'dependabot[bot]' }}
+    # Skip on dependabot PRs (no access to required secrets) and on PRs opened
+    # from forks (also no access to secrets), but always run on merge_group
+    # events since merge queue runs from the base repo.
+    if: ${{ github.event.pull_request.user.login != 'dependabot[bot]' && (github.event_name == 'merge_group' || github.event.pull_request.head.repo.full_name == github.repository) }}
     name: 'Check graphql-codegen has been run'
     runs-on: macos-latest
     timeout-minutes: 30


### PR DESCRIPTION
### WHY are these changes introduced?

The `Check graphql-codegen has been run` job relies on GH secrets to fetch internal schemas. GitHub does not expose secrets to workflows triggered from forks, so the job fails with auth errors on every fork PR — the same reason `dependabot[bot]` PRs are already skipped.

Example: https://github.com/Shopify/cli/pull/7436

### WHAT is this pull request doing?

Skip the job on PRs from forks, while still running for `merge_group` events (where the merge queue runs from the base repo and secrets are available).

### How to test your changes?

CI

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing, so I've added a changelog entry with `pnpm changeset add`