### PR TITLE
[Fix] Move scaffolded project to its final directory before installing deps in `app init`

### DIFF
--- a/.changeset/fix-init-install-in-place.md
+++ b/.changeset/fix-init-install-in-place.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Fix `shopify app init` leaving dangling `node_modules` symlinks on Windows when using `pnpm` (and similarly affected package managers). The scaffolded project is now moved to its final directory before dependencies are installed, so package-manager-managed symlinks/junctions resolve to the final location instead of the temporary scaffold path.

--- a/packages/app/src/cli/services/init/init.ts
+++ b/packages/app/src/cli/services/init/init.ts
@@ -27,6 +27,7 @@ import {
   mkdir,
   moveFile,
   readFile,
+  rmdir,
   writeFile,
 } from '@shopify/cli-kit/node/fs'
 import {joinPath, normalizePath} from '@shopify/cli-kit/node/path'
@@ -174,10 +175,12 @@ async function init(options: InitOptions) {
     // dependencies. pnpm (and other package managers) create absolute-path
     // junctions/symlinks on Windows, so installing in the temp dir and then
     // moving the tree orphans every link under node_modules/.pnpm/*.
+    let outputDirectoryCreated = false
     tasks.push({
       title: 'Preparing project directory',
       task: async () => {
         await ensureAppDirectoryIsAvailable(outputDirectory, hyphenizedName)
+        outputDirectoryCreated = true
         await moveFile(templateScaffoldDir, outputDirectory)
       },
     })
@@ -203,7 +206,17 @@ async function init(options: InitOptions) {
       },
     )
 
-    await renderTasks(tasks)
+    try {
+      await renderTasks(tasks)
+    } catch (error) {
+      // If a task failed after the project was moved to its final directory,
+      // remove the partial project so the user isn't left with a half-baked
+      // scaffold (no node_modules, no cleanup, no git init).
+      if (outputDirectoryCreated) {
+        await rmdir(outputDirectory).catch(() => {})
+      }
+      throw error
+    }
   })
 
   let app: OrganizationApp

--- a/packages/app/src/cli/services/init/init.ts
+++ b/packages/app/src/cli/services/init/init.ts
@@ -170,32 +170,40 @@ async function init(options: InitOptions) {
       })
     }
 
+    // Move the scaffolded template into its final directory BEFORE installing
+    // dependencies. pnpm (and other package managers) create absolute-path
+    // junctions/symlinks on Windows, so installing in the temp dir and then
+    // moving the tree orphans every link under node_modules/.pnpm/*.
+    tasks.push({
+      title: 'Preparing project directory',
+      task: async () => {
+        await ensureAppDirectoryIsAvailable(outputDirectory, hyphenizedName)
+        await moveFile(templateScaffoldDir, outputDirectory)
+      },
+    })
+
     tasks.push(
       {
         title: `Installing dependencies with ${packageManager}`,
         task: async () => {
-          await getDeepInstallNPMTasks({from: templateScaffoldDir, packageManager})
+          await getDeepInstallNPMTasks({from: outputDirectory, packageManager})
         },
       },
       {
         title: 'Cleaning up',
         task: async () => {
-          await cleanup(templateScaffoldDir, packageManager)
+          await cleanup(outputDirectory, packageManager)
         },
       },
       {
         title: 'Initializing a Git repository...',
         task: async () => {
-          await initializeGitRepository(templateScaffoldDir)
+          await initializeGitRepository(outputDirectory)
         },
       },
     )
 
     await renderTasks(tasks)
-
-    // Ensure the app directory is available before moving the template scaffold
-    await ensureAppDirectoryIsAvailable(outputDirectory, hyphenizedName)
-    await moveFile(templateScaffoldDir, outputDirectory)
   })
 
   let app: OrganizationApp


### PR DESCRIPTION
### WHY are these changes introduced?

Cross-OS QA on CLI nightly `0.0.0-nightly-20260521132110` surfaced this as a release blocker on Windows + pnpm: after `app init --package-manager=pnpm`, every `node_modules` symlink was dangling and users had to manually `rm -rf node_modules && pnpm install` before doing anything.

Root cause is the install→move ordering in `packages/app/src/cli/services/init/init.ts`. The whole flow ran inside `inTemporaryDirectory`: download template → liquid render → install deps → cleanup → git init, *then* `moveFile(templateScaffoldDir, outputDirectory)`. pnpm on Windows uses NTFS junctions for the virtual store under `node_modules/.pnpm/*`, and junctions store absolute paths — moving the tree from `%TEMP%\…\app` to the destination orphans every link.

### What is this pull request doing?

In `packages/app/src/cli/services/init/init.ts`, insert a new "Preparing project directory" task into the existing task list that does `ensureAppDirectoryIsAvailable` + `moveFile(templateScaffoldDir → outputDirectory)`. Install, cleanup, and git-init then run against `outputDirectory` instead of the temp dir.

Pre-install steps (template download, liquid render, package.json edits, .gitignore/.npmrc tweaks) still run in the temp dir, so a failure there leaves no half-baked project on disk. The earlier `inTemporaryDirectory` block still owns cleanup of the (now mostly-empty) temp dir.

**Tradeoff worth flagging:** a failure during the install task now leaves the scaffolded project at `outputDirectory` *without* a populated `node_modules`. Before, an install failure would just bail and leave nothing behind. I think this is the better tradeoff — users can re-run `pnpm install` themselves rather than restarting the whole init flow — but happy to add on-failure cleanup if reviewers prefer the old behavior.

### How to test your changes?

On a Windows machine with pnpm installed:

1. Check out this branch and build the CLI (`pnpm build`).
2. `node packages/cli/bin/dev.js app init --package-manager=pnpm --name=test-app --template=https://github.com/Shopify/shopify-app-template-react-router#main-cli` (or use `pnpm create-app`).
3. `cd test-app && pnpm dev` — should run without "module not found" errors. Without this fix it would die immediately because of dangling junctions under `node_modules/.pnpm/`.

Also worth a smoke test on macOS / Linux that init still produces a working project — same task list, just with the move task inserted earlier.

Local test runs done on this branch:

- `vitest run packages/app/src/cli/services/init/` — 28/28 pass.
- `vitest run packages/app/src/cli/commands/app/init.test packages/app/src/cli/prompts/init/` — 12/12 pass.
- `tsc --noEmit` on `@shopify/app` — clean.
- `eslint src/cli/services/init/init.ts` — clean.

### Measuring impact

How do we know this change is successful? Choose one:

- [x] Existing analytics will cater for this addition
- [ ] PR includes analytics changes (Pending Data Discovery Review)
- [ ] Other (please describe)

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev/docs) changes
- [ ] If introducing a user-facing change, I've added a changeset

(A `.changeset/fix-init-install-in-place.md` is included.)