### PR TITLE
[Security] Redact cookies in sanitized headers output

### DIFF
--- a/.changeset/security-redact-cookies-in-logs.md
+++ b/.changeset/security-redact-cookies-in-logs.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': patch
+---
+
+Redact Cookie and Set-Cookie headers from debug logs to prevent sensitive session data leakage.

--- a/packages/cli-kit/src/private/node/api/headers.test.ts
+++ b/packages/cli-kit/src/private/node/api/headers.test.ts
@@ -97,6 +97,25 @@ describe('common API methods', () => {
        - Content-Type: application/json"
     `)
   })
+
+  test('sanitizedHeadersOutput removes the headers that include cookies', () => {
+    // Given
+    const headers = {
+      'User-Agent': 'useragent',
+      Cookie: 'session=abc',
+      'Set-Cookie': 'session=def',
+      'content-type': 'application/json',
+    }
+
+    // When
+    const got = sanitizedHeadersOutput(headers)
+
+    // Then
+    expect(got).toMatchInlineSnapshot(`
+      " - User-Agent: useragent
+       - content-type: application/json"
+    `)
+  })
 })
 
 describe('GraphQLClientError', () => {

--- a/packages/cli-kit/src/private/node/api/headers.ts
+++ b/packages/cli-kit/src/private/node/api/headers.ts
@@ -33,7 +33,7 @@ export class GraphQLClientError extends RequestClientError {
  */
 export function sanitizedHeadersOutput(headers: Record<string, string>): string {
   const sanitized: Record<string, string> = {}
-  const keywords = ['token', 'authorization', 'subject_token']
+  const keywords = ['token', 'authorization', 'subject_token', 'cookie']
   Object.keys(headers).forEach((header) => {
     if (keywords.find((keyword) => header.toLocaleLowerCase().includes(keyword)) === undefined) {
       sanitized[header] = headers[header]!


### PR DESCRIPTION
### WHY are these changes introduced?

To prevent sensitive session information (from \`Cookie\` and \`Set-Cookie\` headers) from being exposed in CLI debug logs.

### WHAT is this pull request doing?

It adds 'cookie' to the list of keywords that are redacted by the \`sanitizedHeadersOutput\` function in \`@shopify/cli-kit\`. This ensures that any header containing the word "cookie" (case-insensitive) is omitted from the sanitized output used for logging.

### How to test your changes?

You can verify this by running any command that performs a Shopify API request with the \`--verbose\` or \`--debug\` flag (which triggers \`shopifyFetch\`).
For example:
\`shopify app info --verbose\`

In the debug output, you should no longer see \`Cookie\` or \`Set-Cookie\` headers listed under "With request headers:".

### Duplicate check

Query run: \`gh pr list --repo Shopify/cli --state all --limit 200 --search 'label:"Jules" "Security" in:title' --json number,title,state,url,body,files\` (Note: \`gh\` was unavailable in the environment, so manual inspection of the codebase and \`git log\` was used as a fallback).

- This PR is meaningfully different as it targets a specific data leakage vector in the general API header sanitization logic that was previously overlooked.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [x] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (\`patch\`) and added a changeset with \`pnpm changeset add\`


---
*PR created automatically by Jules for task [13079893503620611949](https://jules.google.com/task/13079893503620611949) started by @gonzaloriestra*