### PR TITLE
Remove deprecated --type flag from `shopify app generate extension`

### DIFF
--- a/.changeset/remove-app-generate-extension-type-flag.md
+++ b/.changeset/remove-app-generate-extension-type-flag.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': major
+---
+
+Remove the deprecated `--type` (`-t`) flag and `SHOPIFY_FLAG_EXTENSION_TYPE` environment variable from `shopify app generate extension`. Use `--template` (`SHOPIFY_FLAG_EXTENSION_TEMPLATE`) instead.

--- a/docs-shopify.dev/commands/interfaces/app-generate-extension.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/app-generate-extension.interface.ts
@@ -53,12 +53,6 @@ export interface appgenerateextension {
   '-t, --template <value>'?: string
 
   /**
-   * Deprecated. Please use --template
-   * @environment SHOPIFY_FLAG_EXTENSION_TYPE
-   */
-  '-t, --type <value>'?: string
-
-  /**
    * Increase the verbosity of the output.
    * @environment SHOPIFY_FLAG_VERBOSE
    */

--- a/packages/app/src/cli/commands/app/generate/extension.ts
+++ b/packages/app/src/cli/commands/app/generate/extension.ts
@@ -6,7 +6,6 @@ import AppLinkedCommand, {AppLinkedCommandOutput} from '../../../utilities/app-l
 import {linkedAppContext} from '../../../services/app-context.js'
 import {Flags} from '@oclif/core'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
-import {renderWarning} from '@shopify/cli-kit/node/ui'
 
 export default class AppGenerateExtension extends AppLinkedCommand {
   static summary = 'Generate a new app Extension.'
@@ -21,12 +20,6 @@ export default class AppGenerateExtension extends AppLinkedCommand {
   static flags = {
     ...globalFlags,
     ...appFlags,
-    type: Flags.string({
-      char: 't',
-      hidden: false,
-      description: `Deprecated. Please use --template`,
-      env: 'SHOPIFY_FLAG_EXTENSION_TYPE',
-    }),
     template: Flags.string({
       char: 't',
       hidden: false,
@@ -66,14 +59,6 @@ export default class AppGenerateExtension extends AppLinkedCommand {
       cmd_scaffold_template_custom: flags['clone-url'] !== undefined,
       cmd_scaffold_type_owner: '@shopify/app',
     }))
-
-    if (flags.type) {
-      renderWarning({
-        headline: ['The flag --type has been deprecated in favor of --template.'],
-        body: ['Please use --template instead.'],
-      })
-      process.exit(2)
-    }
 
     await checkFolderIsValidApp(flags.path)
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -722,13 +722,12 @@ Generate a new app Extension.
 USAGE
   $ shopify app generate extension [--client-id <value> | -c <value>] [--flavor
     vanilla-js|react|typescript|typescript-react|wasm|rust] [-n <value>] [--no-color] [--path <value>] [--reset | ] [-t
-    <value>] [-t <value>] [--verbose]
+    <value>] [--verbose]
 
 FLAGS
   -c, --config=<value>     [env: SHOPIFY_FLAG_APP_CONFIG] The name of the app configuration.
   -n, --name=<value>       [env: SHOPIFY_FLAG_NAME] name of your Extension
   -t, --template=<value>   [env: SHOPIFY_FLAG_EXTENSION_TEMPLATE] Extension template
-  -t, --type=<value>       [env: SHOPIFY_FLAG_EXTENSION_TYPE] Deprecated. Please use --template
       --client-id=<value>  [env: SHOPIFY_FLAG_CLIENT_ID] The Client ID of your app.
       --flavor=<option>    [env: SHOPIFY_FLAG_FLAVOR] Choose a starting template for your extension, where applicable
                            <options: vanilla-js|react|typescript|typescript-react|wasm|rust>

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -2124,16 +2124,6 @@
           "name": "template",
           "type": "option"
         },
-        "type": {
-          "char": "t",
-          "description": "Deprecated. Please use --template",
-          "env": "SHOPIFY_FLAG_EXTENSION_TYPE",
-          "hasDynamicHelp": false,
-          "hidden": false,
-          "multiple": false,
-          "name": "type",
-          "type": "option"
-        },
         "verbose": {
           "allowNo": false,
           "description": "Increase the verbosity of the output.",


### PR DESCRIPTION
### WHY are these changes introduced?

The `--type` (`-t`) flag and `SHOPIFY_FLAG_EXTENSION_TYPE` environment variable on `shopify app generate extension` have been deprecated for some time in favor of `--template` (`SHOPIFY_FLAG_EXTENSION_TEMPLATE`). The command currently renders a deprecation warning and exits with code 2 when `--type` is used. This PR removes the deprecated flag in preparation for the next major release.

Part of the deprecated-flag-removal stack: [#7522](https://github.com/Shopify/cli/pull/7522) ← this PR → [#7524](https://github.com/Shopify/cli/pull/7524).

### WHAT is this pull request doing?

- Removes the `--type`/`-t` flag definition and the `SHOPIFY_FLAG_EXTENSION_TYPE` env binding from `shopify app generate extension`.
- Removes the runtime deprecation warning and the `process.exit(2)` it triggered.
- Side-effect: the `-t` short alias now maps to `--template`. Previously both flags declared `char: 't'` and `--type`'s registration shadowed `--template`, so `-t` effectively meant `--type`. After this change, `-t` consistently maps to `--template`.
- Regenerates `packages/cli/oclif.manifest.json`, `packages/cli/README.md`, and `docs-shopify.dev/commands/interfaces/app-generate-extension.interface.ts`.

### How to test your changes?

1. Run `pnpm shopify app generate extension --type ui-extension` and confirm it now fails with an unknown-flag error.
2. Run `pnpm shopify app generate extension --help` and confirm `--type` is no longer listed.
3. Run `pnpm shopify app generate extension --template <template>` and confirm it works.
4. Run `pnpm shopify app generate extension -t <template>` and confirm `-t` now maps to `--template` (it would previously have mapped to `--type` and shown the deprecation warning).

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [x] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`
