### PR TITLE
Remove unused 'Breaking change approval' job

### DIFF
--- a/.github/workflows/tests-pr.yml
+++ b/.github/workflows/tests-pr.yml
@@ -333,16 +333,5 @@ jobs:
       - name: Fail if breaking changes detected
         if: steps.check.outputs.has_breaking_changes == 'true'
         run: |
-          echo '::error::Breaking changes detected. A member of @shopify/dev_experience must approve the breaking-change-approval environment.'
+          echo '::error::Breaking changes detected. See the sticky comment on the PR for details.'
           exit 1
-
-  major-change-approval:
-    name: 'Breaking change approval'
-    needs: major-change-check
-    if: always() && needs.major-change-check.outputs.has_breaking_changes == 'true'
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    environment: breaking-change-approval
-    steps:
-      - name: Approved
-        run: echo '✅ Breaking changes approved by dev_experience team member'

--- a/workspace/src/major-change-check.js
+++ b/workspace/src/major-change-check.js
@@ -573,8 +573,6 @@ This PR contains changes that may break the existing contract.
 
 **@shopify/dev_experience** — this PR contains breaking changes that require coordination for the next major release.
 
-> 💬 Head to [#help-dev-platform](https://shopify.enterprise.slack.com/archives/C07UJ7UNMTK) to discuss timing and plan the release.
-
 `
 
   if (majorChangesets.length > 0) {

--- a/workspace/src/major-change-check.js
+++ b/workspace/src/major-change-check.js
@@ -571,7 +571,7 @@ function buildReport({majorChangesets, manifestChanges, schemaChanges}) {
 
 This PR contains changes that may break the existing contract.
 
-**@shopify/dev_experience** — this PR contains breaking changes that require coordination for the next major release. This check will remain failed until a member of the team approves the workflow run.
+**@shopify/dev_experience** — this PR contains breaking changes that require coordination for the next major release.
 
 > 💬 Head to [#help-dev-platform](https://shopify.enterprise.slack.com/archives/C07UJ7UNMTK) to discuss timing and plan the release.
 


### PR DESCRIPTION
### WHY are these changes introduced?

`tests-pr.yml` has two jobs for breaking changes:

- **`major-change-check`** ("Breaking change detection") — runs the script and `exit 1`s on any detected breaking change.
- **`major-change-approval`** ("Breaking change approval") — gated on the `breaking-change-approval` GitHub Environment, intended to require a `@shopify/dev_experience` member to approve before passing.

The second job's environment has **no protection rules** (`gh api repos/Shopify/cli/environments → "protection_rules": []`), so the "approval" job auto-passes in seconds with nobody actually approving anything. On PR #7466 the failure step ran at 09:46:20 and "Breaking change approval" turned green at 09:46:32 — 12s of "review", with zero human input. It's a placebo.

Worse, it's actively misleading: the script's failure message says "A member of @shopify/dev_experience must approve the breaking-change-approval environment", which sends people looking for a Settings → Environments → Required reviewers control that doesn't exist for them to use. PR #7469 (next in the stack) adds a real, working override — this PR removes the fake one so the two don't coexist.

### WHAT is this pull request doing?

#### `.github/workflows/tests-pr.yml`

- Removes the entire `major-change-approval` job.
- Updates the failure-step error message to drop the dead reference to the environment.

#### `workspace/src/major-change-check.js`

- Updates the sticky-comment report to remove the "this check will remain failed until a member of the team approves the workflow run" sentence — there is no workflow run to approve.

The `breaking-change-approval` GitHub Environment is **left alone in repo settings**. Other workflows might reference it, and deleting environments requires a separate API call. It's harmless to leave behind.

### How to test your changes?

```sh
cd workspace
node --test src/major-change-check.test.js
```

All tests still pass — this PR is workflow + comment-text only, no logic changes.

In CI, the "Breaking change approval" check name will simply stop appearing on new PR runs. The "Breaking change detection" check still runs (and after PR #7469 will be unblockable via a code-owner approval).

### Post-release steps

None.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows) — N/A
- [x] I've considered possible documentation changes
- [x] I've considered analytics changes to measure impact — N/A
- [ ] The change is user-facing — N/A (internal CI tooling, no changeset needed)