### PR TITLE
Validate extensions.targeting assets value in include-assets-step

### DIFF
--- a/packages/app/src/cli/services/build/steps/include-assets-step.ts
+++ b/packages/app/src/cli/services/build/steps/include-assets-step.ts
@@ -138,6 +138,7 @@ export async function executeIncludeAssetsStep(
   let configKeyCount = 0
   for (const entry of config.inclusions) {
     if (entry.type !== 'configKey') continue
+
     const warn = (msg: string) => options.stdout.write(msg)
     const rawDest = entry.destination ? sanitizeRelativePath(entry.destination, warn) : undefined
     const sanitizedDest = rawDest === '' ? undefined : rawDest

--- a/packages/app/src/cli/services/build/steps/include-assets/copy-config-key-entry.test.ts
+++ b/packages/app/src/cli/services/build/steps/include-assets/copy-config-key-entry.test.ts
@@ -316,4 +316,132 @@ describe('copyConfigKeyEntry', () => {
       await expect(fileExists(joinPath(outDir, 'tools.json'))).resolves.toBe(true)
     })
   })
+
+  describe('value guard', () => {
+    test('throws when value is an empty string', async () => {
+      await inTemporaryDirectory(async (tmpDir) => {
+        const outDir = joinPath(tmpDir, 'out')
+        await mkdir(outDir)
+        const context = makeContext({assets: ''})
+        await expect(copyConfigKeyEntry({key: 'assets', baseDir: tmpDir, outputDir: outDir, context})).rejects.toThrow(
+          `'assets' can't be empty.`,
+        )
+      })
+    })
+
+    test('throws when value is whitespace-only', async () => {
+      await inTemporaryDirectory(async (tmpDir) => {
+        const outDir = joinPath(tmpDir, 'out')
+        await mkdir(outDir)
+        const context = makeContext({assets: '   '})
+        await expect(copyConfigKeyEntry({key: 'assets', baseDir: tmpDir, outputDir: outDir, context})).rejects.toThrow(
+          `'assets' can't be empty.`,
+        )
+      })
+    })
+
+    test(`throws when value is '.'`, async () => {
+      await inTemporaryDirectory(async (tmpDir) => {
+        const outDir = joinPath(tmpDir, 'out')
+        await mkdir(outDir)
+        const context = makeContext({assets: '.'})
+        await expect(copyConfigKeyEntry({key: 'assets', baseDir: tmpDir, outputDir: outDir, context})).rejects.toThrow(
+          `'assets' is not a valid path: '.'`,
+        )
+      })
+    })
+
+    test(`throws when value is './'`, async () => {
+      await inTemporaryDirectory(async (tmpDir) => {
+        const outDir = joinPath(tmpDir, 'out')
+        await mkdir(outDir)
+        const context = makeContext({assets: './'})
+        await expect(copyConfigKeyEntry({key: 'assets', baseDir: tmpDir, outputDir: outDir, context})).rejects.toThrow(
+          `'assets' is not a valid path: './'`,
+        )
+      })
+    })
+
+    test(`throws when value is './' with surrounding whitespace`, async () => {
+      await inTemporaryDirectory(async (tmpDir) => {
+        const outDir = joinPath(tmpDir, 'out')
+        await mkdir(outDir)
+        const context = makeContext({assets: '  ./  '})
+        await expect(copyConfigKeyEntry({key: 'assets', baseDir: tmpDir, outputDir: outDir, context})).rejects.toThrow(
+          `'assets' is not a valid path: '  ./  '`,
+        )
+      })
+    })
+
+    test(`throws when one path in an array is invalid`, async () => {
+      await inTemporaryDirectory(async (tmpDir) => {
+        const outDir = joinPath(tmpDir, 'out')
+        await mkdir(outDir)
+        const context = makeContext({roots: ['./public', '.']})
+        await expect(copyConfigKeyEntry({key: 'roots', baseDir: tmpDir, outputDir: outDir, context})).rejects.toThrow(
+          `'roots' is not a valid path: '.'`,
+        )
+      })
+    })
+
+    test(`throws when value is '../foo' (escapes via single parent)`, async () => {
+      await inTemporaryDirectory(async (tmpDir) => {
+        const outDir = joinPath(tmpDir, 'out')
+        await mkdir(outDir)
+        const context = makeContext({assets: '../foo'})
+        await expect(copyConfigKeyEntry({key: 'assets', baseDir: tmpDir, outputDir: outDir, context})).rejects.toThrow(
+          `'assets' is not a valid path: '../foo'`,
+        )
+      })
+    })
+
+    test(`throws when value is '../../../foo' (escapes via deep parent chain)`, async () => {
+      await inTemporaryDirectory(async (tmpDir) => {
+        const outDir = joinPath(tmpDir, 'out')
+        await mkdir(outDir)
+        const context = makeContext({assets: '../../../foo'})
+        await expect(copyConfigKeyEntry({key: 'assets', baseDir: tmpDir, outputDir: outDir, context})).rejects.toThrow(
+          `'assets' is not a valid path: '../../../foo'`,
+        )
+      })
+    })
+
+    test(`throws when value escapes via interior '..' segments`, async () => {
+      await inTemporaryDirectory(async (tmpDir) => {
+        const outDir = joinPath(tmpDir, 'out')
+        await mkdir(outDir)
+        const context = makeContext({assets: 'public/../../bad'})
+        await expect(copyConfigKeyEntry({key: 'assets', baseDir: tmpDir, outputDir: outDir, context})).rejects.toThrow(
+          `'assets' is not a valid path: 'public/../../bad'`,
+        )
+      })
+    })
+
+    test(`does not throw when interior '..' resolves back inside`, async () => {
+      await inTemporaryDirectory(async (tmpDir) => {
+        const pubDir = joinPath(tmpDir, 'public')
+        await mkdir(pubDir)
+        await writeFile(joinPath(pubDir, 'index.html'), '<html/>')
+        const outDir = joinPath(tmpDir, 'out')
+        await mkdir(outDir)
+
+        const context = makeContext({assets: 'public/../public'})
+        const result = await copyConfigKeyEntry({key: 'assets', baseDir: tmpDir, outputDir: outDir, context})
+
+        expect(result.filesCopied).toBe(1)
+        await expect(fileExists(joinPath(outDir, 'index.html'))).resolves.toBe(true)
+      })
+    })
+
+    test(`uses leaf segment of dotted configKey for the error message`, async () => {
+      await inTemporaryDirectory(async (tmpDir) => {
+        const outDir = joinPath(tmpDir, 'out')
+        await mkdir(outDir)
+        const context = makeContext({extension_points: [{assets: ''}]})
+        await expect(
+          copyConfigKeyEntry({key: 'extension_points[].assets', baseDir: tmpDir, outputDir: outDir, context}),
+        ).rejects.toThrow(`'assets' can't be empty.`)
+      })
+    })
+  })
 })

--- a/packages/app/src/cli/services/build/steps/include-assets/copy-config-key-entry.ts
+++ b/packages/app/src/cli/services/build/steps/include-assets/copy-config-key-entry.ts
@@ -1,4 +1,4 @@
-import {joinPath, basename, relativePath, extname} from '@shopify/cli-kit/node/path'
+import {joinPath, basename, relativePath, extname, resolvePath, isSubpath} from '@shopify/cli-kit/node/path'
 import {glob, copyFile, copyDirectoryContents, fileExists, mkdir, isDirectory} from '@shopify/cli-kit/node/fs'
 import {outputContent, outputDebug, outputToken} from '@shopify/cli-kit/node/output'
 import {AbortError} from '@shopify/cli-kit/node/error'
@@ -58,6 +58,22 @@ export async function copyConfigKeyEntry(config: {
   // Deduplicate: the same source path shared across multiple targets
   // should only be copied once; the pathMap entry is reused for all references.
   const uniquePaths = [...new Set(paths)]
+
+  // Validate up-front so a bad value fails fast before any copying happens.
+  // Use the leaf segment of `key` as the user-facing field name (e.g.
+  // `extension_points[].assets` → `assets`) so error messages match the
+  // developer's TOML rather than internal config paths.
+  const fieldName = key.split('.').pop()?.replace(/\[\]$/, '') ?? key
+  for (const sourcePath of uniquePaths) {
+    const trimmed = sourcePath.trim()
+    if (trimmed === '') {
+      throw new Error(`'${fieldName}' can't be empty.`)
+    }
+    const resolved = resolvePath(baseDir, trimmed)
+    if (resolved === baseDir || !isSubpath(baseDir, resolved)) {
+      throw new Error(`'${fieldName}' is not a valid path: '${sourcePath}'`)
+    }
+  }
 
   // Process sequentially to avoid filesystem race conditions on shared output paths.
   const pathMap = new Map<string, string | string[]>()


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it's a work in progress
-->

### WHY are these changes introduced?

closes https://github.com/shop/issues-admin-extensibility/issues/2521

When a developer sets an invalid assets value in [[extensions.targeting]] (empty string, ., ./, ../foo, etc.), the CLI currently builds the extension, compresses the bundle, and uploads it to GCS before the server rejects the deployment. When we pivoted to the extensions approach for hosted apps, we lost the contract validations from the admin module.  That included: empty static_root (now called assets), length limit of 80 char, root path `./`, `.`, and parent directories like `../`.

The app will still currently fail, but with an incorrect error message, and further downstream.  i.e. defining assets = `./`, it is attempting to upload the entire project directory which contains node modules and fails the file limit validation:

![image.png](https://app.graphite.com/user-attachments/assets/b59620bc-69e0-4260-85f3-dad886b96f30.png)

<!-- link to issue if one exists -->

<!--
  Context about the problem that's being addressed.
-->

### WHAT is this pull request doing?

Adds a build-time guard in the include_assets step that validates assets values before bundling. Specifically:

- In include-assets-step.ts: when a configKey inclusion targets extension_points[].assets, walk extension_points[] and validate each assets value against the extension directory.
- Rejection cases:
    - Empty / whitespace-only → 'assets' for target '\<target>' can't be empty.
    - ., ./, ../foo, ../../../foo, or any value that resolves to or outside the extension root → 'assets' for target '\<target>' is not a valid path: '\<value>'
- Allowed: interior .. segments that resolve back inside the extension (e.g. public/../public) — validated via resolvePath + isSubpath rather than string-matching, so any chain length of ../ is handled.
- Tests: 10 new cases in include-assets-step.test.ts covering each rejection shape plus the round-trip allowed case.

The guard fires before copyConfigKeyEntry runs, so a misconfigured value short-circuits the build instead of producing a bundle that the server later rejects.

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?

- configure a hosted app: `shopify app init --template https://github.com/Shopify/shopify-app-template-extension-only`
- modify the `assets` value under `extensions.targeting` in `extensions/app-home/shopify.extension.toml`
    - set it to empty
    - set it to `.`
    - set it to `./`
    - set it to `../`
- run `shopify app dev` + `shopify app deploy` in your local CLI, pointing to your app template:
    - `SHOPIFY_CLI_NEVER_USE_PARTNERS_API=1 SHOPIFY_SERVICE_ENV=local pnpm run shopify app dev --path="<PATH_TO_APP>"`
- assert dev/deploy fails on empty and edge cases
- modify the `assets` value in your toml back to valid cases
    - set it to `assets`
    - set it to `./assets`
- assert that correct cases do not cause errors

## Considerations

Considered applying this in two alternative layers:

- Along side file-size/file count validations in core
    - This formats the messages more consistently but there's a major flaw architecturally that I overlooked.  By the time this stage has been reached, the CLI has already uploaded the compressed bundle to GCS.  If the assets path is the root of the folder, it's uploading thousands of files
- Schema level validation in `cli/models/extensions/schemas.ts`
    - currently: `assets: zod.string().optional()`
    - proposed:

```typescript
assets: zod
    .string()
    .trim()
    .min(1, "'assets' can't be empty") // catches all empty cases like "", " ", etc 
    .refine( //logic for handling ./, . etc
    ...
    .optional
```

- these validations are more than just structural validations, deemed less appropriate

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`