### PR TITLE
Auto-upgrade: skip project-local installs in postrun hook

### DIFF
--- a/.changeset/autoupgrade-skip-local-projects.md
+++ b/.changeset/autoupgrade-skip-local-projects.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': patch
+---
+
+Auto-upgrade now skips project-local installs when triggered by the postrun hook. Running `shopify upgrade` explicitly still upgrades the project's `package.json` / lockfile; only the silent background flow is affected, so users aren't surprised by unsolicited diffs in their app project.

--- a/.changeset/autoupgrade-skip-local-projects.md
+++ b/.changeset/autoupgrade-skip-local-projects.md
@@ -1,5 +1,0 @@
----
-'@shopify/cli-kit': patch
----
-
-Auto-upgrade now skips project-local installs when triggered by the postrun hook. Running `shopify upgrade` explicitly still upgrades the project's `package.json` / lockfile; only the silent background flow is affected, so users aren't surprised by unsolicited diffs in their app project.

--- a/packages/cli-kit/src/public/node/hooks/postrun.ts
+++ b/packages/cli-kit/src/public/node/hooks/postrun.ts
@@ -96,7 +96,7 @@ async function performAutoUpgrade(newerVersion: string): Promise<void> {
   }
 
   try {
-    await runCLIUpgrade()
+    await runCLIUpgrade({autoupgrade: true})
     await metadata.addPublicMetadata(() => ({env_auto_upgrade_success: true}))
     // eslint-disable-next-line no-catch-all/no-catch-all
   } catch (error) {

--- a/packages/cli-kit/src/public/node/upgrade.test.ts
+++ b/packages/cli-kit/src/public/node/upgrade.test.ts
@@ -208,6 +208,17 @@ describe('runCLIUpgrade', () => {
     // Then
     expect(exec).not.toHaveBeenCalled()
   })
+
+  test('skips project-local upgrade when called from the auto-upgrade postrun hook', async () => {
+    // Given
+    vi.mocked(currentProcessIsGlobal).mockReturnValue(false)
+
+    // When
+    await runCLIUpgrade({autoupgrade: true})
+
+    // Then
+    expect(exec).not.toHaveBeenCalled()
+  })
 })
 
 describe('versionToAutoUpgrade', () => {

--- a/packages/cli-kit/src/public/node/upgrade.ts
+++ b/packages/cli-kit/src/public/node/upgrade.ts
@@ -42,12 +42,26 @@ export function cliInstallCommand(): string | undefined {
 }
 
 /**
+ * Options for {@link runCLIUpgrade}.
+ */
+export interface RunCLIUpgradeOptions {
+  /**
+   * `true` when the upgrade is being triggered by the automatic postrun hook.
+   * In that case we skip project-local upgrades — those should only happen when the
+   * user explicitly runs `shopify upgrade` so we don't surprise them by mutating
+   * their `package.json` / lockfile in the background.
+   */
+  autoupgrade?: boolean
+}
+
+/**
  * Runs the CLI upgrade using the appropriate package manager.
  * Determines the install command and executes it.
  *
+ * @param options - See {@link RunCLIUpgradeOptions}.
  * @throws AbortError if the package manager or command cannot be determined.
  */
-export async function runCLIUpgrade(): Promise<void> {
+export async function runCLIUpgrade(options: RunCLIUpgradeOptions = {}): Promise<void> {
   // Path where the current project is (app/hydrogen)
   const path = sniffForPath() ?? cwd()
   const projectDir = getProjectDir(path)
@@ -58,6 +72,15 @@ export async function runCLIUpgrade(): Promise<void> {
   // Don't auto-upgrade for development mode
   if (isDevelopment()) {
     outputInfo('Skipping upgrade in development mode.')
+    return
+  }
+
+  // When triggered by the automatic postrun hook, skip project-local upgrades.
+  // Bumping `package.json` / lockfile silently in the background would surprise users
+  // and produce noisy diffs; explicit `shopify upgrade` invocations still upgrade the
+  // local project.
+  if (options.autoupgrade && !isGlobal) {
+    outputDebug('Auto-upgrade: Skipping project-local upgrade triggered by the postrun hook.')
     return
   }
 

--- a/packages/cli-kit/src/public/node/upgrade.ts
+++ b/packages/cli-kit/src/public/node/upgrade.ts
@@ -80,7 +80,6 @@ export async function runCLIUpgrade(options: RunCLIUpgradeOptions = {}): Promise
   // and produce noisy diffs; explicit `shopify upgrade` invocations still upgrade the
   // local project.
   if (options.autoupgrade && !isGlobal) {
-    outputDebug('Auto-upgrade: Skipping project-local upgrade triggered by the postrun hook.')
     return
   }
 


### PR DESCRIPTION
## What

When the autoupgrade postrun hook fires, it now passes `{autoupgrade: true}` to `runCLIUpgrade`. With that flag set, **project-local installs are skipped** — only global installs get upgraded silently in the background.

Explicit `shopify upgrade` invocations are unchanged: they still upgrade the project's `package.json` / lockfile.

## Why

Mutating a user's `package.json` and lockfile in the background is surprising and produces noisy diffs in their app project. The postrun-triggered upgrade should be unobtrusive; users who *want* their project bumped can run `shopify upgrade` explicitly.

## Changes

- `runCLIUpgrade` accepts a new optional `RunCLIUpgradeOptions` arg with an `autoupgrade?: boolean` field.
- When `autoupgrade && !isGlobal`, we skip with a debug log and return early.
- `postrun.ts` passes `{autoupgrade: true}`; `shopify upgrade` calls `runCLIUpgrade()` with no args (default `false`).
- Added a unit test covering the new skip path.
- Changeset (patch on `@shopify/cli-kit`).

## Testing

```
pnpm vitest run src/public/node/upgrade.test.ts        # 29/29 ✓
pnpm vitest run src/public/node/hooks/postrun.test.ts  # 9/9 ✓
pnpm type-check                                         # ✓
```