### PR TITLE
fix(theme): preserve dev preview theme across SFR redirects

### DIFF
--- a/.changeset/tidy-bats-prove.md
+++ b/.changeset/tidy-bats-prove.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Fix `theme dev` preview occasionally rendering the live theme by preserving the Shopify `_shopify_essential` cookie in redirects

--- a/packages/theme/src/cli/utilities/theme-environment/proxy.test.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/proxy.test.ts
@@ -250,6 +250,67 @@ describe('dev proxy', () => {
       expect(ctx.session.sessionCookies).toHaveProperty('_shopify_essential', ':AZFbAlZ..yAAH:')
     })
 
+    test('captures _shopify_essential from Set-Cookie into session on 3xx responses', async () => {
+      const localCtx = {
+        ...ctx,
+        session: {storeFqdn: 'my-store.myshopify.com', sessionCookies: {}},
+      } as unknown as DevServerContext
+
+      const redirectResponse = new Response('should-not-be-read', {
+        status: 302,
+        headers: {
+          Location: 'https://my-store.myshopify.com/foo?bar=1',
+          'Set-Cookie':
+            '_shopify_essential=ABC123; Domain=my-store.myshopify.com; Path=/; Max-Age=31536000; secure; HttpOnly; SameSite=Lax',
+        },
+      })
+
+      const patchedResponse = await patchRenderingResponse(localCtx, redirectResponse)
+
+      expect(patchedResponse.status).toBe(302)
+      expect(localCtx.session.sessionCookies).toHaveProperty('_shopify_essential', 'ABC123')
+    })
+
+    test('rewrites Location header from store domain to local path on 3xx responses', async () => {
+      const localCtx = {
+        ...ctx,
+        session: {storeFqdn: 'my-store.myshopify.com', sessionCookies: {}},
+      } as unknown as DevServerContext
+
+      const redirectResponse = new Response('should-not-be-read', {
+        status: 302,
+        headers: {
+          Location: 'https://my-store.myshopify.com/foo?bar=1',
+        },
+      })
+
+      const patchedResponse = await patchRenderingResponse(localCtx, redirectResponse)
+
+      expect(patchedResponse.status).toBe(302)
+      expect(patchedResponse.headers.get('Location')).toBe('/foo?bar=1')
+    })
+
+    test('returns 3xx responses without reading or patching the body', async () => {
+      const localCtx = {
+        ...ctx,
+        session: {storeFqdn: 'my-store.myshopify.com', sessionCookies: {}},
+      } as unknown as DevServerContext
+
+      const body = '<a href="https://my-store.myshopify.com/cdn/path/to/assets/file1">link</a>'
+      const redirectResponse = new Response(body, {
+        status: 301,
+        headers: {
+          Location: 'https://my-store.myshopify.com/foo',
+        },
+      })
+
+      const patchedResponse = await patchRenderingResponse(localCtx, redirectResponse)
+
+      expect(patchedResponse.status).toBe(301)
+      // CDN injection would rewrite the href; body should be passed through unchanged.
+      await expect(patchedResponse.text()).resolves.toBe(body)
+    })
+
     test('handles 304 Not Modified responses without crashing', async () => {
       // Create 304 response with no body as per HTTP spec
       const notModifiedResponse = new Response(null, {

--- a/packages/theme/src/cli/utilities/theme-environment/proxy.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/proxy.ts
@@ -194,12 +194,12 @@ export async function patchRenderingResponse(
   rawResponse: Response,
   patchCallback?: (html: string) => string | undefined,
 ): Promise<Response> {
-  // 3xx responses should be returned
-  if (rawResponse.status >= 300 && rawResponse.status < 400) {
-    return rawResponse
-  }
-
   const response = patchProxiedResponseHeaders(ctx, rawResponse)
+
+  // 3xx responses should be returned
+  if (response.status >= 300 && response.status < 400) {
+    return response
+  }
 
   // Only set HTML content-type for actual HTML responses, preserve JSON content-type:
   const originalContentType = rawResponse.headers.get('content-type')

--- a/packages/theme/src/cli/utilities/theme-environment/storefront-renderer.test.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/storefront-renderer.test.ts
@@ -205,6 +205,58 @@ describe('render', () => {
     )
   })
 
+  test('does not auto-follow 3xx responses on GET (preserves intermediate Set-Cookie)', async () => {
+    // Given
+    vi.mocked(fetch).mockResolvedValue(
+      new Response('redirected-body-should-not-be-returned', {
+        status: 302,
+        headers: {Location: 'https://store.myshopify.com/products/1'},
+      }),
+    )
+
+    // When
+    const response = await render(session, context)
+
+    // Then
+    expect(response.status).toEqual(302)
+    expect(response.headers.get('Location')).toEqual('https://store.myshopify.com/products/1')
+    expect(fetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        method: 'GET',
+        redirect: 'manual',
+      }),
+    )
+  })
+
+  test('does not auto-follow 3xx responses on POST (replaceTemplates branch)', async () => {
+    // Given
+    vi.mocked(fetch).mockResolvedValue(
+      new Response('redirected-body-should-not-be-returned', {
+        status: 302,
+        headers: {Location: 'https://store.myshopify.com/products/1'},
+      }),
+    )
+
+    // When
+    const response = await render(session, {
+      ...context,
+      method: 'POST',
+      replaceTemplates: {'sections/header.liquid': '<div>hello</div>'},
+    })
+
+    // Then
+    expect(response.status).toEqual(302)
+    expect(response.headers.get('Location')).toEqual('https://store.myshopify.com/products/1')
+    expect(fetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        method: 'POST',
+        redirect: 'manual',
+      }),
+    )
+  })
+
   test('renders using query parameters', async () => {
     // Given
     vi.mocked(fetch).mockResolvedValue(new Response())

--- a/packages/theme/src/cli/utilities/theme-environment/storefront-renderer.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/storefront-renderer.ts
@@ -23,6 +23,7 @@ export async function render(session: DevServerSession, context: DevServerRender
     response = await fetch(url, {
       method: 'POST',
       body: bodyParams,
+      redirect: 'manual',
       headers: {
         ...headers,
         ...defaultHeaders(),
@@ -36,6 +37,7 @@ export async function render(session: DevServerSession, context: DevServerRender
     // eslint-disable-next-line no-restricted-globals
     response = await fetch(url, {
       method: context.method,
+      redirect: 'manual',
       headers: {
         ...headers,
         ...defaultHeaders(),


### PR DESCRIPTION
### WHY are these changes introduced?

The storefront renderer fetch call was using fetch's default redirect behavior ('follow'), which silently dropped the intermediate Set-Cookie headers that bind _shopify_essential to the dev theme.

Set redirect: 'manual' on storefront-renderer fetches and patch response headers (Set-Cookie capture + Location rewrite) on 3xx so the browser can follow the redirect cleanly while we keep the dev-bound session cookie.

### WHAT is this pull request doing?

on 3xx so the browser can follow the redirect cleanly while we keep the dev-bound session cookie.

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
  You can post a comment with `/snapit` to generate a snapshot of the changes to be tested.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`
