### PR TITLE
[Performance] Optimize analytics payload generation

### DIFF
--- a/packages/cli-kit/src/public/node/analytics.ts
+++ b/packages/cli-kit/src/public/node/analytics.ts
@@ -148,7 +148,7 @@ async function buildPayload({config, errorMessage, exitMode}: ReportAnalyticsEve
   const wallClockElapsed = currentTime - startTime
   const totalTimeWithoutSubtimers = wallClockElapsed - totalTimeFromSubtimers
 
-  let payload = {
+  const payload = {
     public: {
       command: startCommand,
       time_start: startTime,
@@ -191,9 +191,6 @@ async function buildPayload({config, errorMessage, exitMode}: ReportAnalyticsEve
       payload.public[metric] = Math.floor(current)
     }
   })
-
-  // strip undefined fields -- they make up the majority of payloads due to wide metadata structure.
-  payload = JSON.parse(JSON.stringify(payload))
 
   return sanitizePayload(payload)
 }


### PR DESCRIPTION
### Why is this changes necessary?
This change removes a redundant `JSON.parse(JSON.stringify(payload))` cycle in the analytics `buildPayload` function. This operation was explicitly intended to strip `undefined` fields from the "wide metadata structure," but it is immediately followed by a call to `sanitizePayload(payload)`, which performs its own `JSON.stringify` and `JSON.parse` to redact sensitive tokens. Since `JSON.stringify` naturally omits keys with `undefined` values, the first cycle was redundant, consuming unnecessary CPU cycles and memory allocations at the end of every command execution.

### How to test your changes?
CI

### Check-list

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (\`patch\` for bug fixes · \`minor\` for new features · \`major\` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with \`pnpm changeset add\`


---
*PR created automatically by Jules for task [17299636540015968088](https://jules.google.com/task/17299636540015968088) started by @gonzaloriestra*