### PR TITLE
Improve auth guidance for agents

### DIFF
--- a/.changeset/brave-agents-login.md
+++ b/.changeset/brave-agents-login.md
@@ -1,0 +1,6 @@
+---
+'@shopify/cli': patch
+'@shopify/cli-kit': patch
+---
+
+Improve Shopify CLI login guidance for agent-driven authentication flows.

--- a/docs/cli/auth.md
+++ b/docs/cli/auth.md
@@ -1,0 +1,32 @@
+# Shopify CLI authentication
+
+Shopify CLI authenticates developers with Shopify through a device-code OAuth flow. This flow is designed to work in terminals, remote development environments, and agent-driven workflows.
+
+## Supported flow
+
+Shopify CLI currently supports user-driven device authentication:
+
+1. Run a command that requires authentication, or run `shopify auth login` directly.
+2. Shopify CLI prints a verification URL and user code, or opens the verification URL in your browser.
+3. The user completes login in the browser.
+4. Keep the CLI process running. It polls for completion and continues automatically after authentication succeeds.
+
+Agents should show the verification URL and user code to the user, ask the user to complete authentication in the browser, and wait for the CLI command to finish.
+
+## Commands
+
+- `shopify auth login`: Start an interactive Shopify account login.
+- `shopify auth logout`: Clear the stored Shopify CLI session.
+- Commands that need authentication may start the same login flow automatically.
+
+## Non-interactive environments
+
+In CI or fully non-interactive environments, use credentials provided through the supported environment variables for the command you are running. Do not start an interactive browser login from CI.
+
+## Scopes
+
+Shopify CLI requests the scopes needed for CLI workflows, including access to Shopify Admin, Partners, Storefront Renderer, Business Platform, and App Management APIs. Individual commands may request additional scopes for the task being performed.
+
+## Support
+
+For issues with Shopify CLI authentication, see https://shopify.dev/docs/api/shopify-cli or contact Shopify support at https://help.shopify.com.

--- a/docs/cli/auth.md
+++ b/docs/cli/auth.md
@@ -6,10 +6,11 @@ Shopify CLI authenticates developers with Shopify through a device-code OAuth fl
 
 Shopify CLI currently supports user-driven device authentication:
 
-1. Run a command that requires authentication, or run `shopify auth login` directly.
-2. Shopify CLI prints a verification URL and user code, or opens the verification URL in your browser.
-3. The user completes login in the browser.
-4. Keep the CLI process running. It polls for completion and continues automatically after authentication succeeds.
+1. Check whether a session is already available with `shopify auth status` or `shopify auth status --json`.
+2. Run a command that requires authentication, or run `shopify auth login` directly.
+3. Shopify CLI prints a verification URL and user code, or opens the verification URL in your browser.
+4. The user completes login in the browser.
+5. Keep the CLI process running. It polls for completion and continues automatically after authentication succeeds.
 
 Agents should show the verification URL and user code to the user, ask the user to complete authentication in the browser, and wait for the CLI command to finish.
 
@@ -17,6 +18,7 @@ Agents should show the verification URL and user code to the user, ask the user 
 
 - `shopify auth login`: Start an interactive Shopify account login.
 - `shopify auth logout`: Clear the stored Shopify CLI session.
+- `shopify auth status`: Check whether Shopify CLI has a usable Shopify account session. Use `--json` for machine-readable output.
 - Commands that need authentication may start the same login flow automatically.
 
 ## Non-interactive environments

--- a/packages/cli-kit/src/private/node/session/device-authorization.test.ts
+++ b/packages/cli-kit/src/private/node/session/device-authorization.test.ts
@@ -12,6 +12,7 @@ import {isTTY} from '../../../public/node/ui.js'
 import {err, ok} from '../../../public/node/result.js'
 import {AbortError} from '../../../public/node/error.js'
 import {isCI} from '../../../public/node/system.js'
+import {mockAndCaptureOutput} from '../../../public/node/testing/output.js'
 
 import {beforeEach, describe, expect, test, vi} from 'vitest'
 import {Response} from 'node-fetch'
@@ -64,6 +65,27 @@ describe('requestDeviceAuthorization', () => {
       body: 'client_id=clientId&scope=scope1 scope2',
     })
     expect(got).toEqual(dataExpected)
+  })
+
+  test('prints explicit guidance for agents when the browser is not opened automatically', async () => {
+    // Given
+    const outputMock = mockAndCaptureOutput()
+    const response = new Response(JSON.stringify(data))
+    vi.mocked(shopifyFetch).mockResolvedValue(response)
+    vi.mocked(identityFqdn).mockResolvedValue('fqdn.com')
+    vi.mocked(clientId).mockReturnValue('clientId')
+    vi.mocked(isTTY).mockReturnValue(false)
+
+    // When
+    await requestDeviceAuthorization(['scope1', 'scope2'])
+
+    // Then
+    expect(outputMock.output()).toContain('User verification code: user_code')
+    expect(outputMock.output()).toContain('Open this link to start the auth process: verification_uri_complete')
+    expect(outputMock.output()).toContain('Waiting for authentication to complete. Keep this command running.')
+    expect(outputMock.output()).toContain(
+      'If you are an agent, show the URL and code to the user, ask them to complete login, then continue after this command finishes.',
+    )
   })
 
   test('when the response is not valid JSON, throw an error with context', async () => {

--- a/packages/cli-kit/src/private/node/session/device-authorization.test.ts
+++ b/packages/cli-kit/src/private/node/session/device-authorization.test.ts
@@ -25,6 +25,7 @@ vi.mock('./exchange.js')
 vi.mock('../../../public/node/system.js')
 
 beforeEach(() => {
+  mockAndCaptureOutput().clear()
   vi.mocked(isTTY).mockReturnValue(true)
   vi.mocked(isCI).mockReturnValue(false)
 })
@@ -84,6 +85,25 @@ describe('requestDeviceAuthorization', () => {
     expect(outputMock.output()).toContain('Open this link to start the auth process: verification_uri_complete')
     expect(outputMock.output()).toContain('Waiting for authentication to complete. Keep this command running.')
     expect(outputMock.output()).toContain(
+      'If you are an agent, show the URL and code to the user, ask them to complete login, then continue after this command finishes.',
+    )
+  })
+
+  test('does not print explicit guidance for agents when TTY is enabled', async () => {
+    // Given
+    const outputMock = mockAndCaptureOutput()
+    const response = new Response(JSON.stringify(data))
+    vi.mocked(shopifyFetch).mockResolvedValue(response)
+    vi.mocked(identityFqdn).mockResolvedValue('fqdn.com')
+    vi.mocked(clientId).mockReturnValue('clientId')
+    vi.mocked(isTTY).mockReturnValue(true)
+
+    // When
+    await requestDeviceAuthorization(['scope1', 'scope2'])
+
+    // Then
+    expect(outputMock.output()).toContain('Waiting for authentication to complete. Keep this command running.')
+    expect(outputMock.output()).not.toContain(
       'If you are an agent, show the URL and code to the user, ask them to complete login, then continue after this command finishes.',
     )
   })

--- a/packages/cli-kit/src/private/node/session/device-authorization.ts
+++ b/packages/cli-kit/src/private/node/session/device-authorization.ts
@@ -80,12 +80,15 @@ export async function requestDeviceAuthorization(scopes: string[]): Promise<Devi
 
   outputInfo(outputContent`User verification code: ${jsonResult.user_code}`)
   const linkToken = outputToken.link(jsonResult.verification_uri_complete)
+  const tty = isTTY()
 
   const waitingMessage = () => {
     outputInfo('Waiting for authentication to complete. Keep this command running.')
-    outputInfo(
-      'If you are an agent, show the URL and code to the user, ask them to complete login, then continue after this command finishes.',
-    )
+    if (!tty) {
+      outputInfo(
+        'If you are an agent, show the URL and code to the user, ask them to complete login, then continue after this command finishes.',
+      )
+    }
   }
 
   const manualLoginMessage = () => {
@@ -93,7 +96,7 @@ export async function requestDeviceAuthorization(scopes: string[]): Promise<Devi
     waitingMessage()
   }
 
-  if (isCloudEnvironment() || !isTTY()) {
+  if (isCloudEnvironment() || !tty) {
     manualLoginMessage()
   } else {
     outputInfo('👉 Press any key to open the login page on your browser')

--- a/packages/cli-kit/src/private/node/session/device-authorization.ts
+++ b/packages/cli-kit/src/private/node/session/device-authorization.ts
@@ -81,20 +81,29 @@ export async function requestDeviceAuthorization(scopes: string[]): Promise<Devi
   outputInfo(outputContent`User verification code: ${jsonResult.user_code}`)
   const linkToken = outputToken.link(jsonResult.verification_uri_complete)
 
-  const cloudMessage = () => {
+  const waitingMessage = () => {
+    outputInfo('Waiting for authentication to complete. Keep this command running.')
+    outputInfo(
+      'If you are an agent, show the URL and code to the user, ask them to complete login, then continue after this command finishes.',
+    )
+  }
+
+  const manualLoginMessage = () => {
     outputInfo(outputContent`👉 Open this link to start the auth process: ${linkToken}`)
+    waitingMessage()
   }
 
   if (isCloudEnvironment() || !isTTY()) {
-    cloudMessage()
+    manualLoginMessage()
   } else {
     outputInfo('👉 Press any key to open the login page on your browser')
     await keypress()
     const opened = await openURL(jsonResult.verification_uri_complete)
     if (opened) {
       outputInfo(outputContent`Opened link to start the auth process: ${linkToken}`)
+      waitingMessage()
     } else {
-      cloudMessage()
+      manualLoginMessage()
     }
   }
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1048,7 +1048,7 @@ DESCRIPTION
 
 ## `shopify auth login`
 
-Logs you in to your Shopify account.
+Log in to a Shopify account.
 
 ```
 USAGE
@@ -1058,7 +1058,20 @@ FLAGS
   --alias=<value>  [env: SHOPIFY_FLAG_AUTH_ALIAS] Alias of the session you want to login to.
 
 DESCRIPTION
-  Logs you in to your Shopify account.
+  Log in to a Shopify account.
+
+  Logs in to a Shopify account using a browser-based device authentication flow.
+
+  If Shopify CLI prints a verification URL and user code, open the URL in a browser, complete login, and keep the
+  command running. The command continues automatically after authentication succeeds.
+
+  When running from an agent, show the verification URL and user code to the user, ask them to complete login in the
+  browser, and wait for the command to finish.
+
+EXAMPLES
+  $ shopify auth login
+
+  $ shopify auth login --alias my-account
 ```
 
 ## `shopify auth logout`

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -3042,8 +3042,13 @@
       ],
       "args": {
       },
-      "description": "Logs you in to your Shopify account.",
+      "description": "Logs in to a Shopify account using a browser-based device authentication flow.\n\nIf Shopify CLI prints a verification URL and user code, open the URL in a browser, complete login, and keep the command running. The command continues automatically after authentication succeeds.\n\nWhen running from an agent, show the verification URL and user code to the user, ask them to complete login in the browser, and wait for the command to finish.",
+      "descriptionWithMarkdown": "Logs in to a Shopify account using a browser-based device authentication flow.\n\nIf Shopify CLI prints a verification URL and user code, open the URL in a browser, complete login, and keep the command running. The command continues automatically after authentication succeeds.\n\nWhen running from an agent, show the verification URL and user code to the user, ask them to complete login in the browser, and wait for the command to finish.",
       "enableJsonFlag": false,
+      "examples": [
+        "<%= config.bin %> <%= command.id %>",
+        "<%= config.bin %> <%= command.id %> --alias my-account"
+      ],
       "flags": {
         "alias": {
           "description": "Alias of the session you want to login to.",
@@ -3061,7 +3066,8 @@
       "pluginAlias": "@shopify/cli",
       "pluginName": "@shopify/cli",
       "pluginType": "core",
-      "strict": true
+      "strict": true,
+      "summary": "Log in to a Shopify account."
     },
     "auth:logout": {
       "aliases": [

--- a/packages/cli/src/cli/commands/auth/login.ts
+++ b/packages/cli/src/cli/commands/auth/login.ts
@@ -4,7 +4,17 @@ import {Flags} from '@oclif/core'
 import {outputCompleted} from '@shopify/cli-kit/node/output'
 
 export default class Login extends Command {
-  static description = 'Logs you in to your Shopify account.'
+  static summary = 'Log in to a Shopify account.'
+
+  static descriptionWithMarkdown = `Logs in to a Shopify account using a browser-based device authentication flow.
+
+If Shopify CLI prints a verification URL and user code, open the URL in a browser, complete login, and keep the command running. The command continues automatically after authentication succeeds.
+
+When running from an agent, show the verification URL and user code to the user, ask them to complete login in the browser, and wait for the command to finish.`
+
+  static description = this.descriptionWithoutMarkdown()
+
+  static examples = ['<%= config.bin %> <%= command.id %>', '<%= config.bin %> <%= command.id %> --alias my-account']
 
   static flags = {
     alias: Flags.string({


### PR DESCRIPTION
### WHY are these changes introduced?

After adding `shopify auth status`, agents should have clear inline and documentation guidance for using the existing device auth flow. This PR builds on the status command by documenting the recommended sequence and making login output easier for agents to relay to users.

### WHAT is this pull request doing?

- Adds `docs/cli/auth.md` to document Shopify CLI's agent-friendly device auth flow, including `shopify auth status`.
- Updates `shopify auth login` help and device auth output to tell agents to show the URL/code to the user and keep the command running.
- Adds regression coverage for the new device auth guidance.

### How to test your changes?

- `pnpm vitest run packages/cli-kit/src/private/node/session/device-authorization.test.ts packages/cli/src/cli/commands/auth/login.test.ts packages/cli-kit/src/public/node/session-auth-status.test.ts packages/cli/src/cli/commands/auth/status.test.ts`
- `pnpm --filter @shopify/cli-kit type-check && pnpm --filter @shopify/cli type-check`

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [x] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`