### PR TITLE
[Security] Redact cookies in sanitized headers output

### DIFF
--- a/packages/cli-kit/src/private/node/api/headers.test.ts
+++ b/packages/cli-kit/src/private/node/api/headers.test.ts
@@ -85,6 +85,8 @@ describe('common API methods', () => {
       authorization: 'token',
       'Content-Type': 'application/json',
       'X-Shopify-Access-Token': 'token',
+      Cookie: 'session=abc',
+      'Set-Cookie': 'session=abc',
     }
 
     // When

--- a/packages/cli-kit/src/private/node/api/headers.ts
+++ b/packages/cli-kit/src/private/node/api/headers.ts
@@ -33,7 +33,7 @@ export class GraphQLClientError extends RequestClientError {
  */
 export function sanitizedHeadersOutput(headers: Record<string, string>): string {
   const sanitized: Record<string, string> = {}
-  const keywords = ['token', 'authorization', 'subject_token']
+  const keywords = ['token', 'authorization', 'subject_token', 'cookie']
   Object.keys(headers).forEach((header) => {
     if (keywords.find((keyword) => header.toLocaleLowerCase().includes(keyword)) === undefined) {
       sanitized[header] = headers[header]!


### PR DESCRIPTION
### WHY are these changes introduced?

To improve the security posture of the Shopify CLI by ensuring that sensitive session identifiers (Cookies) are sanitized and not leaked in debug logs or error reports.

### WHAT is this pull request doing?

This PR adds 'cookie' to the list of keywords used by the `sanitizedHeadersOutput` function in `@shopify/cli-kit` to redact sensitive headers. This ensures that both `Cookie` and `Set-Cookie` headers are removed from sanitized outputs.

### How to test your changes?

Run the following command to verify the header sanitization logic:
`pnpm --filter @shopify/cli-kit vitest run src/private/node/api/headers.test.ts`

### Duplicate check

- Ran: `git log --grep="\[Security\]" --oneline` (as `gh` is unavailable) and manually searched for similar PRs in the history.
- Found no existing PR addressing cookie redaction in `sanitizedHeadersOutput`.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible documentation changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct bump type and added a changeset with `pnpm changeset add` (Note: This is a security enhancement to internal logging/debugging, marked as non-user-facing bump wise if applicable, but changeset can be added if needed. Following Sentinel boundaries of small fixes.)


---
*PR created automatically by Jules for task [8609410605481335748](https://jules.google.com/task/8609410605481335748) started by @gonzaloriestra*