### PR TITLE
[Refactor] Use uniq helper in import-extractor

### DIFF
--- a/packages/cli-kit/src/public/node/import-extractor.ts
+++ b/packages/cli-kit/src/public/node/import-extractor.ts
@@ -1,5 +1,6 @@
 import {fileExistsSync, isDirectorySync} from './fs.js'
 import {dirname, joinPath} from './path.js'
+import {uniq} from '../common/array.js'
 import {openSync, readSync, closeSync} from 'fs'
 
 // Only read the first 128KB of each file for import scanning. This covers
@@ -125,7 +126,7 @@ export function extractImportPathsRecursively(filePath: string, visited: Set<str
     }
   }
 
-  return [...new Set(allImports)]
+  return uniq(allImports)
 }
 
 /**
@@ -183,7 +184,7 @@ function extractJSLikeImports(content: string, filePath: string): string[] {
     }
   }
 
-  return [...new Set(imports)]
+  return uniq(imports)
 }
 
 function extractRustImports(content: string, filePath: string): string[] {
@@ -215,7 +216,7 @@ function extractRustImports(content: string, filePath: string): string[] {
     }
   }
 
-  return [...new Set(imports)]
+  return uniq(imports)
 }
 
 function resolveJSImport(importPath: string, fromFile: string): string | null {


### PR DESCRIPTION
### WHY are these changes introduced?

Improving code consistency and readability by using existing utility helpers.

### WHAT is this pull request doing?

Replaced manual `new Set` spreads with the `uniq` utility from `@shopify/cli-kit/common/array` in `packages/cli-kit/src/public/node/import-extractor.ts`.

### How to test your changes?

CI

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [12023691149304443027](https://jules.google.com/task/12023691149304443027) started by @gonzaloriestra*