### PR TITLE
Drop analyticsNameOverride on `app generate extension`

### DIFF
--- a/packages/app/src/cli/commands/app/generate/extension.ts
+++ b/packages/app/src/cli/commands/app/generate/extension.ts
@@ -47,10 +47,6 @@ export default class AppGenerateExtension extends AppLinkedCommand {
     }),
   }
 
-  public static analyticsNameOverride(): string | undefined {
-    return 'app scaffold extension'
-  }
-
   public async run(): Promise<AppLinkedCommandOutput> {
     const {flags} = await this.parse(AppGenerateExtension)
 


### PR DESCRIPTION
### WHY are these changes introduced?

Addresses [this metric thread on #7524](https://shopify.slack.com/archives/C0AL2BSRZLL/p1778251219996659). The `app generate extension` command currently overrides its analytics name to `app scaffold extension` — a holdover from before the rename. Now that the deprecated `scaffold extension` command itself is being removed in the parent PR (#7525), this override is misleading: analytics events from `app generate extension` should report the actual command name users run.

Stacked on top of [#7525](https://github.com/Shopify/cli/pull/7525).

### WHAT is this pull request doing?

- Removes the `analyticsNameOverride()` method from `AppGenerateExtension`.
- Analytics events for `shopify app generate extension` will now flow through with the natural command name (`app generate extension`) instead of the legacy `app scaffold extension`.

### How to test your changes?

1. Run `pnpm shopify app generate extension --template ...` in dev mode.
2. Confirm the analytics event reports `app generate extension` (e.g. via debug analytics output) — not `app scaffold extension`.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible documentation changes
- [x] I've considered analytics changes to measure impact — this PR *is* the analytics change
- [x] No user-visible behaviour change → no changeset
