### PR TITLE
[Refactor] Use uniq helper in function build

### DIFF
--- a/packages/app/src/cli/services/function/build.ts
+++ b/packages/app/src/cli/services/function/build.ts
@@ -14,6 +14,7 @@ import {FunctionConfigType} from '../../models/extensions/specifications/functio
 import {AppInterface} from '../../models/app/app.js'
 import {EsbuildEnvVarRegex} from '../../constants.js'
 import {hyphenate, camelize} from '@shopify/cli-kit/common/string'
+import {uniq} from '@shopify/cli-kit/common/array'
 import {outputContent, outputDebug, outputToken} from '@shopify/cli-kit/node/output'
 import {exec} from '@shopify/cli-kit/node/system'
 import {dirname, joinPath} from '@shopify/cli-kit/node/path'
@@ -313,7 +314,7 @@ async function importedWasmModules(modulePath: string): Promise<string[]> {
   const imports = WebAssembly.Module.imports(module)
   // Sets preserve insertion order so the returned array should be
   // deterministic when given the same Wasm module
-  return [...new Set(imports.map((importItem) => importItem.module))]
+  return uniq(imports.map((importItem) => importItem.module))
 }
 
 export async function runJavy(


### PR DESCRIPTION
### WHY are these changes introduced?

This refactor replaces a manual `Set` spread pattern with the project's standard `uniq` utility helper from `@shopify/cli-kit/common/array` to improve consistency and readability.

### WHAT is this pull request doing?

Refactors `importedWasmModules` in `packages/app/src/cli/services/function/build.ts` to use `uniq(imports.map(...))` instead of `[...new Set(imports.map(...))]`.

### How to test your changes?

CI

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [10266616747542519786](https://jules.google.com/task/10266616747542519786) started by @gonzaloriestra*