### PR TITLE
[Refactor] Consolidate command execution in system.ts

### DIFF
--- a/packages/cli-kit/src/public/node/system.ts
+++ b/packages/cli-kit/src/public/node/system.ts
@@ -179,26 +179,11 @@ function parseCommand(command: string): string[] {
  * ```
  */
 export async function captureCommandWithExitCode(command: string, options?: ExecOptions): Promise<CaptureOutputResult> {
-  const env = options?.env ?? process.env
-  if (shouldDisplayColors()) {
-    env.FORCE_COLOR = '1'
-  }
-  const executionCwd = options?.cwd ?? cwd()
   const [cmd, ...args] = parseCommand(command)
   if (!cmd) {
     return {stdout: '', stderr: 'Empty command', exitCode: 1}
   }
-  checkCommandSafety(cmd, {cwd: executionCwd})
-  const result = await execa(cmd, args, {
-    env,
-    cwd: executionCwd,
-    reject: false,
-  })
-  return {
-    stdout: result.stdout,
-    stderr: result.stderr,
-    exitCode: result.exitCode ?? 0,
-  }
+  return captureOutputWithExitCode(cmd, args, options)
 }
 
 /**
@@ -208,34 +193,11 @@ export async function captureCommandWithExitCode(command: string, options?: Exec
  * @param options - Optional settings for how to run the command.
  */
 export async function execCommand(command: string, options?: ExecOptions): Promise<void> {
-  const env = options?.env ?? process.env
-  if (shouldDisplayColors()) {
-    env.FORCE_COLOR = '1'
-  }
-  const executionCwd = options?.cwd ?? cwd()
   const [cmd, ...args] = parseCommand(command)
   if (!cmd) {
     throw new AbortError('Empty command')
   }
-  checkCommandSafety(cmd, {cwd: executionCwd})
-  try {
-    await execa(cmd, args, {
-      env,
-      cwd: executionCwd,
-      stdin: options?.stdin,
-      stdout: options?.stdout === 'inherit' ? 'inherit' : undefined,
-      stderr: options?.stderr === 'inherit' ? 'inherit' : undefined,
-    })
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  } catch (processError: any) {
-    if (options?.externalErrorHandler) {
-      await options.externalErrorHandler(processError)
-    } else {
-      const abortError = new ExternalError(processError.message, command, [])
-      abortError.stack = processError.stack
-      throw abortError
-    }
-  }
+  await exec(cmd, args, options)
 }
 
 /**


### PR DESCRIPTION
### WHY are these changes introduced?
`captureCommandWithExitCode` and `execCommand` in `packages/cli-kit/src/public/node/system.ts` were manually duplicating the environment setup, directory handling, and error processing logic already present in their array-based counterparts, `captureOutputWithExitCode` and `exec`.

### WHAT is this pull request doing?
Refactors `captureCommandWithExitCode` and `execCommand` to delegate to `captureOutputWithExitCode` and `exec` respectively. This centralizes the logic for:
- Setting `FORCE_COLOR` based on `shouldDisplayColors()`.
- Handling the working directory (`cwd`).
- Performing `checkCommandSafety` checks.
- Configuring `execa` options like `windowsHide`.

### How to test your changes?
Run any CLI command that uses these utilities, like `shopify app build`

### Checklist
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible documentation changes
- [x] I've considered analytics changes to measure impact


---
*PR created automatically by Jules for task [14120344445568562033](https://jules.google.com/task/14120344445568562033) started by @gonzaloriestra*