### PR TITLE
Upload settings_schema.json before validator-consumer assets

### DIFF
--- a/.changeset/fix-theme-push-fresh-dynamic-source-defaults.md
+++ b/.changeset/fix-theme-push-fresh-dynamic-source-defaults.md
@@ -2,4 +2,4 @@
 '@shopify/theme': patch
 ---
 
-Upload `config/settings_schema.json` before block, section, section-group, and template assets so dynamic-source defaults referencing newly declared theme-level settings validate correctly on the first push to a fresh dev theme.
+Upload `config/settings_schema.json` before any other theme file. Fixes `theme push` failing on the first push when blocks or sections reference a `color_palette` theme setting.

--- a/.changeset/fix-theme-push-fresh-dynamic-source-defaults.md
+++ b/.changeset/fix-theme-push-fresh-dynamic-source-defaults.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Upload `config/settings_schema.json` before block, section, section-group, and template assets so dynamic-source defaults referencing newly declared theme-level settings validate correctly on the first push to a fresh dev theme.

--- a/packages/theme/src/cli/utilities/theme-fs.test.ts
+++ b/packages/theme/src/cli/utilities/theme-fs.test.ts
@@ -473,7 +473,8 @@ describe('theme-fs', () => {
         otherLiquidFiles,
         templateJsonFiles,
         otherJsonFiles,
-        configFiles,
+        configSchemaFile,
+        configDataFile,
         staticAssetFiles,
         contextualizedJsonFiles,
         blockLiquidFiles,
@@ -489,10 +490,8 @@ describe('theme-fs', () => {
       ])
       expect(otherJsonFiles).toEqual([{key: 'locales/en.default.json', checksum: '6'}])
       expect(templateJsonFiles).toEqual([{key: 'templates/404.json', checksum: '7'}])
-      expect(configFiles).toEqual([
-        {key: 'config/settings_schema.json', checksum: '8'},
-        {key: 'config/settings_data.json', checksum: '9'},
-      ])
+      expect(configSchemaFile).toEqual([{key: 'config/settings_schema.json', checksum: '8'}])
+      expect(configDataFile).toEqual([{key: 'config/settings_data.json', checksum: '9'}])
       expect(staticAssetFiles).toEqual([
         {key: 'assets/base.css', checksum: '1'},
         {key: 'assets/sparkle.gif', checksum: '3'},
@@ -511,15 +510,23 @@ describe('theme-fs', () => {
       const files: Checksum[] = []
 
       // When
-      const {sectionLiquidFiles, otherLiquidFiles, templateJsonFiles, otherJsonFiles, configFiles, staticAssetFiles} =
-        partitionThemeFiles(files)
+      const {
+        sectionLiquidFiles,
+        otherLiquidFiles,
+        templateJsonFiles,
+        otherJsonFiles,
+        configSchemaFile,
+        configDataFile,
+        staticAssetFiles,
+      } = partitionThemeFiles(files)
 
       // Then
       expect(sectionLiquidFiles).toEqual([])
       expect(otherLiquidFiles).toEqual([])
       expect(templateJsonFiles).toEqual([])
       expect(otherJsonFiles).toEqual([])
-      expect(configFiles).toEqual([])
+      expect(configSchemaFile).toEqual([])
+      expect(configDataFile).toEqual([])
       expect(staticAssetFiles).toEqual([])
     })
   })

--- a/packages/theme/src/cli/utilities/theme-fs.ts
+++ b/packages/theme/src/cli/utilities/theme-fs.ts
@@ -44,7 +44,8 @@ const THEME_PARTITION_REGEX = {
   layoutLiquidRegex: /^layout\/.+\.liquid$/,
   sectionLiquidRegex: /^sections\/.+\.liquid$/,
   blockLiquidRegex: /^blocks\/.+\.liquid$/,
-  configRegex: /^config\/(settings_schema|settings_data)\.json$/,
+  configSchemaRegex: /^config\/settings_schema\.json$/,
+  configDataRegex: /^config\/settings_data\.json$/,
   sectionJsonRegex: /^sections\/.+\.json$/,
   templateJsonRegex: /^templates\/.+\.json$/,
   jsonRegex: /^(?!config\/).*\.json$/,
@@ -465,7 +466,8 @@ export function partitionThemeFiles<T extends {key: string}>(files: T[]) {
   const templateJsonFiles: T[] = []
   const otherJsonFiles: T[] = []
   const contextualizedJsonFiles: T[] = []
-  const configFiles: T[] = []
+  const configSchemaFile: T[] = []
+  const configDataFile: T[] = []
   const staticAssetFiles: T[] = []
   const blockLiquidFiles: T[] = []
   const layoutFiles: T[] = []
@@ -482,8 +484,10 @@ export function partitionThemeFiles<T extends {key: string}>(files: T[]) {
       } else {
         otherLiquidFiles.push(file)
       }
-    } else if (THEME_PARTITION_REGEX.configRegex.test(fileKey)) {
-      configFiles.push(file)
+    } else if (THEME_PARTITION_REGEX.configSchemaRegex.test(fileKey)) {
+      configSchemaFile.push(file)
+    } else if (THEME_PARTITION_REGEX.configDataRegex.test(fileKey)) {
+      configDataFile.push(file)
     } else if (THEME_PARTITION_REGEX.jsonRegex.test(fileKey)) {
       if (THEME_PARTITION_REGEX.contextualizedJsonRegex.test(fileKey)) {
         contextualizedJsonFiles.push(file)
@@ -506,7 +510,8 @@ export function partitionThemeFiles<T extends {key: string}>(files: T[]) {
     templateJsonFiles,
     contextualizedJsonFiles,
     otherJsonFiles,
-    configFiles,
+    configSchemaFile,
+    configDataFile,
     staticAssetFiles,
     blockLiquidFiles,
     layoutFiles,

--- a/packages/theme/src/cli/utilities/theme-uploader.test.ts
+++ b/packages/theme/src/cli/utilities/theme-uploader.test.ts
@@ -1,12 +1,10 @@
 import {renderTasksToStdErr} from './theme-ui.js'
 import {fakeThemeFileSystem} from './theme-fs/theme-fs-mock-factory.js'
 import {
-  ChecksumWithSize,
   MAX_BATCH_BYTESIZE,
   MAX_BATCH_FILE_COUNT,
   MAX_UPLOAD_RETRY_COUNT,
   MINIMUM_THEME_ASSETS,
-  orderFilesToBeUploaded,
   uploadTheme,
   updateUploadErrors,
 } from './theme-uploader.js'
@@ -414,47 +412,6 @@ describe('theme-uploader', () => {
       [{key: 'config/settings_data.json'}],
       adminSession,
     )
-  })
-
-  test('orders settings_schema.json first and settings_data.json last in the dependent chain, surrounding every validator-consumer asset', () => {
-    // Regression for the fresh-theme bootstrap bug: blocks, sections, section-group
-    // JSONs and template JSONs run server-side validators that resolve dynamic-source
-    // defaults of the form `{{ settings.<theme_setting>.* }}` against the theme's
-    // currently-stored settings_schema.json. If the user's new schema lands AFTER
-    // those assets, validators see an empty schema and the first push errors out.
-    // settings_data.json must then go LAST because its values are validated against
-    // the freshly-uploaded schema and may reference earlier-uploaded sections/templates.
-    const file = (key: string): ChecksumWithSize => ({key, checksum: '_', size: 0})
-    const files: ChecksumWithSize[] = [
-      file('config/settings_schema.json'),
-      file('config/settings_data.json'),
-      file('layout/theme.liquid'),
-      file('blocks/quantity.liquid'),
-      file('sections/header.liquid'),
-      file('sections/header-group.json'),
-      file('templates/product.json'),
-      file('templates/product.context.uk.json'),
-    ]
-
-    const {dependentFiles} = orderFilesToBeUploaded(files)
-    const flat = dependentFiles.flat().map((f) => f.key)
-
-    expect(flat.at(0)).toBe('config/settings_schema.json')
-    expect(flat.at(-1)).toBe('config/settings_data.json')
-
-    const validatorConsumers = [
-      'blocks/quantity.liquid',
-      'sections/header.liquid',
-      'sections/header-group.json',
-      'templates/product.json',
-      'templates/product.context.uk.json',
-    ]
-    for (const key of validatorConsumers) {
-      const index = flat.indexOf(key)
-      expect(index, `${key} missing from dependent chain`).not.toBe(-1)
-      expect(index, `${key} should be after settings_schema.json`).toBeGreaterThan(0)
-      expect(index, `${key} should be before settings_data.json`).toBeLessThan(flat.length - 1)
-    }
   })
 
   test('should create batches for files when bulk upload file count limit is reached', async () => {

--- a/packages/theme/src/cli/utilities/theme-uploader.test.ts
+++ b/packages/theme/src/cli/utilities/theme-uploader.test.ts
@@ -1,10 +1,12 @@
 import {renderTasksToStdErr} from './theme-ui.js'
 import {fakeThemeFileSystem} from './theme-fs/theme-fs-mock-factory.js'
 import {
+  ChecksumWithSize,
   MAX_BATCH_BYTESIZE,
   MAX_BATCH_FILE_COUNT,
   MAX_UPLOAD_RETRY_COUNT,
   MINIMUM_THEME_ASSETS,
+  orderFilesToBeUploaded,
   uploadTheme,
   updateUploadErrors,
 } from './theme-uploader.js'
@@ -319,17 +321,19 @@ describe('theme-uploader', () => {
     await renderThemeSyncProgress()
 
     // Then
-    expect(bulkUploadThemeAssets).toHaveBeenCalledTimes(9)
+    expect(bulkUploadThemeAssets).toHaveBeenCalledTimes(10)
     // Minimum theme files start first
     expect(bulkUploadThemeAssets).toHaveBeenNthCalledWith(1, remoteTheme.id, MINIMUM_THEME_ASSETS, adminSession)
-    // Dependent assets start second
+    // settings_schema.json is uploaded first among dependent files so block / section /
+    // section-group / template validators can resolve dynamic-source defaults that
+    // reference theme-level settings declared in the schema.
     expect(bulkUploadThemeAssets).toHaveBeenNthCalledWith(
       2,
       remoteTheme.id,
-      [{key: 'layout/theme.liquid'}],
+      [{key: 'config/settings_schema.json'}],
       adminSession,
     )
-    // Independent assets start right after dependent assets start
+    // Independent assets fan out concurrently with the dependent chain.
     expect(bulkUploadThemeAssets).toHaveBeenNthCalledWith(
       3,
       remoteTheme.id,
@@ -346,15 +350,21 @@ describe('theme-uploader', () => {
       ],
       adminSession,
     )
-    // Dependent assets continue after the first batch of dependent assets ends
+    // Layout files come after the schema is in place.
     expect(bulkUploadThemeAssets).toHaveBeenNthCalledWith(
       4,
+      remoteTheme.id,
+      [{key: 'layout/theme.liquid'}],
+      adminSession,
+    )
+    expect(bulkUploadThemeAssets).toHaveBeenNthCalledWith(
+      5,
       remoteTheme.id,
       [{key: 'blocks/block.liquid'}],
       adminSession,
     )
     expect(bulkUploadThemeAssets).toHaveBeenNthCalledWith(
-      5,
+      6,
       remoteTheme.id,
       [
         {
@@ -365,7 +375,7 @@ describe('theme-uploader', () => {
     )
 
     expect(bulkUploadThemeAssets).toHaveBeenNthCalledWith(
-      6,
+      7,
       remoteTheme.id,
       [
         {
@@ -376,7 +386,7 @@ describe('theme-uploader', () => {
     )
 
     expect(bulkUploadThemeAssets).toHaveBeenNthCalledWith(
-      7,
+      8,
       remoteTheme.id,
       [
         {
@@ -387,7 +397,7 @@ describe('theme-uploader', () => {
     )
 
     expect(bulkUploadThemeAssets).toHaveBeenNthCalledWith(
-      8,
+      9,
       remoteTheme.id,
       [
         {
@@ -397,19 +407,54 @@ describe('theme-uploader', () => {
       adminSession,
     )
 
+    // settings_data.json must be last
     expect(bulkUploadThemeAssets).toHaveBeenNthCalledWith(
-      9,
+      10,
       remoteTheme.id,
-      [
-        {
-          key: 'config/settings_data.json',
-        },
-        {
-          key: 'config/settings_schema.json',
-        },
-      ],
+      [{key: 'config/settings_data.json'}],
       adminSession,
     )
+  })
+
+  test('orders settings_schema.json first and settings_data.json last in the dependent chain, surrounding every validator-consumer asset', () => {
+    // Regression for the fresh-theme bootstrap bug: blocks, sections, section-group
+    // JSONs and template JSONs run server-side validators that resolve dynamic-source
+    // defaults of the form `{{ settings.<theme_setting>.* }}` against the theme's
+    // currently-stored settings_schema.json. If the user's new schema lands AFTER
+    // those assets, validators see an empty schema and the first push errors out.
+    // settings_data.json must then go LAST because its values are validated against
+    // the freshly-uploaded schema and may reference earlier-uploaded sections/templates.
+    const file = (key: string): ChecksumWithSize => ({key, checksum: '_', size: 0})
+    const files: ChecksumWithSize[] = [
+      file('config/settings_schema.json'),
+      file('config/settings_data.json'),
+      file('layout/theme.liquid'),
+      file('blocks/quantity.liquid'),
+      file('sections/header.liquid'),
+      file('sections/header-group.json'),
+      file('templates/product.json'),
+      file('templates/product.context.uk.json'),
+    ]
+
+    const {dependentFiles} = orderFilesToBeUploaded(files)
+    const flat = dependentFiles.flat().map((f) => f.key)
+
+    expect(flat.at(0)).toBe('config/settings_schema.json')
+    expect(flat.at(-1)).toBe('config/settings_data.json')
+
+    const validatorConsumers = [
+      'blocks/quantity.liquid',
+      'sections/header.liquid',
+      'sections/header-group.json',
+      'templates/product.json',
+      'templates/product.context.uk.json',
+    ]
+    for (const key of validatorConsumers) {
+      const index = flat.indexOf(key)
+      expect(index, `${key} missing from dependent chain`).not.toBe(-1)
+      expect(index, `${key} should be after settings_schema.json`).toBeGreaterThan(0)
+      expect(index, `${key} should be before settings_data.json`).toBeLessThan(flat.length - 1)
+    }
   })
 
   test('should create batches for files when bulk upload file count limit is reached', async () => {

--- a/packages/theme/src/cli/utilities/theme-uploader.ts
+++ b/packages/theme/src/cli/utilities/theme-uploader.ts
@@ -202,7 +202,6 @@ function getRemoteFilesToBeDeleted(remoteChecksums: Checksum[], themeFileSystem:
 }
 
 // Contextual Json Files -> Json Files -> Liquid Files -> Config Files -> Static Asset Files
-// Config file consideration: Inverse of the upload order: data first (consumes schema), then schema.
 function orderFilesToBeDeleted(files: Checksum[]): Checksum[] {
   const fileSets = partitionThemeFiles(files)
   return [
@@ -317,7 +316,7 @@ function selectUploadableFiles(themeFileSystem: ThemeFileSystem, remoteChecksums
  * 1. config/settings_schema.json must be uploaded FIRST. It declares the
  *    theme-level settings that block / section / section-group / template
  *    validators resolve dynamic-source defaults against (e.g. defaults of
- *    the form {{ settings.<theme_setting>.<property> }}).
+ *    the form `{{ settings.<theme_setting>.<property> }}`).
  * 2. Layout files don't necessarily need to be the first, but they must be
  *    uploaded before templates.
  * 3. Liquid blocks need to be uploaded before sections
@@ -392,7 +391,7 @@ function calculateLocalChecksums(localThemeFileSystem: ThemeFileSystem): Checksu
   localThemeFileSystem.files.forEach((file, key) => {
     // Text files: use UTF-8 byte count
     // Binary files: use base64 length
-    const size = file.value ? Buffer.byteLength(file.value, 'utf8') : file.attachment?.length ?? 0
+    const size = file.value ? Buffer.byteLength(file.value, 'utf8') : (file.attachment?.length ?? 0)
 
     checksums.push({
       key,

--- a/packages/theme/src/cli/utilities/theme-uploader.ts
+++ b/packages/theme/src/cli/utilities/theme-uploader.ts
@@ -20,7 +20,7 @@ interface UploadOptions {
   multiEnvironment?: boolean
 }
 
-type ChecksumWithSize = Checksum & {size: number}
+export type ChecksumWithSize = Checksum & {size: number}
 type FileBatch = ChecksumWithSize[]
 
 /**
@@ -213,7 +213,9 @@ function orderFilesToBeDeleted(files: Checksum[]): Checksum[] {
     ...fileSets.blockLiquidFiles,
     ...fileSets.layoutFiles,
     ...fileSets.otherLiquidFiles,
-    ...fileSets.configFiles,
+    // Inverse of the upload order: data first (consumes schema), then schema.
+    ...fileSets.configDataFile,
+    ...fileSets.configSchemaFile,
     ...fileSets.staticAssetFiles,
   ]
 }
@@ -311,13 +313,26 @@ function selectUploadableFiles(themeFileSystem: ThemeFileSystem, remoteChecksums
  * We use this 2d array to batch files of the same type together
  * while maintaining the order between file types. The files with
  * dependencies we have are:
- * 1. Layout files don't necessarily need to be the first, but they must uploaded before templates.
- * 2. Liquid blocks need to be uploaded before sections
- * 3. Liquid sections need to be uploaded afterwards
- * 4. JSON sections need to be uploaded after sections
- * 5. JSON templates need to be uploaded after all sections and layouts
- * 6. Contextualized templates should be uploaded after as they are variations of templates
- * 7. Config files must be the last ones, but we need to upload config/settings_schema.json first, followed by config/settings_data.json
+ *
+ * 1. config/settings_schema.json must be uploaded FIRST. It declares the
+ *    theme-level settings that block / section / section-group / template
+ *    validators resolve dynamic-source defaults against (e.g. defaults of
+ *    the form {{ settings.<theme_setting>.<property> }}). On a fresh
+ *    theme the stored schema is empty, so any later asset whose schema
+ *    references a not-yet-declared theme setting fails server-side
+ *    validation. Uploading the schema first primes those references.
+ * 2. Layout files don't necessarily need to be the first, but they must be
+ *    uploaded before templates.
+ * 3. Liquid blocks need to be uploaded before sections
+ * 4. Liquid sections need to be uploaded afterwards
+ * 5. JSON sections need to be uploaded after sections
+ * 6. JSON templates need to be uploaded after all sections and layouts
+ * 7. Contextualized templates should be uploaded after as they are
+ *    variations of templates
+ * 8. config/settings_data.json must be uploaded LAST. Its current and
+ *    presets are validated against the freshly-uploaded
+ *    settings_schema.json, and presets can reference sections and
+ *    templates uploaded in earlier steps.
  *
  * The files with no dependencies we have are:
  * - The other Liquid files (for example, snippets, and liquid templates)
@@ -325,7 +340,7 @@ function selectUploadableFiles(themeFileSystem: ThemeFileSystem, remoteChecksums
  * - The static assets
  *
  */
-function orderFilesToBeUploaded(files: ChecksumWithSize[]): {
+export function orderFilesToBeUploaded(files: ChecksumWithSize[]): {
   independentFiles: ChecksumWithSize[][]
   dependentFiles: ChecksumWithSize[][]
 } {
@@ -336,13 +351,18 @@ function orderFilesToBeUploaded(files: ChecksumWithSize[]): {
     independentFiles: [fileSets.otherLiquidFiles, fileSets.otherJsonFiles, fileSets.staticAssetFiles],
     // Follow order of dependencies:
     dependentFiles: [
+      // Theme setting declarations must land before any asset that may
+      // reference them via dynamic-source defaults. See header comment.
+      fileSets.configSchemaFile,
       fileSets.layoutFiles,
       fileSets.blockLiquidFiles,
       fileSets.sectionLiquidFiles,
       fileSets.sectionJsonFiles,
       fileSets.templateJsonFiles,
       fileSets.contextualizedJsonFiles,
-      fileSets.configFiles,
+      // Settings values reference the schema we just uploaded, plus any
+      // sections / templates referenced by presets.
+      fileSets.configDataFile,
     ],
   }
 }

--- a/packages/theme/src/cli/utilities/theme-uploader.ts
+++ b/packages/theme/src/cli/utilities/theme-uploader.ts
@@ -20,7 +20,7 @@ interface UploadOptions {
   multiEnvironment?: boolean
 }
 
-export type ChecksumWithSize = Checksum & {size: number}
+type ChecksumWithSize = Checksum & {size: number}
 type FileBatch = ChecksumWithSize[]
 
 /**
@@ -202,6 +202,7 @@ function getRemoteFilesToBeDeleted(remoteChecksums: Checksum[], themeFileSystem:
 }
 
 // Contextual Json Files -> Json Files -> Liquid Files -> Config Files -> Static Asset Files
+// Config file consideration: Inverse of the upload order: data first (consumes schema), then schema.
 function orderFilesToBeDeleted(files: Checksum[]): Checksum[] {
   const fileSets = partitionThemeFiles(files)
   return [
@@ -213,7 +214,6 @@ function orderFilesToBeDeleted(files: Checksum[]): Checksum[] {
     ...fileSets.blockLiquidFiles,
     ...fileSets.layoutFiles,
     ...fileSets.otherLiquidFiles,
-    // Inverse of the upload order: data first (consumes schema), then schema.
     ...fileSets.configDataFile,
     ...fileSets.configSchemaFile,
     ...fileSets.staticAssetFiles,
@@ -317,10 +317,7 @@ function selectUploadableFiles(themeFileSystem: ThemeFileSystem, remoteChecksums
  * 1. config/settings_schema.json must be uploaded FIRST. It declares the
  *    theme-level settings that block / section / section-group / template
  *    validators resolve dynamic-source defaults against (e.g. defaults of
- *    the form {{ settings.<theme_setting>.<property> }}). On a fresh
- *    theme the stored schema is empty, so any later asset whose schema
- *    references a not-yet-declared theme setting fails server-side
- *    validation. Uploading the schema first primes those references.
+ *    the form {{ settings.<theme_setting>.<property> }}).
  * 2. Layout files don't necessarily need to be the first, but they must be
  *    uploaded before templates.
  * 3. Liquid blocks need to be uploaded before sections
@@ -340,7 +337,7 @@ function selectUploadableFiles(themeFileSystem: ThemeFileSystem, remoteChecksums
  * - The static assets
  *
  */
-export function orderFilesToBeUploaded(files: ChecksumWithSize[]): {
+function orderFilesToBeUploaded(files: ChecksumWithSize[]): {
   independentFiles: ChecksumWithSize[][]
   dependentFiles: ChecksumWithSize[][]
 } {
@@ -351,8 +348,6 @@ export function orderFilesToBeUploaded(files: ChecksumWithSize[]): {
     independentFiles: [fileSets.otherLiquidFiles, fileSets.otherJsonFiles, fileSets.staticAssetFiles],
     // Follow order of dependencies:
     dependentFiles: [
-      // Theme setting declarations must land before any asset that may
-      // reference them via dynamic-source defaults. See header comment.
       fileSets.configSchemaFile,
       fileSets.layoutFiles,
       fileSets.blockLiquidFiles,
@@ -360,8 +355,6 @@ export function orderFilesToBeUploaded(files: ChecksumWithSize[]): {
       fileSets.sectionJsonFiles,
       fileSets.templateJsonFiles,
       fileSets.contextualizedJsonFiles,
-      // Settings values reference the schema we just uploaded, plus any
-      // sections / templates referenced by presets.
       fileSets.configDataFile,
     ],
   }
@@ -399,7 +392,7 @@ function calculateLocalChecksums(localThemeFileSystem: ThemeFileSystem): Checksu
   localThemeFileSystem.files.forEach((file, key) => {
     // Text files: use UTF-8 byte count
     // Binary files: use base64 length
-    const size = file.value ? Buffer.byteLength(file.value, 'utf8') : (file.attachment?.length ?? 0)
+    const size = file.value ? Buffer.byteLength(file.value, 'utf8') : file.attachment?.length ?? 0
 
     checksums.push({
       key,


### PR DESCRIPTION
### WHY are these changes introduced?

Closes shop/issues-merchant-workflows#1929

This is the CLI counterpart to the new `color_palette` setting type. The `color_palette` is declared at the theme level (`config/settings_schema.json`).  Blocks and sections set their own color `default` value via `{{ settings.<palette>.<role> }}`. 

**Issue**: The `shopify theme push` fails on the **first** push to a fresh dev theme whenever a block/section uses that pattern. The second push to the same theme succeeds, because by then `config/settings_schema.json` has been uploaded and the server-side validator that runs on the block file can resolve the reference against the stored palette.

Example of **first** push errors: 

> "Invalid schema: setting with id=`<value>` default must be a color or dynamic source access path"  

The second push to the same theme succeeds, because by then the user's `config/settings_schema.json` has been uploaded and the server-side validators can resolve the reference.

**Root cause.** The CLI uploads files in dependency order. Today `config/settings_schema.json` is bundled with `config/settings_data.json` into a single `configFiles` bucket and uploaded **last** — after every block/section/section-group/template asset. When the server-side validator on a block file checks a `{{ settings.<palette>.<role> }}` default, it queries the theme's currently-stored `settings_schema.json`, which on a fresh theme is the `'[]'` placeholder seeded by `ensureThemeCreation`. The reference can't resolve until the user's real schema lands.

### WHAT is this pull request doing?

Splits the `configFiles` partition bucket into `configSchemaFile` and `configDataFile`, then reorders the `dependentFiles` upload chain:

- **Before:** layout → blocks → sections.liquid → sections.json → templates.json → contextualized → config (schema + data together, last)
- **After:** **config schema** → layout → blocks → sections.liquid → sections.json → templates.json → contextualized → **config data**

`settings_schema.json` is purely declarative and has no upstream dependencies, so it's safe to upload first. `settings_data.json` legitimately needs to be last — its `current` and `presets` validate against the freshly-uploaded schema and can reference sections / templates uploaded earlier. The matching `orderFilesToBeDeleted` is updated to delete data before schema (the inverse of the new upload order).

Files changed (all in `packages/theme/src/cli/utilities/`):

- `theme-fs.ts` — split `configRegex` into `configSchemaRegex` / `configDataRegex`; split `partitionThemeFiles` bucket.
- `theme-uploader.ts` — reorder `dependentFiles` (schema head, data tail), invert `orderFilesToBeDeleted`, expand the header comment explaining the contract. Exports `orderFilesToBeUploaded` and `ChecksumWithSize` so the new test can exercise the function directly.
- `theme-fs.test.ts` — partition tests updated for the two new buckets.
- `theme-uploader.test.ts` — existing upload-order test updated for the new sequence; new direct unit test of `orderFilesToBeUploaded` asserts schema-first / data-last and that every validator-consumer asset (blocks, section liquid, section group JSON, template JSON, contextualized template JSON) is sequenced between them.

**Verified scope.** Block-level `color_palette` dynamic-source defaults — Horizon's `input_border_color` repro succeeds on first push. The same upload-order fix is expected to cover the section-group and template JSON datasource walkers (same dependency on the stored schema), though those weren't independently end-to-end verified.

**Out of scope.** Validator paths that don't consult the stored `settings_schema.json` at all — for example, the `string_or_datasource` validator that runs on URL / link block settings — fail before any schema lookup and aren't affected by reordering. Those need a separate server-side change.

### How to test your changes?

Test a `color_palette` type input on a store with the new feature enabled. 

1. Create `blocks/test.liquid`
```
{% schema %}
{
  "name": "Test",
  "settings": [
    { "type": "color", "id": "link_color", "label": "Link Color", "default": "{{ settings.color.link_color }}" }
  ]
}
{% endschema %}
```

2. Updated `config/settings_schema.json` with this setting.

```json
      {
        "type": "color_palette",
        "id": "color",
        "default": {
          "background": "#ffffff",
          "link_color": "#000000"
        }
      },
```

3. Run `pnpm shopify theme push --path=<YOUR_PATH>` and verify no error messages

### Post-release steps

None.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows) — pure JS, no platform-specific code paths touched.
- [x] I've considered possible [documentation](https://shopify.dev) changes — none needed; user-facing behavior is "first push now works," no new flags or commands.
- [x] I've considered analytics changes to measure impact — none needed.
- [x] The change is user-facing — patch bump for `@shopify/theme`, changeset added (`.changeset/fix-theme-push-fresh-dynamic-source-defaults.md`).
