### PR TITLE
[Refactor] Remove redundant @ts-ignore in path.ts

### DIFF
--- a/packages/cli-kit/src/public/node/path.ts
+++ b/packages/cli-kit/src/public/node/path.ts
@@ -135,8 +135,6 @@ export function commonParentDirectory(first: string, second: string): string {
 export function relativizePath(path: string, dir: string = cwd()): string {
   const result = commonParentDirectory(path, dir)
   const relativePath = relative(dir, path)
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
   const relativeComponents = relativePath.split('/').filter((component) => component === '..').length
   if (result === '/' || relativePath === '' || relativeComponents > 2) {
     return path


### PR DESCRIPTION
This PR removes redundant `@ts-ignore` and `eslint-disable-next-line` annotations in `packages/cli-kit/src/public/node/path.ts`. These suppressions were likely added to bypass type errors that are no longer present or were incorrectly identified.

### Changes
- Removed `// eslint-disable-next-line @typescript-eslint/ban-ts-comment` and `// @ts-ignore` before the `split('/')` call in `relativizePath`.

### How to test your changes?
CI

---
*PR created automatically by Jules for task [4648763997876888986](https://jules.google.com/task/4648763997876888986) started by @gonzaloriestra*