### PR TITLE
Prototype agent session start in Shopify CLI

### DIFF
--- a/packages/app/src/cli/commands/app/release.test.ts
+++ b/packages/app/src/cli/commands/app/release.test.ts
@@ -1,28 +1,18 @@
 import Release from './release.js'
 import {testAppLinked, testDeveloperPlatformClient, testOrganizationApp} from '../../models/app/app.test-data.js'
 import {OrganizationSource} from '../../models/organization.js'
+import {linkedAppContext} from '../../services/app-context.js'
+import {release} from '../../services/release.js'
 import {describe, expect, test, vi, beforeEach} from 'vitest'
+import * as agent from '@shopify/cli-kit/node/agent'
 import {renderWarning} from '@shopify/cli-kit/node/ui'
 
 vi.mock('../../services/release.js')
 vi.mock('../../services/app-context.js')
-vi.mock('@shopify/cli-kit/node/metadata', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@shopify/cli-kit/node/metadata')>()
-  return {...actual, addPublicMetadata: vi.fn()}
-})
-vi.mock('@shopify/cli-kit/node/ui', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@shopify/cli-kit/node/ui')>()
-  return {...actual, renderWarning: vi.fn()}
-})
-vi.mock('@shopify/cli-kit/node/agent', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@shopify/cli-kit/node/agent')>()
-  return {...actual, getCurrentAgentSession: vi.fn()}
-})
+vi.mock('@shopify/cli-kit/node/ui')
 
 describe('app release --force deprecation warning', () => {
-  beforeEach(async () => {
-    const {linkedAppContext} = await import('../../services/app-context.js')
-    const {release} = await import('../../services/release.js')
+  beforeEach(() => {
     vi.mocked(linkedAppContext).mockResolvedValue({
       app: testAppLinked(),
       remoteApp: testOrganizationApp(),
@@ -85,10 +75,7 @@ describe('app release --force deprecation warning', () => {
 })
 
 describe('app release agent session behavior', () => {
-  beforeEach(async () => {
-    const {linkedAppContext} = await import('../../services/app-context.js')
-    const {release} = await import('../../services/release.js')
-    const {getCurrentAgentSession} = await import('@shopify/cli-kit/node/agent')
+  beforeEach(() => {
     vi.mocked(linkedAppContext).mockResolvedValue({
       app: testAppLinked(),
       remoteApp: testOrganizationApp(),
@@ -103,12 +90,11 @@ describe('app release agent session behavior', () => {
       activeConfig: {} as any,
     })
     vi.mocked(release).mockResolvedValue(undefined)
-    vi.mocked(getCurrentAgentSession).mockReturnValue(undefined)
+    vi.spyOn(agent, 'getCurrentAgentSession').mockReturnValue(undefined)
   })
 
   test('applies --allow-updates when agent session with defaultNonInteractive=true exists and no explicit flags', async () => {
-    const {getCurrentAgentSession} = await import('@shopify/cli-kit/node/agent')
-    vi.mocked(getCurrentAgentSession).mockReturnValue({
+    vi.mocked(agent.getCurrentAgentSession).mockReturnValue({
       sessionId: 'test-session',
       startedAt: new Date().toISOString(),
       agentName: 'test-agent',
@@ -120,7 +106,6 @@ describe('app release agent session behavior', () => {
 
     await Release.run(['--version', 'v1.0.0'])
 
-    const {release} = await import('../../services/release.js')
     expect(release).toHaveBeenCalledWith(
       expect.objectContaining({
         allowUpdates: true,
@@ -130,8 +115,7 @@ describe('app release agent session behavior', () => {
   })
 
   test('explicit --allow-updates flag wins over agent session', async () => {
-    const {getCurrentAgentSession} = await import('@shopify/cli-kit/node/agent')
-    vi.mocked(getCurrentAgentSession).mockReturnValue({
+    vi.mocked(agent.getCurrentAgentSession).mockReturnValue({
       sessionId: 'test-session',
       startedAt: new Date().toISOString(),
       agentName: 'test-agent',
@@ -143,7 +127,6 @@ describe('app release agent session behavior', () => {
 
     await Release.run(['--version', 'v1.0.0', '--allow-updates'])
 
-    const {release} = await import('../../services/release.js')
     expect(release).toHaveBeenCalledWith(
       expect.objectContaining({
         allowUpdates: true,
@@ -153,8 +136,7 @@ describe('app release agent session behavior', () => {
   })
 
   test('explicit --allow-deletes does not trigger --allow-updates from agent session', async () => {
-    const {getCurrentAgentSession} = await import('@shopify/cli-kit/node/agent')
-    vi.mocked(getCurrentAgentSession).mockReturnValue({
+    vi.mocked(agent.getCurrentAgentSession).mockReturnValue({
       sessionId: 'test-session',
       startedAt: new Date().toISOString(),
       agentName: 'test-agent',
@@ -166,7 +148,6 @@ describe('app release agent session behavior', () => {
 
     await Release.run(['--version', 'v1.0.0', '--allow-deletes'])
 
-    const {release} = await import('../../services/release.js')
     expect(release).toHaveBeenCalledWith(
       expect.objectContaining({
         allowUpdates: false,
@@ -176,8 +157,7 @@ describe('app release agent session behavior', () => {
   })
 
   test('no behavior change when agent session exists but defaultNonInteractive=false', async () => {
-    const {getCurrentAgentSession} = await import('@shopify/cli-kit/node/agent')
-    vi.mocked(getCurrentAgentSession).mockReturnValue({
+    vi.mocked(agent.getCurrentAgentSession).mockReturnValue({
       sessionId: 'test-session',
       startedAt: new Date().toISOString(),
       agentName: 'test-agent',
@@ -189,7 +169,6 @@ describe('app release agent session behavior', () => {
 
     await Release.run(['--version', 'v1.0.0', '--allow-updates'])
 
-    const {release} = await import('../../services/release.js')
     expect(release).toHaveBeenCalledWith(
       expect.objectContaining({
         allowUpdates: true,
@@ -199,8 +178,7 @@ describe('app release agent session behavior', () => {
   })
 
   test('explicit --force flag works with agent session', async () => {
-    const {getCurrentAgentSession} = await import('@shopify/cli-kit/node/agent')
-    vi.mocked(getCurrentAgentSession).mockReturnValue({
+    vi.mocked(agent.getCurrentAgentSession).mockReturnValue({
       sessionId: 'test-session',
       startedAt: new Date().toISOString(),
       agentName: 'test-agent',
@@ -212,7 +190,6 @@ describe('app release agent session behavior', () => {
 
     await Release.run(['--version', 'v1.0.0', '--force'])
 
-    const {release} = await import('../../services/release.js')
     expect(release).toHaveBeenCalledWith(
       expect.objectContaining({
         allowUpdates: true,

--- a/packages/app/src/cli/commands/app/release.test.ts
+++ b/packages/app/src/cli/commands/app/release.test.ts
@@ -1,0 +1,224 @@
+import Release from './release.js'
+import {testAppLinked, testDeveloperPlatformClient, testOrganizationApp} from '../../models/app/app.test-data.js'
+import {OrganizationSource} from '../../models/organization.js'
+import {describe, expect, test, vi, beforeEach} from 'vitest'
+import {renderWarning} from '@shopify/cli-kit/node/ui'
+
+vi.mock('../../services/release.js')
+vi.mock('../../services/app-context.js')
+vi.mock('@shopify/cli-kit/node/metadata', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@shopify/cli-kit/node/metadata')>()
+  return {...actual, addPublicMetadata: vi.fn()}
+})
+vi.mock('@shopify/cli-kit/node/ui', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@shopify/cli-kit/node/ui')>()
+  return {...actual, renderWarning: vi.fn()}
+})
+vi.mock('@shopify/cli-kit/node/agent', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@shopify/cli-kit/node/agent')>()
+  return {...actual, getCurrentAgentSession: vi.fn()}
+})
+
+describe('app release --force deprecation warning', () => {
+  beforeEach(async () => {
+    const {linkedAppContext} = await import('../../services/app-context.js')
+    const {release} = await import('../../services/release.js')
+    vi.mocked(linkedAppContext).mockResolvedValue({
+      app: testAppLinked(),
+      remoteApp: testOrganizationApp(),
+      developerPlatformClient: testDeveloperPlatformClient(),
+      organization: {
+        id: '1',
+        businessName: 'test',
+        source: OrganizationSource.Partners,
+      },
+      specifications: [],
+      project: {} as any,
+      activeConfig: {} as any,
+    })
+    vi.mocked(release).mockResolvedValue(undefined)
+  })
+
+  test('shows deprecation warning when --force is passed', async () => {
+    await Release.run(['--version', 'v1.0.0', '--force'])
+
+    expect(renderWarning).toHaveBeenCalledWith(
+      expect.objectContaining({
+        headline: expect.arrayContaining(['The']),
+        body: expect.arrayContaining(['Use']),
+      }),
+    )
+    const call = vi.mocked(renderWarning).mock.calls[0]![0]
+    expect(JSON.stringify(call)).toContain('--force')
+    expect(JSON.stringify(call)).toContain('next major release')
+  })
+
+  test('shows deprecation warning when SHOPIFY_FLAG_FORCE env var is set', async () => {
+    vi.stubEnv('SHOPIFY_FLAG_FORCE', '1')
+
+    await Release.run(['--version', 'v1.0.0'])
+
+    expect(renderWarning).toHaveBeenCalled()
+    const call = vi.mocked(renderWarning).mock.calls[0]![0]
+    expect(JSON.stringify(call)).toContain('--force')
+
+    vi.unstubAllEnvs()
+  })
+
+  test('does not show deprecation warning when only --allow-updates is passed', async () => {
+    await Release.run(['--version', 'v1.0.0', '--allow-updates'])
+
+    expect(renderWarning).not.toHaveBeenCalled()
+  })
+
+  test('does not show deprecation warning when --allow-updates and --allow-deletes are passed', async () => {
+    await Release.run(['--version', 'v1.0.0', '--allow-updates', '--allow-deletes'])
+
+    expect(renderWarning).not.toHaveBeenCalled()
+  })
+
+  test('does not show deprecation warning when only --allow-deletes is passed', async () => {
+    await Release.run(['--version', 'v1.0.0', '--allow-deletes'])
+
+    expect(renderWarning).not.toHaveBeenCalled()
+  })
+})
+
+describe('app release agent session behavior', () => {
+  beforeEach(async () => {
+    const {linkedAppContext} = await import('../../services/app-context.js')
+    const {release} = await import('../../services/release.js')
+    const {getCurrentAgentSession} = await import('@shopify/cli-kit/node/agent')
+    vi.mocked(linkedAppContext).mockResolvedValue({
+      app: testAppLinked(),
+      remoteApp: testOrganizationApp(),
+      developerPlatformClient: testDeveloperPlatformClient(),
+      organization: {
+        id: '1',
+        businessName: 'test',
+        source: OrganizationSource.Partners,
+      },
+      specifications: [],
+      project: {} as any,
+      activeConfig: {} as any,
+    })
+    vi.mocked(release).mockResolvedValue(undefined)
+    vi.mocked(getCurrentAgentSession).mockReturnValue(undefined)
+  })
+
+  test('applies --allow-updates when agent session with defaultNonInteractive=true exists and no explicit flags', async () => {
+    const {getCurrentAgentSession} = await import('@shopify/cli-kit/node/agent')
+    vi.mocked(getCurrentAgentSession).mockReturnValue({
+      sessionId: 'test-session',
+      startedAt: new Date().toISOString(),
+      agentName: 'test-agent',
+      agentVersion: '1.0.0',
+      agentProvider: 'test-provider',
+      metricsMode: 'on',
+      defaultNonInteractive: true,
+    })
+
+    await Release.run(['--version', 'v1.0.0'])
+
+    const {release} = await import('../../services/release.js')
+    expect(release).toHaveBeenCalledWith(
+      expect.objectContaining({
+        allowUpdates: true,
+        allowDeletes: undefined,
+      }),
+    )
+  })
+
+  test('explicit --allow-updates flag wins over agent session', async () => {
+    const {getCurrentAgentSession} = await import('@shopify/cli-kit/node/agent')
+    vi.mocked(getCurrentAgentSession).mockReturnValue({
+      sessionId: 'test-session',
+      startedAt: new Date().toISOString(),
+      agentName: 'test-agent',
+      agentVersion: '1.0.0',
+      agentProvider: 'test-provider',
+      metricsMode: 'on',
+      defaultNonInteractive: true,
+    })
+
+    await Release.run(['--version', 'v1.0.0', '--allow-updates'])
+
+    const {release} = await import('../../services/release.js')
+    expect(release).toHaveBeenCalledWith(
+      expect.objectContaining({
+        allowUpdates: true,
+        allowDeletes: undefined,
+      }),
+    )
+  })
+
+  test('explicit --allow-deletes does not trigger --allow-updates from agent session', async () => {
+    const {getCurrentAgentSession} = await import('@shopify/cli-kit/node/agent')
+    vi.mocked(getCurrentAgentSession).mockReturnValue({
+      sessionId: 'test-session',
+      startedAt: new Date().toISOString(),
+      agentName: 'test-agent',
+      agentVersion: '1.0.0',
+      agentProvider: 'test-provider',
+      metricsMode: 'on',
+      defaultNonInteractive: true,
+    })
+
+    await Release.run(['--version', 'v1.0.0', '--allow-deletes'])
+
+    const {release} = await import('../../services/release.js')
+    expect(release).toHaveBeenCalledWith(
+      expect.objectContaining({
+        allowUpdates: false,
+        allowDeletes: true,
+      }),
+    )
+  })
+
+  test('no behavior change when agent session exists but defaultNonInteractive=false', async () => {
+    const {getCurrentAgentSession} = await import('@shopify/cli-kit/node/agent')
+    vi.mocked(getCurrentAgentSession).mockReturnValue({
+      sessionId: 'test-session',
+      startedAt: new Date().toISOString(),
+      agentName: 'test-agent',
+      agentVersion: '1.0.0',
+      agentProvider: 'test-provider',
+      metricsMode: 'on',
+      defaultNonInteractive: false,
+    })
+
+    await Release.run(['--version', 'v1.0.0', '--allow-updates'])
+
+    const {release} = await import('../../services/release.js')
+    expect(release).toHaveBeenCalledWith(
+      expect.objectContaining({
+        allowUpdates: true,
+        allowDeletes: undefined,
+      }),
+    )
+  })
+
+  test('explicit --force flag works with agent session', async () => {
+    const {getCurrentAgentSession} = await import('@shopify/cli-kit/node/agent')
+    vi.mocked(getCurrentAgentSession).mockReturnValue({
+      sessionId: 'test-session',
+      startedAt: new Date().toISOString(),
+      agentName: 'test-agent',
+      agentVersion: '1.0.0',
+      agentProvider: 'test-provider',
+      metricsMode: 'on',
+      defaultNonInteractive: true,
+    })
+
+    await Release.run(['--version', 'v1.0.0', '--force'])
+
+    const {release} = await import('../../services/release.js')
+    expect(release).toHaveBeenCalledWith(
+      expect.objectContaining({
+        allowUpdates: true,
+        allowDeletes: true,
+        force: true,
+      }),
+    )
+  })
+})

--- a/packages/app/src/cli/commands/app/release.ts
+++ b/packages/app/src/cli/commands/app/release.ts
@@ -5,6 +5,8 @@ import {linkedAppContext} from '../../services/app-context.js'
 import {Flags} from '@oclif/core'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
 import {addPublicMetadata} from '@shopify/cli-kit/node/metadata'
+import {renderWarning} from '@shopify/cli-kit/node/ui'
+import {getCurrentAgentSession} from '@shopify/cli-kit/node/agent'
 
 export default class Release extends AppLinkedCommand {
   static summary = 'Release an app version.'
@@ -18,6 +20,13 @@ export default class Release extends AppLinkedCommand {
   static flags = {
     ...globalFlags,
     ...appFlags,
+    force: Flags.boolean({
+      hidden: false,
+      description:
+        '[Deprecated] Release without asking for confirmation. Equivalent to --allow-updates --allow-deletes. Use --allow-updates for CI/CD environments instead.',
+      env: 'SHOPIFY_FLAG_FORCE',
+      char: 'f',
+    }),
     'allow-updates': Flags.boolean({
       hidden: false,
       description:
@@ -42,19 +51,31 @@ export default class Release extends AppLinkedCommand {
     const {flags} = await this.parse(Release)
     const clientId = flags['client-id']
 
+    if (flags.force) {
+      renderWarning({
+        headline: ['The', {command: '--force'}, 'flag is deprecated and will be removed in the next major release.'],
+        body: [
+          'Use',
+          {command: '--allow-updates'},
+          'for CI/CD environments, or',
+          {command: '--allow-updates --allow-deletes'},
+          'if you also want to allow removals.',
+        ],
+      })
+    }
+
     await addPublicMetadata(() => ({
       cmd_app_reset_used: flags.reset,
     }))
 
-    const allowUpdates = flags['allow-updates']
-    const allowDeletes = flags['allow-deletes']
-    // `force` (skip confirmation prompt) is implied when both --allow-updates
-    // and --allow-deletes are set.
-    const force = Boolean(allowUpdates && allowDeletes)
-
-    // We require --allow-updates or --allow-deletes for non-TTY.
+    // We require --force or --allow-updates or --allow-deletes for non-TTY.
+    // Agent sessions with defaultNonInteractive=true implicitly provide --allow-updates.
     const requiredNonTTYFlags: string[] = []
-    if (!allowUpdates && !allowDeletes) {
+    const agentSession = getCurrentAgentSession()
+    const isAgentNonInteractive = agentSession?.defaultNonInteractive === true
+    const hasExplicitReleaseFlags = flags.force || flags['allow-updates'] || flags['allow-deletes']
+    const hasReleaseConsent = hasExplicitReleaseFlags || isAgentNonInteractive
+    if (!hasReleaseConsent) {
       requiredNonTTYFlags.push('allow-updates')
     }
     this.failMissingNonTTYFlags(flags, requiredNonTTYFlags)
@@ -66,11 +87,15 @@ export default class Release extends AppLinkedCommand {
       userProvidedConfigName: flags.config,
     })
 
+    const allowUpdates =
+      flags.force || flags['allow-updates'] || (isAgentNonInteractive && !hasExplicitReleaseFlags)
+    const allowDeletes = flags.force || flags['allow-deletes']
+
     await release({
       app,
       remoteApp,
       developerPlatformClient,
-      force,
+      force: flags.force,
       allowUpdates,
       allowDeletes,
       version: flags.version,

--- a/packages/app/src/cli/commands/app/release.ts
+++ b/packages/app/src/cli/commands/app/release.ts
@@ -87,8 +87,7 @@ export default class Release extends AppLinkedCommand {
       userProvidedConfigName: flags.config,
     })
 
-    const allowUpdates =
-      flags.force || flags['allow-updates'] || (isAgentNonInteractive && !hasExplicitReleaseFlags)
+    const allowUpdates = flags.force || flags['allow-updates'] || (isAgentNonInteractive && !hasExplicitReleaseFlags)
     const allowDeletes = flags.force || flags['allow-deletes']
 
     await release({

--- a/packages/cli-kit/src/private/node/analytics.ts
+++ b/packages/cli-kit/src/private/node/analytics.ts
@@ -1,5 +1,6 @@
 import {getLastSeenAuthMethod} from './session.js'
 import {getAutoUpgradeEnabled} from './conf-store.js'
+import {getCurrentAgentSession, packAgentInfo, packAgentIds} from '../../public/node/agent.js'
 import {hashString} from '../../public/node/crypto.js'
 import {getPackageManager, packageManagerFromUserAgent} from '../../public/node/node-package-manager.js'
 import BaseCommand from '../../public/node/base-command.js'
@@ -114,7 +115,22 @@ function getShopifyEnvironmentVariables() {
   // Monorail fields, e.g. SHOPIFY_CLI_AGENT, SHOPIFY_CLI_AGENT_VERSION,
   // SHOPIFY_CLI_AGENT_RUN_ID, SHOPIFY_CLI_AGENT_SESSION_ID, and
   // SHOPIFY_CLI_AGENT_PROVIDER.
-  return Object.fromEntries(Object.entries(process.env).filter(([key]) => key.startsWith('SHOPIFY_')))
+  const envVars = Object.fromEntries(Object.entries(process.env).filter(([key]) => key.startsWith('SHOPIFY_')))
+
+  // Resolve the persisted session once and let the packers preserve the precedence rule
+  // that explicit process env attribution wins over persisted session state.
+  const agentSession = getCurrentAgentSession()
+  const agentInfo = packAgentInfo(agentSession)
+  const agentIds = packAgentIds(agentSession)
+
+  if (agentInfo && !envVars.SHOPIFY_CLI_AGENT_INFO) {
+    envVars.SHOPIFY_CLI_AGENT_INFO = agentInfo
+  }
+  if (agentIds && !envVars.SHOPIFY_CLI_AGENT_IDS) {
+    envVars.SHOPIFY_CLI_AGENT_IDS = agentIds
+  }
+
+  return envVars
 }
 
 function getPluginNames(config: Interfaces.Config) {

--- a/packages/cli-kit/src/private/node/conf-store.test.ts
+++ b/packages/cli-kit/src/private/node/conf-store.test.ts
@@ -13,6 +13,12 @@ import {
   getCachedPartnerAccountStatus,
   setCachedPartnerAccountStatus,
   runWithRateLimit,
+  getAgentSession,
+  setAgentSession,
+  removeAgentSession,
+  getAutoUpgradeEnabled,
+  setAutoUpgradeEnabled,
+  AgentSession,
 } from './conf-store.js'
 import {isLocalEnvironment} from './context/service.js'
 import {LocalStorage} from '../../public/node/local-storage.js'
@@ -584,6 +590,34 @@ describe('runWithRateLimit', () => {
   })
 })
 
+describe('Auto Upgrade Preference', () => {
+  test('defaults to enabled when never set', async () => {
+    await inTemporaryDirectory(async (cwd) => {
+      const config = new LocalStorage<ConfSchema>({cwd})
+
+      expect(getAutoUpgradeEnabled(config)).toBe(true)
+    })
+  })
+
+  test('returns false when explicitly disabled', async () => {
+    await inTemporaryDirectory(async (cwd) => {
+      const config = new LocalStorage<ConfSchema>({cwd})
+      setAutoUpgradeEnabled(false, config)
+
+      expect(getAutoUpgradeEnabled(config)).toBe(false)
+    })
+  })
+
+  test('returns true when explicitly enabled', async () => {
+    await inTemporaryDirectory(async (cwd) => {
+      const config = new LocalStorage<ConfSchema>({cwd})
+      setAutoUpgradeEnabled(true, config)
+
+      expect(getAutoUpgradeEnabled(config)).toBe(true)
+    })
+  })
+})
+
 describe('Partner Account Status Cache', () => {
   beforeEach(() => {
     // Clear the partner status store before each test
@@ -614,6 +648,194 @@ describe('Partner Account Status Cache', () => {
       setCachedPartnerAccountStatus(token)
 
       expect(getCachedPartnerAccountStatus(token)).toBe(true)
+    })
+  })
+})
+
+describe('Agent Session', () => {
+  const mockSession: AgentSession = {
+    sessionId: 'conv_123',
+    startedAt: '2024-01-01T00:00:00Z',
+    agentName: 'test-agent',
+    agentVersion: '1.0.0',
+    agentProvider: 'test-provider',
+    metricsMode: 'on',
+    defaultNonInteractive: false,
+  }
+
+  describe('getAgentSession', () => {
+    test('returns undefined when not set', async () => {
+      await inTemporaryDirectory(async (cwd) => {
+        // Given
+        const config = new LocalStorage<ConfSchema>({cwd})
+
+        // When
+        const got = getAgentSession(config)
+
+        // Then
+        expect(got).toBeUndefined()
+      })
+    })
+
+    test('returns the stored agent session in production', async () => {
+      await inTemporaryDirectory(async (cwd) => {
+        // Given
+        const config = new LocalStorage<ConfSchema>({cwd})
+        config.set('currentAgentSession', mockSession)
+
+        // When
+        const got = getAgentSession(config)
+
+        // Then
+        expect(got).toEqual(mockSession)
+      })
+    })
+
+    test('returns the stored agent session in dev', async () => {
+      await inTemporaryDirectory(async (cwd) => {
+        // Given
+        vi.mocked(isLocalEnvironment).mockReturnValue(true)
+        const config = new LocalStorage<ConfSchema>({cwd})
+        config.set('devAgentSession', mockSession)
+
+        // When
+        const got = getAgentSession(config)
+
+        // Then
+        expect(got).toEqual(mockSession)
+      })
+    })
+
+    test('does not return dev session when in production', async () => {
+      await inTemporaryDirectory(async (cwd) => {
+        // Given
+        const config = new LocalStorage<ConfSchema>({cwd})
+        config.set('devAgentSession', mockSession)
+
+        // When
+        const got = getAgentSession(config)
+
+        // Then
+        expect(got).toBeUndefined()
+      })
+    })
+  })
+
+  describe('setAgentSession', () => {
+    test('saves to currentAgentSession in production', async () => {
+      await inTemporaryDirectory(async (cwd) => {
+        // Given
+        const config = new LocalStorage<ConfSchema>({cwd})
+
+        // When
+        setAgentSession(mockSession, config)
+
+        // Then
+        expect(config.get('currentAgentSession')).toEqual(mockSession)
+        expect(config.get('devAgentSession')).toBeUndefined()
+      })
+    })
+
+    test('saves to devAgentSession in dev', async () => {
+      await inTemporaryDirectory(async (cwd) => {
+        // Given
+        vi.mocked(isLocalEnvironment).mockReturnValue(true)
+        const config = new LocalStorage<ConfSchema>({cwd})
+
+        // When
+        setAgentSession(mockSession, config)
+
+        // Then
+        expect(config.get('devAgentSession')).toEqual(mockSession)
+        expect(config.get('currentAgentSession')).toBeUndefined()
+      })
+    })
+  })
+
+  describe('removeAgentSession', () => {
+    test('removes the currentAgentSession in production', async () => {
+      await inTemporaryDirectory(async (cwd) => {
+        // Given
+        const config = new LocalStorage<ConfSchema>({cwd})
+        config.set('currentAgentSession', mockSession)
+
+        // When
+        removeAgentSession(config)
+
+        // Then
+        expect(config.get('currentAgentSession')).toBeUndefined()
+      })
+    })
+
+    test('removes the devAgentSession in dev', async () => {
+      await inTemporaryDirectory(async (cwd) => {
+        // Given
+        vi.mocked(isLocalEnvironment).mockReturnValue(true)
+        const config = new LocalStorage<ConfSchema>({cwd})
+        config.set('devAgentSession', mockSession)
+
+        // When
+        removeAgentSession(config)
+
+        // Then
+        expect(config.get('devAgentSession')).toBeUndefined()
+      })
+    })
+  })
+
+  describe('agent session environment isolation', () => {
+    test('getAgentSession returns production session in production', async () => {
+      await inTemporaryDirectory(async (cwd) => {
+        // Given
+        const config = new LocalStorage<ConfSchema>({cwd})
+        const prodSession = {...mockSession, agentName: 'prod-agent'}
+        const devSession = {...mockSession, agentName: 'dev-agent'}
+        config.set('currentAgentSession', prodSession)
+        config.set('devAgentSession', devSession)
+
+        // When
+        const got = getAgentSession(config)
+
+        // Then
+        expect(got?.agentName).toEqual('prod-agent')
+      })
+    })
+
+    test('getAgentSession returns dev session in dev', async () => {
+      await inTemporaryDirectory(async (cwd) => {
+        // Given
+        vi.mocked(isLocalEnvironment).mockReturnValue(true)
+        const config = new LocalStorage<ConfSchema>({cwd})
+        const prodSession = {...mockSession, agentName: 'prod-agent'}
+        const devSession = {...mockSession, agentName: 'dev-agent'}
+        config.set('currentAgentSession', prodSession)
+        config.set('devAgentSession', devSession)
+
+        // When
+        const got = getAgentSession(config)
+
+        // Then
+        expect(got?.agentName).toEqual('dev-agent')
+      })
+    })
+
+    test('removeAgentSession only removes session for the current environment', async () => {
+      await inTemporaryDirectory(async (cwd) => {
+        // Given
+        const config = new LocalStorage<ConfSchema>({cwd})
+        const prodSession = {...mockSession, agentName: 'prod-agent'}
+        const devSession = {...mockSession, agentName: 'dev-agent'}
+        config.set('currentAgentSession', prodSession)
+        config.set('devAgentSession', devSession)
+
+        // When
+        vi.mocked(isLocalEnvironment).mockReturnValue(true)
+        removeAgentSession(config)
+
+        // Then
+        expect(config.get('devAgentSession')).toBeUndefined()
+        expect(config.get('currentAgentSession')).toEqual(prodSession)
+      })
     })
   })
 })

--- a/packages/cli-kit/src/private/node/conf-store.ts
+++ b/packages/cli-kit/src/private/node/conf-store.ts
@@ -26,11 +26,24 @@ interface Cache {
   [rateLimitKey: RateLimitKey]: CacheValue<number[]>
 }
 
+export interface AgentSession {
+  sessionId: string
+  startedAt: string
+  agentName: string
+  agentVersion: string
+  agentProvider: string
+  // Controls whether command analytics should be emitted for this agent session.
+  metricsMode: 'on' | 'off'
+  defaultNonInteractive: boolean
+}
+
 export interface ConfSchema {
   sessionStore: string
   currentSessionId?: string
   devSessionStore?: string
   currentDevSessionId?: string
+  currentAgentSession?: AgentSession
+  devAgentSession?: AgentSession
   cache?: Cache
   autoUpgradeEnabled?: boolean
 }
@@ -53,6 +66,10 @@ function sessionStoreKey(): 'devSessionStore' | 'sessionStore' {
 
 function currentSessionIdKey(): 'currentDevSessionId' | 'currentSessionId' {
   return isLocalEnvironment() ? 'currentDevSessionId' : 'currentSessionId'
+}
+
+function agentSessionKey(): 'devAgentSession' | 'currentAgentSession' {
+  return isLocalEnvironment() ? 'devAgentSession' : 'currentAgentSession'
 }
 
 /**
@@ -268,7 +285,8 @@ export async function runWithRateLimit(options: RunWithRateLimitOptions, config 
 
 /**
  * Get auto-upgrade preference.
- * Defaults to true if the preference has never been explicitly set.
+ *
+ * Auto-upgrade is enabled by default when the preference has never been set.
  *
  * @returns Whether auto-upgrade is enabled.
  */
@@ -307,4 +325,32 @@ export function setCachedPartnerAccountStatus(partnersToken: string) {
   const store = getConfigStoreForPartnerStatus()
 
   store.set(partnersToken, {status: true, checkedAt: new Date().toISOString()})
+}
+
+/**
+ * Get current agent session.
+ *
+ * @returns Current agent session.
+ */
+export function getAgentSession(config: LocalStorage<ConfSchema> = cliKitStore()): AgentSession | undefined {
+  outputDebug(outputContent`Getting agent session...`)
+  return config.get(agentSessionKey())
+}
+
+/**
+ * Set current agent session.
+ *
+ * @param session - Agent session.
+ */
+export function setAgentSession(session: AgentSession, config: LocalStorage<ConfSchema> = cliKitStore()): void {
+  outputDebug(outputContent`Setting agent session...`)
+  config.set(agentSessionKey(), session)
+}
+
+/**
+ * Remove current agent session.
+ */
+export function removeAgentSession(config: LocalStorage<ConfSchema> = cliKitStore()): void {
+  outputDebug(outputContent`Removing agent session...`)
+  config.delete(agentSessionKey())
 }

--- a/packages/cli-kit/src/public/node/agent.test.ts
+++ b/packages/cli-kit/src/public/node/agent.test.ts
@@ -1,4 +1,3 @@
-import {describe, expect, test, beforeEach, afterEach, vi} from 'vitest'
 import {
   startAgentSession,
   getCurrentAgentSession,
@@ -7,15 +6,11 @@ import {
   packAgentIds,
   AgentSession,
 } from './agent.js'
-import {
-  getAgentSession,
-  setAgentSession,
-  removeAgentSession,
-  ConfSchema,
-} from '../../private/node/conf-store.js'
 import {LocalStorage} from './local-storage.js'
 import {inTemporaryDirectory} from './fs.js'
+import {getAgentSession, setAgentSession, ConfSchema} from '../../private/node/conf-store.js'
 import {isLocalEnvironment} from '../../private/node/context/service.js'
+import {describe, expect, test, beforeEach, afterEach, vi} from 'vitest'
 
 vi.mock('../../private/node/context/service.js')
 
@@ -37,14 +32,17 @@ describe('startAgentSession', () => {
       const config = new LocalStorage<ConfSchema>({cwd})
 
       // When
-      startAgentSession({
-        sessionId: 'conv_123',
-        agentName: 'test-agent',
-        agentVersion: '1.0.0',
-        agentProvider: 'test-provider',
-        metricsMode: 'on',
-        defaultNonInteractive: true,
-      }, config)
+      startAgentSession(
+        {
+          sessionId: 'conv_123',
+          agentName: 'test-agent',
+          agentVersion: '1.0.0',
+          agentProvider: 'test-provider',
+          metricsMode: 'on',
+          defaultNonInteractive: true,
+        },
+        config,
+      )
 
       // Then
       const session = getAgentSession(config)
@@ -65,12 +63,15 @@ describe('startAgentSession', () => {
       const config = new LocalStorage<ConfSchema>({cwd})
 
       // When
-      startAgentSession({
-        sessionId: 'conv_456',
-        agentName: 'another-agent',
-        agentVersion: '2.0.0',
-        agentProvider: 'another-provider',
-      }, config)
+      startAgentSession(
+        {
+          sessionId: 'conv_456',
+          agentName: 'another-agent',
+          agentVersion: '2.0.0',
+          agentProvider: 'another-provider',
+        },
+        config,
+      )
 
       // Then
       const session = getAgentSession(config)
@@ -86,12 +87,15 @@ describe('startAgentSession', () => {
       const beforeTime = new Date().toISOString()
 
       // When
-      startAgentSession({
-        sessionId: 'conv_789',
-        agentName: 'time-agent',
-        agentVersion: '3.0.0',
-        agentProvider: 'time-provider',
-      }, config)
+      startAgentSession(
+        {
+          sessionId: 'conv_789',
+          agentName: 'time-agent',
+          agentVersion: '3.0.0',
+          agentProvider: 'time-provider',
+        },
+        config,
+      )
 
       // Then
       const session = getAgentSession(config)

--- a/packages/cli-kit/src/public/node/agent.test.ts
+++ b/packages/cli-kit/src/public/node/agent.test.ts
@@ -1,0 +1,342 @@
+import {describe, expect, test, beforeEach, afterEach, vi} from 'vitest'
+import {
+  startAgentSession,
+  getCurrentAgentSession,
+  clearAgentSession,
+  packAgentInfo,
+  packAgentIds,
+  AgentSession,
+} from './agent.js'
+import {
+  getAgentSession,
+  setAgentSession,
+  removeAgentSession,
+  ConfSchema,
+} from '../../private/node/conf-store.js'
+import {LocalStorage} from './local-storage.js'
+import {inTemporaryDirectory} from './fs.js'
+import {isLocalEnvironment} from '../../private/node/context/service.js'
+
+vi.mock('../../private/node/context/service.js')
+
+beforeEach(() => {
+  vi.mocked(isLocalEnvironment).mockReturnValue(false)
+  delete process.env.SHOPIFY_CLI_AGENT_INFO
+  delete process.env.SHOPIFY_CLI_AGENT_IDS
+})
+
+afterEach(() => {
+  delete process.env.SHOPIFY_CLI_AGENT_INFO
+  delete process.env.SHOPIFY_CLI_AGENT_IDS
+})
+
+describe('startAgentSession', () => {
+  test('persists a new agent session with all options', async () => {
+    await inTemporaryDirectory(async (cwd) => {
+      // Given
+      const config = new LocalStorage<ConfSchema>({cwd})
+
+      // When
+      startAgentSession({
+        sessionId: 'conv_123',
+        agentName: 'test-agent',
+        agentVersion: '1.0.0',
+        agentProvider: 'test-provider',
+        metricsMode: 'on',
+        defaultNonInteractive: true,
+      }, config)
+
+      // Then
+      const session = getAgentSession(config)
+      expect(session).toBeDefined()
+      expect(session?.sessionId).toBe('conv_123')
+      expect(session?.agentName).toBe('test-agent')
+      expect(session?.agentVersion).toBe('1.0.0')
+      expect(session?.agentProvider).toBe('test-provider')
+      expect(session?.metricsMode).toBe('on')
+      expect(session?.defaultNonInteractive).toBe(true)
+      expect(session?.startedAt).toBeDefined()
+    })
+  })
+
+  test('uses default values for optional fields', async () => {
+    await inTemporaryDirectory(async (cwd) => {
+      // Given
+      const config = new LocalStorage<ConfSchema>({cwd})
+
+      // When
+      startAgentSession({
+        sessionId: 'conv_456',
+        agentName: 'another-agent',
+        agentVersion: '2.0.0',
+        agentProvider: 'another-provider',
+      }, config)
+
+      // Then
+      const session = getAgentSession(config)
+      expect(session?.metricsMode).toBe('on')
+      expect(session?.defaultNonInteractive).toBe(false)
+    })
+  })
+
+  test('sets startedAt timestamp', async () => {
+    await inTemporaryDirectory(async (cwd) => {
+      // Given
+      const config = new LocalStorage<ConfSchema>({cwd})
+      const beforeTime = new Date().toISOString()
+
+      // When
+      startAgentSession({
+        sessionId: 'conv_789',
+        agentName: 'time-agent',
+        agentVersion: '3.0.0',
+        agentProvider: 'time-provider',
+      }, config)
+
+      // Then
+      const session = getAgentSession(config)
+      const afterTime = new Date().toISOString()
+      expect(session?.startedAt).toBeDefined()
+      expect(session!.startedAt >= beforeTime).toBe(true)
+      expect(session!.startedAt <= afterTime).toBe(true)
+    })
+  })
+})
+
+describe('getCurrentAgentSession', () => {
+  test('returns undefined when no session is active', async () => {
+    await inTemporaryDirectory(async (cwd) => {
+      // Given
+      const config = new LocalStorage<ConfSchema>({cwd})
+
+      // When
+      const session = getCurrentAgentSession(config)
+
+      // Then
+      expect(session).toBeUndefined()
+    })
+  })
+
+  test('returns the current agent session', async () => {
+    await inTemporaryDirectory(async (cwd) => {
+      // Given
+      const config = new LocalStorage<ConfSchema>({cwd})
+      const mockSession: AgentSession = {
+        sessionId: 'conv_current',
+        startedAt: '2024-01-01T00:00:00Z',
+        agentName: 'current-agent',
+        agentVersion: '1.0.0',
+        agentProvider: 'current-provider',
+        metricsMode: 'on',
+        defaultNonInteractive: false,
+      }
+      setAgentSession(mockSession, config)
+
+      // When
+      const session = getCurrentAgentSession(config)
+
+      // Then
+      expect(session).toEqual(mockSession)
+    })
+  })
+})
+
+describe('clearAgentSession', () => {
+  test('removes the persisted agent session', async () => {
+    await inTemporaryDirectory(async (cwd) => {
+      // Given
+      const config = new LocalStorage<ConfSchema>({cwd})
+      const mockSession: AgentSession = {
+        sessionId: 'conv_clear',
+        startedAt: '2024-01-01T00:00:00Z',
+        agentName: 'clear-agent',
+        agentVersion: '1.0.0',
+        agentProvider: 'clear-provider',
+        metricsMode: 'on',
+        defaultNonInteractive: false,
+      }
+      setAgentSession(mockSession, config)
+      expect(getAgentSession(config)).toBeDefined()
+
+      // When
+      clearAgentSession(config)
+
+      // Then
+      expect(getAgentSession(config)).toBeUndefined()
+    })
+  })
+
+  test('does nothing when no session exists', async () => {
+    await inTemporaryDirectory(async (cwd) => {
+      // Given
+      const config = new LocalStorage<ConfSchema>({cwd})
+
+      // When/Then - should not throw
+      expect(() => clearAgentSession(config)).not.toThrow()
+    })
+  })
+})
+
+describe('packAgentInfo', () => {
+  test('returns undefined when no session is active and no env var', async () => {
+    await inTemporaryDirectory(async (cwd) => {
+      // Given
+      const config = new LocalStorage<ConfSchema>({cwd})
+
+      // When
+      const packed = packAgentInfo(undefined, config)
+
+      // Then
+      expect(packed).toBeUndefined()
+    })
+  })
+
+  test('packs agent info from current session', async () => {
+    await inTemporaryDirectory(async (cwd) => {
+      // Given
+      const config = new LocalStorage<ConfSchema>({cwd})
+      const mockSession: AgentSession = {
+        sessionId: 'conv_pack',
+        startedAt: '2024-01-01T00:00:00Z',
+        agentName: 'pack-agent',
+        agentVersion: '1.2.3',
+        agentProvider: 'pack-provider',
+        metricsMode: 'on',
+        defaultNonInteractive: false,
+      }
+      setAgentSession(mockSession, config)
+
+      // When
+      const packed = packAgentInfo(undefined, config)
+
+      // Then
+      expect(packed).toBe('n:pack-agent|v:1.2.3|p:pack-provider')
+    })
+  })
+
+  test('packs agent info from provided session', () => {
+    // Given
+    const mockSession: AgentSession = {
+      sessionId: 'conv_provided',
+      startedAt: '2024-01-01T00:00:00Z',
+      agentName: 'provided-agent',
+      agentVersion: '4.5.6',
+      agentProvider: 'provided-provider',
+      metricsMode: 'off',
+      defaultNonInteractive: true,
+    }
+
+    // When
+    const packed = packAgentInfo(mockSession)
+
+    // Then
+    expect(packed).toBe('n:provided-agent|v:4.5.6|p:provided-provider')
+  })
+
+  test('prefers explicit SHOPIFY_CLI_AGENT_INFO env var over session', async () => {
+    await inTemporaryDirectory(async (cwd) => {
+      // Given
+      const config = new LocalStorage<ConfSchema>({cwd})
+      const mockSession: AgentSession = {
+        sessionId: 'conv_env',
+        startedAt: '2024-01-01T00:00:00Z',
+        agentName: 'session-agent',
+        agentVersion: '1.0.0',
+        agentProvider: 'session-provider',
+        metricsMode: 'on',
+        defaultNonInteractive: false,
+      }
+      setAgentSession(mockSession, config)
+      process.env.SHOPIFY_CLI_AGENT_INFO = 'n:env-agent|v:9.9.9|p:env-provider'
+
+      // When
+      const packed = packAgentInfo(undefined, config)
+
+      // Then
+      expect(packed).toBe(process.env.SHOPIFY_CLI_AGENT_INFO)
+      expect(packed).toBe('n:env-agent|v:9.9.9|p:env-provider')
+    })
+  })
+})
+
+describe('packAgentIds', () => {
+  test('returns undefined when no session is active and no env var', async () => {
+    await inTemporaryDirectory(async (cwd) => {
+      // Given
+      const config = new LocalStorage<ConfSchema>({cwd})
+
+      // When
+      const packed = packAgentIds(undefined, config)
+
+      // Then
+      expect(packed).toBeUndefined()
+    })
+  })
+
+  test('packs agent IDs from current session', async () => {
+    await inTemporaryDirectory(async (cwd) => {
+      // Given
+      const config = new LocalStorage<ConfSchema>({cwd})
+      const mockSession: AgentSession = {
+        sessionId: 'conv_ids',
+        startedAt: '2024-02-15T10:30:00Z',
+        agentName: 'ids-agent',
+        agentVersion: '1.0.0',
+        agentProvider: 'ids-provider',
+        metricsMode: 'on',
+        defaultNonInteractive: false,
+      }
+      setAgentSession(mockSession, config)
+
+      // When
+      const packed = packAgentIds(undefined, config)
+
+      // Then
+      expect(packed).toBe('s:conv_ids')
+    })
+  })
+
+  test('packs agent IDs from provided session', () => {
+    // Given
+    const mockSession: AgentSession = {
+      sessionId: 'conv_provided_ids',
+      startedAt: '2024-03-20T15:45:00Z',
+      agentName: 'provided-ids-agent',
+      agentVersion: '2.0.0',
+      agentProvider: 'provided-ids-provider',
+      metricsMode: 'off',
+      defaultNonInteractive: true,
+    }
+
+    // When
+    const packed = packAgentIds(mockSession)
+
+    // Then
+    expect(packed).toBe('s:conv_provided_ids')
+  })
+
+  test('prefers explicit SHOPIFY_CLI_AGENT_IDS env var over session', async () => {
+    await inTemporaryDirectory(async (cwd) => {
+      // Given
+      const config = new LocalStorage<ConfSchema>({cwd})
+      const mockSession: AgentSession = {
+        sessionId: 'conv_session_ids',
+        startedAt: '2024-01-01T00:00:00Z',
+        agentName: 'session-agent',
+        agentVersion: '1.0.0',
+        agentProvider: 'session-provider',
+        metricsMode: 'on',
+        defaultNonInteractive: false,
+      }
+      setAgentSession(mockSession, config)
+      process.env.SHOPIFY_CLI_AGENT_IDS = 's:conv_env_ids'
+
+      // When
+      const packed = packAgentIds(undefined, config)
+
+      // Then
+      expect(packed).toBe(process.env.SHOPIFY_CLI_AGENT_IDS)
+      expect(packed).toBe('s:conv_env_ids')
+    })
+  })
+})

--- a/packages/cli-kit/src/public/node/agent.ts
+++ b/packages/cli-kit/src/public/node/agent.ts
@@ -27,10 +27,7 @@ export interface StartAgentSessionOptions {
  * @param config - Optional config store for testing.
  * @returns The persisted session value.
  */
-export function startAgentSession(
-  options: StartAgentSessionOptions,
-  config?: LocalStorage<ConfSchema>,
-): AgentSession {
+export function startAgentSession(options: StartAgentSessionOptions, config?: LocalStorage<ConfSchema>): AgentSession {
   const session: AgentSession = {
     sessionId: options.sessionId,
     startedAt: new Date().toISOString(),
@@ -69,7 +66,7 @@ export function clearAgentSession(config?: LocalStorage<ConfSchema>): void {
  * Pack SHOPIFY_CLI_AGENT_INFO environment variable value from agent session.
  *
  * The format is a tagged string with agent metadata:
- * n:<name>|v:<version>|p:<provider>
+ * n:<name>|v:<version>|p:<provider>.
  *
  * Precedence: explicit process.env.SHOPIFY_CLI_AGENT_INFO takes priority over
  * persisted session state.
@@ -96,7 +93,7 @@ export function packAgentInfo(session?: AgentSession, config?: LocalStorage<Conf
  * Pack SHOPIFY_CLI_AGENT_IDS environment variable value from agent session.
  *
  * The format is a tagged string with session identifier:
- * s:<sessionId>
+ * s:<sessionId>.
  *
  * Precedence: explicit process.env.SHOPIFY_CLI_AGENT_IDS takes priority over
  * persisted session state.

--- a/packages/cli-kit/src/public/node/agent.ts
+++ b/packages/cli-kit/src/public/node/agent.ts
@@ -1,0 +1,120 @@
+import {LocalStorage} from './local-storage.js'
+import {
+  getAgentSession,
+  setAgentSession,
+  removeAgentSession,
+  AgentSession,
+  ConfSchema,
+} from '../../private/node/conf-store.js'
+
+export type {AgentSession}
+
+export interface StartAgentSessionOptions {
+  sessionId: string
+  agentName: string
+  agentVersion: string
+  agentProvider: string
+  metricsMode?: 'on' | 'off'
+  defaultNonInteractive?: boolean
+}
+
+/**
+ * Start a new agent session.
+ *
+ * Persists the agent session state to the CLI kit config store.
+ *
+ * @param options - Agent session configuration.
+ * @param config - Optional config store for testing.
+ * @returns The persisted session value.
+ */
+export function startAgentSession(
+  options: StartAgentSessionOptions,
+  config?: LocalStorage<ConfSchema>,
+): AgentSession {
+  const session: AgentSession = {
+    sessionId: options.sessionId,
+    startedAt: new Date().toISOString(),
+    agentName: options.agentName,
+    agentVersion: options.agentVersion,
+    agentProvider: options.agentProvider,
+    metricsMode: options.metricsMode ?? 'on',
+    defaultNonInteractive: options.defaultNonInteractive ?? false,
+  }
+  setAgentSession(session, config)
+  return session
+}
+
+/**
+ * Get the current agent session.
+ *
+ * @param config - Optional config store for testing.
+ * @returns Current agent session, or undefined if no session is active.
+ */
+export function getCurrentAgentSession(config?: LocalStorage<ConfSchema>): AgentSession | undefined {
+  return getAgentSession(config)
+}
+
+/**
+ * Clear the current agent session.
+ *
+ * Removes the persisted agent session state from the CLI kit config store.
+ *
+ * @param config - Optional config store for testing.
+ */
+export function clearAgentSession(config?: LocalStorage<ConfSchema>): void {
+  removeAgentSession(config)
+}
+
+/**
+ * Pack SHOPIFY_CLI_AGENT_INFO environment variable value from agent session.
+ *
+ * The format is a tagged string with agent metadata:
+ * n:<name>|v:<version>|p:<provider>
+ *
+ * Precedence: explicit process.env.SHOPIFY_CLI_AGENT_INFO takes priority over
+ * persisted session state.
+ *
+ * @param session - Optional session to pack from. If not provided, uses current session.
+ * @param config - Optional config store for testing.
+ * @returns Tagged string for SHOPIFY_CLI_AGENT_INFO, or undefined if no data available.
+ */
+export function packAgentInfo(session?: AgentSession, config?: LocalStorage<ConfSchema>): string | undefined {
+  // Explicit env var wins
+  if (process.env.SHOPIFY_CLI_AGENT_INFO) {
+    return process.env.SHOPIFY_CLI_AGENT_INFO
+  }
+
+  const activeSession = session ?? getCurrentAgentSession(config)
+  if (!activeSession) {
+    return undefined
+  }
+
+  return `n:${activeSession.agentName}|v:${activeSession.agentVersion}|p:${activeSession.agentProvider}`
+}
+
+/**
+ * Pack SHOPIFY_CLI_AGENT_IDS environment variable value from agent session.
+ *
+ * The format is a tagged string with session identifier:
+ * s:<sessionId>
+ *
+ * Precedence: explicit process.env.SHOPIFY_CLI_AGENT_IDS takes priority over
+ * persisted session state.
+ *
+ * @param session - Optional session to pack from. If not provided, uses current session.
+ * @param config - Optional config store for testing.
+ * @returns Tagged string for SHOPIFY_CLI_AGENT_IDS, or undefined if no data available.
+ */
+export function packAgentIds(session?: AgentSession, config?: LocalStorage<ConfSchema>): string | undefined {
+  // Explicit env var wins
+  if (process.env.SHOPIFY_CLI_AGENT_IDS) {
+    return process.env.SHOPIFY_CLI_AGENT_IDS
+  }
+
+  const activeSession = session ?? getCurrentAgentSession(config)
+  if (!activeSession) {
+    return undefined
+  }
+
+  return `s:${activeSession.sessionId}`
+}

--- a/packages/cli-kit/src/public/node/analytics.test.ts
+++ b/packages/cli-kit/src/public/node/analytics.test.ts
@@ -20,6 +20,7 @@ import * as store from '../../private/node/analytics/storage.js'
 import {startAnalytics} from '../../private/node/analytics.js'
 import {CLI_KIT_VERSION} from '../common/version.js'
 import {setLastSeenAuthMethod, setLastSeenUserIdAfterAuth} from '../../private/node/session.js'
+import {startAgentSession, clearAgentSession} from './agent.js'
 
 import {test, expect, describe, vi, beforeEach, afterEach, MockedFunction} from 'vitest'
 
@@ -189,12 +190,51 @@ describe('event tracking', () => {
   })
 
   test('sends SHOPIFY_ environment variables in sensitive payload', async () => {
-    const originalEnv = {...process.env}
     process.env.SHOPIFY_TEST_VAR = 'test_value'
     process.env.SHOPIFY_ANOTHER_VAR = 'another_value'
     process.env.NOT_SHOPIFY_VAR = 'should_not_appear'
 
+    try {
+      await inProjectWithFile('package.json', async (args) => {
+        const commandContent = {command: 'dev', topic: 'app'}
+        await startAnalytics({commandContent, args, currentTime: currentDate.getTime() - 100})
+
+        // When
+        const config = {
+          runHook: vi.fn().mockResolvedValue({successes: [], failures: []}),
+          plugins: [],
+        } as any
+        await reportAnalyticsEvent({config, exitMode: 'ok'})
+
+        // Then
+        const sensitivePayload = publishEventMock.mock.calls[0]![2]
+        expect(publishEventMock).toHaveBeenCalledOnce()
+        expect(sensitivePayload).toHaveProperty('env_shopify_variables')
+        expect(sensitivePayload.env_shopify_variables).toBeDefined()
+
+        const shopifyVars = JSON.parse(sensitivePayload.env_shopify_variables as string)
+        expect(shopifyVars).toHaveProperty('SHOPIFY_TEST_VAR', 'test_value')
+        expect(shopifyVars).toHaveProperty('SHOPIFY_ANOTHER_VAR', 'another_value')
+        expect(shopifyVars).not.toHaveProperty('NOT_SHOPIFY_VAR')
+      })
+    } finally {
+      delete process.env.SHOPIFY_TEST_VAR
+      delete process.env.SHOPIFY_ANOTHER_VAR
+      delete process.env.NOT_SHOPIFY_VAR
+    }
+  })
+
+  test('synthesizes agent env vars from persisted session when explicit env vars are absent', async () => {
     await inProjectWithFile('package.json', async (args) => {
+      // Given - start an agent session
+      startAgentSession({
+        sessionId: 'test-session-123',
+        agentName: 'river',
+        agentVersion: '1.2.3',
+        agentProvider: 'shopify',
+        metricsMode: 'on',
+      })
+
       const commandContent = {command: 'dev', topic: 'app'}
       await startAnalytics({commandContent, args, currentTime: currentDate.getTime() - 100})
 
@@ -209,16 +249,135 @@ describe('event tracking', () => {
       const sensitivePayload = publishEventMock.mock.calls[0]![2]
       expect(publishEventMock).toHaveBeenCalledOnce()
       expect(sensitivePayload).toHaveProperty('env_shopify_variables')
-      expect(sensitivePayload.env_shopify_variables).toBeDefined()
 
       const shopifyVars = JSON.parse(sensitivePayload.env_shopify_variables as string)
-      expect(shopifyVars).toHaveProperty('SHOPIFY_TEST_VAR', 'test_value')
-      expect(shopifyVars).toHaveProperty('SHOPIFY_ANOTHER_VAR', 'another_value')
-      expect(shopifyVars).not.toHaveProperty('NOT_SHOPIFY_VAR')
+      expect(shopifyVars).toHaveProperty('SHOPIFY_CLI_AGENT_INFO', 'n:river|v:1.2.3|p:shopify')
+      expect(shopifyVars).toHaveProperty('SHOPIFY_CLI_AGENT_IDS', 's:test-session-123')
+
+      // Cleanup
+      clearAgentSession()
     })
   })
 
-  test('does nothing when analytics are disabled', async () => {
+  test('explicit process.env agent attribution wins over persisted session state', async () => {
+    await inProjectWithFile('package.json', async (args) => {
+      // Given - both explicit env vars and a persisted session
+      process.env.SHOPIFY_CLI_AGENT_INFO = 'n:explicit|v:9.9.9|p:explicit-provider'
+      process.env.SHOPIFY_CLI_AGENT_IDS = 's:explicit-session-id'
+
+      startAgentSession({
+        sessionId: 'session-should-be-ignored',
+        agentName: 'session-agent',
+        agentVersion: '1.0.0',
+        agentProvider: 'session-provider',
+        metricsMode: 'on',
+      })
+
+      const commandContent = {command: 'dev', topic: 'app'}
+      await startAnalytics({commandContent, args, currentTime: currentDate.getTime() - 100})
+
+      // When
+      const config = {
+        runHook: vi.fn().mockResolvedValue({successes: [], failures: []}),
+        plugins: [],
+      } as any
+      await reportAnalyticsEvent({config, exitMode: 'ok'})
+
+      // Then - explicit env vars should win
+      const sensitivePayload = publishEventMock.mock.calls[0]![2]
+      expect(publishEventMock).toHaveBeenCalledOnce()
+      expect(sensitivePayload).toHaveProperty('env_shopify_variables')
+
+      const shopifyVars = JSON.parse(sensitivePayload.env_shopify_variables as string)
+      expect(shopifyVars).toHaveProperty('SHOPIFY_CLI_AGENT_INFO', 'n:explicit|v:9.9.9|p:explicit-provider')
+      expect(shopifyVars).toHaveProperty('SHOPIFY_CLI_AGENT_IDS', 's:explicit-session-id')
+
+      // Cleanup
+      delete process.env.SHOPIFY_CLI_AGENT_INFO
+      delete process.env.SHOPIFY_CLI_AGENT_IDS
+      clearAgentSession()
+    })
+  })
+
+  test('skips analytics when agent session metricsMode is off', async () => {
+    await inProjectWithFile('package.json', async (args) => {
+      // Given - agent session with metrics off
+      startAgentSession({
+        sessionId: 'test-session-metrics-off',
+        agentName: 'river',
+        agentVersion: '1.0.0',
+        agentProvider: 'shopify',
+        metricsMode: 'off',
+      })
+
+      const commandContent = {command: 'dev', topic: 'app'}
+      await startAnalytics({commandContent, args, currentTime: currentDate.getTime() - 100})
+
+      // When
+      const config = {
+        runHook: vi.fn().mockResolvedValue({successes: [], failures: []}),
+        plugins: [],
+      } as any
+      await reportAnalyticsEvent({config, exitMode: 'ok'})
+
+      // Then - should not send to Monorail
+      expect(publishEventMock).not.toHaveBeenCalled()
+
+      // Cleanup
+      clearAgentSession()
+    })
+  })
+
+  test('allows analytics when agent session metricsMode is on', async () => {
+    await inProjectWithFile('package.json', async (args) => {
+      // Given - agent session with metrics on
+      startAgentSession({
+        sessionId: 'test-session-metrics-on',
+        agentName: 'river',
+        agentVersion: '1.0.0',
+        agentProvider: 'shopify',
+        metricsMode: 'on',
+      })
+
+      const commandContent = {command: 'dev', topic: 'app'}
+      await startAnalytics({commandContent, args, currentTime: currentDate.getTime() - 100})
+
+      // When
+      const config = {
+        runHook: vi.fn().mockResolvedValue({successes: [], failures: []}),
+        plugins: [],
+      } as any
+      await reportAnalyticsEvent({config, exitMode: 'ok'})
+
+      // Then - should send to Monorail
+      expect(publishEventMock).toHaveBeenCalledOnce()
+
+      // Cleanup
+      clearAgentSession()
+    })
+  })
+
+  test('allows analytics when no agent session exists', async () => {
+    await inProjectWithFile('package.json', async (args) => {
+      // Given - no agent session
+      clearAgentSession()
+
+      const commandContent = {command: 'dev', topic: 'app'}
+      await startAnalytics({commandContent, args, currentTime: currentDate.getTime() - 100})
+
+      // When
+      const config = {
+        runHook: vi.fn().mockResolvedValue({successes: [], failures: []}),
+        plugins: [],
+      } as any
+      await reportAnalyticsEvent({config, exitMode: 'ok'})
+
+      // Then - should send to Monorail
+      expect(publishEventMock).toHaveBeenCalledOnce()
+    })
+  })
+
+  test('does nothing when analytics are disabled via analyticsDisabled()', async () => {
     await inProjectWithFile('package.json', async (args) => {
       // Given
       vi.mocked(analyticsDisabled).mockReturnValueOnce(true)

--- a/packages/cli-kit/src/public/node/analytics.test.ts
+++ b/packages/cli-kit/src/public/node/analytics.test.ts
@@ -16,11 +16,11 @@ import {mockAndCaptureOutput} from './testing/output.js'
 import {addPublicMetadata} from './metadata.js'
 import {sendErrorToBugsnag} from './error-handler.js'
 import {hashString} from './crypto.js'
+import {startAgentSession, clearAgentSession} from './agent.js'
 import * as store from '../../private/node/analytics/storage.js'
 import {startAnalytics} from '../../private/node/analytics.js'
 import {CLI_KIT_VERSION} from '../common/version.js'
 import {setLastSeenAuthMethod, setLastSeenUserIdAfterAuth} from '../../private/node/session.js'
-import {startAgentSession, clearAgentSession} from './agent.js'
 
 import {test, expect, describe, vi, beforeEach, afterEach, MockedFunction} from 'vitest'
 

--- a/packages/cli-kit/src/public/node/analytics.ts
+++ b/packages/cli-kit/src/public/node/analytics.ts
@@ -4,6 +4,7 @@ import {publishMonorailEvent, MONORAIL_COMMAND_TOPIC} from './monorail.js'
 import {fanoutHooks} from './plugins.js'
 import {sendErrorToBugsnag} from './error-handler.js'
 import {outputContent, outputDebug, outputToken} from './output.js'
+import {getCurrentAgentSession} from './agent.js'
 import {
   recordTiming as storageRecordTiming,
   recordError as storageRecordError,
@@ -63,8 +64,12 @@ export async function reportAnalyticsEvent(options: ReportAnalyticsEventOptions)
       return
     }
 
-    const skipMonorailAnalytics = !alwaysLogAnalytics() && analyticsDisabled()
-    const skipMetricAnalytics = !alwaysLogMetrics() && analyticsDisabled()
+    // Check for metrics-off mode from persisted agent session
+    const agentSession = getCurrentAgentSession()
+    const metricsDisabledByAgent = agentSession?.metricsMode === 'off'
+
+    const skipMonorailAnalytics = !alwaysLogAnalytics() && (analyticsDisabled() || metricsDisabledByAgent)
+    const skipMetricAnalytics = !alwaysLogMetrics() && (analyticsDisabled() || metricsDisabledByAgent)
     if (skipMonorailAnalytics || skipMetricAnalytics) {
       outputDebug(outputContent`Skipping command analytics, payload: ${outputToken.json(payload)}`)
     }

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -1,55 +1,58 @@
 {
   "commands": {
     "app:build": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/app",
+      "aliases": [],
+      "args": {},
       "description": "This command executes the build script specified in the element's TOML file. You can specify a custom script in the file. To learn about configuration files in Shopify apps, refer to \"App configuration\" (https://shopify.dev/docs/apps/tools/cli/configuration).\n\n  If you're building a \"theme app extension\" (https://shopify.dev/docs/apps/online-store/theme-app-extensions), then running the `build` command runs \"Theme Check\" (https://shopify.dev/docs/themes/tools/theme-check) against your extension to ensure that it's valid.",
-      "descriptionWithMarkdown": "This command executes the build script specified in the element's TOML file. You can specify a custom script in the file. To learn about configuration files in Shopify apps, refer to [App configuration](https://shopify.dev/docs/apps/tools/cli/configuration).\n\n  If you're building a [theme app extension](https://shopify.dev/docs/apps/online-store/theme-app-extensions), then running the `build` command runs [Theme Check](https://shopify.dev/docs/themes/tools/theme-check) against your extension to ensure that it's valid.",
       "flags": {
-        "client-id": {
-          "description": "The Client ID of your app.",
-          "env": "SHOPIFY_FLAG_CLIENT_ID",
-          "exclusive": [
-            "config"
-          ],
-          "hasDynamicHelp": false,
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
           "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path to your app directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "name": "path",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
           "multiple": false,
-          "name": "client-id",
           "type": "option"
         },
         "config": {
           "char": "c",
           "description": "The name of the app configuration.",
           "env": "SHOPIFY_FLAG_APP_CONFIG",
-          "hasDynamicHelp": false,
           "hidden": false,
-          "multiple": false,
           "name": "config",
+          "hasDynamicHelp": false,
+          "multiple": false,
           "type": "option"
         },
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
+        "client-id": {
+          "description": "The Client ID of your app.",
+          "env": "SHOPIFY_FLAG_CLIENT_ID",
+          "exclusive": [
+            "config"
+          ],
           "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
-        "path": {
-          "description": "The path to your app directory.",
-          "env": "SHOPIFY_FLAG_PATH",
+          "name": "client-id",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "path",
-          "noCacheDefault": true,
           "type": "option"
         },
         "reset": {
-          "allowNo": false,
           "description": "Reset all your settings.",
           "env": "SHOPIFY_FLAG_RESET",
           "exclusive": [
@@ -57,93 +60,82 @@
           ],
           "hidden": false,
           "name": "reset",
+          "allowNo": false,
           "type": "boolean"
         },
         "skip-dependencies-installation": {
-          "allowNo": false,
           "description": "Skips the installation of dependencies. Deprecated, use workspaces instead.",
           "env": "SHOPIFY_FLAG_SKIP_DEPENDENCIES_INSTALLATION",
           "hidden": false,
           "name": "skip-dependencies-installation",
-          "type": "boolean"
-        },
-        "verbose": {
           "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
           "type": "boolean"
         }
       },
       "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
+      "hiddenAliases": [],
       "id": "app:build",
       "pluginAlias": "@shopify/cli",
       "pluginName": "@shopify/cli",
       "pluginType": "core",
       "strict": true,
-      "summary": "Build the app, including extensions."
+      "summary": "Build the app, including extensions.",
+      "descriptionWithMarkdown": "This command executes the build script specified in the element's TOML file. You can specify a custom script in the file. To learn about configuration files in Shopify apps, refer to [App configuration](https://shopify.dev/docs/apps/tools/cli/configuration).\n\n  If you're building a [theme app extension](https://shopify.dev/docs/apps/online-store/theme-app-extensions), then running the `build` command runs [Theme Check](https://shopify.dev/docs/themes/tools/theme-check) against your extension to ensure that it's valid.",
+      "customPluginName": "@shopify/app"
     },
     "app:bulk:cancel": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/app",
+      "aliases": [],
+      "args": {},
       "description": "Cancels a running bulk operation by ID.",
       "flags": {
-        "client-id": {
-          "description": "The Client ID of your app.",
-          "env": "SHOPIFY_FLAG_CLIENT_ID",
-          "exclusive": [
-            "config"
-          ],
-          "hasDynamicHelp": false,
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
           "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path to your app directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "name": "path",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
           "multiple": false,
-          "name": "client-id",
           "type": "option"
         },
         "config": {
           "char": "c",
           "description": "The name of the app configuration.",
           "env": "SHOPIFY_FLAG_APP_CONFIG",
-          "hasDynamicHelp": false,
           "hidden": false,
-          "multiple": false,
           "name": "config",
-          "type": "option"
-        },
-        "id": {
-          "description": "The bulk operation ID to cancel (numeric ID or full GID).",
-          "env": "SHOPIFY_FLAG_ID",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "id",
-          "required": true,
           "type": "option"
         },
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
+        "client-id": {
+          "description": "The Client ID of your app.",
+          "env": "SHOPIFY_FLAG_CLIENT_ID",
+          "exclusive": [
+            "config"
+          ],
           "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
-        "path": {
-          "description": "The path to your app directory.",
-          "env": "SHOPIFY_FLAG_PATH",
+          "name": "client-id",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "path",
-          "noCacheDefault": true,
           "type": "option"
         },
         "reset": {
-          "allowNo": false,
           "description": "Reset all your settings.",
           "env": "SHOPIFY_FLAG_RESET",
           "exclusive": [
@@ -151,115 +143,91 @@
           ],
           "hidden": false,
           "name": "reset",
+          "allowNo": false,
           "type": "boolean"
+        },
+        "id": {
+          "description": "The bulk operation ID to cancel (numeric ID or full GID).",
+          "env": "SHOPIFY_FLAG_ID",
+          "name": "id",
+          "required": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
         },
         "store": {
           "char": "s",
           "description": "The store domain. Must be an existing dev store.",
           "env": "SHOPIFY_FLAG_STORE",
+          "name": "store",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "store",
           "type": "option"
-        },
-        "verbose": {
-          "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
-          "type": "boolean"
         }
       },
       "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
+      "hiddenAliases": [],
       "id": "app:bulk:cancel",
       "pluginAlias": "@shopify/cli",
       "pluginName": "@shopify/cli",
       "pluginType": "core",
       "strict": true,
-      "summary": "Cancel a bulk operation."
+      "summary": "Cancel a bulk operation.",
+      "customPluginName": "@shopify/app"
     },
-    "app:bulk:execute": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/app",
-      "description": "Executes an Admin API GraphQL query or mutation on the specified store, as a bulk operation. Mutations are only allowed on dev stores.\n\n  Bulk operations allow you to process large amounts of data asynchronously. Learn more about \"bulk query operations\" (https://shopify.dev/docs/api/usage/bulk-operations/queries) and \"bulk mutation operations\" (https://shopify.dev/docs/api/usage/bulk-operations/imports).\n\n  Use \"`bulk status`\" (https://shopify.dev/docs/api/shopify-cli/app/app-bulk-status) to check the status of your bulk operations.",
-      "descriptionWithMarkdown": "Executes an Admin API GraphQL query or mutation on the specified store, as a bulk operation. Mutations are only allowed on dev stores.\n\n  Bulk operations allow you to process large amounts of data asynchronously. Learn more about [bulk query operations](https://shopify.dev/docs/api/usage/bulk-operations/queries) and [bulk mutation operations](https://shopify.dev/docs/api/usage/bulk-operations/imports).\n\n  Use [`bulk status`](https://shopify.dev/docs/api/shopify-cli/app/app-bulk-status) to check the status of your bulk operations.",
+    "app:bulk:status": {
+      "aliases": [],
+      "args": {},
+      "description": "Check the status of a specific bulk operation by ID, or list all bulk operations belonging to this app on this store in the last 7 days.\n\n  Bulk operations allow you to process large amounts of data asynchronously. Learn more about \"bulk query operations\" (https://shopify.dev/docs/api/usage/bulk-operations/queries) and \"bulk mutation operations\" (https://shopify.dev/docs/api/usage/bulk-operations/imports).\n\n  Use \"`bulk execute`\" (https://shopify.dev/docs/api/shopify-cli/app/app-bulk-execute) to start a new bulk operation.",
       "flags": {
-        "client-id": {
-          "description": "The Client ID of your app.",
-          "env": "SHOPIFY_FLAG_CLIENT_ID",
-          "exclusive": [
-            "config"
-          ],
-          "hasDynamicHelp": false,
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
           "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path to your app directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "name": "path",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
           "multiple": false,
-          "name": "client-id",
           "type": "option"
         },
         "config": {
           "char": "c",
           "description": "The name of the app configuration.",
           "env": "SHOPIFY_FLAG_APP_CONFIG",
-          "hasDynamicHelp": false,
           "hidden": false,
-          "multiple": false,
           "name": "config",
+          "hasDynamicHelp": false,
+          "multiple": false,
           "type": "option"
         },
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
-          "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
-        "output-file": {
-          "dependsOn": [
-            "watch"
+        "client-id": {
+          "description": "The Client ID of your app.",
+          "env": "SHOPIFY_FLAG_CLIENT_ID",
+          "exclusive": [
+            "config"
           ],
-          "description": "The file path where results should be written if --watch is specified. If not specified, results will be written to STDOUT.",
-          "env": "SHOPIFY_FLAG_OUTPUT_FILE",
+          "hidden": false,
+          "name": "client-id",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "output-file",
-          "type": "option"
-        },
-        "path": {
-          "description": "The path to your app directory.",
-          "env": "SHOPIFY_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "path",
-          "noCacheDefault": true,
-          "type": "option"
-        },
-        "query": {
-          "char": "q",
-          "description": "The GraphQL query or mutation to run as a bulk operation.",
-          "env": "SHOPIFY_FLAG_QUERY",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "query",
-          "required": false,
-          "type": "option"
-        },
-        "query-file": {
-          "description": "Path to a file containing the GraphQL query or mutation. Can't be used with --query.",
-          "env": "SHOPIFY_FLAG_QUERY_FILE",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "query-file",
           "type": "option"
         },
         "reset": {
-          "allowNo": false,
           "description": "Reset all your settings.",
           "env": "SHOPIFY_FLAG_RESET",
           "exclusive": [
@@ -267,558 +235,127 @@
           ],
           "hidden": false,
           "name": "reset",
-          "type": "boolean"
-        },
-        "store": {
-          "char": "s",
-          "description": "The store domain. Must be an existing dev store.",
-          "env": "SHOPIFY_FLAG_STORE",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "store",
-          "type": "option"
-        },
-        "variable-file": {
-          "description": "Path to a file containing GraphQL variables in JSONL format (one JSON object per line). Can't be used with --variables.",
-          "env": "SHOPIFY_FLAG_VARIABLE_FILE",
-          "exclusive": [
-            "variables"
-          ],
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "variable-file",
-          "type": "option"
-        },
-        "variables": {
-          "char": "v",
-          "description": "The values for any GraphQL variables in your mutation, in JSON format. Can be specified multiple times.",
-          "env": "SHOPIFY_FLAG_VARIABLES",
-          "exclusive": [
-            "variable-file"
-          ],
-          "hasDynamicHelp": false,
-          "multiple": true,
-          "name": "variables",
-          "type": "option"
-        },
-        "verbose": {
           "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
           "type": "boolean"
-        },
-        "version": {
-          "description": "The API version to use for the bulk operation. If not specified, uses the latest stable version.",
-          "env": "SHOPIFY_FLAG_VERSION",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "version",
-          "type": "option"
-        },
-        "watch": {
-          "allowNo": false,
-          "description": "Wait for bulk operation results before exiting. Defaults to false.",
-          "env": "SHOPIFY_FLAG_WATCH",
-          "name": "watch",
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "app:bulk:execute",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true,
-      "summary": "Execute bulk operations."
-    },
-    "app:bulk:status": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/app",
-      "description": "Check the status of a specific bulk operation by ID, or list all bulk operations belonging to this app on this store in the last 7 days.\n\n  Bulk operations allow you to process large amounts of data asynchronously. Learn more about \"bulk query operations\" (https://shopify.dev/docs/api/usage/bulk-operations/queries) and \"bulk mutation operations\" (https://shopify.dev/docs/api/usage/bulk-operations/imports).\n\n  Use \"`bulk execute`\" (https://shopify.dev/docs/api/shopify-cli/app/app-bulk-execute) to start a new bulk operation.",
-      "descriptionWithMarkdown": "Check the status of a specific bulk operation by ID, or list all bulk operations belonging to this app on this store in the last 7 days.\n\n  Bulk operations allow you to process large amounts of data asynchronously. Learn more about [bulk query operations](https://shopify.dev/docs/api/usage/bulk-operations/queries) and [bulk mutation operations](https://shopify.dev/docs/api/usage/bulk-operations/imports).\n\n  Use [`bulk execute`](https://shopify.dev/docs/api/shopify-cli/app/app-bulk-execute) to start a new bulk operation.",
-      "flags": {
-        "client-id": {
-          "description": "The Client ID of your app.",
-          "env": "SHOPIFY_FLAG_CLIENT_ID",
-          "exclusive": [
-            "config"
-          ],
-          "hasDynamicHelp": false,
-          "hidden": false,
-          "multiple": false,
-          "name": "client-id",
-          "type": "option"
-        },
-        "config": {
-          "char": "c",
-          "description": "The name of the app configuration.",
-          "env": "SHOPIFY_FLAG_APP_CONFIG",
-          "hasDynamicHelp": false,
-          "hidden": false,
-          "multiple": false,
-          "name": "config",
-          "type": "option"
         },
         "id": {
           "description": "The bulk operation ID (numeric ID or full GID). If not provided, lists all bulk operations belonging to this app on this store in the last 7 days.",
           "env": "SHOPIFY_FLAG_ID",
-          "hasDynamicHelp": false,
-          "multiple": false,
           "name": "id",
-          "type": "option"
-        },
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
-          "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
-        "path": {
-          "description": "The path to your app directory.",
-          "env": "SHOPIFY_FLAG_PATH",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "path",
-          "noCacheDefault": true,
           "type": "option"
-        },
-        "reset": {
-          "allowNo": false,
-          "description": "Reset all your settings.",
-          "env": "SHOPIFY_FLAG_RESET",
-          "exclusive": [
-            "config"
-          ],
-          "hidden": false,
-          "name": "reset",
-          "type": "boolean"
         },
         "store": {
           "char": "s",
           "description": "The store domain. Must be an existing dev store.",
           "env": "SHOPIFY_FLAG_STORE",
+          "name": "store",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "store",
           "type": "option"
-        },
-        "verbose": {
-          "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
-          "type": "boolean"
         }
       },
       "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
+      "hiddenAliases": [],
       "id": "app:bulk:status",
       "pluginAlias": "@shopify/cli",
       "pluginName": "@shopify/cli",
       "pluginType": "core",
       "strict": true,
-      "summary": "Check the status of bulk operations."
-    },
-    "app:config:link": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/app",
-      "description": "Pulls app configuration from the Developer Dashboard and creates or overwrites a configuration file. You can create a new app with this command to start with a default configuration file.\n\n  For more information on the format of the created TOML configuration file, refer to the \"App configuration\" (https://shopify.dev/docs/apps/tools/cli/configuration) page.\n  ",
-      "descriptionWithMarkdown": "Pulls app configuration from the Developer Dashboard and creates or overwrites a configuration file. You can create a new app with this command to start with a default configuration file.\n\n  For more information on the format of the created TOML configuration file, refer to the [App configuration](https://shopify.dev/docs/apps/tools/cli/configuration) page.\n  ",
-      "flags": {
-        "client-id": {
-          "description": "The Client ID of your app.",
-          "env": "SHOPIFY_FLAG_CLIENT_ID",
-          "exclusive": [
-            "config"
-          ],
-          "hasDynamicHelp": false,
-          "hidden": false,
-          "multiple": false,
-          "name": "client-id",
-          "type": "option"
-        },
-        "config": {
-          "char": "c",
-          "description": "The name of the app configuration.",
-          "env": "SHOPIFY_FLAG_APP_CONFIG",
-          "hasDynamicHelp": false,
-          "hidden": false,
-          "multiple": false,
-          "name": "config",
-          "type": "option"
-        },
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
-          "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
-        "path": {
-          "description": "The path to your app directory.",
-          "env": "SHOPIFY_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "path",
-          "noCacheDefault": true,
-          "type": "option"
-        },
-        "reset": {
-          "allowNo": false,
-          "description": "Reset all your settings.",
-          "env": "SHOPIFY_FLAG_RESET",
-          "exclusive": [
-            "config"
-          ],
-          "hidden": false,
-          "name": "reset",
-          "type": "boolean"
-        },
-        "verbose": {
-          "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "app:config:link",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true,
-      "summary": "Fetch your app configuration from the Developer Dashboard."
-    },
-    "app:config:pull": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/app",
-      "description": "Pulls the latest configuration from the already-linked Shopify app and updates the selected configuration file.\n\nThis command reuses the existing linked app and organization and skips all interactive prompts. Use `--config` to target a specific configuration file, or omit it to use the default one.",
-      "descriptionWithMarkdown": "Pulls the latest configuration from the already-linked Shopify app and updates the selected configuration file.\n\nThis command reuses the existing linked app and organization and skips all interactive prompts. Use `--config` to target a specific configuration file, or omit it to use the default one.",
-      "flags": {
-        "client-id": {
-          "description": "The Client ID of your app.",
-          "env": "SHOPIFY_FLAG_CLIENT_ID",
-          "exclusive": [
-            "config"
-          ],
-          "hasDynamicHelp": false,
-          "hidden": false,
-          "multiple": false,
-          "name": "client-id",
-          "type": "option"
-        },
-        "config": {
-          "char": "c",
-          "description": "The name of the app configuration.",
-          "env": "SHOPIFY_FLAG_APP_CONFIG",
-          "hasDynamicHelp": false,
-          "hidden": false,
-          "multiple": false,
-          "name": "config",
-          "type": "option"
-        },
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
-          "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
-        "path": {
-          "description": "The path to your app directory.",
-          "env": "SHOPIFY_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "path",
-          "noCacheDefault": true,
-          "type": "option"
-        },
-        "reset": {
-          "allowNo": false,
-          "description": "Reset all your settings.",
-          "env": "SHOPIFY_FLAG_RESET",
-          "exclusive": [
-            "config"
-          ],
-          "hidden": false,
-          "name": "reset",
-          "type": "boolean"
-        },
-        "verbose": {
-          "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "app:config:pull",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true,
-      "summary": "Refresh an already-linked app configuration without prompts."
-    },
-    "app:config:use": {
-      "aliases": [
-      ],
-      "args": {
-        "config": {
-          "description": "The name of the app configuration. Can be 'shopify.app.staging.toml' or simply 'staging'.",
-          "name": "config"
-        }
-      },
-      "customPluginName": "@shopify/app",
-      "description": "Sets default configuration when you run app-related CLI commands. If you omit the `config-name` parameter, then you'll be prompted to choose from the configuration files in your project.",
-      "descriptionWithMarkdown": "Sets default configuration when you run app-related CLI commands. If you omit the `config-name` parameter, then you'll be prompted to choose from the configuration files in your project.",
-      "flags": {
-        "client-id": {
-          "description": "The Client ID of your app.",
-          "env": "SHOPIFY_FLAG_CLIENT_ID",
-          "exclusive": [
-            "config"
-          ],
-          "hasDynamicHelp": false,
-          "hidden": false,
-          "multiple": false,
-          "name": "client-id",
-          "type": "option"
-        },
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
-          "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
-        "path": {
-          "description": "The path to your app directory.",
-          "env": "SHOPIFY_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "path",
-          "noCacheDefault": true,
-          "type": "option"
-        },
-        "reset": {
-          "allowNo": false,
-          "description": "Reset all your settings.",
-          "env": "SHOPIFY_FLAG_RESET",
-          "exclusive": [
-            "config"
-          ],
-          "hidden": false,
-          "name": "reset",
-          "type": "boolean"
-        },
-        "verbose": {
-          "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "app:config:use",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true,
-      "summary": "Activate an app configuration.",
-      "usage": "app config use [config] [flags]"
-    },
-    "app:config:validate": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/app",
-      "description": "Validates the selected app configuration file and all extension configurations against their schemas and reports any errors found.",
-      "descriptionWithMarkdown": "Validates the selected app configuration file and all extension configurations against their schemas and reports any errors found.",
-      "flags": {
-        "client-id": {
-          "description": "The Client ID of your app.",
-          "env": "SHOPIFY_FLAG_CLIENT_ID",
-          "exclusive": [
-            "config"
-          ],
-          "hasDynamicHelp": false,
-          "hidden": false,
-          "multiple": false,
-          "name": "client-id",
-          "type": "option"
-        },
-        "config": {
-          "char": "c",
-          "description": "The name of the app configuration.",
-          "env": "SHOPIFY_FLAG_APP_CONFIG",
-          "hasDynamicHelp": false,
-          "hidden": false,
-          "multiple": false,
-          "name": "config",
-          "type": "option"
-        },
-        "json": {
-          "allowNo": false,
-          "char": "j",
-          "description": "Output the result as JSON. Automatically disables color output.",
-          "env": "SHOPIFY_FLAG_JSON",
-          "hidden": false,
-          "name": "json",
-          "type": "boolean"
-        },
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
-          "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
-        "path": {
-          "description": "The path to your app directory.",
-          "env": "SHOPIFY_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "path",
-          "noCacheDefault": true,
-          "type": "option"
-        },
-        "reset": {
-          "allowNo": false,
-          "description": "Reset all your settings.",
-          "env": "SHOPIFY_FLAG_RESET",
-          "exclusive": [
-            "config"
-          ],
-          "hidden": false,
-          "name": "reset",
-          "type": "boolean"
-        },
-        "verbose": {
-          "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "app:config:validate",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true,
-      "summary": "Validate your app configuration and extensions."
+      "summary": "Check the status of bulk operations.",
+      "descriptionWithMarkdown": "Check the status of a specific bulk operation by ID, or list all bulk operations belonging to this app on this store in the last 7 days.\n\n  Bulk operations allow you to process large amounts of data asynchronously. Learn more about [bulk query operations](https://shopify.dev/docs/api/usage/bulk-operations/queries) and [bulk mutation operations](https://shopify.dev/docs/api/usage/bulk-operations/imports).\n\n  Use [`bulk execute`](https://shopify.dev/docs/api/shopify-cli/app/app-bulk-execute) to start a new bulk operation.",
+      "customPluginName": "@shopify/app"
     },
     "app:deploy": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/app",
+      "aliases": [],
+      "args": {},
       "description": "\"Builds the app\" (https://shopify.dev/docs/api/shopify-cli/app/app-build), then deploys your app configuration and extensions.\n\n  This command creates an app version, which is a snapshot of your app configuration and all extensions. This version is then released to users.\n\n  This command doesn't deploy your \"web app\" (https://shopify.dev/docs/apps/tools/cli/structure#web-components). You need to \"deploy your web app\" (https://shopify.dev/docs/apps/deployment/web) to your own hosting solution.\n  ",
-      "descriptionWithMarkdown": "[Builds the app](https://shopify.dev/docs/api/shopify-cli/app/app-build), then deploys your app configuration and extensions.\n\n  This command creates an app version, which is a snapshot of your app configuration and all extensions. This version is then released to users.\n\n  This command doesn't deploy your [web app](https://shopify.dev/docs/apps/tools/cli/structure#web-components). You need to [deploy your web app](https://shopify.dev/docs/apps/deployment/web) to your own hosting solution.\n  ",
       "flags": {
-        "allow-deletes": {
-          "allowNo": false,
-          "description": "Allows removing extensions and configuration without requiring user confirmation. For CI/CD environments, the recommended flag is --allow-updates.",
-          "env": "SHOPIFY_FLAG_ALLOW_DELETES",
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
           "hidden": false,
-          "name": "allow-deletes",
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path to your app directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "name": "path",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "config": {
+          "char": "c",
+          "description": "The name of the app configuration.",
+          "env": "SHOPIFY_FLAG_APP_CONFIG",
+          "hidden": false,
+          "name": "config",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "client-id": {
+          "description": "The Client ID of your app.",
+          "env": "SHOPIFY_FLAG_CLIENT_ID",
+          "exclusive": [
+            "config"
+          ],
+          "hidden": false,
+          "name": "client-id",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "reset": {
+          "description": "Reset all your settings.",
+          "env": "SHOPIFY_FLAG_RESET",
+          "exclusive": [
+            "config"
+          ],
+          "hidden": false,
+          "name": "reset",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "force": {
+          "char": "f",
+          "description": "[Deprecated] Deploy without asking for confirmation. Equivalent to --allow-updates --allow-deletes. Use --allow-updates for CI/CD environments instead.",
+          "env": "SHOPIFY_FLAG_FORCE",
+          "hidden": false,
+          "name": "force",
+          "allowNo": false,
           "type": "boolean"
         },
         "allow-updates": {
-          "allowNo": false,
           "description": "Allows adding and updating extensions and configuration without requiring user confirmation. Recommended option for CI/CD environments.",
           "env": "SHOPIFY_FLAG_ALLOW_UPDATES",
           "hidden": false,
           "name": "allow-updates",
+          "allowNo": false,
           "type": "boolean"
         },
-        "client-id": {
-          "description": "The Client ID of your app.",
-          "env": "SHOPIFY_FLAG_CLIENT_ID",
-          "exclusive": [
-            "config"
-          ],
-          "hasDynamicHelp": false,
+        "allow-deletes": {
+          "description": "Allows removing extensions and configuration without requiring user confirmation. For CI/CD environments, the recommended flag is --allow-updates.",
+          "env": "SHOPIFY_FLAG_ALLOW_DELETES",
           "hidden": false,
-          "multiple": false,
-          "name": "client-id",
-          "type": "option"
-        },
-        "config": {
-          "char": "c",
-          "description": "The name of the app configuration.",
-          "env": "SHOPIFY_FLAG_APP_CONFIG",
-          "hasDynamicHelp": false,
-          "hidden": false,
-          "multiple": false,
-          "name": "config",
-          "type": "option"
-        },
-        "message": {
-          "description": "Optional message that will be associated with this version. This is for internal use only and won't be available externally.",
-          "env": "SHOPIFY_FLAG_MESSAGE",
-          "hasDynamicHelp": false,
-          "hidden": false,
-          "multiple": false,
-          "name": "message",
-          "type": "option"
-        },
-        "no-build": {
+          "name": "allow-deletes",
           "allowNo": false,
-          "description": "Use with caution: Skips building any elements of the app that require building. You should ensure your app has been prepared in advance, such as by running `shopify app build` or by caching build artifacts.",
-          "env": "SHOPIFY_FLAG_NO_BUILD",
-          "name": "no-build",
-          "type": "boolean"
-        },
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
-          "hidden": false,
-          "name": "no-color",
           "type": "boolean"
         },
         "no-release": {
-          "allowNo": false,
           "description": "Creates a version but doesn't release it - it's not made available to merchants. With this flag, a user confirmation is not required.",
           "env": "SHOPIFY_FLAG_NO_RELEASE",
           "exclusive": [
@@ -827,80 +364,93 @@
           ],
           "hidden": false,
           "name": "no-release",
+          "allowNo": false,
           "type": "boolean"
         },
-        "path": {
-          "description": "The path to your app directory.",
-          "env": "SHOPIFY_FLAG_PATH",
+        "no-build": {
+          "description": "Use with caution: Skips building any elements of the app that require building. You should ensure your app has been prepared in advance, such as by running `shopify app build` or by caching build artifacts.",
+          "env": "SHOPIFY_FLAG_NO_BUILD",
+          "name": "no-build",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "message": {
+          "description": "Optional message that will be associated with this version. This is for internal use only and won't be available externally.",
+          "env": "SHOPIFY_FLAG_MESSAGE",
+          "hidden": false,
+          "name": "message",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "path",
-          "noCacheDefault": true,
           "type": "option"
-        },
-        "reset": {
-          "allowNo": false,
-          "description": "Reset all your settings.",
-          "env": "SHOPIFY_FLAG_RESET",
-          "exclusive": [
-            "config"
-          ],
-          "hidden": false,
-          "name": "reset",
-          "type": "boolean"
-        },
-        "source-control-url": {
-          "description": "URL associated with the new app version.",
-          "env": "SHOPIFY_FLAG_SOURCE_CONTROL_URL",
-          "hasDynamicHelp": false,
-          "hidden": false,
-          "multiple": false,
-          "name": "source-control-url",
-          "type": "option"
-        },
-        "verbose": {
-          "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
-          "type": "boolean"
         },
         "version": {
           "description": "Optional version tag that will be associated with this app version. If not provided, an auto-generated identifier will be generated for this app version.",
           "env": "SHOPIFY_FLAG_VERSION",
-          "hasDynamicHelp": false,
           "hidden": false,
-          "multiple": false,
           "name": "version",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "source-control-url": {
+          "description": "URL associated with the new app version.",
+          "env": "SHOPIFY_FLAG_SOURCE_CONTROL_URL",
+          "hidden": false,
+          "name": "source-control-url",
+          "hasDynamicHelp": false,
+          "multiple": false,
           "type": "option"
         }
       },
       "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
+      "hiddenAliases": [],
       "id": "app:deploy",
       "pluginAlias": "@shopify/cli",
       "pluginName": "@shopify/cli",
       "pluginType": "core",
       "strict": true,
-      "summary": "Deploy your Shopify app."
+      "summary": "Deploy your Shopify app.",
+      "descriptionWithMarkdown": "[Builds the app](https://shopify.dev/docs/api/shopify-cli/app/app-build), then deploys your app configuration and extensions.\n\n  This command creates an app version, which is a snapshot of your app configuration and all extensions. This version is then released to users.\n\n  This command doesn't deploy your [web app](https://shopify.dev/docs/apps/tools/cli/structure#web-components). You need to [deploy your web app](https://shopify.dev/docs/apps/deployment/web) to your own hosting solution.\n  ",
+      "customPluginName": "@shopify/app"
     },
     "app:dev": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/app",
+      "aliases": [],
+      "args": {},
       "description": "Builds and previews your app on a dev store, and watches for changes. \"Read more about testing apps locally\" (https://shopify.dev/docs/apps/build/cli-for-apps/test-apps-locally).",
-      "descriptionWithMarkdown": "Builds and previews your app on a dev store, and watches for changes. [Read more about testing apps locally](https://shopify.dev/docs/apps/build/cli-for-apps/test-apps-locally).",
       "flags": {
-        "checkout-cart-url": {
-          "description": "Resource URL for checkout UI extension. Format: \"/cart/{productVariantID}:{productQuantity}\"",
-          "env": "SHOPIFY_FLAG_CHECKOUT_CART_URL",
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path to your app directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "name": "path",
+          "noCacheDefault": true,
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "checkout-cart-url",
+          "type": "option"
+        },
+        "config": {
+          "char": "c",
+          "description": "The name of the app configuration.",
+          "env": "SHOPIFY_FLAG_APP_CONFIG",
+          "hidden": false,
+          "name": "config",
+          "hasDynamicHelp": false,
+          "multiple": false,
           "type": "option"
         },
         "client-id": {
@@ -909,82 +459,13 @@
           "exclusive": [
             "config"
           ],
-          "hasDynamicHelp": false,
           "hidden": false,
-          "multiple": false,
           "name": "client-id",
-          "type": "option"
-        },
-        "config": {
-          "char": "c",
-          "description": "The name of the app configuration.",
-          "env": "SHOPIFY_FLAG_APP_CONFIG",
-          "hasDynamicHelp": false,
-          "hidden": false,
-          "multiple": false,
-          "name": "config",
-          "type": "option"
-        },
-        "graphiql-key": {
-          "description": "Key used to authenticate GraphiQL requests. By default, a key is automatically derived from the app secret. Use this flag to override with a custom key.",
-          "env": "SHOPIFY_FLAG_GRAPHIQL_KEY",
-          "hasDynamicHelp": false,
-          "hidden": true,
-          "multiple": false,
-          "name": "graphiql-key",
-          "type": "option"
-        },
-        "graphiql-port": {
-          "description": "Local port of the GraphiQL development server.",
-          "env": "SHOPIFY_FLAG_GRAPHIQL_PORT",
-          "hasDynamicHelp": false,
-          "hidden": true,
-          "multiple": false,
-          "name": "graphiql-port",
-          "type": "option"
-        },
-        "localhost-port": {
-          "description": "Port to use for localhost.",
-          "env": "SHOPIFY_FLAG_LOCALHOST_PORT",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "localhost-port",
-          "type": "option"
-        },
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
-          "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
-        "no-update": {
-          "allowNo": false,
-          "description": "Uses the app URL from the toml file instead an autogenerated URL for dev.",
-          "env": "SHOPIFY_FLAG_NO_UPDATE",
-          "name": "no-update",
-          "type": "boolean"
-        },
-        "notify": {
-          "description": "The file path or URL. The file path is to a file that you want updated on idle. The URL path is where you want a webhook posted to report on file changes.",
-          "env": "SHOPIFY_FLAG_NOTIFY",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "notify",
-          "type": "option"
-        },
-        "path": {
-          "description": "The path to your app directory.",
-          "env": "SHOPIFY_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "path",
-          "noCacheDefault": true,
           "type": "option"
         },
         "reset": {
-          "allowNo": false,
           "description": "Reset all your settings.",
           "env": "SHOPIFY_FLAG_RESET",
           "exclusive": [
@@ -992,47 +473,46 @@
           ],
           "hidden": false,
           "name": "reset",
-          "type": "boolean"
-        },
-        "skip-dependencies-installation": {
           "allowNo": false,
-          "description": "Skips the installation of dependencies. Deprecated, use workspaces instead.",
-          "env": "SHOPIFY_FLAG_SKIP_DEPENDENCIES_INSTALLATION",
-          "name": "skip-dependencies-installation",
           "type": "boolean"
         },
         "store": {
           "char": "s",
           "description": "Store URL. Must be an existing development or Shopify Plus sandbox store.",
           "env": "SHOPIFY_FLAG_STORE",
+          "name": "store",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "store",
           "type": "option"
+        },
+        "skip-dependencies-installation": {
+          "description": "Skips the installation of dependencies. Deprecated, use workspaces instead.",
+          "env": "SHOPIFY_FLAG_SKIP_DEPENDENCIES_INSTALLATION",
+          "name": "skip-dependencies-installation",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "no-update": {
+          "description": "Uses the app URL from the toml file instead an autogenerated URL for dev.",
+          "env": "SHOPIFY_FLAG_NO_UPDATE",
+          "name": "no-update",
+          "allowNo": false,
+          "type": "boolean"
         },
         "subscription-product-url": {
           "description": "Resource URL for subscription UI extension. Format: \"/products/{productId}\"",
           "env": "SHOPIFY_FLAG_SUBSCRIPTION_PRODUCT_URL",
-          "hasDynamicHelp": false,
-          "multiple": false,
           "name": "subscription-product-url",
-          "type": "option"
-        },
-        "theme": {
-          "char": "t",
-          "description": "Theme ID or name of the theme app extension host theme.",
-          "env": "SHOPIFY_FLAG_THEME",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "theme",
           "type": "option"
         },
-        "theme-app-extension-port": {
-          "description": "Local port of the theme app extension development server.",
-          "env": "SHOPIFY_FLAG_THEME_APP_EXTENSION_PORT",
+        "checkout-cart-url": {
+          "description": "Resource URL for checkout UI extension. Format: \"/cart/{productVariantID}:{productQuantity}\"",
+          "env": "SHOPIFY_FLAG_CHECKOUT_CART_URL",
+          "name": "checkout-cart-url",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "theme-app-extension-port",
           "type": "option"
         },
         "tunnel-url": {
@@ -1041,90 +521,137 @@
           "exclusive": [
             "tunnel"
           ],
+          "name": "tunnel-url",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "tunnel-url",
           "type": "option"
         },
         "use-localhost": {
-          "allowNo": false,
           "description": "Service entry point will listen to localhost. A tunnel won't be used. Will work for testing many app features, but not those that directly invoke your app (E.g: Webhooks)",
           "env": "SHOPIFY_FLAG_USE_LOCALHOST",
           "exclusive": [
             "tunnel-url"
           ],
           "name": "use-localhost",
+          "allowNo": false,
           "type": "boolean"
         },
-        "verbose": {
-          "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
-          "type": "boolean"
+        "localhost-port": {
+          "description": "Port to use for localhost.",
+          "env": "SHOPIFY_FLAG_LOCALHOST_PORT",
+          "name": "localhost-port",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "theme": {
+          "char": "t",
+          "description": "Theme ID or name of the theme app extension host theme.",
+          "env": "SHOPIFY_FLAG_THEME",
+          "name": "theme",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "theme-app-extension-port": {
+          "description": "Local port of the theme app extension development server.",
+          "env": "SHOPIFY_FLAG_THEME_APP_EXTENSION_PORT",
+          "name": "theme-app-extension-port",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "notify": {
+          "description": "The file path or URL. The file path is to a file that you want updated on idle. The URL path is where you want a webhook posted to report on file changes.",
+          "env": "SHOPIFY_FLAG_NOTIFY",
+          "name": "notify",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "graphiql-port": {
+          "description": "Local port of the GraphiQL development server.",
+          "env": "SHOPIFY_FLAG_GRAPHIQL_PORT",
+          "hidden": true,
+          "name": "graphiql-port",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "graphiql-key": {
+          "description": "Key used to authenticate GraphiQL requests. By default, a key is automatically derived from the app secret. Use this flag to override with a custom key.",
+          "env": "SHOPIFY_FLAG_GRAPHIQL_KEY",
+          "hidden": true,
+          "name": "graphiql-key",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
         }
       },
       "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
+      "hiddenAliases": [],
       "id": "app:dev",
       "pluginAlias": "@shopify/cli",
       "pluginName": "@shopify/cli",
       "pluginType": "core",
       "strict": true,
-      "summary": "Run the app."
+      "summary": "Run the app.",
+      "descriptionWithMarkdown": "Builds and previews your app on a dev store, and watches for changes. [Read more about testing apps locally](https://shopify.dev/docs/apps/build/cli-for-apps/test-apps-locally).",
+      "customPluginName": "@shopify/app"
     },
     "app:dev:clean": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/app",
+      "aliases": [],
+      "args": {},
       "description": "Stop the dev preview that was started with `shopify app dev`.\n\n  It restores the app's active version to the selected development store.\n  ",
-      "descriptionWithMarkdown": "Stop the dev preview that was started with `shopify app dev`.\n\n  It restores the app's active version to the selected development store.\n  ",
       "flags": {
-        "client-id": {
-          "description": "The Client ID of your app.",
-          "env": "SHOPIFY_FLAG_CLIENT_ID",
-          "exclusive": [
-            "config"
-          ],
-          "hasDynamicHelp": false,
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
           "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path to your app directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "name": "path",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
           "multiple": false,
-          "name": "client-id",
           "type": "option"
         },
         "config": {
           "char": "c",
           "description": "The name of the app configuration.",
           "env": "SHOPIFY_FLAG_APP_CONFIG",
-          "hasDynamicHelp": false,
           "hidden": false,
-          "multiple": false,
           "name": "config",
+          "hasDynamicHelp": false,
+          "multiple": false,
           "type": "option"
         },
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
+        "client-id": {
+          "description": "The Client ID of your app.",
+          "env": "SHOPIFY_FLAG_CLIENT_ID",
+          "exclusive": [
+            "config"
+          ],
           "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
-        "path": {
-          "description": "The path to your app directory.",
-          "env": "SHOPIFY_FLAG_PATH",
+          "name": "client-id",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "path",
-          "noCacheDefault": true,
           "type": "option"
         },
         "reset": {
-          "allowNo": false,
           "description": "Reset all your settings.",
           "env": "SHOPIFY_FLAG_RESET",
           "exclusive": [
@@ -1132,96 +659,84 @@
           ],
           "hidden": false,
           "name": "reset",
+          "allowNo": false,
           "type": "boolean"
         },
         "store": {
           "char": "s",
           "description": "Store URL. Must be an existing development store.",
           "env": "SHOPIFY_FLAG_STORE",
-          "hasDynamicHelp": false,
           "hidden": false,
-          "multiple": false,
           "name": "store",
+          "hasDynamicHelp": false,
+          "multiple": false,
           "type": "option"
-        },
-        "verbose": {
-          "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
-          "type": "boolean"
         }
       },
       "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
+      "hiddenAliases": [],
       "id": "app:dev:clean",
       "pluginAlias": "@shopify/cli",
       "pluginName": "@shopify/cli",
       "pluginType": "core",
       "strict": true,
-      "summary": "Cleans up the dev preview from the selected store."
+      "summary": "Cleans up the dev preview from the selected store.",
+      "descriptionWithMarkdown": "Stop the dev preview that was started with `shopify app dev`.\n\n  It restores the app's active version to the selected development store.\n  ",
+      "customPluginName": "@shopify/app"
     },
-    "app:env:pull": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/app",
-      "description": "Creates or updates an `.env` files that contains app and app extension environment variables.\n\n  When an existing `.env` file is updated, changes to the variables are displayed in the terminal output. Existing variables and commented variables are preserved.",
-      "descriptionWithMarkdown": "Creates or updates an `.env` files that contains app and app extension environment variables.\n\n  When an existing `.env` file is updated, changes to the variables are displayed in the terminal output. Existing variables and commented variables are preserved.",
+    "app:logs": {
+      "aliases": [],
+      "args": {},
+      "description": "\n  Opens a real-time stream of detailed app logs from the selected app and store.\n  Use the `--source` argument to limit output to a particular log source, such as a specific Shopify Function handle. Use the `shopify app logs sources` command to view a list of sources.\n  Use the `--status` argument to filter on status, either `success` or `failure`.\n  ```\n  shopify app logs --status=success --source=extension.discount-function\n  ```\n  ",
       "flags": {
-        "client-id": {
-          "description": "The Client ID of your app.",
-          "env": "SHOPIFY_FLAG_CLIENT_ID",
-          "exclusive": [
-            "config"
-          ],
-          "hasDynamicHelp": false,
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
           "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path to your app directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "name": "path",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
           "multiple": false,
-          "name": "client-id",
           "type": "option"
         },
         "config": {
           "char": "c",
           "description": "The name of the app configuration.",
           "env": "SHOPIFY_FLAG_APP_CONFIG",
-          "hasDynamicHelp": false,
           "hidden": false,
-          "multiple": false,
           "name": "config",
-          "type": "option"
-        },
-        "env-file": {
-          "description": "Specify an environment file to update if the update flag is set",
-          "env": "SHOPIFY_FLAG_ENV_FILE",
-          "hasDynamicHelp": false,
-          "hidden": false,
-          "multiple": false,
-          "name": "env-file",
-          "type": "option"
-        },
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
-          "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
-        "path": {
-          "description": "The path to your app directory.",
-          "env": "SHOPIFY_FLAG_PATH",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "path",
-          "noCacheDefault": true,
+          "type": "option"
+        },
+        "client-id": {
+          "description": "The Client ID of your app.",
+          "env": "SHOPIFY_FLAG_CLIENT_ID",
+          "exclusive": [
+            "config"
+          ],
+          "hidden": false,
+          "name": "client-id",
+          "hasDynamicHelp": false,
+          "multiple": false,
           "type": "option"
         },
         "reset": {
-          "allowNo": false,
           "description": "Reset all your settings.",
           "env": "SHOPIFY_FLAG_RESET",
           "exclusive": [
@@ -1229,77 +744,1057 @@
           ],
           "hidden": false,
           "name": "reset",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "json": {
+          "char": "j",
+          "description": "Output the result as JSON. Automatically disables color output.",
+          "env": "SHOPIFY_FLAG_JSON",
+          "hidden": false,
+          "name": "json",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "store": {
+          "char": "s",
+          "description": "Store URL. Must be an existing development or Shopify Plus sandbox store.",
+          "env": "SHOPIFY_FLAG_STORE",
+          "name": "store",
+          "hasDynamicHelp": false,
+          "multiple": true,
+          "type": "option"
+        },
+        "source": {
+          "description": "Filters output to the specified log source.",
+          "env": "SHOPIFY_FLAG_SOURCE",
+          "name": "source",
+          "hasDynamicHelp": false,
+          "multiple": true,
+          "type": "option"
+        },
+        "status": {
+          "description": "Filters output to the specified status (success or failure).",
+          "env": "SHOPIFY_FLAG_STATUS",
+          "name": "status",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "options": [
+            "success",
+            "failure"
+          ],
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "app:logs",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "summary": "Stream detailed logs for your Shopify app.",
+      "descriptionWithMarkdown": "\n  Opens a real-time stream of detailed app logs from the selected app and store.\n  Use the `--source` argument to limit output to a particular log source, such as a specific Shopify Function handle. Use the `shopify app logs sources` command to view a list of sources.\n  Use the `--status` argument to filter on status, either `success` or `failure`.\n  ```\n  shopify app logs --status=success --source=extension.discount-function\n  ```\n  ",
+      "customPluginName": "@shopify/app"
+    },
+    "app:logs:sources": {
+      "aliases": [],
+      "args": {},
+      "description": "The output source names can be used with the `--source` argument of `shopify app logs` to filter log output. Currently only function extensions are supported as sources.",
+      "flags": {
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
           "type": "boolean"
         },
         "verbose": {
-          "allowNo": false,
           "description": "Increase the verbosity of the output.",
           "env": "SHOPIFY_FLAG_VERBOSE",
           "hidden": false,
           "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path to your app directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "name": "path",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "config": {
+          "char": "c",
+          "description": "The name of the app configuration.",
+          "env": "SHOPIFY_FLAG_APP_CONFIG",
+          "hidden": false,
+          "name": "config",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "client-id": {
+          "description": "The Client ID of your app.",
+          "env": "SHOPIFY_FLAG_CLIENT_ID",
+          "exclusive": [
+            "config"
+          ],
+          "hidden": false,
+          "name": "client-id",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "reset": {
+          "description": "Reset all your settings.",
+          "env": "SHOPIFY_FLAG_RESET",
+          "exclusive": [
+            "config"
+          ],
+          "hidden": false,
+          "name": "reset",
+          "allowNo": false,
           "type": "boolean"
         }
       },
       "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
+      "hiddenAliases": [],
+      "id": "app:logs:sources",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "summary": "Print out a list of sources that may be used with the logs command.",
+      "descriptionWithMarkdown": "The output source names can be used with the `--source` argument of `shopify app logs` to filter log output. Currently only function extensions are supported as sources.",
+      "customPluginName": "@shopify/app"
+    },
+    "app:import-custom-data-definitions": {
+      "aliases": [],
+      "args": {},
+      "description": "Import metafield and metaobject definitions from your development store. \"Read more about declarative custom data definitions\" (https://shopify.dev/docs/apps/build/custom-data/declarative-custom-data-definitions).",
+      "flags": {
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path to your app directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "name": "path",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "config": {
+          "char": "c",
+          "description": "The name of the app configuration.",
+          "env": "SHOPIFY_FLAG_APP_CONFIG",
+          "hidden": false,
+          "name": "config",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "client-id": {
+          "description": "The Client ID of your app.",
+          "env": "SHOPIFY_FLAG_CLIENT_ID",
+          "exclusive": [
+            "config"
+          ],
+          "hidden": false,
+          "name": "client-id",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "reset": {
+          "description": "Reset all your settings.",
+          "env": "SHOPIFY_FLAG_RESET",
+          "exclusive": [
+            "config"
+          ],
+          "hidden": false,
+          "name": "reset",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "store": {
+          "char": "s",
+          "description": "Store URL. Must be an existing development or Shopify Plus sandbox store.",
+          "env": "SHOPIFY_FLAG_STORE",
+          "name": "store",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "include-existing": {
+          "description": "Include existing declared definitions in the output.",
+          "env": "SHOPIFY_FLAG_INCLUDE_EXISTING",
+          "name": "include-existing",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "app:import-custom-data-definitions",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "summary": "Import metafield and metaobject definitions.",
+      "descriptionWithMarkdown": "Import metafield and metaobject definitions from your development store. [Read more about declarative custom data definitions](https://shopify.dev/docs/apps/build/custom-data/declarative-custom-data-definitions).",
+      "customPluginName": "@shopify/app"
+    },
+    "app:import-extensions": {
+      "aliases": [],
+      "args": {},
+      "description": "Import dashboard-managed extensions into your app.",
+      "flags": {
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path to your app directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "name": "path",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "config": {
+          "char": "c",
+          "description": "The name of the app configuration.",
+          "env": "SHOPIFY_FLAG_APP_CONFIG",
+          "hidden": false,
+          "name": "config",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "client-id": {
+          "description": "The Client ID of your app.",
+          "env": "SHOPIFY_FLAG_CLIENT_ID",
+          "exclusive": [
+            "config"
+          ],
+          "hidden": false,
+          "name": "client-id",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "reset": {
+          "description": "Reset all your settings.",
+          "env": "SHOPIFY_FLAG_RESET",
+          "exclusive": [
+            "config"
+          ],
+          "hidden": false,
+          "name": "reset",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "app:import-extensions",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "customPluginName": "@shopify/app"
+    },
+    "app:info": {
+      "aliases": [],
+      "args": {},
+      "description": "The information returned includes the following:\n\n  - The app and dev store that's used when you run the \"dev\" (https://shopify.dev/docs/api/shopify-cli/app/app-dev) command. You can reset these configurations using \"`dev --reset`\" (https://shopify.dev/docs/api/shopify-cli/app/app-dev#flags-propertydetail-reset).\n  - The \"structure\" (https://shopify.dev/docs/apps/tools/cli/structure) of your app project.\n  - The \"access scopes\" (https://shopify.dev/docs/api/usage) your app has requested.\n  - System information, including the package manager and version of Shopify CLI used in the project.",
+      "flags": {
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path to your app directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "name": "path",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "config": {
+          "char": "c",
+          "description": "The name of the app configuration.",
+          "env": "SHOPIFY_FLAG_APP_CONFIG",
+          "hidden": false,
+          "name": "config",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "client-id": {
+          "description": "The Client ID of your app.",
+          "env": "SHOPIFY_FLAG_CLIENT_ID",
+          "exclusive": [
+            "config"
+          ],
+          "hidden": false,
+          "name": "client-id",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "reset": {
+          "description": "Reset all your settings.",
+          "env": "SHOPIFY_FLAG_RESET",
+          "exclusive": [
+            "config"
+          ],
+          "hidden": false,
+          "name": "reset",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "json": {
+          "char": "j",
+          "description": "Output the result as JSON. Automatically disables color output.",
+          "env": "SHOPIFY_FLAG_JSON",
+          "hidden": false,
+          "name": "json",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "web-env": {
+          "description": "Outputs environment variables necessary for running and deploying web/.",
+          "env": "SHOPIFY_FLAG_OUTPUT_WEB_ENV",
+          "hidden": false,
+          "name": "web-env",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "app:info",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "summary": "Print basic information about your app and extensions.",
+      "descriptionWithMarkdown": "The information returned includes the following:\n\n  - The app and dev store that's used when you run the [dev](https://shopify.dev/docs/api/shopify-cli/app/app-dev) command. You can reset these configurations using [`dev --reset`](https://shopify.dev/docs/api/shopify-cli/app/app-dev#flags-propertydetail-reset).\n  - The [structure](https://shopify.dev/docs/apps/tools/cli/structure) of your app project.\n  - The [access scopes](https://shopify.dev/docs/api/usage) your app has requested.\n  - System information, including the package manager and version of Shopify CLI used in the project.",
+      "customPluginName": "@shopify/app"
+    },
+    "app:init": {
+      "aliases": [],
+      "args": {},
+      "flags": {
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "name": {
+          "char": "n",
+          "description": "The name for the new app. When provided, skips the app selection prompt and creates a new app with this name.",
+          "env": "SHOPIFY_FLAG_NAME",
+          "hidden": false,
+          "name": "name",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "path": {
+          "char": "p",
+          "env": "SHOPIFY_FLAG_PATH",
+          "hidden": false,
+          "name": "path",
+          "default": "/Users/jeremygayed/src/github.com/Shopify/cli/packages/cli",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "template": {
+          "description": "The app template. Accepts one of the following:\n       - <reactRouter|none>\n       - Any GitHub repo with optional branch and subpath, e.g., https://github.com/Shopify/<repository>/[subpath]#[branch]",
+          "env": "SHOPIFY_FLAG_TEMPLATE",
+          "name": "template",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "flavor": {
+          "description": "Which flavor of the given template to use.",
+          "env": "SHOPIFY_FLAG_TEMPLATE_FLAVOR",
+          "name": "flavor",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "package-manager": {
+          "char": "d",
+          "env": "SHOPIFY_FLAG_PACKAGE_MANAGER",
+          "hidden": false,
+          "name": "package-manager",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "options": [
+            "npm",
+            "yarn",
+            "pnpm",
+            "bun"
+          ],
+          "type": "option"
+        },
+        "local": {
+          "char": "l",
+          "env": "SHOPIFY_FLAG_LOCAL",
+          "hidden": true,
+          "name": "local",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "client-id": {
+          "description": "The Client ID of your app. Use this to automatically link your new project to an existing app. Using this flag avoids the app selection prompt.",
+          "env": "SHOPIFY_FLAG_CLIENT_ID",
+          "exclusive": [
+            "config"
+          ],
+          "hidden": false,
+          "name": "client-id",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "organization-id": {
+          "description": "The organization ID. Your organization ID can be found in your Dev Dashboard URL: https://dev.shopify.com/dashboard/<organization-id>",
+          "env": "SHOPIFY_FLAG_ORGANIZATION_ID",
+          "exclusive": [
+            "client-id"
+          ],
+          "hidden": false,
+          "name": "organization-id",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "app:init",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "summary": "Create a new app project",
+      "customPluginName": "@shopify/app"
+    },
+    "app:config:validate": {
+      "aliases": [],
+      "args": {},
+      "description": "Validates the selected app configuration file and all extension configurations against their schemas and reports any errors found.",
+      "flags": {
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path to your app directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "name": "path",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "config": {
+          "char": "c",
+          "description": "The name of the app configuration.",
+          "env": "SHOPIFY_FLAG_APP_CONFIG",
+          "hidden": false,
+          "name": "config",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "client-id": {
+          "description": "The Client ID of your app.",
+          "env": "SHOPIFY_FLAG_CLIENT_ID",
+          "exclusive": [
+            "config"
+          ],
+          "hidden": false,
+          "name": "client-id",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "reset": {
+          "description": "Reset all your settings.",
+          "env": "SHOPIFY_FLAG_RESET",
+          "exclusive": [
+            "config"
+          ],
+          "hidden": false,
+          "name": "reset",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "json": {
+          "char": "j",
+          "description": "Output the result as JSON. Automatically disables color output.",
+          "env": "SHOPIFY_FLAG_JSON",
+          "hidden": false,
+          "name": "json",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "app:config:validate",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "summary": "Validate your app configuration and extensions.",
+      "descriptionWithMarkdown": "Validates the selected app configuration file and all extension configurations against their schemas and reports any errors found.",
+      "customPluginName": "@shopify/app"
+    },
+    "app:release": {
+      "aliases": [],
+      "args": {},
+      "description": "Releases an existing app version. Pass the name of the version that you want to release using the `--version` flag.",
+      "flags": {
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path to your app directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "name": "path",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "config": {
+          "char": "c",
+          "description": "The name of the app configuration.",
+          "env": "SHOPIFY_FLAG_APP_CONFIG",
+          "hidden": false,
+          "name": "config",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "client-id": {
+          "description": "The Client ID of your app.",
+          "env": "SHOPIFY_FLAG_CLIENT_ID",
+          "exclusive": [
+            "config"
+          ],
+          "hidden": false,
+          "name": "client-id",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "reset": {
+          "description": "Reset all your settings.",
+          "env": "SHOPIFY_FLAG_RESET",
+          "exclusive": [
+            "config"
+          ],
+          "hidden": false,
+          "name": "reset",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "force": {
+          "char": "f",
+          "description": "[Deprecated] Release without asking for confirmation. Equivalent to --allow-updates --allow-deletes. Use --allow-updates for CI/CD environments instead.",
+          "env": "SHOPIFY_FLAG_FORCE",
+          "hidden": false,
+          "name": "force",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "allow-updates": {
+          "description": "Allows adding and updating extensions and configuration without requiring user confirmation. Recommended option for CI/CD environments.",
+          "env": "SHOPIFY_FLAG_ALLOW_UPDATES",
+          "hidden": false,
+          "name": "allow-updates",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "allow-deletes": {
+          "description": "Allows removing extensions and configuration without requiring user confirmation. For CI/CD environments, the recommended flag is --allow-updates.",
+          "env": "SHOPIFY_FLAG_ALLOW_DELETES",
+          "hidden": false,
+          "name": "allow-deletes",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "version": {
+          "description": "The name of the app version to release.",
+          "env": "SHOPIFY_FLAG_VERSION",
+          "hidden": false,
+          "name": "version",
+          "required": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "app:release",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "summary": "Release an app version.",
+      "usage": "app release --version <version>",
+      "descriptionWithMarkdown": "Releases an existing app version. Pass the name of the version that you want to release using the `--version` flag.",
+      "customPluginName": "@shopify/app"
+    },
+    "app:config:link": {
+      "aliases": [],
+      "args": {},
+      "description": "Pulls app configuration from the Developer Dashboard and creates or overwrites a configuration file. You can create a new app with this command to start with a default configuration file.\n\n  For more information on the format of the created TOML configuration file, refer to the \"App configuration\" (https://shopify.dev/docs/apps/tools/cli/configuration) page.\n  ",
+      "flags": {
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path to your app directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "name": "path",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "config": {
+          "char": "c",
+          "description": "The name of the app configuration.",
+          "env": "SHOPIFY_FLAG_APP_CONFIG",
+          "hidden": false,
+          "name": "config",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "client-id": {
+          "description": "The Client ID of your app.",
+          "env": "SHOPIFY_FLAG_CLIENT_ID",
+          "exclusive": [
+            "config"
+          ],
+          "hidden": false,
+          "name": "client-id",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "reset": {
+          "description": "Reset all your settings.",
+          "env": "SHOPIFY_FLAG_RESET",
+          "exclusive": [
+            "config"
+          ],
+          "hidden": false,
+          "name": "reset",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "app:config:link",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "summary": "Fetch your app configuration from the Developer Dashboard.",
+      "descriptionWithMarkdown": "Pulls app configuration from the Developer Dashboard and creates or overwrites a configuration file. You can create a new app with this command to start with a default configuration file.\n\n  For more information on the format of the created TOML configuration file, refer to the [App configuration](https://shopify.dev/docs/apps/tools/cli/configuration) page.\n  ",
+      "customPluginName": "@shopify/app"
+    },
+    "app:config:use": {
+      "aliases": [],
+      "args": {
+        "config": {
+          "description": "The name of the app configuration. Can be 'shopify.app.staging.toml' or simply 'staging'.",
+          "name": "config"
+        }
+      },
+      "description": "Sets default configuration when you run app-related CLI commands. If you omit the `config-name` parameter, then you'll be prompted to choose from the configuration files in your project.",
+      "flags": {
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path to your app directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "name": "path",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "client-id": {
+          "description": "The Client ID of your app.",
+          "env": "SHOPIFY_FLAG_CLIENT_ID",
+          "exclusive": [
+            "config"
+          ],
+          "hidden": false,
+          "name": "client-id",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "reset": {
+          "description": "Reset all your settings.",
+          "env": "SHOPIFY_FLAG_RESET",
+          "exclusive": [
+            "config"
+          ],
+          "hidden": false,
+          "name": "reset",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "app:config:use",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "summary": "Activate an app configuration.",
+      "usage": "app config use [config] [flags]",
+      "descriptionWithMarkdown": "Sets default configuration when you run app-related CLI commands. If you omit the `config-name` parameter, then you'll be prompted to choose from the configuration files in your project.",
+      "customPluginName": "@shopify/app"
+    },
+    "app:config:pull": {
+      "aliases": [],
+      "args": {},
+      "description": "Pulls the latest configuration from the already-linked Shopify app and updates the selected configuration file.\n\nThis command reuses the existing linked app and organization and skips all interactive prompts. Use `--config` to target a specific configuration file, or omit it to use the default one.",
+      "flags": {
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path to your app directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "name": "path",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "config": {
+          "char": "c",
+          "description": "The name of the app configuration.",
+          "env": "SHOPIFY_FLAG_APP_CONFIG",
+          "hidden": false,
+          "name": "config",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "client-id": {
+          "description": "The Client ID of your app.",
+          "env": "SHOPIFY_FLAG_CLIENT_ID",
+          "exclusive": [
+            "config"
+          ],
+          "hidden": false,
+          "name": "client-id",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "reset": {
+          "description": "Reset all your settings.",
+          "env": "SHOPIFY_FLAG_RESET",
+          "exclusive": [
+            "config"
+          ],
+          "hidden": false,
+          "name": "reset",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "app:config:pull",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "summary": "Refresh an already-linked app configuration without prompts.",
+      "descriptionWithMarkdown": "Pulls the latest configuration from the already-linked Shopify app and updates the selected configuration file.\n\nThis command reuses the existing linked app and organization and skips all interactive prompts. Use `--config` to target a specific configuration file, or omit it to use the default one.",
+      "customPluginName": "@shopify/app"
+    },
+    "app:env:pull": {
+      "aliases": [],
+      "args": {},
+      "description": "Creates or updates an `.env` files that contains app and app extension environment variables.\n\n  When an existing `.env` file is updated, changes to the variables are displayed in the terminal output. Existing variables and commented variables are preserved.",
+      "flags": {
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path to your app directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "name": "path",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "config": {
+          "char": "c",
+          "description": "The name of the app configuration.",
+          "env": "SHOPIFY_FLAG_APP_CONFIG",
+          "hidden": false,
+          "name": "config",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "client-id": {
+          "description": "The Client ID of your app.",
+          "env": "SHOPIFY_FLAG_CLIENT_ID",
+          "exclusive": [
+            "config"
+          ],
+          "hidden": false,
+          "name": "client-id",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "reset": {
+          "description": "Reset all your settings.",
+          "env": "SHOPIFY_FLAG_RESET",
+          "exclusive": [
+            "config"
+          ],
+          "hidden": false,
+          "name": "reset",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "env-file": {
+          "description": "Specify an environment file to update if the update flag is set",
+          "env": "SHOPIFY_FLAG_ENV_FILE",
+          "hidden": false,
+          "name": "env-file",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
       "id": "app:env:pull",
       "pluginAlias": "@shopify/cli",
       "pluginName": "@shopify/cli",
       "pluginType": "core",
       "strict": true,
-      "summary": "Pull app and extensions environment variables."
+      "summary": "Pull app and extensions environment variables.",
+      "descriptionWithMarkdown": "Creates or updates an `.env` files that contains app and app extension environment variables.\n\n  When an existing `.env` file is updated, changes to the variables are displayed in the terminal output. Existing variables and commented variables are preserved.",
+      "customPluginName": "@shopify/app"
     },
     "app:env:show": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/app",
+      "aliases": [],
+      "args": {},
       "description": "Displays environment variables that can be used to deploy apps and app extensions.",
-      "descriptionWithMarkdown": "Displays environment variables that can be used to deploy apps and app extensions.",
       "flags": {
-        "client-id": {
-          "description": "The Client ID of your app.",
-          "env": "SHOPIFY_FLAG_CLIENT_ID",
-          "exclusive": [
-            "config"
-          ],
-          "hasDynamicHelp": false,
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
           "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path to your app directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "name": "path",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
           "multiple": false,
-          "name": "client-id",
           "type": "option"
         },
         "config": {
           "char": "c",
           "description": "The name of the app configuration.",
           "env": "SHOPIFY_FLAG_APP_CONFIG",
-          "hasDynamicHelp": false,
           "hidden": false,
-          "multiple": false,
           "name": "config",
+          "hasDynamicHelp": false,
+          "multiple": false,
           "type": "option"
         },
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
+        "client-id": {
+          "description": "The Client ID of your app.",
+          "env": "SHOPIFY_FLAG_CLIENT_ID",
+          "exclusive": [
+            "config"
+          ],
           "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
-        "path": {
-          "description": "The path to your app directory.",
-          "env": "SHOPIFY_FLAG_PATH",
+          "name": "client-id",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "path",
-          "noCacheDefault": true,
           "type": "option"
         },
         "reset": {
-          "allowNo": false,
           "description": "Reset all your settings.",
           "env": "SHOPIFY_FLAG_RESET",
           "exclusive": [
@@ -1307,103 +1802,74 @@
           ],
           "hidden": false,
           "name": "reset",
-          "type": "boolean"
-        },
-        "verbose": {
           "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
           "type": "boolean"
         }
       },
       "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
+      "hiddenAliases": [],
       "id": "app:env:show",
       "pluginAlias": "@shopify/cli",
       "pluginName": "@shopify/cli",
       "pluginType": "core",
       "strict": true,
-      "summary": "Display app and extensions environment variables."
+      "summary": "Display app and extensions environment variables.",
+      "descriptionWithMarkdown": "Displays environment variables that can be used to deploy apps and app extensions.",
+      "customPluginName": "@shopify/app"
     },
     "app:execute": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/app",
+      "aliases": [],
+      "args": {},
       "description": "Executes an Admin API GraphQL query or mutation on the specified store. Mutations are only allowed on dev stores.\n\n  For operations that process large amounts of data, use \"`bulk execute`\" (https://shopify.dev/docs/api/shopify-cli/app/app-bulk-execute) instead.",
-      "descriptionWithMarkdown": "Executes an Admin API GraphQL query or mutation on the specified store. Mutations are only allowed on dev stores.\n\n  For operations that process large amounts of data, use [`bulk execute`](https://shopify.dev/docs/api/shopify-cli/app/app-bulk-execute) instead.",
       "flags": {
-        "client-id": {
-          "description": "The Client ID of your app.",
-          "env": "SHOPIFY_FLAG_CLIENT_ID",
-          "exclusive": [
-            "config"
-          ],
-          "hasDynamicHelp": false,
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
           "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path to your app directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "name": "path",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
           "multiple": false,
-          "name": "client-id",
           "type": "option"
         },
         "config": {
           "char": "c",
           "description": "The name of the app configuration.",
           "env": "SHOPIFY_FLAG_APP_CONFIG",
-          "hasDynamicHelp": false,
           "hidden": false,
-          "multiple": false,
           "name": "config",
+          "hasDynamicHelp": false,
+          "multiple": false,
           "type": "option"
         },
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
+        "client-id": {
+          "description": "The Client ID of your app.",
+          "env": "SHOPIFY_FLAG_CLIENT_ID",
+          "exclusive": [
+            "config"
+          ],
           "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
-        "output-file": {
-          "description": "The file name where results should be written, instead of STDOUT.",
-          "env": "SHOPIFY_FLAG_OUTPUT_FILE",
+          "name": "client-id",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "output-file",
-          "type": "option"
-        },
-        "path": {
-          "description": "The path to your app directory.",
-          "env": "SHOPIFY_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "path",
-          "noCacheDefault": true,
-          "type": "option"
-        },
-        "query": {
-          "char": "q",
-          "description": "The GraphQL query or mutation, as a string.",
-          "env": "SHOPIFY_FLAG_QUERY",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "query",
-          "required": false,
-          "type": "option"
-        },
-        "query-file": {
-          "description": "Path to a file containing the GraphQL query or mutation. Can't be used with --query.",
-          "env": "SHOPIFY_FLAG_QUERY_FILE",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "query-file",
           "type": "option"
         },
         "reset": {
-          "allowNo": false,
           "description": "Reset all your settings.",
           "env": "SHOPIFY_FLAG_RESET",
           "exclusive": [
@@ -1411,26 +1877,25 @@
           ],
           "hidden": false,
           "name": "reset",
+          "allowNo": false,
           "type": "boolean"
         },
-        "store": {
-          "char": "s",
-          "description": "The myshopify.com domain of the store to execute against. The app must be installed on the store. If not specified, you will be prompted to select a store.",
-          "env": "SHOPIFY_FLAG_STORE",
+        "query": {
+          "char": "q",
+          "description": "The GraphQL query or mutation, as a string.",
+          "env": "SHOPIFY_FLAG_QUERY",
+          "name": "query",
+          "required": false,
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "store",
           "type": "option"
         },
-        "variable-file": {
-          "description": "Path to a file containing GraphQL variables in JSON format. Can't be used with --variables.",
-          "env": "SHOPIFY_FLAG_VARIABLE_FILE",
-          "exclusive": [
-            "variables"
-          ],
+        "query-file": {
+          "description": "Path to a file containing the GraphQL query or mutation. Can't be used with --query.",
+          "env": "SHOPIFY_FLAG_QUERY_FILE",
+          "name": "query-file",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "variable-file",
           "type": "option"
         },
         "variables": {
@@ -1440,89 +1905,112 @@
           "exclusive": [
             "variable-file"
           ],
+          "name": "variables",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "variables",
           "type": "option"
         },
-        "verbose": {
-          "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
-          "type": "boolean"
+        "variable-file": {
+          "description": "Path to a file containing GraphQL variables in JSON format. Can't be used with --variables.",
+          "env": "SHOPIFY_FLAG_VARIABLE_FILE",
+          "exclusive": [
+            "variables"
+          ],
+          "name": "variable-file",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "store": {
+          "char": "s",
+          "description": "The myshopify.com domain of the store to execute against. The app must be installed on the store. If not specified, you will be prompted to select a store.",
+          "env": "SHOPIFY_FLAG_STORE",
+          "name": "store",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
         },
         "version": {
           "description": "The API version to use for the query or mutation. Defaults to the latest stable version.",
           "env": "SHOPIFY_FLAG_VERSION",
+          "name": "version",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "version",
+          "type": "option"
+        },
+        "output-file": {
+          "description": "The file name where results should be written, instead of STDOUT.",
+          "env": "SHOPIFY_FLAG_OUTPUT_FILE",
+          "name": "output-file",
+          "hasDynamicHelp": false,
+          "multiple": false,
           "type": "option"
         }
       },
       "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
+      "hiddenAliases": [],
       "id": "app:execute",
       "pluginAlias": "@shopify/cli",
       "pluginName": "@shopify/cli",
       "pluginType": "core",
       "strict": true,
-      "summary": "Execute GraphQL queries and mutations."
+      "summary": "Execute GraphQL queries and mutations.",
+      "descriptionWithMarkdown": "Executes an Admin API GraphQL query or mutation on the specified store. Mutations are only allowed on dev stores.\n\n  For operations that process large amounts of data, use [`bulk execute`](https://shopify.dev/docs/api/shopify-cli/app/app-bulk-execute) instead.",
+      "customPluginName": "@shopify/app"
     },
-    "app:function:build": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/app",
-      "description": "Compiles the function in your current directory to WebAssembly (Wasm) for testing purposes.",
-      "descriptionWithMarkdown": "Compiles the function in your current directory to WebAssembly (Wasm) for testing purposes.",
+    "app:bulk:execute": {
+      "aliases": [],
+      "args": {},
+      "description": "Executes an Admin API GraphQL query or mutation on the specified store, as a bulk operation. Mutations are only allowed on dev stores.\n\n  Bulk operations allow you to process large amounts of data asynchronously. Learn more about \"bulk query operations\" (https://shopify.dev/docs/api/usage/bulk-operations/queries) and \"bulk mutation operations\" (https://shopify.dev/docs/api/usage/bulk-operations/imports).\n\n  Use \"`bulk status`\" (https://shopify.dev/docs/api/shopify-cli/app/app-bulk-status) to check the status of your bulk operations.",
       "flags": {
-        "client-id": {
-          "description": "The Client ID of your app.",
-          "env": "SHOPIFY_FLAG_CLIENT_ID",
-          "exclusive": [
-            "config"
-          ],
-          "hasDynamicHelp": false,
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
           "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path to your app directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "name": "path",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
           "multiple": false,
-          "name": "client-id",
           "type": "option"
         },
         "config": {
           "char": "c",
           "description": "The name of the app configuration.",
           "env": "SHOPIFY_FLAG_APP_CONFIG",
-          "hasDynamicHelp": false,
           "hidden": false,
-          "multiple": false,
           "name": "config",
+          "hasDynamicHelp": false,
+          "multiple": false,
           "type": "option"
         },
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
+        "client-id": {
+          "description": "The Client ID of your app.",
+          "env": "SHOPIFY_FLAG_CLIENT_ID",
+          "exclusive": [
+            "config"
+          ],
           "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
-        "path": {
-          "description": "The path to your function directory.",
-          "env": "SHOPIFY_FLAG_PATH",
+          "name": "client-id",
           "hasDynamicHelp": false,
-          "hidden": false,
           "multiple": false,
-          "name": "path",
-          "noCacheDefault": true,
           "type": "option"
         },
         "reset": {
-          "allowNo": false,
           "description": "Reset all your settings.",
           "env": "SHOPIFY_FLAG_RESET",
           "exclusive": [
@@ -1530,87 +2018,311 @@
           ],
           "hidden": false,
           "name": "reset",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "query": {
+          "char": "q",
+          "description": "The GraphQL query or mutation to run as a bulk operation.",
+          "env": "SHOPIFY_FLAG_QUERY",
+          "name": "query",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "query-file": {
+          "description": "Path to a file containing the GraphQL query or mutation. Can't be used with --query.",
+          "env": "SHOPIFY_FLAG_QUERY_FILE",
+          "name": "query-file",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "variables": {
+          "char": "v",
+          "description": "The values for any GraphQL variables in your mutation, in JSON format. Can be specified multiple times.",
+          "env": "SHOPIFY_FLAG_VARIABLES",
+          "exclusive": [
+            "variable-file"
+          ],
+          "name": "variables",
+          "hasDynamicHelp": false,
+          "multiple": true,
+          "type": "option"
+        },
+        "variable-file": {
+          "description": "Path to a file containing GraphQL variables in JSONL format (one JSON object per line). Can't be used with --variables.",
+          "env": "SHOPIFY_FLAG_VARIABLE_FILE",
+          "exclusive": [
+            "variables"
+          ],
+          "name": "variable-file",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "store": {
+          "char": "s",
+          "description": "The store domain. Must be an existing dev store.",
+          "env": "SHOPIFY_FLAG_STORE",
+          "name": "store",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "watch": {
+          "description": "Wait for bulk operation results before exiting. Defaults to false.",
+          "env": "SHOPIFY_FLAG_WATCH",
+          "name": "watch",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "output-file": {
+          "dependsOn": [
+            "watch"
+          ],
+          "description": "The file path where results should be written if --watch is specified. If not specified, results will be written to STDOUT.",
+          "env": "SHOPIFY_FLAG_OUTPUT_FILE",
+          "name": "output-file",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "version": {
+          "description": "The API version to use for the bulk operation. If not specified, uses the latest stable version.",
+          "env": "SHOPIFY_FLAG_VERSION",
+          "name": "version",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "app:bulk:execute",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "summary": "Execute bulk operations.",
+      "descriptionWithMarkdown": "Executes an Admin API GraphQL query or mutation on the specified store, as a bulk operation. Mutations are only allowed on dev stores.\n\n  Bulk operations allow you to process large amounts of data asynchronously. Learn more about [bulk query operations](https://shopify.dev/docs/api/usage/bulk-operations/queries) and [bulk mutation operations](https://shopify.dev/docs/api/usage/bulk-operations/imports).\n\n  Use [`bulk status`](https://shopify.dev/docs/api/shopify-cli/app/app-bulk-status) to check the status of your bulk operations.",
+      "customPluginName": "@shopify/app"
+    },
+    "app:generate:schema": {
+      "aliases": [],
+      "args": {},
+      "description": "\"DEPRECATED, use `app function schema`] Generates the latest [GraphQL schema\" (https://shopify.dev/docs/apps/functions/input-output#graphql-schema) for a function in your app. Run this command from the function directory.\n\n  This command uses the API type and version of your function, as defined in your extension TOML file, to generate the latest GraphQL schema. The schema is written to the `schema.graphql` file.",
+      "flags": {
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
           "type": "boolean"
         },
         "verbose": {
-          "allowNo": false,
           "description": "Increase the verbosity of the output.",
           "env": "SHOPIFY_FLAG_VERBOSE",
           "hidden": false,
           "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path to your function directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "hidden": false,
+          "name": "path",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "config": {
+          "char": "c",
+          "description": "The name of the app configuration.",
+          "env": "SHOPIFY_FLAG_APP_CONFIG",
+          "hidden": false,
+          "name": "config",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "client-id": {
+          "description": "The Client ID of your app.",
+          "env": "SHOPIFY_FLAG_CLIENT_ID",
+          "exclusive": [
+            "config"
+          ],
+          "hidden": false,
+          "name": "client-id",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "reset": {
+          "description": "Reset all your settings.",
+          "env": "SHOPIFY_FLAG_RESET",
+          "exclusive": [
+            "config"
+          ],
+          "hidden": false,
+          "name": "reset",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "stdout": {
+          "description": "Output the schema to stdout instead of writing to a file.",
+          "env": "SHOPIFY_FLAG_STDOUT",
+          "name": "stdout",
+          "required": false,
+          "allowNo": false,
           "type": "boolean"
         }
       },
       "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
+      "hidden": true,
+      "hiddenAliases": [],
+      "id": "app:generate:schema",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "summary": "Fetch the latest GraphQL schema for a function.",
+      "descriptionWithMarkdown": "[DEPRECATED, use `app function schema`] Generates the latest [GraphQL schema](https://shopify.dev/docs/apps/functions/input-output#graphql-schema) for a function in your app. Run this command from the function directory.\n\n  This command uses the API type and version of your function, as defined in your extension TOML file, to generate the latest GraphQL schema. The schema is written to the `schema.graphql` file.",
+      "customPluginName": "@shopify/app"
+    },
+    "app:function:build": {
+      "aliases": [],
+      "args": {},
+      "description": "Compiles the function in your current directory to WebAssembly (Wasm) for testing purposes.",
+      "flags": {
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path to your function directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "hidden": false,
+          "name": "path",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "config": {
+          "char": "c",
+          "description": "The name of the app configuration.",
+          "env": "SHOPIFY_FLAG_APP_CONFIG",
+          "hidden": false,
+          "name": "config",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "client-id": {
+          "description": "The Client ID of your app.",
+          "env": "SHOPIFY_FLAG_CLIENT_ID",
+          "exclusive": [
+            "config"
+          ],
+          "hidden": false,
+          "name": "client-id",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "reset": {
+          "description": "Reset all your settings.",
+          "env": "SHOPIFY_FLAG_RESET",
+          "exclusive": [
+            "config"
+          ],
+          "hidden": false,
+          "name": "reset",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
       "id": "app:function:build",
       "pluginAlias": "@shopify/cli",
       "pluginName": "@shopify/cli",
       "pluginType": "core",
       "strict": true,
-      "summary": "Compile a function to wasm."
+      "summary": "Compile a function to wasm.",
+      "descriptionWithMarkdown": "Compiles the function in your current directory to WebAssembly (Wasm) for testing purposes.",
+      "customPluginName": "@shopify/app"
     },
-    "app:function:info": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/app",
-      "description": "The information returned includes the following:\n\n  - The function handle\n  - The function name\n  - The function API version\n  - The targeting configuration\n  - The schema path\n  - The WASM path\n  - The function runner path",
-      "descriptionWithMarkdown": "The information returned includes the following:\n\n  - The function handle\n  - The function name\n  - The function API version\n  - The targeting configuration\n  - The schema path\n  - The WASM path\n  - The function runner path",
+    "app:function:replay": {
+      "aliases": [],
+      "args": {},
+      "description": "Runs the function from your current directory for \"testing purposes\" (https://shopify.dev/docs/apps/functions/testing-and-debugging). To learn how you can monitor and debug functions when errors occur, refer to \"Shopify Functions error handling\" (https://shopify.dev/docs/api/functions/errors).",
       "flags": {
-        "client-id": {
-          "description": "The Client ID of your app.",
-          "env": "SHOPIFY_FLAG_CLIENT_ID",
-          "exclusive": [
-            "config"
-          ],
-          "hasDynamicHelp": false,
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
           "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path to your function directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "hidden": false,
+          "name": "path",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
           "multiple": false,
-          "name": "client-id",
           "type": "option"
         },
         "config": {
           "char": "c",
           "description": "The name of the app configuration.",
           "env": "SHOPIFY_FLAG_APP_CONFIG",
-          "hasDynamicHelp": false,
           "hidden": false,
-          "multiple": false,
           "name": "config",
+          "hasDynamicHelp": false,
+          "multiple": false,
           "type": "option"
         },
-        "json": {
-          "allowNo": false,
-          "char": "j",
-          "description": "Output the result as JSON. Automatically disables color output.",
-          "env": "SHOPIFY_FLAG_JSON",
+        "client-id": {
+          "description": "The Client ID of your app.",
+          "env": "SHOPIFY_FLAG_CLIENT_ID",
+          "exclusive": [
+            "config"
+          ],
           "hidden": false,
-          "name": "json",
-          "type": "boolean"
-        },
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
-          "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
-        "path": {
-          "description": "The path to your function directory.",
-          "env": "SHOPIFY_FLAG_PATH",
+          "name": "client-id",
           "hasDynamicHelp": false,
-          "hidden": false,
           "multiple": false,
-          "name": "path",
-          "noCacheDefault": true,
           "type": "option"
         },
         "reset": {
-          "allowNo": false,
           "description": "Reset all your settings.",
           "env": "SHOPIFY_FLAG_RESET",
           "exclusive": [
@@ -1618,96 +2330,102 @@
           ],
           "hidden": false,
           "name": "reset",
-          "type": "boolean"
-        },
-        "verbose": {
           "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
           "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "app:function:info",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true,
-      "summary": "Print basic information about your function."
-    },
-    "app:function:replay": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/app",
-      "description": "Runs the function from your current directory for \"testing purposes\" (https://shopify.dev/docs/apps/functions/testing-and-debugging). To learn how you can monitor and debug functions when errors occur, refer to \"Shopify Functions error handling\" (https://shopify.dev/docs/api/functions/errors).",
-      "descriptionWithMarkdown": "Runs the function from your current directory for [testing purposes](https://shopify.dev/docs/apps/functions/testing-and-debugging). To learn how you can monitor and debug functions when errors occur, refer to [Shopify Functions error handling](https://shopify.dev/docs/api/functions/errors).",
-      "flags": {
-        "client-id": {
-          "description": "The Client ID of your app.",
-          "env": "SHOPIFY_FLAG_CLIENT_ID",
-          "exclusive": [
-            "config"
-          ],
-          "hasDynamicHelp": false,
-          "hidden": false,
-          "multiple": false,
-          "name": "client-id",
-          "type": "option"
-        },
-        "config": {
-          "char": "c",
-          "description": "The name of the app configuration.",
-          "env": "SHOPIFY_FLAG_APP_CONFIG",
-          "hasDynamicHelp": false,
-          "hidden": false,
-          "multiple": false,
-          "name": "config",
-          "type": "option"
         },
         "json": {
-          "allowNo": false,
           "char": "j",
           "description": "Output the result as JSON. Automatically disables color output.",
           "env": "SHOPIFY_FLAG_JSON",
           "hidden": false,
           "name": "json",
+          "allowNo": false,
           "type": "boolean"
         },
         "log": {
           "char": "l",
           "description": "Specifies a log identifier to replay instead of selecting from a list. The identifier is provided in the output of `shopify app dev` and is the suffix of the log file name.",
           "env": "SHOPIFY_FLAG_LOG",
+          "name": "log",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "log",
           "type": "option"
         },
+        "watch": {
+          "char": "w",
+          "description": "Re-run the function when the source code changes.",
+          "env": "SHOPIFY_FLAG_WATCH",
+          "hidden": false,
+          "name": "watch",
+          "allowNo": true,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "app:function:replay",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "summary": "Replays a function run from an app log.",
+      "descriptionWithMarkdown": "Runs the function from your current directory for [testing purposes](https://shopify.dev/docs/apps/functions/testing-and-debugging). To learn how you can monitor and debug functions when errors occur, refer to [Shopify Functions error handling](https://shopify.dev/docs/api/functions/errors).",
+      "customPluginName": "@shopify/app"
+    },
+    "app:function:run": {
+      "aliases": [],
+      "args": {},
+      "description": "Runs the function from your current directory for \"testing purposes\" (https://shopify.dev/docs/apps/functions/testing-and-debugging). To learn how you can monitor and debug functions when errors occur, refer to \"Shopify Functions error handling\" (https://shopify.dev/docs/api/functions/errors).",
+      "flags": {
         "no-color": {
-          "allowNo": false,
           "description": "Disable color output.",
           "env": "SHOPIFY_FLAG_NO_COLOR",
           "hidden": false,
           "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
           "type": "boolean"
         },
         "path": {
           "description": "The path to your function directory.",
           "env": "SHOPIFY_FLAG_PATH",
-          "hasDynamicHelp": false,
           "hidden": false,
-          "multiple": false,
           "name": "path",
           "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "config": {
+          "char": "c",
+          "description": "The name of the app configuration.",
+          "env": "SHOPIFY_FLAG_APP_CONFIG",
+          "hidden": false,
+          "name": "config",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "client-id": {
+          "description": "The Client ID of your app.",
+          "env": "SHOPIFY_FLAG_CLIENT_ID",
+          "exclusive": [
+            "config"
+          ],
+          "hidden": false,
+          "name": "client-id",
+          "hasDynamicHelp": false,
+          "multiple": false,
           "type": "option"
         },
         "reset": {
-          "allowNo": false,
           "description": "Reset all your settings.",
           "env": "SHOPIFY_FLAG_RESET",
           "exclusive": [
@@ -1715,194 +2433,103 @@
           ],
           "hidden": false,
           "name": "reset",
-          "type": "boolean"
-        },
-        "verbose": {
           "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
           "type": "boolean"
         },
-        "watch": {
-          "allowNo": true,
-          "char": "w",
-          "description": "Re-run the function when the source code changes.",
-          "env": "SHOPIFY_FLAG_WATCH",
+        "json": {
+          "char": "j",
+          "description": "Output the result as JSON. Automatically disables color output.",
+          "env": "SHOPIFY_FLAG_JSON",
           "hidden": false,
-          "name": "watch",
+          "name": "json",
+          "allowNo": false,
           "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "app:function:replay",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true,
-      "summary": "Replays a function run from an app log."
-    },
-    "app:function:run": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/app",
-      "description": "Runs the function from your current directory for \"testing purposes\" (https://shopify.dev/docs/apps/functions/testing-and-debugging). To learn how you can monitor and debug functions when errors occur, refer to \"Shopify Functions error handling\" (https://shopify.dev/docs/api/functions/errors).",
-      "descriptionWithMarkdown": "Runs the function from your current directory for [testing purposes](https://shopify.dev/docs/apps/functions/testing-and-debugging). To learn how you can monitor and debug functions when errors occur, refer to [Shopify Functions error handling](https://shopify.dev/docs/api/functions/errors).",
-      "flags": {
-        "client-id": {
-          "description": "The Client ID of your app.",
-          "env": "SHOPIFY_FLAG_CLIENT_ID",
-          "exclusive": [
-            "config"
-          ],
-          "hasDynamicHelp": false,
-          "hidden": false,
-          "multiple": false,
-          "name": "client-id",
-          "type": "option"
         },
-        "config": {
-          "char": "c",
-          "description": "The name of the app configuration.",
-          "env": "SHOPIFY_FLAG_APP_CONFIG",
+        "input": {
+          "char": "i",
+          "description": "The input JSON to pass to the function. If omitted, standard input is used.",
+          "env": "SHOPIFY_FLAG_INPUT",
+          "name": "input",
           "hasDynamicHelp": false,
-          "hidden": false,
           "multiple": false,
-          "name": "config",
           "type": "option"
         },
         "export": {
           "char": "e",
           "description": "Name of the WebAssembly export to invoke.",
           "env": "SHOPIFY_FLAG_EXPORT",
-          "hasDynamicHelp": false,
           "hidden": false,
-          "multiple": false,
           "name": "export",
-          "type": "option"
-        },
-        "input": {
-          "char": "i",
-          "description": "The input JSON to pass to the function. If omitted, standard input is used.",
-          "env": "SHOPIFY_FLAG_INPUT",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "input",
           "type": "option"
-        },
-        "json": {
-          "allowNo": false,
-          "char": "j",
-          "description": "Output the result as JSON. Automatically disables color output.",
-          "env": "SHOPIFY_FLAG_JSON",
-          "hidden": false,
-          "name": "json",
-          "type": "boolean"
-        },
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
-          "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
-        "path": {
-          "description": "The path to your function directory.",
-          "env": "SHOPIFY_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "hidden": false,
-          "multiple": false,
-          "name": "path",
-          "noCacheDefault": true,
-          "type": "option"
-        },
-        "reset": {
-          "allowNo": false,
-          "description": "Reset all your settings.",
-          "env": "SHOPIFY_FLAG_RESET",
-          "exclusive": [
-            "config"
-          ],
-          "hidden": false,
-          "name": "reset",
-          "type": "boolean"
-        },
-        "verbose": {
-          "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
-          "type": "boolean"
         }
       },
       "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
+      "hiddenAliases": [],
       "id": "app:function:run",
       "pluginAlias": "@shopify/cli",
       "pluginName": "@shopify/cli",
       "pluginType": "core",
       "strict": true,
-      "summary": "Run a function locally for testing."
+      "summary": "Run a function locally for testing.",
+      "descriptionWithMarkdown": "Runs the function from your current directory for [testing purposes](https://shopify.dev/docs/apps/functions/testing-and-debugging). To learn how you can monitor and debug functions when errors occur, refer to [Shopify Functions error handling](https://shopify.dev/docs/api/functions/errors).",
+      "customPluginName": "@shopify/app"
     },
-    "app:function:schema": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/app",
-      "description": "Generates the latest \"GraphQL schema\" (https://shopify.dev/docs/apps/functions/input-output#graphql-schema) for a function in your app. Run this command from the function directory.\n\n  This command uses the API type and version of your function, as defined in your extension TOML file, to generate the latest GraphQL schema. The schema is written to the `schema.graphql` file.",
-      "descriptionWithMarkdown": "Generates the latest [GraphQL schema](https://shopify.dev/docs/apps/functions/input-output#graphql-schema) for a function in your app. Run this command from the function directory.\n\n  This command uses the API type and version of your function, as defined in your extension TOML file, to generate the latest GraphQL schema. The schema is written to the `schema.graphql` file.",
+    "app:function:info": {
+      "aliases": [],
+      "args": {},
+      "description": "The information returned includes the following:\n\n  - The function handle\n  - The function name\n  - The function API version\n  - The targeting configuration\n  - The schema path\n  - The WASM path\n  - The function runner path",
       "flags": {
-        "client-id": {
-          "description": "The Client ID of your app.",
-          "env": "SHOPIFY_FLAG_CLIENT_ID",
-          "exclusive": [
-            "config"
-          ],
-          "hasDynamicHelp": false,
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
           "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path to your function directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "hidden": false,
+          "name": "path",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
           "multiple": false,
-          "name": "client-id",
           "type": "option"
         },
         "config": {
           "char": "c",
           "description": "The name of the app configuration.",
           "env": "SHOPIFY_FLAG_APP_CONFIG",
-          "hasDynamicHelp": false,
           "hidden": false,
-          "multiple": false,
           "name": "config",
+          "hasDynamicHelp": false,
+          "multiple": false,
           "type": "option"
         },
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
+        "client-id": {
+          "description": "The Client ID of your app.",
+          "env": "SHOPIFY_FLAG_CLIENT_ID",
+          "exclusive": [
+            "config"
+          ],
           "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
-        "path": {
-          "description": "The path to your function directory.",
-          "env": "SHOPIFY_FLAG_PATH",
+          "name": "client-id",
           "hasDynamicHelp": false,
-          "hidden": false,
           "multiple": false,
-          "name": "path",
-          "noCacheDefault": true,
           "type": "option"
         },
         "reset": {
-          "allowNo": false,
           "description": "Reset all your settings.",
           "env": "SHOPIFY_FLAG_RESET",
           "exclusive": [
@@ -1910,86 +2537,168 @@
           ],
           "hidden": false,
           "name": "reset",
+          "allowNo": false,
           "type": "boolean"
         },
-        "stdout": {
-          "allowNo": false,
-          "description": "Output the schema to stdout instead of writing to a file.",
-          "env": "SHOPIFY_FLAG_STDOUT",
-          "name": "stdout",
-          "required": false,
-          "type": "boolean"
-        },
-        "verbose": {
-          "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
+        "json": {
+          "char": "j",
+          "description": "Output the result as JSON. Automatically disables color output.",
+          "env": "SHOPIFY_FLAG_JSON",
           "hidden": false,
-          "name": "verbose",
+          "name": "json",
+          "allowNo": false,
           "type": "boolean"
         }
       },
       "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
+      "hiddenAliases": [],
+      "id": "app:function:info",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "summary": "Print basic information about your function.",
+      "descriptionWithMarkdown": "The information returned includes the following:\n\n  - The function handle\n  - The function name\n  - The function API version\n  - The targeting configuration\n  - The schema path\n  - The WASM path\n  - The function runner path",
+      "customPluginName": "@shopify/app"
+    },
+    "app:function:schema": {
+      "aliases": [],
+      "args": {},
+      "description": "Generates the latest \"GraphQL schema\" (https://shopify.dev/docs/apps/functions/input-output#graphql-schema) for a function in your app. Run this command from the function directory.\n\n  This command uses the API type and version of your function, as defined in your extension TOML file, to generate the latest GraphQL schema. The schema is written to the `schema.graphql` file.",
+      "flags": {
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path to your function directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "hidden": false,
+          "name": "path",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "config": {
+          "char": "c",
+          "description": "The name of the app configuration.",
+          "env": "SHOPIFY_FLAG_APP_CONFIG",
+          "hidden": false,
+          "name": "config",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "client-id": {
+          "description": "The Client ID of your app.",
+          "env": "SHOPIFY_FLAG_CLIENT_ID",
+          "exclusive": [
+            "config"
+          ],
+          "hidden": false,
+          "name": "client-id",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "reset": {
+          "description": "Reset all your settings.",
+          "env": "SHOPIFY_FLAG_RESET",
+          "exclusive": [
+            "config"
+          ],
+          "hidden": false,
+          "name": "reset",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "stdout": {
+          "description": "Output the schema to stdout instead of writing to a file.",
+          "env": "SHOPIFY_FLAG_STDOUT",
+          "name": "stdout",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
       "id": "app:function:schema",
       "pluginAlias": "@shopify/cli",
       "pluginName": "@shopify/cli",
       "pluginType": "core",
       "strict": true,
-      "summary": "Fetch the latest GraphQL schema for a function."
+      "summary": "Fetch the latest GraphQL schema for a function.",
+      "descriptionWithMarkdown": "Generates the latest [GraphQL schema](https://shopify.dev/docs/apps/functions/input-output#graphql-schema) for a function in your app. Run this command from the function directory.\n\n  This command uses the API type and version of your function, as defined in your extension TOML file, to generate the latest GraphQL schema. The schema is written to the `schema.graphql` file.",
+      "customPluginName": "@shopify/app"
     },
     "app:function:typegen": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/app",
+      "aliases": [],
+      "args": {},
       "description": "Creates GraphQL types based on your \"input query\" (https://shopify.dev/docs/apps/functions/input-output#input) for a function. Supports JavaScript functions out of the box, or any language via the `build.typegen_command` configuration.",
-      "descriptionWithMarkdown": "Creates GraphQL types based on your [input query](https://shopify.dev/docs/apps/functions/input-output#input) for a function. Supports JavaScript functions out of the box, or any language via the `build.typegen_command` configuration.",
       "flags": {
-        "client-id": {
-          "description": "The Client ID of your app.",
-          "env": "SHOPIFY_FLAG_CLIENT_ID",
-          "exclusive": [
-            "config"
-          ],
-          "hasDynamicHelp": false,
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
           "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path to your function directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "hidden": false,
+          "name": "path",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
           "multiple": false,
-          "name": "client-id",
           "type": "option"
         },
         "config": {
           "char": "c",
           "description": "The name of the app configuration.",
           "env": "SHOPIFY_FLAG_APP_CONFIG",
-          "hasDynamicHelp": false,
           "hidden": false,
-          "multiple": false,
           "name": "config",
+          "hasDynamicHelp": false,
+          "multiple": false,
           "type": "option"
         },
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
+        "client-id": {
+          "description": "The Client ID of your app.",
+          "env": "SHOPIFY_FLAG_CLIENT_ID",
+          "exclusive": [
+            "config"
+          ],
           "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
-        "path": {
-          "description": "The path to your function directory.",
-          "env": "SHOPIFY_FLAG_PATH",
+          "name": "client-id",
           "hasDynamicHelp": false,
-          "hidden": false,
           "multiple": false,
-          "name": "path",
-          "noCacheDefault": true,
           "type": "option"
         },
         "reset": {
-          "allowNo": false,
           "description": "Reset all your settings.",
           "env": "SHOPIFY_FLAG_RESET",
           "exclusive": [
@@ -1997,75 +2706,131 @@
           ],
           "hidden": false,
           "name": "reset",
-          "type": "boolean"
-        },
-        "verbose": {
           "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
           "type": "boolean"
         }
       },
       "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
+      "hiddenAliases": [],
       "id": "app:function:typegen",
       "pluginAlias": "@shopify/cli",
       "pluginName": "@shopify/cli",
       "pluginType": "core",
       "strict": true,
-      "summary": "Generate GraphQL types for a function."
+      "summary": "Generate GraphQL types for a function.",
+      "descriptionWithMarkdown": "Creates GraphQL types based on your [input query](https://shopify.dev/docs/apps/functions/input-output#input) for a function. Supports JavaScript functions out of the box, or any language via the `build.typegen_command` configuration.",
+      "customPluginName": "@shopify/app"
     },
     "app:generate:extension": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/app",
+      "aliases": [],
+      "args": {},
       "description": "Generates a new \"app extension\" (https://shopify.dev/docs/apps/build/app-extensions). For a list of app extensions that you can generate using this command, refer to \"Supported extensions\" (https://shopify.dev/docs/apps/build/app-extensions/list-of-app-extensions).\n\n  Each new app extension is created in a folder under `extensions/`. To learn more about the extensions file structure, refer to \"App structure\" (https://shopify.dev/docs/apps/build/cli-for-apps/app-structure) and the documentation for your extension.\n  ",
-      "descriptionWithMarkdown": "Generates a new [app extension](https://shopify.dev/docs/apps/build/app-extensions). For a list of app extensions that you can generate using this command, refer to [Supported extensions](https://shopify.dev/docs/apps/build/app-extensions/list-of-app-extensions).\n\n  Each new app extension is created in a folder under `extensions/`. To learn more about the extensions file structure, refer to [App structure](https://shopify.dev/docs/apps/build/cli-for-apps/app-structure) and the documentation for your extension.\n  ",
       "flags": {
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path to your app directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "name": "path",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "config": {
+          "char": "c",
+          "description": "The name of the app configuration.",
+          "env": "SHOPIFY_FLAG_APP_CONFIG",
+          "hidden": false,
+          "name": "config",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
         "client-id": {
           "description": "The Client ID of your app.",
           "env": "SHOPIFY_FLAG_CLIENT_ID",
           "exclusive": [
             "config"
           ],
-          "hasDynamicHelp": false,
           "hidden": false,
-          "multiple": false,
           "name": "client-id",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "reset": {
+          "description": "Reset all your settings.",
+          "env": "SHOPIFY_FLAG_RESET",
+          "exclusive": [
+            "config"
+          ],
+          "hidden": false,
+          "name": "reset",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "type": {
+          "char": "t",
+          "description": "Deprecated. Please use --template",
+          "env": "SHOPIFY_FLAG_EXTENSION_TYPE",
+          "hidden": false,
+          "name": "type",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "template": {
+          "char": "t",
+          "description": "Extension template",
+          "env": "SHOPIFY_FLAG_EXTENSION_TEMPLATE",
+          "hidden": false,
+          "name": "template",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "name": {
+          "char": "n",
+          "description": "name of your Extension",
+          "env": "SHOPIFY_FLAG_NAME",
+          "hidden": false,
+          "name": "name",
+          "hasDynamicHelp": false,
+          "multiple": false,
           "type": "option"
         },
         "clone-url": {
           "char": "u",
           "description": "The Git URL to clone the function extensions templates from. Defaults to: https://github.com/Shopify/function-examples",
           "env": "SHOPIFY_FLAG_CLONE_URL",
-          "hasDynamicHelp": false,
           "hidden": true,
-          "multiple": false,
           "name": "clone-url",
-          "type": "option"
-        },
-        "config": {
-          "char": "c",
-          "description": "The name of the app configuration.",
-          "env": "SHOPIFY_FLAG_APP_CONFIG",
           "hasDynamicHelp": false,
-          "hidden": false,
           "multiple": false,
-          "name": "config",
           "type": "option"
         },
         "flavor": {
           "description": "Choose a starting template for your extension, where applicable",
           "env": "SHOPIFY_FLAG_FLAVOR",
-          "hasDynamicHelp": false,
           "hidden": false,
-          "multiple": false,
           "name": "flavor",
+          "hasDynamicHelp": false,
+          "multiple": false,
           "options": [
             "vanilla-js",
             "react",
@@ -2075,814 +2840,72 @@
             "rust"
           ],
           "type": "option"
-        },
-        "name": {
-          "char": "n",
-          "description": "name of your Extension",
-          "env": "SHOPIFY_FLAG_NAME",
-          "hasDynamicHelp": false,
-          "hidden": false,
-          "multiple": false,
-          "name": "name",
-          "type": "option"
-        },
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
-          "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
-        "path": {
-          "description": "The path to your app directory.",
-          "env": "SHOPIFY_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "path",
-          "noCacheDefault": true,
-          "type": "option"
-        },
-        "reset": {
-          "allowNo": false,
-          "description": "Reset all your settings.",
-          "env": "SHOPIFY_FLAG_RESET",
-          "exclusive": [
-            "config"
-          ],
-          "hidden": false,
-          "name": "reset",
-          "type": "boolean"
-        },
-        "template": {
-          "char": "t",
-          "description": "Extension template",
-          "env": "SHOPIFY_FLAG_EXTENSION_TEMPLATE",
-          "hasDynamicHelp": false,
-          "hidden": false,
-          "multiple": false,
-          "name": "template",
-          "type": "option"
-        },
-        "verbose": {
-          "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
-          "type": "boolean"
         }
       },
       "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
+      "hiddenAliases": [],
       "id": "app:generate:extension",
       "pluginAlias": "@shopify/cli",
       "pluginName": "@shopify/cli",
       "pluginType": "core",
       "strict": true,
-      "summary": "Generate a new app Extension."
-    },
-    "app:import-custom-data-definitions": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/app",
-      "description": "Import metafield and metaobject definitions from your development store. \"Read more about declarative custom data definitions\" (https://shopify.dev/docs/apps/build/custom-data/declarative-custom-data-definitions).",
-      "descriptionWithMarkdown": "Import metafield and metaobject definitions from your development store. [Read more about declarative custom data definitions](https://shopify.dev/docs/apps/build/custom-data/declarative-custom-data-definitions).",
-      "flags": {
-        "client-id": {
-          "description": "The Client ID of your app.",
-          "env": "SHOPIFY_FLAG_CLIENT_ID",
-          "exclusive": [
-            "config"
-          ],
-          "hasDynamicHelp": false,
-          "hidden": false,
-          "multiple": false,
-          "name": "client-id",
-          "type": "option"
-        },
-        "config": {
-          "char": "c",
-          "description": "The name of the app configuration.",
-          "env": "SHOPIFY_FLAG_APP_CONFIG",
-          "hasDynamicHelp": false,
-          "hidden": false,
-          "multiple": false,
-          "name": "config",
-          "type": "option"
-        },
-        "include-existing": {
-          "allowNo": false,
-          "description": "Include existing declared definitions in the output.",
-          "env": "SHOPIFY_FLAG_INCLUDE_EXISTING",
-          "name": "include-existing",
-          "type": "boolean"
-        },
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
-          "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
-        "path": {
-          "description": "The path to your app directory.",
-          "env": "SHOPIFY_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "path",
-          "noCacheDefault": true,
-          "type": "option"
-        },
-        "reset": {
-          "allowNo": false,
-          "description": "Reset all your settings.",
-          "env": "SHOPIFY_FLAG_RESET",
-          "exclusive": [
-            "config"
-          ],
-          "hidden": false,
-          "name": "reset",
-          "type": "boolean"
-        },
-        "store": {
-          "char": "s",
-          "description": "Store URL. Must be an existing development or Shopify Plus sandbox store.",
-          "env": "SHOPIFY_FLAG_STORE",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "store",
-          "type": "option"
-        },
-        "verbose": {
-          "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "app:import-custom-data-definitions",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true,
-      "summary": "Import metafield and metaobject definitions."
-    },
-    "app:import-extensions": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/app",
-      "description": "Import dashboard-managed extensions into your app.",
-      "flags": {
-        "client-id": {
-          "description": "The Client ID of your app.",
-          "env": "SHOPIFY_FLAG_CLIENT_ID",
-          "exclusive": [
-            "config"
-          ],
-          "hasDynamicHelp": false,
-          "hidden": false,
-          "multiple": false,
-          "name": "client-id",
-          "type": "option"
-        },
-        "config": {
-          "char": "c",
-          "description": "The name of the app configuration.",
-          "env": "SHOPIFY_FLAG_APP_CONFIG",
-          "hasDynamicHelp": false,
-          "hidden": false,
-          "multiple": false,
-          "name": "config",
-          "type": "option"
-        },
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
-          "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
-        "path": {
-          "description": "The path to your app directory.",
-          "env": "SHOPIFY_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "path",
-          "noCacheDefault": true,
-          "type": "option"
-        },
-        "reset": {
-          "allowNo": false,
-          "description": "Reset all your settings.",
-          "env": "SHOPIFY_FLAG_RESET",
-          "exclusive": [
-            "config"
-          ],
-          "hidden": false,
-          "name": "reset",
-          "type": "boolean"
-        },
-        "verbose": {
-          "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "app:import-extensions",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true
-    },
-    "app:info": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/app",
-      "description": "The information returned includes the following:\n\n  - The app and dev store that's used when you run the \"dev\" (https://shopify.dev/docs/api/shopify-cli/app/app-dev) command. You can reset these configurations using \"`dev --reset`\" (https://shopify.dev/docs/api/shopify-cli/app/app-dev#flags-propertydetail-reset).\n  - The \"structure\" (https://shopify.dev/docs/apps/tools/cli/structure) of your app project.\n  - The \"access scopes\" (https://shopify.dev/docs/api/usage) your app has requested.\n  - System information, including the package manager and version of Shopify CLI used in the project.",
-      "descriptionWithMarkdown": "The information returned includes the following:\n\n  - The app and dev store that's used when you run the [dev](https://shopify.dev/docs/api/shopify-cli/app/app-dev) command. You can reset these configurations using [`dev --reset`](https://shopify.dev/docs/api/shopify-cli/app/app-dev#flags-propertydetail-reset).\n  - The [structure](https://shopify.dev/docs/apps/tools/cli/structure) of your app project.\n  - The [access scopes](https://shopify.dev/docs/api/usage) your app has requested.\n  - System information, including the package manager and version of Shopify CLI used in the project.",
-      "flags": {
-        "client-id": {
-          "description": "The Client ID of your app.",
-          "env": "SHOPIFY_FLAG_CLIENT_ID",
-          "exclusive": [
-            "config"
-          ],
-          "hasDynamicHelp": false,
-          "hidden": false,
-          "multiple": false,
-          "name": "client-id",
-          "type": "option"
-        },
-        "config": {
-          "char": "c",
-          "description": "The name of the app configuration.",
-          "env": "SHOPIFY_FLAG_APP_CONFIG",
-          "hasDynamicHelp": false,
-          "hidden": false,
-          "multiple": false,
-          "name": "config",
-          "type": "option"
-        },
-        "json": {
-          "allowNo": false,
-          "char": "j",
-          "description": "Output the result as JSON. Automatically disables color output.",
-          "env": "SHOPIFY_FLAG_JSON",
-          "hidden": false,
-          "name": "json",
-          "type": "boolean"
-        },
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
-          "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
-        "path": {
-          "description": "The path to your app directory.",
-          "env": "SHOPIFY_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "path",
-          "noCacheDefault": true,
-          "type": "option"
-        },
-        "reset": {
-          "allowNo": false,
-          "description": "Reset all your settings.",
-          "env": "SHOPIFY_FLAG_RESET",
-          "exclusive": [
-            "config"
-          ],
-          "hidden": false,
-          "name": "reset",
-          "type": "boolean"
-        },
-        "verbose": {
-          "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
-          "type": "boolean"
-        },
-        "web-env": {
-          "allowNo": false,
-          "description": "Outputs environment variables necessary for running and deploying web/.",
-          "env": "SHOPIFY_FLAG_OUTPUT_WEB_ENV",
-          "hidden": false,
-          "name": "web-env",
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "app:info",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true,
-      "summary": "Print basic information about your app and extensions."
-    },
-    "app:init": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/app",
-      "flags": {
-        "client-id": {
-          "description": "The Client ID of your app. Use this to automatically link your new project to an existing app. Using this flag avoids the app selection prompt.",
-          "env": "SHOPIFY_FLAG_CLIENT_ID",
-          "exclusive": [
-            "config"
-          ],
-          "hasDynamicHelp": false,
-          "hidden": false,
-          "multiple": false,
-          "name": "client-id",
-          "type": "option"
-        },
-        "flavor": {
-          "description": "Which flavor of the given template to use.",
-          "env": "SHOPIFY_FLAG_TEMPLATE_FLAVOR",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "flavor",
-          "type": "option"
-        },
-        "local": {
-          "allowNo": false,
-          "char": "l",
-          "env": "SHOPIFY_FLAG_LOCAL",
-          "hidden": true,
-          "name": "local",
-          "type": "boolean"
-        },
-        "name": {
-          "char": "n",
-          "description": "The name for the new app. When provided, skips the app selection prompt and creates a new app with this name.",
-          "env": "SHOPIFY_FLAG_NAME",
-          "hasDynamicHelp": false,
-          "hidden": false,
-          "multiple": false,
-          "name": "name",
-          "type": "option"
-        },
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
-          "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
-        "organization-id": {
-          "description": "The organization ID. Your organization ID can be found in your Dev Dashboard URL: https://dev.shopify.com/dashboard/<organization-id>",
-          "env": "SHOPIFY_FLAG_ORGANIZATION_ID",
-          "exclusive": [
-            "client-id"
-          ],
-          "hasDynamicHelp": false,
-          "hidden": false,
-          "multiple": false,
-          "name": "organization-id",
-          "type": "option"
-        },
-        "package-manager": {
-          "char": "d",
-          "env": "SHOPIFY_FLAG_PACKAGE_MANAGER",
-          "hasDynamicHelp": false,
-          "hidden": false,
-          "multiple": false,
-          "name": "package-manager",
-          "options": [
-            "npm",
-            "yarn",
-            "pnpm",
-            "bun"
-          ],
-          "type": "option"
-        },
-        "path": {
-          "char": "p",
-          "default": ".",
-          "env": "SHOPIFY_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "hidden": false,
-          "multiple": false,
-          "name": "path",
-          "type": "option"
-        },
-        "template": {
-          "description": "The app template. Accepts one of the following:\n       - <reactRouter|none>\n       - Any GitHub repo with optional branch and subpath, e.g., https://github.com/Shopify/<repository>/[subpath]#[branch]",
-          "env": "SHOPIFY_FLAG_TEMPLATE",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "template",
-          "type": "option"
-        },
-        "verbose": {
-          "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "app:init",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true,
-      "summary": "Create a new app project"
-    },
-    "app:logs": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/app",
-      "description": "\n  Opens a real-time stream of detailed app logs from the selected app and store.\n  Use the `--source` argument to limit output to a particular log source, such as a specific Shopify Function handle. Use the `shopify app logs sources` command to view a list of sources.\n  Use the `--status` argument to filter on status, either `success` or `failure`.\n  ```\n  shopify app logs --status=success --source=extension.discount-function\n  ```\n  ",
-      "descriptionWithMarkdown": "\n  Opens a real-time stream of detailed app logs from the selected app and store.\n  Use the `--source` argument to limit output to a particular log source, such as a specific Shopify Function handle. Use the `shopify app logs sources` command to view a list of sources.\n  Use the `--status` argument to filter on status, either `success` or `failure`.\n  ```\n  shopify app logs --status=success --source=extension.discount-function\n  ```\n  ",
-      "flags": {
-        "client-id": {
-          "description": "The Client ID of your app.",
-          "env": "SHOPIFY_FLAG_CLIENT_ID",
-          "exclusive": [
-            "config"
-          ],
-          "hasDynamicHelp": false,
-          "hidden": false,
-          "multiple": false,
-          "name": "client-id",
-          "type": "option"
-        },
-        "config": {
-          "char": "c",
-          "description": "The name of the app configuration.",
-          "env": "SHOPIFY_FLAG_APP_CONFIG",
-          "hasDynamicHelp": false,
-          "hidden": false,
-          "multiple": false,
-          "name": "config",
-          "type": "option"
-        },
-        "json": {
-          "allowNo": false,
-          "char": "j",
-          "description": "Output the result as JSON. Automatically disables color output.",
-          "env": "SHOPIFY_FLAG_JSON",
-          "hidden": false,
-          "name": "json",
-          "type": "boolean"
-        },
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
-          "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
-        "path": {
-          "description": "The path to your app directory.",
-          "env": "SHOPIFY_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "path",
-          "noCacheDefault": true,
-          "type": "option"
-        },
-        "reset": {
-          "allowNo": false,
-          "description": "Reset all your settings.",
-          "env": "SHOPIFY_FLAG_RESET",
-          "exclusive": [
-            "config"
-          ],
-          "hidden": false,
-          "name": "reset",
-          "type": "boolean"
-        },
-        "source": {
-          "description": "Filters output to the specified log source.",
-          "env": "SHOPIFY_FLAG_SOURCE",
-          "hasDynamicHelp": false,
-          "multiple": true,
-          "name": "source",
-          "type": "option"
-        },
-        "status": {
-          "description": "Filters output to the specified status (success or failure).",
-          "env": "SHOPIFY_FLAG_STATUS",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "status",
-          "options": [
-            "success",
-            "failure"
-          ],
-          "type": "option"
-        },
-        "store": {
-          "char": "s",
-          "description": "Store URL. Must be an existing development or Shopify Plus sandbox store.",
-          "env": "SHOPIFY_FLAG_STORE",
-          "hasDynamicHelp": false,
-          "multiple": true,
-          "name": "store",
-          "type": "option"
-        },
-        "verbose": {
-          "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "app:logs",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true,
-      "summary": "Stream detailed logs for your Shopify app."
-    },
-    "app:logs:sources": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/app",
-      "description": "The output source names can be used with the `--source` argument of `shopify app logs` to filter log output. Currently only function extensions are supported as sources.",
-      "descriptionWithMarkdown": "The output source names can be used with the `--source` argument of `shopify app logs` to filter log output. Currently only function extensions are supported as sources.",
-      "flags": {
-        "client-id": {
-          "description": "The Client ID of your app.",
-          "env": "SHOPIFY_FLAG_CLIENT_ID",
-          "exclusive": [
-            "config"
-          ],
-          "hasDynamicHelp": false,
-          "hidden": false,
-          "multiple": false,
-          "name": "client-id",
-          "type": "option"
-        },
-        "config": {
-          "char": "c",
-          "description": "The name of the app configuration.",
-          "env": "SHOPIFY_FLAG_APP_CONFIG",
-          "hasDynamicHelp": false,
-          "hidden": false,
-          "multiple": false,
-          "name": "config",
-          "type": "option"
-        },
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
-          "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
-        "path": {
-          "description": "The path to your app directory.",
-          "env": "SHOPIFY_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "path",
-          "noCacheDefault": true,
-          "type": "option"
-        },
-        "reset": {
-          "allowNo": false,
-          "description": "Reset all your settings.",
-          "env": "SHOPIFY_FLAG_RESET",
-          "exclusive": [
-            "config"
-          ],
-          "hidden": false,
-          "name": "reset",
-          "type": "boolean"
-        },
-        "verbose": {
-          "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "app:logs:sources",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true,
-      "summary": "Print out a list of sources that may be used with the logs command."
-    },
-    "app:release": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/app",
-      "description": "Releases an existing app version. Pass the name of the version that you want to release using the `--version` flag.",
-      "descriptionWithMarkdown": "Releases an existing app version. Pass the name of the version that you want to release using the `--version` flag.",
-      "flags": {
-        "allow-deletes": {
-          "allowNo": false,
-          "description": "Allows removing extensions and configuration without requiring user confirmation. For CI/CD environments, the recommended flag is --allow-updates.",
-          "env": "SHOPIFY_FLAG_ALLOW_DELETES",
-          "hidden": false,
-          "name": "allow-deletes",
-          "type": "boolean"
-        },
-        "allow-updates": {
-          "allowNo": false,
-          "description": "Allows adding and updating extensions and configuration without requiring user confirmation. Recommended option for CI/CD environments.",
-          "env": "SHOPIFY_FLAG_ALLOW_UPDATES",
-          "hidden": false,
-          "name": "allow-updates",
-          "type": "boolean"
-        },
-        "client-id": {
-          "description": "The Client ID of your app.",
-          "env": "SHOPIFY_FLAG_CLIENT_ID",
-          "exclusive": [
-            "config"
-          ],
-          "hasDynamicHelp": false,
-          "hidden": false,
-          "multiple": false,
-          "name": "client-id",
-          "type": "option"
-        },
-        "config": {
-          "char": "c",
-          "description": "The name of the app configuration.",
-          "env": "SHOPIFY_FLAG_APP_CONFIG",
-          "hasDynamicHelp": false,
-          "hidden": false,
-          "multiple": false,
-          "name": "config",
-          "type": "option"
-        },
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
-          "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
-        "path": {
-          "description": "The path to your app directory.",
-          "env": "SHOPIFY_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "path",
-          "noCacheDefault": true,
-          "type": "option"
-        },
-        "reset": {
-          "allowNo": false,
-          "description": "Reset all your settings.",
-          "env": "SHOPIFY_FLAG_RESET",
-          "exclusive": [
-            "config"
-          ],
-          "hidden": false,
-          "name": "reset",
-          "type": "boolean"
-        },
-        "verbose": {
-          "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
-          "type": "boolean"
-        },
-        "version": {
-          "description": "The name of the app version to release.",
-          "env": "SHOPIFY_FLAG_VERSION",
-          "hasDynamicHelp": false,
-          "hidden": false,
-          "multiple": false,
-          "name": "version",
-          "required": true,
-          "type": "option"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "app:release",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true,
-      "summary": "Release an app version.",
-      "usage": "app release --version <version>"
+      "summary": "Generate a new app Extension.",
+      "descriptionWithMarkdown": "Generates a new [app extension](https://shopify.dev/docs/apps/build/app-extensions). For a list of app extensions that you can generate using this command, refer to [Supported extensions](https://shopify.dev/docs/apps/build/app-extensions/list-of-app-extensions).\n\n  Each new app extension is created in a folder under `extensions/`. To learn more about the extensions file structure, refer to [App structure](https://shopify.dev/docs/apps/build/cli-for-apps/app-structure) and the documentation for your extension.\n  ",
+      "customPluginName": "@shopify/app"
     },
     "app:versions:list": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/app",
+      "aliases": [],
+      "args": {},
       "description": "Lists the deployed app versions. An app version is a snapshot of your app extensions.",
-      "descriptionWithMarkdown": "Lists the deployed app versions. An app version is a snapshot of your app extensions.",
       "flags": {
-        "client-id": {
-          "description": "The Client ID of your app.",
-          "env": "SHOPIFY_FLAG_CLIENT_ID",
-          "exclusive": [
-            "config"
-          ],
-          "hasDynamicHelp": false,
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
           "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path to your app directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "name": "path",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
           "multiple": false,
-          "name": "client-id",
           "type": "option"
         },
         "config": {
           "char": "c",
           "description": "The name of the app configuration.",
           "env": "SHOPIFY_FLAG_APP_CONFIG",
-          "hasDynamicHelp": false,
           "hidden": false,
-          "multiple": false,
           "name": "config",
+          "hasDynamicHelp": false,
+          "multiple": false,
           "type": "option"
         },
-        "json": {
-          "allowNo": false,
-          "char": "j",
-          "description": "Output the result as JSON. Automatically disables color output.",
-          "env": "SHOPIFY_FLAG_JSON",
+        "client-id": {
+          "description": "The Client ID of your app.",
+          "env": "SHOPIFY_FLAG_CLIENT_ID",
+          "exclusive": [
+            "config"
+          ],
           "hidden": false,
-          "name": "json",
-          "type": "boolean"
-        },
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
-          "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
-        "path": {
-          "description": "The path to your app directory.",
-          "env": "SHOPIFY_FLAG_PATH",
+          "name": "client-id",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "path",
-          "noCacheDefault": true,
           "type": "option"
         },
         "reset": {
-          "allowNo": false,
           "description": "Reset all your settings.",
           "env": "SHOPIFY_FLAG_RESET",
           "exclusive": [
@@ -2890,54 +2913,52 @@
           ],
           "hidden": false,
           "name": "reset",
+          "allowNo": false,
           "type": "boolean"
         },
-        "verbose": {
-          "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
+        "json": {
+          "char": "j",
+          "description": "Output the result as JSON. Automatically disables color output.",
+          "env": "SHOPIFY_FLAG_JSON",
           "hidden": false,
-          "name": "verbose",
+          "name": "json",
+          "allowNo": false,
           "type": "boolean"
         }
       },
       "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
+      "hiddenAliases": [],
       "id": "app:versions:list",
       "pluginAlias": "@shopify/cli",
       "pluginName": "@shopify/cli",
       "pluginType": "core",
       "strict": true,
-      "summary": "List deployed versions of your app."
+      "summary": "List deployed versions of your app.",
+      "descriptionWithMarkdown": "Lists the deployed app versions. An app version is a snapshot of your app extensions.",
+      "customPluginName": "@shopify/app"
     },
     "app:webhook:trigger": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/app",
+      "aliases": [],
+      "args": {},
       "description": "\n  Triggers the delivery of a sample Admin API event topic payload to a designated address.\n\n  You should use this command to experiment with webhooks, to initially test your webhook configuration, or for unit testing. However, to test your webhook configuration from end to end, you should always trigger webhooks by performing the related action in Shopify.\n\n  Because most webhook deliveries use remote endpoints, you can trigger the command from any directory where you can use Shopify CLI, and send the webhook to any of the supported endpoint types. For example, you can run the command from your app's local directory, but send the webhook to a staging environment endpoint.\n\n  To learn more about using webhooks in a Shopify app, refer to \"Webhooks overview\" (https://shopify.dev/docs/apps/webhooks).\n\n  ### Limitations\n\n  - Webhooks triggered using this method always have the same payload, so they can't be used to test scenarios that differ based on the payload contents.\n  - Webhooks triggered using this method aren't retried when they fail.\n  - Trigger requests are rate-limited using the \"Partner API rate limit\" (https://shopify.dev/docs/api/partner#rate_limits).\n  - You can't use this method to validate your API webhook subscriptions.\n  ",
-      "descriptionWithMarkdown": "\n  Triggers the delivery of a sample Admin API event topic payload to a designated address.\n\n  You should use this command to experiment with webhooks, to initially test your webhook configuration, or for unit testing. However, to test your webhook configuration from end to end, you should always trigger webhooks by performing the related action in Shopify.\n\n  Because most webhook deliveries use remote endpoints, you can trigger the command from any directory where you can use Shopify CLI, and send the webhook to any of the supported endpoint types. For example, you can run the command from your app's local directory, but send the webhook to a staging environment endpoint.\n\n  To learn more about using webhooks in a Shopify app, refer to [Webhooks overview](https://shopify.dev/docs/apps/webhooks).\n\n  ### Limitations\n\n  - Webhooks triggered using this method always have the same payload, so they can't be used to test scenarios that differ based on the payload contents.\n  - Webhooks triggered using this method aren't retried when they fail.\n  - Trigger requests are rate-limited using the [Partner API rate limit](https://shopify.dev/docs/api/partner#rate_limits).\n  - You can't use this method to validate your API webhook subscriptions.\n  ",
       "flags": {
-        "address": {
-          "description": "The URL where the webhook payload should be sent.\n                    You will need a different address type for each delivery-method:\n                          · For remote HTTP testing, use a URL that starts with https://\n      · For local HTTP testing, use http://localhost:{port}/{url-path}\n                          · For Google Pub/Sub, use pubsub://{project-id}:{topic-id}\n                          · For Amazon EventBridge, use an Amazon Resource Name (ARN) starting with arn:aws:events:",
-          "env": "SHOPIFY_FLAG_ADDRESS",
+        "path": {
+          "description": "The path to your app directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "name": "path",
+          "noCacheDefault": true,
           "hasDynamicHelp": false,
-          "hidden": false,
           "multiple": false,
-          "name": "address",
-          "required": false,
           "type": "option"
         },
-        "api-version": {
-          "description": "The API Version of the webhook topic.",
-          "env": "SHOPIFY_FLAG_API_VERSION",
-          "hasDynamicHelp": false,
+        "config": {
+          "char": "c",
+          "description": "The name of the app configuration.",
+          "env": "SHOPIFY_FLAG_APP_CONFIG",
           "hidden": false,
+          "name": "config",
+          "hasDynamicHelp": false,
           "multiple": false,
-          "name": "api-version",
-          "required": false,
           "type": "option"
         },
         "client-id": {
@@ -2946,67 +2967,13 @@
           "exclusive": [
             "config"
           ],
-          "hasDynamicHelp": false,
           "hidden": false,
-          "multiple": false,
           "name": "client-id",
-          "type": "option"
-        },
-        "client-secret": {
-          "description": "Your app's client secret. This secret allows us to return the X-Shopify-Hmac-SHA256 header that lets you validate the origin of the response that you receive.",
-          "env": "SHOPIFY_FLAG_CLIENT_SECRET",
-          "hasDynamicHelp": false,
-          "hidden": false,
-          "multiple": false,
-          "name": "client-secret",
-          "required": false,
-          "type": "option"
-        },
-        "config": {
-          "char": "c",
-          "description": "The name of the app configuration.",
-          "env": "SHOPIFY_FLAG_APP_CONFIG",
-          "hasDynamicHelp": false,
-          "hidden": false,
-          "multiple": false,
-          "name": "config",
-          "type": "option"
-        },
-        "delivery-method": {
-          "description": "Method chosen to deliver the topic payload. If not passed, it's inferred from the address.",
-          "env": "SHOPIFY_FLAG_DELIVERY_METHOD",
-          "hasDynamicHelp": false,
-          "hidden": false,
-          "multiple": false,
-          "name": "delivery-method",
-          "options": [
-            "http",
-            "google-pub-sub",
-            "event-bridge"
-          ],
-          "required": false,
-          "type": "option"
-        },
-        "help": {
-          "allowNo": false,
-          "description": "This help. When you run the trigger command the CLI will prompt you for any information that isn't passed using flags.",
-          "env": "SHOPIFY_FLAG_HELP",
-          "hidden": false,
-          "name": "help",
-          "required": false,
-          "type": "boolean"
-        },
-        "path": {
-          "description": "The path to your app directory.",
-          "env": "SHOPIFY_FLAG_PATH",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "path",
-          "noCacheDefault": true,
           "type": "option"
         },
         "reset": {
-          "allowNo": false,
           "description": "Reset all your settings.",
           "env": "SHOPIFY_FLAG_RESET",
           "exclusive": [
@@ -3014,111 +2981,2966 @@
           ],
           "hidden": false,
           "name": "reset",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "help": {
+          "description": "This help. When you run the trigger command the CLI will prompt you for any information that isn't passed using flags.",
+          "env": "SHOPIFY_FLAG_HELP",
+          "hidden": false,
+          "name": "help",
+          "required": false,
+          "allowNo": false,
           "type": "boolean"
         },
         "topic": {
           "description": "The requested webhook topic.",
           "env": "SHOPIFY_FLAG_TOPIC",
-          "hasDynamicHelp": false,
           "hidden": false,
-          "multiple": false,
           "name": "topic",
           "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "api-version": {
+          "description": "The API Version of the webhook topic.",
+          "env": "SHOPIFY_FLAG_API_VERSION",
+          "hidden": false,
+          "name": "api-version",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "delivery-method": {
+          "description": "Method chosen to deliver the topic payload. If not passed, it's inferred from the address.",
+          "env": "SHOPIFY_FLAG_DELIVERY_METHOD",
+          "hidden": false,
+          "name": "delivery-method",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "options": [
+            "http",
+            "google-pub-sub",
+            "event-bridge"
+          ],
+          "type": "option"
+        },
+        "shared-secret": {
+          "description": "Deprecated. Please use client-secret.",
+          "env": "SHOPIFY_FLAG_SHARED_SECRET",
+          "hidden": false,
+          "name": "shared-secret",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "client-secret": {
+          "description": "Your app's client secret. This secret allows us to return the X-Shopify-Hmac-SHA256 header that lets you validate the origin of the response that you receive.",
+          "env": "SHOPIFY_FLAG_CLIENT_SECRET",
+          "hidden": false,
+          "name": "client-secret",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "address": {
+          "description": "The URL where the webhook payload should be sent.\n                    You will need a different address type for each delivery-method:\n                          · For remote HTTP testing, use a URL that starts with https://\n      · For local HTTP testing, use http://localhost:{port}/{url-path}\n                          · For Google Pub/Sub, use pubsub://{project-id}:{topic-id}\n                          · For Amazon EventBridge, use an Amazon Resource Name (ARN) starting with arn:aws:events:",
+          "env": "SHOPIFY_FLAG_ADDRESS",
+          "hidden": false,
+          "name": "address",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
           "type": "option"
         }
       },
       "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
+      "hiddenAliases": [],
       "id": "app:webhook:trigger",
       "pluginAlias": "@shopify/cli",
       "pluginName": "@shopify/cli",
       "pluginType": "core",
       "strict": true,
-      "summary": "Trigger delivery of a sample webhook topic payload to a designated address."
+      "summary": "Trigger delivery of a sample webhook topic payload to a designated address.",
+      "descriptionWithMarkdown": "\n  Triggers the delivery of a sample Admin API event topic payload to a designated address.\n\n  You should use this command to experiment with webhooks, to initially test your webhook configuration, or for unit testing. However, to test your webhook configuration from end to end, you should always trigger webhooks by performing the related action in Shopify.\n\n  Because most webhook deliveries use remote endpoints, you can trigger the command from any directory where you can use Shopify CLI, and send the webhook to any of the supported endpoint types. For example, you can run the command from your app's local directory, but send the webhook to a staging environment endpoint.\n\n  To learn more about using webhooks in a Shopify app, refer to [Webhooks overview](https://shopify.dev/docs/apps/webhooks).\n\n  ### Limitations\n\n  - Webhooks triggered using this method always have the same payload, so they can't be used to test scenarios that differ based on the payload contents.\n  - Webhooks triggered using this method aren't retried when they fail.\n  - Trigger requests are rate-limited using the [Partner API rate limit](https://shopify.dev/docs/api/partner#rate_limits).\n  - You can't use this method to validate your API webhook subscriptions.\n  ",
+      "customPluginName": "@shopify/app"
     },
-    "auth:login": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "description": "Logs you in to your Shopify account.",
-      "enableJsonFlag": false,
+    "webhook:trigger": {
+      "aliases": [],
+      "args": {},
+      "description": "\n  Triggers the delivery of a sample Admin API event topic payload to a designated address.\n\n  You should use this command to experiment with webhooks, to initially test your webhook configuration, or for unit testing. However, to test your webhook configuration from end to end, you should always trigger webhooks by performing the related action in Shopify.\n\n  Because most webhook deliveries use remote endpoints, you can trigger the command from any directory where you can use Shopify CLI, and send the webhook to any of the supported endpoint types. For example, you can run the command from your app's local directory, but send the webhook to a staging environment endpoint.\n\n  To learn more about using webhooks in a Shopify app, refer to \"Webhooks overview\" (https://shopify.dev/docs/apps/webhooks).\n\n  ### Limitations\n\n  - Webhooks triggered using this method always have the same payload, so they can't be used to test scenarios that differ based on the payload contents.\n  - Webhooks triggered using this method aren't retried when they fail.\n  - Trigger requests are rate-limited using the \"Partner API rate limit\" (https://shopify.dev/docs/api/partner#rate_limits).\n  - You can't use this method to validate your API webhook subscriptions.\n  ",
       "flags": {
-        "alias": {
-          "description": "Alias of the session you want to login to.",
-          "env": "SHOPIFY_FLAG_AUTH_ALIAS",
+        "path": {
+          "description": "The path to your app directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "name": "path",
+          "noCacheDefault": true,
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "alias",
+          "type": "option"
+        },
+        "config": {
+          "char": "c",
+          "description": "The name of the app configuration.",
+          "env": "SHOPIFY_FLAG_APP_CONFIG",
+          "hidden": false,
+          "name": "config",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "client-id": {
+          "description": "The Client ID of your app.",
+          "env": "SHOPIFY_FLAG_CLIENT_ID",
+          "exclusive": [
+            "config"
+          ],
+          "hidden": false,
+          "name": "client-id",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "reset": {
+          "description": "Reset all your settings.",
+          "env": "SHOPIFY_FLAG_RESET",
+          "exclusive": [
+            "config"
+          ],
+          "hidden": false,
+          "name": "reset",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "help": {
+          "description": "This help. When you run the trigger command the CLI will prompt you for any information that isn't passed using flags.",
+          "env": "SHOPIFY_FLAG_HELP",
+          "hidden": false,
+          "name": "help",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "topic": {
+          "description": "The requested webhook topic.",
+          "env": "SHOPIFY_FLAG_TOPIC",
+          "hidden": false,
+          "name": "topic",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "api-version": {
+          "description": "The API Version of the webhook topic.",
+          "env": "SHOPIFY_FLAG_API_VERSION",
+          "hidden": false,
+          "name": "api-version",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "delivery-method": {
+          "description": "Method chosen to deliver the topic payload. If not passed, it's inferred from the address.",
+          "env": "SHOPIFY_FLAG_DELIVERY_METHOD",
+          "hidden": false,
+          "name": "delivery-method",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "options": [
+            "http",
+            "google-pub-sub",
+            "event-bridge"
+          ],
+          "type": "option"
+        },
+        "shared-secret": {
+          "description": "Deprecated. Please use client-secret.",
+          "env": "SHOPIFY_FLAG_SHARED_SECRET",
+          "hidden": false,
+          "name": "shared-secret",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "client-secret": {
+          "description": "Your app's client secret. This secret allows us to return the X-Shopify-Hmac-SHA256 header that lets you validate the origin of the response that you receive.",
+          "env": "SHOPIFY_FLAG_CLIENT_SECRET",
+          "hidden": false,
+          "name": "client-secret",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "address": {
+          "description": "The URL where the webhook payload should be sent.\n                    You will need a different address type for each delivery-method:\n                          · For remote HTTP testing, use a URL that starts with https://\n      · For local HTTP testing, use http://localhost:{port}/{url-path}\n                          · For Google Pub/Sub, use pubsub://{project-id}:{topic-id}\n                          · For Amazon EventBridge, use an Amazon Resource Name (ARN) starting with arn:aws:events:",
+          "env": "SHOPIFY_FLAG_ADDRESS",
+          "hidden": false,
+          "name": "address",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
           "type": "option"
         }
       },
       "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "auth:login",
+      "hidden": true,
+      "hiddenAliases": [],
+      "id": "webhook:trigger",
       "pluginAlias": "@shopify/cli",
       "pluginName": "@shopify/cli",
       "pluginType": "core",
-      "strict": true
+      "summary": "Trigger delivery of a sample webhook topic payload to a designated address.",
+      "descriptionWithMarkdown": "\n  Triggers the delivery of a sample Admin API event topic payload to a designated address.\n\n  You should use this command to experiment with webhooks, to initially test your webhook configuration, or for unit testing. However, to test your webhook configuration from end to end, you should always trigger webhooks by performing the related action in Shopify.\n\n  Because most webhook deliveries use remote endpoints, you can trigger the command from any directory where you can use Shopify CLI, and send the webhook to any of the supported endpoint types. For example, you can run the command from your app's local directory, but send the webhook to a staging environment endpoint.\n\n  To learn more about using webhooks in a Shopify app, refer to [Webhooks overview](https://shopify.dev/docs/apps/webhooks).\n\n  ### Limitations\n\n  - Webhooks triggered using this method always have the same payload, so they can't be used to test scenarios that differ based on the payload contents.\n  - Webhooks triggered using this method aren't retried when they fail.\n  - Trigger requests are rate-limited using the [Partner API rate limit](https://shopify.dev/docs/api/partner#rate_limits).\n  - You can't use this method to validate your API webhook subscriptions.\n  ",
+      "customPluginName": "@shopify/app"
     },
-    "auth:logout": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "description": "Logs you out of the Shopify account or Partner account and store.",
-      "enableJsonFlag": false,
+    "demo:watcher": {
+      "aliases": [],
+      "args": {},
       "flags": {
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "auth:logout",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true
-    },
-    "cache:clear": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "description": "Clear the CLI cache, used to store some API responses and handle notifications status",
-      "enableJsonFlag": false,
-      "flags": {
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path to your app directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "name": "path",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "config": {
+          "char": "c",
+          "description": "The name of the app configuration.",
+          "env": "SHOPIFY_FLAG_APP_CONFIG",
+          "hidden": false,
+          "name": "config",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "client-id": {
+          "description": "The Client ID of your app.",
+          "env": "SHOPIFY_FLAG_CLIENT_ID",
+          "exclusive": [
+            "config"
+          ],
+          "hidden": false,
+          "name": "client-id",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "reset": {
+          "description": "Reset all your settings.",
+          "env": "SHOPIFY_FLAG_RESET",
+          "exclusive": [
+            "config"
+          ],
+          "hidden": false,
+          "name": "reset",
+          "allowNo": false,
+          "type": "boolean"
+        }
       },
       "hasDynamicHelp": false,
       "hidden": true,
-      "hiddenAliases": [
-      ],
-      "id": "cache:clear",
+      "hiddenAliases": [],
+      "id": "demo:watcher",
       "pluginAlias": "@shopify/cli",
       "pluginName": "@shopify/cli",
       "pluginType": "core",
-      "strict": true
+      "strict": true,
+      "summary": "Watch and prints out changes to an app.",
+      "customPluginName": "@shopify/app"
     },
-    "commands": {
+    "organization:list": {
+      "aliases": [],
+      "args": {},
+      "description": "Lists the Shopify organizations that you have access to, along with their organization IDs.",
+      "flags": {
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "json": {
+          "char": "j",
+          "description": "Output the result as JSON. Automatically disables color output.",
+          "env": "SHOPIFY_FLAG_JSON",
+          "hidden": false,
+          "name": "json",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "organization:list",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "summary": "List Shopify organizations you have access to.",
+      "enableJsonFlag": false,
+      "descriptionWithMarkdown": "Lists the Shopify organizations that you have access to, along with their organization IDs.",
+      "customPluginName": "@shopify/app"
+    },
+    "theme:init": {
+      "aliases": [],
+      "args": {
+        "name": {
+          "description": "Name of the new theme",
+          "name": "name",
+          "required": false
+        }
+      },
+      "description": "Clones a Git repository to your local machine to use as the starting point for building a theme.\n\n  If no Git repository is specified, then this command creates a copy of Shopify's \"Skeleton theme\" (https://github.com/Shopify/skeleton-theme.git), with the specified name in the current folder. If no name is provided, then you're prompted to enter one.\n\n  > Caution: If you're building a theme for the Shopify Theme Store, then you can use our example theme as a starting point. However, the theme that you submit needs to be \"substantively different from existing themes\" (https://shopify.dev/docs/themes/store/requirements#uniqueness) so that it provides added value for users.\n  ",
+      "flags": {
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path where you want to run the command. Defaults to the current working directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "name": "path",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "clone-url": {
+          "char": "u",
+          "description": "The Git URL to clone from. Defaults to Shopify's Skeleton theme.",
+          "env": "SHOPIFY_FLAG_CLONE_URL",
+          "name": "clone-url",
+          "default": "https://github.com/Shopify/skeleton-theme.git",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "latest": {
+          "char": "l",
+          "description": "Downloads the latest release of the `clone-url`",
+          "env": "SHOPIFY_FLAG_LATEST",
+          "name": "latest",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "theme:init",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "summary": "Clones a Git repository to use as a starting point for building a new theme.",
+      "usage": "theme init [name] [flags]",
+      "descriptionWithMarkdown": "Clones a Git repository to your local machine to use as the starting point for building a theme.\n\n  If no Git repository is specified, then this command creates a copy of Shopify's [Skeleton theme](https://github.com/Shopify/skeleton-theme.git), with the specified name in the current folder. If no name is provided, then you're prompted to enter one.\n\n  > Caution: If you're building a theme for the Shopify Theme Store, then you can use our example theme as a starting point. However, the theme that you submit needs to be [substantively different from existing themes](https://shopify.dev/docs/themes/store/requirements#uniqueness) so that it provides added value for users.\n  ",
+      "multiEnvironmentsFlags": null,
+      "customPluginName": "@shopify/theme"
+    },
+    "theme:check": {
+      "aliases": [],
+      "args": {},
+      "description": "Calls and runs \"Theme Check\" (https://shopify.dev/docs/themes/tools/theme-check) to analyze your theme code for errors and to ensure that it follows theme and Liquid best practices. \"Learn more about the checks that Theme Check runs.\" (https://shopify.dev/docs/themes/tools/theme-check/checks)",
+      "flags": {
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path where you want to run the command. Defaults to the current working directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "name": "path",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "auto-correct": {
+          "char": "a",
+          "description": "Automatically fix offenses",
+          "env": "SHOPIFY_FLAG_AUTO_CORRECT",
+          "name": "auto-correct",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "config": {
+          "char": "C",
+          "description": "Use the config provided, overriding .theme-check.yml if present\n      Supports all theme-check: config values, e.g., theme-check:theme-app-extension,\n      theme-check:recommended, theme-check:all\n      For backwards compatibility, :theme_app_extension is also supported ",
+          "env": "SHOPIFY_FLAG_CONFIG",
+          "name": "config",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "fail-level": {
+          "description": "Minimum severity for exit with error code",
+          "env": "SHOPIFY_FLAG_FAIL_LEVEL",
+          "name": "fail-level",
+          "required": false,
+          "default": "error",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "options": [
+            "crash",
+            "error",
+            "suggestion",
+            "style",
+            "warning",
+            "info"
+          ],
+          "type": "option"
+        },
+        "init": {
+          "description": "Generate a .theme-check.yml file",
+          "env": "SHOPIFY_FLAG_INIT",
+          "name": "init",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "list": {
+          "description": "List enabled checks",
+          "env": "SHOPIFY_FLAG_LIST",
+          "name": "list",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "output": {
+          "char": "o",
+          "description": "The output format to use",
+          "env": "SHOPIFY_FLAG_OUTPUT",
+          "name": "output",
+          "required": false,
+          "default": "text",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "options": [
+            "text",
+            "json"
+          ],
+          "type": "option"
+        },
+        "print": {
+          "description": "Output active config to STDOUT",
+          "env": "SHOPIFY_FLAG_PRINT",
+          "name": "print",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "version": {
+          "char": "v",
+          "description": "Print Theme Check version",
+          "env": "SHOPIFY_FLAG_VERSION",
+          "name": "version",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "environment": {
+          "char": "e",
+          "description": "The environment to apply to the current command.",
+          "env": "SHOPIFY_FLAG_ENVIRONMENT",
+          "name": "environment",
+          "hasDynamicHelp": false,
+          "multiple": true,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "theme:check",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "summary": "Validate the theme.",
+      "descriptionWithMarkdown": "Calls and runs [Theme Check](https://shopify.dev/docs/themes/tools/theme-check) to analyze your theme code for errors and to ensure that it follows theme and Liquid best practices. [Learn more about the checks that Theme Check runs.](https://shopify.dev/docs/themes/tools/theme-check/checks)",
+      "multiEnvironmentsFlags": [
+        "path"
+      ],
+      "customPluginName": "@shopify/theme"
+    },
+    "theme:console": {
+      "aliases": [],
+      "args": {},
+      "description": "Starts the Shopify Liquid REPL (read-eval-print loop) tool. This tool provides an interactive terminal interface for evaluating Liquid code and exploring Liquid objects, filters, and tags using real store data.\n\n  You can also provide context to the console using a URL, as some Liquid objects are context-specific",
+      "flags": {
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path where you want to run the command. Defaults to the current working directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "name": "path",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "password": {
+          "description": "Password generated from the Theme Access app or an Admin API token.",
+          "env": "SHOPIFY_CLI_THEME_TOKEN",
+          "name": "password",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "store": {
+          "char": "s",
+          "description": "Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).",
+          "env": "SHOPIFY_FLAG_STORE",
+          "name": "store",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "environment": {
+          "char": "e",
+          "description": "The environment to apply to the current command.",
+          "env": "SHOPIFY_FLAG_ENVIRONMENT",
+          "name": "environment",
+          "hasDynamicHelp": false,
+          "multiple": true,
+          "type": "option"
+        },
+        "url": {
+          "description": "The url to be used as context",
+          "env": "SHOPIFY_FLAG_URL",
+          "name": "url",
+          "default": "/",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "store-password": {
+          "description": "The password for storefronts with password protection.",
+          "env": "SHOPIFY_FLAG_STORE_PASSWORD",
+          "name": "store-password",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "theme:console",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "summary": "Shopify Liquid REPL (read-eval-print loop) tool",
+      "usage": [
+        "theme console",
+        "theme console --url /products/classic-leather-jacket"
+      ],
+      "descriptionWithMarkdown": "Starts the Shopify Liquid REPL (read-eval-print loop) tool. This tool provides an interactive terminal interface for evaluating Liquid code and exploring Liquid objects, filters, and tags using real store data.\n\n  You can also provide context to the console using a URL, as some Liquid objects are context-specific",
+      "multiEnvironmentsFlags": null,
+      "customPluginName": "@shopify/theme"
+    },
+    "theme:delete": {
+      "aliases": [],
+      "args": {},
+      "description": "Deletes a theme from your store.\n\n  You can specify multiple themes by ID. If no theme is specified, then you're prompted to select the theme that you want to delete from the list of themes in your store.\n\n  You're asked to confirm that you want to delete the specified themes before they are deleted. You can skip this confirmation using the `--force` flag.",
+      "flags": {
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path where you want to run the command. Defaults to the current working directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "name": "path",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "password": {
+          "description": "Password generated from the Theme Access app or an Admin API token.",
+          "env": "SHOPIFY_CLI_THEME_TOKEN",
+          "name": "password",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "store": {
+          "char": "s",
+          "description": "Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).",
+          "env": "SHOPIFY_FLAG_STORE",
+          "name": "store",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "environment": {
+          "char": "e",
+          "description": "The environment to apply to the current command.",
+          "env": "SHOPIFY_FLAG_ENVIRONMENT",
+          "name": "environment",
+          "hasDynamicHelp": false,
+          "multiple": true,
+          "type": "option"
+        },
+        "development": {
+          "char": "d",
+          "description": "Delete your development theme.",
+          "env": "SHOPIFY_FLAG_DEVELOPMENT",
+          "name": "development",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "show-all": {
+          "char": "a",
+          "description": "Include others development themes in theme list.",
+          "env": "SHOPIFY_FLAG_SHOW_ALL",
+          "name": "show-all",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "force": {
+          "char": "f",
+          "description": "Skip confirmation.",
+          "env": "SHOPIFY_FLAG_FORCE",
+          "name": "force",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "theme": {
+          "char": "t",
+          "description": "Theme ID or name of the remote theme.",
+          "env": "SHOPIFY_FLAG_THEME_ID",
+          "name": "theme",
+          "hasDynamicHelp": false,
+          "multiple": true,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "theme:delete",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "summary": "Delete remote themes from the connected store. This command can't be undone.",
+      "descriptionWithMarkdown": "Deletes a theme from your store.\n\n  You can specify multiple themes by ID. If no theme is specified, then you're prompted to select the theme that you want to delete from the list of themes in your store.\n\n  You're asked to confirm that you want to delete the specified themes before they are deleted. You can skip this confirmation using the `--force` flag.",
+      "multiEnvironmentsFlags": [
+        "store",
+        "password",
+        [
+          "development",
+          "theme"
+        ]
+      ],
+      "customPluginName": "@shopify/theme"
+    },
+    "theme:dev": {
+      "aliases": [],
+      "args": {},
+      "description": "\n  Uploads the current theme as the specified theme, or a \"development theme\" (https://shopify.dev/docs/themes/tools/cli#development-themes), to a store so you can preview it.\n\nThis command returns the following information:\n\n- A link to your development theme at http://127.0.0.1:9292. This URL can hot reload local changes to CSS and sections, or refresh the entire page when a file changes, enabling you to preview changes in real time using the store's data.\n\n  You can specify a different network interface and port using `--host` and `--port`.\n\n- A link to the \"editor\" (https://shopify.dev/docs/themes/tools/online-editor) for the theme in the Shopify admin.\n\n- A \"preview link\" (https://help.shopify.com/manual/online-store/themes/adding-themes#share-a-theme-preview-with-others) that you can share with other developers.\n\nIf you already have a development theme for your current environment, then this command replaces the development theme with your local theme. You can override this using the `--theme-editor-sync` flag.\n\n> Note: You can't preview checkout customizations using http://127.0.0.1:9292.\n\nDevelopment themes are deleted when you run `shopify auth logout`. If you need a preview link that can be used after you log out, then you should \"share\" (https://shopify.dev/docs/api/shopify-cli/theme/theme-share) your theme or \"push\" (https://shopify.dev/docs/api/shopify-cli/theme/theme-push) to an unpublished theme on your store.\n\nYou can run this command only in a directory that matches the \"default Shopify theme folder structure\" (https://shopify.dev/docs/themes/tools/cli#directory-structure).",
+      "flags": {
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path where you want to run the command. Defaults to the current working directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "name": "path",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "password": {
+          "description": "Password generated from the Theme Access app or an Admin API token.",
+          "env": "SHOPIFY_CLI_THEME_TOKEN",
+          "name": "password",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "store": {
+          "char": "s",
+          "description": "Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).",
+          "env": "SHOPIFY_FLAG_STORE",
+          "name": "store",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "environment": {
+          "char": "e",
+          "description": "The environment to apply to the current command.",
+          "env": "SHOPIFY_FLAG_ENVIRONMENT",
+          "name": "environment",
+          "hasDynamicHelp": false,
+          "multiple": true,
+          "type": "option"
+        },
+        "host": {
+          "description": "Set which network interface the web server listens on. The default value is 127.0.0.1.",
+          "env": "SHOPIFY_FLAG_HOST",
+          "name": "host",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "live-reload": {
+          "description": "The live reload mode switches the server behavior when a file is modified:\n- hot-reload Hot reloads local changes to CSS and sections (default)\n- full-page  Always refreshes the entire page\n- off        Deactivate live reload",
+          "env": "SHOPIFY_FLAG_LIVE_RELOAD",
+          "name": "live-reload",
+          "default": "hot-reload",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "options": [
+            "hot-reload",
+            "full-page",
+            "off"
+          ],
+          "type": "option"
+        },
+        "error-overlay": {
+          "description": "Controls the visibility of the error overlay when an theme asset upload fails:\n- silent Prevents the error overlay from appearing.\n- default Displays the error overlay.\n      ",
+          "env": "SHOPIFY_FLAG_ERROR_OVERLAY",
+          "name": "error-overlay",
+          "default": "default",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "options": [
+            "silent",
+            "default"
+          ],
+          "type": "option"
+        },
+        "poll": {
+          "description": "Force polling to detect file changes.",
+          "env": "SHOPIFY_FLAG_POLL",
+          "hidden": true,
+          "name": "poll",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "theme-editor-sync": {
+          "description": "Synchronize Theme Editor updates in the local theme files.",
+          "env": "SHOPIFY_FLAG_THEME_EDITOR_SYNC",
+          "name": "theme-editor-sync",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "port": {
+          "description": "Local port to serve theme preview from.",
+          "env": "SHOPIFY_FLAG_PORT",
+          "name": "port",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "theme": {
+          "char": "t",
+          "description": "Theme ID or name of the remote theme.",
+          "env": "SHOPIFY_FLAG_THEME_ID",
+          "name": "theme",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "listing": {
+          "description": "The listing preset to use for multi-preset themes. Applies preset files from listings/[preset-name] directory.",
+          "env": "SHOPIFY_FLAG_LISTING",
+          "name": "listing",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "nodelete": {
+          "char": "n",
+          "description": "Prevents files from being deleted in the remote theme when a file has been deleted locally. This applies to files that are deleted while the command is running, and files that have been deleted locally before the command is run.",
+          "env": "SHOPIFY_FLAG_NODELETE",
+          "name": "nodelete",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "only": {
+          "char": "o",
+          "description": "Hot reload only files that match the specified pattern.",
+          "env": "SHOPIFY_FLAG_ONLY",
+          "name": "only",
+          "hasDynamicHelp": false,
+          "multiple": true,
+          "type": "option"
+        },
+        "ignore": {
+          "char": "x",
+          "description": "Skip hot reloading any files that match the specified pattern.",
+          "env": "SHOPIFY_FLAG_IGNORE",
+          "name": "ignore",
+          "hasDynamicHelp": false,
+          "multiple": true,
+          "type": "option"
+        },
+        "force": {
+          "char": "f",
+          "description": "Proceed without confirmation, if current directory does not seem to be theme directory.",
+          "env": "SHOPIFY_FLAG_FORCE",
+          "hidden": true,
+          "name": "force",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "notify": {
+          "description": "The file path or URL. The file path is to a file that you want updated on idle. The URL path is where you want a webhook posted to report on file changes.",
+          "env": "SHOPIFY_FLAG_NOTIFY",
+          "name": "notify",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "open": {
+          "description": "Automatically launch the theme preview in your default web browser.",
+          "env": "SHOPIFY_FLAG_OPEN",
+          "name": "open",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "store-password": {
+          "description": "The password for storefronts with password protection.",
+          "env": "SHOPIFY_FLAG_STORE_PASSWORD",
+          "name": "store-password",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "allow-live": {
+          "char": "a",
+          "description": "Allow development on a live theme.",
+          "env": "SHOPIFY_FLAG_ALLOW_LIVE",
+          "name": "allow-live",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "theme:dev",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "summary": "Uploads the current theme as a development theme to the connected store, then prints theme editor and preview URLs to your terminal. While running, changes will push to the store in real time.",
+      "descriptionWithMarkdown": "\n  Uploads the current theme as the specified theme, or a [development theme](https://shopify.dev/docs/themes/tools/cli#development-themes), to a store so you can preview it.\n\nThis command returns the following information:\n\n- A link to your development theme at http://127.0.0.1:9292. This URL can hot reload local changes to CSS and sections, or refresh the entire page when a file changes, enabling you to preview changes in real time using the store's data.\n\n  You can specify a different network interface and port using `--host` and `--port`.\n\n- A link to the [editor](https://shopify.dev/docs/themes/tools/online-editor) for the theme in the Shopify admin.\n\n- A [preview link](https://help.shopify.com/manual/online-store/themes/adding-themes#share-a-theme-preview-with-others) that you can share with other developers.\n\nIf you already have a development theme for your current environment, then this command replaces the development theme with your local theme. You can override this using the `--theme-editor-sync` flag.\n\n> Note: You can't preview checkout customizations using http://127.0.0.1:9292.\n\nDevelopment themes are deleted when you run `shopify auth logout`. If you need a preview link that can be used after you log out, then you should [share](https://shopify.dev/docs/api/shopify-cli/theme/theme-share) your theme or [push](https://shopify.dev/docs/api/shopify-cli/theme/theme-push) to an unpublished theme on your store.\n\nYou can run this command only in a directory that matches the [default Shopify theme folder structure](https://shopify.dev/docs/themes/tools/cli#directory-structure).",
+      "multiEnvironmentsFlags": null,
+      "customPluginName": "@shopify/theme"
+    },
+    "theme:duplicate": {
+      "aliases": [],
+      "args": {},
+      "description": "If you want to duplicate your local theme, you need to run `shopify theme push` first.\n\nIf no theme ID is specified, you're prompted to select the theme that you want to duplicate from the list of themes in your store. You're asked to confirm that you want to duplicate the specified theme.\n\nPrompts and confirmations are not shown when duplicate is run in a CI environment or the `--force` flag is used, therefore you must specify a theme ID using the `--theme` flag.\n\nYou can optionally name the duplicated theme using the `--name` flag.\n\nIf you use the `--json` flag, then theme information is returned in JSON format, which can be used as a machine-readable input for scripts or continuous integration.\n\nSample JSON output:\n\n```json\n{\n  \"theme\": {\n    \"id\": 108267175958,\n    \"name\": \"A Duplicated Theme\",\n    \"role\": \"unpublished\",\n    \"shop\": \"mystore.myshopify.com\"\n  }\n}\n```\n\n```json\n{\n  \"message\": \"The theme 'Summer Edition' could not be duplicated due to errors\",\n  \"errors\": [\"Maximum number of themes reached\"],\n  \"requestId\": \"12345-abcde-67890\"\n}\n```",
+      "flags": {
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "json": {
+          "char": "j",
+          "description": "Output the result as JSON. Automatically disables color output.",
+          "env": "SHOPIFY_FLAG_JSON",
+          "hidden": false,
+          "name": "json",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "password": {
+          "description": "Password generated from the Theme Access app or an Admin API token.",
+          "env": "SHOPIFY_CLI_THEME_TOKEN",
+          "name": "password",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "theme": {
+          "char": "t",
+          "description": "Theme ID or name of the remote theme.",
+          "env": "SHOPIFY_FLAG_THEME_ID",
+          "name": "theme",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "name": {
+          "char": "n",
+          "description": "Name of the newly duplicated theme.",
+          "env": "SHOPIFY_FLAG_NAME",
+          "name": "name",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "store": {
+          "char": "s",
+          "description": "Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).",
+          "env": "SHOPIFY_FLAG_STORE",
+          "name": "store",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "environment": {
+          "char": "e",
+          "description": "The environment to apply to the current command.",
+          "env": "SHOPIFY_FLAG_ENVIRONMENT",
+          "name": "environment",
+          "hasDynamicHelp": false,
+          "multiple": true,
+          "type": "option"
+        },
+        "force": {
+          "char": "f",
+          "description": "Force the duplicate operation to run without prompts or confirmations.",
+          "env": "SHOPIFY_FLAG_FORCE",
+          "name": "force",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "theme:duplicate",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "summary": "Duplicates a theme from your theme library.",
+      "usage": [
+        "theme duplicate",
+        "theme duplicate --theme 10 --name 'New Theme'"
+      ],
+      "descriptionWithMarkdown": "If you want to duplicate your local theme, you need to run `shopify theme push` first.\n\nIf no theme ID is specified, you're prompted to select the theme that you want to duplicate from the list of themes in your store. You're asked to confirm that you want to duplicate the specified theme.\n\nPrompts and confirmations are not shown when duplicate is run in a CI environment or the `--force` flag is used, therefore you must specify a theme ID using the `--theme` flag.\n\nYou can optionally name the duplicated theme using the `--name` flag.\n\nIf you use the `--json` flag, then theme information is returned in JSON format, which can be used as a machine-readable input for scripts or continuous integration.\n\nSample JSON output:\n\n```json\n{\n  \"theme\": {\n    \"id\": 108267175958,\n    \"name\": \"A Duplicated Theme\",\n    \"role\": \"unpublished\",\n    \"shop\": \"mystore.myshopify.com\"\n  }\n}\n```\n\n```json\n{\n  \"message\": \"The theme 'Summer Edition' could not be duplicated due to errors\",\n  \"errors\": [\"Maximum number of themes reached\"],\n  \"requestId\": \"12345-abcde-67890\"\n}\n```",
+      "customPluginName": "@shopify/theme"
+    },
+    "theme:info": {
+      "aliases": [],
+      "args": {},
+      "description": "Displays information about your theme environment, including your current store. Can also retrieve information about a specific theme.",
+      "flags": {
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "json": {
+          "char": "j",
+          "description": "Output the result as JSON. Automatically disables color output.",
+          "env": "SHOPIFY_FLAG_JSON",
+          "hidden": false,
+          "name": "json",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path where you want to run the command. Defaults to the current working directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "name": "path",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "password": {
+          "description": "Password generated from the Theme Access app or an Admin API token.",
+          "env": "SHOPIFY_CLI_THEME_TOKEN",
+          "name": "password",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "store": {
+          "char": "s",
+          "description": "Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).",
+          "env": "SHOPIFY_FLAG_STORE",
+          "name": "store",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "environment": {
+          "char": "e",
+          "description": "The environment to apply to the current command.",
+          "env": "SHOPIFY_FLAG_ENVIRONMENT",
+          "name": "environment",
+          "hasDynamicHelp": false,
+          "multiple": true,
+          "type": "option"
+        },
+        "development": {
+          "char": "d",
+          "description": "Retrieve info from your development theme.",
+          "env": "SHOPIFY_FLAG_DEVELOPMENT",
+          "name": "development",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "theme": {
+          "char": "t",
+          "description": "Theme ID or name of the remote theme.",
+          "env": "SHOPIFY_FLAG_THEME_ID",
+          "name": "theme",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "theme:info",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "multiEnvironmentsFlags": [
+        "store",
+        "password"
+      ],
+      "customPluginName": "@shopify/theme"
+    },
+    "theme:language-server": {
+      "aliases": [],
+      "args": {},
+      "description": "Starts the \"Language Server\" (https://shopify.dev/docs/themes/tools/cli/language-server).",
+      "flags": {
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "theme:language-server",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "summary": "Start a Language Server Protocol server.",
+      "descriptionWithMarkdown": "Starts the [Language Server](https://shopify.dev/docs/themes/tools/cli/language-server).",
+      "multiEnvironmentsFlags": null,
+      "customPluginName": "@shopify/theme"
+    },
+    "theme:list": {
+      "aliases": [],
+      "args": {},
+      "description": "Lists the themes in your store, along with their IDs and statuses.",
+      "flags": {
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "json": {
+          "char": "j",
+          "description": "Output the result as JSON. Automatically disables color output.",
+          "env": "SHOPIFY_FLAG_JSON",
+          "hidden": false,
+          "name": "json",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path where you want to run the command. Defaults to the current working directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "name": "path",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "password": {
+          "description": "Password generated from the Theme Access app or an Admin API token.",
+          "env": "SHOPIFY_CLI_THEME_TOKEN",
+          "name": "password",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "store": {
+          "char": "s",
+          "description": "Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).",
+          "env": "SHOPIFY_FLAG_STORE",
+          "name": "store",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "environment": {
+          "char": "e",
+          "description": "The environment to apply to the current command.",
+          "env": "SHOPIFY_FLAG_ENVIRONMENT",
+          "name": "environment",
+          "hasDynamicHelp": false,
+          "multiple": true,
+          "type": "option"
+        },
+        "role": {
+          "description": "Only list themes with the given role.",
+          "env": "SHOPIFY_FLAG_ROLE",
+          "name": "role",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "options": [
+            "live",
+            "unpublished",
+            "development"
+          ],
+          "type": "option"
+        },
+        "name": {
+          "description": "Only list themes that contain the given name.",
+          "env": "SHOPIFY_FLAG_NAME",
+          "name": "name",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "id": {
+          "description": "Only list theme with the given ID.",
+          "env": "SHOPIFY_FLAG_ID",
+          "name": "id",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "theme:list",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "multiEnvironmentsFlags": [
+        "store",
+        "password"
+      ],
+      "customPluginName": "@shopify/theme"
+    },
+    "theme:metafields:pull": {
+      "aliases": [],
+      "args": {},
+      "description": "Retrieves metafields from Shopify Admin.\n\nIf the metafields file already exists, it will be overwritten.",
+      "flags": {
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path where you want to run the command. Defaults to the current working directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "name": "path",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "password": {
+          "description": "Password generated from the Theme Access app or an Admin API token.",
+          "env": "SHOPIFY_CLI_THEME_TOKEN",
+          "name": "password",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "store": {
+          "char": "s",
+          "description": "Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).",
+          "env": "SHOPIFY_FLAG_STORE",
+          "name": "store",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "environment": {
+          "char": "e",
+          "description": "The environment to apply to the current command.",
+          "env": "SHOPIFY_FLAG_ENVIRONMENT",
+          "name": "environment",
+          "hasDynamicHelp": false,
+          "multiple": true,
+          "type": "option"
+        },
+        "force": {
+          "char": "f",
+          "description": "Proceed without confirmation, if current directory does not seem to be theme directory.",
+          "env": "SHOPIFY_FLAG_FORCE",
+          "hidden": true,
+          "name": "force",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "theme:metafields:pull",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "summary": "Download metafields definitions from your shop into a local file.",
+      "descriptionWithMarkdown": "Retrieves metafields from Shopify Admin.\n\nIf the metafields file already exists, it will be overwritten.",
+      "multiEnvironmentsFlags": null,
+      "customPluginName": "@shopify/theme"
+    },
+    "theme:open": {
+      "aliases": [],
+      "args": {},
+      "description": "Returns links that let you preview the specified theme. The following links are returned:\n\n  - A link to the \"editor\" (https://shopify.dev/docs/themes/tools/online-editor) for the theme in the Shopify admin.\n  - A \"preview link\" (https://help.shopify.com/manual/online-store/themes/adding-themes#share-a-theme-preview-with-others) that you can share with other developers.\n\n  If you don't specify a theme, then you're prompted to select the theme to open from the list of the themes in your store.",
+      "flags": {
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path where you want to run the command. Defaults to the current working directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "name": "path",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "password": {
+          "description": "Password generated from the Theme Access app or an Admin API token.",
+          "env": "SHOPIFY_CLI_THEME_TOKEN",
+          "name": "password",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "store": {
+          "char": "s",
+          "description": "Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).",
+          "env": "SHOPIFY_FLAG_STORE",
+          "name": "store",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "environment": {
+          "char": "e",
+          "description": "The environment to apply to the current command.",
+          "env": "SHOPIFY_FLAG_ENVIRONMENT",
+          "name": "environment",
+          "hasDynamicHelp": false,
+          "multiple": true,
+          "type": "option"
+        },
+        "development": {
+          "char": "d",
+          "description": "Open your development theme.",
+          "env": "SHOPIFY_FLAG_DEVELOPMENT",
+          "name": "development",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "editor": {
+          "char": "E",
+          "description": "Open the theme editor for the specified theme in the browser.",
+          "env": "SHOPIFY_FLAG_EDITOR",
+          "name": "editor",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "live": {
+          "char": "l",
+          "description": "Open your live (published) theme.",
+          "env": "SHOPIFY_FLAG_LIVE",
+          "name": "live",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "theme": {
+          "char": "t",
+          "description": "Theme ID or name of the remote theme.",
+          "env": "SHOPIFY_FLAG_THEME_ID",
+          "name": "theme",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "theme:open",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "summary": "Opens the preview of your remote theme.",
+      "descriptionWithMarkdown": "Returns links that let you preview the specified theme. The following links are returned:\n\n  - A link to the [editor](https://shopify.dev/docs/themes/tools/online-editor) for the theme in the Shopify admin.\n  - A [preview link](https://help.shopify.com/manual/online-store/themes/adding-themes#share-a-theme-preview-with-others) that you can share with other developers.\n\n  If you don't specify a theme, then you're prompted to select the theme to open from the list of the themes in your store.",
+      "multiEnvironmentsFlags": null,
+      "customPluginName": "@shopify/theme"
+    },
+    "theme:package": {
+      "aliases": [],
+      "args": {},
+      "description": "Packages your local theme files into a ZIP file that can be uploaded to Shopify.\n\n  Only folders that match the \"default Shopify theme folder structure\" (https://shopify.dev/docs/storefronts/themes/tools/cli#directory-structure) are included in the package.\n\n  The package includes the `listings` directory if present (required for multi-preset themes per \"Theme Store requirements\" (https://shopify.dev/docs/storefronts/themes/store/requirements#adding-presets-to-your-theme-zip-submission)).\n\n  The ZIP file uses the name `theme_name-theme_version.zip`, based on parameters in your \"settings_schema.json\" (https://shopify.dev/docs/storefronts/themes/architecture/config/settings-schema-json) file.",
+      "flags": {
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path where you want to run the command. Defaults to the current working directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "name": "path",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "theme:package",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "summary": "Package your theme into a .zip file, ready to upload to the Online Store.",
+      "descriptionWithMarkdown": "Packages your local theme files into a ZIP file that can be uploaded to Shopify.\n\n  Only folders that match the [default Shopify theme folder structure](https://shopify.dev/docs/storefronts/themes/tools/cli#directory-structure) are included in the package.\n\n  The package includes the `listings` directory if present (required for multi-preset themes per [Theme Store requirements](https://shopify.dev/docs/storefronts/themes/store/requirements#adding-presets-to-your-theme-zip-submission)).\n\n  The ZIP file uses the name `theme_name-theme_version.zip`, based on parameters in your [settings_schema.json](https://shopify.dev/docs/storefronts/themes/architecture/config/settings-schema-json) file.",
+      "multiEnvironmentsFlags": null,
+      "customPluginName": "@shopify/theme"
+    },
+    "theme:profile": {
+      "aliases": [],
+      "args": {},
+      "description": "Profile the Shopify Liquid on a given page.\n\n  This command will open a web page with the Speedscope profiler detailing the time spent executing Liquid on the given page.",
+      "flags": {
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path where you want to run the command. Defaults to the current working directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "name": "path",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "password": {
+          "description": "Password generated from the Theme Access app or an Admin API token.",
+          "env": "SHOPIFY_CLI_THEME_TOKEN",
+          "name": "password",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "store": {
+          "char": "s",
+          "description": "Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).",
+          "env": "SHOPIFY_FLAG_STORE",
+          "name": "store",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "environment": {
+          "char": "e",
+          "description": "The environment to apply to the current command.",
+          "env": "SHOPIFY_FLAG_ENVIRONMENT",
+          "name": "environment",
+          "hasDynamicHelp": false,
+          "multiple": true,
+          "type": "option"
+        },
+        "theme": {
+          "char": "t",
+          "description": "Theme ID or name of the remote theme.",
+          "env": "SHOPIFY_FLAG_THEME_ID",
+          "name": "theme",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "url": {
+          "description": "The url to be used as context",
+          "env": "SHOPIFY_FLAG_URL",
+          "name": "url",
+          "default": "/",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "store-password": {
+          "description": "The password for storefronts with password protection.",
+          "env": "SHOPIFY_FLAG_STORE_PASSWORD",
+          "name": "store-password",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "json": {
+          "char": "j",
+          "description": "Output the result as JSON. Automatically disables color output.",
+          "env": "SHOPIFY_FLAG_JSON",
+          "hidden": false,
+          "name": "json",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "theme:profile",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "summary": "Profile the Liquid rendering of a theme page.",
+      "usage": [
+        "theme profile",
+        "theme profile --url /products/classic-leather-jacket"
+      ],
+      "descriptionWithMarkdown": "Profile the Shopify Liquid on a given page.\n\n  This command will open a web page with the Speedscope profiler detailing the time spent executing Liquid on the given page.",
+      "multiEnvironmentsFlags": null,
+      "customPluginName": "@shopify/theme"
+    },
+    "theme:publish": {
+      "aliases": [],
+      "args": {},
+      "description": "Publishes an unpublished theme from your theme library.\n\nIf no theme ID is specified, then you're prompted to select the theme that you want to publish from the list of themes in your store.\n\nYou can run this command only in a directory that matches the \"default Shopify theme folder structure\" (https://shopify.dev/docs/themes/tools/cli#directory-structure).\n\nIf you want to publish your local theme, then you need to run `shopify theme push` first. You're asked to confirm that you want to publish the specified theme. You can skip this confirmation using the `--force` flag.",
+      "flags": {
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path where you want to run the command. Defaults to the current working directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "name": "path",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "password": {
+          "description": "Password generated from the Theme Access app or an Admin API token.",
+          "env": "SHOPIFY_CLI_THEME_TOKEN",
+          "name": "password",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "store": {
+          "char": "s",
+          "description": "Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).",
+          "env": "SHOPIFY_FLAG_STORE",
+          "name": "store",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "environment": {
+          "char": "e",
+          "description": "The environment to apply to the current command.",
+          "env": "SHOPIFY_FLAG_ENVIRONMENT",
+          "name": "environment",
+          "hasDynamicHelp": false,
+          "multiple": true,
+          "type": "option"
+        },
+        "force": {
+          "char": "f",
+          "description": "Skip confirmation.",
+          "env": "SHOPIFY_FLAG_FORCE",
+          "name": "force",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "theme": {
+          "char": "t",
+          "description": "Theme ID or name of the remote theme.",
+          "env": "SHOPIFY_FLAG_THEME_ID",
+          "name": "theme",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "theme:publish",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "summary": "Set a remote theme as the live theme.",
+      "descriptionWithMarkdown": "Publishes an unpublished theme from your theme library.\n\nIf no theme ID is specified, then you're prompted to select the theme that you want to publish from the list of themes in your store.\n\nYou can run this command only in a directory that matches the [default Shopify theme folder structure](https://shopify.dev/docs/themes/tools/cli#directory-structure).\n\nIf you want to publish your local theme, then you need to run `shopify theme push` first. You're asked to confirm that you want to publish the specified theme. You can skip this confirmation using the `--force` flag.",
+      "multiEnvironmentsFlags": [
+        "store",
+        "password",
+        "theme"
+      ],
+      "customPluginName": "@shopify/theme"
+    },
+    "theme:preview": {
+      "aliases": [],
+      "args": {},
+      "description": "Applies a JSON overrides file to a theme and creates or updates a preview. This lets you quickly preview changes.\n\n  The command returns a preview URL and a preview identifier. You can reuse the preview identifier with `--preview-id` to update an existing preview instead of creating a new one.",
+      "flags": {
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path where you want to run the command. Defaults to the current working directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "name": "path",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "password": {
+          "description": "Password generated from the Theme Access app or an Admin API token.",
+          "env": "SHOPIFY_CLI_THEME_TOKEN",
+          "name": "password",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "store": {
+          "char": "s",
+          "description": "Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).",
+          "env": "SHOPIFY_FLAG_STORE",
+          "name": "store",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "environment": {
+          "char": "e",
+          "description": "The environment to apply to the current command.",
+          "env": "SHOPIFY_FLAG_ENVIRONMENT",
+          "name": "environment",
+          "hasDynamicHelp": false,
+          "multiple": true,
+          "type": "option"
+        },
+        "theme": {
+          "char": "t",
+          "description": "Theme ID or name of the remote theme.",
+          "env": "SHOPIFY_FLAG_THEME_ID",
+          "name": "theme",
+          "required": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "overrides": {
+          "description": "Path to a JSON overrides file.",
+          "env": "SHOPIFY_FLAG_OVERRIDES",
+          "name": "overrides",
+          "required": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "preview-id": {
+          "description": "An existing preview identifier to update instead of creating a new preview.",
+          "env": "SHOPIFY_FLAG_PREVIEW_ID",
+          "name": "preview-id",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "open": {
+          "description": "Automatically launch the theme preview in your default web browser.",
+          "env": "SHOPIFY_FLAG_OPEN",
+          "name": "open",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "json": {
+          "description": "Output the preview URL and identifier as JSON.",
+          "env": "SHOPIFY_FLAG_JSON",
+          "name": "json",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "theme:preview",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "summary": "Applies JSON overrides to a theme and returns a preview URL.",
+      "descriptionWithMarkdown": "Applies a JSON overrides file to a theme and creates or updates a preview. This lets you quickly preview changes.\n\n  The command returns a preview URL and a preview identifier. You can reuse the preview identifier with `--preview-id` to update an existing preview instead of creating a new one.",
+      "multiEnvironmentsFlags": null,
+      "customPluginName": "@shopify/theme"
+    },
+    "theme:pull": {
+      "aliases": [],
+      "args": {},
+      "description": "Retrieves theme files from Shopify.\n\nIf no theme is specified, then you're prompted to select the theme to pull from the list of the themes in your store.",
+      "flags": {
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path where you want to run the command. Defaults to the current working directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "name": "path",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "password": {
+          "description": "Password generated from the Theme Access app or an Admin API token.",
+          "env": "SHOPIFY_CLI_THEME_TOKEN",
+          "name": "password",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "store": {
+          "char": "s",
+          "description": "Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).",
+          "env": "SHOPIFY_FLAG_STORE",
+          "name": "store",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "environment": {
+          "char": "e",
+          "description": "The environment to apply to the current command.",
+          "env": "SHOPIFY_FLAG_ENVIRONMENT",
+          "name": "environment",
+          "hasDynamicHelp": false,
+          "multiple": true,
+          "type": "option"
+        },
+        "only": {
+          "char": "o",
+          "description": "Download only the specified files (Multiple flags allowed). Wrap the value in double quotes if you're using wildcards.",
+          "env": "SHOPIFY_FLAG_ONLY",
+          "name": "only",
+          "hasDynamicHelp": false,
+          "multiple": true,
+          "type": "option"
+        },
+        "ignore": {
+          "char": "x",
+          "description": "Skip downloading the specified files (Multiple flags allowed). Wrap the value in double quotes if you're using wildcards.",
+          "env": "SHOPIFY_FLAG_IGNORE",
+          "name": "ignore",
+          "hasDynamicHelp": false,
+          "multiple": true,
+          "type": "option"
+        },
+        "theme": {
+          "char": "t",
+          "description": "Theme ID or name of the remote theme.",
+          "env": "SHOPIFY_FLAG_THEME_ID",
+          "name": "theme",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "development": {
+          "char": "d",
+          "description": "Pull theme files from your remote development theme.",
+          "env": "SHOPIFY_FLAG_DEVELOPMENT",
+          "name": "development",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "live": {
+          "char": "l",
+          "description": "Pull theme files from your remote live theme.",
+          "env": "SHOPIFY_FLAG_LIVE",
+          "name": "live",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "nodelete": {
+          "char": "n",
+          "description": "Prevent deleting local files that don't exist remotely.",
+          "env": "SHOPIFY_FLAG_NODELETE",
+          "name": "nodelete",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "force": {
+          "char": "f",
+          "description": "Proceed without confirmation, if current directory does not seem to be theme directory.",
+          "env": "SHOPIFY_FLAG_FORCE",
+          "hidden": true,
+          "name": "force",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "theme:pull",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "summary": "Download your remote theme files locally.",
+      "descriptionWithMarkdown": "Retrieves theme files from Shopify.\n\nIf no theme is specified, then you're prompted to select the theme to pull from the list of the themes in your store.",
+      "multiEnvironmentsFlags": [
+        "store",
+        "password",
+        "path",
+        [
+          "live",
+          "development",
+          "theme"
+        ]
+      ],
+      "customPluginName": "@shopify/theme"
+    },
+    "theme:push": {
+      "aliases": [],
+      "args": {},
+      "description": "Uploads your local theme files to Shopify, overwriting the remote version if specified.\n\n  If no theme is specified, then you're prompted to select the theme to overwrite from the list of the themes in your store.\n\n  You can run this command only in a directory that matches the \"default Shopify theme folder structure\" (https://shopify.dev/docs/themes/tools/cli#directory-structure).\n\n  This command returns the following information:\n\n  - A link to the \"editor\" (https://shopify.dev/docs/themes/tools/online-editor) for the theme in the Shopify admin.\n  - A \"preview link\" (https://help.shopify.com/manual/online-store/themes/adding-themes#share-a-theme-preview-with-others) that you can share with others.\n\n  If you use the `--json` flag, then theme information is returned in JSON format, which can be used as a machine-readable input for scripts or continuous integration.\n\n  Sample output:\n\n  ```json\n  {\n    \"theme\": {\n      \"id\": 108267175958,\n      \"name\": \"MyTheme\",\n      \"role\": \"unpublished\",\n      \"shop\": \"mystore.myshopify.com\",\n      \"editor_url\": \"https://mystore.myshopify.com/admin/themes/108267175958/editor\",\n      \"preview_url\": \"https://mystore.myshopify.com/?preview_theme_id=108267175958\"\n    }\n  }\n  ```\n    ",
+      "flags": {
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path where you want to run the command. Defaults to the current working directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "name": "path",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "password": {
+          "description": "Password generated from the Theme Access app or an Admin API token.",
+          "env": "SHOPIFY_CLI_THEME_TOKEN",
+          "name": "password",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "store": {
+          "char": "s",
+          "description": "Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).",
+          "env": "SHOPIFY_FLAG_STORE",
+          "name": "store",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "environment": {
+          "char": "e",
+          "description": "The environment to apply to the current command.",
+          "env": "SHOPIFY_FLAG_ENVIRONMENT",
+          "name": "environment",
+          "hasDynamicHelp": false,
+          "multiple": true,
+          "type": "option"
+        },
+        "only": {
+          "char": "o",
+          "description": "Upload only the specified files (Multiple flags allowed). Wrap the value in double quotes if you're using wildcards.",
+          "env": "SHOPIFY_FLAG_ONLY",
+          "name": "only",
+          "hasDynamicHelp": false,
+          "multiple": true,
+          "type": "option"
+        },
+        "ignore": {
+          "char": "x",
+          "description": "Skip uploading the specified files (Multiple flags allowed). Wrap the value in double quotes if you're using wildcards.",
+          "env": "SHOPIFY_FLAG_IGNORE",
+          "name": "ignore",
+          "hasDynamicHelp": false,
+          "multiple": true,
+          "type": "option"
+        },
+        "json": {
+          "char": "j",
+          "description": "Output the result as JSON. Automatically disables color output.",
+          "env": "SHOPIFY_FLAG_JSON",
+          "hidden": false,
+          "name": "json",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "theme": {
+          "char": "t",
+          "description": "Theme ID or name of the remote theme.",
+          "env": "SHOPIFY_FLAG_THEME_ID",
+          "name": "theme",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "development": {
+          "char": "d",
+          "description": "Push theme files from your remote development theme.",
+          "env": "SHOPIFY_FLAG_DEVELOPMENT",
+          "name": "development",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "development-context": {
+          "char": "c",
+          "dependsOn": [
+            "development"
+          ],
+          "description": "Unique identifier for a development theme context (e.g., PR number, branch name). Reuses an existing development theme with this context name, or creates one if none exists.",
+          "env": "SHOPIFY_FLAG_DEVELOPMENT_CONTEXT",
+          "exclusive": [
+            "theme"
+          ],
+          "name": "development-context",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "live": {
+          "char": "l",
+          "description": "Push theme files from your remote live theme.",
+          "env": "SHOPIFY_FLAG_LIVE",
+          "name": "live",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "unpublished": {
+          "char": "u",
+          "description": "Create a new unpublished theme and push to it.",
+          "env": "SHOPIFY_FLAG_UNPUBLISHED",
+          "name": "unpublished",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "nodelete": {
+          "char": "n",
+          "description": "Prevent deleting remote files that don't exist locally.",
+          "env": "SHOPIFY_FLAG_NODELETE",
+          "name": "nodelete",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "allow-live": {
+          "char": "a",
+          "description": "Allow push to a live theme.",
+          "env": "SHOPIFY_FLAG_ALLOW_LIVE",
+          "name": "allow-live",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "publish": {
+          "char": "p",
+          "description": "Publish as the live theme after uploading.",
+          "env": "SHOPIFY_FLAG_PUBLISH",
+          "name": "publish",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "force": {
+          "char": "f",
+          "description": "Proceed without confirmation, if current directory does not seem to be theme directory.",
+          "env": "SHOPIFY_FLAG_FORCE",
+          "hidden": true,
+          "name": "force",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "strict": {
+          "description": "Require theme check to pass without errors before pushing. Warnings are allowed.",
+          "env": "SHOPIFY_FLAG_STRICT_PUSH",
+          "name": "strict",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "listing": {
+          "description": "The listing preset to use for multi-preset themes. Applies preset files from listings/[preset-name] directory.",
+          "env": "SHOPIFY_FLAG_LISTING",
+          "name": "listing",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "theme:push",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "summary": "Uploads your local theme files to the connected store, overwriting the remote version if specified.",
+      "usage": [
+        "theme push",
+        "theme push --unpublished --json"
+      ],
+      "descriptionWithMarkdown": "Uploads your local theme files to Shopify, overwriting the remote version if specified.\n\n  If no theme is specified, then you're prompted to select the theme to overwrite from the list of the themes in your store.\n\n  You can run this command only in a directory that matches the [default Shopify theme folder structure](https://shopify.dev/docs/themes/tools/cli#directory-structure).\n\n  This command returns the following information:\n\n  - A link to the [editor](https://shopify.dev/docs/themes/tools/online-editor) for the theme in the Shopify admin.\n  - A [preview link](https://help.shopify.com/manual/online-store/themes/adding-themes#share-a-theme-preview-with-others) that you can share with others.\n\n  If you use the `--json` flag, then theme information is returned in JSON format, which can be used as a machine-readable input for scripts or continuous integration.\n\n  Sample output:\n\n  ```json\n  {\n    \"theme\": {\n      \"id\": 108267175958,\n      \"name\": \"MyTheme\",\n      \"role\": \"unpublished\",\n      \"shop\": \"mystore.myshopify.com\",\n      \"editor_url\": \"https://mystore.myshopify.com/admin/themes/108267175958/editor\",\n      \"preview_url\": \"https://mystore.myshopify.com/?preview_theme_id=108267175958\"\n    }\n  }\n  ```\n    ",
+      "multiEnvironmentsFlags": [
+        "store",
+        "password",
+        "path",
+        [
+          "live",
+          "development",
+          "theme"
+        ]
+      ],
+      "customPluginName": "@shopify/theme"
+    },
+    "theme:rename": {
+      "aliases": [],
+      "args": {},
+      "description": "Renames a theme in your store.\n\n  If no theme is specified, then you're prompted to select the theme that you want to rename from the list of themes in your store.\n  ",
+      "flags": {
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path where you want to run the command. Defaults to the current working directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "name": "path",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "password": {
+          "description": "Password generated from the Theme Access app or an Admin API token.",
+          "env": "SHOPIFY_CLI_THEME_TOKEN",
+          "name": "password",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "store": {
+          "char": "s",
+          "description": "Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).",
+          "env": "SHOPIFY_FLAG_STORE",
+          "name": "store",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "environment": {
+          "char": "e",
+          "description": "The environment to apply to the current command.",
+          "env": "SHOPIFY_FLAG_ENVIRONMENT",
+          "name": "environment",
+          "hasDynamicHelp": false,
+          "multiple": true,
+          "type": "option"
+        },
+        "name": {
+          "char": "n",
+          "description": "The new name for the theme.",
+          "env": "SHOPIFY_FLAG_NEW_NAME",
+          "name": "name",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "development": {
+          "char": "d",
+          "description": "Rename your development theme.",
+          "env": "SHOPIFY_FLAG_DEVELOPMENT",
+          "name": "development",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "theme": {
+          "char": "t",
+          "description": "Theme ID or name of the remote theme.",
+          "env": "SHOPIFY_FLAG_THEME_ID",
+          "name": "theme",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "live": {
+          "char": "l",
+          "description": "Rename your remote live theme.",
+          "env": "SHOPIFY_FLAG_LIVE",
+          "name": "live",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "theme:rename",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "summary": "Renames an existing theme.",
+      "descriptionWithMarkdown": "Renames a theme in your store.\n\n  If no theme is specified, then you're prompted to select the theme that you want to rename from the list of themes in your store.\n  ",
+      "multiEnvironmentsFlags": [
+        "store",
+        "password",
+        "name",
+        [
+          "live",
+          "development",
+          "theme"
+        ]
+      ],
+      "customPluginName": "@shopify/theme"
+    },
+    "theme:serve": {
+      "aliases": [],
+      "args": {},
+      "description": "\n  Uploads the current theme as the specified theme, or a \"development theme\" (https://shopify.dev/docs/themes/tools/cli#development-themes), to a store so you can preview it.\n\nThis command returns the following information:\n\n- A link to your development theme at http://127.0.0.1:9292. This URL can hot reload local changes to CSS and sections, or refresh the entire page when a file changes, enabling you to preview changes in real time using the store's data.\n\n  You can specify a different network interface and port using `--host` and `--port`.\n\n- A link to the \"editor\" (https://shopify.dev/docs/themes/tools/online-editor) for the theme in the Shopify admin.\n\n- A \"preview link\" (https://help.shopify.com/manual/online-store/themes/adding-themes#share-a-theme-preview-with-others) that you can share with other developers.\n\nIf you already have a development theme for your current environment, then this command replaces the development theme with your local theme. You can override this using the `--theme-editor-sync` flag.\n\n> Note: You can't preview checkout customizations using http://127.0.0.1:9292.\n\nDevelopment themes are deleted when you run `shopify auth logout`. If you need a preview link that can be used after you log out, then you should \"share\" (https://shopify.dev/docs/api/shopify-cli/theme/theme-share) your theme or \"push\" (https://shopify.dev/docs/api/shopify-cli/theme/theme-push) to an unpublished theme on your store.\n\nYou can run this command only in a directory that matches the \"default Shopify theme folder structure\" (https://shopify.dev/docs/themes/tools/cli#directory-structure).",
+      "flags": {
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path where you want to run the command. Defaults to the current working directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "name": "path",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "password": {
+          "description": "Password generated from the Theme Access app or an Admin API token.",
+          "env": "SHOPIFY_CLI_THEME_TOKEN",
+          "name": "password",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "store": {
+          "char": "s",
+          "description": "Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).",
+          "env": "SHOPIFY_FLAG_STORE",
+          "name": "store",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "environment": {
+          "char": "e",
+          "description": "The environment to apply to the current command.",
+          "env": "SHOPIFY_FLAG_ENVIRONMENT",
+          "name": "environment",
+          "hasDynamicHelp": false,
+          "multiple": true,
+          "type": "option"
+        },
+        "host": {
+          "description": "Set which network interface the web server listens on. The default value is 127.0.0.1.",
+          "env": "SHOPIFY_FLAG_HOST",
+          "name": "host",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "live-reload": {
+          "description": "The live reload mode switches the server behavior when a file is modified:\n- hot-reload Hot reloads local changes to CSS and sections (default)\n- full-page  Always refreshes the entire page\n- off        Deactivate live reload",
+          "env": "SHOPIFY_FLAG_LIVE_RELOAD",
+          "name": "live-reload",
+          "default": "hot-reload",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "options": [
+            "hot-reload",
+            "full-page",
+            "off"
+          ],
+          "type": "option"
+        },
+        "error-overlay": {
+          "description": "Controls the visibility of the error overlay when an theme asset upload fails:\n- silent Prevents the error overlay from appearing.\n- default Displays the error overlay.\n      ",
+          "env": "SHOPIFY_FLAG_ERROR_OVERLAY",
+          "name": "error-overlay",
+          "default": "default",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "options": [
+            "silent",
+            "default"
+          ],
+          "type": "option"
+        },
+        "poll": {
+          "description": "Force polling to detect file changes.",
+          "env": "SHOPIFY_FLAG_POLL",
+          "hidden": true,
+          "name": "poll",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "theme-editor-sync": {
+          "description": "Synchronize Theme Editor updates in the local theme files.",
+          "env": "SHOPIFY_FLAG_THEME_EDITOR_SYNC",
+          "name": "theme-editor-sync",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "port": {
+          "description": "Local port to serve theme preview from.",
+          "env": "SHOPIFY_FLAG_PORT",
+          "name": "port",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "theme": {
+          "char": "t",
+          "description": "Theme ID or name of the remote theme.",
+          "env": "SHOPIFY_FLAG_THEME_ID",
+          "name": "theme",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "listing": {
+          "description": "The listing preset to use for multi-preset themes. Applies preset files from listings/[preset-name] directory.",
+          "env": "SHOPIFY_FLAG_LISTING",
+          "name": "listing",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "nodelete": {
+          "char": "n",
+          "description": "Prevents files from being deleted in the remote theme when a file has been deleted locally. This applies to files that are deleted while the command is running, and files that have been deleted locally before the command is run.",
+          "env": "SHOPIFY_FLAG_NODELETE",
+          "name": "nodelete",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "only": {
+          "char": "o",
+          "description": "Hot reload only files that match the specified pattern.",
+          "env": "SHOPIFY_FLAG_ONLY",
+          "name": "only",
+          "hasDynamicHelp": false,
+          "multiple": true,
+          "type": "option"
+        },
+        "ignore": {
+          "char": "x",
+          "description": "Skip hot reloading any files that match the specified pattern.",
+          "env": "SHOPIFY_FLAG_IGNORE",
+          "name": "ignore",
+          "hasDynamicHelp": false,
+          "multiple": true,
+          "type": "option"
+        },
+        "force": {
+          "char": "f",
+          "description": "Proceed without confirmation, if current directory does not seem to be theme directory.",
+          "env": "SHOPIFY_FLAG_FORCE",
+          "hidden": true,
+          "name": "force",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "notify": {
+          "description": "The file path or URL. The file path is to a file that you want updated on idle. The URL path is where you want a webhook posted to report on file changes.",
+          "env": "SHOPIFY_FLAG_NOTIFY",
+          "name": "notify",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "open": {
+          "description": "Automatically launch the theme preview in your default web browser.",
+          "env": "SHOPIFY_FLAG_OPEN",
+          "name": "open",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "store-password": {
+          "description": "The password for storefronts with password protection.",
+          "env": "SHOPIFY_FLAG_STORE_PASSWORD",
+          "name": "store-password",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "allow-live": {
+          "char": "a",
+          "description": "Allow development on a live theme.",
+          "env": "SHOPIFY_FLAG_ALLOW_LIVE",
+          "name": "allow-live",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hidden": true,
+      "hiddenAliases": [],
+      "id": "theme:serve",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "summary": "Uploads the current theme as a development theme to the connected store, then prints theme editor and preview URLs to your terminal. While running, changes will push to the store in real time.",
+      "descriptionWithMarkdown": "\n  Uploads the current theme as the specified theme, or a [development theme](https://shopify.dev/docs/themes/tools/cli#development-themes), to a store so you can preview it.\n\nThis command returns the following information:\n\n- A link to your development theme at http://127.0.0.1:9292. This URL can hot reload local changes to CSS and sections, or refresh the entire page when a file changes, enabling you to preview changes in real time using the store's data.\n\n  You can specify a different network interface and port using `--host` and `--port`.\n\n- A link to the [editor](https://shopify.dev/docs/themes/tools/online-editor) for the theme in the Shopify admin.\n\n- A [preview link](https://help.shopify.com/manual/online-store/themes/adding-themes#share-a-theme-preview-with-others) that you can share with other developers.\n\nIf you already have a development theme for your current environment, then this command replaces the development theme with your local theme. You can override this using the `--theme-editor-sync` flag.\n\n> Note: You can't preview checkout customizations using http://127.0.0.1:9292.\n\nDevelopment themes are deleted when you run `shopify auth logout`. If you need a preview link that can be used after you log out, then you should [share](https://shopify.dev/docs/api/shopify-cli/theme/theme-share) your theme or [push](https://shopify.dev/docs/api/shopify-cli/theme/theme-push) to an unpublished theme on your store.\n\nYou can run this command only in a directory that matches the [default Shopify theme folder structure](https://shopify.dev/docs/themes/tools/cli#directory-structure).",
+      "multiEnvironmentsFlags": null,
+      "customPluginName": "@shopify/theme"
+    },
+    "theme:share": {
+      "aliases": [],
+      "args": {},
+      "description": "Uploads your theme as a new, unpublished theme in your theme library. The theme is given a randomized name.\n\n  This command returns a \"preview link\" (https://help.shopify.com/manual/online-store/themes/adding-themes#share-a-theme-preview-with-others) that you can share with others.",
+      "flags": {
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path where you want to run the command. Defaults to the current working directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "name": "path",
+          "noCacheDefault": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "password": {
+          "description": "Password generated from the Theme Access app or an Admin API token.",
+          "env": "SHOPIFY_CLI_THEME_TOKEN",
+          "name": "password",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "store": {
+          "char": "s",
+          "description": "Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).",
+          "env": "SHOPIFY_FLAG_STORE",
+          "name": "store",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "environment": {
+          "char": "e",
+          "description": "The environment to apply to the current command.",
+          "env": "SHOPIFY_FLAG_ENVIRONMENT",
+          "name": "environment",
+          "hasDynamicHelp": false,
+          "multiple": true,
+          "type": "option"
+        },
+        "force": {
+          "char": "f",
+          "description": "Proceed without confirmation, if current directory does not seem to be theme directory.",
+          "env": "SHOPIFY_FLAG_FORCE",
+          "hidden": true,
+          "name": "force",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "listing": {
+          "description": "The listing preset to use for multi-preset themes. Applies preset files from listings/[preset-name] directory.",
+          "env": "SHOPIFY_FLAG_LISTING",
+          "name": "listing",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "theme:share",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "summary": "Creates a shareable, unpublished, and new theme on your theme library with a randomized name.",
+      "descriptionWithMarkdown": "Uploads your theme as a new, unpublished theme in your theme library. The theme is given a randomized name.\n\n  This command returns a [preview link](https://help.shopify.com/manual/online-store/themes/adding-themes#share-a-theme-preview-with-others) that you can share with others.",
+      "multiEnvironmentsFlags": [
+        "store",
+        "password",
+        "path"
+      ],
+      "customPluginName": "@shopify/theme"
+    },
+    "plugins": {
+      "aliases": [],
+      "args": {},
+      "description": "List installed plugins.",
+      "examples": [
+        "<%= config.bin %> <%= command.id %>"
+      ],
+      "flags": {
+        "json": {
+          "description": "Format output as json.",
+          "helpGroup": "GLOBAL",
+          "name": "json",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "core": {
+          "description": "Show core plugins.",
+          "name": "core",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hidden": true,
+      "hiddenAliases": [],
+      "id": "plugins",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": true,
+      "customPluginName": "@oclif/plugin-plugins"
+    },
+    "plugins:inspect": {
+      "aliases": [],
+      "args": {
+        "plugin": {
+          "default": ".",
+          "description": "Plugin to inspect.",
+          "name": "plugin",
+          "required": true
+        }
+      },
+      "description": "Displays installation properties of a plugin.",
+      "examples": [
+        "<%= config.bin %> <%= command.id %> <%- config.pjson.oclif.examplePlugin || \"myplugin\" %> "
+      ],
+      "flags": {
+        "json": {
+          "description": "Format output as json.",
+          "helpGroup": "GLOBAL",
+          "name": "json",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "help": {
+          "char": "h",
+          "description": "Show CLI help.",
+          "name": "help",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "char": "v",
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "plugins:inspect",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": false,
+      "usage": "plugins:inspect PLUGIN...",
+      "enableJsonFlag": true,
+      "customPluginName": "@oclif/plugin-plugins"
+    },
+    "plugins:install": {
       "aliases": [
+        "plugins:add"
       ],
       "args": {
+        "plugin": {
+          "description": "Plugin to install.",
+          "name": "plugin",
+          "required": true
+        }
       },
-      "customPluginName": "@oclif/plugin-commands",
-      "description": "List all <%= config.bin %> commands.",
-      "enableJsonFlag": true,
+      "description": "",
+      "examples": [
+        {
+          "command": "<%= config.bin %> <%= command.id %> <%- config.pjson.oclif.examplePlugin || \"myplugin\" %> ",
+          "description": "Install a plugin from npm registry."
+        },
+        {
+          "command": "<%= config.bin %> <%= command.id %> https://github.com/someuser/someplugin",
+          "description": "Install a plugin from a github url."
+        },
+        {
+          "command": "<%= config.bin %> <%= command.id %> someuser/someplugin",
+          "description": "Install a plugin from a github slug."
+        }
+      ],
       "flags": {
+        "json": {
+          "description": "Format output as json.",
+          "helpGroup": "GLOBAL",
+          "name": "json",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "force": {
+          "char": "f",
+          "description": "Force npm to fetch remote resources even if a local copy exists on disk.",
+          "name": "force",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "help": {
+          "char": "h",
+          "description": "Show CLI help.",
+          "name": "help",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "jit": {
+          "hidden": true,
+          "name": "jit",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "silent": {
+          "char": "s",
+          "description": "Silences npm output.",
+          "exclusive": [
+            "verbose"
+          ],
+          "name": "silent",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "char": "v",
+          "description": "Show verbose npm output.",
+          "exclusive": [
+            "silent"
+          ],
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "plugins:install",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": false,
+      "summary": "Installs a plugin into <%= config.bin %>.",
+      "enableJsonFlag": true,
+      "customPluginName": "@oclif/plugin-plugins"
+    },
+    "plugins:link": {
+      "aliases": [],
+      "args": {
+        "path": {
+          "default": ".",
+          "description": "path to plugin",
+          "name": "path",
+          "required": true
+        }
+      },
+      "description": "Installation of a linked plugin will override a user-installed or core plugin.\n\ne.g. If you have a user-installed or core plugin that has a 'hello' command, installing a linked plugin with a 'hello' command will override the user-installed or core plugin implementation. This is useful for development work.\n",
+      "examples": [
+        "<%= config.bin %> <%= command.id %> <%- config.pjson.oclif.examplePlugin || \"myplugin\" %> "
+      ],
+      "flags": {
+        "help": {
+          "char": "h",
+          "description": "Show CLI help.",
+          "name": "help",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "install": {
+          "description": "Install dependencies after linking the plugin.",
+          "name": "install",
+          "allowNo": true,
+          "type": "boolean"
+        },
+        "verbose": {
+          "char": "v",
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "plugins:link",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "summary": "Links a plugin into the CLI for development.",
+      "enableJsonFlag": false,
+      "customPluginName": "@oclif/plugin-plugins"
+    },
+    "plugins:reset": {
+      "aliases": [],
+      "args": {},
+      "flags": {
+        "hard": {
+          "name": "hard",
+          "summary": "Delete node_modules and package manager related files in addition to uninstalling plugins.",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "reinstall": {
+          "name": "reinstall",
+          "summary": "Reinstall all plugins after uninstalling.",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "plugins:reset",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "summary": "Remove all user-installed and linked plugins.",
+      "enableJsonFlag": false,
+      "customPluginName": "@oclif/plugin-plugins"
+    },
+    "plugins:uninstall": {
+      "aliases": [
+        "plugins:unlink",
+        "plugins:remove"
+      ],
+      "args": {
+        "plugin": {
+          "description": "plugin to uninstall",
+          "name": "plugin"
+        }
+      },
+      "description": "Removes a plugin from the CLI.",
+      "examples": [
+        "<%= config.bin %> <%= command.id %> <%- config.pjson.oclif.examplePlugin || \"myplugin\" %>"
+      ],
+      "flags": {
+        "help": {
+          "char": "h",
+          "description": "Show CLI help.",
+          "name": "help",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "char": "v",
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "plugins:uninstall",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": false,
+      "enableJsonFlag": false,
+      "customPluginName": "@oclif/plugin-plugins"
+    },
+    "plugins:update": {
+      "aliases": [],
+      "args": {},
+      "description": "Update installed plugins.",
+      "flags": {
+        "help": {
+          "char": "h",
+          "description": "Show CLI help.",
+          "name": "help",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "char": "v",
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "plugins:update",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false,
+      "customPluginName": "@oclif/plugin-plugins"
+    },
+    "config:autocorrect:off": {
+      "aliases": [],
+      "args": {},
+      "description": "Disable autocorrect. Off by default.\n\n  When autocorrection is enabled, Shopify CLI automatically runs a corrected version of your command if a correction is available.\n\n  When autocorrection is disabled, you need to confirm that you want to run corrections for mistyped commands.\n",
+      "flags": {},
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "config:autocorrect:off",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "summary": "Disable autocorrect. Off by default.",
+      "enableJsonFlag": false,
+      "descriptionWithMarkdown": "Disable autocorrect. Off by default.\n\n  When autocorrection is enabled, Shopify CLI automatically runs a corrected version of your command if a correction is available.\n\n  When autocorrection is disabled, you need to confirm that you want to run corrections for mistyped commands.\n",
+      "customPluginName": "@shopify/plugin-did-you-mean"
+    },
+    "config:autocorrect:status": {
+      "aliases": [],
+      "args": {},
+      "description": "Check whether autocorrect is enabled or disabled. On by default.\n\n  When autocorrection is enabled, Shopify CLI automatically runs a corrected version of your command if a correction is available.\n\n  When autocorrection is disabled, you need to confirm that you want to run corrections for mistyped commands.\n",
+      "flags": {},
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "config:autocorrect:status",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "summary": "Check whether autocorrect is enabled or disabled. On by default.",
+      "enableJsonFlag": false,
+      "descriptionWithMarkdown": "Check whether autocorrect is enabled or disabled. On by default.\n\n  When autocorrection is enabled, Shopify CLI automatically runs a corrected version of your command if a correction is available.\n\n  When autocorrection is disabled, you need to confirm that you want to run corrections for mistyped commands.\n",
+      "customPluginName": "@shopify/plugin-did-you-mean"
+    },
+    "config:autocorrect:on": {
+      "aliases": [],
+      "args": {},
+      "description": "Enable autocorrect. Off by default.\n\n  When autocorrection is enabled, Shopify CLI automatically runs a corrected version of your command if a correction is available.\n\n  When autocorrection is disabled, you need to confirm that you want to run corrections for mistyped commands.\n",
+      "flags": {},
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "config:autocorrect:on",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "summary": "Enable autocorrect. Off by default.",
+      "enableJsonFlag": false,
+      "descriptionWithMarkdown": "Enable autocorrect. Off by default.\n\n  When autocorrection is enabled, Shopify CLI automatically runs a corrected version of your command if a correction is available.\n\n  When autocorrection is disabled, you need to confirm that you want to run corrections for mistyped commands.\n",
+      "customPluginName": "@shopify/plugin-did-you-mean"
+    },
+    "commands": {
+      "aliases": [],
+      "args": {},
+      "description": "List all <%= config.bin %> commands.",
+      "flags": {
+        "json": {
+          "description": "Format output as json.",
+          "helpGroup": "GLOBAL",
+          "name": "json",
+          "allowNo": false,
+          "type": "boolean"
+        },
         "columns": {
           "char": "c",
-          "delimiter": ",",
           "description": "Only show provided columns (comma-separated).",
           "exclusive": [
             "tree"
           ],
+          "name": "columns",
+          "delimiter": ",",
           "hasDynamicHelp": false,
           "multiple": true,
-          "name": "columns",
           "options": [
             "id",
             "plugin",
@@ -3128,52 +5950,45 @@
           "type": "option"
         },
         "deprecated": {
-          "allowNo": false,
           "description": "Show deprecated commands.",
           "name": "deprecated",
+          "allowNo": false,
           "type": "boolean"
         },
         "extended": {
-          "allowNo": false,
           "char": "x",
           "description": "Show extra columns.",
           "exclusive": [
             "tree"
           ],
           "name": "extended",
+          "allowNo": false,
           "type": "boolean"
         },
         "hidden": {
-          "allowNo": false,
           "description": "Show hidden commands.",
           "name": "hidden",
-          "type": "boolean"
-        },
-        "json": {
           "allowNo": false,
-          "description": "Format output as json.",
-          "helpGroup": "GLOBAL",
-          "name": "json",
           "type": "boolean"
         },
         "no-truncate": {
-          "allowNo": false,
           "description": "Do not truncate output.",
           "exclusive": [
             "tree"
           ],
           "name": "no-truncate",
+          "allowNo": false,
           "type": "boolean"
         },
         "sort": {
-          "default": "id",
           "description": "Property to sort by.",
           "exclusive": [
             "tree"
           ],
+          "name": "sort",
+          "default": "id",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "sort",
           "options": [
             "id",
             "plugin",
@@ -3183,410 +5998,57 @@
           "type": "option"
         },
         "tree": {
-          "allowNo": false,
           "description": "Show tree of commands.",
           "name": "tree",
+          "allowNo": false,
           "type": "boolean"
         }
       },
       "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
+      "hiddenAliases": [],
       "id": "commands",
       "pluginAlias": "@shopify/cli",
       "pluginName": "@shopify/cli",
       "pluginType": "core",
-      "strict": true
-    },
-    "config:autocorrect:off": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/plugin-did-you-mean",
-      "description": "Disable autocorrect. Off by default.\n\n  When autocorrection is enabled, Shopify CLI automatically runs a corrected version of your command if a correction is available.\n\n  When autocorrection is disabled, you need to confirm that you want to run corrections for mistyped commands.\n",
-      "descriptionWithMarkdown": "Disable autocorrect. Off by default.\n\n  When autocorrection is enabled, Shopify CLI automatically runs a corrected version of your command if a correction is available.\n\n  When autocorrection is disabled, you need to confirm that you want to run corrections for mistyped commands.\n",
-      "enableJsonFlag": false,
-      "flags": {
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "config:autocorrect:off",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
       "strict": true,
-      "summary": "Disable autocorrect. Off by default."
+      "enableJsonFlag": true,
+      "customPluginName": "@oclif/plugin-commands"
     },
-    "config:autocorrect:on": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/plugin-did-you-mean",
-      "description": "Enable autocorrect. Off by default.\n\n  When autocorrection is enabled, Shopify CLI automatically runs a corrected version of your command if a correction is available.\n\n  When autocorrection is disabled, you need to confirm that you want to run corrections for mistyped commands.\n",
-      "descriptionWithMarkdown": "Enable autocorrect. Off by default.\n\n  When autocorrection is enabled, Shopify CLI automatically runs a corrected version of your command if a correction is available.\n\n  When autocorrection is disabled, you need to confirm that you want to run corrections for mistyped commands.\n",
-      "enableJsonFlag": false,
+    "hydrogen:dev": {
+      "aliases": [],
+      "args": {},
+      "description": "Runs Hydrogen storefront in an Oxygen worker for development.",
       "flags": {
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "config:autocorrect:on",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true,
-      "summary": "Enable autocorrect. Off by default."
-    },
-    "config:autocorrect:status": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/plugin-did-you-mean",
-      "description": "Check whether autocorrect is enabled or disabled. On by default.\n\n  When autocorrection is enabled, Shopify CLI automatically runs a corrected version of your command if a correction is available.\n\n  When autocorrection is disabled, you need to confirm that you want to run corrections for mistyped commands.\n",
-      "descriptionWithMarkdown": "Check whether autocorrect is enabled or disabled. On by default.\n\n  When autocorrection is enabled, Shopify CLI automatically runs a corrected version of your command if a correction is available.\n\n  When autocorrection is disabled, you need to confirm that you want to run corrections for mistyped commands.\n",
-      "enableJsonFlag": false,
-      "flags": {
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "config:autocorrect:status",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true,
-      "summary": "Check whether autocorrect is enabled or disabled. On by default."
-    },
-    "config:autoupgrade:off": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "description": "Disable automatic upgrades for Shopify CLI.\n\n  When auto-upgrade is disabled, Shopify CLI won't automatically update. Run `shopify upgrade` to update manually.\n\n  To enable auto-upgrade, run `shopify config autoupgrade on`.\n",
-      "descriptionWithMarkdown": "Disable automatic upgrades for Shopify CLI.\n\n  When auto-upgrade is disabled, Shopify CLI won't automatically update. Run `shopify upgrade` to update manually.\n\n  To enable auto-upgrade, run `shopify config autoupgrade on`.\n",
-      "enableJsonFlag": false,
-      "flags": {
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "config:autoupgrade:off",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true,
-      "summary": "Disable automatic upgrades for Shopify CLI."
-    },
-    "config:autoupgrade:on": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "description": "Enable automatic upgrades for Shopify CLI.\n\n  When auto-upgrade is enabled, Shopify CLI automatically updates to the latest version once per day. Major version upgrades are skipped and must be done manually.\n\n  To disable auto-upgrade, run `shopify config autoupgrade off`.\n",
-      "descriptionWithMarkdown": "Enable automatic upgrades for Shopify CLI.\n\n  When auto-upgrade is enabled, Shopify CLI automatically updates to the latest version once per day. Major version upgrades are skipped and must be done manually.\n\n  To disable auto-upgrade, run `shopify config autoupgrade off`.\n",
-      "enableJsonFlag": false,
-      "flags": {
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "config:autoupgrade:on",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true,
-      "summary": "Enable automatic upgrades for Shopify CLI."
-    },
-    "config:autoupgrade:status": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "description": "Check whether auto-upgrade is enabled, disabled, or not yet configured.\n\n  When auto-upgrade is enabled, Shopify CLI automatically updates to the latest version after each command.\n\n  Run `shopify config autoupgrade on` or `shopify config autoupgrade off` to configure it.\n",
-      "descriptionWithMarkdown": "Check whether auto-upgrade is enabled, disabled, or not yet configured.\n\n  When auto-upgrade is enabled, Shopify CLI automatically updates to the latest version after each command.\n\n  Run `shopify config autoupgrade on` or `shopify config autoupgrade off` to configure it.\n",
-      "enableJsonFlag": false,
-      "flags": {
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "config:autoupgrade:status",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true,
-      "summary": "Check whether auto-upgrade is enabled, disabled, or not yet configured."
-    },
-    "debug:command-flags": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "description": "View all the available command flags",
-      "enableJsonFlag": false,
-      "flags": {
-        "csv": {
-          "allowNo": false,
-          "description": "Output as CSV",
-          "env": "SHOPIFY_FLAG_OUTPUT_CSV",
-          "name": "csv",
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hidden": true,
-      "hiddenAliases": [
-      ],
-      "id": "debug:command-flags",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true
-    },
-    "demo:watcher": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/app",
-      "flags": {
-        "client-id": {
-          "description": "The Client ID of your app.",
-          "env": "SHOPIFY_FLAG_CLIENT_ID",
-          "exclusive": [
-            "config"
-          ],
-          "hasDynamicHelp": false,
-          "hidden": false,
-          "multiple": false,
-          "name": "client-id",
-          "type": "option"
-        },
-        "config": {
-          "char": "c",
-          "description": "The name of the app configuration.",
-          "env": "SHOPIFY_FLAG_APP_CONFIG",
-          "hasDynamicHelp": false,
-          "hidden": false,
-          "multiple": false,
-          "name": "config",
-          "type": "option"
-        },
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
-          "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
         "path": {
-          "description": "The path to your app directory.",
-          "env": "SHOPIFY_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "multiple": false,
+          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
           "name": "path",
-          "noCacheDefault": true,
-          "type": "option"
-        },
-        "reset": {
-          "allowNo": false,
-          "description": "Reset all your settings.",
-          "env": "SHOPIFY_FLAG_RESET",
-          "exclusive": [
-            "config"
-          ],
-          "hidden": false,
-          "name": "reset",
-          "type": "boolean"
-        },
-        "verbose": {
-          "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hidden": true,
-      "hiddenAliases": [
-      ],
-      "id": "demo:watcher",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true,
-      "summary": "Watch and prints out changes to an app."
-    },
-    "docs:generate": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "description": "Generate CLI commands documentation",
-      "enableJsonFlag": false,
-      "flags": {
-      },
-      "hasDynamicHelp": false,
-      "hidden": true,
-      "hiddenAliases": [
-      ],
-      "id": "docs:generate",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true
-    },
-    "doctor-release": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "description": "Run CLI doctor-release tests",
-      "enableJsonFlag": false,
-      "flags": {
-      },
-      "hasDynamicHelp": false,
-      "hidden": true,
-      "hiddenAliases": [
-      ],
-      "id": "doctor-release",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true
-    },
-    "doctor-release:theme": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "description": "Run all theme command doctor-release tests",
-      "enableJsonFlag": false,
-      "flags": {
-        "environment": {
-          "char": "e",
-          "description": "The environment to use from shopify.theme.toml (required for store-connected tests).",
-          "env": "SHOPIFY_FLAG_ENVIRONMENT",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "environment",
-          "required": true,
           "type": "option"
         },
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
-          "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
-        "password": {
-          "description": "Password from Theme Access app (overrides environment).",
-          "env": "SHOPIFY_FLAG_PASSWORD",
+        "entry": {
+          "description": "Entry file for the worker. Defaults to `./server`.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_ENTRY",
+          "name": "entry",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "password",
           "type": "option"
         },
-        "path": {
-          "char": "p",
-          "default": ".",
-          "description": "The path to run tests in. Defaults to current directory.",
-          "env": "SHOPIFY_FLAG_PATH",
+        "port": {
+          "description": "The port to run the server on. Defaults to 3000.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_PORT",
+          "name": "port",
+          "required": false,
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "path",
           "type": "option"
-        },
-        "store": {
-          "char": "s",
-          "description": "Store URL (overrides environment).",
-          "env": "SHOPIFY_FLAG_STORE",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "store",
-          "type": "option"
-        },
-        "verbose": {
-          "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hidden": true,
-      "hiddenAliases": [
-      ],
-      "id": "doctor-release:theme",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true
-    },
-    "help": {
-      "aliases": [
-      ],
-      "args": {
-        "command": {
-          "description": "Command to show help for.",
-          "name": "command",
-          "required": false
-        }
-      },
-      "description": "Display help for Shopify CLI",
-      "enableJsonFlag": false,
-      "flags": {
-        "nested-commands": {
-          "allowNo": false,
-          "char": "n",
-          "description": "Include all nested commands in the output.",
-          "env": "SHOPIFY_FLAG_CLI_NESTED_COMMANDS",
-          "name": "nested-commands",
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "help",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": false,
-      "usage": "help [command] [flags]"
-    },
-    "hydrogen:build": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/cli-hydrogen",
-      "description": "Builds a Hydrogen storefront for production.",
-      "descriptionWithMarkdown": "Builds a Hydrogen storefront for production. The client and app worker files are compiled to a `/dist` folder in your Hydrogen project directory.",
-      "enableJsonFlag": false,
-      "flags": {
-        "bundle-stats": {
-          "allowNo": true,
-          "description": "Show a bundle size summary after building. Defaults to true, use `--no-bundle-stats` to disable.",
-          "name": "bundle-stats",
-          "type": "boolean"
         },
         "codegen": {
-          "allowNo": false,
           "description": "Automatically generates GraphQL types for your project’s Storefront API queries.",
           "name": "codegen",
           "required": false,
+          "allowNo": false,
           "type": "boolean"
         },
         "codegen-config-path": {
@@ -3594,76 +6056,208 @@
             "codegen"
           ],
           "description": "Specifies a path to a codegen configuration file. Defaults to `<root>/codegen.ts` if this file exists.",
-          "hasDynamicHelp": false,
-          "multiple": false,
           "name": "codegen-config-path",
           "required": false,
-          "type": "option"
-        },
-        "disable-route-warning": {
-          "allowNo": false,
-          "description": "Disables any warnings about missing standard routes.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_DISABLE_ROUTE_WARNING",
-          "name": "disable-route-warning",
-          "type": "boolean"
-        },
-        "entry": {
-          "description": "Entry file for the worker. Defaults to `./server`.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_ENTRY",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "entry",
           "type": "option"
         },
-        "force-client-sourcemap": {
+        "disable-virtual-routes": {
+          "description": "Disable rendering fallback routes when a route file doesn't exist.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_DISABLE_VIRTUAL_ROUTES",
+          "name": "disable-virtual-routes",
           "allowNo": false,
-          "description": "Client sourcemapping is avoided by default because it makes backend code visible in the browser. Use this flag to force enabling it.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_FORCE_CLIENT_SOURCEMAP",
-          "name": "force-client-sourcemap",
           "type": "boolean"
         },
-        "lockfile-check": {
-          "allowNo": true,
-          "description": "Checks that there is exactly one valid lockfile in the project. Defaults to `true`. Deactivate with `--no-lockfile-check`.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_LOCKFILE_CHECK",
-          "name": "lockfile-check",
+        "debug": {
+          "description": "Enables inspector connections to the server with a debugger such as Visual Studio Code or Chrome DevTools.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_DEBUG",
+          "name": "debug",
+          "allowNo": false,
           "type": "boolean"
         },
-        "path": {
-          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
+        "inspector-port": {
+          "description": "The port where the inspector is available. Defaults to 9229.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_INSPECTOR_PORT",
+          "name": "inspector-port",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "path",
           "type": "option"
         },
-        "sourcemap": {
-          "allowNo": true,
-          "description": "Controls whether server sourcemaps are generated. Default to `true`. Deactivate `--no-sourcemaps`.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_SOURCEMAP",
-          "name": "sourcemap",
+        "env": {
+          "description": "Specifies the environment to perform the operation using its handle. Fetch the handle using the `env list` command.",
+          "exclusive": [
+            "env-branch"
+          ],
+          "name": "env",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "env-branch": {
+          "deprecated": {
+            "to": "env",
+            "message": "--env-branch is deprecated. Use --env instead."
+          },
+          "description": "Specifies the environment to perform the operation using its Git branch name.",
+          "env": "SHOPIFY_HYDROGEN_ENVIRONMENT_BRANCH",
+          "name": "env-branch",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "env-file": {
+          "description": "Path to an environment file to override existing environment variables. Defaults to the '.env' located in your project path `--path`.",
+          "name": "env-file",
+          "required": false,
+          "default": ".env",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "disable-version-check": {
+          "description": "Skip the version check when running `hydrogen dev`",
+          "name": "disable-version-check",
+          "required": false,
+          "allowNo": false,
           "type": "boolean"
         },
-        "watch": {
+        "customer-account-push": {
+          "description": "Use tunneling for local development and push the tunneling domain to admin. Required to use Customer Account API's OAuth flow",
+          "env": "SHOPIFY_HYDROGEN_FLAG_CUSTOMER_ACCOUNT_PUSH",
+          "name": "customer-account-push",
+          "required": false,
           "allowNo": false,
-          "description": "Watches for changes and rebuilds the project writing output to disk.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_WATCH",
-          "name": "watch",
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Outputs more information about the command's execution.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_VERBOSE",
+          "name": "verbose",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "host": {
+          "description": "Expose the server to the local network",
+          "name": "host",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "disable-deps-optimizer": {
+          "description": "Disable adding dependencies to Vite's `ssr.optimizeDeps.include` automatically",
+          "env": "SHOPIFY_HYDROGEN_FLAG_DISABLE_DEPS_OPTIMIZER",
+          "name": "disable-deps-optimizer",
+          "allowNo": false,
           "type": "boolean"
         }
       },
       "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
+      "hiddenAliases": [],
+      "id": "hydrogen:dev",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false,
+      "descriptionWithMarkdown": "Runs a Hydrogen storefront in a local runtime that emulates an Oxygen worker for development.\n\n  If your project is [linked](https://shopify.dev/docs/api/shopify-cli/hydrogen/hydrogen-link) to a Hydrogen storefront, then its environment variables will be loaded with the runtime.",
+      "customPluginName": "@shopify/cli-hydrogen"
+    },
+    "hydrogen:build": {
+      "aliases": [],
+      "args": {},
+      "description": "Builds a Hydrogen storefront for production.",
+      "flags": {
+        "path": {
+          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
+          "name": "path",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "entry": {
+          "description": "Entry file for the worker. Defaults to `./server`.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_ENTRY",
+          "name": "entry",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "sourcemap": {
+          "description": "Controls whether server sourcemaps are generated. Default to `true`. Deactivate `--no-sourcemaps`.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_SOURCEMAP",
+          "name": "sourcemap",
+          "allowNo": true,
+          "type": "boolean"
+        },
+        "lockfile-check": {
+          "description": "Checks that there is exactly one valid lockfile in the project. Defaults to `true`. Deactivate with `--no-lockfile-check`.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_LOCKFILE_CHECK",
+          "name": "lockfile-check",
+          "allowNo": true,
+          "type": "boolean"
+        },
+        "disable-route-warning": {
+          "description": "Disables any warnings about missing standard routes.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_DISABLE_ROUTE_WARNING",
+          "name": "disable-route-warning",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "codegen": {
+          "description": "Automatically generates GraphQL types for your project’s Storefront API queries.",
+          "name": "codegen",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "codegen-config-path": {
+          "dependsOn": [
+            "codegen"
+          ],
+          "description": "Specifies a path to a codegen configuration file. Defaults to `<root>/codegen.ts` if this file exists.",
+          "name": "codegen-config-path",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "watch": {
+          "description": "Watches for changes and rebuilds the project writing output to disk.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_WATCH",
+          "name": "watch",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "bundle-stats": {
+          "description": "Show a bundle size summary after building. Defaults to true, use `--no-bundle-stats` to disable.",
+          "name": "bundle-stats",
+          "allowNo": true,
+          "type": "boolean"
+        },
+        "force-client-sourcemap": {
+          "description": "Client sourcemapping is avoided by default because it makes backend code visible in the browser. Use this flag to force enabling it.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_FORCE_CLIENT_SOURCEMAP",
+          "name": "force-client-sourcemap",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
       "id": "hydrogen:build",
       "pluginAlias": "@shopify/cli",
       "pluginName": "@shopify/cli",
       "pluginType": "core",
-      "strict": true
+      "strict": true,
+      "enableJsonFlag": false,
+      "descriptionWithMarkdown": "Builds a Hydrogen storefront for production. The client and app worker files are compiled to a `/dist` folder in your Hydrogen project directory.",
+      "customPluginName": "@shopify/cli-hydrogen"
     },
     "hydrogen:check": {
-      "aliases": [
-      ],
+      "aliases": [],
       "args": {
         "resource": {
           "description": "The resource to check. Currently only 'routes' is supported.",
@@ -3674,197 +6268,148 @@
           "required": true
         }
       },
-      "customPluginName": "@shopify/cli-hydrogen",
       "description": "Returns diagnostic information about a Hydrogen storefront.",
-      "descriptionWithMarkdown": "Checks whether your Hydrogen app includes a set of standard Shopify routes.",
-      "enableJsonFlag": false,
       "flags": {
         "path": {
           "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
           "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
+          "name": "path",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "path",
           "type": "option"
         }
       },
       "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
+      "hiddenAliases": [],
       "id": "hydrogen:check",
       "pluginAlias": "@shopify/cli",
       "pluginName": "@shopify/cli",
       "pluginType": "core",
-      "strict": true
+      "strict": true,
+      "enableJsonFlag": false,
+      "descriptionWithMarkdown": "Checks whether your Hydrogen app includes a set of standard Shopify routes.",
+      "customPluginName": "@shopify/cli-hydrogen"
     },
     "hydrogen:codegen": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/cli-hydrogen",
+      "aliases": [],
+      "args": {},
       "description": "Generate types for the Storefront API queries found in your project.",
-      "descriptionWithMarkdown": "Automatically generates GraphQL types for your project’s Storefront API queries.",
-      "enableJsonFlag": false,
       "flags": {
-        "codegen-config-path": {
-          "description": "Specify a path to a codegen configuration file. Defaults to `<root>/codegen.ts` if it exists.",
+        "path": {
+          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
+          "name": "path",
           "hasDynamicHelp": false,
           "multiple": false,
+          "type": "option"
+        },
+        "codegen-config-path": {
+          "description": "Specify a path to a codegen configuration file. Defaults to `<root>/codegen.ts` if it exists.",
           "name": "codegen-config-path",
           "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
           "type": "option"
         },
         "force-sfapi-version": {
           "description": "Force generating Storefront API types for a specific version instead of using the one provided in Hydrogen. A token can also be provided with this format: `<version>:<token>`.",
-          "hasDynamicHelp": false,
           "hidden": true,
-          "multiple": false,
           "name": "force-sfapi-version",
-          "type": "option"
-        },
-        "path": {
-          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "path",
           "type": "option"
         },
         "watch": {
-          "allowNo": false,
           "description": "Watch the project for changes to update types on file save.",
           "name": "watch",
           "required": false,
+          "allowNo": false,
           "type": "boolean"
         }
       },
       "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
+      "hiddenAliases": [],
       "id": "hydrogen:codegen",
       "pluginAlias": "@shopify/cli",
       "pluginName": "@shopify/cli",
       "pluginType": "core",
-      "strict": true
-    },
-    "hydrogen:customer-account-push": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/cli-hydrogen",
-      "description": "Push project configuration to admin",
+      "strict": true,
       "enableJsonFlag": false,
-      "flags": {
-        "dev-origin": {
-          "description": "The development domain of your application.",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "dev-origin",
-          "required": true,
-          "type": "option"
-        },
-        "path": {
-          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "path",
-          "type": "option"
-        },
-        "relative-logout-uri": {
-          "description": "The relative url of allowed url that will be redirected to post-logout for Customer Account API OAuth flow. Default to nothing.",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "relative-logout-uri",
-          "type": "option"
-        },
-        "relative-redirect-uri": {
-          "description": "The relative url of allowed callback url for Customer Account API OAuth flow. Default is '/account/authorize'",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "relative-redirect-uri",
-          "type": "option"
-        },
-        "storefront-id": {
-          "description": "The id of the storefront the configuration should be pushed to. Must start with 'gid://shopify/HydrogenStorefront/'",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "storefront-id",
-          "type": "option"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "hydrogen:customer-account-push",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true
+      "descriptionWithMarkdown": "Automatically generates GraphQL types for your project’s Storefront API queries.",
+      "customPluginName": "@shopify/cli-hydrogen"
     },
-    "hydrogen:debug:cpu": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/cli-hydrogen",
-      "description": "Builds and profiles the server startup time the app.",
-      "descriptionWithMarkdown": "Builds the app and runs the resulting code to profile the server startup time, watching for changes. This command can be used to [debug slow app startup times](https://shopify.dev/docs/custom-storefronts/hydrogen/debugging/cpu-startup) that cause failed deployments in Oxygen.\n\n  The profiling results are written to a `.cpuprofile` file that can be viewed with certain tools such as [Flame Chart Visualizer for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=ms-vscode.vscode-js-profile-flame).",
-      "enableJsonFlag": false,
+    "hydrogen:deploy": {
+      "aliases": [],
+      "args": {},
+      "description": "Builds and deploys a Hydrogen storefront to Oxygen.",
       "flags": {
         "entry": {
           "description": "Entry file for the worker. Defaults to `./server`.",
           "env": "SHOPIFY_HYDROGEN_FLAG_ENTRY",
-          "hasDynamicHelp": false,
-          "multiple": false,
           "name": "entry",
-          "type": "option"
-        },
-        "output": {
-          "default": "startup.cpuprofile",
-          "description": "Specify a path to generate the profile file. Defaults to \"startup.cpuprofile\".",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "output",
+          "type": "option"
+        },
+        "env": {
+          "description": "Specifies the environment to perform the operation using its handle. Fetch the handle using the `env list` command.",
+          "exclusive": [
+            "env-branch"
+          ],
+          "name": "env",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "env-branch": {
+          "deprecated": {
+            "to": "env",
+            "message": "--env-branch is deprecated. Use --env instead."
+          },
+          "description": "Specifies the environment to perform the operation using its Git branch name.",
+          "env": "SHOPIFY_HYDROGEN_ENVIRONMENT_BRANCH",
+          "name": "env-branch",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "env-file": {
+          "description": "Path to an environment file to override existing environment variables for the deployment.",
+          "name": "env-file",
           "required": false,
-          "type": "option"
-        },
-        "path": {
-          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "path",
           "type": "option"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "hydrogen:debug:cpu",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true
-    },
-    "hydrogen:deploy": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/cli-hydrogen",
-      "description": "Builds and deploys a Hydrogen storefront to Oxygen.",
-      "descriptionWithMarkdown": "Builds and deploys your Hydrogen storefront to Oxygen. Requires an Oxygen deployment token to be set with the `--token` flag or an environment variable (`SHOPIFY_HYDROGEN_DEPLOYMENT_TOKEN`). If the storefront is [linked](https://shopify.dev/docs/api/shopify-cli/hydrogen/hydrogen-link) then the Oxygen deployment token for the linked storefront will be used automatically.",
-      "enableJsonFlag": false,
-      "flags": {
-        "auth-bypass-token": {
+        },
+        "preview": {
+          "description": "Deploys to the Preview environment.",
+          "name": "preview",
+          "required": false,
           "allowNo": false,
+          "type": "boolean"
+        },
+        "force": {
+          "char": "f",
+          "description": "Forces a deployment to proceed if there are uncommited changes in its Git repository.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_FORCE",
+          "name": "force",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "no-verify": {
+          "description": "Skip the routability verification step after deployment.",
+          "name": "no-verify",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "auth-bypass-token": {
           "description": "Generate an authentication bypass token, which can be used to perform end-to-end tests against the deployment.",
           "env": "AUTH_BYPASS_TOKEN",
           "name": "auth-bypass-token",
           "required": false,
+          "allowNo": false,
           "type": "boolean"
         },
         "auth-bypass-token-duration": {
@@ -3873,26 +6418,390 @@
           ],
           "description": "Specify the duration (in hours) up to 12 hours for the authentication bypass token. Defaults to `2`",
           "env": "AUTH_BYPASS_TOKEN_DURATION",
-          "hasDynamicHelp": false,
-          "multiple": false,
           "name": "auth-bypass-token-duration",
           "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
           "type": "option"
         },
         "build-command": {
           "description": "Specify a build command to run before deploying. If not specified, `shopify hydrogen build` will be used.",
-          "hasDynamicHelp": false,
-          "multiple": false,
           "name": "build-command",
           "required": false,
-          "type": "option"
-        },
-        "entry": {
-          "description": "Entry file for the worker. Defaults to `./server`.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_ENTRY",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "entry",
+          "type": "option"
+        },
+        "lockfile-check": {
+          "description": "Checks that there is exactly one valid lockfile in the project. Defaults to `true`. Deactivate with `--no-lockfile-check`.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_LOCKFILE_CHECK",
+          "name": "lockfile-check",
+          "allowNo": true,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
+          "name": "path",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "shop": {
+          "char": "s",
+          "description": "Shop URL. It can be the shop prefix (janes-apparel) or the full myshopify.com URL (janes-apparel.myshopify.com, https://janes-apparel.myshopify.com).",
+          "env": "SHOPIFY_SHOP",
+          "name": "shop",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "json-output": {
+          "description": "Create a JSON file containing the deployment details in CI environments. Defaults to true, use `--no-json-output` to disable.",
+          "name": "json-output",
+          "required": false,
+          "allowNo": true,
+          "type": "boolean"
+        },
+        "token": {
+          "char": "t",
+          "description": "Oxygen deployment token. Defaults to the linked storefront's token if available.",
+          "env": "SHOPIFY_HYDROGEN_DEPLOYMENT_TOKEN",
+          "name": "token",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "metadata-description": {
+          "description": "Description of the changes in the deployment. Defaults to the commit message of the latest commit if there are no uncommited changes.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_METADATA_DESCRIPTION",
+          "name": "metadata-description",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "metadata-url": {
+          "env": "SHOPIFY_HYDROGEN_FLAG_METADATA_URL",
+          "hidden": true,
+          "name": "metadata-url",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "metadata-user": {
+          "description": "User that initiated the deployment. Will be saved and displayed in the Shopify admin",
+          "env": "SHOPIFY_HYDROGEN_FLAG_METADATA_USER",
+          "name": "metadata-user",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "metadata-version": {
+          "env": "SHOPIFY_HYDROGEN_FLAG_METADATA_VERSION",
+          "hidden": true,
+          "name": "metadata-version",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "force-client-sourcemap": {
+          "description": "Client sourcemapping is avoided by default because it makes backend code visible in the browser. Use this flag to force enabling it.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_FORCE_CLIENT_SOURCEMAP",
+          "name": "force-client-sourcemap",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "hydrogen:deploy",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false,
+      "descriptionWithMarkdown": "Builds and deploys your Hydrogen storefront to Oxygen. Requires an Oxygen deployment token to be set with the `--token` flag or an environment variable (`SHOPIFY_HYDROGEN_DEPLOYMENT_TOKEN`). If the storefront is [linked](https://shopify.dev/docs/api/shopify-cli/hydrogen/hydrogen-link) then the Oxygen deployment token for the linked storefront will be used automatically.",
+      "customPluginName": "@shopify/cli-hydrogen"
+    },
+    "hydrogen:g": {
+      "aliases": [],
+      "args": {},
+      "description": "Shortcut for `hydrogen generate`. See `hydrogen generate --help` for more information.",
+      "flags": {},
+      "hasDynamicHelp": false,
+      "hidden": true,
+      "hiddenAliases": [],
+      "id": "hydrogen:g",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": false,
+      "enableJsonFlag": false,
+      "customPluginName": "@shopify/cli-hydrogen"
+    },
+    "hydrogen:init": {
+      "aliases": [],
+      "args": {},
+      "description": "Creates a new Hydrogen storefront.",
+      "flags": {
+        "force": {
+          "char": "f",
+          "description": "Overwrites the destination directory and files if they already exist.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_FORCE",
+          "name": "force",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path to the directory of the new Hydrogen storefront.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
+          "name": "path",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "language": {
+          "description": "Sets the template language to use. One of `js` or `ts`.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_LANGUAGE",
+          "name": "language",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "template": {
+          "description": "Scaffolds project based on an existing template or example from the Hydrogen repository.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_TEMPLATE",
+          "name": "template",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "install-deps": {
+          "description": "Auto installs dependencies using the active package manager.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_INSTALL_DEPS",
+          "name": "install-deps",
+          "allowNo": true,
+          "type": "boolean"
+        },
+        "mock-shop": {
+          "description": "Use mock.shop as the data source for the storefront.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_MOCK_DATA",
+          "name": "mock-shop",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "styling": {
+          "description": "Sets the styling strategy to use. One of `tailwind`, `vanilla-extract`, `css-modules`, `postcss`, `none`.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_STYLING",
+          "name": "styling",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "markets": {
+          "description": "Sets the URL structure to support multiple markets. Must be one of: `subfolders`, `domains`, `subdomains`, `none`. Example: `--markets subfolders`.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_I18N",
+          "name": "markets",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "shortcut": {
+          "description": "Creates a global h2 shortcut for Shopify CLI using shell aliases. Deactivate with `--no-shortcut`.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_SHORTCUT",
+          "name": "shortcut",
+          "allowNo": true,
+          "type": "boolean"
+        },
+        "git": {
+          "description": "Init Git and create initial commits.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_GIT",
+          "name": "git",
+          "allowNo": true,
+          "type": "boolean"
+        },
+        "quickstart": {
+          "description": "Scaffolds a new Hydrogen project with a set of sensible defaults. Equivalent to `shopify hydrogen init --path hydrogen-quickstart --mock-shop --language js --shortcut --markets none`",
+          "env": "SHOPIFY_HYDROGEN_FLAG_QUICKSTART",
+          "name": "quickstart",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "package-manager": {
+          "env": "SHOPIFY_HYDROGEN_FLAG_PACKAGE_MANAGER",
+          "hidden": true,
+          "name": "package-manager",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "options": [
+            "npm",
+            "yarn",
+            "pnpm",
+            "unknown"
+          ],
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "hydrogen:init",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false,
+      "descriptionWithMarkdown": "Creates a new Hydrogen storefront.",
+      "customPluginName": "@shopify/cli-hydrogen"
+    },
+    "hydrogen:link": {
+      "aliases": [],
+      "args": {},
+      "description": "Link a local project to one of your shop's Hydrogen storefronts.",
+      "flags": {
+        "force": {
+          "char": "f",
+          "description": "Overwrites the destination directory and files if they already exist.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_FORCE",
+          "name": "force",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
+          "name": "path",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "storefront": {
+          "description": "The name of a Hydrogen Storefront (e.g. \"Jane's Apparel\")",
+          "env": "SHOPIFY_HYDROGEN_STOREFRONT",
+          "name": "storefront",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "hydrogen:link",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false,
+      "descriptionWithMarkdown": "Links your local development environment to a remote Hydrogen storefront. You can link an unlimited number of development environments to a single Hydrogen storefront.\n\n  Linking to a Hydrogen storefront enables you to run [dev](https://shopify.dev/docs/api/shopify-cli/hydrogen/hydrogen-dev) and automatically inject your linked Hydrogen storefront's environment variables directly into the server runtime.\n\n  After you run the `link` command, you can access the [env list](https://shopify.dev/docs/api/shopify-cli/hydrogen/hydrogen-env-list), [env pull](https://shopify.dev/docs/api/shopify-cli/hydrogen/hydrogen-env-pull), and [unlink](https://shopify.dev/docs/api/shopify-cli/hydrogen/hydrogen-unlink) commands.",
+      "customPluginName": "@shopify/cli-hydrogen"
+    },
+    "hydrogen:list": {
+      "aliases": [],
+      "args": {},
+      "description": "Returns a list of Hydrogen storefronts available on a given shop.",
+      "flags": {
+        "path": {
+          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
+          "name": "path",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "hydrogen:list",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false,
+      "descriptionWithMarkdown": "Lists all remote Hydrogen storefronts available to link to your local development environment.",
+      "customPluginName": "@shopify/cli-hydrogen"
+    },
+    "hydrogen:login": {
+      "aliases": [],
+      "args": {},
+      "description": "Login to your Shopify account.",
+      "flags": {
+        "path": {
+          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
+          "name": "path",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "shop": {
+          "char": "s",
+          "description": "Shop URL. It can be the shop prefix (janes-apparel) or the full myshopify.com URL (janes-apparel.myshopify.com, https://janes-apparel.myshopify.com).",
+          "env": "SHOPIFY_SHOP",
+          "name": "shop",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "hydrogen:login",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false,
+      "descriptionWithMarkdown": "Logs in to the specified shop and saves the shop domain to the project.",
+      "customPluginName": "@shopify/cli-hydrogen"
+    },
+    "hydrogen:logout": {
+      "aliases": [],
+      "args": {},
+      "description": "Logout of your local session.",
+      "flags": {
+        "path": {
+          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
+          "name": "path",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "hydrogen:logout",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false,
+      "descriptionWithMarkdown": "Log out from the current shop.",
+      "customPluginName": "@shopify/cli-hydrogen"
+    },
+    "hydrogen:preview": {
+      "aliases": [],
+      "args": {},
+      "description": "Runs a Hydrogen storefront in an Oxygen worker for production.",
+      "flags": {
+        "path": {
+          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
+          "name": "path",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "port": {
+          "description": "The port to run the server on. Defaults to 3000.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_PORT",
+          "name": "port",
+          "hasDynamicHelp": false,
+          "multiple": false,
           "type": "option"
         },
         "env": {
@@ -3900,163 +6809,89 @@
           "exclusive": [
             "env-branch"
           ],
+          "name": "env",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "env",
           "type": "option"
         },
         "env-branch": {
           "deprecated": {
-            "message": "--env-branch is deprecated. Use --env instead.",
-            "to": "env"
+            "to": "env",
+            "message": "--env-branch is deprecated. Use --env instead."
           },
           "description": "Specifies the environment to perform the operation using its Git branch name.",
           "env": "SHOPIFY_HYDROGEN_ENVIRONMENT_BRANCH",
+          "name": "env-branch",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "env-branch",
           "type": "option"
         },
         "env-file": {
-          "description": "Path to an environment file to override existing environment variables for the deployment.",
-          "hasDynamicHelp": false,
-          "multiple": false,
+          "description": "Path to an environment file to override existing environment variables. Defaults to the '.env' located in your project path `--path`.",
           "name": "env-file",
           "required": false,
+          "default": ".env",
+          "hasDynamicHelp": false,
+          "multiple": false,
           "type": "option"
         },
-        "force": {
+        "inspector-port": {
+          "description": "The port where the inspector is available. Defaults to 9229.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_INSPECTOR_PORT",
+          "name": "inspector-port",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "debug": {
+          "description": "Enables inspector connections to the server with a debugger such as Visual Studio Code or Chrome DevTools.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_DEBUG",
+          "name": "debug",
           "allowNo": false,
-          "char": "f",
-          "description": "Forces a deployment to proceed if there are uncommited changes in its Git repository.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_FORCE",
-          "name": "force",
-          "required": false,
           "type": "boolean"
         },
-        "force-client-sourcemap": {
+        "verbose": {
+          "description": "Outputs more information about the command's execution.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_VERBOSE",
+          "name": "verbose",
+          "required": false,
           "allowNo": false,
-          "description": "Client sourcemapping is avoided by default because it makes backend code visible in the browser. Use this flag to force enabling it.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_FORCE_CLIENT_SOURCEMAP",
-          "name": "force-client-sourcemap",
           "type": "boolean"
         },
-        "json-output": {
-          "allowNo": true,
-          "description": "Create a JSON file containing the deployment details in CI environments. Defaults to true, use `--no-json-output` to disable.",
-          "name": "json-output",
-          "required": false,
-          "type": "boolean"
-        },
-        "lockfile-check": {
-          "allowNo": true,
-          "description": "Checks that there is exactly one valid lockfile in the project. Defaults to `true`. Deactivate with `--no-lockfile-check`.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_LOCKFILE_CHECK",
-          "name": "lockfile-check",
-          "type": "boolean"
-        },
-        "metadata-description": {
-          "description": "Description of the changes in the deployment. Defaults to the commit message of the latest commit if there are no uncommited changes.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_METADATA_DESCRIPTION",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "metadata-description",
-          "required": false,
-          "type": "option"
-        },
-        "metadata-url": {
-          "env": "SHOPIFY_HYDROGEN_FLAG_METADATA_URL",
-          "hasDynamicHelp": false,
-          "hidden": true,
-          "multiple": false,
-          "name": "metadata-url",
-          "required": false,
-          "type": "option"
-        },
-        "metadata-user": {
-          "description": "User that initiated the deployment. Will be saved and displayed in the Shopify admin",
-          "env": "SHOPIFY_HYDROGEN_FLAG_METADATA_USER",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "metadata-user",
-          "required": false,
-          "type": "option"
-        },
-        "metadata-version": {
-          "env": "SHOPIFY_HYDROGEN_FLAG_METADATA_VERSION",
-          "hasDynamicHelp": false,
-          "hidden": true,
-          "multiple": false,
-          "name": "metadata-version",
-          "required": false,
-          "type": "option"
-        },
-        "no-verify": {
+        "build": {
+          "description": "Builds the app before starting the preview server.",
+          "name": "build",
           "allowNo": false,
-          "description": "Skip the routability verification step after deployment.",
-          "name": "no-verify",
-          "required": false,
           "type": "boolean"
         },
-        "path": {
-          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "path",
-          "type": "option"
-        },
-        "preview": {
+        "watch": {
+          "dependsOn": [
+            "build"
+          ],
+          "description": "Watches for changes and rebuilds the project.",
+          "name": "watch",
           "allowNo": false,
-          "description": "Deploys to the Preview environment.",
-          "name": "preview",
-          "required": false,
           "type": "boolean"
         },
-        "shop": {
-          "char": "s",
-          "description": "Shop URL. It can be the shop prefix (janes-apparel) or the full myshopify.com URL (janes-apparel.myshopify.com, https://janes-apparel.myshopify.com).",
-          "env": "SHOPIFY_SHOP",
+        "entry": {
+          "dependsOn": [
+            "build"
+          ],
+          "description": "Entry file for the worker. Defaults to `./server`.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_ENTRY",
+          "name": "entry",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "shop",
           "type": "option"
         },
-        "token": {
-          "char": "t",
-          "description": "Oxygen deployment token. Defaults to the linked storefront's token if available.",
-          "env": "SHOPIFY_HYDROGEN_DEPLOYMENT_TOKEN",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "token",
-          "required": false,
-          "type": "option"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "hydrogen:deploy",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true
-    },
-    "hydrogen:dev": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/cli-hydrogen",
-      "description": "Runs Hydrogen storefront in an Oxygen worker for development.",
-      "descriptionWithMarkdown": "Runs a Hydrogen storefront in a local runtime that emulates an Oxygen worker for development.\n\n  If your project is [linked](https://shopify.dev/docs/api/shopify-cli/hydrogen/hydrogen-link) to a Hydrogen storefront, then its environment variables will be loaded with the runtime.",
-      "enableJsonFlag": false,
-      "flags": {
         "codegen": {
-          "allowNo": false,
+          "dependsOn": [
+            "build"
+          ],
           "description": "Automatically generates GraphQL types for your project’s Storefront API queries.",
           "name": "codegen",
           "required": false,
+          "allowNo": false,
           "type": "boolean"
         },
         "codegen-config-path": {
@@ -4064,301 +6899,390 @@
             "codegen"
           ],
           "description": "Specifies a path to a codegen configuration file. Defaults to `<root>/codegen.ts` if this file exists.",
-          "hasDynamicHelp": false,
-          "multiple": false,
           "name": "codegen-config-path",
           "required": false,
-          "type": "option"
-        },
-        "customer-account-push": {
-          "allowNo": false,
-          "description": "Use tunneling for local development and push the tunneling domain to admin. Required to use Customer Account API's OAuth flow",
-          "env": "SHOPIFY_HYDROGEN_FLAG_CUSTOMER_ACCOUNT_PUSH",
-          "name": "customer-account-push",
-          "required": false,
-          "type": "boolean"
-        },
-        "debug": {
-          "allowNo": false,
-          "description": "Enables inspector connections to the server with a debugger such as Visual Studio Code or Chrome DevTools.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_DEBUG",
-          "name": "debug",
-          "type": "boolean"
-        },
-        "disable-deps-optimizer": {
-          "allowNo": false,
-          "description": "Disable adding dependencies to Vite's `ssr.optimizeDeps.include` automatically",
-          "env": "SHOPIFY_HYDROGEN_FLAG_DISABLE_DEPS_OPTIMIZER",
-          "name": "disable-deps-optimizer",
-          "type": "boolean"
-        },
-        "disable-version-check": {
-          "allowNo": false,
-          "description": "Skip the version check when running `hydrogen dev`",
-          "name": "disable-version-check",
-          "required": false,
-          "type": "boolean"
-        },
-        "disable-virtual-routes": {
-          "allowNo": false,
-          "description": "Disable rendering fallback routes when a route file doesn't exist.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_DISABLE_VIRTUAL_ROUTES",
-          "name": "disable-virtual-routes",
-          "type": "boolean"
-        },
-        "entry": {
-          "description": "Entry file for the worker. Defaults to `./server`.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_ENTRY",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "entry",
-          "type": "option"
-        },
-        "env": {
-          "description": "Specifies the environment to perform the operation using its handle. Fetch the handle using the `env list` command.",
-          "exclusive": [
-            "env-branch"
-          ],
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "env",
-          "type": "option"
-        },
-        "env-branch": {
-          "deprecated": {
-            "message": "--env-branch is deprecated. Use --env instead.",
-            "to": "env"
-          },
-          "description": "Specifies the environment to perform the operation using its Git branch name.",
-          "env": "SHOPIFY_HYDROGEN_ENVIRONMENT_BRANCH",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "env-branch",
-          "type": "option"
-        },
-        "env-file": {
-          "default": ".env",
-          "description": "Path to an environment file to override existing environment variables. Defaults to the '.env' located in your project path `--path`.",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "env-file",
-          "required": false,
-          "type": "option"
-        },
-        "host": {
-          "allowNo": false,
-          "description": "Expose the server to the local network",
-          "name": "host",
-          "required": false,
-          "type": "boolean"
-        },
-        "inspector-port": {
-          "description": "The port where the inspector is available. Defaults to 9229.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_INSPECTOR_PORT",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "inspector-port",
-          "type": "option"
-        },
-        "path": {
-          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "path",
-          "type": "option"
-        },
-        "port": {
-          "description": "The port to run the server on. Defaults to 3000.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_PORT",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "port",
-          "required": false,
-          "type": "option"
-        },
-        "verbose": {
-          "allowNo": false,
-          "description": "Outputs more information about the command's execution.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_VERBOSE",
-          "name": "verbose",
-          "required": false,
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "hydrogen:dev",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true
-    },
-    "hydrogen:env:list": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/cli-hydrogen",
-      "description": "List the environments on your linked Hydrogen storefront.",
-      "descriptionWithMarkdown": "Lists all environments available on the linked Hydrogen storefront.",
-      "enableJsonFlag": false,
-      "flags": {
-        "path": {
-          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "path",
           "type": "option"
         }
       },
       "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "hydrogen:env:list",
+      "hiddenAliases": [],
+      "id": "hydrogen:preview",
       "pluginAlias": "@shopify/cli",
       "pluginName": "@shopify/cli",
       "pluginType": "core",
-      "strict": true
-    },
-    "hydrogen:env:pull": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/cli-hydrogen",
-      "description": "Populate your .env with variables from your Hydrogen storefront.",
-      "descriptionWithMarkdown": "Pulls environment variables from the linked Hydrogen storefront and writes them to an `.env` file.",
+      "strict": true,
       "enableJsonFlag": false,
+      "descriptionWithMarkdown": "Runs a server in your local development environment that serves your Hydrogen app's production build. Requires running the [build](https://shopify.dev/docs/api/shopify-cli/hydrogen/hydrogen-build) command first.",
+      "customPluginName": "@shopify/cli-hydrogen"
+    },
+    "hydrogen:setup": {
+      "aliases": [],
+      "args": {},
+      "description": "Scaffold routes and core functionality.",
       "flags": {
-        "env": {
-          "description": "Specifies the environment to perform the operation using its handle. Fetch the handle using the `env list` command.",
-          "exclusive": [
-            "env-branch"
-          ],
+        "path": {
+          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
+          "name": "path",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "env",
-          "type": "option"
-        },
-        "env-branch": {
-          "deprecated": {
-            "message": "--env-branch is deprecated. Use --env instead.",
-            "to": "env"
-          },
-          "description": "Specifies the environment to perform the operation using its Git branch name.",
-          "env": "SHOPIFY_HYDROGEN_ENVIRONMENT_BRANCH",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "env-branch",
-          "type": "option"
-        },
-        "env-file": {
-          "default": ".env",
-          "description": "Path to an environment file to override existing environment variables. Defaults to the '.env' located in your project path `--path`.",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "env-file",
-          "required": false,
           "type": "option"
         },
         "force": {
-          "allowNo": false,
           "char": "f",
           "description": "Overwrites the destination directory and files if they already exist.",
           "env": "SHOPIFY_HYDROGEN_FLAG_FORCE",
           "name": "force",
+          "allowNo": false,
           "type": "boolean"
         },
+        "markets": {
+          "description": "Sets the URL structure to support multiple markets. Must be one of: `subfolders`, `domains`, `subdomains`, `none`. Example: `--markets subfolders`.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_I18N",
+          "name": "markets",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "shortcut": {
+          "description": "Creates a global h2 shortcut for Shopify CLI using shell aliases. Deactivate with `--no-shortcut`.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_SHORTCUT",
+          "name": "shortcut",
+          "allowNo": true,
+          "type": "boolean"
+        },
+        "install-deps": {
+          "description": "Auto installs dependencies using the active package manager.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_INSTALL_DEPS",
+          "name": "install-deps",
+          "allowNo": true,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "hydrogen:setup",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false,
+      "customPluginName": "@shopify/cli-hydrogen"
+    },
+    "hydrogen:shortcut": {
+      "aliases": [],
+      "args": {},
+      "description": "Creates a global `h2` shortcut for the Hydrogen CLI",
+      "flags": {},
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "hydrogen:shortcut",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false,
+      "descriptionWithMarkdown": "Creates a global h2 shortcut for Shopify CLI using shell aliases.\n\n  The following shells are supported:\n\n  - Bash (using `~/.bashrc`)\n  - ZSH (using `~/.zshrc`)\n  - Fish (using `~/.config/fish/functions`)\n  - PowerShell (added to `$PROFILE`)\n\n  After the alias is created, you can call Shopify CLI from anywhere in your project using `h2 <command>`.",
+      "customPluginName": "@shopify/cli-hydrogen"
+    },
+    "hydrogen:unlink": {
+      "aliases": [],
+      "args": {},
+      "description": "Unlink a local project from a Hydrogen storefront.",
+      "flags": {
         "path": {
           "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
           "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
+          "name": "path",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "path",
           "type": "option"
         }
       },
       "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "hydrogen:env:pull",
+      "hiddenAliases": [],
+      "id": "hydrogen:unlink",
       "pluginAlias": "@shopify/cli",
       "pluginName": "@shopify/cli",
       "pluginType": "core",
-      "strict": true
-    },
-    "hydrogen:env:push": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/cli-hydrogen",
-      "description": "Push environment variables from the local .env file to your linked Hydrogen storefront.",
+      "strict": true,
       "enableJsonFlag": false,
+      "descriptionWithMarkdown": "Unlinks your local development environment from a remote Hydrogen storefront.",
+      "customPluginName": "@shopify/cli-hydrogen"
+    },
+    "hydrogen:upgrade": {
+      "aliases": [],
+      "args": {},
+      "description": "Upgrade Remix and Hydrogen npm dependencies.",
+      "flags": {
+        "path": {
+          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
+          "name": "path",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "version": {
+          "char": "v",
+          "description": "A target hydrogen version to update to",
+          "name": "version",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "force": {
+          "char": "f",
+          "description": "Ignore warnings and force the upgrade to the target version",
+          "env": "SHOPIFY_HYDROGEN_FLAG_FORCE",
+          "name": "force",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "hydrogen:upgrade",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false,
+      "descriptionWithMarkdown": "Upgrade Hydrogen project dependencies, preview features, fixes and breaking changes. The command also generates an instruction file for each upgrade.",
+      "customPluginName": "@shopify/cli-hydrogen"
+    },
+    "hydrogen:customer-account-push": {
+      "aliases": [],
+      "args": {},
+      "description": "Push project configuration to admin",
+      "flags": {
+        "path": {
+          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
+          "name": "path",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "storefront-id": {
+          "description": "The id of the storefront the configuration should be pushed to. Must start with 'gid://shopify/HydrogenStorefront/'",
+          "name": "storefront-id",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "dev-origin": {
+          "description": "The development domain of your application.",
+          "name": "dev-origin",
+          "required": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "relative-redirect-uri": {
+          "description": "The relative url of allowed callback url for Customer Account API OAuth flow. Default is '/account/authorize'",
+          "name": "relative-redirect-uri",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "relative-logout-uri": {
+          "description": "The relative url of allowed url that will be redirected to post-logout for Customer Account API OAuth flow. Default to nothing.",
+          "name": "relative-logout-uri",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "hydrogen:customer-account-push",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false,
+      "customPluginName": "@shopify/cli-hydrogen"
+    },
+    "hydrogen:debug:cpu": {
+      "aliases": [],
+      "args": {},
+      "description": "Builds and profiles the server startup time the app.",
+      "flags": {
+        "path": {
+          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
+          "name": "path",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "entry": {
+          "description": "Entry file for the worker. Defaults to `./server`.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_ENTRY",
+          "name": "entry",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "output": {
+          "description": "Specify a path to generate the profile file. Defaults to \"startup.cpuprofile\".",
+          "name": "output",
+          "required": false,
+          "default": "startup.cpuprofile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "hydrogen:debug:cpu",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false,
+      "descriptionWithMarkdown": "Builds the app and runs the resulting code to profile the server startup time, watching for changes. This command can be used to [debug slow app startup times](https://shopify.dev/docs/custom-storefronts/hydrogen/debugging/cpu-startup) that cause failed deployments in Oxygen.\n\n  The profiling results are written to a `.cpuprofile` file that can be viewed with certain tools such as [Flame Chart Visualizer for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=ms-vscode.vscode-js-profile-flame).",
+      "customPluginName": "@shopify/cli-hydrogen"
+    },
+    "hydrogen:env:list": {
+      "aliases": [],
+      "args": {},
+      "description": "List the environments on your linked Hydrogen storefront.",
+      "flags": {
+        "path": {
+          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
+          "name": "path",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "hydrogen:env:list",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false,
+      "descriptionWithMarkdown": "Lists all environments available on the linked Hydrogen storefront.",
+      "customPluginName": "@shopify/cli-hydrogen"
+    },
+    "hydrogen:env:pull": {
+      "aliases": [],
+      "args": {},
+      "description": "Populate your .env with variables from your Hydrogen storefront.",
       "flags": {
         "env": {
           "description": "Specifies the environment to perform the operation using its handle. Fetch the handle using the `env list` command.",
           "exclusive": [
             "env-branch"
           ],
+          "name": "env",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "env",
+          "type": "option"
+        },
+        "env-branch": {
+          "deprecated": {
+            "to": "env",
+            "message": "--env-branch is deprecated. Use --env instead."
+          },
+          "description": "Specifies the environment to perform the operation using its Git branch name.",
+          "env": "SHOPIFY_HYDROGEN_ENVIRONMENT_BRANCH",
+          "name": "env-branch",
+          "hasDynamicHelp": false,
+          "multiple": false,
           "type": "option"
         },
         "env-file": {
-          "default": ".env",
           "description": "Path to an environment file to override existing environment variables. Defaults to the '.env' located in your project path `--path`.",
-          "hasDynamicHelp": false,
-          "multiple": false,
           "name": "env-file",
           "required": false,
+          "default": ".env",
+          "hasDynamicHelp": false,
+          "multiple": false,
           "type": "option"
         },
         "path": {
           "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
           "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
+          "name": "path",
           "hasDynamicHelp": false,
           "multiple": false,
+          "type": "option"
+        },
+        "force": {
+          "char": "f",
+          "description": "Overwrites the destination directory and files if they already exist.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_FORCE",
+          "name": "force",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "hydrogen:env:pull",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false,
+      "descriptionWithMarkdown": "Pulls environment variables from the linked Hydrogen storefront and writes them to an `.env` file.",
+      "customPluginName": "@shopify/cli-hydrogen"
+    },
+    "hydrogen:env:push": {
+      "aliases": [],
+      "args": {},
+      "description": "Push environment variables from the local .env file to your linked Hydrogen storefront.",
+      "flags": {
+        "env": {
+          "description": "Specifies the environment to perform the operation using its handle. Fetch the handle using the `env list` command.",
+          "exclusive": [
+            "env-branch"
+          ],
+          "name": "env",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "env-file": {
+          "description": "Path to an environment file to override existing environment variables. Defaults to the '.env' located in your project path `--path`.",
+          "name": "env-file",
+          "required": false,
+          "default": ".env",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "path": {
+          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
           "name": "path",
+          "hasDynamicHelp": false,
+          "multiple": false,
           "type": "option"
         }
       },
       "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
+      "hiddenAliases": [],
       "id": "hydrogen:env:push",
       "pluginAlias": "@shopify/cli",
       "pluginName": "@shopify/cli",
       "pluginType": "core",
-      "strict": true
-    },
-    "hydrogen:g": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/cli-hydrogen",
-      "description": "Shortcut for `hydrogen generate`. See `hydrogen generate --help` for more information.",
+      "strict": true,
       "enableJsonFlag": false,
-      "flags": {
-      },
-      "hasDynamicHelp": false,
-      "hidden": true,
-      "hiddenAliases": [
-      ],
-      "id": "hydrogen:g",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": false
+      "customPluginName": "@shopify/cli-hydrogen"
     },
     "hydrogen:generate:route": {
-      "aliases": [
-      ],
+      "aliases": [],
       "args": {
         "routeName": {
           "description": "The route to generate. One of home,page,cart,products,collections,policies,blogs,account,search,robots,sitemap,tokenlessApi,all.",
@@ -4381,569 +7305,116 @@
           "required": true
         }
       },
-      "customPluginName": "@shopify/cli-hydrogen",
       "description": "Generates a standard Shopify route.",
-      "descriptionWithMarkdown": "Generates a set of default routes from the starter template.",
-      "enableJsonFlag": false,
       "flags": {
         "adapter": {
           "description": "Remix adapter used in the route. The default is `@shopify/remix-oxygen`.",
           "env": "SHOPIFY_HYDROGEN_FLAG_ADAPTER",
+          "name": "adapter",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "adapter",
           "type": "option"
         },
-        "force": {
+        "typescript": {
+          "description": "Generate TypeScript files",
+          "env": "SHOPIFY_HYDROGEN_FLAG_TYPESCRIPT",
+          "name": "typescript",
           "allowNo": false,
-          "char": "f",
-          "description": "Overwrites the destination directory and files if they already exist.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_FORCE",
-          "name": "force",
           "type": "boolean"
         },
         "locale-param": {
           "description": "The param name in Remix routes for the i18n locale, if any. Example: `locale` becomes ($locale).",
           "env": "SHOPIFY_HYDROGEN_FLAG_ADAPTER",
+          "name": "locale-param",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "locale-param",
           "type": "option"
+        },
+        "force": {
+          "char": "f",
+          "description": "Overwrites the destination directory and files if they already exist.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_FORCE",
+          "name": "force",
+          "allowNo": false,
+          "type": "boolean"
         },
         "path": {
           "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
           "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
+          "name": "path",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "path",
           "type": "option"
-        },
-        "typescript": {
-          "allowNo": false,
-          "description": "Generate TypeScript files",
-          "env": "SHOPIFY_HYDROGEN_FLAG_TYPESCRIPT",
-          "name": "typescript",
-          "type": "boolean"
         }
       },
       "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
+      "hiddenAliases": [],
       "id": "hydrogen:generate:route",
       "pluginAlias": "@shopify/cli",
       "pluginName": "@shopify/cli",
       "pluginType": "core",
-      "strict": true
+      "strict": true,
+      "enableJsonFlag": false,
+      "descriptionWithMarkdown": "Generates a set of default routes from the starter template.",
+      "customPluginName": "@shopify/cli-hydrogen"
     },
     "hydrogen:generate:routes": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/cli-hydrogen",
+      "aliases": [],
+      "args": {},
       "description": "Generates all supported standard shopify routes.",
-      "enableJsonFlag": false,
       "flags": {
         "adapter": {
           "description": "Remix adapter used in the route. The default is `@shopify/remix-oxygen`.",
           "env": "SHOPIFY_HYDROGEN_FLAG_ADAPTER",
+          "name": "adapter",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "adapter",
           "type": "option"
         },
-        "force": {
+        "typescript": {
+          "description": "Generate TypeScript files",
+          "env": "SHOPIFY_HYDROGEN_FLAG_TYPESCRIPT",
+          "name": "typescript",
           "allowNo": false,
-          "char": "f",
-          "description": "Overwrites the destination directory and files if they already exist.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_FORCE",
-          "name": "force",
           "type": "boolean"
         },
         "locale-param": {
           "description": "The param name in Remix routes for the i18n locale, if any. Example: `locale` becomes ($locale).",
           "env": "SHOPIFY_HYDROGEN_FLAG_ADAPTER",
+          "name": "locale-param",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "locale-param",
           "type": "option"
+        },
+        "force": {
+          "char": "f",
+          "description": "Overwrites the destination directory and files if they already exist.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_FORCE",
+          "name": "force",
+          "allowNo": false,
+          "type": "boolean"
         },
         "path": {
           "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
           "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
+          "name": "path",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "path",
           "type": "option"
-        },
-        "typescript": {
-          "allowNo": false,
-          "description": "Generate TypeScript files",
-          "env": "SHOPIFY_HYDROGEN_FLAG_TYPESCRIPT",
-          "name": "typescript",
-          "type": "boolean"
         }
       },
       "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
+      "hiddenAliases": [],
       "id": "hydrogen:generate:routes",
       "pluginAlias": "@shopify/cli",
       "pluginName": "@shopify/cli",
       "pluginType": "core",
-      "strict": true
-    },
-    "hydrogen:init": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/cli-hydrogen",
-      "description": "Creates a new Hydrogen storefront.",
-      "descriptionWithMarkdown": "Creates a new Hydrogen storefront.",
+      "strict": true,
       "enableJsonFlag": false,
-      "flags": {
-        "force": {
-          "allowNo": false,
-          "char": "f",
-          "description": "Overwrites the destination directory and files if they already exist.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_FORCE",
-          "name": "force",
-          "type": "boolean"
-        },
-        "git": {
-          "allowNo": true,
-          "description": "Init Git and create initial commits.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_GIT",
-          "name": "git",
-          "type": "boolean"
-        },
-        "install-deps": {
-          "allowNo": true,
-          "description": "Auto installs dependencies using the active package manager.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_INSTALL_DEPS",
-          "name": "install-deps",
-          "type": "boolean"
-        },
-        "language": {
-          "description": "Sets the template language to use. One of `js` or `ts`.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_LANGUAGE",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "language",
-          "type": "option"
-        },
-        "markets": {
-          "description": "Sets the URL structure to support multiple markets. Must be one of: `subfolders`, `domains`, `subdomains`, `none`. Example: `--markets subfolders`.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_I18N",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "markets",
-          "type": "option"
-        },
-        "mock-shop": {
-          "allowNo": false,
-          "description": "Use mock.shop as the data source for the storefront.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_MOCK_DATA",
-          "name": "mock-shop",
-          "type": "boolean"
-        },
-        "package-manager": {
-          "env": "SHOPIFY_HYDROGEN_FLAG_PACKAGE_MANAGER",
-          "hasDynamicHelp": false,
-          "hidden": true,
-          "multiple": false,
-          "name": "package-manager",
-          "options": [
-            "npm",
-            "yarn",
-            "pnpm",
-            "unknown"
-          ],
-          "type": "option"
-        },
-        "path": {
-          "description": "The path to the directory of the new Hydrogen storefront.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "path",
-          "type": "option"
-        },
-        "quickstart": {
-          "allowNo": false,
-          "description": "Scaffolds a new Hydrogen project with a set of sensible defaults. Equivalent to `shopify hydrogen init --path hydrogen-quickstart --mock-shop --language js --shortcut --markets none`",
-          "env": "SHOPIFY_HYDROGEN_FLAG_QUICKSTART",
-          "name": "quickstart",
-          "type": "boolean"
-        },
-        "shortcut": {
-          "allowNo": true,
-          "description": "Creates a global h2 shortcut for Shopify CLI using shell aliases. Deactivate with `--no-shortcut`.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_SHORTCUT",
-          "name": "shortcut",
-          "type": "boolean"
-        },
-        "styling": {
-          "description": "Sets the styling strategy to use. One of `tailwind`, `vanilla-extract`, `css-modules`, `postcss`, `none`.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_STYLING",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "styling",
-          "type": "option"
-        },
-        "template": {
-          "description": "Scaffolds project based on an existing template or example from the Hydrogen repository.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_TEMPLATE",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "template",
-          "type": "option"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "hydrogen:init",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true
-    },
-    "hydrogen:link": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/cli-hydrogen",
-      "description": "Link a local project to one of your shop's Hydrogen storefronts.",
-      "descriptionWithMarkdown": "Links your local development environment to a remote Hydrogen storefront. You can link an unlimited number of development environments to a single Hydrogen storefront.\n\n  Linking to a Hydrogen storefront enables you to run [dev](https://shopify.dev/docs/api/shopify-cli/hydrogen/hydrogen-dev) and automatically inject your linked Hydrogen storefront's environment variables directly into the server runtime.\n\n  After you run the `link` command, you can access the [env list](https://shopify.dev/docs/api/shopify-cli/hydrogen/hydrogen-env-list), [env pull](https://shopify.dev/docs/api/shopify-cli/hydrogen/hydrogen-env-pull), and [unlink](https://shopify.dev/docs/api/shopify-cli/hydrogen/hydrogen-unlink) commands.",
-      "enableJsonFlag": false,
-      "flags": {
-        "force": {
-          "allowNo": false,
-          "char": "f",
-          "description": "Overwrites the destination directory and files if they already exist.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_FORCE",
-          "name": "force",
-          "type": "boolean"
-        },
-        "path": {
-          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "path",
-          "type": "option"
-        },
-        "storefront": {
-          "description": "The name of a Hydrogen Storefront (e.g. \"Jane's Apparel\")",
-          "env": "SHOPIFY_HYDROGEN_STOREFRONT",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "storefront",
-          "type": "option"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "hydrogen:link",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true
-    },
-    "hydrogen:list": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/cli-hydrogen",
-      "description": "Returns a list of Hydrogen storefronts available on a given shop.",
-      "descriptionWithMarkdown": "Lists all remote Hydrogen storefronts available to link to your local development environment.",
-      "enableJsonFlag": false,
-      "flags": {
-        "path": {
-          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "path",
-          "type": "option"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "hydrogen:list",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true
-    },
-    "hydrogen:login": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/cli-hydrogen",
-      "description": "Login to your Shopify account.",
-      "descriptionWithMarkdown": "Logs in to the specified shop and saves the shop domain to the project.",
-      "enableJsonFlag": false,
-      "flags": {
-        "path": {
-          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "path",
-          "type": "option"
-        },
-        "shop": {
-          "char": "s",
-          "description": "Shop URL. It can be the shop prefix (janes-apparel) or the full myshopify.com URL (janes-apparel.myshopify.com, https://janes-apparel.myshopify.com).",
-          "env": "SHOPIFY_SHOP",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "shop",
-          "type": "option"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "hydrogen:login",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true
-    },
-    "hydrogen:logout": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/cli-hydrogen",
-      "description": "Logout of your local session.",
-      "descriptionWithMarkdown": "Log out from the current shop.",
-      "enableJsonFlag": false,
-      "flags": {
-        "path": {
-          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "path",
-          "type": "option"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "hydrogen:logout",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true
-    },
-    "hydrogen:preview": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/cli-hydrogen",
-      "description": "Runs a Hydrogen storefront in an Oxygen worker for production.",
-      "descriptionWithMarkdown": "Runs a server in your local development environment that serves your Hydrogen app's production build. Requires running the [build](https://shopify.dev/docs/api/shopify-cli/hydrogen/hydrogen-build) command first.",
-      "enableJsonFlag": false,
-      "flags": {
-        "build": {
-          "allowNo": false,
-          "description": "Builds the app before starting the preview server.",
-          "name": "build",
-          "type": "boolean"
-        },
-        "codegen": {
-          "allowNo": false,
-          "dependsOn": [
-            "build"
-          ],
-          "description": "Automatically generates GraphQL types for your project’s Storefront API queries.",
-          "name": "codegen",
-          "required": false,
-          "type": "boolean"
-        },
-        "codegen-config-path": {
-          "dependsOn": [
-            "codegen"
-          ],
-          "description": "Specifies a path to a codegen configuration file. Defaults to `<root>/codegen.ts` if this file exists.",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "codegen-config-path",
-          "required": false,
-          "type": "option"
-        },
-        "debug": {
-          "allowNo": false,
-          "description": "Enables inspector connections to the server with a debugger such as Visual Studio Code or Chrome DevTools.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_DEBUG",
-          "name": "debug",
-          "type": "boolean"
-        },
-        "entry": {
-          "dependsOn": [
-            "build"
-          ],
-          "description": "Entry file for the worker. Defaults to `./server`.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_ENTRY",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "entry",
-          "type": "option"
-        },
-        "env": {
-          "description": "Specifies the environment to perform the operation using its handle. Fetch the handle using the `env list` command.",
-          "exclusive": [
-            "env-branch"
-          ],
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "env",
-          "type": "option"
-        },
-        "env-branch": {
-          "deprecated": {
-            "message": "--env-branch is deprecated. Use --env instead.",
-            "to": "env"
-          },
-          "description": "Specifies the environment to perform the operation using its Git branch name.",
-          "env": "SHOPIFY_HYDROGEN_ENVIRONMENT_BRANCH",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "env-branch",
-          "type": "option"
-        },
-        "env-file": {
-          "default": ".env",
-          "description": "Path to an environment file to override existing environment variables. Defaults to the '.env' located in your project path `--path`.",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "env-file",
-          "required": false,
-          "type": "option"
-        },
-        "inspector-port": {
-          "description": "The port where the inspector is available. Defaults to 9229.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_INSPECTOR_PORT",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "inspector-port",
-          "type": "option"
-        },
-        "path": {
-          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "path",
-          "type": "option"
-        },
-        "port": {
-          "description": "The port to run the server on. Defaults to 3000.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_PORT",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "port",
-          "type": "option"
-        },
-        "verbose": {
-          "allowNo": false,
-          "description": "Outputs more information about the command's execution.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_VERBOSE",
-          "name": "verbose",
-          "required": false,
-          "type": "boolean"
-        },
-        "watch": {
-          "allowNo": false,
-          "dependsOn": [
-            "build"
-          ],
-          "description": "Watches for changes and rebuilds the project.",
-          "name": "watch",
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "hydrogen:preview",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true
-    },
-    "hydrogen:setup": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/cli-hydrogen",
-      "description": "Scaffold routes and core functionality.",
-      "enableJsonFlag": false,
-      "flags": {
-        "force": {
-          "allowNo": false,
-          "char": "f",
-          "description": "Overwrites the destination directory and files if they already exist.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_FORCE",
-          "name": "force",
-          "type": "boolean"
-        },
-        "install-deps": {
-          "allowNo": true,
-          "description": "Auto installs dependencies using the active package manager.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_INSTALL_DEPS",
-          "name": "install-deps",
-          "type": "boolean"
-        },
-        "markets": {
-          "description": "Sets the URL structure to support multiple markets. Must be one of: `subfolders`, `domains`, `subdomains`, `none`. Example: `--markets subfolders`.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_I18N",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "markets",
-          "type": "option"
-        },
-        "path": {
-          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "path",
-          "type": "option"
-        },
-        "shortcut": {
-          "allowNo": true,
-          "description": "Creates a global h2 shortcut for Shopify CLI using shell aliases. Deactivate with `--no-shortcut`.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_SHORTCUT",
-          "name": "shortcut",
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "hydrogen:setup",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true
+      "customPluginName": "@shopify/cli-hydrogen"
     },
     "hydrogen:setup:css": {
-      "aliases": [
-      ],
+      "aliases": [],
       "args": {
         "strategy": {
           "description": "The CSS strategy to setup. One of tailwind,vanilla-extract,css-modules,postcss",
@@ -4956,47 +7427,45 @@
           ]
         }
       },
-      "customPluginName": "@shopify/cli-hydrogen",
       "description": "Setup CSS strategies for your project.",
-      "descriptionWithMarkdown": "Adds support for certain CSS strategies to your project.",
-      "enableJsonFlag": false,
       "flags": {
+        "path": {
+          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
+          "name": "path",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
         "force": {
-          "allowNo": false,
           "char": "f",
           "description": "Overwrites the destination directory and files if they already exist.",
           "env": "SHOPIFY_HYDROGEN_FLAG_FORCE",
           "name": "force",
+          "allowNo": false,
           "type": "boolean"
         },
         "install-deps": {
-          "allowNo": true,
           "description": "Auto installs dependencies using the active package manager.",
           "env": "SHOPIFY_HYDROGEN_FLAG_INSTALL_DEPS",
           "name": "install-deps",
+          "allowNo": true,
           "type": "boolean"
-        },
-        "path": {
-          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "path",
-          "type": "option"
         }
       },
       "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
+      "hiddenAliases": [],
       "id": "hydrogen:setup:css",
       "pluginAlias": "@shopify/cli",
       "pluginName": "@shopify/cli",
       "pluginType": "core",
-      "strict": true
+      "strict": true,
+      "enableJsonFlag": false,
+      "descriptionWithMarkdown": "Adds support for certain CSS strategies to your project.",
+      "customPluginName": "@shopify/cli-hydrogen"
     },
     "hydrogen:setup:markets": {
-      "aliases": [
-      ],
+      "aliases": [],
       "args": {
         "strategy": {
           "description": "The URL structure strategy to setup multiple markets. One of subfolders,domains,subdomains",
@@ -5008,743 +7477,121 @@
           ]
         }
       },
-      "customPluginName": "@shopify/cli-hydrogen",
       "description": "Setup support for multiple markets in your project.",
-      "descriptionWithMarkdown": "Adds support for multiple [markets](https://shopify.dev/docs/custom-storefronts/hydrogen/markets) to your project by using the URL structure.",
-      "enableJsonFlag": false,
       "flags": {
         "path": {
           "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
           "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
+          "name": "path",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "path",
           "type": "option"
         }
       },
       "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
+      "hiddenAliases": [],
       "id": "hydrogen:setup:markets",
       "pluginAlias": "@shopify/cli",
       "pluginName": "@shopify/cli",
       "pluginType": "core",
-      "strict": true
+      "strict": true,
+      "enableJsonFlag": false,
+      "descriptionWithMarkdown": "Adds support for multiple [markets](https://shopify.dev/docs/custom-storefronts/hydrogen/markets) to your project by using the URL structure.",
+      "customPluginName": "@shopify/cli-hydrogen"
     },
     "hydrogen:setup:vite": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/cli-hydrogen",
+      "aliases": [],
+      "args": {},
       "description": "EXPERIMENTAL: Upgrades the project to use Vite.",
-      "enableJsonFlag": false,
       "flags": {
         "path": {
           "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
           "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
+          "name": "path",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "path",
           "type": "option"
         }
       },
       "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
+      "hiddenAliases": [],
       "id": "hydrogen:setup:vite",
       "pluginAlias": "@shopify/cli",
       "pluginName": "@shopify/cli",
       "pluginType": "core",
-      "strict": true
-    },
-    "hydrogen:shortcut": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/cli-hydrogen",
-      "description": "Creates a global `h2` shortcut for the Hydrogen CLI",
-      "descriptionWithMarkdown": "Creates a global h2 shortcut for Shopify CLI using shell aliases.\n\n  The following shells are supported:\n\n  - Bash (using `~/.bashrc`)\n  - ZSH (using `~/.zshrc`)\n  - Fish (using `~/.config/fish/functions`)\n  - PowerShell (added to `$PROFILE`)\n\n  After the alias is created, you can call Shopify CLI from anywhere in your project using `h2 <command>`.",
-      "enableJsonFlag": false,
-      "flags": {
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "hydrogen:shortcut",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true
-    },
-    "hydrogen:unlink": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/cli-hydrogen",
-      "description": "Unlink a local project from a Hydrogen storefront.",
-      "descriptionWithMarkdown": "Unlinks your local development environment from a remote Hydrogen storefront.",
-      "enableJsonFlag": false,
-      "flags": {
-        "path": {
-          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "path",
-          "type": "option"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "hydrogen:unlink",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true
-    },
-    "hydrogen:upgrade": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/cli-hydrogen",
-      "description": "Upgrade Remix and Hydrogen npm dependencies.",
-      "descriptionWithMarkdown": "Upgrade Hydrogen project dependencies, preview features, fixes and breaking changes. The command also generates an instruction file for each upgrade.",
-      "enableJsonFlag": false,
-      "flags": {
-        "force": {
-          "allowNo": false,
-          "char": "f",
-          "description": "Ignore warnings and force the upgrade to the target version",
-          "env": "SHOPIFY_HYDROGEN_FLAG_FORCE",
-          "name": "force",
-          "type": "boolean"
-        },
-        "path": {
-          "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "path",
-          "type": "option"
-        },
-        "version": {
-          "char": "v",
-          "description": "A target hydrogen version to update to",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "version",
-          "required": false,
-          "type": "option"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "hydrogen:upgrade",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true
-    },
-    "kitchen-sink": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "description": "View all the available UI kit components",
-      "enableJsonFlag": false,
-      "flags": {
-      },
-      "hasDynamicHelp": false,
-      "hidden": true,
-      "hiddenAliases": [
-        "kitchen-sink all"
-      ],
-      "id": "kitchen-sink",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true
-    },
-    "kitchen-sink:async": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "description": "View the UI kit components that process async tasks",
-      "enableJsonFlag": false,
-      "flags": {
-      },
-      "hasDynamicHelp": false,
-      "hidden": true,
-      "hiddenAliases": [
-      ],
-      "id": "kitchen-sink:async",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true
-    },
-    "kitchen-sink:prompts": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "description": "View the UI kit components prompts",
-      "enableJsonFlag": false,
-      "flags": {
-      },
-      "hasDynamicHelp": false,
-      "hidden": true,
-      "hiddenAliases": [
-      ],
-      "id": "kitchen-sink:prompts",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true
-    },
-    "kitchen-sink:static": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "description": "View the UI kit components that display static output",
-      "enableJsonFlag": false,
-      "flags": {
-      },
-      "hasDynamicHelp": false,
-      "hidden": true,
-      "hiddenAliases": [
-      ],
-      "id": "kitchen-sink:static",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true
-    },
-    "notifications:generate": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "description": "Generate a notifications.json file for the the CLI, appending a new notification to the current file.",
-      "enableJsonFlag": false,
-      "flags": {
-      },
-      "hasDynamicHelp": false,
-      "hidden": true,
-      "hiddenAliases": [
-      ],
-      "id": "notifications:generate",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true
-    },
-    "notifications:list": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "description": "List current notifications configured for the CLI.",
-      "enableJsonFlag": false,
-      "flags": {
-        "ignore-errors": {
-          "allowNo": false,
-          "description": "Don't fail if an error occurs.",
-          "env": "SHOPIFY_FLAG_IGNORE_ERRORS",
-          "hidden": false,
-          "name": "ignore-errors",
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hidden": true,
-      "hiddenAliases": [
-      ],
-      "id": "notifications:list",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true
-    },
-    "organization:list": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/app",
-      "description": "Lists the Shopify organizations that you have access to, along with their organization IDs.",
-      "descriptionWithMarkdown": "Lists the Shopify organizations that you have access to, along with their organization IDs.",
-      "enableJsonFlag": false,
-      "flags": {
-        "json": {
-          "allowNo": false,
-          "char": "j",
-          "description": "Output the result as JSON. Automatically disables color output.",
-          "env": "SHOPIFY_FLAG_JSON",
-          "hidden": false,
-          "name": "json",
-          "type": "boolean"
-        },
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
-          "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
-        "verbose": {
-          "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "organization:list",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
       "strict": true,
-      "summary": "List Shopify organizations you have access to."
-    },
-    "plugins": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@oclif/plugin-plugins",
-      "description": "List installed plugins.",
-      "enableJsonFlag": true,
-      "examples": [
-        "<%= config.bin %> <%= command.id %>"
-      ],
-      "flags": {
-        "core": {
-          "allowNo": false,
-          "description": "Show core plugins.",
-          "name": "core",
-          "type": "boolean"
-        },
-        "json": {
-          "allowNo": false,
-          "description": "Format output as json.",
-          "helpGroup": "GLOBAL",
-          "name": "json",
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hidden": true,
-      "hiddenAliases": [
-      ],
-      "id": "plugins",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true
-    },
-    "plugins:inspect": {
-      "aliases": [
-      ],
-      "args": {
-        "plugin": {
-          "default": ".",
-          "description": "Plugin to inspect.",
-          "name": "plugin",
-          "required": true
-        }
-      },
-      "customPluginName": "@oclif/plugin-plugins",
-      "description": "Displays installation properties of a plugin.",
-      "enableJsonFlag": true,
-      "examples": [
-        "<%= config.bin %> <%= command.id %> <%- config.pjson.oclif.examplePlugin || \"myplugin\" %> "
-      ],
-      "flags": {
-        "help": {
-          "allowNo": false,
-          "char": "h",
-          "description": "Show CLI help.",
-          "name": "help",
-          "type": "boolean"
-        },
-        "json": {
-          "allowNo": false,
-          "description": "Format output as json.",
-          "helpGroup": "GLOBAL",
-          "name": "json",
-          "type": "boolean"
-        },
-        "verbose": {
-          "allowNo": false,
-          "char": "v",
-          "name": "verbose",
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "plugins:inspect",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": false,
-      "usage": "plugins:inspect PLUGIN..."
-    },
-    "plugins:install": {
-      "aliases": [
-        "plugins:add"
-      ],
-      "args": {
-        "plugin": {
-          "description": "Plugin to install.",
-          "name": "plugin",
-          "required": true
-        }
-      },
-      "customPluginName": "@oclif/plugin-plugins",
-      "description": "",
-      "enableJsonFlag": true,
-      "examples": [
-        {
-          "command": "<%= config.bin %> <%= command.id %> <%- config.pjson.oclif.examplePlugin || \"myplugin\" %> ",
-          "description": "Install a plugin from npm registry."
-        },
-        {
-          "command": "<%= config.bin %> <%= command.id %> https://github.com/someuser/someplugin",
-          "description": "Install a plugin from a github url."
-        },
-        {
-          "command": "<%= config.bin %> <%= command.id %> someuser/someplugin",
-          "description": "Install a plugin from a github slug."
-        }
-      ],
-      "flags": {
-        "force": {
-          "allowNo": false,
-          "char": "f",
-          "description": "Force npm to fetch remote resources even if a local copy exists on disk.",
-          "name": "force",
-          "type": "boolean"
-        },
-        "help": {
-          "allowNo": false,
-          "char": "h",
-          "description": "Show CLI help.",
-          "name": "help",
-          "type": "boolean"
-        },
-        "jit": {
-          "allowNo": false,
-          "hidden": true,
-          "name": "jit",
-          "type": "boolean"
-        },
-        "json": {
-          "allowNo": false,
-          "description": "Format output as json.",
-          "helpGroup": "GLOBAL",
-          "name": "json",
-          "type": "boolean"
-        },
-        "silent": {
-          "allowNo": false,
-          "char": "s",
-          "description": "Silences npm output.",
-          "exclusive": [
-            "verbose"
-          ],
-          "name": "silent",
-          "type": "boolean"
-        },
-        "verbose": {
-          "allowNo": false,
-          "char": "v",
-          "description": "Show verbose npm output.",
-          "exclusive": [
-            "silent"
-          ],
-          "name": "verbose",
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "plugins:install",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": false,
-      "summary": "Installs a plugin into <%= config.bin %>."
-    },
-    "plugins:link": {
-      "aliases": [
-      ],
-      "args": {
-        "path": {
-          "default": ".",
-          "description": "path to plugin",
-          "name": "path",
-          "required": true
-        }
-      },
-      "customPluginName": "@oclif/plugin-plugins",
-      "description": "Installation of a linked plugin will override a user-installed or core plugin.\n\ne.g. If you have a user-installed or core plugin that has a 'hello' command, installing a linked plugin with a 'hello' command will override the user-installed or core plugin implementation. This is useful for development work.\n",
       "enableJsonFlag": false,
-      "examples": [
-        "<%= config.bin %> <%= command.id %> <%- config.pjson.oclif.examplePlugin || \"myplugin\" %> "
-      ],
-      "flags": {
-        "help": {
-          "allowNo": false,
-          "char": "h",
-          "description": "Show CLI help.",
-          "name": "help",
-          "type": "boolean"
-        },
-        "install": {
-          "allowNo": true,
-          "description": "Install dependencies after linking the plugin.",
-          "name": "install",
-          "type": "boolean"
-        },
-        "verbose": {
-          "allowNo": false,
-          "char": "v",
-          "name": "verbose",
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "plugins:link",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true,
-      "summary": "Links a plugin into the CLI for development."
-    },
-    "plugins:reset": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@oclif/plugin-plugins",
-      "enableJsonFlag": false,
-      "flags": {
-        "hard": {
-          "allowNo": false,
-          "name": "hard",
-          "summary": "Delete node_modules and package manager related files in addition to uninstalling plugins.",
-          "type": "boolean"
-        },
-        "reinstall": {
-          "allowNo": false,
-          "name": "reinstall",
-          "summary": "Reinstall all plugins after uninstalling.",
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "plugins:reset",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true,
-      "summary": "Remove all user-installed and linked plugins."
-    },
-    "plugins:uninstall": {
-      "aliases": [
-        "plugins:unlink",
-        "plugins:remove"
-      ],
-      "args": {
-        "plugin": {
-          "description": "plugin to uninstall",
-          "name": "plugin"
-        }
-      },
-      "customPluginName": "@oclif/plugin-plugins",
-      "description": "Removes a plugin from the CLI.",
-      "enableJsonFlag": false,
-      "examples": [
-        "<%= config.bin %> <%= command.id %> <%- config.pjson.oclif.examplePlugin || \"myplugin\" %>"
-      ],
-      "flags": {
-        "help": {
-          "allowNo": false,
-          "char": "h",
-          "description": "Show CLI help.",
-          "name": "help",
-          "type": "boolean"
-        },
-        "verbose": {
-          "allowNo": false,
-          "char": "v",
-          "name": "verbose",
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "plugins:uninstall",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": false
-    },
-    "plugins:update": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@oclif/plugin-plugins",
-      "description": "Update installed plugins.",
-      "enableJsonFlag": false,
-      "flags": {
-        "help": {
-          "allowNo": false,
-          "char": "h",
-          "description": "Show CLI help.",
-          "name": "help",
-          "type": "boolean"
-        },
-        "verbose": {
-          "allowNo": false,
-          "char": "v",
-          "name": "verbose",
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "plugins:update",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true
-    },
-    "search": {
-      "aliases": [
-      ],
-      "args": {
-        "query": {
-          "name": "query"
-        }
-      },
-      "description": "Starts a search on shopify.dev.",
-      "enableJsonFlag": false,
-      "examples": [
-        "# open the search modal on Shopify.dev\n    shopify search\n\n    # search for a term on Shopify.dev\n    shopify search <query>\n\n    # search for a phrase on Shopify.dev\n    shopify search \"<a search query separated by spaces>\"\n    "
-      ],
-      "flags": {
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "search",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true,
-      "usage": "search [query]"
+      "customPluginName": "@shopify/cli-hydrogen"
     },
     "store:auth": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/store",
+      "aliases": [],
+      "args": {},
       "description": "Authenticates the app against the specified store for store commands and stores an online access token for later reuse.\n\nRe-run this command if the stored token is missing, expires, or no longer has the scopes you need.",
-      "descriptionWithMarkdown": "Authenticates the app against the specified store for store commands and stores an online access token for later reuse.\n\nRe-run this command if the stored token is missing, expires, or no longer has the scopes you need.",
       "examples": [
         "<%= config.bin %> <%= command.id %> --store shop.myshopify.com --scopes read_products,write_products",
         "<%= config.bin %> <%= command.id %> --store shop.myshopify.com --scopes read_products,write_products --json"
       ],
       "flags": {
-        "json": {
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
           "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "json": {
           "char": "j",
           "description": "Output the result as JSON. Automatically disables color output.",
           "env": "SHOPIFY_FLAG_JSON",
           "hidden": false,
           "name": "json",
-          "type": "boolean"
-        },
-        "no-color": {
           "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
-          "hidden": false,
-          "name": "no-color",
           "type": "boolean"
-        },
-        "scopes": {
-          "description": "Comma-separated Admin API scopes to request for the app.",
-          "env": "SHOPIFY_FLAG_SCOPES",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "scopes",
-          "required": true,
-          "type": "option"
         },
         "store": {
           "char": "s",
           "description": "The myshopify.com domain of the store to authenticate against.",
           "env": "SHOPIFY_FLAG_STORE",
-          "hasDynamicHelp": false,
-          "multiple": false,
           "name": "store",
           "required": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
           "type": "option"
         },
-        "verbose": {
-          "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
-          "type": "boolean"
+        "scopes": {
+          "description": "Comma-separated Admin API scopes to request for the app.",
+          "env": "SHOPIFY_FLAG_SCOPES",
+          "name": "scopes",
+          "required": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
         }
       },
       "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
+      "hiddenAliases": [],
       "id": "store:auth",
       "pluginAlias": "@shopify/cli",
       "pluginName": "@shopify/cli",
       "pluginType": "core",
       "strict": true,
-      "summary": "Authenticate an app against a store for store commands."
+      "summary": "Authenticate an app against a store for store commands.",
+      "descriptionWithMarkdown": "Authenticates the app against the specified store for store commands and stores an online access token for later reuse.\n\nRe-run this command if the stored token is missing, expires, or no longer has the scopes you need.",
+      "customPluginName": "@shopify/store"
     },
     "store:execute": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/store",
+      "aliases": [],
+      "args": {},
       "description": "Executes an Admin API GraphQL query or mutation on the specified store using previously stored app authentication.\n\nRun `shopify store auth` first to create stored auth for the store.\n\nMutations are disabled by default. Re-run with `--allow-mutations` if you intend to modify store data.",
-      "descriptionWithMarkdown": "Executes an Admin API GraphQL query or mutation on the specified store using previously stored app authentication.\n\nRun `shopify store auth` first to create stored auth for the store.\n\nMutations are disabled by default. Re-run with `--allow-mutations` if you intend to modify store data.",
       "examples": [
         "<%= config.bin %> <%= command.id %> --store shop.myshopify.com --query \"query { shop { name } }\"",
         "<%= config.bin %> <%= command.id %> --store shop.myshopify.com --query-file ./operation.graphql --variables '{\"id\":\"gid://shopify/Product/1\"}'",
@@ -5752,75 +7599,47 @@
         "<%= config.bin %> <%= command.id %> --store shop.myshopify.com --query \"query { shop { name } }\" --json"
       ],
       "flags": {
-        "allow-mutations": {
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
           "allowNo": false,
-          "description": "Allow GraphQL mutations to run against the target store.",
-          "env": "SHOPIFY_FLAG_ALLOW_MUTATIONS",
-          "name": "allow-mutations",
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
           "type": "boolean"
         },
         "json": {
-          "allowNo": false,
           "char": "j",
           "description": "Output the result as JSON. Automatically disables color output.",
           "env": "SHOPIFY_FLAG_JSON",
           "hidden": false,
           "name": "json",
-          "type": "boolean"
-        },
-        "no-color": {
           "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
-          "hidden": false,
-          "name": "no-color",
           "type": "boolean"
-        },
-        "output-file": {
-          "description": "The file name where results should be written, instead of STDOUT.",
-          "env": "SHOPIFY_FLAG_OUTPUT_FILE",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "output-file",
-          "type": "option"
         },
         "query": {
           "char": "q",
           "description": "The GraphQL query or mutation, as a string.",
           "env": "SHOPIFY_FLAG_QUERY",
-          "hasDynamicHelp": false,
-          "multiple": false,
           "name": "query",
           "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
           "type": "option"
         },
         "query-file": {
           "description": "Path to a file containing the GraphQL query or mutation. Can't be used with --query.",
           "env": "SHOPIFY_FLAG_QUERY_FILE",
-          "hasDynamicHelp": false,
-          "multiple": false,
           "name": "query-file",
-          "type": "option"
-        },
-        "store": {
-          "char": "s",
-          "description": "The myshopify.com domain of the store to execute against.",
-          "env": "SHOPIFY_FLAG_STORE",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "store",
-          "required": true,
-          "type": "option"
-        },
-        "variable-file": {
-          "description": "Path to a file containing GraphQL variables in JSON format. Can't be used with --variables.",
-          "env": "SHOPIFY_FLAG_VARIABLE_FILE",
-          "exclusive": [
-            "variables"
-          ],
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "variable-file",
           "type": "option"
         },
         "variables": {
@@ -5830,2160 +7649,889 @@
           "exclusive": [
             "variable-file"
           ],
+          "name": "variables",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "variables",
           "type": "option"
         },
-        "verbose": {
-          "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
-          "type": "boolean"
+        "variable-file": {
+          "description": "Path to a file containing GraphQL variables in JSON format. Can't be used with --variables.",
+          "env": "SHOPIFY_FLAG_VARIABLE_FILE",
+          "exclusive": [
+            "variables"
+          ],
+          "name": "variable-file",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "store": {
+          "char": "s",
+          "description": "The myshopify.com domain of the store to execute against.",
+          "env": "SHOPIFY_FLAG_STORE",
+          "name": "store",
+          "required": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
         },
         "version": {
           "description": "The API version to use for the query or mutation. Defaults to the latest stable version.",
           "env": "SHOPIFY_FLAG_VERSION",
+          "name": "version",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "version",
           "type": "option"
+        },
+        "output-file": {
+          "description": "The file name where results should be written, instead of STDOUT.",
+          "env": "SHOPIFY_FLAG_OUTPUT_FILE",
+          "name": "output-file",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "allow-mutations": {
+          "description": "Allow GraphQL mutations to run against the target store.",
+          "env": "SHOPIFY_FLAG_ALLOW_MUTATIONS",
+          "name": "allow-mutations",
+          "allowNo": false,
+          "type": "boolean"
         }
       },
       "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
+      "hiddenAliases": [],
       "id": "store:execute",
       "pluginAlias": "@shopify/cli",
       "pluginName": "@shopify/cli",
       "pluginType": "core",
       "strict": true,
-      "summary": "Execute GraphQL queries and mutations on a store."
+      "summary": "Execute GraphQL queries and mutations on a store.",
+      "descriptionWithMarkdown": "Executes an Admin API GraphQL query or mutation on the specified store using previously stored app authentication.\n\nRun `shopify store auth` first to create stored auth for the store.\n\nMutations are disabled by default. Re-run with `--allow-mutations` if you intend to modify store data.",
+      "customPluginName": "@shopify/store"
     },
-    "theme:check": {
-      "aliases": [
-      ],
+    "search": {
+      "aliases": [],
       "args": {
-      },
-      "customPluginName": "@shopify/theme",
-      "description": "Calls and runs \"Theme Check\" (https://shopify.dev/docs/themes/tools/theme-check) to analyze your theme code for errors and to ensure that it follows theme and Liquid best practices. \"Learn more about the checks that Theme Check runs.\" (https://shopify.dev/docs/themes/tools/theme-check/checks)",
-      "descriptionWithMarkdown": "Calls and runs [Theme Check](https://shopify.dev/docs/themes/tools/theme-check) to analyze your theme code for errors and to ensure that it follows theme and Liquid best practices. [Learn more about the checks that Theme Check runs.](https://shopify.dev/docs/themes/tools/theme-check/checks)",
-      "flags": {
-        "auto-correct": {
-          "allowNo": false,
-          "char": "a",
-          "description": "Automatically fix offenses",
-          "env": "SHOPIFY_FLAG_AUTO_CORRECT",
-          "name": "auto-correct",
-          "required": false,
-          "type": "boolean"
-        },
-        "config": {
-          "char": "C",
-          "description": "Use the config provided, overriding .theme-check.yml if present\n      Supports all theme-check: config values, e.g., theme-check:theme-app-extension,\n      theme-check:recommended, theme-check:all\n      For backwards compatibility, :theme_app_extension is also supported ",
-          "env": "SHOPIFY_FLAG_CONFIG",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "config",
-          "required": false,
-          "type": "option"
-        },
-        "environment": {
-          "char": "e",
-          "description": "The environment to apply to the current command.",
-          "env": "SHOPIFY_FLAG_ENVIRONMENT",
-          "hasDynamicHelp": false,
-          "multiple": true,
-          "name": "environment",
-          "type": "option"
-        },
-        "fail-level": {
-          "default": "error",
-          "description": "Minimum severity for exit with error code",
-          "env": "SHOPIFY_FLAG_FAIL_LEVEL",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "fail-level",
-          "options": [
-            "crash",
-            "error",
-            "suggestion",
-            "style",
-            "warning",
-            "info"
-          ],
-          "required": false,
-          "type": "option"
-        },
-        "init": {
-          "allowNo": false,
-          "description": "Generate a .theme-check.yml file",
-          "env": "SHOPIFY_FLAG_INIT",
-          "name": "init",
-          "required": false,
-          "type": "boolean"
-        },
-        "list": {
-          "allowNo": false,
-          "description": "List enabled checks",
-          "env": "SHOPIFY_FLAG_LIST",
-          "name": "list",
-          "required": false,
-          "type": "boolean"
-        },
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
-          "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
-        "output": {
-          "char": "o",
-          "default": "text",
-          "description": "The output format to use",
-          "env": "SHOPIFY_FLAG_OUTPUT",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "output",
-          "options": [
-            "text",
-            "json"
-          ],
-          "required": false,
-          "type": "option"
-        },
-        "path": {
-          "description": "The path where you want to run the command. Defaults to the current working directory.",
-          "env": "SHOPIFY_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "path",
-          "noCacheDefault": true,
-          "type": "option"
-        },
-        "print": {
-          "allowNo": false,
-          "description": "Output active config to STDOUT",
-          "env": "SHOPIFY_FLAG_PRINT",
-          "name": "print",
-          "required": false,
-          "type": "boolean"
-        },
-        "verbose": {
-          "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
-          "type": "boolean"
-        },
-        "version": {
-          "allowNo": false,
-          "char": "v",
-          "description": "Print Theme Check version",
-          "env": "SHOPIFY_FLAG_VERSION",
-          "name": "version",
-          "required": false,
-          "type": "boolean"
+        "query": {
+          "name": "query"
         }
       },
+      "description": "Starts a search on shopify.dev.",
+      "examples": [
+        "# open the search modal on Shopify.dev\n    shopify search\n\n    # search for a term on Shopify.dev\n    shopify search <query>\n\n    # search for a phrase on Shopify.dev\n    shopify search \"<a search query separated by spaces>\"\n    "
+      ],
+      "flags": {},
       "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "theme:check",
-      "multiEnvironmentsFlags": [
-        "path"
-      ],
+      "hiddenAliases": [],
+      "id": "search",
       "pluginAlias": "@shopify/cli",
       "pluginName": "@shopify/cli",
       "pluginType": "core",
       "strict": true,
-      "summary": "Validate the theme."
-    },
-    "theme:console": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/theme",
-      "description": "Starts the Shopify Liquid REPL (read-eval-print loop) tool. This tool provides an interactive terminal interface for evaluating Liquid code and exploring Liquid objects, filters, and tags using real store data.\n\n  You can also provide context to the console using a URL, as some Liquid objects are context-specific",
-      "descriptionWithMarkdown": "Starts the Shopify Liquid REPL (read-eval-print loop) tool. This tool provides an interactive terminal interface for evaluating Liquid code and exploring Liquid objects, filters, and tags using real store data.\n\n  You can also provide context to the console using a URL, as some Liquid objects are context-specific",
-      "flags": {
-        "environment": {
-          "char": "e",
-          "description": "The environment to apply to the current command.",
-          "env": "SHOPIFY_FLAG_ENVIRONMENT",
-          "hasDynamicHelp": false,
-          "multiple": true,
-          "name": "environment",
-          "type": "option"
-        },
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
-          "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
-        "password": {
-          "description": "Password generated from the Theme Access app or an Admin API token.",
-          "env": "SHOPIFY_CLI_THEME_TOKEN",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "password",
-          "type": "option"
-        },
-        "path": {
-          "description": "The path where you want to run the command. Defaults to the current working directory.",
-          "env": "SHOPIFY_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "path",
-          "noCacheDefault": true,
-          "type": "option"
-        },
-        "store": {
-          "char": "s",
-          "description": "Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).",
-          "env": "SHOPIFY_FLAG_STORE",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "store",
-          "type": "option"
-        },
-        "store-password": {
-          "description": "The password for storefronts with password protection.",
-          "env": "SHOPIFY_FLAG_STORE_PASSWORD",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "store-password",
-          "type": "option"
-        },
-        "url": {
-          "default": "/",
-          "description": "The url to be used as context",
-          "env": "SHOPIFY_FLAG_URL",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "url",
-          "type": "option"
-        },
-        "verbose": {
-          "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "theme:console",
-      "multiEnvironmentsFlags": null,
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true,
-      "summary": "Shopify Liquid REPL (read-eval-print loop) tool",
-      "usage": [
-        "theme console",
-        "theme console --url /products/classic-leather-jacket"
-      ]
-    },
-    "theme:delete": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/theme",
-      "description": "Deletes a theme from your store.\n\n  You can specify multiple themes by ID. If no theme is specified, then you're prompted to select the theme that you want to delete from the list of themes in your store.\n\n  You're asked to confirm that you want to delete the specified themes before they are deleted. You can skip this confirmation using the `--force` flag.",
-      "descriptionWithMarkdown": "Deletes a theme from your store.\n\n  You can specify multiple themes by ID. If no theme is specified, then you're prompted to select the theme that you want to delete from the list of themes in your store.\n\n  You're asked to confirm that you want to delete the specified themes before they are deleted. You can skip this confirmation using the `--force` flag.",
-      "flags": {
-        "development": {
-          "allowNo": false,
-          "char": "d",
-          "description": "Delete your development theme.",
-          "env": "SHOPIFY_FLAG_DEVELOPMENT",
-          "name": "development",
-          "type": "boolean"
-        },
-        "environment": {
-          "char": "e",
-          "description": "The environment to apply to the current command.",
-          "env": "SHOPIFY_FLAG_ENVIRONMENT",
-          "hasDynamicHelp": false,
-          "multiple": true,
-          "name": "environment",
-          "type": "option"
-        },
-        "force": {
-          "allowNo": false,
-          "char": "f",
-          "description": "Skip confirmation.",
-          "env": "SHOPIFY_FLAG_FORCE",
-          "name": "force",
-          "type": "boolean"
-        },
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
-          "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
-        "password": {
-          "description": "Password generated from the Theme Access app or an Admin API token.",
-          "env": "SHOPIFY_CLI_THEME_TOKEN",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "password",
-          "type": "option"
-        },
-        "path": {
-          "description": "The path where you want to run the command. Defaults to the current working directory.",
-          "env": "SHOPIFY_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "path",
-          "noCacheDefault": true,
-          "type": "option"
-        },
-        "show-all": {
-          "allowNo": false,
-          "char": "a",
-          "description": "Include others development themes in theme list.",
-          "env": "SHOPIFY_FLAG_SHOW_ALL",
-          "name": "show-all",
-          "type": "boolean"
-        },
-        "store": {
-          "char": "s",
-          "description": "Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).",
-          "env": "SHOPIFY_FLAG_STORE",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "store",
-          "type": "option"
-        },
-        "theme": {
-          "char": "t",
-          "description": "Theme ID or name of the remote theme.",
-          "env": "SHOPIFY_FLAG_THEME_ID",
-          "hasDynamicHelp": false,
-          "multiple": true,
-          "name": "theme",
-          "type": "option"
-        },
-        "verbose": {
-          "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "theme:delete",
-      "multiEnvironmentsFlags": [
-        "store",
-        "password",
-        [
-          "development",
-          "theme"
-        ]
-      ],
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true,
-      "summary": "Delete remote themes from the connected store. This command can't be undone."
-    },
-    "theme:dev": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/theme",
-      "description": "\n  Uploads the current theme as the specified theme, or a \"development theme\" (https://shopify.dev/docs/themes/tools/cli#development-themes), to a store so you can preview it.\n\nThis command returns the following information:\n\n- A link to your development theme at http://127.0.0.1:9292. This URL can hot reload local changes to CSS and sections, or refresh the entire page when a file changes, enabling you to preview changes in real time using the store's data.\n\n  You can specify a different network interface and port using `--host` and `--port`.\n\n- A link to the \"editor\" (https://shopify.dev/docs/themes/tools/online-editor) for the theme in the Shopify admin.\n\n- A \"preview link\" (https://help.shopify.com/manual/online-store/themes/adding-themes#share-a-theme-preview-with-others) that you can share with other developers.\n\nIf you already have a development theme for your current environment, then this command replaces the development theme with your local theme. You can override this using the `--theme-editor-sync` flag.\n\n> Note: You can't preview checkout customizations using http://127.0.0.1:9292.\n\nDevelopment themes are deleted when you run `shopify auth logout`. If you need a preview link that can be used after you log out, then you should \"share\" (https://shopify.dev/docs/api/shopify-cli/theme/theme-share) your theme or \"push\" (https://shopify.dev/docs/api/shopify-cli/theme/theme-push) to an unpublished theme on your store.\n\nYou can run this command only in a directory that matches the \"default Shopify theme folder structure\" (https://shopify.dev/docs/themes/tools/cli#directory-structure).",
-      "descriptionWithMarkdown": "\n  Uploads the current theme as the specified theme, or a [development theme](https://shopify.dev/docs/themes/tools/cli#development-themes), to a store so you can preview it.\n\nThis command returns the following information:\n\n- A link to your development theme at http://127.0.0.1:9292. This URL can hot reload local changes to CSS and sections, or refresh the entire page when a file changes, enabling you to preview changes in real time using the store's data.\n\n  You can specify a different network interface and port using `--host` and `--port`.\n\n- A link to the [editor](https://shopify.dev/docs/themes/tools/online-editor) for the theme in the Shopify admin.\n\n- A [preview link](https://help.shopify.com/manual/online-store/themes/adding-themes#share-a-theme-preview-with-others) that you can share with other developers.\n\nIf you already have a development theme for your current environment, then this command replaces the development theme with your local theme. You can override this using the `--theme-editor-sync` flag.\n\n> Note: You can't preview checkout customizations using http://127.0.0.1:9292.\n\nDevelopment themes are deleted when you run `shopify auth logout`. If you need a preview link that can be used after you log out, then you should [share](https://shopify.dev/docs/api/shopify-cli/theme/theme-share) your theme or [push](https://shopify.dev/docs/api/shopify-cli/theme/theme-push) to an unpublished theme on your store.\n\nYou can run this command only in a directory that matches the [default Shopify theme folder structure](https://shopify.dev/docs/themes/tools/cli#directory-structure).",
-      "flags": {
-        "allow-live": {
-          "allowNo": false,
-          "char": "a",
-          "description": "Allow development on a live theme.",
-          "env": "SHOPIFY_FLAG_ALLOW_LIVE",
-          "name": "allow-live",
-          "type": "boolean"
-        },
-        "environment": {
-          "char": "e",
-          "description": "The environment to apply to the current command.",
-          "env": "SHOPIFY_FLAG_ENVIRONMENT",
-          "hasDynamicHelp": false,
-          "multiple": true,
-          "name": "environment",
-          "type": "option"
-        },
-        "error-overlay": {
-          "default": "default",
-          "description": "Controls the visibility of the error overlay when an theme asset upload fails:\n- silent Prevents the error overlay from appearing.\n- default Displays the error overlay.\n      ",
-          "env": "SHOPIFY_FLAG_ERROR_OVERLAY",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "error-overlay",
-          "options": [
-            "silent",
-            "default"
-          ],
-          "type": "option"
-        },
-        "force": {
-          "allowNo": false,
-          "char": "f",
-          "description": "Proceed without confirmation, if current directory does not seem to be theme directory.",
-          "env": "SHOPIFY_FLAG_FORCE",
-          "hidden": true,
-          "name": "force",
-          "type": "boolean"
-        },
-        "host": {
-          "description": "Set which network interface the web server listens on. The default value is 127.0.0.1.",
-          "env": "SHOPIFY_FLAG_HOST",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "host",
-          "type": "option"
-        },
-        "ignore": {
-          "char": "x",
-          "description": "Skip hot reloading any files that match the specified pattern.",
-          "env": "SHOPIFY_FLAG_IGNORE",
-          "hasDynamicHelp": false,
-          "multiple": true,
-          "name": "ignore",
-          "type": "option"
-        },
-        "listing": {
-          "description": "The listing preset to use for multi-preset themes. Applies preset files from listings/[preset-name] directory.",
-          "env": "SHOPIFY_FLAG_LISTING",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "listing",
-          "type": "option"
-        },
-        "live-reload": {
-          "default": "hot-reload",
-          "description": "The live reload mode switches the server behavior when a file is modified:\n- hot-reload Hot reloads local changes to CSS and sections (default)\n- full-page  Always refreshes the entire page\n- off        Deactivate live reload",
-          "env": "SHOPIFY_FLAG_LIVE_RELOAD",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "live-reload",
-          "options": [
-            "hot-reload",
-            "full-page",
-            "off"
-          ],
-          "type": "option"
-        },
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
-          "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
-        "nodelete": {
-          "allowNo": false,
-          "char": "n",
-          "description": "Prevents files from being deleted in the remote theme when a file has been deleted locally. This applies to files that are deleted while the command is running, and files that have been deleted locally before the command is run.",
-          "env": "SHOPIFY_FLAG_NODELETE",
-          "name": "nodelete",
-          "type": "boolean"
-        },
-        "notify": {
-          "description": "The file path or URL. The file path is to a file that you want updated on idle. The URL path is where you want a webhook posted to report on file changes.",
-          "env": "SHOPIFY_FLAG_NOTIFY",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "notify",
-          "type": "option"
-        },
-        "only": {
-          "char": "o",
-          "description": "Hot reload only files that match the specified pattern.",
-          "env": "SHOPIFY_FLAG_ONLY",
-          "hasDynamicHelp": false,
-          "multiple": true,
-          "name": "only",
-          "type": "option"
-        },
-        "open": {
-          "allowNo": false,
-          "description": "Automatically launch the theme preview in your default web browser.",
-          "env": "SHOPIFY_FLAG_OPEN",
-          "name": "open",
-          "type": "boolean"
-        },
-        "password": {
-          "description": "Password generated from the Theme Access app or an Admin API token.",
-          "env": "SHOPIFY_CLI_THEME_TOKEN",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "password",
-          "type": "option"
-        },
-        "path": {
-          "description": "The path where you want to run the command. Defaults to the current working directory.",
-          "env": "SHOPIFY_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "path",
-          "noCacheDefault": true,
-          "type": "option"
-        },
-        "poll": {
-          "allowNo": false,
-          "description": "Force polling to detect file changes.",
-          "env": "SHOPIFY_FLAG_POLL",
-          "hidden": true,
-          "name": "poll",
-          "type": "boolean"
-        },
-        "port": {
-          "description": "Local port to serve theme preview from.",
-          "env": "SHOPIFY_FLAG_PORT",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "port",
-          "type": "option"
-        },
-        "store": {
-          "char": "s",
-          "description": "Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).",
-          "env": "SHOPIFY_FLAG_STORE",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "store",
-          "type": "option"
-        },
-        "store-password": {
-          "description": "The password for storefronts with password protection.",
-          "env": "SHOPIFY_FLAG_STORE_PASSWORD",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "store-password",
-          "type": "option"
-        },
-        "theme": {
-          "char": "t",
-          "description": "Theme ID or name of the remote theme.",
-          "env": "SHOPIFY_FLAG_THEME_ID",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "theme",
-          "type": "option"
-        },
-        "theme-editor-sync": {
-          "allowNo": false,
-          "description": "Synchronize Theme Editor updates in the local theme files.",
-          "env": "SHOPIFY_FLAG_THEME_EDITOR_SYNC",
-          "name": "theme-editor-sync",
-          "type": "boolean"
-        },
-        "verbose": {
-          "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "theme:dev",
-      "multiEnvironmentsFlags": null,
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true,
-      "summary": "Uploads the current theme as a development theme to the connected store, then prints theme editor and preview URLs to your terminal. While running, changes will push to the store in real time."
-    },
-    "theme:duplicate": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/theme",
-      "description": "If you want to duplicate your local theme, you need to run `shopify theme push` first.\n\nIf no theme ID is specified, you're prompted to select the theme that you want to duplicate from the list of themes in your store. You're asked to confirm that you want to duplicate the specified theme.\n\nPrompts and confirmations are not shown when duplicate is run in a CI environment or the `--force` flag is used, therefore you must specify a theme ID using the `--theme` flag.\n\nYou can optionally name the duplicated theme using the `--name` flag.\n\nIf you use the `--json` flag, then theme information is returned in JSON format, which can be used as a machine-readable input for scripts or continuous integration.\n\nSample JSON output:\n\n```json\n{\n  \"theme\": {\n    \"id\": 108267175958,\n    \"name\": \"A Duplicated Theme\",\n    \"role\": \"unpublished\",\n    \"shop\": \"mystore.myshopify.com\"\n  }\n}\n```\n\n```json\n{\n  \"message\": \"The theme 'Summer Edition' could not be duplicated due to errors\",\n  \"errors\": [\"Maximum number of themes reached\"],\n  \"requestId\": \"12345-abcde-67890\"\n}\n```",
-      "descriptionWithMarkdown": "If you want to duplicate your local theme, you need to run `shopify theme push` first.\n\nIf no theme ID is specified, you're prompted to select the theme that you want to duplicate from the list of themes in your store. You're asked to confirm that you want to duplicate the specified theme.\n\nPrompts and confirmations are not shown when duplicate is run in a CI environment or the `--force` flag is used, therefore you must specify a theme ID using the `--theme` flag.\n\nYou can optionally name the duplicated theme using the `--name` flag.\n\nIf you use the `--json` flag, then theme information is returned in JSON format, which can be used as a machine-readable input for scripts or continuous integration.\n\nSample JSON output:\n\n```json\n{\n  \"theme\": {\n    \"id\": 108267175958,\n    \"name\": \"A Duplicated Theme\",\n    \"role\": \"unpublished\",\n    \"shop\": \"mystore.myshopify.com\"\n  }\n}\n```\n\n```json\n{\n  \"message\": \"The theme 'Summer Edition' could not be duplicated due to errors\",\n  \"errors\": [\"Maximum number of themes reached\"],\n  \"requestId\": \"12345-abcde-67890\"\n}\n```",
-      "flags": {
-        "environment": {
-          "char": "e",
-          "description": "The environment to apply to the current command.",
-          "env": "SHOPIFY_FLAG_ENVIRONMENT",
-          "hasDynamicHelp": false,
-          "multiple": true,
-          "name": "environment",
-          "type": "option"
-        },
-        "force": {
-          "allowNo": false,
-          "char": "f",
-          "description": "Force the duplicate operation to run without prompts or confirmations.",
-          "env": "SHOPIFY_FLAG_FORCE",
-          "name": "force",
-          "type": "boolean"
-        },
-        "json": {
-          "allowNo": false,
-          "char": "j",
-          "description": "Output the result as JSON. Automatically disables color output.",
-          "env": "SHOPIFY_FLAG_JSON",
-          "hidden": false,
-          "name": "json",
-          "type": "boolean"
-        },
-        "name": {
-          "char": "n",
-          "description": "Name of the newly duplicated theme.",
-          "env": "SHOPIFY_FLAG_NAME",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "name",
-          "type": "option"
-        },
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
-          "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
-        "password": {
-          "description": "Password generated from the Theme Access app or an Admin API token.",
-          "env": "SHOPIFY_CLI_THEME_TOKEN",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "password",
-          "type": "option"
-        },
-        "store": {
-          "char": "s",
-          "description": "Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).",
-          "env": "SHOPIFY_FLAG_STORE",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "store",
-          "type": "option"
-        },
-        "theme": {
-          "char": "t",
-          "description": "Theme ID or name of the remote theme.",
-          "env": "SHOPIFY_FLAG_THEME_ID",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "theme",
-          "type": "option"
-        },
-        "verbose": {
-          "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "theme:duplicate",
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true,
-      "summary": "Duplicates a theme from your theme library.",
-      "usage": [
-        "theme duplicate",
-        "theme duplicate --theme 10 --name 'New Theme'"
-      ]
-    },
-    "theme:info": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/theme",
-      "description": "Displays information about your theme environment, including your current store. Can also retrieve information about a specific theme.",
-      "flags": {
-        "development": {
-          "allowNo": false,
-          "char": "d",
-          "description": "Retrieve info from your development theme.",
-          "env": "SHOPIFY_FLAG_DEVELOPMENT",
-          "name": "development",
-          "type": "boolean"
-        },
-        "environment": {
-          "char": "e",
-          "description": "The environment to apply to the current command.",
-          "env": "SHOPIFY_FLAG_ENVIRONMENT",
-          "hasDynamicHelp": false,
-          "multiple": true,
-          "name": "environment",
-          "type": "option"
-        },
-        "json": {
-          "allowNo": false,
-          "char": "j",
-          "description": "Output the result as JSON. Automatically disables color output.",
-          "env": "SHOPIFY_FLAG_JSON",
-          "hidden": false,
-          "name": "json",
-          "type": "boolean"
-        },
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
-          "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
-        "password": {
-          "description": "Password generated from the Theme Access app or an Admin API token.",
-          "env": "SHOPIFY_CLI_THEME_TOKEN",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "password",
-          "type": "option"
-        },
-        "path": {
-          "description": "The path where you want to run the command. Defaults to the current working directory.",
-          "env": "SHOPIFY_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "path",
-          "noCacheDefault": true,
-          "type": "option"
-        },
-        "store": {
-          "char": "s",
-          "description": "Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).",
-          "env": "SHOPIFY_FLAG_STORE",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "store",
-          "type": "option"
-        },
-        "theme": {
-          "char": "t",
-          "description": "Theme ID or name of the remote theme.",
-          "env": "SHOPIFY_FLAG_THEME_ID",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "theme",
-          "type": "option"
-        },
-        "verbose": {
-          "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "theme:info",
-      "multiEnvironmentsFlags": [
-        "store",
-        "password"
-      ],
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true
-    },
-    "theme:init": {
-      "aliases": [
-      ],
-      "args": {
-        "name": {
-          "description": "Name of the new theme",
-          "name": "name",
-          "required": false
-        }
-      },
-      "customPluginName": "@shopify/theme",
-      "description": "Clones a Git repository to your local machine to use as the starting point for building a theme.\n\n  If no Git repository is specified, then this command creates a copy of Shopify's \"Skeleton theme\" (https://github.com/Shopify/skeleton-theme.git), with the specified name in the current folder. If no name is provided, then you're prompted to enter one.\n\n  > Caution: If you're building a theme for the Shopify Theme Store, then you can use our example theme as a starting point. However, the theme that you submit needs to be \"substantively different from existing themes\" (https://shopify.dev/docs/themes/store/requirements#uniqueness) so that it provides added value for users.\n  ",
-      "descriptionWithMarkdown": "Clones a Git repository to your local machine to use as the starting point for building a theme.\n\n  If no Git repository is specified, then this command creates a copy of Shopify's [Skeleton theme](https://github.com/Shopify/skeleton-theme.git), with the specified name in the current folder. If no name is provided, then you're prompted to enter one.\n\n  > Caution: If you're building a theme for the Shopify Theme Store, then you can use our example theme as a starting point. However, the theme that you submit needs to be [substantively different from existing themes](https://shopify.dev/docs/themes/store/requirements#uniqueness) so that it provides added value for users.\n  ",
-      "flags": {
-        "clone-url": {
-          "char": "u",
-          "default": "https://github.com/Shopify/skeleton-theme.git",
-          "description": "The Git URL to clone from. Defaults to Shopify's Skeleton theme.",
-          "env": "SHOPIFY_FLAG_CLONE_URL",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "clone-url",
-          "type": "option"
-        },
-        "latest": {
-          "allowNo": false,
-          "char": "l",
-          "description": "Downloads the latest release of the `clone-url`",
-          "env": "SHOPIFY_FLAG_LATEST",
-          "name": "latest",
-          "type": "boolean"
-        },
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
-          "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
-        "path": {
-          "description": "The path where you want to run the command. Defaults to the current working directory.",
-          "env": "SHOPIFY_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "path",
-          "noCacheDefault": true,
-          "type": "option"
-        },
-        "verbose": {
-          "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "theme:init",
-      "multiEnvironmentsFlags": null,
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true,
-      "summary": "Clones a Git repository to use as a starting point for building a new theme.",
-      "usage": "theme init [name] [flags]"
-    },
-    "theme:language-server": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/theme",
-      "description": "Starts the \"Language Server\" (https://shopify.dev/docs/themes/tools/cli/language-server).",
-      "descriptionWithMarkdown": "Starts the [Language Server](https://shopify.dev/docs/themes/tools/cli/language-server).",
-      "flags": {
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
-          "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
-        "verbose": {
-          "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "theme:language-server",
-      "multiEnvironmentsFlags": null,
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true,
-      "summary": "Start a Language Server Protocol server."
-    },
-    "theme:list": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/theme",
-      "description": "Lists the themes in your store, along with their IDs and statuses.",
-      "flags": {
-        "environment": {
-          "char": "e",
-          "description": "The environment to apply to the current command.",
-          "env": "SHOPIFY_FLAG_ENVIRONMENT",
-          "hasDynamicHelp": false,
-          "multiple": true,
-          "name": "environment",
-          "type": "option"
-        },
-        "id": {
-          "description": "Only list theme with the given ID.",
-          "env": "SHOPIFY_FLAG_ID",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "id",
-          "type": "option"
-        },
-        "json": {
-          "allowNo": false,
-          "char": "j",
-          "description": "Output the result as JSON. Automatically disables color output.",
-          "env": "SHOPIFY_FLAG_JSON",
-          "hidden": false,
-          "name": "json",
-          "type": "boolean"
-        },
-        "name": {
-          "description": "Only list themes that contain the given name.",
-          "env": "SHOPIFY_FLAG_NAME",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "name",
-          "type": "option"
-        },
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
-          "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
-        "password": {
-          "description": "Password generated from the Theme Access app or an Admin API token.",
-          "env": "SHOPIFY_CLI_THEME_TOKEN",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "password",
-          "type": "option"
-        },
-        "path": {
-          "description": "The path where you want to run the command. Defaults to the current working directory.",
-          "env": "SHOPIFY_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "path",
-          "noCacheDefault": true,
-          "type": "option"
-        },
-        "role": {
-          "description": "Only list themes with the given role.",
-          "env": "SHOPIFY_FLAG_ROLE",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "role",
-          "options": [
-            "live",
-            "unpublished",
-            "development"
-          ],
-          "type": "option"
-        },
-        "store": {
-          "char": "s",
-          "description": "Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).",
-          "env": "SHOPIFY_FLAG_STORE",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "store",
-          "type": "option"
-        },
-        "verbose": {
-          "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "theme:list",
-      "multiEnvironmentsFlags": [
-        "store",
-        "password"
-      ],
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true
-    },
-    "theme:metafields:pull": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/theme",
-      "description": "Retrieves metafields from Shopify Admin.\n\nIf the metafields file already exists, it will be overwritten.",
-      "descriptionWithMarkdown": "Retrieves metafields from Shopify Admin.\n\nIf the metafields file already exists, it will be overwritten.",
-      "flags": {
-        "environment": {
-          "char": "e",
-          "description": "The environment to apply to the current command.",
-          "env": "SHOPIFY_FLAG_ENVIRONMENT",
-          "hasDynamicHelp": false,
-          "multiple": true,
-          "name": "environment",
-          "type": "option"
-        },
-        "force": {
-          "allowNo": false,
-          "char": "f",
-          "description": "Proceed without confirmation, if current directory does not seem to be theme directory.",
-          "env": "SHOPIFY_FLAG_FORCE",
-          "hidden": true,
-          "name": "force",
-          "type": "boolean"
-        },
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
-          "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
-        "password": {
-          "description": "Password generated from the Theme Access app or an Admin API token.",
-          "env": "SHOPIFY_CLI_THEME_TOKEN",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "password",
-          "type": "option"
-        },
-        "path": {
-          "description": "The path where you want to run the command. Defaults to the current working directory.",
-          "env": "SHOPIFY_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "path",
-          "noCacheDefault": true,
-          "type": "option"
-        },
-        "store": {
-          "char": "s",
-          "description": "Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).",
-          "env": "SHOPIFY_FLAG_STORE",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "store",
-          "type": "option"
-        },
-        "verbose": {
-          "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "theme:metafields:pull",
-      "multiEnvironmentsFlags": null,
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true,
-      "summary": "Download metafields definitions from your shop into a local file."
-    },
-    "theme:open": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/theme",
-      "description": "Returns links that let you preview the specified theme. The following links are returned:\n\n  - A link to the \"editor\" (https://shopify.dev/docs/themes/tools/online-editor) for the theme in the Shopify admin.\n  - A \"preview link\" (https://help.shopify.com/manual/online-store/themes/adding-themes#share-a-theme-preview-with-others) that you can share with other developers.\n\n  If you don't specify a theme, then you're prompted to select the theme to open from the list of the themes in your store.",
-      "descriptionWithMarkdown": "Returns links that let you preview the specified theme. The following links are returned:\n\n  - A link to the [editor](https://shopify.dev/docs/themes/tools/online-editor) for the theme in the Shopify admin.\n  - A [preview link](https://help.shopify.com/manual/online-store/themes/adding-themes#share-a-theme-preview-with-others) that you can share with other developers.\n\n  If you don't specify a theme, then you're prompted to select the theme to open from the list of the themes in your store.",
-      "flags": {
-        "development": {
-          "allowNo": false,
-          "char": "d",
-          "description": "Open your development theme.",
-          "env": "SHOPIFY_FLAG_DEVELOPMENT",
-          "name": "development",
-          "type": "boolean"
-        },
-        "editor": {
-          "allowNo": false,
-          "char": "E",
-          "description": "Open the theme editor for the specified theme in the browser.",
-          "env": "SHOPIFY_FLAG_EDITOR",
-          "name": "editor",
-          "type": "boolean"
-        },
-        "environment": {
-          "char": "e",
-          "description": "The environment to apply to the current command.",
-          "env": "SHOPIFY_FLAG_ENVIRONMENT",
-          "hasDynamicHelp": false,
-          "multiple": true,
-          "name": "environment",
-          "type": "option"
-        },
-        "live": {
-          "allowNo": false,
-          "char": "l",
-          "description": "Open your live (published) theme.",
-          "env": "SHOPIFY_FLAG_LIVE",
-          "name": "live",
-          "type": "boolean"
-        },
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
-          "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
-        "password": {
-          "description": "Password generated from the Theme Access app or an Admin API token.",
-          "env": "SHOPIFY_CLI_THEME_TOKEN",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "password",
-          "type": "option"
-        },
-        "path": {
-          "description": "The path where you want to run the command. Defaults to the current working directory.",
-          "env": "SHOPIFY_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "path",
-          "noCacheDefault": true,
-          "type": "option"
-        },
-        "store": {
-          "char": "s",
-          "description": "Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).",
-          "env": "SHOPIFY_FLAG_STORE",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "store",
-          "type": "option"
-        },
-        "theme": {
-          "char": "t",
-          "description": "Theme ID or name of the remote theme.",
-          "env": "SHOPIFY_FLAG_THEME_ID",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "theme",
-          "type": "option"
-        },
-        "verbose": {
-          "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "theme:open",
-      "multiEnvironmentsFlags": null,
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true,
-      "summary": "Opens the preview of your remote theme."
-    },
-    "theme:package": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/theme",
-      "description": "Packages your local theme files into a ZIP file that can be uploaded to Shopify.\n\n  Only folders that match the \"default Shopify theme folder structure\" (https://shopify.dev/docs/storefronts/themes/tools/cli#directory-structure) are included in the package.\n\n  The package includes the `listings` directory if present (required for multi-preset themes per \"Theme Store requirements\" (https://shopify.dev/docs/storefronts/themes/store/requirements#adding-presets-to-your-theme-zip-submission)).\n\n  The ZIP file uses the name `theme_name-theme_version.zip`, based on parameters in your \"settings_schema.json\" (https://shopify.dev/docs/storefronts/themes/architecture/config/settings-schema-json) file.",
-      "descriptionWithMarkdown": "Packages your local theme files into a ZIP file that can be uploaded to Shopify.\n\n  Only folders that match the [default Shopify theme folder structure](https://shopify.dev/docs/storefronts/themes/tools/cli#directory-structure) are included in the package.\n\n  The package includes the `listings` directory if present (required for multi-preset themes per [Theme Store requirements](https://shopify.dev/docs/storefronts/themes/store/requirements#adding-presets-to-your-theme-zip-submission)).\n\n  The ZIP file uses the name `theme_name-theme_version.zip`, based on parameters in your [settings_schema.json](https://shopify.dev/docs/storefronts/themes/architecture/config/settings-schema-json) file.",
-      "flags": {
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
-          "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
-        "path": {
-          "description": "The path where you want to run the command. Defaults to the current working directory.",
-          "env": "SHOPIFY_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "path",
-          "noCacheDefault": true,
-          "type": "option"
-        },
-        "verbose": {
-          "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "theme:package",
-      "multiEnvironmentsFlags": null,
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true,
-      "summary": "Package your theme into a .zip file, ready to upload to the Online Store."
-    },
-    "theme:preview": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/theme",
-      "description": "Applies a JSON overrides file to a theme and creates or updates a preview. This lets you quickly preview changes.\n\n  The command returns a preview URL and a preview identifier. You can reuse the preview identifier with `--preview-id` to update an existing preview instead of creating a new one.",
-      "descriptionWithMarkdown": "Applies a JSON overrides file to a theme and creates or updates a preview. This lets you quickly preview changes.\n\n  The command returns a preview URL and a preview identifier. You can reuse the preview identifier with `--preview-id` to update an existing preview instead of creating a new one.",
-      "flags": {
-        "environment": {
-          "char": "e",
-          "description": "The environment to apply to the current command.",
-          "env": "SHOPIFY_FLAG_ENVIRONMENT",
-          "hasDynamicHelp": false,
-          "multiple": true,
-          "name": "environment",
-          "type": "option"
-        },
-        "json": {
-          "allowNo": false,
-          "description": "Output the preview URL and identifier as JSON.",
-          "env": "SHOPIFY_FLAG_JSON",
-          "name": "json",
-          "type": "boolean"
-        },
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
-          "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
-        "open": {
-          "allowNo": false,
-          "description": "Automatically launch the theme preview in your default web browser.",
-          "env": "SHOPIFY_FLAG_OPEN",
-          "name": "open",
-          "type": "boolean"
-        },
-        "overrides": {
-          "description": "Path to a JSON overrides file.",
-          "env": "SHOPIFY_FLAG_OVERRIDES",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "overrides",
-          "required": true,
-          "type": "option"
-        },
-        "password": {
-          "description": "Password generated from the Theme Access app or an Admin API token.",
-          "env": "SHOPIFY_CLI_THEME_TOKEN",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "password",
-          "type": "option"
-        },
-        "path": {
-          "description": "The path where you want to run the command. Defaults to the current working directory.",
-          "env": "SHOPIFY_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "path",
-          "noCacheDefault": true,
-          "type": "option"
-        },
-        "preview-id": {
-          "description": "An existing preview identifier to update instead of creating a new preview.",
-          "env": "SHOPIFY_FLAG_PREVIEW_ID",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "preview-id",
-          "type": "option"
-        },
-        "store": {
-          "char": "s",
-          "description": "Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).",
-          "env": "SHOPIFY_FLAG_STORE",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "store",
-          "type": "option"
-        },
-        "theme": {
-          "char": "t",
-          "description": "Theme ID or name of the remote theme.",
-          "env": "SHOPIFY_FLAG_THEME_ID",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "theme",
-          "required": true,
-          "type": "option"
-        },
-        "verbose": {
-          "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "theme:preview",
-      "multiEnvironmentsFlags": null,
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true,
-      "summary": "Applies JSON overrides to a theme and returns a preview URL."
-    },
-    "theme:profile": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/theme",
-      "description": "Profile the Shopify Liquid on a given page.\n\n  This command will open a web page with the Speedscope profiler detailing the time spent executing Liquid on the given page.",
-      "descriptionWithMarkdown": "Profile the Shopify Liquid on a given page.\n\n  This command will open a web page with the Speedscope profiler detailing the time spent executing Liquid on the given page.",
-      "flags": {
-        "environment": {
-          "char": "e",
-          "description": "The environment to apply to the current command.",
-          "env": "SHOPIFY_FLAG_ENVIRONMENT",
-          "hasDynamicHelp": false,
-          "multiple": true,
-          "name": "environment",
-          "type": "option"
-        },
-        "json": {
-          "allowNo": false,
-          "char": "j",
-          "description": "Output the result as JSON. Automatically disables color output.",
-          "env": "SHOPIFY_FLAG_JSON",
-          "hidden": false,
-          "name": "json",
-          "type": "boolean"
-        },
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
-          "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
-        "password": {
-          "description": "Password generated from the Theme Access app or an Admin API token.",
-          "env": "SHOPIFY_CLI_THEME_TOKEN",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "password",
-          "type": "option"
-        },
-        "path": {
-          "description": "The path where you want to run the command. Defaults to the current working directory.",
-          "env": "SHOPIFY_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "path",
-          "noCacheDefault": true,
-          "type": "option"
-        },
-        "store": {
-          "char": "s",
-          "description": "Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).",
-          "env": "SHOPIFY_FLAG_STORE",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "store",
-          "type": "option"
-        },
-        "store-password": {
-          "description": "The password for storefronts with password protection.",
-          "env": "SHOPIFY_FLAG_STORE_PASSWORD",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "store-password",
-          "type": "option"
-        },
-        "theme": {
-          "char": "t",
-          "description": "Theme ID or name of the remote theme.",
-          "env": "SHOPIFY_FLAG_THEME_ID",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "theme",
-          "type": "option"
-        },
-        "url": {
-          "default": "/",
-          "description": "The url to be used as context",
-          "env": "SHOPIFY_FLAG_URL",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "url",
-          "type": "option"
-        },
-        "verbose": {
-          "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "theme:profile",
-      "multiEnvironmentsFlags": null,
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true,
-      "summary": "Profile the Liquid rendering of a theme page.",
-      "usage": [
-        "theme profile",
-        "theme profile --url /products/classic-leather-jacket"
-      ]
-    },
-    "theme:publish": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/theme",
-      "description": "Publishes an unpublished theme from your theme library.\n\nIf no theme ID is specified, then you're prompted to select the theme that you want to publish from the list of themes in your store.\n\nYou can run this command only in a directory that matches the \"default Shopify theme folder structure\" (https://shopify.dev/docs/themes/tools/cli#directory-structure).\n\nIf you want to publish your local theme, then you need to run `shopify theme push` first. You're asked to confirm that you want to publish the specified theme. You can skip this confirmation using the `--force` flag.",
-      "descriptionWithMarkdown": "Publishes an unpublished theme from your theme library.\n\nIf no theme ID is specified, then you're prompted to select the theme that you want to publish from the list of themes in your store.\n\nYou can run this command only in a directory that matches the [default Shopify theme folder structure](https://shopify.dev/docs/themes/tools/cli#directory-structure).\n\nIf you want to publish your local theme, then you need to run `shopify theme push` first. You're asked to confirm that you want to publish the specified theme. You can skip this confirmation using the `--force` flag.",
-      "flags": {
-        "environment": {
-          "char": "e",
-          "description": "The environment to apply to the current command.",
-          "env": "SHOPIFY_FLAG_ENVIRONMENT",
-          "hasDynamicHelp": false,
-          "multiple": true,
-          "name": "environment",
-          "type": "option"
-        },
-        "force": {
-          "allowNo": false,
-          "char": "f",
-          "description": "Skip confirmation.",
-          "env": "SHOPIFY_FLAG_FORCE",
-          "name": "force",
-          "type": "boolean"
-        },
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
-          "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
-        "password": {
-          "description": "Password generated from the Theme Access app or an Admin API token.",
-          "env": "SHOPIFY_CLI_THEME_TOKEN",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "password",
-          "type": "option"
-        },
-        "path": {
-          "description": "The path where you want to run the command. Defaults to the current working directory.",
-          "env": "SHOPIFY_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "path",
-          "noCacheDefault": true,
-          "type": "option"
-        },
-        "store": {
-          "char": "s",
-          "description": "Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).",
-          "env": "SHOPIFY_FLAG_STORE",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "store",
-          "type": "option"
-        },
-        "theme": {
-          "char": "t",
-          "description": "Theme ID or name of the remote theme.",
-          "env": "SHOPIFY_FLAG_THEME_ID",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "theme",
-          "type": "option"
-        },
-        "verbose": {
-          "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "theme:publish",
-      "multiEnvironmentsFlags": [
-        "store",
-        "password",
-        "theme"
-      ],
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true,
-      "summary": "Set a remote theme as the live theme."
-    },
-    "theme:pull": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/theme",
-      "description": "Retrieves theme files from Shopify.\n\nIf no theme is specified, then you're prompted to select the theme to pull from the list of the themes in your store.",
-      "descriptionWithMarkdown": "Retrieves theme files from Shopify.\n\nIf no theme is specified, then you're prompted to select the theme to pull from the list of the themes in your store.",
-      "flags": {
-        "development": {
-          "allowNo": false,
-          "char": "d",
-          "description": "Pull theme files from your remote development theme.",
-          "env": "SHOPIFY_FLAG_DEVELOPMENT",
-          "name": "development",
-          "type": "boolean"
-        },
-        "environment": {
-          "char": "e",
-          "description": "The environment to apply to the current command.",
-          "env": "SHOPIFY_FLAG_ENVIRONMENT",
-          "hasDynamicHelp": false,
-          "multiple": true,
-          "name": "environment",
-          "type": "option"
-        },
-        "force": {
-          "allowNo": false,
-          "char": "f",
-          "description": "Proceed without confirmation, if current directory does not seem to be theme directory.",
-          "env": "SHOPIFY_FLAG_FORCE",
-          "hidden": true,
-          "name": "force",
-          "type": "boolean"
-        },
-        "ignore": {
-          "char": "x",
-          "description": "Skip downloading the specified files (Multiple flags allowed). Wrap the value in double quotes if you're using wildcards.",
-          "env": "SHOPIFY_FLAG_IGNORE",
-          "hasDynamicHelp": false,
-          "multiple": true,
-          "name": "ignore",
-          "type": "option"
-        },
-        "live": {
-          "allowNo": false,
-          "char": "l",
-          "description": "Pull theme files from your remote live theme.",
-          "env": "SHOPIFY_FLAG_LIVE",
-          "name": "live",
-          "type": "boolean"
-        },
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
-          "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
-        "nodelete": {
-          "allowNo": false,
-          "char": "n",
-          "description": "Prevent deleting local files that don't exist remotely.",
-          "env": "SHOPIFY_FLAG_NODELETE",
-          "name": "nodelete",
-          "type": "boolean"
-        },
-        "only": {
-          "char": "o",
-          "description": "Download only the specified files (Multiple flags allowed). Wrap the value in double quotes if you're using wildcards.",
-          "env": "SHOPIFY_FLAG_ONLY",
-          "hasDynamicHelp": false,
-          "multiple": true,
-          "name": "only",
-          "type": "option"
-        },
-        "password": {
-          "description": "Password generated from the Theme Access app or an Admin API token.",
-          "env": "SHOPIFY_CLI_THEME_TOKEN",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "password",
-          "type": "option"
-        },
-        "path": {
-          "description": "The path where you want to run the command. Defaults to the current working directory.",
-          "env": "SHOPIFY_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "path",
-          "noCacheDefault": true,
-          "type": "option"
-        },
-        "store": {
-          "char": "s",
-          "description": "Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).",
-          "env": "SHOPIFY_FLAG_STORE",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "store",
-          "type": "option"
-        },
-        "theme": {
-          "char": "t",
-          "description": "Theme ID or name of the remote theme.",
-          "env": "SHOPIFY_FLAG_THEME_ID",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "theme",
-          "type": "option"
-        },
-        "verbose": {
-          "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "theme:pull",
-      "multiEnvironmentsFlags": [
-        "store",
-        "password",
-        "path",
-        [
-          "live",
-          "development",
-          "theme"
-        ]
-      ],
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true,
-      "summary": "Download your remote theme files locally."
-    },
-    "theme:push": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/theme",
-      "description": "Uploads your local theme files to Shopify, overwriting the remote version if specified.\n\n  If no theme is specified, then you're prompted to select the theme to overwrite from the list of the themes in your store.\n\n  You can run this command only in a directory that matches the \"default Shopify theme folder structure\" (https://shopify.dev/docs/themes/tools/cli#directory-structure).\n\n  This command returns the following information:\n\n  - A link to the \"editor\" (https://shopify.dev/docs/themes/tools/online-editor) for the theme in the Shopify admin.\n  - A \"preview link\" (https://help.shopify.com/manual/online-store/themes/adding-themes#share-a-theme-preview-with-others) that you can share with others.\n\n  If you use the `--json` flag, then theme information is returned in JSON format, which can be used as a machine-readable input for scripts or continuous integration.\n\n  Sample output:\n\n  ```json\n  {\n    \"theme\": {\n      \"id\": 108267175958,\n      \"name\": \"MyTheme\",\n      \"role\": \"unpublished\",\n      \"shop\": \"mystore.myshopify.com\",\n      \"editor_url\": \"https://mystore.myshopify.com/admin/themes/108267175958/editor\",\n      \"preview_url\": \"https://mystore.myshopify.com/?preview_theme_id=108267175958\"\n    }\n  }\n  ```\n    ",
-      "descriptionWithMarkdown": "Uploads your local theme files to Shopify, overwriting the remote version if specified.\n\n  If no theme is specified, then you're prompted to select the theme to overwrite from the list of the themes in your store.\n\n  You can run this command only in a directory that matches the [default Shopify theme folder structure](https://shopify.dev/docs/themes/tools/cli#directory-structure).\n\n  This command returns the following information:\n\n  - A link to the [editor](https://shopify.dev/docs/themes/tools/online-editor) for the theme in the Shopify admin.\n  - A [preview link](https://help.shopify.com/manual/online-store/themes/adding-themes#share-a-theme-preview-with-others) that you can share with others.\n\n  If you use the `--json` flag, then theme information is returned in JSON format, which can be used as a machine-readable input for scripts or continuous integration.\n\n  Sample output:\n\n  ```json\n  {\n    \"theme\": {\n      \"id\": 108267175958,\n      \"name\": \"MyTheme\",\n      \"role\": \"unpublished\",\n      \"shop\": \"mystore.myshopify.com\",\n      \"editor_url\": \"https://mystore.myshopify.com/admin/themes/108267175958/editor\",\n      \"preview_url\": \"https://mystore.myshopify.com/?preview_theme_id=108267175958\"\n    }\n  }\n  ```\n    ",
-      "flags": {
-        "allow-live": {
-          "allowNo": false,
-          "char": "a",
-          "description": "Allow push to a live theme.",
-          "env": "SHOPIFY_FLAG_ALLOW_LIVE",
-          "name": "allow-live",
-          "type": "boolean"
-        },
-        "development": {
-          "allowNo": false,
-          "char": "d",
-          "description": "Push theme files from your remote development theme.",
-          "env": "SHOPIFY_FLAG_DEVELOPMENT",
-          "name": "development",
-          "type": "boolean"
-        },
-        "development-context": {
-          "char": "c",
-          "dependsOn": [
-            "development"
-          ],
-          "description": "Unique identifier for a development theme context (e.g., PR number, branch name). Reuses an existing development theme with this context name, or creates one if none exists.",
-          "env": "SHOPIFY_FLAG_DEVELOPMENT_CONTEXT",
-          "exclusive": [
-            "theme"
-          ],
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "development-context",
-          "type": "option"
-        },
-        "environment": {
-          "char": "e",
-          "description": "The environment to apply to the current command.",
-          "env": "SHOPIFY_FLAG_ENVIRONMENT",
-          "hasDynamicHelp": false,
-          "multiple": true,
-          "name": "environment",
-          "type": "option"
-        },
-        "force": {
-          "allowNo": false,
-          "char": "f",
-          "description": "Proceed without confirmation, if current directory does not seem to be theme directory.",
-          "env": "SHOPIFY_FLAG_FORCE",
-          "hidden": true,
-          "name": "force",
-          "type": "boolean"
-        },
-        "ignore": {
-          "char": "x",
-          "description": "Skip uploading the specified files (Multiple flags allowed). Wrap the value in double quotes if you're using wildcards.",
-          "env": "SHOPIFY_FLAG_IGNORE",
-          "hasDynamicHelp": false,
-          "multiple": true,
-          "name": "ignore",
-          "type": "option"
-        },
-        "json": {
-          "allowNo": false,
-          "char": "j",
-          "description": "Output the result as JSON. Automatically disables color output.",
-          "env": "SHOPIFY_FLAG_JSON",
-          "hidden": false,
-          "name": "json",
-          "type": "boolean"
-        },
-        "listing": {
-          "description": "The listing preset to use for multi-preset themes. Applies preset files from listings/[preset-name] directory.",
-          "env": "SHOPIFY_FLAG_LISTING",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "listing",
-          "type": "option"
-        },
-        "live": {
-          "allowNo": false,
-          "char": "l",
-          "description": "Push theme files from your remote live theme.",
-          "env": "SHOPIFY_FLAG_LIVE",
-          "name": "live",
-          "type": "boolean"
-        },
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
-          "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
-        "nodelete": {
-          "allowNo": false,
-          "char": "n",
-          "description": "Prevent deleting remote files that don't exist locally.",
-          "env": "SHOPIFY_FLAG_NODELETE",
-          "name": "nodelete",
-          "type": "boolean"
-        },
-        "only": {
-          "char": "o",
-          "description": "Upload only the specified files (Multiple flags allowed). Wrap the value in double quotes if you're using wildcards.",
-          "env": "SHOPIFY_FLAG_ONLY",
-          "hasDynamicHelp": false,
-          "multiple": true,
-          "name": "only",
-          "type": "option"
-        },
-        "password": {
-          "description": "Password generated from the Theme Access app or an Admin API token.",
-          "env": "SHOPIFY_CLI_THEME_TOKEN",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "password",
-          "type": "option"
-        },
-        "path": {
-          "description": "The path where you want to run the command. Defaults to the current working directory.",
-          "env": "SHOPIFY_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "path",
-          "noCacheDefault": true,
-          "type": "option"
-        },
-        "publish": {
-          "allowNo": false,
-          "char": "p",
-          "description": "Publish as the live theme after uploading.",
-          "env": "SHOPIFY_FLAG_PUBLISH",
-          "name": "publish",
-          "type": "boolean"
-        },
-        "store": {
-          "char": "s",
-          "description": "Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).",
-          "env": "SHOPIFY_FLAG_STORE",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "store",
-          "type": "option"
-        },
-        "strict": {
-          "allowNo": false,
-          "description": "Require theme check to pass without errors before pushing. Warnings are allowed.",
-          "env": "SHOPIFY_FLAG_STRICT_PUSH",
-          "name": "strict",
-          "type": "boolean"
-        },
-        "theme": {
-          "char": "t",
-          "description": "Theme ID or name of the remote theme.",
-          "env": "SHOPIFY_FLAG_THEME_ID",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "theme",
-          "type": "option"
-        },
-        "unpublished": {
-          "allowNo": false,
-          "char": "u",
-          "description": "Create a new unpublished theme and push to it.",
-          "env": "SHOPIFY_FLAG_UNPUBLISHED",
-          "name": "unpublished",
-          "type": "boolean"
-        },
-        "verbose": {
-          "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "theme:push",
-      "multiEnvironmentsFlags": [
-        "store",
-        "password",
-        "path",
-        [
-          "live",
-          "development",
-          "theme"
-        ]
-      ],
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true,
-      "summary": "Uploads your local theme files to the connected store, overwriting the remote version if specified.",
-      "usage": [
-        "theme push",
-        "theme push --unpublished --json"
-      ]
-    },
-    "theme:rename": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/theme",
-      "description": "Renames a theme in your store.\n\n  If no theme is specified, then you're prompted to select the theme that you want to rename from the list of themes in your store.\n  ",
-      "descriptionWithMarkdown": "Renames a theme in your store.\n\n  If no theme is specified, then you're prompted to select the theme that you want to rename from the list of themes in your store.\n  ",
-      "flags": {
-        "development": {
-          "allowNo": false,
-          "char": "d",
-          "description": "Rename your development theme.",
-          "env": "SHOPIFY_FLAG_DEVELOPMENT",
-          "name": "development",
-          "type": "boolean"
-        },
-        "environment": {
-          "char": "e",
-          "description": "The environment to apply to the current command.",
-          "env": "SHOPIFY_FLAG_ENVIRONMENT",
-          "hasDynamicHelp": false,
-          "multiple": true,
-          "name": "environment",
-          "type": "option"
-        },
-        "live": {
-          "allowNo": false,
-          "char": "l",
-          "description": "Rename your remote live theme.",
-          "env": "SHOPIFY_FLAG_LIVE",
-          "name": "live",
-          "type": "boolean"
-        },
-        "name": {
-          "char": "n",
-          "description": "The new name for the theme.",
-          "env": "SHOPIFY_FLAG_NEW_NAME",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "name",
-          "required": false,
-          "type": "option"
-        },
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
-          "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
-        "password": {
-          "description": "Password generated from the Theme Access app or an Admin API token.",
-          "env": "SHOPIFY_CLI_THEME_TOKEN",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "password",
-          "type": "option"
-        },
-        "path": {
-          "description": "The path where you want to run the command. Defaults to the current working directory.",
-          "env": "SHOPIFY_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "path",
-          "noCacheDefault": true,
-          "type": "option"
-        },
-        "store": {
-          "char": "s",
-          "description": "Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).",
-          "env": "SHOPIFY_FLAG_STORE",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "store",
-          "type": "option"
-        },
-        "theme": {
-          "char": "t",
-          "description": "Theme ID or name of the remote theme.",
-          "env": "SHOPIFY_FLAG_THEME_ID",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "theme",
-          "type": "option"
-        },
-        "verbose": {
-          "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "theme:rename",
-      "multiEnvironmentsFlags": [
-        "store",
-        "password",
-        "name",
-        [
-          "live",
-          "development",
-          "theme"
-        ]
-      ],
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true,
-      "summary": "Renames an existing theme."
-    },
-    "theme:share": {
-      "aliases": [
-      ],
-      "args": {
-      },
-      "customPluginName": "@shopify/theme",
-      "description": "Uploads your theme as a new, unpublished theme in your theme library. The theme is given a randomized name.\n\n  This command returns a \"preview link\" (https://help.shopify.com/manual/online-store/themes/adding-themes#share-a-theme-preview-with-others) that you can share with others.",
-      "descriptionWithMarkdown": "Uploads your theme as a new, unpublished theme in your theme library. The theme is given a randomized name.\n\n  This command returns a [preview link](https://help.shopify.com/manual/online-store/themes/adding-themes#share-a-theme-preview-with-others) that you can share with others.",
-      "flags": {
-        "environment": {
-          "char": "e",
-          "description": "The environment to apply to the current command.",
-          "env": "SHOPIFY_FLAG_ENVIRONMENT",
-          "hasDynamicHelp": false,
-          "multiple": true,
-          "name": "environment",
-          "type": "option"
-        },
-        "force": {
-          "allowNo": false,
-          "char": "f",
-          "description": "Proceed without confirmation, if current directory does not seem to be theme directory.",
-          "env": "SHOPIFY_FLAG_FORCE",
-          "hidden": true,
-          "name": "force",
-          "type": "boolean"
-        },
-        "listing": {
-          "description": "The listing preset to use for multi-preset themes. Applies preset files from listings/[preset-name] directory.",
-          "env": "SHOPIFY_FLAG_LISTING",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "listing",
-          "type": "option"
-        },
-        "no-color": {
-          "allowNo": false,
-          "description": "Disable color output.",
-          "env": "SHOPIFY_FLAG_NO_COLOR",
-          "hidden": false,
-          "name": "no-color",
-          "type": "boolean"
-        },
-        "password": {
-          "description": "Password generated from the Theme Access app or an Admin API token.",
-          "env": "SHOPIFY_CLI_THEME_TOKEN",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "password",
-          "type": "option"
-        },
-        "path": {
-          "description": "The path where you want to run the command. Defaults to the current working directory.",
-          "env": "SHOPIFY_FLAG_PATH",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "path",
-          "noCacheDefault": true,
-          "type": "option"
-        },
-        "store": {
-          "char": "s",
-          "description": "Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).",
-          "env": "SHOPIFY_FLAG_STORE",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "store",
-          "type": "option"
-        },
-        "verbose": {
-          "allowNo": false,
-          "description": "Increase the verbosity of the output.",
-          "env": "SHOPIFY_FLAG_VERBOSE",
-          "hidden": false,
-          "name": "verbose",
-          "type": "boolean"
-        }
-      },
-      "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
-      "id": "theme:share",
-      "multiEnvironmentsFlags": [
-        "store",
-        "password",
-        "path"
-      ],
-      "pluginAlias": "@shopify/cli",
-      "pluginName": "@shopify/cli",
-      "pluginType": "core",
-      "strict": true,
-      "summary": "Creates a shareable, unpublished, and new theme on your theme library with a randomized name."
+      "usage": "search [query]",
+      "enableJsonFlag": false
     },
     "upgrade": {
-      "aliases": [
-      ],
-      "args": {
-      },
+      "aliases": [],
+      "args": {},
       "description": "Upgrades Shopify CLI using your package manager.",
-      "descriptionWithMarkdown": "Upgrades Shopify CLI using your package manager.",
-      "enableJsonFlag": false,
-      "flags": {
-      },
+      "flags": {},
       "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
+      "hiddenAliases": [],
       "id": "upgrade",
       "pluginAlias": "@shopify/cli",
       "pluginName": "@shopify/cli",
       "pluginType": "core",
       "strict": true,
-      "summary": "Upgrades Shopify CLI."
+      "summary": "Upgrades Shopify CLI.",
+      "enableJsonFlag": false,
+      "descriptionWithMarkdown": "Upgrades Shopify CLI using your package manager."
     },
     "version": {
-      "aliases": [
-      ],
-      "args": {
-      },
+      "aliases": [],
+      "args": {},
       "description": "Shopify CLI version currently installed.",
-      "enableJsonFlag": false,
-      "flags": {
-      },
+      "flags": {},
       "hasDynamicHelp": false,
-      "hiddenAliases": [
-      ],
+      "hiddenAliases": [],
       "id": "version",
       "pluginAlias": "@shopify/cli",
       "pluginName": "@shopify/cli",
       "pluginType": "core",
-      "strict": true
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "help": {
+      "aliases": [],
+      "args": {
+        "command": {
+          "description": "Command to show help for.",
+          "name": "command",
+          "required": false
+        }
+      },
+      "description": "Display help for Shopify CLI",
+      "flags": {
+        "nested-commands": {
+          "char": "n",
+          "description": "Include all nested commands in the output.",
+          "env": "SHOPIFY_FLAG_CLI_NESTED_COMMANDS",
+          "name": "nested-commands",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "help",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": false,
+      "usage": "help [command] [flags]",
+      "enableJsonFlag": false
+    },
+    "auth:logout": {
+      "aliases": [],
+      "args": {},
+      "description": "Logs you out of the Shopify account or Partner account and store.",
+      "flags": {},
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "auth:logout",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "auth:login": {
+      "aliases": [],
+      "args": {},
+      "description": "Logs you in to your Shopify account.",
+      "flags": {
+        "alias": {
+          "description": "Alias of the session you want to login to.",
+          "env": "SHOPIFY_FLAG_AUTH_ALIAS",
+          "name": "alias",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "auth:login",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "debug:command-flags": {
+      "aliases": [],
+      "args": {},
+      "description": "View all the available command flags",
+      "flags": {
+        "csv": {
+          "description": "Output as CSV",
+          "env": "SHOPIFY_FLAG_OUTPUT_CSV",
+          "name": "csv",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hidden": true,
+      "hiddenAliases": [],
+      "id": "debug:command-flags",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "kitchen-sink": {
+      "aliases": [],
+      "args": {},
+      "description": "View all the available UI kit components",
+      "flags": {},
+      "hasDynamicHelp": false,
+      "hidden": true,
+      "hiddenAliases": [
+        "kitchen-sink all"
+      ],
+      "id": "kitchen-sink",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "kitchen-sink:async": {
+      "aliases": [],
+      "args": {},
+      "description": "View the UI kit components that process async tasks",
+      "flags": {},
+      "hasDynamicHelp": false,
+      "hidden": true,
+      "hiddenAliases": [],
+      "id": "kitchen-sink:async",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "kitchen-sink:prompts": {
+      "aliases": [],
+      "args": {},
+      "description": "View the UI kit components prompts",
+      "flags": {},
+      "hasDynamicHelp": false,
+      "hidden": true,
+      "hiddenAliases": [],
+      "id": "kitchen-sink:prompts",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "kitchen-sink:static": {
+      "aliases": [],
+      "args": {},
+      "description": "View the UI kit components that display static output",
+      "flags": {},
+      "hasDynamicHelp": false,
+      "hidden": true,
+      "hiddenAliases": [],
+      "id": "kitchen-sink:static",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "doctor-release": {
+      "aliases": [],
+      "args": {},
+      "description": "Run CLI doctor-release tests",
+      "flags": {},
+      "hasDynamicHelp": false,
+      "hidden": true,
+      "hiddenAliases": [],
+      "id": "doctor-release",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "doctor-release:theme": {
+      "aliases": [],
+      "args": {},
+      "description": "Run all theme command doctor-release tests",
+      "flags": {
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "path": {
+          "char": "p",
+          "description": "The path to run tests in. Defaults to current directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "name": "path",
+          "default": "/Users/jeremygayed/src/github.com/Shopify/cli/packages/cli",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "environment": {
+          "char": "e",
+          "description": "The environment to use from shopify.theme.toml (required for store-connected tests).",
+          "env": "SHOPIFY_FLAG_ENVIRONMENT",
+          "name": "environment",
+          "required": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "store": {
+          "char": "s",
+          "description": "Store URL (overrides environment).",
+          "env": "SHOPIFY_FLAG_STORE",
+          "name": "store",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "password": {
+          "description": "Password from Theme Access app (overrides environment).",
+          "env": "SHOPIFY_FLAG_PASSWORD",
+          "name": "password",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hidden": true,
+      "hiddenAliases": [],
+      "id": "doctor-release:theme",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "docs:generate": {
+      "aliases": [],
+      "args": {},
+      "description": "Generate CLI commands documentation",
+      "flags": {},
+      "hasDynamicHelp": false,
+      "hidden": true,
+      "hiddenAliases": [],
+      "id": "docs:generate",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "notifications:list": {
+      "aliases": [],
+      "args": {},
+      "description": "List current notifications configured for the CLI.",
+      "flags": {
+        "ignore-errors": {
+          "description": "Don't fail if an error occurs.",
+          "env": "SHOPIFY_FLAG_IGNORE_ERRORS",
+          "hidden": false,
+          "name": "ignore-errors",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hidden": true,
+      "hiddenAliases": [],
+      "id": "notifications:list",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "notifications:generate": {
+      "aliases": [],
+      "args": {},
+      "description": "Generate a notifications.json file for the the CLI, appending a new notification to the current file.",
+      "flags": {},
+      "hasDynamicHelp": false,
+      "hidden": true,
+      "hiddenAliases": [],
+      "id": "notifications:generate",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "cache:clear": {
+      "aliases": [],
+      "args": {},
+      "description": "Clear the CLI cache, used to store some API responses and handle notifications status",
+      "flags": {},
+      "hasDynamicHelp": false,
+      "hidden": true,
+      "hiddenAliases": [],
+      "id": "cache:clear",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "config:autoupgrade:off": {
+      "aliases": [],
+      "args": {},
+      "description": "Disable automatic upgrades for Shopify CLI.\n\n  When auto-upgrade is disabled, Shopify CLI won't automatically update. Run `shopify upgrade` to update manually.\n\n  To enable auto-upgrade, run `shopify config autoupgrade on`.\n",
+      "flags": {},
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "config:autoupgrade:off",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "summary": "Disable automatic upgrades for Shopify CLI.",
+      "enableJsonFlag": false,
+      "descriptionWithMarkdown": "Disable automatic upgrades for Shopify CLI.\n\n  When auto-upgrade is disabled, Shopify CLI won't automatically update. Run `shopify upgrade` to update manually.\n\n  To enable auto-upgrade, run `shopify config autoupgrade on`.\n"
+    },
+    "config:autoupgrade:on": {
+      "aliases": [],
+      "args": {},
+      "description": "Enable automatic upgrades for Shopify CLI.\n\n  When auto-upgrade is enabled, Shopify CLI automatically updates to the latest version once per day. Major version upgrades are skipped and must be done manually.\n\n  To disable auto-upgrade, run `shopify config autoupgrade off`.\n",
+      "flags": {},
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "config:autoupgrade:on",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "summary": "Enable automatic upgrades for Shopify CLI.",
+      "enableJsonFlag": false,
+      "descriptionWithMarkdown": "Enable automatic upgrades for Shopify CLI.\n\n  When auto-upgrade is enabled, Shopify CLI automatically updates to the latest version once per day. Major version upgrades are skipped and must be done manually.\n\n  To disable auto-upgrade, run `shopify config autoupgrade off`.\n"
+    },
+    "config:autoupgrade:status": {
+      "aliases": [],
+      "args": {},
+      "description": "Check whether auto-upgrade is enabled, disabled, or not yet configured.\n\n  When auto-upgrade is enabled, Shopify CLI automatically updates to the latest version after each command.\n\n  Run `shopify config autoupgrade on` or `shopify config autoupgrade off` to configure it.\n",
+      "flags": {},
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "config:autoupgrade:status",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "summary": "Check whether auto-upgrade is enabled, disabled, or not yet configured.",
+      "enableJsonFlag": false,
+      "descriptionWithMarkdown": "Check whether auto-upgrade is enabled, disabled, or not yet configured.\n\n  When auto-upgrade is enabled, Shopify CLI automatically updates to the latest version after each command.\n\n  Run `shopify config autoupgrade on` or `shopify config autoupgrade off` to configure it.\n"
+    },
+    "preview:create": {
+      "aliases": [],
+      "args": {},
+      "description": "Calls Core's /services/preview-stores orchestrator. Returns a shop, an Admin API token, and a one-time-use magic-link URL the user can open to land in admin without an Identity login.\n\nTargets a local Core rig by default (https://app.shop.dev). Override --core-url to point elsewhere.",
+      "examples": [
+        "<%= config.bin %> <%= command.id %> --shop-name my-preview",
+        "<%= config.bin %> <%= command.id %> --shop-name my-preview --email demo@previewstore.invalid",
+        "<%= config.bin %> <%= command.id %> --shop-name my-preview --json"
+      ],
+      "flags": {
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "json": {
+          "char": "j",
+          "description": "Output the result as JSON. Automatically disables color output.",
+          "env": "SHOPIFY_FLAG_JSON",
+          "hidden": false,
+          "name": "json",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "shop-name": {
+          "char": "n",
+          "description": "Subdomain prefix for the new preview store (e.g. \"my-preview\"). Auto-generated if omitted.",
+          "env": "SHOPIFY_FLAG_PREVIEW_STORE_SHOP_NAME",
+          "name": "shop-name",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "email": {
+          "description": "Email to associate with the placeholder identity. Defaults to a generated @previewstore.invalid address.",
+          "env": "SHOPIFY_FLAG_PREVIEW_STORE_EMAIL",
+          "name": "email",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "country": {
+          "description": "ISO country code for the new store. Defaults to US.",
+          "env": "SHOPIFY_FLAG_PREVIEW_STORE_COUNTRY",
+          "name": "country",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "core-url": {
+          "description": "Base URL of the Core orchestrator. Defaults to https://app.shop.dev.",
+          "env": "SHOPIFY_FLAG_PREVIEW_STORE_CORE_URL",
+          "name": "core-url",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "cli-username": {
+          "description": "Basic-auth username for the Core endpoint. Defaults to \"preview-store-cli\".",
+          "env": "SHOPIFY_FLAG_PREVIEW_STORE_CLI_USERNAME",
+          "name": "cli-username",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "cli-secret": {
+          "description": "Basic-auth secret for the Core endpoint. Defaults to the dev value \"preview-store-cli-dev\".",
+          "env": "SHOPIFY_FLAG_PREVIEW_STORE_CLI_SECRET",
+          "name": "cli-secret",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "preview:create",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "summary": "Create a Preview Store backed by a placeholder identity.",
+      "enableJsonFlag": false
+    },
+    "preview:claim": {
+      "aliases": [],
+      "args": {},
+      "description": "Calls Core's /services/preview-stores/claim endpoint, which wraps the existing org-based vibe transfer flow used today by Lovable. Returns a claim URL the recipient opens to take ownership of the store.",
+      "examples": [
+        "<%= config.bin %> <%= command.id %> --shop-id 21 --recipient-email merchant@example.com"
+      ],
+      "flags": {
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "json": {
+          "char": "j",
+          "description": "Output the result as JSON. Automatically disables color output.",
+          "env": "SHOPIFY_FLAG_JSON",
+          "hidden": false,
+          "name": "json",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "shop-id": {
+          "description": "Numeric shop id returned by `preview create`.",
+          "env": "SHOPIFY_FLAG_PREVIEW_STORE_SHOP_ID",
+          "name": "shop-id",
+          "required": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "recipient-email": {
+          "description": "Email of the merchant identity that should take ownership after they accept the claim link.",
+          "env": "SHOPIFY_FLAG_PREVIEW_STORE_RECIPIENT_EMAIL",
+          "name": "recipient-email",
+          "required": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "core-url": {
+          "description": "Base URL of the Core orchestrator. Defaults to https://app.shop.dev.",
+          "env": "SHOPIFY_FLAG_PREVIEW_STORE_CORE_URL",
+          "name": "core-url",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "cli-username": {
+          "description": "Basic-auth username for the Core endpoint. Defaults to \"preview-store-cli\".",
+          "env": "SHOPIFY_FLAG_PREVIEW_STORE_CLI_USERNAME",
+          "name": "cli-username",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "cli-secret": {
+          "description": "Basic-auth secret for the Core endpoint. Defaults to the dev value \"preview-store-cli-dev\".",
+          "env": "SHOPIFY_FLAG_PREVIEW_STORE_CLI_SECRET",
+          "name": "cli-secret",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "preview:claim",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "summary": "Generate a claim URL that transfers a Preview Store to a real merchant identity.",
+      "enableJsonFlag": false
+    },
+    "preview:execute": {
+      "aliases": [],
+      "args": {},
+      "description": "Reads the shop domain and admin API token straight from `preview create --json` output (or accepts them as flags). Calls the Admin GraphQL endpoint at the requested API version. Mutations are blocked unless --allow-mutations is set.",
+      "examples": [
+        "<%= config.bin %> <%= command.id %> --from-file /tmp/preview.json --query \"{ shop { name } }\"",
+        "<%= config.bin %> <%= command.id %> --from-file /tmp/preview.json --query-file ./query.graphql",
+        "<%= config.bin %> <%= command.id %> --domain shop.myshopify.io --token shpat_... --query \"...\"",
+        "<%= config.bin %> <%= command.id %> --from-file /tmp/preview.json --allow-mutations --query-file ./mutation.graphql"
+      ],
+      "flags": {
+        "no-color": {
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "verbose": {
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "json": {
+          "char": "j",
+          "description": "Output the result as JSON. Automatically disables color output.",
+          "env": "SHOPIFY_FLAG_JSON",
+          "hidden": false,
+          "name": "json",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "from-file": {
+          "description": "Path to JSON produced by `preview create --json`. Provides domain + admin token.",
+          "env": "SHOPIFY_FLAG_PREVIEW_STORE_FROM_FILE",
+          "exclusive": [
+            "domain",
+            "token"
+          ],
+          "name": "from-file",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "domain": {
+          "dependsOn": [
+            "token"
+          ],
+          "description": "Permanent shop domain (e.g. preview-123.myshopify.io). Required if --from-file is omitted.",
+          "env": "SHOPIFY_FLAG_PREVIEW_STORE_DOMAIN",
+          "name": "domain",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "token": {
+          "dependsOn": [
+            "domain"
+          ],
+          "description": "Admin API token (shpat_...). Required if --from-file is omitted.",
+          "env": "SHOPIFY_FLAG_PREVIEW_STORE_TOKEN",
+          "name": "token",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "query": {
+          "char": "q",
+          "description": "GraphQL query or mutation as a string.",
+          "env": "SHOPIFY_FLAG_PREVIEW_STORE_QUERY",
+          "exclusive": [
+            "query-file"
+          ],
+          "name": "query",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "query-file": {
+          "description": "Path to a file containing a GraphQL query or mutation.",
+          "env": "SHOPIFY_FLAG_PREVIEW_STORE_QUERY_FILE",
+          "exclusive": [
+            "query"
+          ],
+          "name": "query-file",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "variables": {
+          "description": "GraphQL variables as a JSON string.",
+          "env": "SHOPIFY_FLAG_PREVIEW_STORE_VARIABLES",
+          "exclusive": [
+            "variable-file"
+          ],
+          "name": "variables",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "variable-file": {
+          "description": "Path to a JSON file containing GraphQL variables.",
+          "env": "SHOPIFY_FLAG_PREVIEW_STORE_VARIABLE_FILE",
+          "exclusive": [
+            "variables"
+          ],
+          "name": "variable-file",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "api-version": {
+          "description": "Admin API version. Defaults to \"unstable\".",
+          "env": "SHOPIFY_FLAG_PREVIEW_STORE_API_VERSION",
+          "name": "api-version",
+          "required": false,
+          "default": "unstable",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "allow-mutations": {
+          "description": "Allow mutation operations. Required for any GraphQL document with `mutation`.",
+          "env": "SHOPIFY_FLAG_PREVIEW_STORE_ALLOW_MUTATIONS",
+          "name": "allow-mutations",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "preview:execute",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "summary": "Run an Admin GraphQL operation against a Preview Store using its shop-scoped token.",
+      "enableJsonFlag": false
+    },
+    "agent:session:start": {
+      "aliases": [],
+      "args": {},
+      "description": "Initializes and persists a new agent session with the specified configuration.",
+      "examples": [
+        "<%= config.bin %> <%= command.id %> --agent river --agent-version 1.0.0 --provider openai --metrics on",
+        "<%= config.bin %> <%= command.id %> --agent river --agent-version 1.0.0 --provider openai --metrics off --default-non-interactive",
+        "<%= config.bin %> <%= command.id %> --agent river --agent-version 1.0.0 --provider openai --metrics on --json"
+      ],
+      "flags": {
+        "json": {
+          "char": "j",
+          "description": "Output the result as JSON. Automatically disables color output.",
+          "env": "SHOPIFY_FLAG_JSON",
+          "hidden": false,
+          "name": "json",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "agent": {
+          "description": "Agent name.",
+          "env": "SHOPIFY_FLAG_AGENT_NAME",
+          "name": "agent",
+          "required": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "agent-version": {
+          "description": "Agent version.",
+          "env": "SHOPIFY_FLAG_AGENT_VERSION",
+          "name": "agent-version",
+          "required": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "provider": {
+          "description": "Agent provider.",
+          "env": "SHOPIFY_FLAG_AGENT_PROVIDER",
+          "name": "provider",
+          "required": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "metrics": {
+          "description": "Metrics mode (on or off).",
+          "env": "SHOPIFY_FLAG_AGENT_METRICS",
+          "name": "metrics",
+          "required": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "options": [
+            "on",
+            "off"
+          ],
+          "type": "option"
+        },
+        "default-non-interactive": {
+          "description": "Set default non-interactive mode.",
+          "env": "SHOPIFY_FLAG_AGENT_DEFAULT_NON_INTERACTIVE",
+          "name": "default-non-interactive",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "agent:session:start",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "summary": "Start a new agent session.",
+      "enableJsonFlag": false
     }
   },
   "version": "3.94.0"

--- a/packages/cli/src/cli/commands/agent/session/start.test.ts
+++ b/packages/cli/src/cli/commands/agent/session/start.test.ts
@@ -1,5 +1,5 @@
-import {describe, expect, test, vi, beforeEach} from 'vitest'
 import AgentSessionStart from './start.js'
+import {describe, expect, test, vi, beforeEach} from 'vitest'
 import {startAgentSession} from '@shopify/cli-kit/node/agent'
 import {mockAndCaptureOutput} from '@shopify/cli-kit/node/testing/output'
 import {randomUUID} from 'crypto'
@@ -10,7 +10,8 @@ vi.mock('crypto', () => ({
 }))
 
 describe('AgentSessionStart', () => {
-  const mockSessionId = 'conv_test-uuid-1234'
+  const mockUuid = '00000000-0000-4000-8000-000000000001'
+  const mockSessionId = `conv_${mockUuid}`
   const mockSession = {
     sessionId: mockSessionId,
     startedAt: '2024-01-15T10:00:00.000Z',
@@ -22,7 +23,7 @@ describe('AgentSessionStart', () => {
   }
 
   beforeEach(() => {
-    vi.mocked(randomUUID).mockReturnValue('test-uuid-1234')
+    vi.mocked(randomUUID).mockReturnValue(mockUuid)
     vi.mocked(startAgentSession).mockReturnValue(mockSession)
   })
 
@@ -33,12 +34,7 @@ describe('AgentSessionStart', () => {
 
     // When
     await AgentSessionStart.run(
-      [
-        '--agent', 'test-agent',
-        '--agent-version', '1.2.3',
-        '--provider', 'test-provider',
-        '--metrics', 'on',
-      ],
+      ['--agent', 'test-agent', '--agent-version', '1.2.3', '--provider', 'test-provider', '--metrics', 'on'],
       import.meta.url,
     )
 
@@ -70,12 +66,7 @@ describe('AgentSessionStart', () => {
 
     // When
     await AgentSessionStart.run(
-      [
-        '--agent', 'test-agent',
-        '--agent-version', '1.2.3',
-        '--provider', 'test-provider',
-        '--metrics', 'off',
-      ],
+      ['--agent', 'test-agent', '--agent-version', '1.2.3', '--provider', 'test-provider', '--metrics', 'off'],
       import.meta.url,
     )
 
@@ -102,10 +93,14 @@ describe('AgentSessionStart', () => {
     // When
     await AgentSessionStart.run(
       [
-        '--agent', 'test-agent',
-        '--agent-version', '1.2.3',
-        '--provider', 'test-provider',
-        '--metrics', 'on',
+        '--agent',
+        'test-agent',
+        '--agent-version',
+        '1.2.3',
+        '--provider',
+        'test-provider',
+        '--metrics',
+        'on',
         '--default-non-interactive',
       ],
       import.meta.url,
@@ -131,13 +126,7 @@ describe('AgentSessionStart', () => {
 
     // When
     await AgentSessionStart.run(
-      [
-        '--agent', 'test-agent',
-        '--agent-version', '1.2.3',
-        '--provider', 'test-provider',
-        '--metrics', 'on',
-        '--json',
-      ],
+      ['--agent', 'test-agent', '--agent-version', '1.2.3', '--provider', 'test-provider', '--metrics', 'on', '--json'],
       import.meta.url,
     )
 
@@ -156,25 +145,20 @@ describe('AgentSessionStart', () => {
 
   test('generates unique session ID using randomUUID', async () => {
     // Given
-    vi.mocked(randomUUID).mockReturnValue('unique-uuid-5678')
+    vi.mocked(randomUUID).mockReturnValue('00000000-0000-4000-8000-000000000002')
     const outputMock = mockAndCaptureOutput()
     outputMock.clear()
 
     // When
     await AgentSessionStart.run(
-      [
-        '--agent', 'test-agent',
-        '--agent-version', '1.2.3',
-        '--provider', 'test-provider',
-        '--metrics', 'on',
-      ],
+      ['--agent', 'test-agent', '--agent-version', '1.2.3', '--provider', 'test-provider', '--metrics', 'on'],
       import.meta.url,
     )
 
     // Then
     expect(vi.mocked(startAgentSession)).toHaveBeenCalledWith(
       expect.objectContaining({
-        sessionId: 'conv_unique-uuid-5678',
+        sessionId: 'conv_00000000-0000-4000-8000-000000000002',
       }),
     )
   })

--- a/packages/cli/src/cli/commands/agent/session/start.test.ts
+++ b/packages/cli/src/cli/commands/agent/session/start.test.ts
@@ -1,0 +1,181 @@
+import {describe, expect, test, vi, beforeEach} from 'vitest'
+import AgentSessionStart from './start.js'
+import {startAgentSession} from '@shopify/cli-kit/node/agent'
+import {mockAndCaptureOutput} from '@shopify/cli-kit/node/testing/output'
+import {randomUUID} from 'crypto'
+
+vi.mock('@shopify/cli-kit/node/agent')
+vi.mock('crypto', () => ({
+  randomUUID: vi.fn(),
+}))
+
+describe('AgentSessionStart', () => {
+  const mockSessionId = 'conv_test-uuid-1234'
+  const mockSession = {
+    sessionId: mockSessionId,
+    startedAt: '2024-01-15T10:00:00.000Z',
+    agentName: 'test-agent',
+    agentVersion: '1.2.3',
+    agentProvider: 'test-provider',
+    metricsMode: 'on' as const,
+    defaultNonInteractive: false,
+  }
+
+  beforeEach(() => {
+    vi.mocked(randomUUID).mockReturnValue('test-uuid-1234')
+    vi.mocked(startAgentSession).mockReturnValue(mockSession)
+  })
+
+  test('starts an agent session with required flags', async () => {
+    // Given
+    const outputMock = mockAndCaptureOutput()
+    outputMock.clear()
+
+    // When
+    await AgentSessionStart.run(
+      [
+        '--agent', 'test-agent',
+        '--agent-version', '1.2.3',
+        '--provider', 'test-provider',
+        '--metrics', 'on',
+      ],
+      import.meta.url,
+    )
+
+    // Then
+    expect(vi.mocked(startAgentSession)).toHaveBeenCalledWith({
+      sessionId: mockSessionId,
+      agentName: 'test-agent',
+      agentVersion: '1.2.3',
+      agentProvider: 'test-provider',
+      metricsMode: 'on',
+      defaultNonInteractive: false,
+    })
+
+    expect(outputMock.info()).toContain('Agent session started:')
+    expect(outputMock.info()).toContain(`Session ID: ${mockSessionId}`)
+    expect(outputMock.info()).toContain('Agent: test-agent')
+    expect(outputMock.info()).toContain('Version: 1.2.3')
+    expect(outputMock.info()).toContain('Provider: test-provider')
+    expect(outputMock.info()).toContain('Metrics: on')
+    expect(outputMock.info()).toContain('Default non-interactive: false')
+  })
+
+  test('starts an agent session with metrics off', async () => {
+    // Given
+    const sessionWithMetricsOff = {...mockSession, metricsMode: 'off' as const}
+    vi.mocked(startAgentSession).mockReturnValue(sessionWithMetricsOff)
+    const outputMock = mockAndCaptureOutput()
+    outputMock.clear()
+
+    // When
+    await AgentSessionStart.run(
+      [
+        '--agent', 'test-agent',
+        '--agent-version', '1.2.3',
+        '--provider', 'test-provider',
+        '--metrics', 'off',
+      ],
+      import.meta.url,
+    )
+
+    // Then
+    expect(vi.mocked(startAgentSession)).toHaveBeenCalledWith({
+      sessionId: mockSessionId,
+      agentName: 'test-agent',
+      agentVersion: '1.2.3',
+      agentProvider: 'test-provider',
+      metricsMode: 'off',
+      defaultNonInteractive: false,
+    })
+
+    expect(outputMock.info()).toContain('Metrics: off')
+  })
+
+  test('starts an agent session with default-non-interactive flag', async () => {
+    // Given
+    const sessionWithNonInteractive = {...mockSession, defaultNonInteractive: true}
+    vi.mocked(startAgentSession).mockReturnValue(sessionWithNonInteractive)
+    const outputMock = mockAndCaptureOutput()
+    outputMock.clear()
+
+    // When
+    await AgentSessionStart.run(
+      [
+        '--agent', 'test-agent',
+        '--agent-version', '1.2.3',
+        '--provider', 'test-provider',
+        '--metrics', 'on',
+        '--default-non-interactive',
+      ],
+      import.meta.url,
+    )
+
+    // Then
+    expect(vi.mocked(startAgentSession)).toHaveBeenCalledWith({
+      sessionId: mockSessionId,
+      agentName: 'test-agent',
+      agentVersion: '1.2.3',
+      agentProvider: 'test-provider',
+      metricsMode: 'on',
+      defaultNonInteractive: true,
+    })
+
+    expect(outputMock.info()).toContain('Default non-interactive: true')
+  })
+
+  test('outputs JSON when --json flag is provided', async () => {
+    // Given
+    const outputMock = mockAndCaptureOutput()
+    outputMock.clear()
+
+    // When
+    await AgentSessionStart.run(
+      [
+        '--agent', 'test-agent',
+        '--agent-version', '1.2.3',
+        '--provider', 'test-provider',
+        '--metrics', 'on',
+        '--json',
+      ],
+      import.meta.url,
+    )
+
+    // Then
+    const output = outputMock.output()
+    const jsonOutput = JSON.parse(output)
+
+    expect(jsonOutput).toEqual(mockSession)
+    expect(jsonOutput.sessionId).toBe(mockSessionId)
+    expect(jsonOutput.agentName).toBe('test-agent')
+    expect(jsonOutput.agentVersion).toBe('1.2.3')
+    expect(jsonOutput.agentProvider).toBe('test-provider')
+    expect(jsonOutput.metricsMode).toBe('on')
+    expect(jsonOutput.defaultNonInteractive).toBe(false)
+  })
+
+  test('generates unique session ID using randomUUID', async () => {
+    // Given
+    vi.mocked(randomUUID).mockReturnValue('unique-uuid-5678')
+    const outputMock = mockAndCaptureOutput()
+    outputMock.clear()
+
+    // When
+    await AgentSessionStart.run(
+      [
+        '--agent', 'test-agent',
+        '--agent-version', '1.2.3',
+        '--provider', 'test-provider',
+        '--metrics', 'on',
+      ],
+      import.meta.url,
+    )
+
+    // Then
+    expect(vi.mocked(startAgentSession)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: 'conv_unique-uuid-5678',
+      }),
+    )
+  })
+})

--- a/packages/cli/src/cli/commands/agent/session/start.ts
+++ b/packages/cli/src/cli/commands/agent/session/start.ts
@@ -1,0 +1,83 @@
+import Command from '@shopify/cli-kit/node/base-command'
+import {startAgentSession, AgentSession} from '@shopify/cli-kit/node/agent'
+import {jsonFlag} from '@shopify/cli-kit/node/cli'
+import {outputResult, outputInfo} from '@shopify/cli-kit/node/output'
+import {Flags} from '@oclif/core'
+import {randomUUID} from 'crypto'
+
+export default class AgentSessionStart extends Command {
+  static summary = 'Start a new agent session.'
+
+  static description = 'Initializes and persists a new agent session with the specified configuration.'
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %> --agent river --agent-version 1.0.0 --provider openai --metrics on',
+    '<%= config.bin %> <%= command.id %> --agent river --agent-version 1.0.0 --provider openai --metrics off --default-non-interactive',
+    '<%= config.bin %> <%= command.id %> --agent river --agent-version 1.0.0 --provider openai --metrics on --json',
+  ]
+
+  static flags = {
+    ...jsonFlag,
+    agent: Flags.string({
+      description: 'Agent name.',
+      required: true,
+      env: 'SHOPIFY_FLAG_AGENT_NAME',
+    }),
+    'agent-version': Flags.string({
+      description: 'Agent version.',
+      required: true,
+      env: 'SHOPIFY_FLAG_AGENT_VERSION',
+    }),
+    provider: Flags.string({
+      description: 'Agent provider.',
+      required: true,
+      env: 'SHOPIFY_FLAG_AGENT_PROVIDER',
+    }),
+    metrics: Flags.string({
+      description: 'Metrics mode (on or off).',
+      required: true,
+      options: ['on', 'off'],
+      env: 'SHOPIFY_FLAG_AGENT_METRICS',
+    }),
+    'default-non-interactive': Flags.boolean({
+      description: 'Set default non-interactive mode.',
+      default: false,
+      env: 'SHOPIFY_FLAG_AGENT_DEFAULT_NON_INTERACTIVE',
+    }),
+  }
+
+  async run(): Promise<void> {
+    const {flags} = await this.parse(AgentSessionStart)
+
+    const sessionId = `conv_${randomUUID()}`
+
+    const session = startAgentSession({
+      sessionId,
+      agentName: flags.agent,
+      agentVersion: flags['agent-version'],
+      agentProvider: flags.provider,
+      metricsMode: flags.metrics as 'on' | 'off',
+      defaultNonInteractive: flags['default-non-interactive'],
+    })
+
+    if (flags.json) {
+      outputResult(JSON.stringify(session, null, 2))
+      return
+    }
+
+    outputInfo(formatSessionOutput(session))
+  }
+}
+
+function formatSessionOutput(session: AgentSession): string {
+  return [
+    `Agent session started:`,
+    `  Session ID: ${session.sessionId}`,
+    `  Agent: ${session.agentName}`,
+    `  Version: ${session.agentVersion}`,
+    `  Provider: ${session.agentProvider}`,
+    `  Metrics: ${session.metricsMode}`,
+    `  Default non-interactive: ${session.defaultNonInteractive}`,
+    `  Started at: ${session.startedAt}`,
+  ].join('\n')
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -18,9 +18,6 @@ import ClearCache from './cli/commands/cache/clear.js'
 import AutoupgradeOff from './cli/commands/config/autoupgrade/off.js'
 import AutoupgradeOn from './cli/commands/config/autoupgrade/on.js'
 import AutoupgradeStatus from './cli/commands/config/autoupgrade/status.js'
-import PreviewStoreCreate from './cli/commands/preview/create.js'
-import PreviewStoreClaim from './cli/commands/preview/claim.js'
-import PreviewStoreExecute from './cli/commands/preview/execute.js'
 import AgentSessionStart from './cli/commands/agent/session/start.js'
 import {createGlobalProxyAgent} from 'global-agent'
 import StoreCommands from '@shopify/store'
@@ -168,9 +165,6 @@ export const COMMANDS: any = {
   'config:autoupgrade:off': AutoupgradeOff,
   'config:autoupgrade:on': AutoupgradeOn,
   'config:autoupgrade:status': AutoupgradeStatus,
-  'preview:create': PreviewStoreCreate,
-  'preview:claim': PreviewStoreClaim,
-  'preview:execute': PreviewStoreExecute,
   'agent:session:start': AgentSessionStart,
 }
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -18,6 +18,10 @@ import ClearCache from './cli/commands/cache/clear.js'
 import AutoupgradeOff from './cli/commands/config/autoupgrade/off.js'
 import AutoupgradeOn from './cli/commands/config/autoupgrade/on.js'
 import AutoupgradeStatus from './cli/commands/config/autoupgrade/status.js'
+import PreviewStoreCreate from './cli/commands/preview/create.js'
+import PreviewStoreClaim from './cli/commands/preview/claim.js'
+import PreviewStoreExecute from './cli/commands/preview/execute.js'
+import AgentSessionStart from './cli/commands/agent/session/start.js'
 import {createGlobalProxyAgent} from 'global-agent'
 import StoreCommands from '@shopify/store'
 import ThemeCommands from '@shopify/theme'
@@ -164,6 +168,10 @@ export const COMMANDS: any = {
   'config:autoupgrade:off': AutoupgradeOff,
   'config:autoupgrade:on': AutoupgradeOn,
   'config:autoupgrade:status': AutoupgradeStatus,
+  'preview:create': PreviewStoreCreate,
+  'preview:claim': PreviewStoreClaim,
+  'preview:execute': PreviewStoreExecute,
+  'agent:session:start': AgentSessionStart,
 }
 
 export default runShopifyCLI


### PR DESCRIPTION
## What

Prototype CLI-owned agent session state.

This PR adds:
- `shopify agent session start`
- persisted agent session state in `cli-kit`
- analytics attribution from persisted session state when explicit `SHOPIFY_CLI_AGENT_*` env vars are absent
- prototype analytics opt-out through `metricsMode=off`
- one downstream default-mode proof in `app release`

## Why

`ai-toolkit-source` currently attributes agent-run Shopify CLI commands by prefixing each command with `SHOPIFY_CLI_AGENT_INFO` and `SHOPIFY_CLI_AGENT_IDS`. That works, but it is noisy, token-expensive, and harness-specific.

This prototype tests a different shape: start one agent session in Shopify CLI, persist it there, and let later CLI commands reuse that state for attribution and behavior.

`app release` is the default-mode proof because it already has an established non-interactive path through `--allow-updates`. Reusing that seam makes the prototype easier to evaluate: it shows that agent session state can affect later CLI behavior without inventing a new global `--no-input` contract or taking on a larger command surface like `app init`.

## Behavior

- `shopify agent session start` persists:
  - agent identity
  - session id
  - metrics mode
  - `defaultNonInteractive`
- analytics synthesize packed `SHOPIFY_CLI_AGENT_INFO` / `SHOPIFY_CLI_AGENT_IDS` from persisted session state when explicit env vars are absent
- `metricsMode=off` suppresses command analytics for this prototype path
- when `defaultNonInteractive=true` and the user passed no explicit release-control flags, `app release` follows its existing non-interactive `--allow-updates` path

## Boundaries

This PR does not:
- migrate all deterministic ai-toolkit helpers into CLI
- add a universal `--no-input` contract
- redesign Monorail schema
- generalize agent-mode behavior across all commands

The goal is to demonstrate the value of CLI-owned agent session state clearly.

## Manual testing

Start a session and inspect the stored shape:

```bash
shopify agent session start \
  --agent river \
  --agent-version 1.0.0 \
  --provider openai \
  --metrics on \
  --json
```

Confirm later CLI analytics can pick up packed agent attribution without explicit `SHOPIFY_CLI_AGENT_*` env vars.

Then start a non-interactive session:

```bash
shopify agent session start \
  --agent river \
  --agent-version 1.0.0 \
  --provider openai \
  --metrics off \
  --default-non-interactive
```

Then verify:

```bash
shopify app release --version <version>
```

uses the prototype agent-mode path without requiring an explicit `--allow-updates`.
