### PR TITLE
[Security] Harden git commands against flag injection

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-01-24 - [Security] Prevent flag injection in Git commands
+**Vulnerability:** User-controlled strings (like repository URLs, file paths, or tag names) passed to Git commands can be interpreted as flags if they start with a dash.
+**Learning:** Even when using structured arguments (execa), Git commands like `clone` and `check-ignore` require the `--` delimiter to explicitly separate options from positional arguments. For `checkout`, using `--` treats the argument as a pathspec, so using the `refs/tags/` prefix is a safer way to force the argument to be treated as a revision.
+**Prevention:** Use the `--` separator before positional arguments in Git commands like `clone` and `check-ignore`. For revisions in commands like `checkout`, use explicit prefixes like `refs/tags/` or `refs/heads/`.

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,4 +1,0 @@
-## 2025-01-24 - [Security] Prevent flag injection in Git commands
-**Vulnerability:** User-controlled strings (like repository URLs, file paths, or tag names) passed to Git commands can be interpreted as flags if they start with a dash.
-**Learning:** Even when using structured arguments (execa), Git commands like `clone` and `check-ignore` require the `--` delimiter to explicitly separate options from positional arguments. For `checkout`, using `--` treats the argument as a pathspec, so using the `refs/tags/` prefix is a safer way to force the argument to be treated as a revision.
-**Prevention:** Use the `--` separator before positional arguments in Git commands like `clone` and `check-ignore`. For revisions in commands like `checkout`, use explicit prefixes like `refs/tags/` or `refs/heads/`.

--- a/packages/app/src/cli/api/graphql/business-platform-organizations/generated/types.d.ts
+++ b/packages/app/src/cli/api/graphql/business-platform-organizations/generated/types.d.ts
@@ -22,6 +22,8 @@ export type Scalars = {
   ActionAuditID: { input: any; output: any; }
   /** The ID for a Address. */
   AddressID: { input: any; output: any; }
+  /** The ID for a Attestation. */
+  AttestationID: { input: any; output: any; }
   /** The ID for a BulkDataOperation. */
   BulkDataOperationID: { input: any; output: any; }
   /** The ID for a BusinessUser. */

--- a/packages/cli-kit/src/public/node/git.test.ts
+++ b/packages/cli-kit/src/public/node/git.test.ts
@@ -120,7 +120,26 @@ describe('downloadRepository()', async () => {
     await git.downloadGitRepository({repoUrl, destination, latestTag})
 
     expect(mockedExeca).toHaveBeenCalledWith('git', ['clone', '--recurse-submodules', '--', repoUrl, destination])
-    expect(mockedExeca).toHaveBeenCalledWith('git', ['checkout', '--', '1.2.3'], {cwd: destination})
+    expect(mockedExeca).toHaveBeenCalledWith('git', ['checkout', 'refs/tags/1.2.3'], {cwd: destination})
+  })
+
+  test('clones and checks out a flag-like tag', async () => {
+    mockGitCommandSequence([
+      // clone
+      {stdout: ''},
+      // describe --tags --abbrev=0
+      {stdout: '--flag-like-tag'},
+      // checkout
+      {stdout: ''},
+    ])
+
+    const repoUrl = 'http://repoUrl'
+    const destination = 'destination'
+    const latestTag = true
+
+    await git.downloadGitRepository({repoUrl, destination, latestTag})
+
+    expect(mockedExeca).toHaveBeenCalledWith('git', ['checkout', 'refs/tags/--flag-like-tag'], {cwd: destination})
   })
 
   test('throws when destination exists as a file', async () => {

--- a/packages/cli-kit/src/public/node/git.test.ts
+++ b/packages/cli-kit/src/public/node/git.test.ts
@@ -36,7 +36,7 @@ describe('downloadRepository()', async () => {
 
     await git.downloadGitRepository({repoUrl, destination})
 
-    expect(mockedExeca).toHaveBeenCalledWith('git', ['clone', '--recurse-submodules', repoUrl, destination])
+    expect(mockedExeca).toHaveBeenCalledWith('git', ['clone', '--recurse-submodules', '--', repoUrl, destination])
   })
 
   test('calls git clone with branch', async () => {
@@ -50,9 +50,19 @@ describe('downloadRepository()', async () => {
       '--recurse-submodules',
       '--branch',
       'my-branch',
+      '--',
       'http://repoUrl',
       destination,
     ])
+  })
+
+  test('calls git clone with flag-like repository URL', async () => {
+    const repoUrl = '-repoUrl'
+    const destination = 'destination'
+
+    await git.downloadGitRepository({repoUrl, destination})
+
+    expect(mockedExeca).toHaveBeenCalledWith('git', ['clone', '--recurse-submodules', '--', repoUrl, destination])
   })
 
   test('fails when the shallow and latestTag properties are passed', async () => {
@@ -109,7 +119,7 @@ describe('downloadRepository()', async () => {
 
     await git.downloadGitRepository({repoUrl, destination, latestTag})
 
-    expect(mockedExeca).toHaveBeenCalledWith('git', ['clone', '--recurse-submodules', repoUrl, destination])
+    expect(mockedExeca).toHaveBeenCalledWith('git', ['clone', '--recurse-submodules', '--', repoUrl, destination])
     expect(mockedExeca).toHaveBeenCalledWith('git', ['checkout', '1.2.3'], {cwd: destination})
   })
 
@@ -159,7 +169,7 @@ describe('downloadRepository()', async () => {
 
       await git.downloadGitRepository({repoUrl, destination})
 
-      expect(mockedExeca).toHaveBeenCalledWith('git', ['clone', '--recurse-submodules', repoUrl, destination])
+      expect(mockedExeca).toHaveBeenCalledWith('git', ['clone', '--recurse-submodules', '--', repoUrl, destination])
     })
   })
 
@@ -170,7 +180,7 @@ describe('downloadRepository()', async () => {
 
       await git.downloadGitRepository({repoUrl, destination})
 
-      expect(mockedExeca).toHaveBeenCalledWith('git', ['clone', '--recurse-submodules', repoUrl, destination])
+      expect(mockedExeca).toHaveBeenCalledWith('git', ['clone', '--recurse-submodules', '--', repoUrl, destination])
     })
   })
 })
@@ -183,6 +193,41 @@ describe('initializeRepository()', () => {
 
     expect(mockedExeca).toHaveBeenCalledWith('git', ['init'], {cwd: directory})
     expect(mockedExeca).toHaveBeenCalledWith('git', ['checkout', '-b', 'my-branch'], {cwd: directory})
+  })
+})
+
+describe('checkIfIgnoredInGitRepository()', () => {
+  test('calls git check-ignore with -- and the list of files', async () => {
+    const directory = '/tmp/git-repo'
+    const files = ['file1', 'file2']
+    mockGitCommand('file1\n')
+
+    const result = await git.checkIfIgnoredInGitRepository(directory, files)
+
+    expect(mockedExeca).toHaveBeenCalledWith('git', ['check-ignore', '--', 'file1', 'file2'], {cwd: directory})
+    expect(result).toEqual(['file1'])
+  })
+
+  test('calls git check-ignore with flag-like file paths', async () => {
+    const directory = '/tmp/git-repo'
+    const files = ['-file1', '--file2']
+    mockGitCommand('-file1\n')
+
+    const result = await git.checkIfIgnoredInGitRepository(directory, files)
+
+    expect(mockedExeca).toHaveBeenCalledWith('git', ['check-ignore', '--', '-file1', '--file2'], {cwd: directory})
+    expect(result).toEqual(['-file1'])
+  })
+
+  test('returns an empty array when no files are ignored', async () => {
+    const directory = '/tmp/git-repo'
+    const files = ['file1']
+    const error = Object.assign(new Error('not ignored'), {exitCode: 1})
+    mockedExeca.mockRejectedValue(error)
+
+    const result = await git.checkIfIgnoredInGitRepository(directory, files)
+
+    expect(result).toEqual([])
   })
 })
 

--- a/packages/cli-kit/src/public/node/git.test.ts
+++ b/packages/cli-kit/src/public/node/git.test.ts
@@ -120,7 +120,7 @@ describe('downloadRepository()', async () => {
     await git.downloadGitRepository({repoUrl, destination, latestTag})
 
     expect(mockedExeca).toHaveBeenCalledWith('git', ['clone', '--recurse-submodules', '--', repoUrl, destination])
-    expect(mockedExeca).toHaveBeenCalledWith('git', ['checkout', '1.2.3'], {cwd: destination})
+    expect(mockedExeca).toHaveBeenCalledWith('git', ['checkout', '--', '1.2.3'], {cwd: destination})
   })
 
   test('throws when destination exists as a file', async () => {

--- a/packages/cli-kit/src/public/node/git.ts
+++ b/packages/cli-kit/src/public/node/git.ts
@@ -69,7 +69,8 @@ export async function initializeGitRepository(directory: string, initialBranch =
  */
 export async function checkIfIgnoredInGitRepository(directory: string, files: string[]): Promise<string[]> {
   try {
-    const stdout = await gitCommand(['check-ignore', ...files], directory)
+    // Security: Use -- to separate flags from positional arguments (file paths)
+    const stdout = await gitCommand(['check-ignore', '--', ...files], directory)
     return stdout.split('\n').filter(Boolean)
   } catch (error) {
     // git check-ignore exits with code 1 when no files are ignored
@@ -209,7 +210,8 @@ export async function downloadGitRepository(cloneOptions: GitCloneOptions): Prom
     if (!isTerminalInteractive()) {
       args.push('-c', 'core.askpass=true')
     }
-    args.push(repository!, destination)
+    // Security: Use -- to separate flags from positional arguments (repository URL and destination)
+    args.push('--', repository!, destination)
 
     try {
       await execa('git', args)

--- a/packages/cli-kit/src/public/node/git.ts
+++ b/packages/cli-kit/src/public/node/git.ts
@@ -218,7 +218,7 @@ export async function downloadGitRepository(cloneOptions: GitCloneOptions): Prom
 
       if (latestTag) {
         const tag = await getLatestTagFromDirectory(destination, repoUrl)
-        await gitCommand(['checkout', tag], destination)
+        await gitCommand(['checkout', '--', tag], destination)
       }
     } catch (err) {
       if (err instanceof AbortError) {

--- a/packages/cli-kit/src/public/node/git.ts
+++ b/packages/cli-kit/src/public/node/git.ts
@@ -218,7 +218,8 @@ export async function downloadGitRepository(cloneOptions: GitCloneOptions): Prom
 
       if (latestTag) {
         const tag = await getLatestTagFromDirectory(destination, repoUrl)
-        await gitCommand(['checkout', '--', tag], destination)
+        // Security: Use refs/tags/ prefix to ensure the tag is treated as a revision and not a flag
+        await gitCommand(['checkout', `refs/tags/${tag}`], destination)
       }
     } catch (err) {
       if (err instanceof AbortError) {


### PR DESCRIPTION
### WHY are these changes introduced?

Prevent command-line flag injection in Git utility functions.

### WHAT is this pull request doing?

This PR hardens the `git` utility functions `downloadGitRepository` and `checkIfIgnoredInGitRepository` by using the `--` separator. This ensures that repository URLs and file paths starting with a dash are correctly interpreted as positional arguments and not as command flags.

### How to test your changes?

CI

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [13294469305582373459](https://jules.google.com/task/13294469305582373459) started by @gonzaloriestra*