### PR TITLE
[Refactor] Use .find() in error-handler

### DIFF
--- a/packages/cli-kit/src/public/node/error-handler.ts
+++ b/packages/cli-kit/src/public/node/error-handler.ts
@@ -192,7 +192,7 @@ export function cleanStackFrameFilePath({
     ? currentFilePath
     : path.joinPath(projectRoot, currentFilePath)
 
-  const matchingPluginPath = pluginLocations.filter(({pluginPath}) => fullLocation.startsWith(pluginPath))[0]
+  const matchingPluginPath = pluginLocations.find(({pluginPath}) => fullLocation.startsWith(pluginPath))
 
   if (matchingPluginPath !== undefined) {
     // the plugin name (e.g. @shopify/cli-kit), plus the relative path of the error line from within the plugin's code (e.g. dist/something.js )


### PR DESCRIPTION
### Why is this change needed?
Using `.find()` is more idiomatic and readable than `.filter(...)[0]`. It also improves performance by avoiding the creation of an intermediate array and stopping iteration at the first match.

### How to test your changes?
CI

---
*PR created automatically by Jules for task [12458542961865459053](https://jules.google.com/task/12458542961865459053) started by @gonzaloriestra*