### PR TITLE
Allow theme profile with Theme Access tokens

### DIFF
--- a/packages/theme/src/cli/services/profile.test.ts
+++ b/packages/theme/src/cli/services/profile.test.ts
@@ -110,15 +110,38 @@ describe('profile', () => {
     await expect(result).rejects.toThrow('Bad response: 404: {"error":"Some error message"}')
   })
 
-  test('throws error when a password is used', async () => {
+  test('uses Theme Access tokens when a password is provided', async () => {
+    // Given
+    vi.mocked(ensureAuthenticatedStorefront).mockResolvedValue('shptka_hello')
+
+    // When
+    await profile(mockAdminSession, themeId, urlPath, true, 'shptka_hello', undefined)
+
+    // Then
+    expect(render).toHaveBeenCalledWith(
+      expect.objectContaining({
+        storefrontToken: 'shptka_hello',
+      }),
+      expect.any(Object),
+    )
+  })
+
+  test('throws error when an Admin API token is used', async () => {
     // When
     const result = profile(mockAdminSession, themeId, urlPath, true, 'shpat_hello', undefined)
 
     // Then
     await expect(result).rejects.toThrow(
       new AbortError(
-        'Unable to use Admin API or Theme Access tokens with the profile command',
-        'You must authenticate manually by not passing the --password flag.',
+        'Unable to use Admin API tokens with the profile command',
+        `To use this command with the --password flag you must:
+
+1. Install the Theme Access app on your shop
+2. Generate a new password
+
+Alternatively, you can authenticate normally by not passing the --password flag.
+
+Learn more: https://shopify.dev/docs/storefronts/themes/tools/theme-access`,
       ),
     )
   })

--- a/packages/theme/src/cli/services/profile.ts
+++ b/packages/theme/src/cli/services/profile.ts
@@ -22,10 +22,17 @@ export async function profile(
     ? await ensureValidPassword(storefrontPassword, adminSession.storeFqdn)
     : undefined
 
-  if (themeAccessPassword) {
+  if (themeAccessPassword?.startsWith('shpat_')) {
     throw new AbortError(
-      'Unable to use Admin API or Theme Access tokens with the profile command',
-      'You must authenticate manually by not passing the --password flag.',
+      'Unable to use Admin API tokens with the profile command',
+      `To use this command with the --password flag you must:
+
+1. Install the Theme Access app on your shop
+2. Generate a new password
+
+Alternatively, you can authenticate normally by not passing the --password flag.
+
+Learn more: https://shopify.dev/docs/storefronts/themes/tools/theme-access`,
     )
   }
 


### PR DESCRIPTION
### WHY are these changes introduced?

The interactivity audit found that theme profile required browser OAuth even when a Theme Access token was available for non-interactive runs.

### WHAT is this pull request doing?

- Allows theme profile to use Theme Access tokens.
- Keeps the existing rejection for raw Admin API tokens with clearer guidance.

### How to test your changes?

- pnpm vitest run packages/theme/src/cli/services/profile.test.ts

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible documentation changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing, so I've added a changelog entry with pnpm changeset add
