### PR TITLE
Trigger auto-upgrade when dev is quit via q or Ctrl+C

### DIFF
--- a/packages/app/src/cli/services/dev/ui/components/Dev.test.tsx
+++ b/packages/app/src/cli/services/dev/ui/components/Dev.test.tsx
@@ -27,6 +27,13 @@ vi.mock('@shopify/cli-kit/node/system', async () => {
 vi.mock('../../../context.js')
 vi.mock('../../fetch.js')
 vi.mock('../../processes/dev-session.js')
+vi.mock('@shopify/cli-kit/node/hooks/postrun', async () => {
+  const actual: any = await vi.importActual('@shopify/cli-kit/node/hooks/postrun')
+  return {
+    ...actual,
+    waitForPostRunHookAndExit: vi.fn(),
+  }
+})
 
 const developerPlatformClient = testDeveloperPlatformClient()
 

--- a/packages/app/src/cli/services/dev/ui/components/Dev.tsx
+++ b/packages/app/src/cli/services/dev/ui/components/Dev.tsx
@@ -10,8 +10,7 @@ import {Box, Text, useInput, useStdin} from '@shopify/cli-kit/node/ink'
 import {handleCtrlC} from '@shopify/cli-kit/node/ui'
 import {openURL} from '@shopify/cli-kit/node/system'
 import figures from '@shopify/cli-kit/node/figures'
-import {isUnitTest} from '@shopify/cli-kit/node/context/local'
-import {treeKill} from '@shopify/cli-kit/node/tree-kill'
+import {waitForPostRunHookAndExit} from '@shopify/cli-kit/node/hooks/postrun'
 import {Writable} from 'stream'
 
 export interface DeveloperPreviewController {
@@ -74,12 +73,7 @@ const Dev: FunctionComponent<DevProps> = ({
       setIsShuttingDownMessage('Shutting down dev because of an error ...')
     } else {
       setIsShuttingDownMessage('Shutting down dev ...')
-      setTimeout(() => {
-        if (isUnitTest()) return
-        treeKill(process.pid, 'SIGINT', false, () => {
-          process.exit(0)
-        })
-      }, 2000)
+      waitForPostRunHookAndExit()
     }
     clearInterval(pollingInterval.current)
     await developerPreview.disable()

--- a/packages/app/src/cli/services/dev/ui/components/DevSessionUI.test.tsx
+++ b/packages/app/src/cli/services/dev/ui/components/DevSessionUI.test.tsx
@@ -24,6 +24,13 @@ vi.mock('@shopify/cli-kit/node/system', async () => {
 })
 vi.mock('@shopify/cli-kit/node/context/local')
 vi.mock('@shopify/cli-kit/node/tree-kill')
+vi.mock('@shopify/cli-kit/node/hooks/postrun', async () => {
+  const actual: any = await vi.importActual('@shopify/cli-kit/node/hooks/postrun')
+  return {
+    ...actual,
+    waitForPostRunHookAndExit: vi.fn(),
+  }
+})
 
 const mocks = vi.hoisted(() => {
   return {

--- a/packages/app/src/cli/services/dev/ui/components/DevSessionUI.tsx
+++ b/packages/app/src/cli/services/dev/ui/components/DevSessionUI.tsx
@@ -17,9 +17,7 @@ import {Box, Text, useInput, useStdin} from '@shopify/cli-kit/node/ink'
 import {handleCtrlC} from '@shopify/cli-kit/node/ui'
 import {openURL, terminalSupportsHyperlinks} from '@shopify/cli-kit/node/system'
 import figures from '@shopify/cli-kit/node/figures'
-import {isUnitTest} from '@shopify/cli-kit/node/context/local'
-import {treeKill} from '@shopify/cli-kit/node/tree-kill'
-import {postRunHookHasCompleted} from '@shopify/cli-kit/node/hooks/postrun'
+import {waitForPostRunHookAndExit} from '@shopify/cli-kit/node/hooks/postrun'
 import {Writable} from 'stream'
 
 interface DevStatusShortcut extends TabShortcut {
@@ -70,18 +68,7 @@ const DevSessionUI: FunctionComponent<DevSesionUIProps> = ({
       setIsShuttingDownMessage('Shutting down dev ...')
       await onAbort()
     }
-    if (isUnitTest()) return
-
-    // Wait for the post run hook to complete or timeout after 5 seconds.
-    let totalTime = 0
-    setInterval(() => {
-      if (postRunHookHasCompleted() || totalTime > 5000) {
-        treeKill(process.pid, 'SIGINT', false, () => {
-          process.exit(0)
-        })
-      }
-      totalTime += 100
-    }, 100)
+    waitForPostRunHookAndExit()
   })
 
   const errorHandledProcesses = useMemo(() => {

--- a/packages/cli-kit/src/public/node/hooks/postrun.ts
+++ b/packages/cli-kit/src/public/node/hooks/postrun.ts
@@ -2,6 +2,7 @@
  * Postrun hook — uses dynamic imports to avoid loading heavy modules (base-command, analytics)
  * at module evaluation time. These are only needed after the command has already finished.
  */
+import {treeKill} from '../tree-kill.js'
 import {Command, Hook} from '@oclif/core'
 
 let postRunHookCompleted = false
@@ -13,6 +14,42 @@ let postRunHookCompleted = false
  */
 export function postRunHookHasCompleted(): boolean {
   return postRunHookCompleted
+}
+
+/**
+ * Wait for the postrun hook to finish (so auto-upgrade has a chance to run) and then
+ * tree-kill the current process tree before exiting.
+ *
+ * Long-running interactive commands like `app dev` need this when the user terminates
+ * the command via `q` or Ctrl+C. The dev sub-processes such as servers and watchers keep
+ * the event loop alive, so even after oclif's postrun hook completes the node process
+ * won't exit on its own and we have to `treeKill` the process tree. We must not do that
+ * before the postrun hook has actually finished running auto-upgrade, otherwise we would
+ * kill the upgrade mid-way while `npm install` is still running.
+ *
+ * The flag `postRunHookCompleted` is flipped at the very end of the hook after
+ * `autoUpgradeIfNeeded` resolves, so polling it here is safe.
+ */
+export function waitForPostRunHookAndExit(): void {
+  const pollIntervalMs = 100
+  // Auto-upgrade can take a while (npm/pnpm/yarn install). Cap the wait generously so
+  // a stuck upgrade still terminates the process eventually.
+  const maxWaitMs = 120000
+
+  let elapsed = 0
+  let terminating = false
+  const handle = setInterval(() => {
+    if (terminating) return
+    if (postRunHookHasCompleted() || elapsed >= maxWaitMs) {
+      terminating = true
+      clearInterval(handle)
+      treeKill(process.pid, 'SIGINT', false, () => {
+        process.exit(0)
+      })
+      return
+    }
+    elapsed += pollIntervalMs
+  }, pollIntervalMs)
 }
 
 // This hook is called after each successful command run. More info: https://oclif.io/docs/hooks
@@ -28,9 +65,9 @@ export const hook: Hook.Postrun = async ({config, Command}) => {
   const {outputDebug} = await import('../output.js')
   const command = Command.id.replace(/:/g, ' ')
   outputDebug(`Completed command ${command}`)
-  postRunHookCompleted = true
 
   if (!command.includes('notifications') && !command.includes('upgrade')) await autoUpgradeIfNeeded()
+  postRunHookCompleted = true
 }
 
 /**


### PR DESCRIPTION
### WHY are these changes introduced?

When a developer runs `shopify app dev` and quits the command via `q` or `Ctrl+C`, the CLI's auto-upgrade either never started or — more confusingly — started and got killed mid-stream. There were two distinct bugs combining to produce this:

1. **`Dev.tsx`** (the legacy dev UI) hard-killed the process tree with a fixed 2 s `setTimeout` immediately after the abort fired. Once the postrun hook entered the auto-upgrade flow, the `treeKill` would race against it; if `npm/pnpm/yarn install` took longer than 2 s (almost always), the kill won and the upgrade was lost.

2. **`DevSessionUI.tsx`** (the dev-session UI) tried to do better by polling `postRunHookHasCompleted()`. But the flag was being set in the postrun hook **before** `autoUpgradeIfNeeded()` was awaited — so as soon as the hook entered auto-upgrade the flag flipped to `true`, the poll fired, and `treeKill` ran while the upgrade was still in progress. (This explains the inconsistent reports of "auto-upgrade started — sometimes finished — sometimes didn't".)

Once the user aborts a dev command, `useAbortSignal` does eventually call `complete()` → Ink's `exit()` → `waitUntilExit()` resolves → the dev `run()` returns → oclif fires the postrun hook → `autoUpgradeIfNeeded()` runs. The dev sub-processes (servers, watchers, …) keep the event loop alive after that, so the node process won't exit on its own — we still need to `treeKill`. We just need to do so **after** auto-upgrade actually finishes.

### WHAT is this pull request doing?

Two changes in `packages/cli-kit/src/public/node/hooks/postrun.ts`:

1. Move `postRunHookCompleted = true` to **after** `autoUpgradeIfNeeded()` resolves, so the flag accurately reflects "the postrun hook (including auto-upgrade) is done".
2. Add a small helper `waitForPostRunHookAndExit()` that polls `postRunHookHasCompleted()` every 100 ms and, once true, `treeKill`s the process tree and exits. A 120 s safety cap guarantees a stuck upgrade can't keep the dev process alive forever.

Both `Dev.tsx` and `DevSessionUI.tsx` now call `waitForPostRunHookAndExit()` from their abort handler instead of doing their own `setTimeout` / leaky polling. The corresponding unit tests mock `waitForPostRunHookAndExit` so the abort-path scenarios don't trigger real intervals or `treeKill`/`process.exit`.

Files changed:
- `packages/cli-kit/src/public/node/hooks/postrun.ts` — flag-ordering fix + new `waitForPostRunHookAndExit()` helper.
- `packages/app/src/cli/services/dev/ui/components/Dev.tsx` — use the helper, drop the 2 s `setTimeout` and the `isUnitTest`/`treeKill`/`context/local` imports.
- `packages/app/src/cli/services/dev/ui/components/DevSessionUI.tsx` — use the helper, drop the leaky inline polling and the `isUnitTest`/`treeKill`/`context/local` imports.
- `packages/app/src/cli/services/dev/ui/components/Dev.test.tsx` — mock the helper.
- `packages/app/src/cli/services/dev/ui/components/DevSessionUI.test.tsx` — mock the helper.

### How to test your changes?

1. Make sure auto-upgrade has a target available locally — easiest: set `SHOPIFY_CLI_FORCE_AUTO_UPGRADE=1` and ensure `versionToAutoUpgrade()` would return a newer version (e.g. by pointing the CLI at a stale version).
2. Run `shopify app dev` against a sample app.
3. Press `q` (or `Ctrl+C`) to quit.
4. Expected: the dev UI prints `Shutting down dev …`, the auto-upgrade output appears and completes, and only then does the process exit. On `main` today the process exits before the upgrade can run, or the upgrade gets killed mid-install.
5. Repeat against an app that goes through the dev-session path (`DevSessionUI`) — same expected behavior.

### Post-release steps

N/A.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows) — only the existing `treeKill` path is reused.
- [x] I've considered possible [documentation](https://shopify.dev) changes — none required.
- [x] I've considered analytics changes to measure impact — auto-upgrade success/skip metadata is unchanged.
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`
