### PR TITLE
[Performance] Optimize unstyled utility

### DIFF
--- a/packages/cli-kit/src/public/node/output.ts
+++ b/packages/cli-kit/src/public/node/output.ts
@@ -402,6 +402,10 @@ export function outputWhereAppropriate(logLevel: LogLevel, logger: Logger, messa
  * @returns The message without styles.
  */
 export function unstyled(message: string): string {
+  // Optimization: skip regex execution for strings that don't have ANSI escape codes.
+  // In high-frequency paths like terminal layout calculations, this can save significant CPU time.
+  if (!message.includes('\u001b')) return message
+
   return stripAnsi(message)
 }
 


### PR DESCRIPTION
### WHY are these changes introduced?

The `unstyled` utility is used frequently in CLI operations, especially during logging and terminal layout calculations. The underlying `stripAnsi` function uses a complex regular expression that can be computationally expensive when called repeatedly on plain strings.

### WHAT is this pull request doing?

Optimizes the `unstyled` function in `packages/cli-kit/src/public/node/output.ts` by adding an early return: `if (!message.includes('\u001b')) return message`. This avoids the regex overhead for any string that doesn't contain ANSI escape codes.

### How to test your changes?

CI

### Post-release steps

None

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [6608015497183229439](https://jules.google.com/task/6608015497183229439) started by @gonzaloriestra*