### PR TITLE
[Security] Harden random selection in takeRandomFromArray

### DIFF
--- a/packages/cli-kit/src/public/common/array.test.ts
+++ b/packages/cli-kit/src/public/common/array.test.ts
@@ -1,5 +1,19 @@
-import {difference, uniq, uniqBy} from './array.js'
+import {difference, takeRandomFromArray, uniq, uniqBy} from './array.js'
 import {describe, test, expect} from 'vitest'
+
+describe('takeRandomFromArray', () => {
+  test('returns an element from the array', () => {
+    const array = [1, 2, 3]
+    const got = takeRandomFromArray(array)
+    expect(array).toContain(got)
+  })
+
+  test('returns undefined for an empty array', () => {
+    const array: number[] = []
+    const got = takeRandomFromArray(array)
+    expect(got).toBeUndefined()
+  })
+})
 
 describe('uniqBy', () => {
   test('removes duplicates', () => {

--- a/packages/cli-kit/src/public/common/array.ts
+++ b/packages/cli-kit/src/public/common/array.ts
@@ -1,5 +1,6 @@
 import lodashUniqBy from 'lodash/uniqBy.js'
 import lodashDifference from 'lodash/difference.js'
+import {randomInt} from 'node:crypto'
 import type {List, ValueIteratee} from 'lodash'
 
 /**
@@ -9,7 +10,8 @@ import type {List, ValueIteratee} from 'lodash'
  * @returns A random element from the array.
  */
 export function takeRandomFromArray<T>(array: T[]): T {
-  return array[Math.floor(Math.random() * array.length)]!
+  if (array.length === 0) return undefined as unknown as T
+  return array[randomInt(array.length)]!
 }
 
 /**


### PR DESCRIPTION
### Why is this change needed?

The `takeRandomFromArray` utility was using `Math.random()`, which is not cryptographically secure. While its current primary use is for generating random names for new app/theme directories, using a CSPRNG is a better default for any random selection utility in the CLI.

### How to test your changes?

CI

### Post-release steps

None.

---
*PR created automatically by Jules for task [8018340101932167753](https://jules.google.com/task/8018340101932167753) started by @gonzaloriestra*