### PR TITLE
Reject empty or whitespace-only configKey values in include_assets builds

### DIFF
--- a/packages/app/src/cli/services/build/steps/include-assets/copy-config-key-entry.test.ts
+++ b/packages/app/src/cli/services/build/steps/include-assets/copy-config-key-entry.test.ts
@@ -361,7 +361,13 @@ describe('copyConfigKeyEntry', () => {
         const outDir = joinPath(tmpDir, 'out')
         await mkdir(outDir)
         const context = makeContext({assets: ''})
-        const promise = copyConfigKeyEntry({key: 'assets', baseDir: tmpDir, outputDir: outDir, context})
+        const promise = copyConfigKeyEntry({
+          key: 'assets',
+          baseDir: tmpDir,
+          outputDir: outDir,
+          context,
+          appDirectory: tmpDir,
+        })
         await expect(promise).rejects.toThrow(AbortError)
         await expect(promise).rejects.toThrow(`'assets' can't be empty.`)
       })
@@ -372,13 +378,19 @@ describe('copyConfigKeyEntry', () => {
         const outDir = joinPath(tmpDir, 'out')
         await mkdir(outDir)
         const context = makeContext({assets: '   '})
-        const promise = copyConfigKeyEntry({key: 'assets', baseDir: tmpDir, outputDir: outDir, context})
+        const promise = copyConfigKeyEntry({
+          key: 'assets',
+          baseDir: tmpDir,
+          outputDir: outDir,
+          context,
+          appDirectory: tmpDir,
+        })
         await expect(promise).rejects.toThrow(AbortError)
         await expect(promise).rejects.toThrow(`'assets' can't be empty.`)
       })
     })
 
-    test('throws with the field name only, not the full configKey, when the key is nested', async () => {
+    test('throws with the full configKey when the key is nested', async () => {
       await inTemporaryDirectory(async (tmpDir) => {
         const outDir = joinPath(tmpDir, 'out')
         await mkdir(outDir)
@@ -388,9 +400,10 @@ describe('copyConfigKeyEntry', () => {
           baseDir: tmpDir,
           outputDir: outDir,
           context,
+          appDirectory: tmpDir,
         })
         await expect(promise).rejects.toThrow(AbortError)
-        await expect(promise).rejects.toThrow(`'assets' can't be empty.`)
+        await expect(promise).rejects.toThrow(`'extension_points[].assets' can't be empty.`)
       })
     })
   })

--- a/packages/app/src/cli/services/build/steps/include-assets/copy-config-key-entry.test.ts
+++ b/packages/app/src/cli/services/build/steps/include-assets/copy-config-key-entry.test.ts
@@ -354,4 +354,44 @@ describe('copyConfigKeyEntry', () => {
       await expect(fileExists(joinPath(outDir, 'tools.json'))).resolves.toBe(true)
     })
   })
+
+  describe('value guard', () => {
+    test('throws when value is an empty string', async () => {
+      await inTemporaryDirectory(async (tmpDir) => {
+        const outDir = joinPath(tmpDir, 'out')
+        await mkdir(outDir)
+        const context = makeContext({assets: ''})
+        const promise = copyConfigKeyEntry({key: 'assets', baseDir: tmpDir, outputDir: outDir, context})
+        await expect(promise).rejects.toThrow(AbortError)
+        await expect(promise).rejects.toThrow(`'assets' can't be empty.`)
+      })
+    })
+
+    test('throws when value is whitespace-only', async () => {
+      await inTemporaryDirectory(async (tmpDir) => {
+        const outDir = joinPath(tmpDir, 'out')
+        await mkdir(outDir)
+        const context = makeContext({assets: '   '})
+        const promise = copyConfigKeyEntry({key: 'assets', baseDir: tmpDir, outputDir: outDir, context})
+        await expect(promise).rejects.toThrow(AbortError)
+        await expect(promise).rejects.toThrow(`'assets' can't be empty.`)
+      })
+    })
+
+    test('throws with the field name only, not the full configKey, when the key is nested', async () => {
+      await inTemporaryDirectory(async (tmpDir) => {
+        const outDir = joinPath(tmpDir, 'out')
+        await mkdir(outDir)
+        const context = makeContext({extension_points: [{assets: ''}]})
+        const promise = copyConfigKeyEntry({
+          key: 'extension_points[].assets',
+          baseDir: tmpDir,
+          outputDir: outDir,
+          context,
+        })
+        await expect(promise).rejects.toThrow(AbortError)
+        await expect(promise).rejects.toThrow(`'assets' can't be empty.`)
+      })
+    })
+  })
 })

--- a/packages/app/src/cli/services/build/steps/include-assets/copy-config-key-entry.ts
+++ b/packages/app/src/cli/services/build/steps/include-assets/copy-config-key-entry.ts
@@ -62,6 +62,13 @@ export async function copyConfigKeyEntry(config: {
   // should only be copied once; the pathMap entry is reused for all references.
   const uniquePaths = [...new Set(paths)]
 
+  const fieldName = key.split('.').pop()?.replace(/\[\]$/, '') ?? key
+  for (const sourcePath of uniquePaths) {
+    if (sourcePath.trim() === '') {
+      throw new AbortError(`'${fieldName}' can't be empty.`)
+    }
+  }
+
   // Process sequentially to avoid filesystem race conditions on shared output paths.
   const pathMap = new Map<string, string | string[]>()
   let filesCopied = 0

--- a/packages/app/src/cli/services/build/steps/include-assets/copy-config-key-entry.ts
+++ b/packages/app/src/cli/services/build/steps/include-assets/copy-config-key-entry.ts
@@ -51,6 +51,12 @@ export async function copyConfigKeyEntry(config: {
     paths = []
   }
 
+  for (const sourcePath of paths) {
+    if (sourcePath.trim() === '') {
+      throw new AbortError(`'${key}' can't be empty.`)
+    }
+  }
+
   if (paths.length === 0) {
     outputDebug(`No value for configKey '${key}', skipping\n`, stdout)
     return {filesCopied: 0, pathMap: new Map()}
@@ -61,13 +67,6 @@ export async function copyConfigKeyEntry(config: {
   // Deduplicate: the same source path shared across multiple targets
   // should only be copied once; the pathMap entry is reused for all references.
   const uniquePaths = [...new Set(paths)]
-
-  const fieldName = key.split('.').pop()?.replace(/\[\]$/, '') ?? key
-  for (const sourcePath of uniquePaths) {
-    if (sourcePath.trim() === '') {
-      throw new AbortError(`'${fieldName}' can't be empty.`)
-    }
-  }
 
   // Process sequentially to avoid filesystem race conditions on shared output paths.
   const pathMap = new Map<string, string | string[]>()


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it's a work in progress
-->

### WHY are these changes introduced?

Splitting out the empty/whitespace validation from https://github.com/Shopify/cli/pull/7504.  
The additional path validation from that PR requires a larger conversation, while this portion is a lot simpler.

<!-- link to issue if one exists -->

<!--
  Context about the problem that's being addressed.
-->

### WHAT is this pull request doing?

Adds an empty-value validation pass in copyConfigKeyEntry that throws AbortError with message '\<field>' can't be empty. when a configKey resolves to an empty or whitespace-only string.

- Validation runs before any filesystem I/O — no partial copies on failure
- Error message uses the leaf segment of the configKey ('assets', not 'extension_points[].assets'), matching what the developer wrote in their TOML
- Field omitted entirely still works — the check only triggers when a value is explicitly written as empty.  Optional fields still allowed.
- Applies to every configKey routed through this helper: assets, tools, instructions, and intents[].schema (on extension_points[] and targeting[])

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?

Follow the steps in https://github.com/Shopify/cli/pull/7504

- test deploying an app with assets = "./assets".  assert correct value does not error
- test deploying an app with assets = "" `assert "cannot be empty"` error is thrown
- test deploying an app with assets = "   " assert `cannot be empty` error is thrown

<!--
  Please, provide steps for the reviewer to test your changes locally.
  You can post a comment with `/snapit` to generate a snapshot of the changes to be tested.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`