### PR TITLE
[Security] Harden openURL protocol validation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,4 +1,0 @@
-## 2026-05-20 - Protocol validation in system openers
-**Vulnerability:** The `openURL` function allowed any URL protocol to be passed to the system's default opener (via the `open` library). This could allow execution of dangerous protocols like `javascript:` or `data:` if an attacker could influence the URL passed to this function.
-**Learning:** System openers often handle a wide variety of protocols beyond `http:` and `https:`. In a CLI context where some URLs might be constructed from external data (e.g., from a CDN or API), it's important to restrict allowed protocols at the trust boundary.
-**Prevention:** Implement strict allowlists for URL protocols in functions that trigger external actions like opening a browser or executing a command.

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-05-20 - Protocol validation in system openers
+**Vulnerability:** The `openURL` function allowed any URL protocol to be passed to the system's default opener (via the `open` library). This could allow execution of dangerous protocols like `javascript:` or `data:` if an attacker could influence the URL passed to this function.
+**Learning:** System openers often handle a wide variety of protocols beyond `http:` and `https:`. In a CLI context where some URLs might be constructed from external data (e.g., from a CDN or API), it's important to restrict allowed protocols at the trust boundary.
+**Prevention:** Implement strict allowlists for URL protocols in functions that trigger external actions like opening a browser or executing a command.

--- a/packages/app/src/cli/api/graphql/business-platform-organizations/generated/types.d.ts
+++ b/packages/app/src/cli/api/graphql/business-platform-organizations/generated/types.d.ts
@@ -22,6 +22,8 @@ export type Scalars = {
   ActionAuditID: { input: any; output: any; }
   /** The ID for a Address. */
   AddressID: { input: any; output: any; }
+  /** The ID for a Attestation. */
+  AttestationID: { input: any; output: any; }
   /** The ID for a BulkDataOperation. */
   BulkDataOperationID: { input: any; output: any; }
   /** The ID for a BusinessUser. */

--- a/packages/cli-kit/src/public/node/system.test.ts
+++ b/packages/cli-kit/src/public/node/system.test.ts
@@ -2,10 +2,12 @@ import * as system from './system.js'
 import {execa} from 'execa'
 import {describe, expect, test, vi} from 'vitest'
 import which from 'which'
+import open from 'open'
 import {Readable} from 'stream'
 
 import * as fs from 'fs'
 
+vi.mock('open')
 vi.mock('which')
 vi.mock('execa')
 vi.mock('fs', async (importOriginal) => {
@@ -14,6 +16,80 @@ vi.mock('fs', async (importOriginal) => {
     ...actual,
     fstatSync: vi.fn(),
   }
+})
+
+describe('openURL', () => {
+  test('opens http URLs', async () => {
+    // Given
+    const url = 'http://shopify.com'
+
+    // When
+    const got = await system.openURL(url)
+
+    // Then
+    expect(got).toBe(true)
+    expect(open).toHaveBeenCalledWith(url)
+  })
+
+  test('opens https URLs', async () => {
+    // Given
+    const url = 'https://shopify.com'
+
+    // When
+    const got = await system.openURL(url)
+
+    // Then
+    expect(got).toBe(true)
+    expect(open).toHaveBeenCalledWith(url)
+  })
+
+  test('opens file URLs', async () => {
+    // Given
+    const url = 'file:///path/to/file.html'
+
+    // When
+    const got = await system.openURL(url)
+
+    // Then
+    expect(got).toBe(true)
+    expect(open).toHaveBeenCalledWith(url)
+  })
+
+  test('blocks javascript URLs', async () => {
+    // Given
+    const url = 'javascript:alert("hello")'
+
+    // When
+    const got = await system.openURL(url)
+
+    // Then
+    expect(got).toBe(false)
+    expect(open).not.toHaveBeenCalled()
+  })
+
+  test('blocks data URLs', async () => {
+    // Given
+    const url = 'data:text/html,<html><body>hi</body></html>'
+
+    // When
+    const got = await system.openURL(url)
+
+    // Then
+    expect(got).toBe(false)
+    expect(open).not.toHaveBeenCalled()
+  })
+
+  test('returns false for invalid URLs', async () => {
+    // Given
+    const url = 'not-a-url'
+
+    // When
+    const got = await system.openURL(url)
+
+    // Then
+    expect(got).toBe(false)
+    expect(open).not.toHaveBeenCalled()
+  })
 })
 
 describe('captureOutput', () => {

--- a/packages/cli-kit/src/public/node/system.ts
+++ b/packages/cli-kit/src/public/node/system.ts
@@ -53,6 +53,16 @@ interface BuildExecOptions {
 export async function openURL(url: string): Promise<boolean> {
   const externalOpen = await import('open')
   try {
+    const parsed = new URL(url)
+    const allowedProtocols = ['http:', 'https:', 'file:']
+
+    // Security: Validate protocol to prevent execution of dangerous protocols
+    // (e.g. javascript:, data:, etc.) via the system opener.
+    if (!allowedProtocols.includes(parsed.protocol)) {
+      outputDebug(`Skipped opening URL with unsecure protocol: ${parsed.protocol}`)
+      return false
+    }
+
     await externalOpen.default(url)
     return true
     // eslint-disable-next-line no-catch-all/no-catch-all


### PR DESCRIPTION
### Why is this change necessary?
The `openURL` function was previously passing the input string directly to the `open` library without validation. This allowed any URL protocol to be handled by the system's default opener, which could lead to security risks if an attacker can influence the URL (e.g., via `javascript:` or `data:` protocols).

### How to test your changes?
CI

### Checklist
- [ ] I've added a description of what is changed and why.
- [ ] I've added a link to the [document](https://shopify.dev/docs/apps/tools/cli/development-guidelines) or [issue](https://github.com/Shopify/cli/issues) it's fixing (if applicable).
- [ ] I've added some screenshots/recordings of the before/after (if applicable).
- [ ] I've added tests for the new/updated code.
- [ ] I've followed the [standard guidelines](https://shopify.dev/docs/apps/tools/cli/development-guidelines).
- [ ] I've used [existing components](https://github.com/Shopify/cli/tree/main/packages/cli-kit/src/public/node/ui/components) (if applicable).
- [ ] I've checked that the changes are backwards compatible (if applicable).
- [ ] I've added a [changeset](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#changesets) (if applicable).


---
*PR created automatically by Jules for task [4911786415154034671](https://jules.google.com/task/4911786415154034671) started by @gonzaloriestra*