### PR TITLE
Remove "3.0" version reference from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <img src="https://img.shields.io/badge/License-MIT-green.svg" alt="License">
 <a href="https://github.com/Shopify/cli/actions/workflows/shopify-cli.yml">![badge](https://github.com/Shopify/cli/actions/workflows/shopify-cli.yml/badge.svg)</a>
 
-With the Shopify command line interface (Shopify CLI 3.0), you can:
+With the Shopify command line interface (Shopify CLI), you can:
 - initialize, build, dev, and deploy Shopify apps, extensions, functions and themes
 - build custom storefronts and manage their hosting
 


### PR DESCRIPTION
## Summary
- Drop the hard-coded `Shopify CLI 3.0` from the README lead-in so the description doesn't age with major versions.
- Scope kept narrow: only `README.md`. The 2022 decision records that mention `3.0` were intentionally left alone — they document the historical 2.0 → 3.0 migration and lose meaning without the version.

## Test plan
- [ ] Verify the README renders correctly on GitHub.
- [ ] Confirm no other current-facing docs/READMEs reference a CLI major version (decision records excluded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)