### PR TITLE
[Security] Harden devConsoleAssetsMiddleware against path traversal

### DIFF
--- a/packages/app/src/cli/services/dev/extension/server/middlewares.test.ts
+++ b/packages/app/src/cli/services/dev/extension/server/middlewares.test.ts
@@ -6,15 +6,17 @@ import {
   noCacheMiddleware,
   redirectToDevConsoleMiddleware,
   getExtensionPointMiddleware,
+  devConsoleAssetsMiddleware,
 } from './middlewares.js'
 import * as utilities from './utilities.js'
 import {GetExtensionsMiddlewareOptions} from './models.js'
+import {copyConfigKeyEntry} from '../../../build/steps/include-assets/copy-config-key-entry.js'
 import * as templates from '../templates.js'
 import * as payload from '../payload.js'
 import {UIExtensionPayload} from '../payload/models.js'
 import {testUIExtension} from '../../../../models/app/app.test-data.js'
 import {AppEventWatcher} from '../../app-events/app-event-watcher.js'
-import {copyConfigKeyEntry} from '../../../build/steps/include-assets/copy-config-key-entry.js'
+import * as path from '@shopify/cli-kit/node/path'
 import {describe, expect, vi, test} from 'vitest'
 import {inTemporaryDirectory, mkdir, touchFile, writeFile} from '@shopify/cli-kit/node/fs'
 import * as h3 from 'h3'
@@ -844,5 +846,49 @@ describe('getExtensionPointMiddleware()', () => {
     await getExtensionPayloadMiddleware(options)(event)
 
     expect(h3.sendRedirect).toHaveBeenCalledWith(event, 'http://www.mock.com/redirect/url', 307)
+  })
+})
+
+describe('devConsoleAssetsMiddleware()', () => {
+  test('returns the file content when the asset is within the root directory', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      const assetsDir = joinPath(tmpDir, 'assets/dev-console/extensions/dev-console/assets')
+      await mkdir(assetsDir)
+      const assetPath = 'style.css'
+      const filePath = joinPath(assetsDir, assetPath)
+      const content = 'body { color: red; }'
+      await writeFile(filePath, content)
+
+      vi.spyOn(path, 'moduleDirectory').mockReturnValue(tmpDir)
+      vi.spyOn(h3, 'getRouterParams').mockReturnValue({assetPath})
+
+      const event = getMockEvent()
+      const result = await devConsoleAssetsMiddleware(event)
+
+      expect(event.node.res.setHeader).toHaveBeenCalledWith('Content-Type', 'text/css')
+      expect(String(result)).toBe(content)
+    })
+  })
+
+  test('returns 404 when the asset is outside the root directory', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      const assetsDir = joinPath(tmpDir, 'assets/dev-console/extensions/dev-console/assets')
+      await mkdir(assetsDir)
+
+      const secretPath = joinPath(tmpDir, 'secret.txt')
+      await writeFile(secretPath, 'secret content')
+
+      vi.spyOn(path, 'moduleDirectory').mockReturnValue(tmpDir)
+      vi.spyOn(h3, 'getRouterParams').mockReturnValue({assetPath: '../../../../secret.txt'})
+      vi.spyOn(utilities, 'sendError').mockImplementation(() => {})
+
+      const event = getMockEvent()
+      await devConsoleAssetsMiddleware(event)
+
+      expect(utilities.sendError).toHaveBeenCalledWith(event, {
+        statusCode: 404,
+        statusMessage: 'Not Found',
+      })
+    })
   })
 })

--- a/packages/app/src/cli/services/dev/extension/server/middlewares.ts
+++ b/packages/app/src/cli/services/dev/extension/server/middlewares.ts
@@ -6,7 +6,15 @@ import {getWebSocketUrl} from '../../extension.js'
 import {resolveOutputDir} from '../../../build/steps/include-assets/generate-manifest.js'
 import {fileExists, isDirectory, readFile, findPathUp} from '@shopify/cli-kit/node/fs'
 import {sendRedirect, defineEventHandler, getRequestHeader, getRouterParams, setResponseHeader} from 'h3'
-import {joinPath, resolvePath, relativePath, isAbsolutePath, extname, moduleDirectory} from '@shopify/cli-kit/node/path'
+import {
+  joinPath,
+  resolvePath,
+  relativePath,
+  isAbsolutePath,
+  extname,
+  moduleDirectory,
+  isSubpath,
+} from '@shopify/cli-kit/node/path'
 import {outputDebug} from '@shopify/cli-kit/node/output'
 
 import type {H3Event} from 'h3'
@@ -147,8 +155,13 @@ export const devConsoleAssetsMiddleware = defineEventHandler(async (event) => {
     })
   }
 
+  const candidate = resolvePath(joinPath(rootDirectory, assetPath))
+  if (!isSubpath(rootDirectory, candidate)) {
+    return sendError(event, {statusCode: 404, statusMessage: 'Not Found'})
+  }
+
   return fileServerMiddleware(event, {
-    filePath: joinPath(rootDirectory, assetPath),
+    filePath: candidate,
   })
 })
 


### PR DESCRIPTION
### WHY are these changes introduced?

The `devConsoleAssetsMiddleware` was vulnerable to path traversal attacks because it joined user-provided `assetPath` with the `rootDirectory` without validating that the resulting path remained within the intended directory.

### WHAT is this pull request doing?

- Updated `devConsoleAssetsMiddleware` in `packages/app/src/cli/services/dev/extension/server/middlewares.ts` to use `resolvePath` and `isSubpath` for path validation.
- Added regression tests in `packages/app/src/cli/services/dev/extension/server/middlewares.test.ts`.
- Ensured proper use of `utilities.sendError` for error handling in the middleware.

### How to test your changes?

CI handles testing. You can also run the specific tests:
`pnpm --filter app vitest run src/cli/services/dev/extension/server/middlewares.test.ts`

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [15346866280291798229](https://jules.google.com/task/15346866280291798229) started by @gonzaloriestra*