### PR TITLE
[Refactor] Fix incorrect Promise.all usage in app preDeployValidation

### DIFF
--- a/packages/app/src/cli/models/app/app.test.ts
+++ b/packages/app/src/cli/models/app/app.test.ts
@@ -851,3 +851,37 @@ function createPackageJson(tmpDir: string, type: string, version: string) {
   const dirPath = joinPath(tmpDir, 'node_modules', '@shopify', type)
   return mkdir(dirPath).then(() => writeFile(packagePath, JSON.stringify(packageJson)))
 }
+
+describe('preDeployValidation awaiting', () => {
+  test('awaits extension validation and catches rejections', async () => {
+    // Given
+    const extension = await testUIExtension()
+    vi.spyOn(extension, 'preDeployValidation').mockRejectedValue(new Error('Validation failed'))
+
+    const app = testApp({
+      allExtensions: [extension],
+    })
+
+    // When / Then
+    await expect(app.preDeployValidation()).rejects.toThrow('Validation failed')
+  })
+
+  test('awaits validation for multiple extensions and catches rejections', async () => {
+    // Given
+    const validExtension = await testUIExtension()
+    const invalidExtension = await testUIExtension()
+    const validPreDeployValidation = vi.spyOn(validExtension, 'preDeployValidation').mockResolvedValue()
+    const invalidPreDeployValidation = vi
+      .spyOn(invalidExtension, 'preDeployValidation')
+      .mockRejectedValue(new Error('Validation failed'))
+
+    const app = testApp({
+      allExtensions: [validExtension, invalidExtension],
+    })
+
+    // When / Then
+    await expect(app.preDeployValidation()).rejects.toThrow('Validation failed')
+    expect(validPreDeployValidation).toHaveBeenCalledOnce()
+    expect(invalidPreDeployValidation).toHaveBeenCalledOnce()
+  })
+})

--- a/packages/app/src/cli/models/app/app.ts
+++ b/packages/app/src/cli/models/app/app.ts
@@ -405,7 +405,7 @@ export class App<
       }
     }
 
-    await Promise.all([this.allExtensions.map((ext) => ext.preDeployValidation())])
+    await Promise.all(this.allExtensions.map((ext) => ext.preDeployValidation()))
   }
 
   extensionsForType(specification: {identifier: string; externalIdentifier: string}): ExtensionInstance[] {


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes an anti-pattern where `Promise.all` was called with an array containing another array (the result of `map`). This caused the inner promises to be ignored and the `preDeployValidation` to resolve immediately without waiting for actual extension validations to complete.

### WHAT is this pull request doing?

- Corrects `Promise.all([array.map(...)])` to `Promise.all(array.map(...))` in `packages/app/src/cli/models/app/app.ts`.
- Adds a regression test in `packages/app/src/cli/models/app/app.test.ts` to ensure extension validations are properly awaited and rejections are caught.

### How to test your changes?

CI

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch`) and added a changeset with `pnpm changeset add` (Note: Changeset skipped to avoid modifying files outside of the immediate fix scope per agent constraints).

---
*PR created automatically by Jules for task [11540683829797935190](https://jules.google.com/task/11540683829797935190) started by @gonzaloriestra*