### PR TITLE
[Performance] Memoize isVerbose and isUnitTest in local context

### DIFF
--- a/packages/cli-kit/src/public/node/context/local.ts
+++ b/packages/cli-kit/src/public/node/context/local.ts
@@ -35,6 +35,16 @@ export function homeDirectory(): string {
 }
 
 /**
+ * Memoized value for the verbose check.
+ */
+let memoizedIsVerbose: boolean | undefined
+
+/**
+ * Memoized value for the unit test check.
+ */
+let memoizedIsUnitTest: boolean | undefined
+
+/**
  * Returns true if the CLI is running in debug mode.
  *
  * @param env - The environment variables from the environment of the current process.
@@ -51,6 +61,11 @@ export function isDevelopment(env = process.env): boolean {
  * @returns True if SHOPIFY_FLAG_VERBOSE is truthy or the flag --verbose has been passed.
  */
 export function isVerbose(env = process.env): boolean {
+  if (env === process.env) {
+    // Memoize the result to avoid repeated scans of process.argv and env lookups
+    // in high-frequency paths like outputDebug.
+    return (memoizedIsVerbose ??= isTruthy(env[environmentVariables.verbose]) || process.argv.includes('--verbose'))
+  }
   return isTruthy(env[environmentVariables.verbose]) || process.argv.includes('--verbose')
 }
 
@@ -88,6 +103,11 @@ export async function isShopify(env = process.env): Promise<boolean> {
  * @returns True if the SHOPIFY_UNIT_TEST environment variable is truthy.
  */
 export function isUnitTest(env = process.env): boolean {
+  if (env === process.env) {
+    // Memoize the result as SHOPIFY_UNIT_TEST is static during execution
+    // and checked frequently to suppress output.
+    return (memoizedIsUnitTest ??= isTruthy(env[environmentVariables.unitTest]))
+  }
   return isTruthy(env[environmentVariables.unitTest])
 }
 


### PR DESCRIPTION
### WHY are these changes introduced?

Performance-obsessed optimization for hot paths. Environment checks like `isVerbose` and `isUnitTest` are static during the execution of a CLI command but are often checked repeatedly (e.g., in every `outputDebug` call).

### WHAT is this pull request doing?

This PR implements lazy-initialized memoization for `isVerbose` and `isUnitTest` in `packages/cli-kit/src/public/node/context/local.ts`.

- Adds `memoizedIsVerbose` and `memoizedIsUnitTest` module-level variables.
- Implements a check to ensure memoization only occurs when using `process.env`.
- Bypasses the cache when a custom `env` object is passed (crucial for unit tests).
- Adds comments explaining the rationale and safety of the optimization.

### How to test your changes?

CI

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [7311632441309857235](https://jules.google.com/task/7311632441309857235) started by @gonzaloriestra*