### PR TITLE
[Performance] Optimize outputDebug to skip expensive work when disabled

### DIFF
--- a/packages/cli-kit/src/public/node/output.test.ts
+++ b/packages/cli-kit/src/public/node/output.test.ts
@@ -1,5 +1,8 @@
 import {
+  collectedLogs,
+  clearCollectedLogs,
   LogLevel,
+  outputDebug,
   outputWhereAppropriate,
   outputToken,
   shouldDisplayColors,
@@ -7,16 +10,25 @@ import {
 } from './output.js'
 
 import {currentProcessIsGlobal} from './is-global.js'
-import {describe, expect, test, vi} from 'vitest'
+import {beforeEach, describe, expect, test, vi} from 'vitest'
 import {Writable} from 'stream'
+
+const isVerboseMock = vi.hoisted(() => vi.fn(() => false))
+const isUnitTestMock = vi.hoisted(() => vi.fn(() => false))
 
 vi.mock('./context/local.js', async () => {
   return {
-    isVerbose: () => false,
-    isUnitTest: () => false,
+    isVerbose: isVerboseMock,
+    isUnitTest: isUnitTestMock,
   }
 })
 vi.mock('./is-global.js')
+
+beforeEach(() => {
+  isVerboseMock.mockReturnValue(false)
+  isUnitTestMock.mockReturnValue(false)
+  clearCollectedLogs()
+})
 
 describe('Output helpers', () => {
   test('can format dependency manager commands with flags', () => {
@@ -84,6 +96,38 @@ describe('outputWhereAppropriate', () => {
     vi.spyOn(mockLogger, 'write')
     outputWhereAppropriate(logLevel, mockLogger, message)
     expect(mockLogger.write).toHaveBeenCalledWith(message)
+  })
+})
+
+describe('outputDebug', () => {
+  test('collects debug logs during unit tests', () => {
+    // Given
+    const logger = vi.fn()
+    isUnitTestMock.mockReturnValue(true)
+
+    // When
+    outputDebug('debug message', logger)
+
+    // Then
+    expect(collectedLogs.debug).toEqual(['debug message'])
+    expect(logger).not.toHaveBeenCalled()
+  })
+
+  test('skips timestamp and logger work when debug output is disabled', () => {
+    // Given
+    const logger = vi.fn()
+    const toISOStringSpy = vi.spyOn(Date.prototype, 'toISOString')
+
+    try {
+      // When
+      outputDebug('debug message', logger)
+
+      // Then
+      expect(toISOStringSpy).not.toHaveBeenCalled()
+      expect(logger).not.toHaveBeenCalled()
+    } finally {
+      toISOStringSpy.mockRestore()
+    }
   })
 })
 

--- a/packages/cli-kit/src/public/node/output.ts
+++ b/packages/cli-kit/src/public/node/output.ts
@@ -313,6 +313,8 @@ export function outputCompleted(content: OutputMessage, logger: Logger = console
  */
 export function outputDebug(content: OutputMessage, logger: Logger = consoleWarn): void {
   if (isUnitTest()) collectLog('debug', content)
+  if (!shouldOutput('debug')) return
+
   const message = colors.gray(stringifyMessage(content))
   outputWhereAppropriate('debug', logger, `${new Date().toISOString()}: ${message}`)
 }


### PR DESCRIPTION
### WHY are these changes introduced?

In high-frequency logging scenarios, \`outputDebug\` can become a bottleneck because it performs string construction, colorization, and timestamp generation (\`new Date().toISOString()\`) even when debug logging is disabled.

### WHAT is this pull request doing?

This PR adds an early return to \`outputDebug\` using \`shouldOutput('debug')\`. This ensures that expensive string processing and timestamp generation only happen when debug logs are actually going to be displayed.

### How to test your changes?

CI

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (\`patch\` for bug fixes · \`minor\` for new features · \`major\` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with \`pnpm changeset add\`

---
*PR created automatically by Jules for task [16389867832635500132](https://jules.google.com/task/16389867832635500132) started by @gonzaloriestra*