### PR TITLE
[Performance] Optimize linesToColumns

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-05-20 - Optimize linesToColumns
+**Learning:** Utilities that handle CLI output formatting, like `linesToColumns`, often call expensive regex-based helpers (e.g., `unstyled` for ANSI strip) multiple times for the same input. Caching these lengths in a single pass over the data significantly reduces overhead.
+**Action:** Always check if string measurement utilities are called repeatedly in loops or nested maps, and use pre-calculation/caching to avoid redundant work.

--- a/packages/cli-kit/src/public/common/string.ts
+++ b/packages/cli-kit/src/public/common/string.ts
@@ -251,16 +251,29 @@ export function tryParseInt(maybeInt: string | undefined): number | undefined {
  * @returns A string with the columns aligned.
  */
 export function linesToColumns(lines: string[][]): string {
+  if (lines.length === 0 || !lines[0]) return ''
+
   const widths: number[] = []
-  for (let i = 0; lines[0] && i < lines[0].length; i++) {
-    const columnRows = lines.map((line) => line[i]!)
-    widths.push(Math.max(...columnRows.map((row) => unstyled(row).length)))
+  const unstyledLengths: number[][] = []
+
+  // Pre-calculate unstyled lengths and column widths in a single pass
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]!
+    unstyledLengths[i] = []
+    for (let j = 0; j < line.length; j++) {
+      const cell = line[j]!
+      const length = unstyled(cell).length
+      unstyledLengths[i]![j] = length
+      widths[j] = Math.max(widths[j] ?? 0, length)
+    }
   }
+
   const paddedLines = lines
-    .map((line) => {
+    .map((line, rowIndex) => {
       return line
-        .map((col, index) => {
-          return `${col}${' '.repeat(widths[index]! - unstyled(col).length)}`
+        .map((cell, colIndex) => {
+          const padding = ' '.repeat(widths[colIndex]! - unstyledLengths[rowIndex]![colIndex]!)
+          return `${cell}${padding}`
         })
         .join('   ')
         .trimEnd()


### PR DESCRIPTION
### WHY are these changes introduced?

The `linesToColumns` function currently performs two passes over the input data and calls the expensive `unstyled` utility (which uses regex to strip ANSI codes) multiple times for the same strings. This introduces measurable overhead in CLI output generation.

### WHAT is this pull request doing?

- Optimizes `linesToColumns` to use a single pass that caches the unstyled lengths of each cell.
- Reduces calls to the expensive `unstyled` utility by 50%.
- Eliminates redundant intermediate array mappings.
- Adds an early return for empty or nullish input to improve robustness.

### How to test your changes?

CI

### Post-release steps

None

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [12050113292855011574](https://jules.google.com/task/12050113292855011574) started by @gonzaloriestra*