### PR TITLE
Add analytics opt-out that matches ai-toolkit

### DIFF
--- a/.changeset/quiet-otters-wave.md
+++ b/.changeset/quiet-otters-wave.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': patch
+---
+
+Also treat `OPT_OUT_INSTRUMENTATION=true` as an analytics opt-out, in addition to the existing `SHOPIFY_CLI_NO_ANALYTICS=1` environment variable.

--- a/docs-shopify.dev/generated/generated_static_pages.json
+++ b/docs-shopify.dev/generated/generated_static_pages.json
@@ -83,7 +83,7 @@
         "type": "Generic",
         "anchorLink": "reporting",
         "title": "Usage reporting",
-        "sectionContent": "Anonymous usage statistics are collected by default. To opt out, you can use the environment variable `SHOPIFY_CLI_NO_ANALYTICS=1`."
+        "sectionContent": "Anonymous usage statistics are collected by default. To opt out, you can use either `SHOPIFY_CLI_NO_ANALYTICS=1` or `OPT_OUT_INSTRUMENTATION=true`."
       },
       {
         "type": "Generic",

--- a/docs-shopify.dev/static/cli.doc.ts
+++ b/docs-shopify.dev/static/cli.doc.ts
@@ -97,7 +97,7 @@ Or, run the \`help\` command to get this information right in your terminal.
       type: 'Generic',
       anchorLink: 'reporting',
       title: 'Usage reporting',
-      sectionContent: `Anonymous usage statistics are collected by default. To opt out, you can use the environment variable \`SHOPIFY_CLI_NO_ANALYTICS=1\`.`,
+      sectionContent: `Anonymous usage statistics are collected by default. To opt out, you can use either \`SHOPIFY_CLI_NO_ANALYTICS=1\` or \`OPT_OUT_INSTRUMENTATION=true\`.`,
     },
     {
       type: 'Generic',

--- a/packages/cli-kit/src/private/node/constants.ts
+++ b/packages/cli-kit/src/private/node/constants.ts
@@ -21,6 +21,7 @@ export const environmentVariables = {
   env: 'SHOPIFY_CLI_ENV',
   firstPartyDev: 'SHOPIFY_CLI_1P_DEV',
   noAnalytics: 'SHOPIFY_CLI_NO_ANALYTICS',
+  optOutInstrumentation: 'OPT_OUT_INSTRUMENTATION',
   appAutomationToken: 'SHOPIFY_APP_AUTOMATION_TOKEN',
   partnersToken: 'SHOPIFY_CLI_PARTNERS_TOKEN',
   runAsUser: 'SHOPIFY_RUN_AS_USER',

--- a/packages/cli-kit/src/public/node/context/local.test.ts
+++ b/packages/cli-kit/src/public/node/context/local.test.ts
@@ -183,6 +183,31 @@ describe('analitycsDisabled', () => {
     expect(got).toBe(true)
   })
 
+  test('returns true when OPT_OUT_INSTRUMENTATION is truthy', () => {
+    // Given
+    const env = {OPT_OUT_INSTRUMENTATION: 'true'}
+
+    // When
+    const got = analyticsDisabled(env)
+
+    // Then
+    expect(got).toBe(true)
+  })
+
+  test('returns true when either opt-out env var is truthy', () => {
+    // Given
+    const env = {
+      SHOPIFY_CLI_NO_ANALYTICS: '1',
+      OPT_OUT_INSTRUMENTATION: 'true',
+    }
+
+    // When
+    const got = analyticsDisabled(env)
+
+    // Then
+    expect(got).toBe(true)
+  })
+
   test('returns true when in development', () => {
     // Given
     const env = {SHOPIFY_CLI_ENV: 'development'}

--- a/packages/cli-kit/src/public/node/context/local.ts
+++ b/packages/cli-kit/src/public/node/context/local.ts
@@ -95,10 +95,14 @@ export function isUnitTest(env = process.env): boolean {
  * Returns true if reporting analytics is enabled.
  *
  * @param env - The environment variables from the environment of the current process.
- * @returns True unless SHOPIFY_CLI_NO_ANALYTICS is truthy or debug mode is enabled.
+ * @returns True unless SHOPIFY_CLI_NO_ANALYTICS or OPT_OUT_INSTRUMENTATION is truthy, or debug mode is enabled.
  */
 export function analyticsDisabled(env = process.env): boolean {
-  return isTruthy(env[environmentVariables.noAnalytics]) || isDevelopment(env)
+  return (
+    isTruthy(env[environmentVariables.noAnalytics]) ||
+    isTruthy(env[environmentVariables.optOutInstrumentation]) ||
+    isDevelopment(env)
+  )
 }
 
 /**


### PR DESCRIPTION
## What

Make the CLI treat `OPT_OUT_INSTRUMENTATION=true` as an analytics opt-out, alongside the existing `SHOPIFY_CLI_NO_ANALYTICS=1` env var.

This also updates the usage-reporting docs to mention both opt-out paths.

## Why

`ai-toolkit` and related Shopify agent surfaces already use `OPT_OUT_INSTRUMENTATION` as the common telemetry opt-out.

When those tools invoke Shopify CLI, the mismatch is awkward: the surrounding tooling can be opted out with one env var, but the CLI still requires a different one. This makes the CLI accept the same opt-out signal as an alias without changing the existing `SHOPIFY_CLI_NO_ANALYTICS` behavior.

## How

- add `OPT_OUT_INSTRUMENTATION` to the shared environment-variable constants in `cli-kit`
- update `analyticsDisabled()` to return true when either opt-out env var is truthy
- update the usage-reporting docs to mention both env vars
