### PR TITLE
Fix device auth debug output redaction

### DIFF
--- a/.changeset/redact-device-auth-debug.md
+++ b/.changeset/redact-device-auth-debug.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': patch
+---
+
+Redact device authorization secrets from verbose debug logs.

--- a/packages/cli-kit/src/private/node/session/device-authorization.test.ts
+++ b/packages/cli-kit/src/private/node/session/device-authorization.test.ts
@@ -12,6 +12,7 @@ import {isTTY} from '../../../public/node/ui.js'
 import {err, ok} from '../../../public/node/result.js'
 import {AbortError} from '../../../public/node/error.js'
 import {isCI} from '../../../public/node/system.js'
+import {clearCollectedLogs, collectedLogs} from '../../../public/node/output.js'
 
 import {beforeEach, describe, expect, test, vi} from 'vitest'
 import {Response} from 'node-fetch'
@@ -24,6 +25,7 @@ vi.mock('./exchange.js')
 vi.mock('../../../public/node/system.js')
 
 beforeEach(() => {
+  clearCollectedLogs()
   vi.mocked(isTTY).mockReturnValue(true)
   vi.mocked(isCI).mockReturnValue(false)
 })
@@ -64,6 +66,30 @@ describe('requestDeviceAuthorization', () => {
       body: 'client_id=clientId&scope=scope1 scope2',
     })
     expect(got).toEqual(dataExpected)
+  })
+
+  test('redacts sensitive device authorization fields from debug output', async () => {
+    // Given
+    const sensitiveData = {
+      ...data,
+      device_code: 'secret-device-code',
+      user_code: 'secret-user-code',
+      verification_uri_complete: 'https://accounts.shopify.com/activate?user_code=secret-user-code',
+    }
+    const response = new Response(JSON.stringify(sensitiveData))
+    vi.mocked(shopifyFetch).mockResolvedValue(response)
+    vi.mocked(identityFqdn).mockResolvedValue('fqdn.com')
+    vi.mocked(clientId).mockReturnValue('clientId')
+
+    // When
+    await requestDeviceAuthorization(['scope1', 'scope2'])
+
+    // Then
+    const debugOutput = collectedLogs.debug?.join('\n') ?? ''
+    expect(debugOutput).toContain('Received device authorization response')
+    expect(debugOutput).toContain('****')
+    expect(debugOutput).not.toContain('secret-device-code')
+    expect(debugOutput).not.toContain('secret-user-code')
   })
 
   test('when the response is not valid JSON, throw an error with context', async () => {

--- a/packages/cli-kit/src/private/node/session/device-authorization.ts
+++ b/packages/cli-kit/src/private/node/session/device-authorization.ts
@@ -11,6 +11,8 @@ import {isTTY, keypress} from '../../../public/node/ui.js'
 
 import {Response} from 'node-fetch'
 
+const DEVICE_AUTHORIZATION_DEBUG_REDACTED_FIELDS = ['device_code', 'user_code', 'verification_uri_complete'] as const
+
 export interface DeviceAuthorizationResponse {
   deviceCode: string
   userCode: string
@@ -64,7 +66,9 @@ export async function requestDeviceAuthorization(scopes: string[]): Promise<Devi
     throw new BugError(errorMessage)
   }
 
-  outputDebug(outputContent`Received device authorization code: ${outputToken.json(jsonResult)}`)
+  outputDebug(
+    outputContent`Received device authorization response: ${outputToken.json(redactDeviceAuthorizationResponse(jsonResult))}`,
+  )
   if (!jsonResult.device_code || !jsonResult.verification_uri_complete) {
     throw new BugError('Failed to start authorization process')
   }
@@ -106,6 +110,16 @@ export async function requestDeviceAuthorization(scopes: string[]): Promise<Devi
     verificationUriComplete: jsonResult.verification_uri_complete,
     interval: jsonResult.interval,
   }
+}
+
+function redactDeviceAuthorizationResponse(jsonResult: Record<string, unknown>): Record<string, unknown> {
+  const redactedResult = {...jsonResult}
+
+  for (const field of DEVICE_AUTHORIZATION_DEBUG_REDACTED_FIELDS) {
+    if (redactedResult[field]) redactedResult[field] = '****'
+  }
+
+  return redactedResult
 }
 
 /**


### PR DESCRIPTION
### WHY are these changes introduced?

Verbose device authorization logging currently writes the raw authorization response. That response can include temporary auth values such as `device_code`, `user_code`, and `verification_uri_complete`, which can leak when users share `--verbose` logs.

### WHAT is this pull request doing?

Redacts sensitive device authorization fields before writing the response to debug output.

Adds a focused `cli-kit` unit test that verifies the debug log does not contain the raw temporary auth values.

Adds a patch changeset for `@shopify/cli-kit`.

### How to test your changes?

```sh
pnpm vitest run packages/cli-kit/src/private/node/session/device-authorization.test.ts
pnpm nx run cli-kit:type-check
pnpm nx run cli-kit:lint
git diff --check
```

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [x] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`