### PR TITLE
Friendlier auto-upgrade messaging (version range + success banner)

### DIFF
--- a/packages/cli-kit/src/public/node/upgrade.ts
+++ b/packages/cli-kit/src/public/node/upgrade.ts
@@ -12,6 +12,7 @@ import {
   getPackageManager,
 } from './node-package-manager.js'
 import {outputContent, outputDebug, outputInfo, outputToken, outputWarn} from './output.js'
+import {renderSuccess} from './ui.js'
 import {cwd, moduleDirectory, sniffForPath} from './path.js'
 import {exec, isCI} from './system.js'
 import {isPreReleaseVersion} from './version.js'
@@ -92,8 +93,23 @@ export async function runCLIUpgrade(options: RunCLIUpgradeOptions = {}): Promise
     if (!command) {
       throw new Error('Could not determine the command to run')
     }
-    outputInfo(outputContent`Upgrading Shopify CLI by running: ${outputToken.genericShellCommand(installCommand)}...`)
+    // Cache lookup — already populated by versionToAutoUpgrade() upstream, so this
+    // is just a synchronous cache read, no extra network call.
+    const newerVersion = checkForCachedNewVersion('@shopify/cli', CLI_KIT_VERSION)
+    const headline = newerVersion
+      ? `✨ New version of Shopify CLI available! (${CLI_KIT_VERSION} → ${newerVersion})`
+      : '✨ New version of Shopify CLI available!'
+    outputInfo(
+      outputContent`${headline}
+   Now upgrading by running: ${outputToken.genericShellCommand(installCommand)}...`,
+    )
     await exec(command, args, {stdio: 'inherit'})
+    renderSuccess({
+      headline: 'Shopify CLI upgraded',
+      body: newerVersion
+        ? `You're now on version ${newerVersion}.`
+        : "You're now on the latest version.",
+    })
   } else if (projectDir) {
     await upgradeLocalShopify(projectDir, CLI_KIT_VERSION)
   } else {

--- a/packages/cli-kit/src/public/node/upgrade.ts
+++ b/packages/cli-kit/src/public/node/upgrade.ts
@@ -105,10 +105,8 @@ export async function runCLIUpgrade(options: RunCLIUpgradeOptions = {}): Promise
     )
     await exec(command, args, {stdio: 'inherit'})
     renderSuccess({
-      headline: 'Shopify CLI upgraded',
-      body: newerVersion
-        ? `You're now on version ${newerVersion}.`
-        : "You're now on the latest version.",
+      headline: 'Shopify CLI upgraded.',
+      body: newerVersion ? `You're now on version ${newerVersion}.` : "You're now on the latest version.",
     })
   } else if (projectDir) {
     await upgradeLocalShopify(projectDir, CLI_KIT_VERSION)


### PR DESCRIPTION
### WHY are these changes introduced?

Today the auto-upgrade flow prints a single, easy-to-miss line and then nothing else (until the next prompt) when it's done:

```
Upgrading Shopify CLI by running: `pnpm add -g @shopify/cli@latest`...
```

There's no acknowledgement of *why* it's running, no version context, and no confirmation when it finished — a side-effect ran on the user's machine and we leave them guessing.

### WHAT is this pull request doing?

Two minimal, additive changes in `packages/cli-kit/src/public/node/upgrade.ts` (`runCLIUpgrade` only, and only on the global path — local-project upgrades are unchanged):

**1. Friendlier pre-message with the version range.**

```
✨ New version of Shopify CLI available! (3.94.3 → 3.95.0)
   Now upgrading by running: `pnpm add -g @shopify/cli@latest`...
```

The version range is derived from `checkForCachedNewVersion`, which is already populated by `versionToAutoUpgrade()` upstream — it's a synchronous cache read, no extra network call, no signature change.

**2. Green `renderSuccess` banner after a successful upgrade.**

```
╭─ success ──────────────────────────────╮
│  Shopify CLI upgraded                  │
│                                        │
│  You're now on version 3.95.0.         │
╰────────────────────────────────────────╯
```

Reuses `renderSuccess` from `@shopify/cli-kit/node/ui` — the same banner used elsewhere in the CLI for deploy confirmations, so no new visual primitives.

### Diff

`packages/cli-kit/src/public/node/upgrade.ts` — +17 / -1.

### How to test your changes?

```sh
cd packages/cli-kit
pnpm vitest run src/public/node/upgrade.test.ts
pnpm type-check
```

End-to-end (snapshot-based, same as the bug bash setup):

```sh
pnpm install -g @shopify/cli@<older-snapshot>
SHOPIFY_CLI_FORCE_AUTO_UPGRADE=1 shopify version
```

You should see the new pre-message with the version range, the package-manager output, then the green success banner.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows) — pure messaging change, no platform calls
- [x] I've considered possible documentation changes — N/A
- [x] I've considered analytics changes to measure impact — none required; existing `env_auto_upgrade_success` metadata is unchanged
- [ ] No user-visible behaviour change → no changeset (cosmetic message change only; happy to add a patch changeset if preferred)
