### PR TITLE
docs(readme): fix grammar in Homebrew install instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ To work with themes, the CLI needs to be installed globally with:
 
 - `npm install -g @shopify/cli`
 
-You can also use do it through Homebrew on macOS: `brew tap shopify/shopify && brew install shopify-cli`
+You can also install it through Homebrew on macOS: `brew tap shopify/shopify && brew install shopify-cli`
 
 Learn more in the docs: [Shopify CLI for themes](https://shopify.dev/docs/storefronts/themes/tools/cli)
 


### PR DESCRIPTION
The themes-development section of `README.md` says "You can also use do it through Homebrew on macOS" — "use do it" reads as a copy-paste leftover from a sentence rewrite. Changing to "install it" to match the context (the line is about installing the CLI globally).

```diff
-You can also use do it through Homebrew on macOS: `brew tap shopify/shopify && brew install shopify-cli`
+You can also install it through Homebrew on macOS: `brew tap shopify/shopify && brew install shopify-cli`
```