### PR TITLE
[Refactor] Use uniq helper in ui_extension specification

### DIFF
--- a/packages/app/src/cli/models/extensions/specifications/ui_extension.ts
+++ b/packages/app/src/cli/models/extensions/specifications/ui_extension.ts
@@ -15,6 +15,7 @@ import {loadLocalesConfig} from '../../../utilities/extensions/locales-configura
 import {getExtensionPointTargetSurface} from '../../../services/dev/extension/utilities.js'
 import {ExtensionInstance} from '../extension-instance.js'
 import {formatContent} from '../../../utilities/file-formatter.js'
+import {uniq} from '@shopify/cli-kit/common/array'
 import {err, ok, Result} from '@shopify/cli-kit/node/result'
 import {fileExists, readFile} from '@shopify/cli-kit/node/fs'
 import {joinPath} from '@shopify/cli-kit/node/path'
@@ -288,7 +289,7 @@ const uiExtensionSpec = createExtensionSpecification({
       const typeFilePath = joinPath(tsConfigDir, 'shopify.d.ts')
 
       // Remove duplicates from targets
-      const uniqueTargets = [...new Set(targets)]
+      const uniqueTargets = uniq(targets)
       const generatedTypesHelperImportPath = getGeneratedTypesHelperImportPath(uniqueTargets)
 
       try {


### PR DESCRIPTION
### WHY are these changes introduced?

This refactor replaces a manual `Set` spread with the `uniq` utility helper from `@shopify/cli-kit/common/array` to improve readability and consistency across the codebase.

### WHAT is this pull request doing?

Replaced `[...new Set(targets)]` with `uniq(targets)` in `packages/app/src/cli/models/extensions/specifications/ui_extension.ts`.

### How to test your changes?

CI

### Post-release steps

None

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [16755862680652474581](https://jules.google.com/task/16755862680652474581) started by @gonzaloriestra*