### PR TITLE
Add flags to avoid prompts in app config link

### DIFF
--- a/.changeset/app-config-link-flags.md
+++ b/.changeset/app-config-link-flags.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Add `--client-id` and `--file-name` options to `app config link`.

--- a/docs-shopify.dev/generated/generated_docs_data_v2.json
+++ b/docs-shopify.dev/generated/generated_docs_data_v2.json
@@ -439,6 +439,24 @@
         {
           "filePath": "docs-shopify.dev/commands/interfaces/app-config-link.interface.ts",
           "syntaxKind": "PropertySignature",
+          "name": "--file-name <value>",
+          "value": "string",
+          "description": "The name of the app configuration file to create or overwrite.",
+          "isOptional": true,
+          "environmentValue": "SHOPIFY_FLAG_APP_CONFIG_FILE_NAME"
+        },
+        {
+          "filePath": "docs-shopify.dev/commands/interfaces/app-config-link.interface.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "--force",
+          "value": "''",
+          "description": "Overwrite an existing configuration file without prompting.",
+          "isOptional": true,
+          "environmentValue": "SHOPIFY_FLAG_FORCE"
+        },
+        {
+          "filePath": "docs-shopify.dev/commands/interfaces/app-config-link.interface.ts",
+          "syntaxKind": "PropertySignature",
           "name": "--no-color",
           "value": "''",
           "description": "Disable color output.",
@@ -482,7 +500,7 @@
           "environmentValue": "SHOPIFY_FLAG_APP_CONFIG"
         }
       ],
-      "value": "export interface appconfiglink {\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--auth-alias <value>'?: string\n\n  /**\n   * The Client ID of your app.\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your app directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Reset all your settings.\n   * @environment SHOPIFY_FLAG_RESET\n   */\n  '--reset'?: ''\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+      "value": "export interface appconfiglink {\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--auth-alias <value>'?: string\n\n  /**\n   * The Client ID of your app.\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * The name of the app configuration file to create or overwrite.\n   * @environment SHOPIFY_FLAG_APP_CONFIG_FILE_NAME\n   */\n  '--file-name <value>'?: string\n\n  /**\n   * Overwrite an existing configuration file without prompting.\n   * @environment SHOPIFY_FLAG_FORCE\n   */\n  '--force'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your app directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Reset all your settings.\n   * @environment SHOPIFY_FLAG_RESET\n   */\n  '--reset'?: ''\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
     }
   },
   "appconfigpull": {

--- a/packages/app/src/cli/commands/app/config/link.test.ts
+++ b/packages/app/src/cli/commands/app/config/link.test.ts
@@ -1,0 +1,83 @@
+import ConfigLink from './link.js'
+import link from '../../../services/app/config/link.js'
+import {linkedAppContext} from '../../../services/app-context.js'
+import {testAppLinked, testOrganizationApp} from '../../../models/app/app.test-data.js'
+import {inTemporaryDirectory} from '@shopify/cli-kit/node/fs'
+import {beforeEach, describe, expect, test, vi} from 'vitest'
+
+vi.mock('../../../services/app/config/link.js')
+vi.mock('../../../services/app-context.js')
+
+describe('app config link command', () => {
+  beforeEach(() => {
+    vi.mocked(link).mockReset()
+    vi.mocked(linkedAppContext).mockReset()
+  })
+
+  test('accepts --client-id with --file-name to link a specific app to a specific config file', async () => {
+    await inTemporaryDirectory(async (tmp) => {
+      const app = testAppLinked()
+      vi.mocked(link).mockResolvedValue({
+        remoteApp: testOrganizationApp(),
+        configFileName: 'shopify.app.staging.toml',
+        configuration: app.configuration,
+      })
+      vi.mocked(linkedAppContext).mockResolvedValue({app} as Awaited<ReturnType<typeof linkedAppContext>>)
+
+      await ConfigLink.run(
+        ['--path', tmp, '--client-id', 'api-key', '--file-name', 'staging', '--force'],
+        import.meta.url,
+      )
+
+      expect(link).toHaveBeenCalledWith({
+        directory: tmp,
+        apiKey: 'api-key',
+        configName: undefined,
+        fileName: 'staging',
+        force: true,
+      })
+      expect(linkedAppContext).toHaveBeenCalledWith({
+        directory: tmp,
+        clientId: undefined,
+        forceRelink: false,
+        userProvidedConfigName: 'shopify.app.staging.toml',
+      })
+    })
+  })
+
+  test('accepts --config without requiring --file-name when --force is not passed', async () => {
+    await inTemporaryDirectory(async (tmp) => {
+      const app = testAppLinked()
+      vi.mocked(link).mockResolvedValue({
+        remoteApp: testOrganizationApp(),
+        configFileName: 'shopify.app.secondary.toml',
+        configuration: app.configuration,
+      })
+      vi.mocked(linkedAppContext).mockResolvedValue({app} as Awaited<ReturnType<typeof linkedAppContext>>)
+
+      await ConfigLink.run(['--path', tmp, '--config', 'secondary'], import.meta.url)
+
+      expect(link).toHaveBeenCalledWith({
+        directory: tmp,
+        apiKey: undefined,
+        configName: 'secondary',
+        fileName: undefined,
+        force: false,
+      })
+      expect(linkedAppContext).toHaveBeenCalledWith({
+        directory: tmp,
+        clientId: undefined,
+        forceRelink: false,
+        userProvidedConfigName: 'shopify.app.secondary.toml',
+      })
+    })
+  })
+
+  test('requires --file-name when --force is passed', async () => {
+    await inTemporaryDirectory(async (tmp) => {
+      await expect(ConfigLink.run(['--path', tmp, '--force'], import.meta.url)).rejects.toThrow()
+
+      expect(link).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/packages/app/src/cli/commands/app/config/link.ts
+++ b/packages/app/src/cli/commands/app/config/link.ts
@@ -23,6 +23,18 @@ export default class ConfigLink extends AppLinkedCommand {
       env: 'SHOPIFY_FLAG_ORGANIZATION_ID',
       exclusive: ['client-id'],
     }),
+    'file-name': Flags.string({
+      hidden: false,
+      description: 'The name of the app configuration file to create or overwrite.',
+      env: 'SHOPIFY_FLAG_APP_CONFIG_FILE_NAME',
+      exclusive: ['config'],
+    }),
+    force: Flags.boolean({
+      hidden: false,
+      description: 'Overwrite an existing configuration file without prompting.',
+      env: 'SHOPIFY_FLAG_FORCE',
+      dependsOn: ['file-name'],
+    }),
   }
 
   public async run(): Promise<AppLinkedCommandOutput> {
@@ -33,6 +45,8 @@ export default class ConfigLink extends AppLinkedCommand {
       apiKey: flags['client-id'],
       organizationId: flags['organization-id'],
       configName: flags.config,
+      fileName: flags['file-name'],
+      force: flags.force ?? false,
     }
 
     const result = await link(options)

--- a/packages/app/src/cli/services/app/config/link.test.ts
+++ b/packages/app/src/cli/services/app/config/link.test.ts
@@ -115,6 +115,76 @@ describe('link', () => {
     })
   })
 
+  test('does not ask for a name when a file name is provided as a flag', async () => {
+    await inTemporaryDirectory(async (tmp) => {
+      // Given
+      const developerPlatformClient = buildDeveloperPlatformClient()
+      const options: LinkOptions = {
+        directory: tmp,
+        fileName: 'staging',
+        developerPlatformClient,
+      }
+      await mockLoadOpaqueAppWithApp(tmp)
+      vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue(mockRemoteApp({developerPlatformClient}))
+
+      // When
+      const {configFileName} = await link(options)
+
+      // Then
+      expect(selectConfigName).not.toHaveBeenCalled()
+      expect(configFileName).toBe('shopify.app.staging.toml')
+      expect(fileExistsSync(joinPath(tmp, 'shopify.app.staging.toml'))).toBeTruthy()
+    })
+  })
+
+  test('throws when a file name is provided for an existing file without force', async () => {
+    await inTemporaryDirectory(async (tmp) => {
+      // Given
+      const developerPlatformClient = buildDeveloperPlatformClient()
+      const options: LinkOptions = {
+        directory: tmp,
+        fileName: 'staging',
+        developerPlatformClient,
+      }
+      writeFileSync(joinPath(tmp, 'shopify.app.staging.toml'), 'client_id = "12345"')
+      await mockLoadOpaqueAppWithApp(tmp)
+      vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue(mockRemoteApp({developerPlatformClient}))
+
+      // When
+      const result = link(options)
+
+      // Then
+      await expect(result).rejects.toThrow(/Configuration file shopify\.app\.staging\.toml already exists/)
+      expect(selectConfigName).not.toHaveBeenCalled()
+    })
+  })
+
+  test('overwrites an existing file name when force is provided', async () => {
+    await inTemporaryDirectory(async (tmp) => {
+      // Given
+      const developerPlatformClient = buildDeveloperPlatformClient()
+      const options: LinkOptions = {
+        directory: tmp,
+        fileName: 'staging',
+        force: true,
+        developerPlatformClient,
+      }
+      writeFileSync(joinPath(tmp, 'shopify.app.staging.toml'), 'name = "old app"')
+      await mockLoadOpaqueAppWithApp(tmp)
+      vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue(mockRemoteApp({developerPlatformClient}))
+
+      // When
+      const {configFileName} = await link(options)
+
+      // Then
+      const content = await readFile(joinPath(tmp, 'shopify.app.staging.toml'))
+      expect(selectConfigName).not.toHaveBeenCalled()
+      expect(configFileName).toBe('shopify.app.staging.toml')
+      expect(content).toContain('client_id = "12345"')
+      expect(content).not.toContain('old app')
+    })
+  })
+
   test('does not ask for a name when the selected app is already linked', async () => {
     await inTemporaryDirectory(async (tmp) => {
       // Given

--- a/packages/app/src/cli/services/app/config/link.ts
+++ b/packages/app/src/cli/services/app/config/link.ts
@@ -26,6 +26,7 @@ import {loadLocalExtensionsSpecifications} from '../../../models/extensions/load
 import {renderSuccess} from '@shopify/cli-kit/node/ui'
 import {formatPackageManagerCommand} from '@shopify/cli-kit/node/output'
 import {deepMergeObjects, isEmpty} from '@shopify/cli-kit/common/object'
+import {fileExists} from '@shopify/cli-kit/node/fs'
 import {joinPath} from '@shopify/cli-kit/node/path'
 import {AbortError} from '@shopify/cli-kit/node/error'
 import {PackageManager} from '@shopify/cli-kit/node/node-package-manager'
@@ -36,6 +37,8 @@ export interface LinkOptions {
   appId?: string
   organizationId?: string
   configName?: string
+  fileName?: string
+  force?: boolean
   developerPlatformClient?: DeveloperPlatformClient
   isNewApp?: boolean
 }
@@ -297,6 +300,18 @@ async function loadConfigurationFileName(
     appDirectory?: string
   },
 ): Promise<AppConfigurationFileName> {
+  if (options.fileName) {
+    const fileName = getAppConfigurationFileName(options.fileName)
+    const appDirectory = localAppInfo.appDirectory ?? options.directory
+    if (!options.force && (await fileExists(joinPath(appDirectory, fileName)))) {
+      throw new AbortError(
+        `Configuration file ${fileName} already exists.`,
+        'Run the command with --force to overwrite it.',
+      )
+    }
+    return fileName
+  }
+
   if (options.configName) {
     return getAppConfigurationFileName(options.configName)
   }

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -367,8 +367,8 @@ Fetch your app configuration from the Developer Dashboard.
 
 ```
 USAGE
-  $ shopify app config link [--auth-alias <value>] [--client-id <value> | -c <value>] [--no-color] [--path <value>]
-    [--reset | ] [--verbose]
+  $ shopify app config link [--auth-alias <value>] [--client-id <value> | -c <value>] [--force [--file-name <value> |
+    ]] [--no-color] [--path <value>] [--reset | ] [--verbose]
 
 FLAGS
   -c, --config=<value>
@@ -382,6 +382,14 @@ FLAGS
   --client-id=<value>
       The Client ID of your app.
       [env: SHOPIFY_FLAG_CLIENT_ID]
+
+  --file-name=<value>
+      The name of the app configuration file to create or overwrite.
+      [env: SHOPIFY_FLAG_APP_CONFIG_FILE_NAME]
+
+  --force
+      Overwrite an existing configuration file without prompting.
+      [env: SHOPIFY_FLAG_FORCE]
 
   --no-color
       Disable color output.

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -501,6 +501,29 @@
           "name": "config",
           "type": "option"
         },
+        "file-name": {
+          "description": "The name of the app configuration file to create or overwrite.",
+          "env": "SHOPIFY_FLAG_APP_CONFIG_FILE_NAME",
+          "exclusive": [
+            "config"
+          ],
+          "hasDynamicHelp": false,
+          "hidden": false,
+          "multiple": false,
+          "name": "file-name",
+          "type": "option"
+        },
+        "force": {
+          "allowNo": false,
+          "dependsOn": [
+            "file-name"
+          ],
+          "description": "Overwrite an existing configuration file without prompting.",
+          "env": "SHOPIFY_FLAG_FORCE",
+          "hidden": false,
+          "name": "force",
+          "type": "boolean"
+        },
         "no-color": {
           "allowNo": false,
           "description": "Disable color output.",


### PR DESCRIPTION
### WHY are these changes introduced?

Related to https://github.com/shop/issues-develop/issues/22869

The interactivity audit found that `shopify app config link --client-id <id>` can still prompt for a local configuration file name when the target file cannot be inferred.

### WHAT is this pull request doing?

- Adds `--file-name` to choose the config file that `app config link` should create.
- Adds `--force` to overwrite an existing config file without prompting.

### How to test your changes?

With a new client-id (not used in any toml file) and an existing shopify.app.toml:

- `shopify app config link --client-id XXX` => should ask for the file
- `shopify app config link --client-id XXX --file-name staging` => should create shopify.app.staging.toml
- `shopify app config link --client-id XXX --file-name shopify.app.toml` => already exists error
- `shopify app config link --client-id XXX --file-name shopify.app.toml --force` => works

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible documentation changes
- [x] I've considered analytics changes to measure impact
- [x] The change is user-facing, so I've added a changelog entry with `pnpm changeset add`