### PR TITLE
[Security] Harden archiver against Zip Slip traversal

### DIFF
--- a/packages/cli-kit/src/public/node/archiver.integration.test.ts
+++ b/packages/cli-kit/src/public/node/archiver.integration.test.ts
@@ -58,6 +58,30 @@ describe('zip', () => {
       expect(expectedEntries.sort()).toEqual(archiveEntries.sort())
     })
   })
+
+  test('prevents zipping files outside the input directory', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      const zipPath = joinPath(tmpDir, 'output.zip')
+      const inputDirectory = joinPath(tmpDir, 'input')
+      const outsideFile = joinPath(tmpDir, 'outside.txt')
+      await mkdir(inputDirectory)
+      await touchFile(outsideFile)
+      fs.writeFileSync(outsideFile, 'outside content')
+
+      // When
+      await zip({
+        inputDirectory,
+        outputZipPath: zipPath,
+        matchFilePattern: '../outside.txt',
+      })
+
+      // Then
+      const archiveEntries = await readArchiveFiles(zipPath)
+      expect(archiveEntries).not.toContain('../outside.txt')
+      expect(archiveEntries).not.toContain('outside.txt')
+    })
+  })
 })
 
 describe('brotliCompress', () => {

--- a/packages/cli-kit/src/public/node/archiver.ts
+++ b/packages/cli-kit/src/public/node/archiver.ts
@@ -1,6 +1,7 @@
 import {outputDebug, outputContent, outputToken} from './output.js'
 import {glob, removeFile} from './fs.js'
-import {relativePath, joinPath, dirname} from './path.js'
+import {relativePath, joinPath, dirname, isSubpath} from './path.js'
+import {AbortError} from './error.js'
 import archiver from 'archiver'
 import {createWriteStream, readFileSync, writeFileSync} from 'fs'
 import {readFile} from 'fs/promises'
@@ -35,12 +36,14 @@ interface ZipOptions {
 export async function zip(options: ZipOptions): Promise<void> {
   const {inputDirectory, outputZipPath, matchFilePattern = '**/*'} = options
   outputDebug(outputContent`Zipping ${outputToken.path(inputDirectory)} into ${outputToken.path(outputZipPath)}`)
-  const pathsToZip = await glob(matchFilePattern, {
+  let pathsToZip = await glob(matchFilePattern, {
     cwd: inputDirectory,
     absolute: true,
     dot: true,
     followSymbolicLinks: false,
   })
+
+  pathsToZip = pathsToZip.filter((filePath) => isSubpath(inputDirectory, filePath))
 
   return new Promise((resolve, reject) => {
     const archive = archiver('zip')
@@ -96,6 +99,9 @@ function collectParentDirectories(fileRelativePath: string, accumulator: Set<str
 }
 
 async function archiveFile(inputDirectory: string, filePath: string, archive: archiver.Archiver): Promise<void> {
+  if (!isSubpath(inputDirectory, filePath)) {
+    throw new AbortError(outputContent`Skipped archiving of file ${outputToken.path(filePath)} outside the directory.`)
+  }
   const fileRelativePath = relativePath(inputDirectory, filePath)
   if (!filePath || !fileRelativePath) return
 
@@ -169,8 +175,9 @@ export async function brotliCompress(options: BrotliOptions): Promise<void> {
         followSymbolicLinks: false,
       })
         .then(async (pathsToZip) => {
+          const filteredPaths = pathsToZip.filter((filePath) => isSubpath(options.inputDirectory, filePath))
           // Read all files immediately to prevent ENOENT errors during race conditions
-          const addFilesPromises = pathsToZip.map(async (filePath) => {
+          const addFilesPromises = filteredPaths.map(async (filePath) => {
             await archiveFile(options.inputDirectory, filePath, archive)
           })
 


### PR DESCRIPTION
### WHY are these changes introduced?

To prevent Zip Slip vulnerabilities where files outside the intended input directory could be included in archives via path traversal patterns in glob expressions.

### WHAT is this pull request doing?

This PR hardens the `zip` and `brotliCompress` utilities in `@shopify/cli-kit` by:
- Filtering the results of directory globs to ensure all files are within the input directory using `isSubpath`.
- Adding a "fail-closed" safety check in the internal `archiveFile` helper that throws an `AbortError` if a path escapes the trust boundary.
- Adding a regression test in `archiver.integration.test.ts` that specifically verifies traversal attempts are blocked.

### How to test your changes?

CI

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [5148143385783206268](https://jules.google.com/task/5148143385783206268) started by @gonzaloriestra*