### PR TITLE
[Security] Harden header redaction in debug logs

### DIFF
--- a/packages/cli-kit/src/private/node/api/headers.test.ts
+++ b/packages/cli-kit/src/private/node/api/headers.test.ts
@@ -121,6 +121,30 @@ describe('common API methods', () => {
       toLocaleLowerCaseSpy.mockRestore()
     }
   })
+
+  test('sanitizedHeadersOutput redacts additional sensitive headers', () => {
+    // Given
+    const headers = {
+      'X-Api-Key': 'secret-key',
+      'X-Shopify-Signature': 'secret-signature',
+      'X-Shopify-Shared-Secret': 'secret-secret',
+      'X-Auth-Token': 'secret-auth-token',
+      Password: 'secret-password',
+      'X-Auth-Key': 'secret-auth-key',
+    }
+
+    // When
+    const got = sanitizedHeadersOutput(headers)
+
+    // Then
+    expect(got).not.toContain('X-Api-Key')
+    expect(got).not.toContain('X-Shopify-Signature')
+    expect(got).not.toContain('X-Shopify-Shared-Secret')
+    expect(got).not.toContain('Password')
+    expect(got).not.toContain('X-Auth-Token')
+    expect(got).not.toContain('X-Auth-Key')
+    expect(got).not.toContain('secret')
+  })
 })
 
 describe('GraphQLClientError', () => {

--- a/packages/cli-kit/src/private/node/api/headers.ts
+++ b/packages/cli-kit/src/private/node/api/headers.ts
@@ -33,7 +33,8 @@ export class GraphQLClientError extends RequestClientError {
  */
 export function sanitizedHeadersOutput(headers: Record<string, string>): string {
   const sanitized: Record<string, string> = {}
-  const keywords = ['token', 'authorization', 'subject_token', 'cookie']
+  // Security: Redact sensitive headers to prevent leaking credentials in debug logs.
+  const keywords = ['token', 'auth', 'sig', 'secret', 'key', 'password', 'cookie']
   Object.keys(headers).forEach((header) => {
     if (keywords.find((keyword) => header.toLowerCase().includes(keyword)) === undefined) {
       sanitized[header] = headers[header]!


### PR DESCRIPTION
### WHY are these changes introduced?

Redacting sensitive headers in debug logs is a critical security measure to prevent credentials from being leaked. The current list of keywords was missing several common sensitive headers used in Shopify services, such as API keys and signatures.

### WHAT is this pull request doing?

This PR expands the list of keywords used to redact sensitive HTTP headers in debug logs. It now covers variations of API keys, signatures, secrets, and passwords by using broader terms like 'sig', 'secret', 'key', and 'auth'.

### How to test your changes?

CI

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [2432387245366474037](https://jules.google.com/task/2432387245366474037) started by @gonzaloriestra*