### PR TITLE
[Security] Sanitize Cookie headers in debug logs

### DIFF
--- a/packages/cli-kit/src/private/node/api/headers.test.ts
+++ b/packages/cli-kit/src/private/node/api/headers.test.ts
@@ -85,6 +85,8 @@ describe('common API methods', () => {
       authorization: 'token',
       'Content-Type': 'application/json',
       'X-Shopify-Access-Token': 'token',
+      Cookie: 'session=123',
+      'Set-Cookie': 'session=456',
     }
 
     // When

--- a/packages/cli-kit/src/private/node/api/headers.ts
+++ b/packages/cli-kit/src/private/node/api/headers.ts
@@ -33,7 +33,7 @@ export class GraphQLClientError extends RequestClientError {
  */
 export function sanitizedHeadersOutput(headers: Record<string, string>): string {
   const sanitized: Record<string, string> = {}
-  const keywords = ['token', 'authorization', 'subject_token']
+  const keywords = ['token', 'authorization', 'subject_token', 'cookie']
   Object.keys(headers).forEach((header) => {
     if (keywords.find((keyword) => header.toLocaleLowerCase().includes(keyword)) === undefined) {
       sanitized[header] = headers[header]!


### PR DESCRIPTION
### WHY are these changes introduced?
Sensitive session data from `Cookie` and `Set-Cookie` headers can currently be leaked in debug logs when network request info is printed. This poses a security risk if logs are shared or stored insecurely.

### WHAT is this pull request doing?
This PR adds `'cookie'` to the list of keywords in `sanitizedHeadersOutput`. This ensures that any header containing "cookie" (case-insensitive) is redacted from the debug output.

### How to test your changes?
Run any command that performs a network request with cookies and check the debug logs. The `Cookie` and `Set-Cookie` headers should no longer appear in the "With request headers:" section of the output.

### Duplicate check
I ran `git log --grep="Security" --oneline -n 200` and `git log --grep="Jules" --oneline -n 200` as a fallback since `gh` was unavailable. I found no previous PRs addressing this specific header sanitization.
Closest PR considered:
- `3a92d0375 Merge pull request #7481 from Shopify/fix/theme-push-fresh-dynamic-source-defaults`: Touched the same file for theme-related fixes, but did not address security sanitization of headers.

### Checklist
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible documentation changes
- [x] I've considered analytics changes to measure impact


---
*PR created automatically by Jules for task [10005827685003157313](https://jules.google.com/task/10005827685003157313) started by @gonzaloriestra*