### PR TITLE
Remove deprecated --shared-secret flag from `shopify app webhook trigger`

### DIFF
--- a/.changeset/remove-webhook-trigger-shared-secret-flag.md
+++ b/.changeset/remove-webhook-trigger-shared-secret-flag.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': major
+---
+
+Remove the deprecated `--shared-secret` flag and `SHOPIFY_FLAG_SHARED_SECRET` environment variable from `shopify app webhook trigger`. Use `--client-secret` (`SHOPIFY_FLAG_CLIENT_SECRET`) instead.

--- a/docs-shopify.dev/commands/interfaces/app-webhook-trigger.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/app-webhook-trigger.interface.ts
@@ -64,12 +64,6 @@ export interface appwebhooktrigger {
   '--reset'?: ''
 
   /**
-   * Deprecated. Please use client-secret.
-   * @environment SHOPIFY_FLAG_SHARED_SECRET
-   */
-  '--shared-secret <value>'?: string
-
-  /**
    * The requested webhook topic.
    * @environment SHOPIFY_FLAG_TOPIC
    */

--- a/packages/app/src/cli/commands/app/webhook/trigger.ts
+++ b/packages/app/src/cli/commands/app/webhook/trigger.ts
@@ -5,7 +5,6 @@ import {appFlags} from '../../../flags.js'
 import AppLinkedCommand, {AppLinkedCommandOutput} from '../../../utilities/app-linked-command.js'
 import {linkedAppContext} from '../../../services/app-context.js'
 import {Flags} from '@oclif/core'
-import {renderWarning} from '@shopify/cli-kit/node/ui'
 
 export default class WebhookTrigger extends AppLinkedCommand {
   static summary = 'Trigger delivery of a sample webhook topic payload to a designated address.'
@@ -56,12 +55,6 @@ export default class WebhookTrigger extends AppLinkedCommand {
       env: 'SHOPIFY_FLAG_DELIVERY_METHOD',
       description: `Method chosen to deliver the topic payload. If not passed, it's inferred from the address.`,
     }),
-    'shared-secret': Flags.string({
-      required: false,
-      hidden: false,
-      env: 'SHOPIFY_FLAG_SHARED_SECRET',
-      description: `Deprecated. Please use client-secret.`,
-    }),
     'client-secret': Flags.string({
       required: false,
       hidden: false,
@@ -83,15 +76,6 @@ export default class WebhookTrigger extends AppLinkedCommand {
   public async run(): Promise<AppLinkedCommandOutput> {
     const {flags} = await this.parse(WebhookTrigger)
 
-    if (flags['shared-secret']) {
-      renderWarning({
-        headline: [
-          'The flag shared-secret has been deprecated in favor of client-secret and will eventually be deleted.',
-        ],
-        body: ['Please use --client-secret instead.'],
-      })
-    }
-
     const appContextResult = await linkedAppContext({
       directory: flags.path,
       clientId: flags['client-id'],
@@ -106,7 +90,7 @@ export default class WebhookTrigger extends AppLinkedCommand {
       deliveryMethod: flags['delivery-method'],
       address: flags.address,
       clientId: flags['client-id'],
-      clientSecret: flags['client-secret'] || flags['shared-secret'], // eslint-disable-line @typescript-eslint/prefer-nullish-coalescing -- empty flag should try next
+      clientSecret: flags['client-secret'],
       path: flags.path,
       config: flags.config,
       organizationId: appContextResult.organization.id,

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -977,7 +977,7 @@ Trigger delivery of a sample webhook topic payload to a designated address.
 USAGE
   $ shopify app webhook trigger [--address <value>] [--api-version <value>] [--client-id <value> | -c <value>]
     [--client-secret <value>] [--delivery-method http|google-pub-sub|event-bridge] [--help] [--path <value>] [--reset |
-    ] [--shared-secret <value>] [--topic <value>]
+    ] [--topic <value>]
 
 FLAGS
   -c, --config=<value>
@@ -1015,9 +1015,6 @@ FLAGS
 
   --reset
       [env: SHOPIFY_FLAG_RESET] Reset all your settings.
-
-  --shared-secret=<value>
-      [env: SHOPIFY_FLAG_SHARED_SECRET] Deprecated. Please use client-secret.
 
   --topic=<value>
       [env: SHOPIFY_FLAG_TOPIC] The requested webhook topic.

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -3113,16 +3113,6 @@
           "name": "reset",
           "type": "boolean"
         },
-        "shared-secret": {
-          "description": "Deprecated. Please use client-secret.",
-          "env": "SHOPIFY_FLAG_SHARED_SECRET",
-          "hasDynamicHelp": false,
-          "hidden": false,
-          "multiple": false,
-          "name": "shared-secret",
-          "required": false,
-          "type": "option"
-        },
         "topic": {
           "description": "The requested webhook topic.",
           "env": "SHOPIFY_FLAG_TOPIC",
@@ -8409,16 +8399,6 @@
           "hidden": false,
           "name": "reset",
           "type": "boolean"
-        },
-        "shared-secret": {
-          "description": "Deprecated. Please use client-secret.",
-          "env": "SHOPIFY_FLAG_SHARED_SECRET",
-          "hasDynamicHelp": false,
-          "hidden": false,
-          "multiple": false,
-          "name": "shared-secret",
-          "required": false,
-          "type": "option"
         },
         "topic": {
           "description": "The requested webhook topic.",


### PR DESCRIPTION
### WHY are these changes introduced?

The `--shared-secret` flag and `SHOPIFY_FLAG_SHARED_SECRET` environment variable on `shopify app webhook trigger` have been deprecated for some time in favor of `--client-secret` (`SHOPIFY_FLAG_CLIENT_SECRET`). The command currently renders a deprecation warning when `--shared-secret` is used and falls back to copying it into the service's `clientSecret` field. This PR removes the deprecated flag in preparation for the next major release.

Part of the deprecated-flag-removal stack: [#7521](https://github.com/Shopify/cli/pull/7521) ← this PR → [#7523](https://github.com/Shopify/cli/pull/7523).

### WHAT is this pull request doing?

- Removes the `--shared-secret` flag definition and the `SHOPIFY_FLAG_SHARED_SECRET` env binding from `shopify app webhook trigger`.
- Removes the runtime deprecation warning.
- Removes the `flags['client-secret'] || flags['shared-secret']` fallback in favor of just `flags['client-secret']`.
- Internal/service-level fields named `sharedSecret` (e.g. in the GraphQL request and `send-app-uninstalled-webhook.ts`) are intentionally untouched — they correspond to the GraphQL schema and are unrelated to the user-facing flag.
- Regenerates `packages/cli/oclif.manifest.json`, `packages/cli/README.md`, and `docs-shopify.dev/commands/interfaces/app-webhook-trigger.interface.ts`.

### How to test your changes?

1. Run `pnpm shopify app webhook trigger --shared-secret abc` and confirm it now fails with an unknown-flag error.
2. Run `pnpm shopify app webhook trigger --help` and confirm `--shared-secret` is no longer listed and `--client-secret` is.
3. Run `pnpm shopify app webhook trigger --client-secret <secret> ...` end-to-end and confirm the webhook is signed and delivered as before.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [x] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`
