### PR TITLE
[Refactor] Use uniq helper in copyConfigKeyEntry

### DIFF
--- a/packages/app/src/cli/services/build/steps/include-assets/copy-config-key-entry.ts
+++ b/packages/app/src/cli/services/build/steps/include-assets/copy-config-key-entry.ts
@@ -1,4 +1,5 @@
 import {assertPathWithinAppDir} from './assert-path-within-app.js'
+import {uniq} from '@shopify/cli-kit/common/array'
 import {joinPath, basename, relativePath, extname} from '@shopify/cli-kit/node/path'
 import {glob, copyFile, copyDirectoryContents, fileExists, mkdir, isDirectory} from '@shopify/cli-kit/node/fs'
 import {outputContent, outputDebug, outputToken} from '@shopify/cli-kit/node/output'
@@ -66,7 +67,7 @@ export async function copyConfigKeyEntry(config: {
 
   // Deduplicate: the same source path shared across multiple targets
   // should only be copied once; the pathMap entry is reused for all references.
-  const uniquePaths = [...new Set(paths)]
+  const uniquePaths = uniq(paths)
 
   // Process sequentially to avoid filesystem race conditions on shared output paths.
   const pathMap = new Map<string, string | string[]>()


### PR DESCRIPTION
### WHY are these changes introduced?

Follows the repository's convention of using the `uniq` helper from `@shopify/cli-kit/common/array` for array deduplication instead of manual `Set` spreads.

### WHAT is this pull request doing?

Replaces `[...new Set(paths)]` with `uniq(paths)` in `packages/app/src/cli/services/build/steps/include-assets/copy-config-key-entry.ts`.

### How to test your changes?

pnpm --filter @shopify/app vitest run src/cli/services/build/steps/include-assets/copy-config-key-entry.test.ts

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [7367686964592034586](https://jules.google.com/task/7367686964592034586) started by @gonzaloriestra*