### PR TITLE
[Refactor] Extract shared execution environment logic in system.ts

### DIFF
--- a/packages/cli-kit/src/public/node/system.ts
+++ b/packages/cli-kit/src/public/node/system.ts
@@ -179,11 +179,7 @@ function parseCommand(command: string): string[] {
  * ```
  */
 export async function captureCommandWithExitCode(command: string, options?: ExecOptions): Promise<CaptureOutputResult> {
-  const env = options?.env ?? process.env
-  if (shouldDisplayColors()) {
-    env.FORCE_COLOR = '1'
-  }
-  const executionCwd = options?.cwd ?? cwd()
+  const {env, executionCwd} = getExecutionEnvironment(options)
   const [cmd, ...args] = parseCommand(command)
   if (!cmd) {
     return {stdout: '', stderr: 'Empty command', exitCode: 1}
@@ -208,11 +204,7 @@ export async function captureCommandWithExitCode(command: string, options?: Exec
  * @param options - Optional settings for how to run the command.
  */
 export async function execCommand(command: string, options?: ExecOptions): Promise<void> {
-  const env = options?.env ?? process.env
-  if (shouldDisplayColors()) {
-    env.FORCE_COLOR = '1'
-  }
-  const executionCwd = options?.cwd ?? cwd()
+  const {env, executionCwd} = getExecutionEnvironment(options)
   const [cmd, ...args] = parseCommand(command)
   if (!cmd) {
     throw new AbortError('Empty command')
@@ -305,11 +297,7 @@ function buildExec(
   options?: ExecOptions,
   execaOptions?: BuildExecOptions,
 ): ExecaChildProcess {
-  const env = options?.env ?? process.env
-  if (shouldDisplayColors()) {
-    env.FORCE_COLOR = '1'
-  }
-  const executionCwd = options?.cwd ?? cwd()
+  const {env, executionCwd} = getExecutionEnvironment(options)
   checkCommandSafety(command, {cwd: executionCwd})
   const commandProcess = execa(command, args, {
     env,
@@ -331,6 +319,18 @@ function buildExec(
   · Working directory: ${executionCwd}
 `)
   return commandProcess
+}
+
+function getExecutionEnvironment(options?: ExecOptions): {
+  env: {[key: string]: string | undefined}
+  executionCwd: string
+} {
+  const env = options?.env ?? process.env
+  if (shouldDisplayColors()) {
+    env.FORCE_COLOR = '1'
+  }
+  const executionCwd = options?.cwd ?? cwd()
+  return {env, executionCwd}
 }
 
 function checkCommandSafety(command: string, _options: {cwd: string}): void {


### PR DESCRIPTION
### WHY are these changes introduced?

The `packages/cli-kit/src/public/node/system.ts` file contained duplicated logic for preparing the execution environment (setting `FORCE_COLOR` and determining the `cwd`) across three different functions: `captureCommandWithExitCode`, `execCommand`, and `buildExec`.

### WHAT is this pull request doing?

This PR extracts the shared environment and CWD setup logic into a new private helper function `getExecutionEnvironment`. It then refactors `captureCommandWithExitCode`, `execCommand`, and `buildExec` to use this helper, improving maintainability and reducing code duplication.

### How to test your changes?

Run the unit tests for `system.ts`:
`pnpm vitest run packages/cli-kit/src/public/node/system.test.ts`

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible documentation changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct bump type and added a changeset with `pnpm changeset add`

### Duplicate check

I performed a duplicate check using `git log --grep="\[Refactor\]" --grep="Jules" --oneline` as `gh` is not available. No previous PRs were found targeting this specific duplication in `system.ts`.

---
*PR created automatically by Jules for task [9574303689973063028](https://jules.google.com/task/9574303689973063028) started by @gonzaloriestra*