### PR TITLE
Fix stale E2E CLI assumptions

### DIFF
--- a/packages/e2e/setup/app.ts
+++ b/packages/e2e/setup/app.ts
@@ -147,7 +147,8 @@ export async function deployApp(
     version?: string
     message?: string
     config?: string
-    force?: boolean
+    allowUpdates?: boolean
+    allowDeletes?: boolean
     noBuild?: boolean
   },
 ): Promise<ExecResult> {
@@ -155,7 +156,8 @@ export async function deployApp(
   if (ctx.version) args.push('--version', ctx.version)
   if (ctx.message) args.push('--message', ctx.message)
   if (ctx.config) args.push('--config', ctx.config)
-  if (ctx.force ?? true) args.push('--force')
+  if (ctx.allowUpdates ?? true) args.push('--allow-updates')
+  if (ctx.allowDeletes) args.push('--allow-deletes')
   if (ctx.noBuild) args.push('--no-build')
   args.push('--path', ctx.appDir)
   return ctx.cli.exec(args, {timeout: CLI_TIMEOUT.long})

--- a/packages/e2e/setup/env.ts
+++ b/packages/e2e/setup/env.ts
@@ -139,10 +139,16 @@ export const envFixture = base.extend<{testSection: void}, {env: E2EEnv}>({
       fs.mkdirSync(tmpBase, {recursive: true})
 
       const {tempDir, xdgEnv} = createIsolatedEnv(tmpBase)
+      const cloudflaredPath = path.join(
+        tempDir,
+        'cloudflared',
+        process.platform === 'win32' ? 'cloudflared.exe' : 'cloudflared',
+      )
 
       const processEnv: NodeJS.ProcessEnv = {
         ...process.env,
         ...xdgEnv,
+        SHOPIFY_CLI_CLOUDFLARED_PATH: cloudflaredPath,
         SHOPIFY_RUN_AS_USER: '0',
         NODE_OPTIONS: '',
         CI: '1',

--- a/packages/e2e/tests/smoke-pty.spec.ts
+++ b/packages/e2e/tests/smoke-pty.spec.ts
@@ -4,7 +4,6 @@ import {expect} from '@playwright/test'
 test.describe('PTY smoke test', () => {
   test('shopify version runs via PTY', async ({cli}) => {
     const proc = await cli.spawn(['version'])
-    await proc.waitForOutput('3.')
     const code = await proc.waitForExit()
     expect(code, `shopify version (PTY) failed. Output:\n${proc.getOutput()}`).toBe(0)
     expect(proc.getOutput()).toMatch(/\d+\.\d+\.\d+/)


### PR DESCRIPTION
## What changed

- Updates the E2E `deployApp` helper to pass `--allow-updates` by default instead of the removed `--force` flag.
- Removes the PTY smoke test's hard-coded wait for CLI version output containing `3.`. The test still asserts the command exits successfully and emits semver output.

## Why

Recent PR and merge-queue runs are green at the workflow level but E2E jobs are failing because `e2e-tests` has `continue-on-error: true`.

The current job-level failures are stale test assumptions:

- Shard 1: `tests/app-deploy.spec.ts` fails at deploy step 2 with `Nonexistent flag: --force`.
- Shard 2: `tests/smoke-pty.spec.ts` fails waiting for output `3.` while the CLI now prints `4.0.0`.

## Validation

- `git diff --check`
- `pnpm --filter @shopify/e2e type-check`
- `pnpm --filter @shopify/e2e lint`

I did not run the full E2E suite locally because it depends on CI secrets and live Shopify test resources.
