### PR TITLE
[Refactor] Use uniq helper in Cloudflare tunnel

### DIFF
--- a/packages/plugin-cloudflare/src/tunnel.ts
+++ b/packages/plugin-cloudflare/src/tunnel.ts
@@ -14,6 +14,7 @@ import {joinPath, dirname} from '@shopify/cli-kit/node/path'
 import {outputDebug} from '@shopify/cli-kit/node/output'
 import {isUnitTest} from '@shopify/cli-kit/node/context/local'
 import {BugError} from '@shopify/cli-kit/node/error'
+import {uniq} from '@shopify/cli-kit/common/array'
 
 import {Writable} from 'stream'
 import {fileURLToPath} from 'url'
@@ -92,7 +93,7 @@ class TunnelClientInstance implements TunnelClient {
     setTimeout(() => {
       if (!resolved) {
         resolved = true
-        const lastErrors = [...new Set(errors)].slice(-5).join('\n')
+        const lastErrors = uniq(errors).slice(-5).join('\n')
         if (lastErrors === '') {
           this.currentStatus = {
             status: 'error',


### PR DESCRIPTION
### WHY are these changes introduced?

Internal refactoring to use consistent utility helpers for array deduplication.

### WHAT is this pull request doing?

Replaces manual `Set` spreads with the `uniq` helper from `@shopify/cli-kit/common/array` in `packages/plugin-cloudflare/src/tunnel.ts`.

### How to test your changes?

CI

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [13075179151143793518](https://jules.google.com/task/13075179151143793518) started by @gonzaloriestra*