### PR TITLE
[Performance] Remove redundant JSON cycle in analytics

### DIFF
--- a/packages/cli-kit/src/public/node/analytics.ts
+++ b/packages/cli-kit/src/public/node/analytics.ts
@@ -148,7 +148,7 @@ async function buildPayload({config, errorMessage, exitMode}: ReportAnalyticsEve
   const wallClockElapsed = currentTime - startTime
   const totalTimeWithoutSubtimers = wallClockElapsed - totalTimeFromSubtimers
 
-  let payload = {
+  const payload = {
     public: {
       command: startCommand,
       time_start: startTime,
@@ -191,9 +191,6 @@ async function buildPayload({config, errorMessage, exitMode}: ReportAnalyticsEve
       payload.public[metric] = Math.floor(current)
     }
   })
-
-  // strip undefined fields -- they make up the majority of payloads due to wide metadata structure.
-  payload = JSON.parse(JSON.stringify(payload))
 
   return sanitizePayload(payload)
 }


### PR DESCRIPTION
### WHY are these changes introduced?

The `buildPayload` function in `packages/cli-kit/src/public/node/analytics.ts` was performing an expensive `JSON.parse(JSON.stringify(payload))` cycle to strip `undefined` fields. This is redundant because the subsequent `sanitizePayload` call already performs a full stringification and parsing pass, and `JSON.stringify` naturally omits `undefined` properties.

### WHAT is this pull request doing?

- Removes the redundant `JSON.parse(JSON.stringify(payload))` in `buildPayload`.
- Updates `payload` declaration from `let` to `const` as it is no longer reassigned.

### How to test your changes?

CI

### Post-release steps

None

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`


---
*PR created automatically by Jules for task [6213550805808898868](https://jules.google.com/task/6213550805808898868) started by @gonzaloriestra*