### PR TITLE
ci: declare workflow-level `contents: read` on 3 workflows

### DIFF
--- a/.github/workflows/tests-main.yml
+++ b/.github/workflows/tests-main.yml
@@ -24,6 +24,9 @@ env:
   GH_TOKEN_SHOP: ${{ secrets.SHOP_GH_READ_CONTENT_TOKEN }}
   DEFAULT_NODE_VERSION: '26.1.0'
 
+permissions:
+  contents: read
+
 jobs:
   main:
     name: '[Main] Node ${{ matrix.node }} in ${{ matrix.os }}'

--- a/.github/workflows/tests-manual.yml
+++ b/.github/workflows/tests-manual.yml
@@ -44,6 +44,9 @@ env:
   DEFAULT_NODE_VERSION: '26.1.0'
   DEFAULT_OS: 'ubuntu-latest'
 
+permissions:
+  contents: read
+
 jobs:
   manually-triggered:
     name: '[Manual] Test with Node ${{ inputs.node-version }} in ${{ inputs.os }}'

--- a/.github/workflows/tests-pr.yml
+++ b/.github/workflows/tests-pr.yml
@@ -18,6 +18,9 @@ env:
   GH_TOKEN_SHOP: ${{ secrets.SHOP_GH_READ_CONTENT_TOKEN }}
   DEFAULT_NODE_VERSION: '26.1.0'
 
+permissions:
+  contents: read
+
 jobs:
   type-check:
     name: 'Type check'


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to `contents: read` on 3 workflows in `.github/workflows/` that don't call a GitHub API beyond the initial checkout.

The following files were left implicit because they reference `GITHUB_TOKEN` / use a write-scope action / trigger on `pull_request_target`. Those scopes are best declared by maintainers: `cla.yml`, `shopify-dev-preview-automation.yml`, `update-graphql-deps.yml`, `workflow-cleaner.yml`.

## Why

CVE-2025-30066 (March 2025 `tj-actions/changed-files` supply-chain compromise) exfiltrated `GITHUB_TOKEN` from workflow logs. Pinning per workflow caps runtime authority irrespective of the repo or org default, gives drift protection if the default ever widens, and is credited per-file by the OpenSSF Scorecard `Token-Permissions` check.

YAML validated locally with `yaml.safe_load` on each touched file.