### PR TITLE
[Security] Fix locale-sensitive header redaction

### DIFF
--- a/packages/cli-kit/src/private/node/api/headers.test.ts
+++ b/packages/cli-kit/src/private/node/api/headers.test.ts
@@ -99,6 +99,28 @@ describe('common API methods', () => {
        - Content-Type: application/json"
     `)
   })
+
+  test('sanitizedHeadersOutput redacts AUTHORIZATION even when toLocaleLowerCase returns dotless i (Turkish locale simulation)', () => {
+    // Given
+    const headers = {
+      AUTHORIZATION: 'secret-token',
+    }
+
+    // Simulate Turkish locale where 'I' becomes 'ı' (dotless i)
+    // 'AUTHORIZATION'.toLocaleLowerCase() -> 'authorızatıon'
+    const toLocaleLowerCaseSpy = vi.spyOn(String.prototype, 'toLocaleLowerCase').mockReturnValue('authorızatıon')
+
+    try {
+      // When
+      const got = sanitizedHeadersOutput(headers)
+
+      // Then
+      expect(got).not.toContain('AUTHORIZATION: secret-token')
+      expect(got).not.toContain('secret-token')
+    } finally {
+      toLocaleLowerCaseSpy.mockRestore()
+    }
+  })
 })
 
 describe('GraphQLClientError', () => {

--- a/packages/cli-kit/src/private/node/api/headers.ts
+++ b/packages/cli-kit/src/private/node/api/headers.ts
@@ -35,7 +35,7 @@ export function sanitizedHeadersOutput(headers: Record<string, string>): string 
   const sanitized: Record<string, string> = {}
   const keywords = ['token', 'authorization', 'subject_token', 'cookie']
   Object.keys(headers).forEach((header) => {
-    if (keywords.find((keyword) => header.toLocaleLowerCase().includes(keyword)) === undefined) {
+    if (keywords.find((keyword) => header.toLowerCase().includes(keyword)) === undefined) {
       sanitized[header] = headers[header]!
     }
   })


### PR DESCRIPTION
### WHY are these changes introduced?

Redaction of sensitive headers (like \`AUTHORIZATION\`) could be bypassed on systems with certain locales (e.g., Turkish) because \`toLocaleLowerCase()\` is non-deterministic for ASCII characters like 'I' (which becomes 'ı' in Turkish).

### WHAT is this pull request doing?

This PR replaces \`toLocaleLowerCase()\` with \`toLowerCase()\` in \`sanitizedHeadersOutput\` to ensure consistent ASCII-based matching for HTTP headers regardless of the user's locale. It also adds a regression test that simulates the problematic locale behavior.

### How to test your changes?

CI

### Post-release steps

None.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (\`patch\` for bug fixes · \`minor\` for new features · \`major\` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with \`pnpm changeset add\`

---
*PR created automatically by Jules for task [14224719727929470904](https://jules.google.com/task/14224719727929470904) started by @gonzaloriestra*