### PR TITLE
[Tests] Remove redundant filesystem mocks in stage-file.test.ts

### DIFF
--- a/packages/app/src/cli/services/bulk-operations/stage-file.test.ts
+++ b/packages/app/src/cli/services/bulk-operations/stage-file.test.ts
@@ -1,18 +1,14 @@
 import {stageFile} from './stage-file.js'
 import {adminRequestDoc} from '@shopify/cli-kit/node/api/admin'
-import {readFile, fileSize} from '@shopify/cli-kit/node/fs'
 import {fetch} from '@shopify/cli-kit/node/http'
 import {describe, test, expect, vi, beforeEach} from 'vitest'
 
 vi.mock('@shopify/cli-kit/node/api/admin')
 vi.mock('@shopify/cli-kit/node/session')
-vi.mock('@shopify/cli-kit/node/fs')
 vi.mock('@shopify/cli-kit/node/http')
 
 describe('stageFile', () => {
   const mockSession = {token: 'test-token', storeFqdn: 'test-store.myshopify.com'}
-  const mockFileContents = '{"id":"gid://shopify/Product/123","title":"Test"}'
-  const mockFileSize = 52
   const mockUploadUrl = 'https://storage.googleapis.com/test-bucket/test-file'
   const mockResourceUrl = 'tmp/staged-uploads/test-resource.jsonl'
 
@@ -35,8 +31,6 @@ describe('stageFile', () => {
   let formDataAppendSpy: ReturnType<typeof vi.spyOn>
 
   beforeEach(() => {
-    vi.mocked(readFile).mockResolvedValue(Buffer.from(mockFileContents))
-    vi.mocked(fileSize).mockResolvedValue(mockFileSize)
     vi.mocked(fetch).mockResolvedValue({
       ok: true,
       text: vi.fn().mockResolvedValue(''),


### PR DESCRIPTION
### WHY are these changes introduced?

Technical debt cleanup. The test file `packages/app/src/cli/services/bulk-operations/stage-file.test.ts` contained redundant mocks for filesystem operations (`readFile` and `fileSize`) that are not used by the code under test, which instead uses `Buffer.from` and `buffer.length`.

### WHAT is this pull request doing?

Removes `vi.mock('@shopify/cli-kit/node/fs')` and associated unused mock setups in `packages/app/src/cli/services/bulk-operations/stage-file.test.ts`.

### How to test your changes?

CI

### Post-release steps

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [18354233134098056568](https://jules.google.com/task/18354233134098056568) started by @gonzaloriestra*