### PR TITLE
Handle missing Git in optional repo checks

### DIFF
--- a/.changeset/old-poems-speak.md
+++ b/.changeset/old-poems-speak.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': patch
+---
+
+Fix error reporting of cli-kit methods that try to run git when git is unavailable

--- a/packages/cli-kit/src/public/node/git.test.ts
+++ b/packages/cli-kit/src/public/node/git.test.ts
@@ -311,6 +311,16 @@ describe('ensurePresentOrAbort()', () => {
 })
 
 describe('ensureInsideGitDirectory()', () => {
+  test('throws a friendly error if git is not present', async () => {
+    // Given
+    vi.mocked(hasGit).mockResolvedValue(false)
+
+    // Then
+    await expect(() => git.ensureInsideGitDirectory()).rejects.toThrowError(
+      /Git is necessary in the environment to continue/,
+    )
+  })
+
   test('throws an error if not inside a git directory', async () => {
     const error = Object.assign(new Error('not a git repo'), {exitCode: 128})
     mockedExeca.mockRejectedValue(error)
@@ -326,6 +336,15 @@ describe('ensureInsideGitDirectory()', () => {
 })
 
 describe('insideGitDirectory()', () => {
+  test('returns false if git is not present', async () => {
+    // Given
+    vi.mocked(hasGit).mockResolvedValue(false)
+
+    // Then
+    await expect(git.insideGitDirectory()).resolves.toBe(false)
+    expect(mockedExeca).not.toHaveBeenCalled()
+  })
+
   test('returns true if inside a git directory', async () => {
     mockGitCommand('.git')
 

--- a/packages/cli-kit/src/public/node/git.ts
+++ b/packages/cli-kit/src/public/node/git.ts
@@ -349,7 +349,9 @@ export class OutsideGitDirectoryError extends AbortError {}
  * @param directory - The directory to check.
  */
 export async function ensureInsideGitDirectory(directory?: string): Promise<void> {
-  if (!(await insideGitDirectory(directory))) {
+  await ensureGitIsPresentOrAbort()
+
+  if (!(await checkIfInsideGitDirectory(directory))) {
     throw new OutsideGitDirectoryError(`${outputToken.path(directory ?? cwd())} is not a Git directory`)
   }
 }
@@ -361,6 +363,14 @@ export async function ensureInsideGitDirectory(directory?: string): Promise<void
  * @returns True if the directory is inside a .git directory tree.
  */
 export async function insideGitDirectory(directory?: string): Promise<boolean> {
+  if (!(await hasGit())) {
+    return false
+  }
+
+  return checkIfInsideGitDirectory(directory)
+}
+
+async function checkIfInsideGitDirectory(directory?: string): Promise<boolean> {
   try {
     await execa('git', ['rev-parse', '--git-dir'], {cwd: directory})
     return true


### PR DESCRIPTION
## Why

Some theme workflows use Git only as an optional safety check before continuing. When Git is not installed or unavailable on PATH, those checks should not surface raw command failures to users.

## What changed

- Treat missing Git as “not inside a Git directory” for optional repository detection.
- Keep a friendly, actionable error for flows that explicitly require Git.
- Added unit coverage for both behaviours.

## Testing

- `pnpm vitest run packages/cli-kit/src/public/node/git.test.ts --config packages/cli-kit/vite.config.ts`
- `pnpm vitest run packages/theme/src/cli/services/pull.test.ts --config packages/theme/vite.config.ts`

Fixes shop/issues#47568
