### PR TITLE
[Tests] Remove filesystem mocks in bundle-size.test.ts

### DIFF
--- a/packages/app/src/cli/services/build/bundle-size.test.ts
+++ b/packages/app/src/cli/services/build/bundle-size.test.ts
@@ -1,77 +1,85 @@
 import {getBundleSize, formatBundleSize} from './bundle-size.js'
-import {describe, expect, test, vi} from 'vitest'
-import {readFile} from '@shopify/cli-kit/node/fs'
+import {describe, expect, test} from 'vitest'
+import {inTemporaryDirectory, writeFile} from '@shopify/cli-kit/node/fs'
+import {joinPath} from '@shopify/cli-kit/node/path'
 import {deflate} from 'node:zlib'
 import {promisify} from 'node:util'
 
 const deflateAsync = promisify(deflate)
 
-vi.mock('@shopify/cli-kit/node/fs')
-
 describe('getBundleSize', () => {
   test('returns raw and compressed sizes', async () => {
-    // Given
-    const content = 'a'.repeat(10000)
-    vi.mocked(readFile).mockResolvedValue(content as any)
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      const content = 'a'.repeat(10000)
+      const filePath = joinPath(tmpDir, 'bundle.js')
+      await writeFile(filePath, content)
 
-    // When
-    const result = await getBundleSize('/some/path.js')
+      // When
+      const result = await getBundleSize(filePath)
 
-    // Then
-    expect(result.rawBytes).toBe(10000)
-    expect(result.compressedBytes).toBe((await deflateAsync(Buffer.from(content))).byteLength)
-    expect(result.compressedBytes).toBeLessThan(result.rawBytes)
+      // Then
+      expect(result.rawBytes).toBe(10000)
+      expect(result.compressedBytes).toBe((await deflateAsync(Buffer.from(content))).byteLength)
+      expect(result.compressedBytes).toBeLessThan(result.rawBytes)
+    })
   })
 
   test('compressed size uses deflate to match the backend (Ruby Zlib::Deflate.deflate)', async () => {
-    // Given
-    const content = JSON.stringify({key: 'value', nested: {array: [1, 2, 3]}})
-    vi.mocked(readFile).mockResolvedValue(content as any)
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      const content = JSON.stringify({key: 'value', nested: {array: [1, 2, 3]}})
+      const filePath = joinPath(tmpDir, 'bundle.js')
+      await writeFile(filePath, content)
 
-    // When
-    const result = await getBundleSize('/some/path.js')
+      // When
+      const result = await getBundleSize(filePath)
 
-    // Then
-    const expectedCompressed = (await deflateAsync(Buffer.from(content))).byteLength
-    expect(result.compressedBytes).toBe(expectedCompressed)
+      // Then
+      const expectedCompressed = (await deflateAsync(Buffer.from(content))).byteLength
+      expect(result.compressedBytes).toBe(expectedCompressed)
+    })
   })
 })
 
 describe('formatBundleSize', () => {
   test('returns formatted size string with raw and compressed sizes', async () => {
-    // Given
-    const content = 'x'.repeat(50000)
-    const compressedSize = (await deflateAsync(Buffer.from(content))).byteLength
-    vi.mocked(readFile).mockResolvedValue(content as any)
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      const content = 'x'.repeat(50000)
+      const filePath = joinPath(tmpDir, 'bundle.js')
+      await writeFile(filePath, content)
+      const compressedSize = (await deflateAsync(Buffer.from(content))).byteLength
 
-    // When
-    const result = await formatBundleSize('/some/path.js')
+      // When
+      const result = await formatBundleSize(filePath)
 
-    // Then
-    const expectedRaw = (50000 / 1024).toFixed(1)
-    const expectedCompressed = (compressedSize / 1024).toFixed(1)
-    expect(result).toBe(` (${expectedRaw} KB original, ~${expectedCompressed} KB compressed)`)
+      // Then
+      const expectedRaw = (50000 / 1024).toFixed(1)
+      const expectedCompressed = (compressedSize / 1024).toFixed(1)
+      expect(result).toBe(` (${expectedRaw} KB original, ~${expectedCompressed} KB compressed)`)
+    })
   })
 
   test('formats MB for large files', async () => {
-    // Given
-    const content = 'a'.repeat(2 * 1024 * 1024)
-    const compressedSize = (await deflateAsync(Buffer.from(content))).byteLength
-    vi.mocked(readFile).mockResolvedValue(content as any)
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      const content = 'a'.repeat(2 * 1024 * 1024)
+      const filePath = joinPath(tmpDir, 'bundle.js')
+      await writeFile(filePath, content)
+      const compressedSize = (await deflateAsync(Buffer.from(content))).byteLength
 
-    // When
-    const result = await formatBundleSize('/some/path.js')
+      // When
+      const result = await formatBundleSize(filePath)
 
-    // Then
-    const expectedRaw = (Buffer.byteLength(content) / (1024 * 1024)).toFixed(2)
-    const expectedCompressed = (compressedSize / 1024).toFixed(1)
-    expect(result).toBe(` (${expectedRaw} MB original, ~${expectedCompressed} KB compressed)`)
+      // Then
+      const expectedRaw = (Buffer.byteLength(content) / (1024 * 1024)).toFixed(2)
+      const expectedCompressed = (compressedSize / 1024).toFixed(1)
+      expect(result).toBe(` (${expectedRaw} MB original, ~${expectedCompressed} KB compressed)`)
+    })
   })
 
   test('returns empty string on error', async () => {
-    // Given
-    vi.mocked(readFile).mockRejectedValue(new Error('file not found'))
-
     // When
     const result = await formatBundleSize('/missing/path.js')
 


### PR DESCRIPTION
### Description
This PR refactors `packages/app/src/cli/services/build/bundle-size.test.ts` to replace global filesystem mocks (`vi.mock('@shopify/cli-kit/node/fs')`) with real filesystem operations using `inTemporaryDirectory` and `writeFile`. This makes the tests more reliable and realistic by testing against the actual disk.

### Changes
- Removed `vi.mock('@shopify/cli-kit/node/fs')`.
- Wrapped test cases in `inTemporaryDirectory`.
- Used `writeFile` to create test files on disk.
- Updated assertions to use the actual file paths in the temporary directory.
- Cleaned up unused imports (`vi`, `readFile`).

---
*PR created automatically by Jules for task [6938643062223810454](https://jules.google.com/task/6938643062223810454) started by @gonzaloriestra*