### PR TITLE
[Performance] Optimize getArrayContainsDuplicates with early exit

### DIFF
--- a/packages/cli-kit/src/public/common/array.test.ts
+++ b/packages/cli-kit/src/public/common/array.test.ts
@@ -1,4 +1,4 @@
-import {difference, uniq, uniqBy} from './array.js'
+import {difference, getArrayContainsDuplicates, uniq, uniqBy} from './array.js'
 import {describe, test, expect} from 'vitest'
 
 describe('uniqBy', () => {
@@ -60,5 +60,40 @@ describe('difference', () => {
 
     // Then
     expect(got).toEqual([1])
+  })
+})
+
+describe('getArrayContainsDuplicates', () => {
+  test('returns true if the array contains duplicates', () => {
+    // Given
+    const array = [1, 2, 2, 3]
+
+    // When
+    const got = getArrayContainsDuplicates(array)
+
+    // Then
+    expect(got).toBe(true)
+  })
+
+  test('returns false if the array does not contain duplicates', () => {
+    // Given
+    const array = [1, 2, 3]
+
+    // When
+    const got = getArrayContainsDuplicates(array)
+
+    // Then
+    expect(got).toBe(false)
+  })
+
+  test('returns false for an empty array', () => {
+    // Given
+    const array: number[] = []
+
+    // When
+    const got = getArrayContainsDuplicates(array)
+
+    // Then
+    expect(got).toBe(false)
   })
 })

--- a/packages/cli-kit/src/public/common/array.ts
+++ b/packages/cli-kit/src/public/common/array.ts
@@ -25,11 +25,22 @@ export function getArrayRejectingUndefined<T>(array: (T | undefined)[]): T[] {
 /**
  * Returns true if an array contains duplicates.
  *
+ * This implementation is optimized to exit early as soon as the first duplicate
+ * is found, avoiding unnecessary processing of the rest of the array.
+ * Time complexity: O(k) where k is the index of the first duplicate, O(n) otherwise.
+ *
  * @param array - The array to check against.
  * @returns True if the array contains duplicates.
  */
 export function getArrayContainsDuplicates<T>(array: T[]): boolean {
-  return array.length !== new Set(array).size
+  const seen = new Set<T>()
+  for (const item of array) {
+    if (seen.has(item)) {
+      return true
+    }
+    seen.add(item)
+  }
+  return false
 }
 
 /**


### PR DESCRIPTION
### WHY are these changes introduced?

The current implementation of `getArrayContainsDuplicates` always processes the entire array to create a `Set`, even if a duplicate is found early on. This is inefficient for large arrays with early duplicates.

### WHAT is this pull request doing?

Refactors `getArrayContainsDuplicates` to use a `for...of` loop and a `Set` to track seen elements, allowing it to return `true` immediately when a duplicate is encountered.

### How to test your changes?

CI

### Post-release steps

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [12501024952324881799](https://jules.google.com/task/12501024952324881799) started by @gonzaloriestra*