### PR TITLE
[Security] Upgrade hashing to SHA-256

### DIFF
--- a/packages/app/src/cli/services/generate/extension.test.ts
+++ b/packages/app/src/cli/services/generate/extension.test.ts
@@ -266,7 +266,7 @@ describe('initialize a extension', async () => {
           name,
           handle: slugify(name),
           flavor,
-          uid: 'ba7c20a9-578d-6fee-8cd2-044af992dabd92d8bbfe',
+          uid: '37e88e17-2d38-e2a3-4753-3e3066cf549c',
         })
       })
     },

--- a/packages/cli-kit/src/private/node/session/exchange.test.ts
+++ b/packages/cli-kit/src/private/node/session/exchange.test.ts
@@ -263,7 +263,7 @@ describe.each(tokenExchangeMethods)(
   ({tokenExchangeMethod, expectedScopes, expectedApi, expectedErrorName}) => {
     const automationToken = 'customToken'
     // Generated from `customToken` using `nonRandomUUID()`
-    const userId = 'eab16ac4-0690-5fed-9d00-71bd202a3c2b37259a8f'
+    const userId = '9d5342f1-beb2-14c1-9f5d-deee6b83513c'
 
     const grantType = 'urn:ietf:params:oauth:grant-type:token-exchange'
     const accessTokenType = 'urn:ietf:params:oauth:token-type:access_token'

--- a/packages/cli-kit/src/public/node/crypto.test.ts
+++ b/packages/cli-kit/src/public/node/crypto.test.ts
@@ -6,7 +6,7 @@ describe('hashString', () => {
     const hash1 = hashString('hello')
     const hash2 = hashString('hello')
     expect(hash1).toEqual(hash2)
-    expect(hash1).toMatch(/[a-f0-9]{40}/)
+    expect(hash1).toMatch(/[a-f0-9]{64}/)
   })
 })
 

--- a/packages/cli-kit/src/public/node/crypto.ts
+++ b/packages/cli-kit/src/public/node/crypto.ts
@@ -31,13 +31,13 @@ export function sha256(str: string): Buffer {
 }
 
 /**
- * Generate the SHA1 hash of a string.
+ * Generate the SHA256 hash of a string.
  *
  * @param str - The string to hash.
- * @returns The SHA1 hash of the string.
+ * @returns The SHA256 hash of the string.
  */
 export function hashString(str: string): string {
-  return crypto.createHash('sha1').update(str).digest('hex')
+  return crypto.createHash('sha256').update(str).digest('hex')
 }
 
 /**
@@ -81,10 +81,10 @@ export function nonRandomUUID(subject: string): string {
   // A fixed namespace UUID
   const namespace = '6ba7b810-9dad-11d1-80b4-00c04fd430c8'
   return crypto
-    .createHash('sha1')
+    .createHash('sha256')
     .update(Buffer.from(namespace.replace(/-/g, ''), 'hex'))
     .update(subject)
     .digest()
     .toString('hex')
-    .replace(/(.{8})(.{4})(.{4})(.{4})(.{12})/, '$1-$2-$3-$4-$5')
+    .replace(/(.{8})(.{4})(.{4})(.{4})(.{12}).*/, '$1-$2-$3-$4-$5')
 }

--- a/packages/cli-kit/src/public/node/session.test.ts
+++ b/packages/cli-kit/src/public/node/session.test.ts
@@ -264,11 +264,11 @@ describe('ensureAuthenticatedAppManagementAndBusinessPlatform', () => {
     vi.mocked(getAppAutomationToken).mockReturnValue('custom_cli_token')
     vi.mocked(exchangeAppAutomationTokenForAppManagementAccessToken).mockResolvedValueOnce({
       accessToken: 'app-management-token',
-      userId: '575e2102-cb13-7bea-4631-ce3469eac491cdcba07d',
+      userId: '2f900c8f-1240-6a83-5c00-8e03e7ecb2fb',
     })
     vi.mocked(exchangeAppAutomationTokenForBusinessPlatformAccessToken).mockResolvedValueOnce({
       accessToken: 'business-platform-token',
-      userId: '575e2102-cb13-7bea-4631-ce3469eac491cdcba07d',
+      userId: '2f900c8f-1240-6a83-5c00-8e03e7ecb2fb',
     })
 
     // When
@@ -277,7 +277,7 @@ describe('ensureAuthenticatedAppManagementAndBusinessPlatform', () => {
     // Then
     expect(got).toEqual({
       appManagementToken: 'app-management-token',
-      userId: '575e2102-cb13-7bea-4631-ce3469eac491cdcba07d',
+      userId: '2f900c8f-1240-6a83-5c00-8e03e7ecb2fb',
       businessPlatformToken: 'business-platform-token',
     })
     expect(ensureAuthenticated).not.toHaveBeenCalled()

--- a/packages/cli-kit/src/public/node/session.test.ts
+++ b/packages/cli-kit/src/public/node/session.test.ts
@@ -63,7 +63,7 @@ describe('ensureAuthenticatedStorefront', () => {
     // Then
     expect(got).toEqual('theme_access_password')
     expect(setLastSeenAuthMethod).toBeCalledWith('custom_app_token')
-    expect(setLastSeenUserIdAfterAuth).toBeCalledWith('dd5e7850-e2de-d283-9c5f-79c8190a19d18b52e0ce')
+    expect(setLastSeenUserIdAfterAuth).toBeCalledWith('21534e73-fdc5-9bd3-8c9f-3f45815510a7')
   })
 
   test('returns the password if provided, and auth method is theme_access_token', async () => {
@@ -73,7 +73,7 @@ describe('ensureAuthenticatedStorefront', () => {
     // Then
     expect(got).toEqual('shptka_theme_access_password')
     expect(setLastSeenAuthMethod).toBeCalledWith('theme_access_token')
-    expect(setLastSeenUserIdAfterAuth).toBeCalledWith('730a64df-ab2c-3d92-8b11-76a66aadee947aa5c1ce')
+    expect(setLastSeenUserIdAfterAuth).toBeCalledWith('b7d6d99f-3f60-301f-71b8-3108eacc993e')
   })
 
   test('throws error if there is no storefront token', async () => {
@@ -142,7 +142,7 @@ describe('ensureAuthenticatedPartners', () => {
     // Given
     vi.mocked(exchangeCustomPartnerToken).mockResolvedValueOnce({
       accessToken: partnersToken.accessToken,
-      userId: '575e2102-cb13-7bea-4631-ce3469eac491cdcba07d',
+      userId: '92112423-a55e-049e-b81b-5e6878c7755f',
     })
     vi.mocked(getAppAutomationToken).mockReturnValue('custom_cli_token')
 
@@ -150,7 +150,7 @@ describe('ensureAuthenticatedPartners', () => {
     const got = await ensureAuthenticatedPartners([])
 
     // Then
-    expect(got).toEqual({token: 'custom_partners_token', userId: '575e2102-cb13-7bea-4631-ce3469eac491cdcba07d'})
+    expect(got).toEqual({token: 'custom_partners_token', userId: '92112423-a55e-049e-b81b-5e6878c7755f'})
     expect(ensureAuthenticated).not.toHaveBeenCalled()
   })
 })
@@ -190,7 +190,7 @@ describe('ensureAuthenticatedTheme', () => {
     // Then
     expect(got).toEqual({token: 'password', storeFqdn: 'mystore.myshopify.com'})
     expect(setLastSeenAuthMethod).toBeCalledWith('custom_app_token')
-    expect(setLastSeenUserIdAfterAuth).toBeCalledWith('f5c7086f-320b-3b93-bcdc-a2296adbec02d71eb733')
+    expect(setLastSeenUserIdAfterAuth).toBeCalledWith('18a8698d-f12b-f2db-4737-cecd09bb2c1e')
   })
 
   test('returns the password when is provided and theme_access_token', async () => {
@@ -200,7 +200,7 @@ describe('ensureAuthenticatedTheme', () => {
     // Then
     expect(got).toEqual({token: 'shptka_password', storeFqdn: 'mystore.myshopify.com'})
     expect(setLastSeenAuthMethod).toBeCalledWith('theme_access_token')
-    expect(setLastSeenUserIdAfterAuth).toBeCalledWith('e3d08cca-4e68-504a-00ec-23e2cea12a6340bb257b')
+    expect(setLastSeenUserIdAfterAuth).toBeCalledWith('aea5e074-48e7-cb2a-4b3b-6cebbb5d6f26')
   })
 })
 


### PR DESCRIPTION
### WHY are these changes introduced?

SHA-1 is considered a weak cryptographic hash and should be replaced with a stronger algorithm like SHA-256, especially when handling sensitive data or generating identifiers.

### WHAT is this pull request doing?

- Upgrades `hashString` to use SHA-256.
- Upgrades `nonRandomUUID` to use SHA-256 while maintaining the 36-character UUID format by truncating the hash.
- Updates relevant unit tests in `cli-kit` that were affected by the change in hash algorithm and generated values.

### How to test your changes?

CI

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [811138014799838999](https://jules.google.com/task/811138014799838999) started by @gonzaloriestra*