### PR TITLE
[Security] Sanitize Cookie headers in debug logs

### DIFF
--- a/packages/cli-kit/src/private/node/api/headers.test.ts
+++ b/packages/cli-kit/src/private/node/api/headers.test.ts
@@ -85,6 +85,8 @@ describe('common API methods', () => {
       authorization: 'token',
       'Content-Type': 'application/json',
       'X-Shopify-Access-Token': 'token',
+      Cookie: 'session=123',
+      'Set-Cookie': 'session=456',
     }
 
     // When

--- a/packages/cli-kit/src/private/node/api/headers.ts
+++ b/packages/cli-kit/src/private/node/api/headers.ts
@@ -33,7 +33,7 @@ export class GraphQLClientError extends RequestClientError {
  */
 export function sanitizedHeadersOutput(headers: Record<string, string>): string {
   const sanitized: Record<string, string> = {}
-  const keywords = ['token', 'authorization', 'subject_token']
+  const keywords = ['token', 'authorization', 'subject_token', 'cookie']
   Object.keys(headers).forEach((header) => {
     if (keywords.find((keyword) => header.toLocaleLowerCase().includes(keyword)) === undefined) {
       sanitized[header] = headers[header]!


### PR DESCRIPTION
This PR enhances the `sanitizedHeadersOutput` utility to redact `Cookie` and `Set-Cookie` headers from debug logs. This prevents sensitive session data from being accidentally exposed when debug logging is enabled.

---
*PR created automatically by Jules for task [16142315547275017735](https://jules.google.com/task/16142315547275017735) started by @gonzaloriestra*