### PR TITLE
fix(dev): Register static assets without identifier for relative src paths

### DIFF
--- a/packages/app/src/cli/services/dev/extension/payload.test.ts
+++ b/packages/app/src/cli/services/dev/extension/payload.test.ts
@@ -412,14 +412,14 @@ describe('getUIExtensionPayload', () => {
           assets: {
             assets: {
               name: 'assets',
-              url: 'http://tunnel-url.com/extensions/devUUID/assets/CUSTOM_EXTENSION_POINT/assets/',
+              url: 'http://tunnel-url.com/extensions/devUUID/assets/CUSTOM_EXTENSION_POINT/',
               lastUpdated: expect.any(Number),
             },
           },
         },
       ])
-      expect(resolver.get('CUSTOM_EXTENSION_POINT/assets/foo.json')).toBe('foo.json')
-      expect(resolver.get('CUSTOM_EXTENSION_POINT/assets/subdir/bar.png')).toBe('subdir/bar.png')
+      expect(resolver.get('CUSTOM_EXTENSION_POINT/foo.json')).toBe('foo.json')
+      expect(resolver.get('CUSTOM_EXTENSION_POINT/subdir/bar.png')).toBe('subdir/bar.png')
     })
   })
 
@@ -465,16 +465,16 @@ describe('getUIExtensionPayload', () => {
       expect(got.extensionPoints).toMatchObject([
         {
           target: 'TARGET_A',
-          assets: {assets: {url: 'http://tunnel-url.com/extensions/devUUID/assets/TARGET_A/assets/'}},
+          assets: {assets: {url: 'http://tunnel-url.com/extensions/devUUID/assets/TARGET_A/'}},
         },
         {
           target: 'TARGET_B',
-          assets: {assets: {url: 'http://tunnel-url.com/extensions/devUUID/assets/TARGET_B/assets/'}},
+          assets: {assets: {url: 'http://tunnel-url.com/extensions/devUUID/assets/TARGET_B/'}},
         },
       ])
       // Both targets' resolver entries point at the same output-relative file.
-      expect(resolver.get('TARGET_A/assets/foo.json')).toBe('foo.json')
-      expect(resolver.get('TARGET_B/assets/foo.json')).toBe('foo.json')
+      expect(resolver.get('TARGET_A/foo.json')).toBe('foo.json')
+      expect(resolver.get('TARGET_B/foo.json')).toBe('foo.json')
     })
   })
 

--- a/packages/app/src/cli/services/dev/extension/payload.ts
+++ b/packages/app/src/cli/services/dev/extension/payload.ts
@@ -250,9 +250,8 @@ async function staticAssetsMapper(
   files: string[],
 ): Promise<Partial<DevNewExtensionPointSchema>> {
   if (files.length === 0) return {}
-  const urlSubpath = `${target}/${identifier}`
   for (const file of files) {
-    resolver?.set(`${urlSubpath}/${file}`, file)
+    resolver?.set(`${target}/${file}`, file)
   }
   const updatedTimestamps = await Promise.all(
     files.map(async (file) => (await fileLastUpdatedTimestamp(joinPath(buildDirectory, file))) ?? 0),
@@ -261,7 +260,7 @@ async function staticAssetsMapper(
     assets: {
       [identifier]: {
         name: identifier,
-        url: `${url}/assets/${urlSubpath}/`,
+        url: `${url}/assets/${target}/`,
         lastUpdated: Math.max(...updatedTimestamps),
       },
     },


### PR DESCRIPTION
## Summary

Static assets in UI extensions weren't resolving correctly when using relative paths like `src='./cat.png'`.

## Root Cause

Assets were registered at `target/identifier/file` (e.g., `target/assets/Shoe1.png`), but relative paths like `src='./Shoe1.png'` resolve to `target/Shoe1.png`.

## Changes

### Dev server
Register assets at `target/file` instead of `target/identifier/file`:

```diff
- resolver?.set(\`\${urlSubpath}/\${file}\`, file)
+ resolver?.set(\`\${target}/\${file}\`, file)
```

### Deploy
Add `destination: 'assets'` to the `include_assets` step so files are copied to `assets/` subdirectory with correct manifest paths.

## Note

A corresponding server-side fix is needed to use the full manifest paths when constructing CDN URLs.

Fixes https://github.com/Shopify/cli/issues/5285