### PR TITLE
Fix Windows auto-upgrade for local CLI installs

### DIFF
--- a/.changeset/fix-windows-autoupgrade-local-dep.md
+++ b/.changeset/fix-windows-autoupgrade-local-dep.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': patch
+---
+
+Fix Windows-only bug where `currentProcessIsGlobal()` misclassified a project-local Shopify CLI install as global, causing the auto-upgrade flow to run `npm install -g @shopify/cli@latest` after every command on Windows. The path comparison now goes through `isSubpath` (pathe-based) so backslash-separated `argv[1]` and forward-slash `projectDir` compare correctly. macOS and Linux were unaffected.

--- a/.changeset/fix-windows-autoupgrade-local-dep.md
+++ b/.changeset/fix-windows-autoupgrade-local-dep.md
@@ -1,5 +1,0 @@
----
-'@shopify/cli-kit': patch
----
-
-Fix Windows-only bug where `currentProcessIsGlobal()` misclassified a project-local Shopify CLI install as global, causing the auto-upgrade flow to run `npm install -g @shopify/cli@latest` after every command on Windows. The path comparison now goes through `isSubpath` (pathe-based) so backslash-separated `argv[1]` and forward-slash `projectDir` compare correctly. macOS and Linux were unaffected.

--- a/packages/cli-kit/src/public/node/is-global.test.ts
+++ b/packages/cli-kit/src/public/node/is-global.test.ts
@@ -81,6 +81,23 @@ describe('currentProcessIsGlobal', () => {
     // Then
     expect(got).toBeFalsy()
   })
+
+  test('returns false on Windows when argv uses backslashes and projectDir uses forward slashes', () => {
+    // Given - mimic the exact Windows shape:
+    //   projectDir comes from pathe -> normalized forward slashes
+    //   argv[1] is OS-native -> backslash separated
+    const winProjectDir = 'C:/Users/me/project'
+    const winArgv1 = 'C:\\Users\\me\\project\\node_modules\\@shopify\\cli\\bin\\run.js'
+    vi.mocked(findPathUpSync).mockReturnValue(`${winProjectDir}/shopify.app.toml`)
+    const argv = ['node', winArgv1, 'shopify']
+
+    // When
+    const got = currentProcessIsGlobal(argv)
+
+    // Then - regression test for the path-separator bug that misclassified
+    // Windows local installs as global, triggering an unwanted `npm install -g`.
+    expect(got).toBeFalsy()
+  })
 })
 
 describe('inferPackageManagerForGlobalCLI', () => {

--- a/packages/cli-kit/src/public/node/is-global.ts
+++ b/packages/cli-kit/src/public/node/is-global.ts
@@ -1,4 +1,4 @@
-import {cwd, dirname, joinPath, sniffForPath} from './path.js'
+import {cwd, dirname, isSubpath, joinPath, sniffForPath} from './path.js'
 import {isUnitTest} from './context/local.js'
 import {findPathUpSync, globSync} from './fs.js'
 import {realpathSync} from 'fs'
@@ -27,9 +27,17 @@ export function currentProcessIsGlobal(argv = process.argv): boolean {
 
     // From node docs: "The second element [of the array] will be the path to the JavaScript file being executed"
     const binDir = argv[1] ?? ''
+    if (!binDir) {
+      return true
+    }
 
-    // If binDir starts with projectDir, then we are running a local CLI
-    const isLocal = binDir.startsWith(projectDir.trim())
+    // If binDir lives inside projectDir, we are running a local CLI.
+    // Use isSubpath (pathe.relative under the hood) instead of a raw
+    // string startsWith: projectDir flows through normalizePath and is
+    // forward-slash on every platform, while argv[1] is OS-native, so on
+    // Windows it arrives backslash-separated and a naive startsWith would
+    // misclassify a local install as global.
+    const isLocal = isSubpath(projectDir.trim(), binDir)
 
     _isGlobal = !isLocal
     return _isGlobal


### PR DESCRIPTION
### WHY are these changes introduced?

Reported by Nick Wesselman in [#shopify-cli](https://shopify.slack.com/archives/C0AL2BSRZLL/p1778724786049769): on Windows, running `shopify app dev` (or any command) in a project where `@shopify/cli` is a project-local dependency still triggers the global auto-upgrade flow — it runs `npm install -g @shopify/cli@latest` after every command. Confirmed working correctly on macOS + Linux.

Root-cause analysis by River:

`currentProcessIsGlobal()` in `packages/cli-kit/src/public/node/is-global.ts` decides between global and local installs by comparing the project root against `process.argv[1]`:

```ts
const isLocal = binDir.startsWith(projectDir.trim())
```

- `projectDir` flows through `getProjectDir` → `findPathUpSync` → `normalizePath` (pathe). **Pathe always normalizes to forward slashes on every platform** → `C:/Users/me/proj`.
- `process.argv[1]` arrives in **OS-native** form. On Windows that's backslash-separated → `C:\Users\me\proj\node_modules\@shopify\cli\bin\run.js`.
- `binDir.startsWith(projectDir)` → `false`.
- The local install is classified as global → `runCLIUpgrade()` takes the global branch → `npm install -g @shopify/cli@latest`.

macOS + Linux are unaffected because their native `argv[1]` already uses `/`.

### WHAT is this pull request doing?

Two-line behavioural fix + a regression test:

- **`packages/cli-kit/src/public/node/is-global.ts`** — replace the raw `startsWith` with `isSubpath(projectDir, binDir)`, which goes through `pathe.relative` and tolerates either separator. Also bail early if `argv[1]` is empty so we don't accidentally classify "no script path" as "inside any directory".

- **`packages/cli-kit/src/public/node/is-global.test.ts`** — new test that constructs the exact Windows shape (`projectDir = 'C:/Users/me/project'`, `argv[1] = 'C:\\Users\\me\\project\\…'`). The existing POSIX-shaped tests happened to agree on slashes when CI runs on Linux, which is why this slipped through.

- **`.changeset/fix-windows-autoupgrade-local-dep.md`** — patch on `@shopify/cli-kit`.

| Scenario | OLD (`startsWith`) | NEW (`isSubpath`) | Expected |
|---|---|---|---|
| Windows local dep | ❌ false | ✅ true | local |
| macOS local dep | ✅ true | ✅ true | local |
| POSIX global | ✅ false | ✅ false | global |
| Windows global | ✅ false | ✅ false | global |

### How to test your changes?

```sh
cd packages/cli-kit
pnpm vitest run src/public/node/is-global.test.ts   # 18/18 ✓
pnpm type-check
pnpm lint
```

End-to-end, on Windows, in a project that has `@shopify/cli` declared in `package.json`:

```powershell
$env:SHOPIFY_CLI_FORCE_AUTO_UPGRADE=1; npm run shopify -- version
```

Before: a global `npm install -g @shopify/cli@latest` runs after the command.
After: no global install runs — the project-local code path is taken (which, for now, also short-circuits per the auto-upgrade-skip-local change).

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows) — fix is **specifically** cross-platform; new test pins Windows shape
- [x] I've considered possible documentation changes — N/A
- [x] I've considered analytics changes to measure impact — none required
- [ ] The change is user-facing — patch-level changeset added on `@shopify/cli-kit`

Credit: bug reported by @nickwesselman; root-cause + suggested fix by River.
