### PR TITLE
[Performance] Memoize isShopify environment check

### DIFF
--- a/packages/cli-kit/src/public/node/context/local.ts
+++ b/packages/cli-kit/src/public/node/context/local.ts
@@ -55,6 +55,11 @@ export function isVerbose(env = process.env): boolean {
 }
 
 /**
+ * Memoized value for the Shopify environment check.
+ */
+let memoizedIsShopify: Promise<boolean> | undefined
+
+/**
  * Returns true if the environment in which the CLI is running is either
  * a local environment (where dev is present).
  *
@@ -62,11 +67,23 @@ export function isVerbose(env = process.env): boolean {
  * @returns True if the CLI is used in a Shopify environment.
  */
 export async function isShopify(env = process.env): Promise<boolean> {
-  if (Object.prototype.hasOwnProperty.call(env, environmentVariables.runAsUser)) {
-    return !isTruthy(env[environmentVariables.runAsUser])
+  if (env === process.env && memoizedIsShopify !== undefined && !isUnitTest()) {
+    return memoizedIsShopify
   }
-  const devInstalled = await lazyFileExists(pathConstants.executables.dev)
-  return devInstalled
+
+  const resultPromise = (async () => {
+    if (Object.prototype.hasOwnProperty.call(env, environmentVariables.runAsUser)) {
+      return !isTruthy(env[environmentVariables.runAsUser])
+    }
+    const devInstalled = await lazyFileExists(pathConstants.executables.dev)
+    return devInstalled
+  })()
+
+  if (env === process.env && !isUnitTest()) {
+    memoizedIsShopify = resultPromise
+  }
+
+  return resultPromise
 }
 
 /**


### PR DESCRIPTION
### Description
This PR implements memoization for the `isShopify` function in `@shopify/cli-kit`. This function determines if the CLI is running in a Shopify internal development environment by checking environment variables and performing a file existence check for the `/opt/dev/bin/dev` executable.

Since `isShopify` is called multiple times during a CLI command's lifecycle (e.g., in analytics reporting), caching the result promise prevents redundant disk I/O. The memoization is restricted to calls using the default `process.env` and is bypassed during unit tests to ensure test isolation.

### How to test your changes?
CI

### Checklist
- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (\`patch\` for bug fixes · \`minor\` for new features · \`major\` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with \`pnpm changeset add\`

---
*PR created automatically by Jules for task [1733951532173800447](https://jules.google.com/task/1733951532173800447) started by @gonzaloriestra*