### PR TITLE
[Tests] Remove filesystem mocks in git.test.ts

### DIFF
--- a/packages/cli-kit/src/public/node/git.test.ts
+++ b/packages/cli-kit/src/public/node/git.test.ts
@@ -1,30 +1,11 @@
 import * as git from './git.js'
-import {
-  appendFileSync,
-  fileExists,
-  fileExistsSync,
-  glob,
-  inTemporaryDirectory,
-  isDirectory,
-  readFileSync,
-  writeFileSync,
-} from './fs.js'
+import {fileExistsSync, inTemporaryDirectory, mkdirSync, readFileSync, writeFileSync} from './fs.js'
 import {hasGit, isTerminalInteractive} from './context/local.js'
 import {beforeEach, describe, expect, test, vi} from 'vitest'
 import {execa} from 'execa'
 
 vi.mock('execa')
 vi.mock('./context/local.js')
-vi.mock('./fs.js', async () => {
-  const fs = await vi.importActual('./fs.js')
-  return {
-    ...fs,
-    appendFileSync: vi.fn(),
-    fileExists: vi.fn(),
-    isDirectory: vi.fn(),
-    glob: vi.fn(),
-  }
-})
 
 const mockedExeca = vi.mocked(execa)
 
@@ -133,60 +114,64 @@ describe('downloadRepository()', async () => {
   })
 
   test('throws when destination exists as a file', async () => {
-    await expect(async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
       const repoUrl = 'http://repoUrl'
-      const destination = 'destination'
-      vi.mocked(fileExists).mockResolvedValue(true)
-      vi.mocked(isDirectory).mockResolvedValue(false)
+      const destination = `${tmpDir}/file.txt`
+      writeFileSync(destination, '')
 
-      await git.downloadGitRepository({repoUrl, destination})
-    }).rejects.toThrowError(/Can't clone to/)
+      await expect(async () => {
+        await git.downloadGitRepository({repoUrl, destination})
+      }).rejects.toThrowError(/Can't clone to/)
+    })
   })
 
   test('throws when destination directory is not empty', async () => {
-    await expect(async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
       const repoUrl = 'http://repoUrl'
-      const destination = 'destination'
-      vi.mocked(fileExists).mockResolvedValue(true)
-      vi.mocked(isDirectory).mockResolvedValue(true)
-      vi.mocked(glob).mockResolvedValue(['file1.txt', 'file2.txt'])
+      const destination = `${tmpDir}/dir`
+      mkdirSync(destination)
+      writeFileSync(`${destination}/file1.txt`, '')
 
-      await git.downloadGitRepository({repoUrl, destination})
-    }).rejects.toThrowError(/already exists and is not empty/)
+      await expect(async () => {
+        await git.downloadGitRepository({repoUrl, destination})
+      }).rejects.toThrowError(/already exists and is not empty/)
+    })
   })
 
   test('throws when destination contains only hidden files', async () => {
-    await expect(async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
       const repoUrl = 'http://repoUrl'
-      const destination = 'destination'
-      vi.mocked(fileExists).mockResolvedValue(true)
-      vi.mocked(isDirectory).mockResolvedValue(true)
-      vi.mocked(glob).mockResolvedValue(['.git', '.DS_Store'])
+      const destination = `${tmpDir}/dir`
+      mkdirSync(destination)
+      writeFileSync(`${destination}/.git`, '')
 
-      await git.downloadGitRepository({repoUrl, destination})
-    }).rejects.toThrowError(/already exists and is not empty/)
+      await expect(async () => {
+        await git.downloadGitRepository({repoUrl, destination})
+      }).rejects.toThrowError(/already exists and is not empty/)
+    })
   })
 
   test('succeeds when destination directory is empty', async () => {
-    const repoUrl = 'http://repoUrl'
-    const destination = 'destination'
-    vi.mocked(fileExists).mockResolvedValue(true)
-    vi.mocked(isDirectory).mockResolvedValue(true)
-    vi.mocked(glob).mockResolvedValue([])
+    await inTemporaryDirectory(async (tmpDir) => {
+      const repoUrl = 'http://repoUrl'
+      const destination = `${tmpDir}/dir`
+      mkdirSync(destination)
 
-    await git.downloadGitRepository({repoUrl, destination})
+      await git.downloadGitRepository({repoUrl, destination})
 
-    expect(mockedExeca).toHaveBeenCalledWith('git', ['clone', '--recurse-submodules', repoUrl, destination])
+      expect(mockedExeca).toHaveBeenCalledWith('git', ['clone', '--recurse-submodules', repoUrl, destination])
+    })
   })
 
   test('succeeds when destination does not exist', async () => {
-    const repoUrl = 'http://repoUrl'
-    const destination = 'destination'
-    vi.mocked(fileExists).mockResolvedValue(false)
+    await inTemporaryDirectory(async (tmpDir) => {
+      const repoUrl = 'http://repoUrl'
+      const destination = `${tmpDir}/nonexistent`
 
-    await git.downloadGitRepository({repoUrl, destination})
+      await git.downloadGitRepository({repoUrl, destination})
 
-    expect(mockedExeca).toHaveBeenCalledWith('git', ['clone', '--recurse-submodules', repoUrl, destination])
+      expect(mockedExeca).toHaveBeenCalledWith('git', ['clone', '--recurse-submodules', repoUrl, destination])
+    })
   })
 })
 
@@ -203,18 +188,17 @@ describe('initializeRepository()', () => {
 
 describe('createGitIgnore()', () => {
   test('writes to a file in the provided directory', async () => {
-    const mockedAppendSync = vi.fn()
-    vi.mocked(appendFileSync).mockImplementation(mockedAppendSync)
-    const directory = '/unit/test'
-    const template = {
-      section: ['first', 'second'],
-    }
+    await inTemporaryDirectory(async (tmpDir) => {
+      const template = {
+        section: ['first', 'second'],
+      }
 
-    git.createGitIgnore(directory, template)
+      git.createGitIgnore(tmpDir, template)
 
-    expect(mockedAppendSync).toHaveBeenCalledOnce()
-    expect(mockedAppendSync.mock.lastCall?.[0]).toBe(`${directory}/.gitignore`)
-    expect(mockedAppendSync.mock.lastCall?.[1]).toBe('# section\nfirst\nsecond\n\n')
+      const gitIgnorePath = `${tmpDir}/.gitignore`
+      expect(fileExistsSync(gitIgnorePath)).toBe(true)
+      expect(readFileSync(gitIgnorePath).toString()).toBe('# section\nfirst\nsecond\n\n')
+    })
   })
 })
 


### PR DESCRIPTION
### WHY are these changes introduced?

Following the "Tester" mission to improve test quality by removing filesystem mocks. Mocking the filesystem is considered a "bad test" pattern when a real temporary directory can be used, as it tests implementation details rather than behavior.

### WHAT is this pull request doing?

Refactors `packages/cli-kit/src/public/node/git.test.ts` to:
- Remove the module-level `vi.mock('./fs.js')` which partially mocked filesystem operations.
- Replace these mocks with real disk interactions using `inTemporaryDirectory`.
- Update tests for `downloadGitRepository` and `createGitIgnore` to set up real files/directories and assert on the resulting filesystem state.
- Clean up unused imports and fix formatting.

### How to test your changes?

CI

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`


---
*PR created automatically by Jules for task [1108447129653858516](https://jules.google.com/task/1108447129653858516) started by @gonzaloriestra*