### PR TITLE
[Performance] Remove redundant JSON serialization in analytics

### DIFF
--- a/packages/cli-kit/src/public/node/analytics.ts
+++ b/packages/cli-kit/src/public/node/analytics.ts
@@ -148,7 +148,7 @@ async function buildPayload({config, errorMessage, exitMode}: ReportAnalyticsEve
   const wallClockElapsed = currentTime - startTime
   const totalTimeWithoutSubtimers = wallClockElapsed - totalTimeFromSubtimers
 
-  let payload = {
+  const payload = {
     public: {
       command: startCommand,
       time_start: startTime,
@@ -191,9 +191,6 @@ async function buildPayload({config, errorMessage, exitMode}: ReportAnalyticsEve
       payload.public[metric] = Math.floor(current)
     }
   })
-
-  // strip undefined fields -- they make up the majority of payloads due to wide metadata structure.
-  payload = JSON.parse(JSON.stringify(payload))
 
   return sanitizePayload(payload)
 }


### PR DESCRIPTION
Removed a redundant `JSON.parse(JSON.stringify(payload))` cycle in `packages/cli-kit/src/public/node/analytics.ts`.

`JSON.stringify` automatically omits properties with `undefined` values, so the explicit cycle used to strip them was unnecessary as `sanitizePayload` performs its own `JSON.stringify`/`JSON.parse` cycle immediately after.

This change reduces CPU overhead and memory allocations during analytics reporting.

How to test your changes?
CI


---
*PR created automatically by Jules for task [3531353586136633232](https://jules.google.com/task/3531353586136633232) started by @gonzaloriestra*