### PR TITLE
Fix custom tunnel URL precedence in Codespaces app dev

### DIFF
--- a/.changeset/fix-codespaces-custom-tunnel.md
+++ b/.changeset/fix-codespaces-custom-tunnel.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Respect `--tunnel-url` when running `shopify app dev` in GitHub Codespaces.

--- a/packages/app/src/cli/services/dev/urls.test.ts
+++ b/packages/app/src/cli/services/dev/urls.test.ts
@@ -410,6 +410,19 @@ describe('generateFrontendURL', () => {
     expect(got).toEqual({frontendUrl: 'https://my-tunnel-provider.io', frontendPort: 4242, usingLocalhost: false})
   })
 
+  test('returns tunnelUrl when running in a codespace environment', async () => {
+    // Given
+    vi.mocked(codespaceURL).mockReturnValue('codespace.url.fqdn.com')
+    vi.mocked(codespacePortForwardingDomain).mockReturnValue('app.github.dev')
+    const options = {...defaultOptions, tunnelUrl: 'https://my-tunnel-provider.io:4242'}
+
+    // When
+    const got = await generateFrontendURL(options)
+
+    // Then
+    expect(got).toEqual({frontendUrl: 'https://my-tunnel-provider.io', frontendPort: 4242, usingLocalhost: false})
+  })
+
   test('generates a tunnel url with cloudflare when there is no tunnelUrl and use cloudflare is true', async () => {
     // Given
     const options: FrontendURLOptions = {

--- a/packages/app/src/cli/services/dev/urls.ts
+++ b/packages/app/src/cli/services/dev/urls.ts
@@ -47,10 +47,10 @@ interface FrontendURLResult {
 
 /**
  * The tunnel creation logic depends on 7 variables:
- * - If a Codespaces environment is detected, then the URL is built using the codespaces hostname. No need for tunnel
- * - If a Gitpod environment is detected, then the URL is built using the gitpod hostname. No need for tunnel
- *   No need for tunnel. In case problems with that configuration, the flags Tunnel or Custom Tunnel url could be used
  * - If a tunnelUrl is provided, that takes preference and is returned as the frontendURL
+ * - If a Codespaces environment is detected, then the URL is built using the codespaces hostname. No need for tunnel
+ * - If a Gitpod environment is detected, then the URL is built using the gitpod hostname.
+ *   In case problems with that configuration, the Custom Tunnel URL flag could be used
  * - If noTunnel is true, that takes second preference and localhost is used
  * - Otherwise, a tunnel is created. (by default using cloudflare)
  *
@@ -69,17 +69,6 @@ export async function generateFrontendURL(options: FrontendURLOptions): Promise<
   let frontendUrl = ''
   const usingLocalhost = options.noTunnelUseLocalhost
 
-  if (codespaceURL()) {
-    frontendUrl = `https://${codespaceURL()}-${frontendPort}.${codespacePortForwardingDomain()}`
-    return {frontendUrl, frontendPort, usingLocalhost}
-  }
-
-  if (gitpodURL()) {
-    const defaultUrl = gitpodURL()?.replace('https://', '')
-    frontendUrl = `https://${frontendPort}-${defaultUrl}`
-    return {frontendUrl, frontendPort, usingLocalhost}
-  }
-
   if (options.tunnelUrl) {
     const matches = options.tunnelUrl.match(/(https:\/\/[^:]+):([0-9]+)/)
     if (!matches) {
@@ -88,6 +77,17 @@ export async function generateFrontendURL(options: FrontendURLOptions): Promise<
     frontendPort = Number(matches[2])
 
     frontendUrl = matches[1]!
+    return {frontendUrl, frontendPort, usingLocalhost}
+  }
+
+  if (codespaceURL()) {
+    frontendUrl = `https://${codespaceURL()}-${frontendPort}.${codespacePortForwardingDomain()}`
+    return {frontendUrl, frontendPort, usingLocalhost}
+  }
+
+  if (gitpodURL()) {
+    const defaultUrl = gitpodURL()?.replace('https://', '')
+    frontendUrl = `https://${frontendPort}-${defaultUrl}`
     return {frontendUrl, frontendPort, usingLocalhost}
   }
 


### PR DESCRIPTION
### WHY are these changes introduced?

Related to #6235

When `shopify app dev` runs inside GitHub Codespaces, `generateFrontendURL` currently detects the Codespaces environment before checking `--tunnel-url`. That means an explicit custom tunnel URL is ignored and the CLI always builds a Codespaces forwarding URL instead.

This blocks developers who need to bring their own tunnel in Codespaces, for example to avoid embedded app preview failures caused by GitHub/Codespaces framing or cookie behavior.

### WHAT is this pull request doing?

- Gives `--tunnel-url` precedence before Codespaces and Gitpod auto URL detection.
- Preserves the existing Codespaces and Gitpod URL behavior when no custom tunnel URL is provided.
- Adds a regression test proving custom tunnel URLs win in a Codespaces environment.
- Adds a patch changeset for `@shopify/app`.

### How to test your changes?

Automated checks run locally:

```bash
pnpm vitest run packages/app/src/cli/services/dev/urls.test.ts
pnpm nx run app:type-check
pnpm nx run app:lint
git diff --check
```

Manual behavior to verify:

```bash
shopify app dev --tunnel-url="https://my-tunnel-provider.io:4242"
```

In a Codespaces environment, the app dev frontend URL should use `https://my-tunnel-provider.io` with port `4242`, instead of replacing it with the Codespaces forwarding URL.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [x] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`
