### PR TITLE
[Refactor] Use .find() in error-handler

### DIFF
--- a/packages/cli-kit/src/public/node/error-handler.ts
+++ b/packages/cli-kit/src/public/node/error-handler.ts
@@ -192,7 +192,7 @@ export function cleanStackFrameFilePath({
     ? currentFilePath
     : path.joinPath(projectRoot, currentFilePath)
 
-  const matchingPluginPath = pluginLocations.filter(({pluginPath}) => fullLocation.startsWith(pluginPath))[0]
+  const matchingPluginPath = pluginLocations.find(({pluginPath}) => fullLocation.startsWith(pluginPath))
 
   if (matchingPluginPath !== undefined) {
     // the plugin name (e.g. @shopify/cli-kit), plus the relative path of the error line from within the plugin's code (e.g. dist/something.js )


### PR DESCRIPTION
### What this PR does
Replace `.filter(...)[0]` with `.find(...)` in `packages/cli-kit/src/public/node/error-handler.ts`.

### How to test your changes?
CI

---
*PR created automatically by Jules for task [9969201988462291035](https://jules.google.com/task/9969201988462291035) started by @gonzaloriestra*