### PR TITLE
[Security] Harden URL sanitization

### DIFF
--- a/packages/cli-kit/src/private/node/api/urls.test.ts
+++ b/packages/cli-kit/src/private/node/api/urls.test.ts
@@ -56,6 +56,11 @@ describe('sanitizeURL', () => {
     'client_secret',
     'code',
     'token',
+    'password',
+    'code_verifier',
+    'client_assertion',
+    'assertion',
+    'auth_token',
   ])('sanitizes %s query parameter', (param) => {
     // Given
     const url = `https://example.com?${param}=secret-value`
@@ -78,5 +83,27 @@ describe('sanitizeURL', () => {
     expect(sanitizedUrl).toBe(
       'https://example.com/?access_token=****&refresh_token=****&device_code=****&subject_token=****&other=keep',
     )
+  })
+
+  test('redacts password from URL authority', () => {
+    // Given
+    const url = 'https://user:password123@example.com/path'
+
+    // When
+    const sanitizedUrl = sanitizeURL(url)
+
+    // Then
+    expect(sanitizedUrl).toBe('https://user:****@example.com/path')
+  })
+
+  test('redacts both password and sensitive query parameters', () => {
+    // Given
+    const url = 'https://user:secret@example.com/path?access_token=tok&other=keep'
+
+    // When
+    const sanitizedUrl = sanitizeURL(url)
+
+    // Then
+    expect(sanitizedUrl).toBe('https://user:****@example.com/path?access_token=****&other=keep')
   })
 })

--- a/packages/cli-kit/src/private/node/api/urls.ts
+++ b/packages/cli-kit/src/private/node/api/urls.ts
@@ -12,11 +12,16 @@ const SENSITIVE_QUERY_PARAMS = [
   'client_secret',
   'code',
   'token',
+  'password',
+  'code_verifier',
+  'client_assertion',
+  'assertion',
+  'auth_token',
 ]
 
 /**
  * Removes the sensitive data from the url and outputs them as a string.
- * @param url - HTTP headers.
+ * @param url - The URL to sanitize.
  * @returns A sanitized version of the url as a string.
  */
 export function sanitizeURL(url: string): string {
@@ -25,6 +30,9 @@ export function sanitizeURL(url: string): string {
     if (parsedUrl.searchParams.has(param)) {
       parsedUrl.searchParams.set(param, '****')
     }
+  }
+  if (parsedUrl.password) {
+    parsedUrl.password = '****'
   }
   return parsedUrl.toString()
 }


### PR DESCRIPTION
### Why is this change necessary?

Currently, `sanitizeURL` redacts some sensitive query parameters but misses several others commonly used in OAuth 2.0 and authentication flows. It also fails to redact passwords in the URL authority (Basic Auth), which are preserved by the `URL` object.

### Internal Consideration

This change hardens a core utility used for logging URLs, ensuring better protection against accidental credential leakage.

### Checklist

- [ ] I've added a [changeset](https://github.com/shopify/cli/blob/main/CONTRIBUTING.md#changesets) (if applicable)
- [ ] I've followed the [contributing guidelines](https://github.com/shopify/cli/blob/main/CONTRIBUTING.md)
- [ ] I've linted and formatted my code
- [ ] I've added tests to cover my changes
- [ ] I've verified my changes on a real-world app (if applicable)
- [ ] I've [documented my changes](https://github.com/shopify/cli/blob/main/CONTRIBUTING.md#documentation) (if applicable)


---
*PR created automatically by Jules for task [3281329784931291247](https://jules.google.com/task/3281329784931291247) started by @gonzaloriestra*