### PR TITLE
[Refactor] Use isSubpath in getExtensionAssetMiddleware

### DIFF
--- a/packages/app/src/cli/services/dev/extension/server/middlewares.ts
+++ b/packages/app/src/cli/services/dev/extension/server/middlewares.ts
@@ -6,7 +6,7 @@ import {getWebSocketUrl} from '../../extension.js'
 import {resolveOutputDir} from '../../../build/steps/include-assets/generate-manifest.js'
 import {fileExists, isDirectory, readFile, findPathUp} from '@shopify/cli-kit/node/fs'
 import {sendRedirect, defineEventHandler, getRequestHeader, getRouterParams, setResponseHeader} from 'h3'
-import {joinPath, resolvePath, relativePath, isAbsolutePath, extname, moduleDirectory} from '@shopify/cli-kit/node/path'
+import {joinPath, resolvePath, isSubpath, extname, moduleDirectory} from '@shopify/cli-kit/node/path'
 import {outputDebug} from '@shopify/cli-kit/node/output'
 
 import type {H3Event} from 'h3'
@@ -97,9 +97,8 @@ export function getExtensionAssetMiddleware({getExtensions, payloadStore}: GetEx
 
     const resolvedOutputDir = resolvePath(resolveOutputDir(extension.outputPath))
     const candidate = resolvePath(joinPath(resolvedOutputDir, filesystemPath))
-    const rel = relativePath(resolvedOutputDir, candidate)
 
-    if (rel.startsWith('..') || isAbsolutePath(rel)) {
+    if (!isSubpath(resolvedOutputDir, candidate)) {
       return sendError(event, {statusCode: 404, statusMessage: 'Not Found'})
     }
 


### PR DESCRIPTION
### WHY are these changes introduced?

This refactor improves code readability and maintainability by using the existing \`isSubpath\` utility from \`@shopify/cli-kit/node/path\` instead of manually implementing path traversal checks.

### WHAT is this pull request doing?

- Imports \`isSubpath\` from \`@shopify/cli-kit/node/path\`.
- Replaces manual path containment check in \`getExtensionAssetMiddleware\` with \`isSubpath\`.
- Removes unused \`relativePath\` and \`isAbsolutePath\` imports.

### How to test your changes?

CI

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (\`patch\` for bug fixes · \`minor\` for new features · \`major\` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with \`pnpm changeset add\`

---
*PR created automatically by Jules for task [14973263709385850766](https://jules.google.com/task/14973263709385850766) started by @gonzaloriestra*