### PR TITLE
[Security] Redact Cookie headers in debug logs

### DIFF
--- a/packages/cli-kit/src/private/node/api/headers.test.ts
+++ b/packages/cli-kit/src/private/node/api/headers.test.ts
@@ -97,6 +97,25 @@ describe('common API methods', () => {
        - Content-Type: application/json"
     `)
   })
+
+  test('sanitizedHeadersOutput removes the headers that include cookies', () => {
+    // Given
+    const headers = {
+      'User-Agent': 'useragent',
+      Cookie: 'session=abc',
+      'Set-Cookie': 'session=def',
+      'Content-Type': 'application/json',
+    }
+
+    // When
+    const got = sanitizedHeadersOutput(headers)
+
+    // Then
+    expect(got).toMatchInlineSnapshot(`
+      " - User-Agent: useragent
+       - Content-Type: application/json"
+    `)
+  })
 })
 
 describe('GraphQLClientError', () => {

--- a/packages/cli-kit/src/private/node/api/headers.ts
+++ b/packages/cli-kit/src/private/node/api/headers.ts
@@ -33,7 +33,7 @@ export class GraphQLClientError extends RequestClientError {
  */
 export function sanitizedHeadersOutput(headers: Record<string, string>): string {
   const sanitized: Record<string, string> = {}
-  const keywords = ['token', 'authorization', 'subject_token']
+  const keywords = ['token', 'authorization', 'subject_token', 'cookie']
   Object.keys(headers).forEach((header) => {
     if (keywords.find((keyword) => header.toLocaleLowerCase().includes(keyword)) === undefined) {
       sanitized[header] = headers[header]!


### PR DESCRIPTION
### Why is this change necessary?
To prevent sensitive session data (like session IDs in `Cookie` or `Set-Cookie` headers) from being exposed in debug logs or console output when the CLI is run with debug flags.

### How to test your changes?
1. Run a command that makes API calls with debug logging enabled (e.g., `DEBUG=shopify:* shopify app dev`).
2. Verify that any headers containing 'cookie' (case-insensitive) are not printed in the output.

### Duplicate check
- Query: `git log --grep="Security" --grep="Jules" --oneline -n 200`
- Results: No duplicate PRs found addressing header redaction for cookies.

### Jules Label
The `Jules` label is applied to this PR.

---
*PR created automatically by Jules for task [11015064662283064479](https://jules.google.com/task/11015064662283064479) started by @gonzaloriestra*