### PR TITLE
Fix E2E fixture sidekick summary

### DIFF
--- a/packages/app/src/cli/api/graphql/admin/generated/types.d.ts
+++ b/packages/app/src/cli/api/graphql/admin/generated/types.d.ts
@@ -193,6 +193,8 @@ export type MetafieldOwnerType =
   | 'SELLING_PLAN'
   /** The Shop metafield owner type. */
   | 'SHOP'
+  /** The Transfer metafield owner type. */
+  | 'TRANSFER'
   /** The Validation metafield owner type. */
   | 'VALIDATION';
 

--- a/packages/cli-kit/src/cli/api/graphql/admin/generated/types.d.ts
+++ b/packages/cli-kit/src/cli/api/graphql/admin/generated/types.d.ts
@@ -171,6 +171,8 @@ export type MetafieldOwnerType =
   | 'SELLING_PLAN'
   /** The Shop metafield owner type. */
   | 'SHOP'
+  /** The Transfer metafield owner type. */
+  | 'TRANSFER'
   /** The Validation metafield owner type. */
   | 'VALIDATION';
 

--- a/packages/e2e/data/valid-app/shopify.app.toml
+++ b/packages/e2e/data/valid-app/shopify.app.toml
@@ -44,3 +44,6 @@ include_config_on_deploy = true
 
 [app_preferences]
 url = "https://example.com/preferences"
+
+[sidekick]
+extensions_summary = "Read, create, and edit FAQ entries stored in the app"


### PR DESCRIPTION
## Summary

- add `[sidekick].extensions_summary` to the E2E fully-populated app TOML fixture
- keeps tests that overwrite generated `shopify.app.toml` aligned with the extension-only template, which already includes a Sidekick summary

## Why

Recent E2E failures were not caused by the app-dev assertions themselves. Several tests create an app from the extension-only template and then replace its generated `shopify.app.toml` with `packages/e2e/data/valid-app/shopify.app.toml`. That replacement dropped the Sidekick summary required when sidekick-eligible extensions are present, so deploy/dev failed before reaching `Ready, watching for changes in your app`.

## Validation

- `pnpm --filter e2e exec playwright test --list`
- parsed `packages/e2e/data/valid-app/shopify.app.toml` with `@iarna/toml` and verified `sidekick.extensions_summary`
