### PR TITLE
Show Local URL in dev info when no App URL is available

### DIFF
--- a/.changeset/dev-local-url-fallback.md
+++ b/.changeset/dev-local-url-fallback.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Show Local URL in dev info when no App URL is available

--- a/packages/app/src/cli/services/dev.ts
+++ b/packages/app/src/cli/services/dev.ts
@@ -439,6 +439,7 @@ async function launchDevProcesses({
     appName: config.remoteApp.title,
     organizationName: config.commandOptions.organization.businessName,
     configPath: config.localApp.configPath,
+    localURL: config.network.proxyUrl,
   })
 }
 

--- a/packages/app/src/cli/services/dev/ui.tsx
+++ b/packages/app/src/cli/services/dev/ui.tsx
@@ -21,12 +21,14 @@ export async function renderDev({
   appName,
   organizationName,
   configPath,
+  localURL,
 }: DevProps & {
   devSessionStatusManager: DevSessionStatusManager
   appURL?: string
   appName?: string
   organizationName?: string
   configPath?: string
+  localURL?: string
 }) {
   if (!terminalSupportsPrompting()) {
     await renderDevNonInteractive({processes, app, abortController, developerPreview, shopFqdn})
@@ -41,6 +43,7 @@ export async function renderDev({
         appName={appName}
         organizationName={organizationName}
         configPath={configPath}
+        localURL={localURL}
         onAbort={async () => {
           await app.developerPlatformClient.devSessionDelete({appId: app.id, shopFqdn})
         }}

--- a/packages/app/src/cli/services/dev/ui/components/DevSessionUI.test.tsx
+++ b/packages/app/src/cli/services/dev/ui/components/DevSessionUI.test.tsx
@@ -554,6 +554,64 @@ describe('DevSessionUI', () => {
     renderInstance.unmount()
   })
 
+  test('hides Local URL in app info when an app URL is available', async () => {
+    // Given
+    const renderInstance = render(
+      <DevSessionUI
+        processes={[]}
+        abortController={new AbortController()}
+        devSessionStatusManager={devSessionStatusManager}
+        shopFqdn="mystore.myshopify.com"
+        appURL="https://my-app.ngrok.io"
+        localURL="http://localhost:3000"
+        appName="My Test App"
+        onAbort={onAbort}
+      />,
+    )
+
+    await waitForInputsToBeReady()
+
+    // When
+    await sendInputAndWait(renderInstance, 10, 'a')
+
+    // Then - only App URL is shown, Local URL is hidden
+    const output = unstyled(renderInstance.lastFrame()!)
+    expect(output).toContain('App URL:')
+    expect(output).toContain('https://my-app.ngrok.io')
+    expect(output).not.toContain('Local URL:')
+    expect(output).not.toContain('http://localhost:3000')
+
+    renderInstance.unmount()
+  })
+
+  test('shows Local URL in app info when no app URL is available', async () => {
+    // Given
+    const renderInstance = render(
+      <DevSessionUI
+        processes={[]}
+        abortController={new AbortController()}
+        devSessionStatusManager={devSessionStatusManager}
+        shopFqdn="mystore.myshopify.com"
+        localURL="http://localhost:3000"
+        appName="My Test App"
+        onAbort={onAbort}
+      />,
+    )
+
+    await waitForInputsToBeReady()
+
+    // When
+    await sendInputAndWait(renderInstance, 10, 'a')
+
+    // Then - Local URL is shown in place of App URL
+    const output = unstyled(renderInstance.lastFrame()!)
+    expect(output).toContain('Local URL:')
+    expect(output).toContain('http://localhost:3000')
+    expect(output).not.toContain('App URL:')
+
+    renderInstance.unmount()
+  })
+
   test('hides URL list when terminal supports hyperlinks', async () => {
     // Given
     mocks.terminalSupportsHyperlinks.mockReturnValue(true)

--- a/packages/app/src/cli/services/dev/ui/components/DevSessionUI.tsx
+++ b/packages/app/src/cli/services/dev/ui/components/DevSessionUI.tsx
@@ -37,6 +37,7 @@ interface DevSesionUIProps {
   appName?: string
   organizationName?: string
   configPath?: string
+  localURL?: string
   onAbort: () => Promise<void>
 }
 
@@ -49,6 +50,7 @@ const DevSessionUI: FunctionComponent<DevSesionUIProps> = ({
   appName,
   organizationName,
   configPath,
+  localURL,
   onAbort,
 }) => {
   const {isRawModeSupported: canUseShortcuts} = useStdin()
@@ -230,6 +232,7 @@ const DevSessionUI: FunctionComponent<DevSesionUIProps> = ({
             tabularData={[
               ['App:', appName ?? ''],
               ['App URL:', appURL ?? ''],
+              ['Local URL:', appURL ? '' : (localURL ?? '')],
               ['Config:', configPath?.split('/').pop() ?? ''],
               ['Org:', organizationName ?? ''],
             ].filter(([, value]) => value)}


### PR DESCRIPTION
### WHY are these changes introduced?

When running `dev`, the App info tab showed only the public App URL. For setups where no public App URL is available (e.g. extension-only apps), there was no way to see the URL used to serve the local extensions.

### WHAT is this pull request doing?

- Adds `localURL` (the proxy URL from network config) through `dev.ts` → `renderDev` → `DevSessionUI`.
- In the App info tab, shows **App URL** when available, otherwise falls back to **Local URL**. The two are mutually exclusive — never both.
- Adds tests covering each branch of the fallback.

### How to test your changes?

1. Run `dev` against an app/config where the public App URL is set → App info tab shows `App URL:` only.
2. Run `dev` in a setup without a public App URL → App info tab shows `Local URL:` only.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [x] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`