### PR TITLE
[Refactor] Use .find() in loader

### DIFF
--- a/packages/app/src/cli/models/app/loader.ts
+++ b/packages/app/src/cli/models/app/loader.ts
@@ -1048,7 +1048,7 @@ async function logMetadataForLoadedAppUsingRawValues(
 
     const webBackendCount = webs.filter((web) => isWebType(web, WebType.Backend)).length
     const webBackendFramework =
-      webBackendCount === 1 ? webs.filter((web) => isWebType(web, WebType.Backend))[0]?.framework : undefined
+      webBackendCount === 1 ? webs.find((web) => isWebType(web, WebType.Backend))?.framework : undefined
     const webFrontendCount = webs.filter((web) => isWebType(web, WebType.Frontend)).length
 
     const extensionsBreakdownMapping: {[key: string]: number} = {}


### PR DESCRIPTION
### WHY are these changes introduced?

This refactor improves code readability and leverages short-circuiting in the `loader.ts` file within the `app` package. Replacing `filter(...)[0]` with `find(...)` is a more expressive way to retrieve the first matching element.

### WHAT is this pull request doing?

Replaces an instance of `.filter(...)[0]` with `.find(...)` in the `logMetadataForLoadedAppUsingRawValues` function in `packages/app/src/cli/models/app/loader.ts`.

### How to test your changes?

CI

### Post-release steps

N/A

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [13838649973733832410](https://jules.google.com/task/13838649973733832410) started by @gonzaloriestra*