### PR TITLE
Use bun for autoupgrade when CLI installed via bun add -g

### DIFF
--- a/packages/cli-kit/src/public/node/is-global.test.ts
+++ b/packages/cli-kit/src/public/node/is-global.test.ts
@@ -246,6 +246,25 @@ describe('inferPackageManagerForGlobalCLI', () => {
     expect(got).toBe('homebrew')
   })
 
+  test('returns bun when symlink under ~/.bun/bin resolves out of the bun install dir', async () => {
+    // Given: `bun add -g @shopify/cli` creates ~/.bun/bin/shopify as a symlink to
+    // ../../node_modules/@shopify/cli/bin/run.js, which on most setups resolves to
+    // <home>/node_modules/@shopify/cli/bin/run.js — a path that does NOT contain "bun".
+    // Without inspecting the original symlink path we'd fall through to npm and the
+    // autoupgrade flow would shell out to `npm install -g` instead of `bun add -g`.
+    const symlinkPath = '/users/fonso/.bun/bin/shopify'
+    const realBunPath = '/users/fonso/node_modules/@shopify/cli/bin/run.js'
+    const argv = ['node', symlinkPath, 'shopify']
+
+    vi.mocked(realpathSync).mockImplementationOnce(() => realBunPath)
+
+    // When
+    const got = inferPackageManagerForGlobalCLI(argv)
+
+    // Then
+    expect(got).toBe('bun')
+  })
+
   test('defaults to npm if realpath fails and no other indicator is present', async () => {
     // Given: A path that realpathSync cannot resolve
     const nonExistentPath = '/opt/homebrew/bin/shopify'

--- a/packages/cli-kit/src/public/node/is-global.ts
+++ b/packages/cli-kit/src/public/node/is-global.ts
@@ -105,9 +105,10 @@ export function inferPackageManagerForGlobalCLI(argv = process.argv, env = proce
   }
 
   const processArgv = argv[1] ?? ''
+  const symlinkPath = processArgv.toLowerCase()
 
   // Resolve symlinks to get the real path of the binary.
-  let realPath = processArgv.toLowerCase()
+  let realPath = symlinkPath
   try {
     realPath = realpathSync(processArgv).toLowerCase()
     // eslint-disable-next-line no-catch-all/no-catch-all
@@ -115,9 +116,16 @@ export function inferPackageManagerForGlobalCLI(argv = process.argv, env = proce
     // fall back to using the original path for detection
   }
 
-  if (realPath.includes('yarn')) return 'yarn'
-  if (realPath.includes('pnpm')) return 'pnpm'
-  if (realPath.includes('bun')) return 'bun'
+  // Inspect both the (unresolved) symlink path and the resolved real path. Some
+  // package managers — notably bun (`~/.bun/bin/<name>`) — install global binaries
+  // as symlinks pointing into a generic `node_modules` directory whose real path
+  // no longer contains the package manager name. The original symlink under the
+  // PM's bin dir is the most reliable signal in that case.
+  const matches = (needle: string) => realPath.includes(needle) || symlinkPath.includes(needle)
+
+  if (matches('yarn')) return 'yarn'
+  if (matches('pnpm')) return 'pnpm'
+  if (matches('bun')) return 'bun'
 
   // Check for Homebrew via Cellar path (resolved symlink)
   if (realPath.includes('/cellar/')) return 'homebrew'


### PR DESCRIPTION
### WHY are these changes introduced?

When the global Shopify CLI is installed via `bun add -g @shopify/cli`, the autoupgrade flow incorrectly shells out to `npm install -g @shopify/cli@latest` instead of using `bun`. Reproduction:

```
$ SHOPIFY_CLI_FORCE_AUTO_UPGRADE=1 shopify version
0.0.0-snapshot-20260513102036
Upgrading Shopify CLI by running: `npm install -g @shopify/cli@latest`...
npm is no longer supported in a global context.
Please migrate to pnpm, or come talk to us in #dev-up.
💡 Version 3.94.3 available! Run `npm install -g @shopify/cli@latest`
$ which shopify
/Users/fonso/.bun/bin/shopify
```

Root cause: `inferPackageManagerForGlobalCLI` in `packages/cli-kit/src/public/node/is-global.ts` only looked at the resolved `realpathSync(argv[1])` to decide which package manager to use. But `bun add -g` creates `~/.bun/bin/<name>` as a symlink whose target is `../../node_modules/<pkg>/bin/run.js`, which resolves to `<HOME>/node_modules/<pkg>/bin/run.js` — a path that no longer contains the string `bun`. Detection fell through to the default `npm` branch, so the autoupgrade and the upgrade-available reminder both suggested the wrong command.

### WHAT is this pull request doing?

- Inspects both the unresolved symlink path (`argv[1]`, e.g. `~/.bun/bin/shopify`) and the resolved real path when matching the `yarn` / `pnpm` / `bun` signal. The original symlink under the package manager's bin dir is the most reliable indicator when the real path leaves that directory.
- Keeps the existing Homebrew detection (env var first, then `/cellar/` in the resolved path) unchanged.
- Adds a regression test that mirrors the exact reproduction: a symlink at `~/.bun/bin/shopify` resolving to `<HOME>/node_modules/@shopify/cli/bin/run.js`.

### How to test your changes?

1. Install bun (e.g. via Homebrew: `brew install bun`).
2. `bun add -g @shopify/cli` and confirm `which shopify` returns a path under `~/.bun/bin`.
3. With this branch's `cli-kit` build, run `SHOPIFY_CLI_FORCE_AUTO_UPGRADE=1 shopify version`.
4. Expected: the upgrade message reads ``Upgrading Shopify CLI by running: `bun install -g @shopify/cli@latest`...`` and bun (not npm) performs the install.

Unit tests:

```
pnpm --filter @shopify/cli-kit vitest run src/public/node/is-global.test.ts
```

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows) — fix is symmetric across platforms; the only path-shape assumption is that bun's bin dir contains the substring `bun`, which holds on all OSes.
- [x] I've considered possible [documentation](https://shopify.dev) changes — none needed; behavior matches what users already expect.
- [x] I've considered analytics changes to measure impact — none needed.
- [ ] The change is user-facing — bug fix, but **no changeset is included in this PR per request**. If shipped on its own it should be a `patch`.
