### PR TITLE
Fix theme dev serving theme asset for /cdn/extensions/ requests

### DIFF
--- a/.changeset/river-theme-dev-cdn-extensions-collision.md
+++ b/.changeset/river-theme-dev-cdn-extensions-collision.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Fix `theme dev` serving a same-named theme asset in response to a `/cdn/extensions/...` request. When a theme and an installed app extension shared an asset filename (e.g. `app.js`), the local dev server's theme matcher swallowed the extension URL prefix and returned the theme file. Extension asset requests now fall through to the CDN proxy (or to a locally-developed extension's filesystem) as intended.

--- a/packages/theme/src/cli/utilities/theme-environment/local-assets.test.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/local-assets.test.ts
@@ -1,0 +1,99 @@
+import {findLocalFile} from './local-assets.js'
+import {emptyThemeFileSystem, emptyThemeExtFileSystem} from '../theme-fs-empty.js'
+import {describe, expect, test} from 'vitest'
+import {createEvent} from 'h3'
+import {IncomingMessage, ServerResponse} from 'node:http'
+import {Socket} from 'node:net'
+import type {DevServerContext} from './types.js'
+
+function createH3Event(path: string) {
+  const req = new IncomingMessage(new Socket())
+  const res = new ServerResponse(req)
+  req.method = 'GET'
+  req.url = path
+  req.headers = {}
+  return createEvent(req, res)
+}
+
+function buildCtx({
+  themeFiles = [] as [string, unknown][],
+  extFiles = [] as [string, unknown][],
+}): DevServerContext {
+  const themeFs = emptyThemeFileSystem()
+  for (const [key, value] of themeFiles) themeFs.files.set(key, value as never)
+  const extFs = emptyThemeExtFileSystem()
+  for (const [key, value] of extFiles) extFs.files.set(key, value as never)
+  return {localThemeFileSystem: themeFs, localThemeExtensionFileSystem: extFs} as unknown as DevServerContext
+}
+
+describe('findLocalFile', () => {
+  const themeAsset = {checksum: 't', key: 'assets/app.js', value: '// theme app.js'}
+  const extAsset = {checksum: 'e', key: 'assets/app.js', value: '// extension app.js'}
+
+  test('serves a local theme asset for /cdn/<vanity>/assets/<name>', () => {
+    const ctx = buildCtx({themeFiles: [['assets/app.js', themeAsset]]})
+    const result = findLocalFile(createH3Event('/cdn/shop/t/12/assets/app.js?v=1'), ctx)
+
+    expect(result.fileKey).toBe('assets/app.js')
+    expect(result.file).toBe(themeAsset)
+  })
+
+  test('serves a local theme asset for a bare /assets/<name> request', () => {
+    const ctx = buildCtx({themeFiles: [['assets/app.js', themeAsset]]})
+    const result = findLocalFile(createH3Event('/assets/app.js'), ctx)
+
+    expect(result.fileKey).toBe('assets/app.js')
+    expect(result.file).toBe(themeAsset)
+  })
+
+  test('serves a local extension asset for /ext/cdn/extensions/<uuid>/<app>/assets/<name>', () => {
+    const ctx = buildCtx({extFiles: [['assets/app.js', extAsset]]})
+    const result = findLocalFile(
+      createH3Event('/ext/cdn/extensions/019e1813-804f-7f97-ad2d-278904fdd92f/my-app/assets/app.js'),
+      ctx,
+    )
+
+    expect(result.fileKey).toBe('assets/app.js')
+    expect(result.file).toBe(extAsset)
+  })
+
+  test('does not serve a theme asset in response to /cdn/extensions/<uuid>/<app>/assets/<name> (regression)', () => {
+    // A request for an installed-app extension asset must not be answered with a
+    // same-named theme asset. With no local extension file present the request
+    // must fall through (fileKey === undefined) so getProxyHandler can forward
+    // it to cdn.shopify.com.
+    const ctx = buildCtx({themeFiles: [['assets/app.js', themeAsset]]})
+    const result = findLocalFile(
+      createH3Event('/cdn/extensions/019e1813-804f-7f97-ad2d-278904fdd92f/klaviyo-email-marketing-54/assets/app.js'),
+      ctx,
+    )
+
+    expect(result.fileKey).toBeUndefined()
+    expect(result.file).toBeUndefined()
+  })
+
+  test('prefers the local extension asset for /cdn/extensions/... when one exists locally', () => {
+    // Both filesystems have assets/app.js. The extension matcher must win
+    // (and the theme matcher must not match this path at all), so the
+    // extension content is served instead of the theme content.
+    const ctx = buildCtx({
+      themeFiles: [['assets/app.js', themeAsset]],
+      extFiles: [['assets/app.js', extAsset]],
+    })
+    const result = findLocalFile(
+      createH3Event('/cdn/extensions/019e1813-804f-7f97-ad2d-278904fdd92f/my-app/assets/app.js'),
+      ctx,
+    )
+
+    expect(result.fileKey).toBe('assets/app.js')
+    expect(result.file).toBe(extAsset)
+  })
+
+  test('returns no match when neither filesystem has the file', () => {
+    const ctx = buildCtx({})
+    const result = findLocalFile(createH3Event('/cdn/shop/t/12/assets/missing.js'), ctx)
+
+    expect(result.fileKey).toBeUndefined()
+    expect(result.file).toBeUndefined()
+  })
+})

--- a/packages/theme/src/cli/utilities/theme-environment/local-assets.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/local-assets.ts
@@ -66,7 +66,17 @@ export function getAssetsHandler(_theme: Theme, ctx: DevServerContext) {
   })
 }
 
-function findLocalFile(event: H3Event, ctx: DevServerContext) {
+// Theme assets are served under either a bare `/assets/...` path or the vanity CDN
+// prefix `/cdn/.../assets/...`. The negative lookahead prevents this matcher from
+// claiming `/cdn/extensions/...` paths, which belong to theme app extensions.
+const THEME_ASSET_PATTERN = /^(?:\/cdn\/(?!extensions\/).*?)?\/assets\/([^?]+)/
+
+// Theme app extension assets are served under either `/ext/cdn/extensions/...`
+// (locally-developed extensions, rewritten by `injectCdnProxy` via EXTENSION_CDN_PREFIX)
+// or `/cdn/extensions/...` (storefront-emitted URLs for installed extensions).
+const THEME_EXTENSION_ASSET_PATTERN = /^(?:\/(?:ext\/)?cdn\/extensions\/.*?)?\/assets\/([^?]+)/
+
+export function findLocalFile(event: H3Event, ctx: DevServerContext) {
   const tryGetFile = (pattern: RegExp, fileSystem: VirtualFileSystem) => {
     const matchedFileName = event.path.match(pattern)?.[1]
 
@@ -81,10 +91,13 @@ function findLocalFile(event: H3Event, ctx: DevServerContext) {
     }
   }
 
-  // Try to match theme asset files first and fallback to theme extension asset files
+  // Try to match theme asset files first and fallback to theme extension asset files.
+  // When neither matches (e.g. `/cdn/extensions/<uuid>/<app>/assets/<name>` for an
+  // installed third-party app), the request falls through to `getProxyHandler` which
+  // forwards to cdn.shopify.com.
   return (
-    tryGetFile(/^(?:\/cdn\/.*?)?\/assets\/([^?]+)/, ctx.localThemeFileSystem) ??
-    tryGetFile(/^(?:\/ext\/cdn\/extensions\/.*?)?\/assets\/([^?]+)/, ctx.localThemeExtensionFileSystem) ?? {
+    tryGetFile(THEME_ASSET_PATTERN, ctx.localThemeFileSystem) ??
+    tryGetFile(THEME_EXTENSION_ASSET_PATTERN, ctx.localThemeExtensionFileSystem) ?? {
       isUnsynced: false,
       fileKey: undefined,
       file: undefined,


### PR DESCRIPTION
### Summary

`shopify theme dev` was serving a **theme** asset in response to an app extension's asset request (`/cdn/extensions/<uuid>/<app>/assets/<name>`) whenever the theme had a same-named file. The colliding script then loaded twice (once as the theme asset, once as the extension asset that was silently swapped), causing duplicated execution — e.g. double-bound event handlers. Reported in [this community thread](https://community.shopify.dev/t/cli-is-serving-incorrect-cdn-assets/34726) (Klaviyo Email Marketing's `app.js` vs a theme `app.js`).

The live storefront serves both URLs correctly; this was local-dev only. Reproduces on `main` and on `@shopify/cli` 4.1.0.

### Root cause

In `packages/theme/src/cli/utilities/theme-environment/local-assets.ts`, `findLocalFile` tried the theme matcher first via `??`:

```ts
tryGetFile(/^(?:\/cdn\/.*?)?\/assets\/([^?]+)/, ctx.localThemeFileSystem) ??
tryGetFile(/^(?:\/ext\/cdn\/extensions\/.*?)?\/assets\/([^?]+)/, ctx.localThemeExtensionFileSystem) ??
```

The theme matcher's optional `(?:\/cdn\/.*?)?` prefix is greedy enough to swallow the entire `/cdn/extensions/<uuid>/<app>` segment, capturing only the basename after `/assets/`. `tryGetFile` derives the lookup key from the capture alone (`joinPath('assets', matchedFileName)`), discarding the URL path, so `/cdn/extensions/.../assets/app.js` resolves to `assets/app.js` in `localThemeFileSystem` and is served.

The extension matcher only accepts `/ext/cdn/extensions/` (note `/ext/`), so it never gets a chance for a bare `/cdn/extensions/` request, and the `??` short-circuits before `getProxyHandler` (which already forwards extension CDN traffic to `cdn.shopify.com`) is ever reached.

### Fix

Tighten the theme regex with a negative lookahead so its `/cdn/` prefix cannot be followed by `extensions/`, and broaden the extension regex to also accept `/cdn/extensions/...` in addition to `/ext/cdn/extensions/...`.

```ts
const THEME_ASSET_PATTERN = /^(?:\/cdn\/(?!extensions\/).*?)?\/assets\/([^?]+)/
const THEME_EXTENSION_ASSET_PATTERN = /^(?:\/(?:ext\/)?cdn\/extensions\/.*?)?\/assets\/([^?]+)/
```

When the requested extension asset is *not* in `localThemeExtensionFileSystem`, `findLocalFile` returns `{fileKey: undefined}` and `getAssetsHandler` returns early — the request falls through to `getProxyHandler` which forwards to `cdn.shopify.com` and the real installed-app asset is returned.

### Behaviour after fix

- `/cdn/extensions/<uuid>/<app>/assets/<name>` → proxied to CDN, or served from `localThemeExtensionFileSystem` when present (covers theme-app-extension dev against the vanity CDN form).
- `/cdn/shop/t/<id>/assets/<name>` → still served from `localThemeFileSystem`.
- `/ext/cdn/extensions/...` → still served from `localThemeExtensionFileSystem`.
- Bare `/assets/<name>` → unchanged.

### Test coverage

New `packages/theme/src/cli/utilities/theme-environment/local-assets.test.ts` covers six cases for `findLocalFile`, including the regression (a theme `assets/app.js` must **not** be returned for a `/cdn/extensions/.../assets/app.js` request) and the locally-developed-extension precedence case. Confirmed locally: with the regex change reverted, exactly the 2 collision tests fail; with the fix applied, all 6 new tests pass and the full `packages/theme` test suite (163 tests) still passes, along with `nx type-check theme` and `nx lint theme`.

### Tophatting

In a project that uses `shopify theme dev`:

1. Install an app whose extension bundles an asset, e.g. `assets/app.js`.
2. Add a theme asset with the same filename: `assets/app.js`, with distinct contents (e.g. `console.log('THEME')` vs the app's content).
3. Run `shopify theme dev` and load a page that renders both:
   - theme tag: `<script src="/cdn/shop/t/<id>/assets/app.js?v=...">`
   - extension tag (from `content_for_header`): `<script src="/cdn/extensions/<uuid>/<app>/assets/app.js">`
4. `curl http://localhost:9292/cdn/extensions/<uuid>/<app>/assets/app.js` — before the fix this returns the theme's `app.js`; after the fix it returns the real app's `app.js` (proxied from `cdn.shopify.com`).
5. Confirm `curl http://localhost:9292/cdn/shop/t/<id>/assets/app.js` still returns the local theme's `app.js`.

### Notes

- File/line references are from `main`; 4.1.0 line numbers differ slightly but the logic is identical.
- No existing Shopify/cli issue or PR tracks this. Related but distinct: #4549, #4567, #3488.
- Per `.github/CODEOWNERS`, `packages/theme/**` is owned by `@shopify/developer-platforms` and `@shopify/dev_experience`.

Requested by Wes Shaw <wes.shaw@shopify.com>
