### PR TITLE
[Security] Redact cookies from debug logs

### DIFF
--- a/packages/cli-kit/src/private/node/api/headers.test.ts
+++ b/packages/cli-kit/src/private/node/api/headers.test.ts
@@ -76,7 +76,7 @@ describe('common API methods', () => {
     },
   )
 
-  test('sanitizedHeadersOutput removes the headers that include the token', () => {
+  test('sanitizedHeadersOutput removes sensitive headers', () => {
     // Given
     const headers = {
       'User-Agent': 'useragent',
@@ -85,6 +85,8 @@ describe('common API methods', () => {
       authorization: 'token',
       'Content-Type': 'application/json',
       'X-Shopify-Access-Token': 'token',
+      Cookie: 'session=123',
+      'Set-Cookie': 'session=456',
     }
 
     // When

--- a/packages/cli-kit/src/private/node/api/headers.ts
+++ b/packages/cli-kit/src/private/node/api/headers.ts
@@ -33,7 +33,7 @@ export class GraphQLClientError extends RequestClientError {
  */
 export function sanitizedHeadersOutput(headers: Record<string, string>): string {
   const sanitized: Record<string, string> = {}
-  const keywords = ['token', 'authorization', 'subject_token']
+  const keywords = ['token', 'authorization', 'subject_token', 'cookie']
   Object.keys(headers).forEach((header) => {
     if (keywords.find((keyword) => header.toLocaleLowerCase().includes(keyword)) === undefined) {
       sanitized[header] = headers[header]!


### PR DESCRIPTION
### WHY are these changes introduced?
Session identifiers and other sensitive data stored in `Cookie` and `Set-Cookie` headers were being leaked in debug logs when API requests failed or when debug logging was enabled. This poses a security risk as it could expose user sessions or other private information.

### WHAT is this pull request doing?
This PR adds `cookie` to the list of redacted keywords in `sanitizedHeadersOutput`. This ensures that any header containing "cookie" (case-insensitive) is omitted from the sanitized headers output used for logging.

### How to test your changes?
1. Run a command that makes an API request with cookies (e.g., `shopify theme console --verbose`).
2. Verify that any `Cookie` or `Set-Cookie` headers in the logged request/response headers are redacted.

### Checklist
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible documentation changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct bump type (`patch`) and added a changeset with `pnpm changeset add` (Note: skip changeset as per standard Jules instructions unless explicitly asked, but I'll mark it as considered).

---
*PR created automatically by Jules for task [3070110335838284999](https://jules.google.com/task/3070110335838284999) started by @gonzaloriestra*