### PR TITLE
[Refactor] Use uniq helper in ExtensionInstance

### DIFF
--- a/packages/app/src/cli/models/extensions/extension-instance.ts
+++ b/packages/app/src/cli/models/extensions/extension-instance.ts
@@ -474,7 +474,7 @@ export class ExtensionInstance<TConfiguration extends BaseConfigType = BaseConfi
       watchedFiles.push(...importedFiles)
     }
 
-    return [...new Set(watchedFiles.map((file) => normalizePath(file)))]
+    return uniq(watchedFiles.map((file) => normalizePath(file)))
   }
 
   /**


### PR DESCRIPTION
### Why is this change necessary?
To improve code readability and consistency by using the established `uniq` helper instead of a manual `Set` spread for array deduplication.

### How to test your changes?
CI

---
*PR created automatically by Jules for task [15975511811109691340](https://jules.google.com/task/15975511811109691340) started by @gonzaloriestra*