### PR TITLE
[Tests] Fix flaky TCP port detection

### DIFF
--- a/packages/cli-kit/src/public/node/tcp.ts
+++ b/packages/cli-kit/src/public/node/tcp.ts
@@ -45,14 +45,24 @@ export async function getAvailableTCPPort(preferredPort?: number, options?: GetT
  * @returns A promise that resolves with a boolean indicating if the port is available.
  */
 export async function checkPortAvailability(portNumber: number): Promise<boolean> {
-  return new Promise((resolve) => {
-    const server = createServer()
-    server.unref()
-    server.once('error', () => resolve(false))
-    server.listen(portNumber, 'localhost', () => {
-      server.close(() => resolve(true))
+  const check = (host: string) =>
+    new Promise<boolean>((resolve) => {
+      const server = createServer()
+      server.unref()
+      server.once('error', (err: any) => {
+        if (host === '::1' && ['EADDRNOTAVAIL', 'EAFNOSUPPORT'].includes(err.code)) {
+          resolve(true)
+        } else {
+          resolve(false)
+        }
+      })
+      server.listen(portNumber, host, () => {
+        server.close(() => resolve(true))
+      })
     })
-  })
+
+  const [v4Available, v6Available] = await Promise.all([check('127.0.0.1'), check('::1')])
+  return v4Available && v6Available
 }
 
 /**
@@ -60,21 +70,30 @@ export async function checkPortAvailability(portNumber: number): Promise<boolean
  *
  * @returns A promise that resolves with an available port number.
  */
-function getRandomPort(): Promise<number> {
-  return new Promise((resolve, reject) => {
-    const server = createServer()
-    server.unref()
-    server.once('error', reject)
-    server.listen(0, 'localhost', () => {
-      const address = server.address()
-      if (address && typeof address === 'object') {
-        const assignedPort = address.port
-        server.close(() => resolve(assignedPort))
-      } else {
-        server.close(() => reject(new Error('Unable to determine assigned port')))
-      }
+async function getRandomPort(): Promise<number> {
+  for (let i = 0; i < 10; i++) {
+    // eslint-disable-next-line no-await-in-loop
+    const port = await new Promise<number>((resolve, reject) => {
+      const server = createServer()
+      server.unref()
+      server.once('error', reject)
+      server.listen(0, '127.0.0.1', () => {
+        const address = server.address()
+        if (address && typeof address === 'object') {
+          const assignedPort = address.port
+          server.close(() => resolve(assignedPort))
+        } else {
+          server.close(() => reject(new Error('Unable to determine assigned port')))
+        }
+      })
     })
-  })
+
+    // eslint-disable-next-line no-await-in-loop
+    if (await checkPortAvailability(port)) {
+      return port
+    }
+  }
+  throw new Error('Failed to find a port available on both IPv4 and IPv6 after 10 tries')
 }
 
 /**


### PR DESCRIPTION
This PR addresses flakiness in TCP-related tests by ensuring that port availability checks consider both IPv4 and IPv6 loopback interfaces. Previously, a port might be reported as available if it was free on one stack but occupied on the other, leading to subsequent bind failures.

Key changes:
- `checkPortAvailability` now checks both `127.0.0.1` and `::1`. It considers a port available if it's free on both, or if IPv6 is unsupported (`EADDRNOTAVAIL` or `EAFNOSUPPORT`).
- `getRandomPort` now awaits `server.close()` to avoid race conditions when re-checking the assigned port's availability.
- `getRandomPort` verifies that the OS-assigned port is available on both stacks and retries up to 10 times if a conflict is detected.

How to test your changes?
1. Run `pnpm --filter @shopify/cli-kit vitest run src/public/node/tcp.test.ts`
2. Run `pnpm --filter @shopify/cli-kit vitest run src/public/node/tcp-retry.test.ts`

---
*PR created automatically by Jules for task [11691781972559635197](https://jules.google.com/task/11691781972559635197) started by @gonzaloriestra*