### PR TITLE
[Security] Limit stdin read size in readStdinString

### DIFF
--- a/packages/cli-kit/src/public/node/system.test.ts
+++ b/packages/cli-kit/src/public/node/system.test.ts
@@ -377,4 +377,19 @@ describe('readStdinString', () => {
     // Then
     expect(got).toBe('hello world')
   })
+
+  test('throws AbortError when stdin content exceeds the limit', async () => {
+    // Given
+    vi.mocked(fs.fstatSync).mockReturnValue({isFIFO: () => true, isFile: () => false} as fs.Stats)
+    // Create a chunk that is larger than 10MB
+    const largeChunk = 'a'.repeat(10 * 1024 * 1024 + 1)
+    const mockStdin = Readable.from([largeChunk])
+    vi.spyOn(process, 'stdin', 'get').mockReturnValue(mockStdin as unknown as typeof process.stdin)
+
+    // When
+    const got = system.readStdinString()
+
+    // Then
+    await expect(got).rejects.toThrow('Stdin input exceeded the maximum allowed size.')
+  })
 })

--- a/packages/cli-kit/src/public/node/system.ts
+++ b/packages/cli-kit/src/public/node/system.ts
@@ -14,6 +14,13 @@ import {delimiter} from 'pathe'
 import {fstatSync} from 'fs'
 import type {Writable, Readable} from 'stream'
 
+/**
+ * The maximum size of data that can be read from stdin in bytes.
+ * This is to prevent memory exhaustion when reading from stdin.
+ * 10MB.
+ */
+const MAX_STDIN_SIZE = 10 * 1024 * 1024
+
 export interface ExecOptions {
   cwd?: string
   env?: Record<string, string | undefined>
@@ -425,9 +432,15 @@ export async function readStdinString(): Promise<string | undefined> {
   }
 
   let data = ''
+  let totalSize = 0
   process.stdin.setEncoding('utf8')
   for await (const chunk of process.stdin) {
-    data += String(chunk)
+    const chunkString = String(chunk)
+    totalSize += Buffer.byteLength(chunkString, 'utf8')
+    if (totalSize > MAX_STDIN_SIZE) {
+      throw new AbortError('Stdin input exceeded the maximum allowed size.')
+    }
+    data += chunkString
   }
   return data.trim()
 }


### PR DESCRIPTION
### WHY are these changes introduced?

The `readStdinString` function was reading all data from standard input without any size limitations, which could lead to memory exhaustion and Denial of Service (DoS) if processing untrusted or excessively large input.

### WHAT is this pull request doing?

Introduces a 10MB limit to `readStdinString`. It now tracks total bytes read and throws an `AbortError` if the limit is exceeded.

### How to test your changes?

CI

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact

---
*PR created automatically by Jules for task [10535475246681127260](https://jules.google.com/task/10535475246681127260) started by @gonzaloriestra*