### PR TITLE
[Security] Redact all Shopify tokens in analytics

### DIFF
--- a/packages/cli-kit/src/public/node/analytics.test.ts
+++ b/packages/cli-kit/src/public/node/analytics.test.ts
@@ -196,11 +196,6 @@ describe('event tracking', () => {
       }
       expect(publishEventMock).toHaveBeenCalledOnce()
       expect(publishEventMock.mock.calls[0]![2]).toMatchObject(expectedPayloadSensitive)
-      const sensitivePayload = JSON.stringify(publishEventMock.mock.calls[0]![2])
-      expect(sensitivePayload).not.toContain('shptka_abc123')
-      expect(sensitivePayload).not.toContain('shpat_abc123')
-      expect(sensitivePayload).not.toContain('shpua_abc123')
-      expect(sensitivePayload).not.toContain('shpca_abc123')
     })
   })
 

--- a/packages/cli-kit/src/public/node/analytics.test.ts
+++ b/packages/cli-kit/src/public/node/analytics.test.ts
@@ -164,12 +164,21 @@ describe('event tracking', () => {
     })
   })
 
-  test('does not send passwords to Monorail', async () => {
+  test('does not send any shopify tokens to Monorail', async () => {
     await inProjectWithFile('package.json', async (args) => {
       // Given
       const commandContent = {command: 'dev', topic: 'app'}
-      const argsWithPassword = args.concat(['--password', 'shptka_abc123'])
-      await startAnalytics({commandContent, args: argsWithPassword, currentTime: currentDate.getTime() - 100})
+      const argsWithTokens = args.concat([
+        '--password',
+        'shptka_abc123',
+        '--token',
+        'shpat_abc123',
+        '--user-token',
+        'shpua_abc123',
+        '--custom-token',
+        'shpca_abc123',
+      ])
+      await startAnalytics({commandContent, args: argsWithTokens, currentTime: currentDate.getTime() - 100})
 
       // When
       const config = {
@@ -180,11 +189,18 @@ describe('event tracking', () => {
 
       // Then
       const expectedPayloadSensitive = {
-        args: expect.stringMatching(/.*password \*\*\*\*\*/),
+        args: expect.stringMatching(
+          /.*password \*\*\*\*\*.*token \*\*\*\*\*.*user-token \*\*\*\*\*.*custom-token \*\*\*\*\*/,
+        ),
         metadata: expect.anything(),
       }
       expect(publishEventMock).toHaveBeenCalledOnce()
       expect(publishEventMock.mock.calls[0]![2]).toMatchObject(expectedPayloadSensitive)
+      const sensitivePayload = JSON.stringify(publishEventMock.mock.calls[0]![2])
+      expect(sensitivePayload).not.toContain('shptka_abc123')
+      expect(sensitivePayload).not.toContain('shpat_abc123')
+      expect(sensitivePayload).not.toContain('shpua_abc123')
+      expect(sensitivePayload).not.toContain('shpca_abc123')
     })
   })
 

--- a/packages/cli-kit/src/public/node/analytics.ts
+++ b/packages/cli-kit/src/public/node/analytics.ts
@@ -200,8 +200,8 @@ async function buildPayload({config, errorMessage, exitMode}: ReportAnalyticsEve
 
 function sanitizePayload<T>(payload: T): T {
   const payloadString = JSON.stringify(payload)
-  // Remove Theme Access passwords from the payload
-  const sanitizedPayloadString = payloadString.replace(/shptka_\w*/g, '*****')
+  // Remove Shopify tokens from the payload
+  const sanitizedPayloadString = payloadString.replace(/shp[a-z0-9]{1,6}_\w*/g, '*****')
   return JSON.parse(sanitizedPayloadString)
 }
 


### PR DESCRIPTION
### WHY are these changes introduced?

Shopify access tokens were not fully redacted from analytics payloads, with only Theme Access tokens being covered. This could lead to sensitive credentials being inadvertently leaked to analytics services.

### WHAT is this pull request doing?

This PR updates the analytics sanitization logic to use a more comprehensive regex pattern that captures all known Shopify-style access token prefixes. This ensures broader protection against credential leakage in analytics data.

### How to test your changes?

CI

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---

_PR created automatically by Jules for task_ [_9602644060096884862_](https://jules.google.com/task/9602644060096884862) _started by_ @gonzaloriestra