### PR TITLE
[Refactor] Fix incorrect Promise.all usage in app.ts

### DIFF
--- a/packages/app/src/cli/models/app/app.ts
+++ b/packages/app/src/cli/models/app/app.ts
@@ -405,7 +405,7 @@ export class App<
       }
     }
 
-    await Promise.all([this.allExtensions.map((ext) => ext.preDeployValidation())])
+    await Promise.all(this.allExtensions.map((ext) => ext.preDeployValidation()))
   }
 
   extensionsForType(specification: {identifier: string; externalIdentifier: string}): ExtensionInstance[] {


### PR DESCRIPTION
### WHY are these changes introduced?

The `preDeployValidation` function in `packages/app/src/cli/models/app/app.ts` was not correctly awaiting the validation of all extensions. It was using `Promise.all([this.allExtensions.map(...)])`, which creates an array containing a single element (the array of promises returned by `.map()`). `Promise.all` then resolves immediately because it sees an array of non-promise values (the array itself).

### WHAT is this pull request doing?

Fixed the incorrect `Promise.all` usage by removing the unnecessary outer array brackets. Now it correctly awaits all validation promises: `Promise.all(this.allExtensions.map(...))`.

### How to test your changes?

CI

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type] (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes]) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [14262157258669614203](https://jules.google.com/task/14262157258669614203) started by @gonzaloriestra*