### PR TITLE
Use consistent label for extension-only template in app init

### DIFF
--- a/packages/app/src/cli/prompts/init/init.test.ts
+++ b/packages/app/src/cli/prompts/init/init.test.ts
@@ -50,7 +50,7 @@ describe('init', () => {
   })
 
   describe('buildNoneTemplate', () => {
-    test('returns hosted app label and URL when HOSTED_APPS is enabled', () => {
+    test('returns extension-only template URL when HOSTED_APPS is enabled', () => {
       // Given
       vi.mocked(isHostedAppsMode).mockReturnValue(true)
 
@@ -58,11 +58,10 @@ describe('init', () => {
       const got = buildNoneTemplate()
 
       // Then
-      expect(got.label).toBe('Build an extension-only app (Shopify-hosted Preact app home and extensions, no back-end)')
       expect(got.url).toBe('https://github.com/Shopify/shopify-app-template-extension-only')
     })
 
-    test('returns default label and URL when HOSTED_APPS is not set', () => {
+    test('returns default template URL when HOSTED_APPS is not set', () => {
       // Given
       vi.mocked(isHostedAppsMode).mockReturnValue(false)
 
@@ -70,7 +69,6 @@ describe('init', () => {
       const got = buildNoneTemplate()
 
       // Then
-      expect(got.label).toBe('Build an extension-only app')
       expect(got.url).toBe('https://github.com/Shopify/shopify-app-template-none')
     })
   })

--- a/packages/app/src/cli/prompts/init/init.ts
+++ b/packages/app/src/cli/prompts/init/init.ts
@@ -30,14 +30,11 @@ interface Template {
 }
 
 export function buildNoneTemplate(): Template {
-  const hostedAppsEnabled = isHostedAppsMode()
   return {
-    url: hostedAppsEnabled
+    url: isHostedAppsMode()
       ? 'https://github.com/Shopify/shopify-app-template-extension-only'
       : 'https://github.com/Shopify/shopify-app-template-none',
-    label: hostedAppsEnabled
-      ? 'Build an extension-only app (Shopify-hosted Preact app home and extensions, no back-end)'
-      : 'Build an extension-only app',
+    label: 'Build an extension-only app',
     visible: true,
   }
 }


### PR DESCRIPTION
## Summary
- The `HOSTED_APPS` env var no longer changes the label of the extension-only template option in `shopify app init` — it only swaps the template URL.
- Both modes now show "Build an extension-only app".

## Test plan
- [ ] `pnpm vitest run packages/app/src/cli/prompts/init/init.test.ts`
- [ ] `pnpm eslint packages/app/src/cli/prompts/init/init.ts packages/app/src/cli/prompts/init/init.test.ts`
- [ ] `pnpm nx type-check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)