### PR TITLE
Pin Playwright E2E CI to Node 24

### DIFF
--- a/.github/workflows/tests-pr.yml
+++ b/.github/workflows/tests-pr.yml
@@ -17,6 +17,7 @@ env:
   GH_TOKEN: ${{ secrets.SHOPIFY_GH_READ_CONTENT_TOKEN }}
   GH_TOKEN_SHOP: ${{ secrets.SHOP_GH_READ_CONTENT_TOKEN }}
   DEFAULT_NODE_VERSION: '26.1.0'
+  PLAYWRIGHT_NODE_VERSION: '24.1.0'
 
 jobs:
   type-check:
@@ -237,7 +238,7 @@ jobs:
       - name: Setup deps
         uses: ./.github/actions/setup-cli-deps
         with:
-          node-version: ${{ env.DEFAULT_NODE_VERSION }}
+          node-version: ${{ env.PLAYWRIGHT_NODE_VERSION }}
       - name: Build
         run: pnpm nx run-many --all --skip-nx-cache --target=build --output-style=stream
       - name: Install Playwright Chromium


### PR DESCRIPTION
## What changed

Pins the PR E2E job's dependency setup to Node 24.1.0 via `PLAYWRIGHT_NODE_VERSION`, while leaving `DEFAULT_NODE_VERSION` on Node 26.1.0 for the rest of PR CI.

## Why

The E2E jobs are hanging in `pnpm exec playwright install chromium` under Node 26: the browser download reaches 100%, then the process emits no completion line until the 20-minute job timeout cancels it. Earlier Node 24 runs completed the same Playwright browser install in seconds.

Playwright currently lists Node 20/22/24 as the supported Node.js versions, so the browser install should stay on Node 24 until Playwright supports Node 26.

## Validation

- `git diff --check`
- `pnpm exec prettier --parser yaml .github/workflows/tests-pr.yml >/dev/null`

`actionlint` is not installed locally. `prettier --check` already fails on the base workflow formatting, so I used Prettier only as a YAML parser for this targeted workflow change.
