### PR TITLE
Fix hot module reloading for theme development

### DIFF
--- a/.changeset/fix-theme-editor-hot-reload-cors.md
+++ b/.changeset/fix-theme-editor-hot-reload-cors.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Fix `theme dev` hot reload not working in the theme editor by allowing the Online Store Editor origin through the dev server's CORS policy

--- a/.changeset/perky-melons-arrive.md
+++ b/.changeset/perky-melons-arrive.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Bump @shopify/theme-hot-reload to address HMR issues

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -49,7 +49,7 @@
     "yaml": "2.8.3"
   },
   "devDependencies": {
-    "@shopify/theme-hot-reload": "^0.0.18",
+    "@shopify/theme-hot-reload": "^0.0.22",
     "@vitest/coverage-istanbul": "^3.1.4",
     "node-stream-zip": "^1.15.0"
   },

--- a/packages/theme/src/cli/utilities/theme-environment/theme-environment.test.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/theme-environment.test.ts
@@ -257,6 +257,27 @@ describe('setupDevServer', () => {
       expect(vi.mocked(render)).not.toHaveBeenCalled()
     })
 
+    test('CORS allows the theme editor (Online Store Editor) origin so hot reload works in the editor', async () => {
+      const {res} = await dispatchEvent('/assets/file2.css', {origin: 'https://online-store-web.shopifyapps.com'})
+      expect(res.getHeader('access-control-allow-origin')).toEqual('https://online-store-web.shopifyapps.com')
+    })
+
+    test('CORS allows the storefront origin', async () => {
+      const origin = `https://${defaultServerContext.session.storeFqdn}`
+      const {res} = await dispatchEvent('/assets/file2.css', {origin})
+      expect(res.getHeader('access-control-allow-origin')).toEqual(origin)
+    })
+
+    test('CORS does not allow unknown origins', async () => {
+      const {res} = await dispatchEvent('/assets/file2.css', {origin: 'https://evil.example.com'})
+      expect(res.getHeader('access-control-allow-origin')).toBeUndefined()
+    })
+
+    test('CORS does not set headers on direct navigation without an Origin header', async () => {
+      const {res} = await dispatchEvent('/assets/file2.css')
+      expect(res.getHeader('access-control-allow-origin')).toBeUndefined()
+    })
+
     test('serves proxied local assets', async () => {
       const eventPromise = dispatchEvent('/cdn/somepathhere/assets/file1.css')
       await expect(eventPromise).resolves.not.toThrow()

--- a/packages/theme/src/cli/utilities/theme-environment/theme-environment.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/theme-environment.ts
@@ -130,7 +130,12 @@ interface DevelopmentServerInstance {
 
 function createDevelopmentServer(theme: Theme, ctx: DevServerContext, initialWork: Promise<void>) {
   const app = createApp()
-  const allowedOrigins = [`http://${ctx.options.host}:${ctx.options.port}`, `https://${ctx.session.storeFqdn}`]
+  const allowedOrigins = [
+    `http://${ctx.options.host}:${ctx.options.port}`,
+    `https://${ctx.session.storeFqdn}`,
+    // Required for HMR with the theme editor
+    'https://online-store-web.shopifyapps.com',
+  ]
 
   app.use(
     defineLazyEventHandler(async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -681,8 +681,8 @@ importers:
         version: 2.8.3
     devDependencies:
       '@shopify/theme-hot-reload':
-        specifier: ^0.0.18
-        version: 0.0.18
+        specifier: ^0.0.22
+        version: 0.0.22
       '@vitest/coverage-istanbul':
         specifier: ^3.1.4
         version: 3.2.4(vitest@3.2.4(@types/node@22.19.17)(jiti@2.6.1)(jsdom@28.1.0)(msw@2.12.10(@types/node@22.19.17)(typescript@5.9.3))(sass@1.97.3)(tsx@4.21.0)(yaml@2.8.3))
@@ -3810,8 +3810,8 @@ packages:
     resolution: {integrity: sha512-ro9PL+5FGMxkLzYfhC6hfv/WlpxK7tUXDlv5uWson/TQIfbs1fo7Nm+VePpJXry0Y+umRDppTRWNmud7YnSuvA==}
     hasBin: true
 
-  '@shopify/theme-hot-reload@0.0.18':
-    resolution: {integrity: sha512-l+IBuk+rG5T+5PKYyPrwgh7PDCxmEMpBFJeen6PM+h6RI4CDhAGRaiwUo5eN1o1JX51HdHHCts3rTEW+KUgq+Q==}
+  '@shopify/theme-hot-reload@0.0.22':
+    resolution: {integrity: sha512-RiaLPqhW3iAJKlO3KRvU4sQJ0cJIwhZ5Zx77wYw+3+oFXHC+vNrB+mjIarxoqCbUdm+E1eUwAs0aGU74YjFWkA==}
 
   '@shopify/theme-language-server-common@2.21.0':
     resolution: {integrity: sha512-/jdb51pAEAsSBKGMxrSV/n/xVWbPsJ00aUQHqL2VXtiFkb5x3Ny4PShlENAee9OIOyJxxmnrOqObKkpzfeg+aA==}
@@ -13105,7 +13105,7 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@shopify/theme-hot-reload@0.0.18': {}
+  '@shopify/theme-hot-reload@0.0.22': {}
 
   '@shopify/theme-language-server-common@2.21.0':
     dependencies:


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes Shopify/developer-tools-team#1033.

Hot reload stopped working in the theme editor (Online Store Editor) a while back. With `shopify theme dev` running, reloading the customizer just logs `[HotReload] Connection closed by the server, attempting to reconnect...` and never reconnects. It's been reported a few times (community forum threads, dev-tools issue #1033), and an earlier attempt to fix it (#6833) stalled.

There are two separate problems:

1. The hot-reload client was a few versions behind and didn't trigger a full reload on `{% schema %}` changes.
2. The bigger one: the dev server's CORS allowlist was locked down to `localhost` and the store domain in 226b49e740 (to close a hole where any website could read from the localhost server). The theme editor renders its preview in an iframe served from `https://online-store-web.shopifyapps.com`, which opens the hot-reload `EventSource` back to the local dev server. That origin isn't on the allowlist, so the browser blocks the connection — which is the reconnect loop above.

The dependency bump on its own doesn't fix this — I confirmed the CORS errors on #6833 back in March. The server has to allow the editor's origin too.

### WHAT is this pull request doing?

- Bumps `@shopify/theme-hot-reload` from `0.0.18` to `0.0.22`. On the client side this triggers a full reload on schema changes, restricts the EventSource to known origins, and uses the original storefront domain when calling the Section Rendering API.
- Adds `https://online-store-web.shopifyapps.com` to the dev server's CORS allowlist so the theme editor's preview iframe can open the hot-reload connection.
- Adds tests for the allowlist: editor origin allowed, storefront origin allowed, unknown origins rejected, and no CORS headers on direct navigation (no `Origin` header).

This intentionally keeps the allowlist approach from 226b49e740 instead of going back to wildcard CORS, so the original vulnerability stays closed. It also only allowlists the production editor origin.

### How to test your changes?

A snapshot has been created for easy testing:

```sh
pnpm i -g --@shopify:registry=https://registry.npmjs.org @shopify/cli@0.0.0-snapshot-20260529205834
```

1. Install the snapshot (or pull this branch down).
2. Run `shopify theme dev` against a store and open the theme editor (use `e` shortcut).
3. Edit code locally
4. Expected: the preview hot reloads and the console logs `[HotReload] Connected`. Before this change you'd get `[HotReload] Connection closed by the server, attempting to reconnect...` instead.