### PR TITLE
[Refactor] Use uniq helper in store auth scopes

### DIFF
--- a/packages/store/src/cli/services/store/auth/scopes.ts
+++ b/packages/store/src/cli/services/store/auth/scopes.ts
@@ -1,5 +1,6 @@
 import {AbortError} from '@shopify/cli-kit/node/error'
 import {outputContent, outputDebug} from '@shopify/cli-kit/node/output'
+import {uniq} from '@shopify/cli-kit/common/array'
 import type {StoreTokenResponse} from './token-client.js'
 
 export function parseStoreAuthScopes(input: string): string[] {
@@ -9,7 +10,7 @@ export function parseStoreAuthScopes(input: string): string[] {
     throw new AbortError('At least one scope is required.', 'Pass --scopes as a comma-separated list.')
   }
 
-  return [...new Set(scopes)]
+  return uniq(scopes)
 }
 
 function expandImpliedStoreScopes(scopes: string[]): Set<string> {


### PR DESCRIPTION
### WHY are these changes introduced?

Follows the repository's preference for using the `uniq` utility from `@shopify/cli-kit` instead of manual `Set` spreads for array deduplication.

### WHAT is this pull request doing?

Replaces `[...new Set(scopes)]` with `uniq(scopes)` in `packages/store/src/cli/services/store/auth/scopes.ts`.

### How to test your changes?

CI

### Post-release steps

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [8495668938836215213](https://jules.google.com/task/8495668938836215213) started by @gonzaloriestra*