### PR TITLE
[Refactor] Fix incorrect string formatting in addNPMDependencies

### DIFF
--- a/packages/cli-kit/src/public/node/node-package-manager.test.ts
+++ b/packages/cli-kit/src/public/node/node-package-manager.test.ts
@@ -1156,6 +1156,30 @@ describe('addNPMDependencies', () => {
     })
   })
 
+  test('writes a space-separated install message to stdout', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      const stdout = {write: vi.fn()}
+
+      // When
+      await addNPMDependencies(
+        [
+          {name: 'first', version: '0.0.1'},
+          {name: 'second', version: '0.0.2'},
+        ],
+        {
+          type: 'prod',
+          packageManager: 'npm',
+          directory: tmpDir,
+          stdout: stdout as any,
+        },
+      )
+
+      // Then
+      expect(stdout.write).toHaveBeenCalledWith('Installing first@0.0.1 second@0.0.2 with npm')
+    })
+  })
+
   test('when the package manager is unknown an error is thrown', async () => {
     await inTemporaryDirectory(async (tmpDir) => {
       // Given

--- a/packages/cli-kit/src/public/node/node-package-manager.ts
+++ b/packages/cli-kit/src/public/node/node-package-manager.ts
@@ -544,7 +544,7 @@ export async function addNPMDependencies(
   const dependenciesWithVersion = dependencies.map((dep) => {
     return dep.version ? `${dep.name}@${dep.version}` : dep.name
   })
-  options.stdout?.write(`Installing ${[dependenciesWithVersion].join(' ')} with ${options.packageManager}`)
+  options.stdout?.write(`Installing ${dependenciesWithVersion.join(' ')} with ${options.packageManager}`)
   switch (options.packageManager) {
     case 'npm':
       // npm isn't too smart when resolving the dependency tree. For example, admin ui extensions include react as


### PR DESCRIPTION
### What was improved
Fixed a minor code quality and formatting issue in `addNPMDependencies` where an array of dependency strings was being wrapped in another array before calling `.join(' ')`. This resulted in a comma-separated string instead of a space-separated one.

### How to test your changes?
Run any command that triggers `addNPMDependencies` and verify the "Installing ..." output message correctly space-separates multiple dependencies.

---
*PR created automatically by Jules for task [6314282184458645698](https://jules.google.com/task/6314282184458645698) started by @gonzaloriestra*