### PR TITLE
[Security] Harden permissions of .env files

### DIFF
--- a/packages/app/src/cli/services/app/env/pull.test.ts
+++ b/packages/app/src/cli/services/app/env/pull.test.ts
@@ -35,6 +35,7 @@ describe('env pull', () => {
       expect(file.writeFile).toHaveBeenCalledWith(
         filePath,
         'SHOPIFY_API_KEY=api-key\nSHOPIFY_API_SECRET=api-secret\nSCOPES=my-scope',
+        {encoding: 'utf8', mode: 0o600},
       )
       expect(unstyled(stringifyMessage(result))).toMatchInlineSnapshot(`
       "Created ${filePath}:
@@ -61,6 +62,7 @@ describe('env pull', () => {
       expect(file.writeFile).toHaveBeenCalledWith(
         filePath,
         'SHOPIFY_API_KEY=api-key\nSHOPIFY_API_SECRET=api-secret\nSCOPES=my-scope',
+        {encoding: 'utf8', mode: 0o600},
       )
       expect(unstyled(stringifyMessage(result))).toMatchInlineSnapshot(`
       "Updated ${filePath} to be:

--- a/packages/app/src/cli/services/app/env/pull.ts
+++ b/packages/app/src/cli/services/app/env/pull.ts
@@ -31,7 +31,7 @@ export async function pullEnv({app, remoteApp, organization, envFile}: PullEnvOp
     if (updatedEnvFileContent === envFileContent) {
       return outputContent`No changes to ${outputToken.path(envFile)}`
     } else {
-      await writeFile(envFile, updatedEnvFileContent)
+      await writeFile(envFile, updatedEnvFileContent, {encoding: 'utf8', mode: 0o600})
 
       const diff = diffLines(envFileContent ?? '', updatedEnvFileContent)
       return outputContent`Updated ${outputToken.path(envFile)} to be:
@@ -46,7 +46,7 @@ ${outputToken.linesDiff(diff)}
   } else {
     const newEnvFileContent = patchEnvFile(null, updatedValues)
 
-    await writeFile(envFile, newEnvFileContent)
+    await writeFile(envFile, newEnvFileContent, {encoding: 'utf8', mode: 0o600})
 
     return outputContent`Created ${outputToken.path(envFile)}:
 

--- a/packages/cli-kit/src/public/node/dot-env.ts
+++ b/packages/cli-kit/src/public/node/dot-env.ts
@@ -43,7 +43,7 @@ export async function writeDotEnv(file: DotEnvFile): Promise<void> {
     .map(([key, value]) => createDotEnvFileLine(key, value))
     .join('\n')
 
-  await writeFile(file.path, fileContent)
+  await writeFile(file.path, fileContent, {encoding: 'utf8', mode: 0o600})
 }
 
 /**

--- a/packages/cli-kit/src/public/node/fs.test.ts
+++ b/packages/cli-kit/src/public/node/fs.test.ts
@@ -26,6 +26,7 @@ import {
 import {joinPath, normalizePath} from './path.js'
 import * as array from '../common/array.js'
 import {describe, expect, test, vi} from 'vitest'
+import {statSync} from 'fs'
 
 describe('inTemporaryDirectory', () => {
   test('ties the lifecycle of the temporary directory to the lifecycle of the callback', async () => {
@@ -93,6 +94,49 @@ describe('copy', () => {
       // When / Then — fs-extra would otherwise throw "Source and destination must not be the same"
       await expect(copyFile(path, joinPath(path, '..', 'file'))).resolves.not.toThrow()
       await expect(readFile(path)).resolves.toEqual(content)
+    })
+  })
+})
+
+describe('writeFile', () => {
+  test('writes the file and sets the permissions', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      const filePath = joinPath(tmpDir, 'test-file')
+      const content = 'test-content'
+
+      // When
+      await writeFile(filePath, content, {encoding: 'utf8', mode: 0o600})
+
+      // Then
+      await expect(readFile(filePath)).resolves.toBe(content)
+      if (process.platform !== 'win32') {
+        const stats = statSync(filePath)
+        expect(stats.mode & 0o777).toBe(0o600)
+      }
+    })
+  })
+
+  test('sets permissions even if the file already exists', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      const filePath = joinPath(tmpDir, 'test-file')
+      const content = 'test-content'
+      await writeFile(filePath, 'old-content')
+      // Make it world-readable first if possible
+      if (process.platform !== 'win32') {
+        await chmod(filePath, 0o644)
+      }
+
+      // When
+      await writeFile(filePath, content, {encoding: 'utf8', mode: 0o600})
+
+      // Then
+      await expect(readFile(filePath)).resolves.toBe(content)
+      if (process.platform !== 'win32') {
+        const stats = statSync(filePath)
+        expect(stats.mode & 0o777).toBe(0o600)
+      }
     })
   })
 })

--- a/packages/cli-kit/src/public/node/fs.ts
+++ b/packages/cli-kit/src/public/node/fs.ts
@@ -211,6 +211,7 @@ export function appendFileSync(path: string, data: string): void {
 
 export interface WriteOptions {
   encoding: BufferEncoding
+  mode?: number | string
 }
 
 /**
@@ -227,6 +228,9 @@ export async function writeFile(
 ): Promise<void> {
   outputDebug(outputContent`Writing some content to file at ${outputToken.path(path)}...`)
   await fsWriteFile(path, data, options)
+  if (options.mode) {
+    await chmod(path, options.mode)
+  }
 }
 
 /**


### PR DESCRIPTION
This PR hardens the security of `.env` files created or updated by the Shopify CLI by ensuring they have restrictive file permissions (`0o600`).

Key changes:
- Updated the core `writeFile` utility in `cli-kit` to support a `mode` parameter.
- Explicitly call `chmod` in `writeFile` after writing the file. This ensures that permissions are correctly set even for files that already existed with broader permissions.
- Updated `.env` file writing logic in `writeDotEnv` and `pullEnv` to use `0o600` (readable/writable only by the owner).
- Added unit tests to verify that `writeFile` correctly applies permissions on POSIX systems.

Security: Prevents other local users on the same system from reading sensitive environment variables like `SHOPIFY_API_SECRET`.

---
*PR created automatically by Jules for task [11733830971334597419](https://jules.google.com/task/11733830971334597419) started by @gonzaloriestra*