### PR TITLE
remove deprecated force flag from e2e tests

### DIFF
--- a/packages/e2e/tests/toml-config-invalid.spec.ts
+++ b/packages/e2e/tests/toml-config-invalid.spec.ts
@@ -28,7 +28,7 @@ test.describe('TOML config invalid', () => {
           JSON.stringify({name: `invalid-${label}`, version: '1.0.0', private: true}),
         )
 
-        const result = await cli.exec(['app', 'deploy', '--path', appDir, '--force'], {
+        const result = await cli.exec(['app', 'deploy', '--path', appDir, '--allow-updates', '--allow-deletes'], {
           timeout: CLI_TIMEOUT.medium,
         })
         const output = result.stdout + result.stderr

--- a/packages/e2e/tests/toml-config.spec.ts
+++ b/packages/e2e/tests/toml-config.spec.ts
@@ -29,7 +29,7 @@ test.describe('TOML config regression', () => {
       // Overwrite with fully populated TOML fixture (injects the real client_id)
       injectFixtureToml(appDir, FIXTURE_TOML, appName)
 
-      const result = await cli.exec(['app', 'deploy', '--path', appDir, '--force'], {
+      const result = await cli.exec(['app', 'deploy', '--path', appDir, '--allow-updates', '--allow-deletes'], {
         timeout: CLI_TIMEOUT.long,
       })
       const output = result.stdout + result.stderr


### PR DESCRIPTION
### WHY are these changes introduced?

The `--force` flag used in the TOML config e2e tests has been replaced with the more explicit `--allow-updates` and `--allow-deletes` flags, aligning the tests with the updated CLI interface for the `app deploy` command.

### WHAT is this pull request doing?

Replaces `--force` with `--allow-updates --allow-deletes` in the `app deploy` commands within the TOML config e2e tests (both the valid and invalid config specs).

### How to test your changes?

Run the affected e2e tests locally:

- `packages/e2e/tests/toml-config.spec.ts`
- `packages/e2e/tests/toml-config-invalid.spec.ts`

Verify that the deploy commands execute as expected with the new flags.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`