### PR TITLE
Print URLs in non-interactive app dev

### DIFF
--- a/packages/app/src/cli/services/dev/ui.test.tsx
+++ b/packages/app/src/cli/services/dev/ui.test.tsx
@@ -73,6 +73,42 @@ describe('ui', () => {
       )
     })
 
+    test("shows preview and GraphiQL URLs when terminal doesn't support TTY", async () => {
+      vi.mocked(terminalSupportsPrompting).mockReturnValue(false)
+      const write = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+      const concurrentProcess = {
+        prefix: 'prefix',
+        action: vi.fn(async (_stdout, _stderr, _signal) => {}),
+      }
+
+      const abortController = new AbortController()
+
+      await renderDev({
+        processes: [concurrentProcess],
+        previewUrl: 'https://lala.cloudflare.io/',
+        graphiqlUrl: 'https://lala.cloudflare.io/graphiql',
+        graphiqlPort: 1234,
+        app: {
+          canEnablePreviewMode: true,
+          developmentStorePreviewEnabled: false,
+          apiKey: '123',
+          id: '123',
+          developerPlatformClient,
+          extensions: [],
+        },
+        abortController,
+        developerPreview,
+        shopFqdn: 'mystore.shopify.io',
+        devSessionStatusManager,
+      })
+
+      const output = write.mock.calls.map(([message]) => message).join('')
+      expect(output).toContain('Preview URL: https://lala.cloudflare.io/')
+      expect(output).toContain('GraphiQL URL (Admin API): https://lala.cloudflare.io/graphiql')
+
+      write.mockRestore()
+    })
+
     test("enable dev preview when terminal doesn't support TTY and the app supports it", async () => {
       vi.mocked(terminalSupportsPrompting).mockReturnValue(false)
       const concurrentProcess = {

--- a/packages/app/src/cli/services/dev/ui.tsx
+++ b/packages/app/src/cli/services/dev/ui.tsx
@@ -31,7 +31,15 @@ export async function renderDev({
   localURL?: string
 }) {
   if (!terminalSupportsPrompting()) {
-    await renderDevNonInteractive({processes, app, abortController, developerPreview, shopFqdn})
+    await renderDevNonInteractive({
+      processes,
+      previewUrl,
+      graphiqlUrl,
+      app,
+      abortController,
+      developerPreview,
+      shopFqdn,
+    })
   } else if (app.developerPlatformClient.supportsDevSessions) {
     return render(
       <DevSessionUI
@@ -74,16 +82,23 @@ export async function renderDev({
 
 async function renderDevNonInteractive({
   processes,
+  previewUrl,
+  graphiqlUrl,
   app: {canEnablePreviewMode},
   abortController,
   developerPreview,
-}: Omit<DevProps, 'previewUrl' | 'graphiqlPort'>) {
+}: Omit<DevProps, 'graphiqlPort'>) {
   if (canEnablePreviewMode) {
     await developerPreview.enable()
     abortController?.signal.addEventListener('abort', async () => {
       await developerPreview.disable()
     })
   }
+  process.stdout.write(`\nPreview URL: ${previewUrl}\n`)
+  if (graphiqlUrl) {
+    process.stdout.write(`GraphiQL URL (Admin API): ${graphiqlUrl}\n`)
+  }
+
   return Promise.all(
     processes.map(async (concurrentProcess) => {
       await concurrentProcess.action(process.stdout, process.stderr, abortController.signal)


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/shop/issues-develop/issues/22868

Non-interactive `shopify app dev` is not showing preview and GraphiQL URLs, so agents can't share them.

### WHAT is this pull request doing?

Prints the preview URL and GraphiQL Admin API URL from `renderDevNonInteractive`

### How to test your changes?

`CI=1 shopify app dev` 

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible documentation changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct bump type (`patch`) and added a changeset with `pnpm changeset add`
