### PR TITLE
Fix multiple-installation-warning snapshot padding after 4.0.0 bump

### DIFF
--- a/packages/cli-kit/src/public/node/plugins/multiple-installation-warning.test.ts
+++ b/packages/cli-kit/src/public/node/plugins/multiple-installation-warning.test.ts
@@ -30,7 +30,7 @@ describe('showMultipleCLIWarningIfNeeded', () => {
         │                                                                              │
         │  Two Shopify CLI installations found – using global installation             │
         │                                                                              │
-        │  A global installation (v${CLI_KIT_VERSION}) and a local dependency (v3.70.0) were       │
+        │  A global installation (v${CLI_KIT_VERSION}) and a local dependency (v3.70.0) were        │
         │  detected.                                                                   │
         │  We recommend removing the @shopify/cli and @shopify/app dependencies from   │
         │  your package.json, unless you want to use different versions across         │
@@ -62,7 +62,7 @@ describe('showMultipleCLIWarningIfNeeded', () => {
         │                                                                              │
         │  Two Shopify CLI installations found – using local dependency                │
         │                                                                              │
-        │  A global installation (v3.70.0) and a local dependency (v${CLI_KIT_VERSION}) were       │
+        │  A global installation (v3.70.0) and a local dependency (v${CLI_KIT_VERSION}) were        │
         │  detected.                                                                   │
         │  We recommend removing the @shopify/cli and @shopify/app dependencies from   │
         │  your package.json, unless you want to use different versions across         │
@@ -95,7 +95,7 @@ describe('showMultipleCLIWarningIfNeeded', () => {
         │                                                                              │
         │  Two Shopify CLI installations found – using global installation             │
         │                                                                              │
-        │  A global installation (v${CLI_KIT_VERSION}) and a local dependency (v3.70.0) were       │
+        │  A global installation (v${CLI_KIT_VERSION}) and a local dependency (v3.70.0) were        │
         │  detected.                                                                   │
         │  We recommend removing the @shopify/cli and @shopify/app dependencies from   │
         │  your package.json, unless you want to use different versions across         │


### PR DESCRIPTION
### WHY are these changes introduced?

Main CI started failing immediately after the 4.0.0 release was merged: https://github.com/Shopify/cli/actions/runs/26248300903

The `showMultipleCLIWarningIfNeeded` test uses inline snapshots that interpolate `${CLI_KIT_VERSION}` into a UI info box rendered by cli-kit. The box auto-pads trailing whitespace to keep itself rectangular, so when `CLI_KIT_VERSION` shortened from `3.94.3` (6 chars) to `4.0.0` (5 chars), the renderer added one extra trailing space on the affected line. The snapshot's literal whitespace did not follow, so all three affected tests fail with a one-character mismatch:

```
- │  A global installation (v4.0.0) and a local dependency (v3.70.0) were       │
+ │  A global installation (v4.0.0) and a local dependency (v3.70.0) were        │
```

### WHAT is this pull request doing?

Adds one trailing space before the closing `│` on the three affected snapshot lines (33, 65, 98) in `packages/cli-kit/src/public/node/plugins/multiple-installation-warning.test.ts`.

The `${CLI_KIT_VERSION}` template literal is preserved deliberately. `vitest --update` would inline `v4.0.0`, but keeping the template means future bumps that don't change the rendered length (the common case) won't re-break the test.

This snapshot remains brittle to any future change in the length of `CLI_KIT_VERSION` (e.g. 4.0.0 → 4.10.0 will break it again). A more robust fix would be to assert on the inner content only and not on the box geometry — out of scope for this PR but worth a follow-up.

### How to test your changes?

```bash
cd packages/cli-kit
pnpm vitest run src/public/node/plugins/multiple-installation-warning.test.ts
```

All 5 tests pass.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows) — whitespace-only change in a test fixture, no cross-platform implications
- [x] I've considered possible [documentation](https://shopify.dev) changes — N/A
- [x] I've considered analytics changes to measure impact — N/A
- [x] The change is user-facing — No, test-only fix; no changeset needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)