### PR TITLE
Fix GitHub release creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,14 +160,27 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          if gh release view "$TAG" >/dev/null 2>&1; then
-            echo "Release $TAG already exists, skipping"
+          # gh release create does not support the REST API's make_latest=legacy option.
+          RELEASE_ID="$(gh release view "$TAG" --json databaseId --jq .databaseId 2>/dev/null || true)"
+          if [ -n "$RELEASE_ID" ]; then
+            gh api \
+              --method PATCH \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID" \
+              -f make_latest=legacy >/dev/null
+            echo "Release $TAG already exists; ensured make_latest=legacy"
             exit 0
           fi
-          gh release create "$TAG" \
-            --title "$TAG" \
-            --generate-notes \
-            --latest=legacy
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "repos/$GITHUB_REPOSITORY/releases" \
+            -f tag_name="$TAG" \
+            -f name="$TAG" \
+            -F generate_release_notes=true \
+            -f make_latest=legacy >/dev/null
           echo "Created release $TAG"
 
   # Manual/Cron release job - runs on schedule or manual trigger with tag


### PR DESCRIPTION
## Summary

- replace `gh release create --latest=legacy` with a REST API call because the installed `gh` treats `--latest` as a boolean flag
- preserve GitHub's `make_latest=legacy` release behavior through `gh api`
- make reruns converge by PATCHing an existing release to `make_latest=legacy` instead of skipping it

## Why

The `Release` workflow published `4.1.0`, created the `4.1.0` tag, and created `stable/4.1`, but failed while creating the GitHub release:

```text
invalid argument "legacy" for "--latest" flag: strconv.ParseBool: parsing "legacy": invalid syntax
```

`gh release create` no longer accepts `--latest=legacy`; that value is only available through the Releases REST API as `make_latest=legacy`.

## Testing

- `git diff --check`
- extracted the `Create GitHub release` shell block and ran `bash -n`
- verified `gh release view --json databaseId` works against the existing `4.1.0` release

## Notes

This intentionally does not re-run the live release creation locally. The new step is written to be safe on workflow reruns: if the release already exists, it reconciles `make_latest=legacy` via PATCH and exits successfully.
