### PR TITLE
[Security] Harden ExtensionServerClient ID generation

### DIFF
--- a/packages/ui-extensions-server-kit/src/ExtensionServerClient/ExtensionServerClient.test.ts
+++ b/packages/ui-extensions-server-kit/src/ExtensionServerClient/ExtensionServerClient.test.ts
@@ -163,6 +163,12 @@ describe('ExtensionServerClient', () => {
   })
 
   describe('initialization', () => {
+    test('generates a random UUID as id', () => {
+      const client = new ExtensionServerClient(defaultOptions)
+      const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+      expect(client.id).toMatch(uuidRegex)
+    })
+
     test('connects to the target websocket', async () => {
       // Create client
       const client = new ExtensionServerClient(defaultOptions)

--- a/packages/ui-extensions-server-kit/src/ExtensionServerClient/ExtensionServerClient.ts
+++ b/packages/ui-extensions-server-kit/src/ExtensionServerClient/ExtensionServerClient.ts
@@ -32,7 +32,8 @@ export class ExtensionServerClient implements ExtensionServer.Client {
   private uiExtensionsByUuid: Record<string, ExtensionServer.UIExtension> = {}
 
   constructor(options: DeepPartial<ExtensionServer.Options> = {}) {
-    this.id = (Math.random() + 1).toString(36).substring(7)
+    // Security: Use a cryptographically secure random UUID to prevent ID predictability
+    this.id = globalThis.crypto.randomUUID()
     this.options = getValidatedOptions({
       ...options,
       connection: {


### PR DESCRIPTION
### WHY are these changes introduced?

Improve security of client identifiers.

### WHAT is this pull request doing?

Replaces non-secure random ID generation with a cryptographically secure UUID.

### How to test your changes?

CI

### Post-release steps

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [17948761102267722685](https://jules.google.com/task/17948761102267722685) started by @gonzaloriestra*