### PR TITLE
prepend api_version to schema

### DIFF
--- a/packages/app/src/cli/services/build/extension.test.ts
+++ b/packages/app/src/cli/services/build/extension.test.ts
@@ -1,6 +1,7 @@
 import {buildFunctionExtension} from './extension.js'
 import {testFunctionExtension} from '../../models/app/app.test-data.js'
 import {buildGraphqlTypes, buildJSFunction, runWasmOpt, runTrampoline} from '../function/build.js'
+import {validateSchemaApiVersion} from '../function/schema-version.js'
 import {ExtensionInstance} from '../../models/extensions/extension-instance.js'
 import {FunctionConfigType} from '../../models/extensions/specifications/function.js'
 import {beforeEach, describe, expect, test, vi} from 'vitest'
@@ -12,6 +13,7 @@ import {joinPath} from '@shopify/cli-kit/node/path'
 
 vi.mock('@shopify/cli-kit/node/system')
 vi.mock('../function/build.js')
+vi.mock('../function/schema-version.js')
 vi.mock('proper-lockfile')
 vi.mock('@shopify/cli-kit/node/fs')
 
@@ -416,6 +418,26 @@ describe('buildFunctionExtension', () => {
     })
     expect(releaseLock).toHaveBeenCalled()
     expect(runWasmOpt).toHaveBeenCalled()
+  })
+
+  test('calls validateSchemaApiVersion with the values from the extension config', async () => {
+    // When
+    await expect(
+      buildFunctionExtension(extension, {
+        stdout,
+        stderr,
+        signal,
+        app,
+        environment: 'production',
+      }),
+    ).resolves.toBeUndefined()
+
+    // Then
+    expect(validateSchemaApiVersion).toHaveBeenCalledWith({
+      directory: extension.directory,
+      localIdentifier: extension.localIdentifier,
+      apiVersion: extension.configuration.api_version,
+    })
   })
 
   test('does not rebundle when build.path stays in the default output directory', async () => {

--- a/packages/app/src/cli/services/build/extension.ts
+++ b/packages/app/src/cli/services/build/extension.ts
@@ -2,6 +2,7 @@ import {formatBundleSize} from './bundle-size.js'
 import {AppInterface} from '../../models/app/app.js'
 import {bundleExtension} from '../extensions/bundle.js'
 import {buildGraphqlTypes, buildJSFunction, runTrampoline, runWasmOpt} from '../function/build.js'
+import {validateSchemaApiVersion} from '../function/schema-version.js'
 import {ExtensionInstance} from '../../models/extensions/extension-instance.js'
 import {FunctionConfigType} from '../../models/extensions/specifications/function.js'
 import {exec} from '@shopify/cli-kit/node/system'
@@ -156,11 +157,17 @@ export async function buildFunctionExtension(
   }
 
   try {
+    const functionConfiguration = (extension as ExtensionInstance<FunctionConfigType>).configuration
     const bundlePath = extension.outputPath
-    const relativeBuildPath =
-      (extension as ExtensionInstance<FunctionConfigType>).configuration.build?.path ?? extension.outputRelativePath
+    const relativeBuildPath = functionConfiguration.build?.path ?? extension.outputRelativePath
 
     extension.outputPath = joinPath(extension.directory, relativeBuildPath)
+
+    await validateSchemaApiVersion({
+      directory: extension.directory,
+      localIdentifier: extension.localIdentifier,
+      apiVersion: functionConfiguration.api_version,
+    })
 
     if (extension.isJavaScript) {
       await runCommandOrBuildJSFunction(extension, options)

--- a/packages/app/src/cli/services/function/schema-version.test.ts
+++ b/packages/app/src/cli/services/function/schema-version.test.ts
@@ -1,0 +1,109 @@
+import {
+  prependSchemaVersionHeader,
+  readSchemaApiVersion,
+  validateSchemaApiVersion,
+  SCHEMA_VERSION_MARKER_PREFIX,
+} from './schema-version.js'
+import {describe, expect, test} from 'vitest'
+import {AbortError} from '@shopify/cli-kit/node/error'
+import {inTemporaryDirectory, writeFile} from '@shopify/cli-kit/node/fs'
+import {joinPath} from '@shopify/cli-kit/node/path'
+
+function options(directory: string, apiVersion: string) {
+  return {directory, localIdentifier: 'my-function', apiVersion}
+}
+
+describe('prependSchemaVersionHeader', () => {
+  test('prepends a comment block with the version marker', () => {
+    const result = prependSchemaVersionHeader('type Query { id: ID }', '2025-10')
+
+    expect(result.startsWith(`${SCHEMA_VERSION_MARKER_PREFIX}2025-10\n`)).toBe(true)
+    expect(result.endsWith('type Query { id: ID }')).toBe(true)
+  })
+})
+
+describe('readSchemaApiVersion', () => {
+  test('returns the version when the marker is present', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      const path = joinPath(tmpDir, 'schema.graphql')
+      await writeFile(path, prependSchemaVersionHeader('type Query { id: ID }', '2025-10'))
+
+      await expect(readSchemaApiVersion(path)).resolves.toEqual('2025-10')
+    })
+  })
+
+  test('returns undefined when the file has no marker', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      const path = joinPath(tmpDir, 'schema.graphql')
+      await writeFile(path, '# some other comment\ntype Query { id: ID }')
+
+      await expect(readSchemaApiVersion(path)).resolves.toBeUndefined()
+    })
+  })
+
+  test('returns undefined when the file does not exist', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      await expect(readSchemaApiVersion(joinPath(tmpDir, 'missing.graphql'))).resolves.toBeUndefined()
+    })
+  })
+
+  test('does not match the marker once SDL content has started', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      const path = joinPath(tmpDir, 'schema.graphql')
+      // Marker buried after SDL content should be ignored.
+      await writeFile(path, `type Query { id: ID }\n${SCHEMA_VERSION_MARKER_PREFIX}2025-10\n`)
+
+      await expect(readSchemaApiVersion(path)).resolves.toBeUndefined()
+    })
+  })
+
+  test('trims surrounding whitespace from the marker value', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      const path = joinPath(tmpDir, 'schema.graphql')
+      await writeFile(path, `${SCHEMA_VERSION_MARKER_PREFIX}  2025-10  \ntype Query { id: ID }`)
+
+      await expect(readSchemaApiVersion(path)).resolves.toEqual('2025-10')
+    })
+  })
+})
+
+describe('validateSchemaApiVersion', () => {
+  test('no-ops when the schema file does not exist', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      await expect(validateSchemaApiVersion(options(tmpDir, '2025-10'))).resolves.toBeUndefined()
+    })
+  })
+
+  test('no-ops when the schema file has no version marker', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      await writeFile(joinPath(tmpDir, 'schema.graphql'), 'type Query { id: ID }')
+
+      await expect(validateSchemaApiVersion(options(tmpDir, '2025-10'))).resolves.toBeUndefined()
+    })
+  })
+
+  test('no-ops when the marker matches the configured api_version', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      await writeFile(
+        joinPath(tmpDir, 'schema.graphql'),
+        prependSchemaVersionHeader('type Query { id: ID }', '2025-10'),
+      )
+
+      await expect(validateSchemaApiVersion(options(tmpDir, '2025-10'))).resolves.toBeUndefined()
+    })
+  })
+
+  test('throws an AbortError with remediation when the marker is stale', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      await writeFile(
+        joinPath(tmpDir, 'schema.graphql'),
+        prependSchemaVersionHeader('type Query { id: ID }', '2025-07'),
+      )
+
+      const result = validateSchemaApiVersion(options(tmpDir, '2025-10'))
+
+      await expect(result).rejects.toThrow(AbortError)
+      await expect(result).rejects.toThrow(/2025-07[\s\S]*2025-10/)
+    })
+  })
+})

--- a/packages/app/src/cli/services/function/schema-version.ts
+++ b/packages/app/src/cli/services/function/schema-version.ts
@@ -1,0 +1,79 @@
+import {AbortError} from '@shopify/cli-kit/node/error'
+import {fileExists, readFile} from '@shopify/cli-kit/node/fs'
+import {joinPath} from '@shopify/cli-kit/node/path'
+import {outputContent, outputDebug, outputToken} from '@shopify/cli-kit/node/output'
+
+/**
+ * Marker used in the leading comments of `schema.graphql` to record the
+ * `api_version` the schema was fetched for. Format: `# api_version: <version>`.
+ */
+export const SCHEMA_VERSION_MARKER_PREFIX = '# api_version: '
+
+/**
+ * Prepends a versioned header to a schema definition. The header documents
+ * which `api_version` the schema was generated for so subsequent builds can
+ * detect when the on-disk schema is stale.
+ */
+export function prependSchemaVersionHeader(definition: string, apiVersion: string): string {
+  return `${SCHEMA_VERSION_MARKER_PREFIX}${apiVersion}\n\n${definition}`
+}
+
+/**
+ * Reads the `api_version` recorded in the leading comments of a schema file.
+ * Returns `undefined` if the file does not have the marker (e.g. hand-authored
+ * schemas, or schemas generated before this header existed).
+ */
+export async function readSchemaApiVersion(filePath: string): Promise<string | undefined> {
+  if (!(await fileExists(filePath))) {
+    outputDebug(`Could not determine api_version: schema file not found at ${filePath}.`)
+    return undefined
+  }
+
+  const contents = await readFile(filePath)
+  // The marker is always written as the first line by `prependSchemaVersionHeader`.
+  const firstLine = contents.split('\n', 1)[0]!
+  if (firstLine.startsWith(SCHEMA_VERSION_MARKER_PREFIX)) {
+    return firstLine.slice(SCHEMA_VERSION_MARKER_PREFIX.length).trim()
+  }
+
+  outputDebug(
+    `Could not determine api_version from ${filePath}: missing '${SCHEMA_VERSION_MARKER_PREFIX}' marker on the first line.`,
+  )
+  return undefined
+}
+
+/**
+ * Validates that `<extension>/schema.graphql` matches the `api_version`
+ * declared in the extension TOML. Throws an `AbortError` with a remediation
+ * pointing at `shopify app function schema` when the on-disk schema is stale.
+ *
+ * Silently no-ops when:
+ *   - the schema file does not exist (handled by codegen / out of scope here)
+ *   - the schema file has no version marker (hand-authored schema, or one
+ *     generated before this header existed)
+ */
+interface ValidateSchemaApiVersionOptions {
+  directory: string
+  localIdentifier: string
+  apiVersion: string
+}
+
+export async function validateSchemaApiVersion({
+  directory,
+  localIdentifier,
+  apiVersion,
+}: ValidateSchemaApiVersionOptions): Promise<void> {
+  const schemaPath = joinPath(directory, 'schema.graphql')
+  const versionFromSchema = await readSchemaApiVersion(schemaPath)
+  if (versionFromSchema === undefined) return
+  if (versionFromSchema === apiVersion) return
+
+  throw new AbortError(
+    outputContent`The ${outputToken.cyan(
+      'schema.graphql',
+    )} file for ${outputToken.cyan(localIdentifier)} was generated for api_version ${outputToken.yellow(
+      versionFromSchema,
+    )} but your function is now on api_version ${outputToken.yellow(apiVersion)}.`,
+    outputContent`Run ${outputToken.genericShellCommand('shopify app function schema')} to refresh it.`,
+  )
+}

--- a/packages/app/src/cli/services/generate-schema.test.ts
+++ b/packages/app/src/cli/services/generate-schema.test.ts
@@ -47,7 +47,7 @@ describe('generateSchemaService', () => {
 
       // Then
       const outputFile = await readFile(joinPath(extension.directory, 'schema.graphql'))
-      expect(outputFile).toEqual('schema')
+      expect(outputFile).toEqual(`# api_version: ${extension.configuration.api_version}\n\nschema`)
     })
   })
 
@@ -72,7 +72,7 @@ describe('generateSchemaService', () => {
       })
 
       // Then
-      expect(mockOutput).toHaveBeenCalledWith('schema')
+      expect(mockOutput).toHaveBeenCalledWith(`# api_version: ${extension.configuration.api_version}\n\nschema`)
     })
   })
 

--- a/packages/app/src/cli/services/generate-schema.ts
+++ b/packages/app/src/cli/services/generate-schema.ts
@@ -1,3 +1,4 @@
+import {prependSchemaVersionHeader} from './function/schema-version.js'
 import {DeveloperPlatformClient} from '../utilities/developer-platform-client.js'
 import {SchemaDefinitionByApiTypeQueryVariables} from '../api/graphql/functions/generated/schema-definition-by-api-type.js'
 import {SchemaDefinitionByTargetQueryVariables} from '../api/graphql/functions/generated/schema-definition-by-target.js'
@@ -22,7 +23,7 @@ export async function generateSchemaService(options: GenerateSchemaOptions) {
   const apiKey = app.configuration.client_id
   const {api_version: version, type, targeting} = extension.configuration
   const usingTargets = Boolean(targeting?.length)
-  const definition = await (usingTargets
+  const fetchedDefinition = await (usingTargets
     ? generateSchemaFromTarget({
         localIdentifier: extension.localIdentifier,
         developerPlatformClient,
@@ -40,6 +41,8 @@ export async function generateSchemaService(options: GenerateSchemaOptions) {
         version,
         orgId,
       }))
+
+  const definition = prependSchemaVersionHeader(fetchedDefinition, version)
 
   if (stdout) {
     outputResult(definition)


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it's a work in progress
-->

### WHY are these changes introduced?

Part of https://github.com/shop/issues-shopifyvm/issues/945

When a developer bumps `api_version` in a function's `shopify.extension.toml`, the on-disk `schema.graphql` becomes stale. The next `shopify app function build` then fails with cryptic `graphql-code-generator` errors like:

> Cannot query field "parentRelationship" on type "CartLine"

…with no indication that the underlying problem is a stale schema that just needs to be re-fetched. Today the build path is fully local — it never consults `api_version` and `schema.graphql` carries no version metadata, so staleness is undetectable.

The error surfaced gives them no actionable hint pointing at `shopify app function schema`.

### WHAT is this pull request doing?

Stamps the `api_version` into `schema.graphql` when `shopify app function schema` writes it, then validates that marker against the extension's TOML at the start of every `shopify app function build`. When they disagree, the build aborts up-front with an actionable message instead of letting codegen fail mysteriously.

**New file**

- `packages/app/src/cli/services/function/schema-version.ts` — self-contained helpers:
  - `prependSchemaVersionHeader(definition, version)` — adds a `# api_version: <ver>` marker line to the top of the SDL.
  - `readSchemaApiVersion(path)` — scans the leading comment block for the marker; returns `undefined` for missing files or legacy schemas (no marker).
  - `validateSchemaApiVersion({directory, localIdentifier, apiVersion})` — throws an `AbortError` with remediation when the on-disk marker disagrees with the configured `api_version`.

**Modified files**

- `services/generate-schema.ts` — `shopify app function schema` now writes the marker as the first line of the SDL (both file and stdout output).
- `services/build/extension.ts` — `buildFunctionExtension` invokes `validateSchemaApiVersion` once, up-front, before any function build work (typegen, esbuild, javy, wasm-opt, trampoline).

**Behavior**

- **Mismatched marker** → fails fast with:
  > The `schema.graphql` file for `<extension>` was generated for api_version `2025-07` but your function is now on api_version `2025-10`. Run `shopify app function schema` to refresh it.
- **Missing schema file** → no-op (out of scope for this change; codegen handles its own missing-file error).
- **Legacy schema with no marker** → no-op (don't break existing setups; the marker self-heals on the next `shopify app function schema`).

The schema header is a single line:
```
# api_version: 2025-10

<SDL>
```

### How to test your changes?

- Checkout this branch
- In a Shopify app with a function (e.g. discount function), set `api_version = "2025-07"` in the function's `shopify.extension.toml`.
- Run the schema command locally, and confirm `schema.graphql` now starts with `# api_version: 2025-07`.
```
pnpm shopify app function schema --path /Users/lopert/code/functions/schema-sync
```
- Bump `api_version` to `"2025-10"` in the TOML.
- Run the build command locally, it should abort immediately with a message naming both versions and pointing at `shopify app function schema`.
```
pnpm shopify app function build --path /Users/lopert/code/functions/schema-sync
```
- Run the schema command again to refresh, then the build command — it should now succeed.
- Sanity check the legacy path: delete the marker line from `schema.graphql` (simulate an older fetched file). The build command should behave exactly as it did before this change (no false-positive abort).

### Post-release steps

N/A.

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`
