### PR TITLE
[Refactor] Optimize copyDirectoryContents with glob cwd

### DIFF
--- a/packages/cli-kit/src/public/node/fs.ts
+++ b/packages/cli-kit/src/public/node/fs.ts
@@ -728,16 +728,11 @@ export async function copyDirectoryContents(srcDir: string, destDir: string): Pr
   }
 
   // Get all files and directories in the source directory
-  const items = await glob(joinPath(srcDir, '**/*'))
+  const items = await glob('**/*', {cwd: srcDir})
 
-  const filesToCopy = []
-
-  for (const item of items) {
-    const relativePath = item.replace(srcDir, '').replace(/^[/\\]/, '')
-    const destPath = joinPath(destDir, relativePath)
-
-    filesToCopy.push(copyFile(item, destPath))
-  }
+  const filesToCopy = items.map((relativePath) => {
+    return copyFile(joinPath(srcDir, relativePath), joinPath(destDir, relativePath))
+  })
 
   await Promise.all(filesToCopy)
 }


### PR DESCRIPTION
### WHY are these changes introduced?

This refactor improves the performance and readability of the `copyDirectoryContents` utility. By using the `cwd` option in the `glob` call, we avoid brittle manual string manipulation to calculate relative paths, which aligns with the project's performance guidelines for file-intensive operations.

### WHAT is this pull request doing?

- Updated `copyDirectoryContents` in `packages/cli-kit/src/public/node/fs.ts` to use `glob('**/*', {cwd: srcDir})`.
- Replaced the manual `for...of` loop with a more idiomatic `.map()` and `Promise.all()` approach.
- Removed manual regex-based path stripping.

### How to test your changes?

Run the unit tests for the affected package:
```bash
pnpm --filter @shopify/cli-kit vitest run src/public/node/fs.test.ts
```

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing

### Duplicate check

Query: `git log --grep="Refactor" --pretty=format:"%h %s" -n 50`

No previous PRs were found that address this specific optimization in the `copyDirectoryContents` function within `cli-kit`.


---
*PR created automatically by Jules for task [7992711792130112196](https://jules.google.com/task/7992711792130112196) started by @gonzaloriestra*