### PR TITLE
Open auth browser without keypress prompt

### DIFF
--- a/.changeset/green-wolves-wash.md
+++ b/.changeset/green-wolves-wash.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': patch
+---
+
+Open the browser immediately when starting an interactive login flow instead of waiting for a keypress.

--- a/packages/cli-kit/src/private/node/session/device-authorization.test.ts
+++ b/packages/cli-kit/src/private/node/session/device-authorization.test.ts
@@ -11,7 +11,8 @@ import {shopifyFetch} from '../../../public/node/http.js'
 import {isTTY} from '../../../public/node/ui.js'
 import {err, ok} from '../../../public/node/result.js'
 import {AbortError} from '../../../public/node/error.js'
-import {isCI} from '../../../public/node/system.js'
+import {isCI, openURL} from '../../../public/node/system.js'
+import * as output from '../../../public/node/output.js'
 
 import {beforeEach, describe, expect, test, vi} from 'vitest'
 import {Response} from 'node-fetch'
@@ -26,6 +27,7 @@ vi.mock('../../../public/node/system.js')
 beforeEach(() => {
   vi.mocked(isTTY).mockReturnValue(true)
   vi.mocked(isCI).mockReturnValue(false)
+  vi.mocked(openURL).mockResolvedValue(true)
 })
 
 describe('requestDeviceAuthorization', () => {
@@ -64,6 +66,22 @@ describe('requestDeviceAuthorization', () => {
       body: 'client_id=clientId&scope=scope1 scope2',
     })
     expect(got).toEqual(dataExpected)
+  })
+
+  test('opens the browser directly in an interactive terminal', async () => {
+    // Given
+    const outputInfo = vi.spyOn(output, 'outputInfo')
+    const response = new Response(JSON.stringify(data))
+    vi.mocked(shopifyFetch).mockResolvedValue(response)
+    vi.mocked(identityFqdn).mockResolvedValue('fqdn.com')
+    vi.mocked(clientId).mockReturnValue('clientId')
+
+    // When
+    await requestDeviceAuthorization(['scope1', 'scope2'])
+
+    // Then
+    expect(openURL).toHaveBeenCalledWith(data.verification_uri_complete)
+    expect(outputInfo).not.toHaveBeenCalledWith('👉 Press any key to open the login page on your browser')
   })
 
   test('when the response is not valid JSON, throw an error with context', async () => {

--- a/packages/cli-kit/src/private/node/session/device-authorization.ts
+++ b/packages/cli-kit/src/private/node/session/device-authorization.ts
@@ -5,9 +5,7 @@ import {identityFqdn} from '../../../public/node/context/fqdn.js'
 import {shopifyFetch} from '../../../public/node/http.js'
 import {outputContent, outputDebug, outputInfo, outputToken} from '../../../public/node/output.js'
 import {AbortError, BugError} from '../../../public/node/error.js'
-import {isCloudEnvironment} from '../../../public/node/context/local.js'
 import {isCI, openURL} from '../../../public/node/system.js'
-import {isTTY, keypress} from '../../../public/node/ui.js'
 
 import {Response} from 'node-fetch'
 
@@ -81,21 +79,11 @@ export async function requestDeviceAuthorization(scopes: string[]): Promise<Devi
   outputInfo(outputContent`User verification code: ${jsonResult.user_code}`)
   const linkToken = outputToken.link(jsonResult.verification_uri_complete)
 
-  const cloudMessage = () => {
-    outputInfo(outputContent`👉 Open this link to start the auth process: ${linkToken}`)
-  }
-
-  if (isCloudEnvironment() || !isTTY()) {
-    cloudMessage()
+  const opened = await openURL(jsonResult.verification_uri_complete)
+  if (opened) {
+    outputInfo(outputContent`Opened link to start the auth process: ${linkToken}`)
   } else {
-    outputInfo('👉 Press any key to open the login page on your browser')
-    await keypress()
-    const opened = await openURL(jsonResult.verification_uri_complete)
-    if (opened) {
-      outputInfo(outputContent`Opened link to start the auth process: ${linkToken}`)
-    } else {
-      cloudMessage()
-    }
+    outputInfo(outputContent`👉 Open this link to start the auth process: ${linkToken}`)
   }
 
   return {

--- a/packages/e2e/setup/auth.ts
+++ b/packages/e2e/setup/auth.ts
@@ -86,7 +86,7 @@ export const authFixture = browserFixture.extend<{}, {authLogin: void}>({
         if (process.env.DEBUG === '1') process.stdout.write(data)
       })
 
-      await waitForText(() => output, 'Open this link to start the auth process', CLI_TIMEOUT.short)
+      await waitForText(() => output, 'link to start the auth process', CLI_TIMEOUT.short)
 
       const stripped = stripAnsi(output)
       const urlMatch = stripped.match(/https:\/\/accounts\.shopify\.com\S+/)

--- a/packages/e2e/setup/global-auth.ts
+++ b/packages/e2e/setup/global-auth.ts
@@ -92,7 +92,7 @@ export default async function globalSetup() {
   })
 
   try {
-    await waitForText(() => output, 'Open this link to start the auth process', CLI_TIMEOUT.short)
+    await waitForText(() => output, 'link to start the auth process', CLI_TIMEOUT.short)
 
     const stripped = stripAnsi(output)
     const urlMatch = stripped.match(/https:\/\/accounts\.shopify\.com\S+/)


### PR DESCRIPTION
### WHY are these changes introduced?

The login flow currently pauses in interactive terminals and asks users to press a key before Shopify CLI opens the browser. We want authentication to start directly by opening the browser, making it easier for agents.

### WHAT is this pull request doing?

- Removes the `keypress()` wait and "Press any key" message from the interactive device auth flow.
- Keeps the existing manual-link fallback when the browser can't be opened.

### How to test your changes?

`shopify auth login`

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [x] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`
