### PR TITLE
[Refactor] Remove duplication in git latest tag retrieval

### DIFF
--- a/packages/cli-kit/src/public/node/git.ts
+++ b/packages/cli-kit/src/public/node/git.ts
@@ -233,8 +233,7 @@ export async function downloadGitRepository(cloneOptions: GitCloneOptions): Prom
 }
 
 async function getLatestTagFromDirectory(directory: string, repoUrl: string): Promise<string> {
-  const stdout = await gitCommand(['describe', '--tags', '--abbrev=0'], directory)
-  const tag = stdout.trim()
+  const tag = await getLatestTag(directory)
 
   if (!tag) {
     throw new AbortError(`Couldn't obtain the most recent tag of the repository ${repoUrl}`)


### PR DESCRIPTION
### WHY are these changes introduced?

The logic for executing `git describe --tags --abbrev=0` and trimming the output was duplicated in `getLatestTagFromDirectory` and `getLatestTag` within `packages/cli-kit/src/public/node/git.ts`. Centralizing this logic improves maintainability.

### WHAT is this pull request doing?

Refactors `getLatestTagFromDirectory` to call the existing `getLatestTag` helper function, removing the duplicated command execution.

### How to test your changes?

CI

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [12497117072717296991](https://jules.google.com/task/12497117072717296991) started by @gonzaloriestra*