### PR TITLE
Use validated storefront password for theme apps

### DIFF
--- a/.changeset/strict-toys-try.md
+++ b/.changeset/strict-toys-try.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Fix `app dev` always prompting for storefront password

--- a/packages/app/src/cli/services/dev/processes/theme-app-extension.test.ts
+++ b/packages/app/src/cli/services/dev/processes/theme-app-extension.test.ts
@@ -14,6 +14,7 @@ import {Theme} from '@shopify/cli-kit/node/themes/types'
 import {vi, describe, test, expect, beforeEach} from 'vitest'
 import {renderInfo} from '@shopify/cli-kit/node/ui'
 import {partnersFqdn, adminFqdn} from '@shopify/cli-kit/node/context/fqdn'
+import {ensureValidPassword, isStorefrontPasswordProtected} from '@shopify/theme'
 
 vi.mock('../../../utilities/extensions/theme/host-theme-manager')
 vi.mock('@shopify/cli-kit/node/output')
@@ -33,6 +34,14 @@ vi.mock('@shopify/cli-kit/node/ui', async (realImport) => {
       }
       return {}
     }),
+  }
+})
+vi.mock('@shopify/theme', async (realImport) => {
+  const realModule = await realImport<typeof import('@shopify/theme')>()
+  return {
+    ...realModule,
+    ensureValidPassword: vi.fn(),
+    isStorefrontPasswordProtected: vi.fn(),
   }
 })
 
@@ -175,6 +184,25 @@ describe('setupPreviewThemeAppExtensionsProcess', () => {
       ],
       orderedNextSteps: true,
     })
+  })
+
+  test('returns the validated storefront password when one is required', async () => {
+    const mockTheme = {id: 123} as Theme
+    const storefrontPassword = 'typed-password'
+    vi.mocked(fetchTheme).mockResolvedValue(mockTheme)
+    vi.mocked(isStorefrontPasswordProtected).mockResolvedValue(true)
+    vi.mocked(ensureValidPassword).mockResolvedValue(storefrontPassword)
+
+    const result = await setupPreviewThemeAppExtensionsProcess({
+      localApp: testApp({allExtensions: [await testThemeExtensions()]}),
+      remoteApp: testOrganizationApp(),
+      storeFqdn: 'test.myshopify.com',
+      theme: '1',
+    })
+
+    expect(ensureValidPassword).toHaveBeenCalledOnce()
+    expect(ensureValidPassword).toHaveBeenCalledWith(undefined, 'test.myshopify.com')
+    expect(result!.options.storefrontPassword).toEqual(storefrontPassword)
   })
 })
 

--- a/packages/app/src/cli/services/dev/processes/theme-app-extension.ts
+++ b/packages/app/src/cli/services/dev/processes/theme-app-extension.ts
@@ -53,7 +53,7 @@ export async function setupPreviewThemeAppExtensionsProcess(
 
   const storeFqdn = adminSession.storeFqdn
   const storefrontPassword = (await isStorefrontPasswordProtected(adminSession))
-    ? await ensureValidPassword('', storeFqdn)
+    ? await ensureValidPassword(undefined, storeFqdn)
     : undefined
 
   const theme = await findOrCreateHostTheme(adminSession, options.theme)


### PR DESCRIPTION
- [Community post](https://community.shopify.dev/t/shopify-cli-4-1-0-keeps-asking-for-store-password/34735/2)

### WHY are these changes introduced?

`ensureValidPassword` now treats an empty string as a provided password (https://github.com/Shopify/cli/pull/7010), so passing `''` from the `app dev` flow skips the normal prompt/local storage fallback.

Pass `undefined` instead so password-protected stores use the same validation path as `theme dev`, and keep the returned password on the theme app extension process options.

### How to test your changes?

1. Run `shopify app dev` against a shop that has a storefront password
2. Enter the password
3. Ensure that the server runs normally
4. Stop the server and start it again
5. Ensure that you are not prompted for the password again (ie it should not say "Incorrect store password") 