### PR TITLE
[Tests] Remove filesystem mocks in execute-operation.test.ts

### DIFF
--- a/.jules/tester.md
+++ b/.jules/tester.md
@@ -1,4 +1,0 @@
-## 2026-05-20 - False passes from filesystem mocks
-**Gap:** Tests using `inTemporaryDirectory` were passing even with failing assertions inside the callback because the filesystem was mocked.
-**Learning:** In Vitest, automocking a function that takes a callback (like `inTemporaryDirectory`) often results in the callback never being executed, leading to "false pass" tests that verify nothing.
-**Action:** Always prefer real temporary directories over filesystem mocks, especially for functions that manage lifecycle through callbacks.

--- a/.jules/tester.md
+++ b/.jules/tester.md
@@ -1,0 +1,4 @@
+## 2026-05-20 - False passes from filesystem mocks
+**Gap:** Tests using `inTemporaryDirectory` were passing even with failing assertions inside the callback because the filesystem was mocked.
+**Learning:** In Vitest, automocking a function that takes a callback (like `inTemporaryDirectory`) often results in the callback never being executed, leading to "false pass" tests that verify nothing.
+**Action:** Always prefer real temporary directories over filesystem mocks, especially for functions that manage lifecycle through callbacks.

--- a/packages/app/src/cli/services/execute-operation.test.ts
+++ b/packages/app/src/cli/services/execute-operation.test.ts
@@ -236,7 +236,8 @@ describe('executeOperation', () => {
       })
 
       const expectedContent = JSON.stringify(mockResult, null, 2)
-      await expect(readFile(outputFile)).resolves.toEqual(expectedContent)
+      const actualContent = await readFile(outputFile)
+      expect(actualContent).toBe(expectedContent)
       expect(renderSuccess).toHaveBeenCalledWith(
         expect.objectContaining({
           body: expect.stringContaining(outputFile),

--- a/packages/app/src/cli/services/execute-operation.test.ts
+++ b/packages/app/src/cli/services/execute-operation.test.ts
@@ -4,7 +4,7 @@ import {OrganizationApp, OrganizationSource, OrganizationStore} from '../models/
 import {renderSuccess, renderError, renderSingleTask} from '@shopify/cli-kit/node/ui'
 import {adminRequestDoc} from '@shopify/cli-kit/node/api/admin'
 import {ClientError} from 'graphql-request'
-import {inTemporaryDirectory, writeFile} from '@shopify/cli-kit/node/fs'
+import {inTemporaryDirectory, writeFile, readFile} from '@shopify/cli-kit/node/fs'
 import {joinPath} from '@shopify/cli-kit/node/path'
 import {mockAndCaptureOutput} from '@shopify/cli-kit/node/testing/output'
 import {describe, test, expect, vi, beforeEach, afterEach} from 'vitest'
@@ -12,7 +12,6 @@ import {describe, test, expect, vi, beforeEach, afterEach} from 'vitest'
 vi.mock('./graphql/common.js')
 vi.mock('@shopify/cli-kit/node/ui')
 vi.mock('@shopify/cli-kit/node/api/admin')
-vi.mock('@shopify/cli-kit/node/fs')
 
 describe('executeOperation', () => {
   const mockOrganization = {
@@ -219,7 +218,6 @@ describe('executeOperation', () => {
 
     const expectedOutput = JSON.stringify(mockResult, null, 2)
     expect(mockOutput.info()).toContain(expectedOutput)
-    expect(writeFile).not.toHaveBeenCalled()
   })
 
   test('writes results to file when outputFile is provided', async () => {
@@ -238,7 +236,7 @@ describe('executeOperation', () => {
       })
 
       const expectedContent = JSON.stringify(mockResult, null, 2)
-      expect(writeFile).toHaveBeenCalledWith(outputFile, expectedContent)
+      await expect(readFile(outputFile)).resolves.toEqual(expectedContent)
       expect(renderSuccess).toHaveBeenCalledWith(
         expect.objectContaining({
           body: expect.stringContaining(outputFile),


### PR DESCRIPTION
### WHY are these changes introduced?

Filesystem mocks in `execute-operation.test.ts` were causing "false pass" tests. Specifically, when `inTemporaryDirectory` is automocked, its callback is never executed, meaning assertions inside the callback are skipped but the test still passes.

### WHAT is this pull request doing?

This PR removes the global `vi.mock('@shopify/cli-kit/node/fs')` in `packages/app/src/cli/services/execute-operation.test.ts` and updates the tests to use real filesystem operations. Assertions now verify the actual state of the filesystem (using `readFile`) rather than just checking if a mock was called.

### How to test your changes?

CI

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [4182148104859929075](https://jules.google.com/task/4182148104859929075) started by @gonzaloriestra*