### PR TITLE
[Performance] Memoize shouldDisplayColors

### DIFF
--- a/packages/cli-kit/src/public/node/output.ts
+++ b/packages/cli-kit/src/public/node/output.ts
@@ -230,6 +230,11 @@ function shouldOutput(logLevel: LogLevel): boolean {
 export let collectedLogs: Record<string, string[]> = {}
 
 /**
+ * Memoized value for the color check.
+ */
+let memoizedShouldDisplayColors: boolean | undefined
+
+/**
  * This is only used during UnitTesting.
  * If we are in a testing context, instead of printing the logs to the console,
  * we will store them in a variable that can be accessed from the tests.
@@ -410,12 +415,18 @@ export function unstyled(message: string): string {
  * @returns True if the console outputs should display colors, false otherwise.
  */
 export function shouldDisplayColors(_process = process): boolean {
-  const {env, stdout} = _process
-  if (Object.hasOwnProperty.call(env, 'FORCE_COLOR')) {
-    return isTruthy(env.FORCE_COLOR)
-  } else {
-    return Boolean(stdout.isTTY)
+  if (_process === process && memoizedShouldDisplayColors !== undefined) {
+    return memoizedShouldDisplayColors
   }
+
+  const {env, stdout} = _process
+  const result = Object.hasOwnProperty.call(env, 'FORCE_COLOR') ? isTruthy(env.FORCE_COLOR) : Boolean(stdout.isTTY)
+
+  if (_process === process) {
+    memoizedShouldDisplayColors = result
+  }
+
+  return result
 }
 
 /**


### PR DESCRIPTION
### WHY are these changes introduced?

High-frequency logging paths call `shouldDisplayColors` repeatedly to determine if output should be colorized. Accessing `process.env` and checking TTY status on `process.stdout` involves small but measurable overhead that adds up over the lifecycle of a CLI command, especially when debug logging is enabled or many messages are processed.

### WHAT is this pull request doing?

This PR introduces memoization for the `shouldDisplayColors` function in `@shopify/cli-kit`.
- Results are cached in a module-level variable when called with the default `process` object.
- Custom process objects (e.g., used in unit tests) bypass the cache to ensure isolation and correct behavior during testing.
- The logic remains identical, preserving current behavior while improving efficiency for the common case.

### How to test your changes?

CI

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [303941856508991664](https://jules.google.com/task/303941856508991664) started by @gonzaloriestra*