### PR TITLE
Error before app config link prompts in non-TTY

### DIFF
--- a/packages/app/src/cli/services/app/config/link-service.test.ts
+++ b/packages/app/src/cli/services/app/config/link-service.test.ts
@@ -9,6 +9,7 @@ import {selectOrganizationPrompt} from '@shopify/organizations'
 import {beforeEach, describe, expect, test, vi} from 'vitest'
 import {inTemporaryDirectory, readFile, writeFileSync} from '@shopify/cli-kit/node/fs'
 import {joinPath} from '@shopify/cli-kit/node/path'
+import {terminalSupportsPrompting} from '@shopify/cli-kit/node/system'
 
 vi.mock('./use.js')
 vi.mock('../../../prompts/dev.js')
@@ -16,10 +17,12 @@ vi.mock('@shopify/organizations')
 vi.mock('../../../prompts/config.js')
 vi.mock('../../local-storage')
 vi.mock('@shopify/cli-kit/node/ui')
+vi.mock('@shopify/cli-kit/node/system')
 vi.mock('../../dev/fetch.js')
 vi.mock('../../../utilities/developer-platform-client.js')
 vi.mock('../../../models/app/validation/multi-cli-warning.js')
 beforeEach(async () => {
+  vi.mocked(terminalSupportsPrompting).mockReturnValue(true)
   // Default mock for selectConfigName - tests that need a specific value can override
   vi.mocked(selectConfigName).mockResolvedValue('shopify.app.toml')
   vi.mocked(fetchOrganizations).mockResolvedValue([

--- a/packages/app/src/cli/services/app/config/link.test.ts
+++ b/packages/app/src/cli/services/app/config/link.test.ts
@@ -20,6 +20,7 @@ import {joinPath} from '@shopify/cli-kit/node/path'
 import {renderSuccess} from '@shopify/cli-kit/node/ui'
 import {outputContent} from '@shopify/cli-kit/node/output'
 import {setPathValue} from '@shopify/cli-kit/common/object'
+import {terminalSupportsPrompting} from '@shopify/cli-kit/node/system'
 
 vi.mock('./use.js')
 vi.mock('../../../prompts/config.js')
@@ -36,6 +37,7 @@ vi.mock('../../../models/app/loader.js', async () => {
 })
 vi.mock('../../local-storage')
 vi.mock('@shopify/cli-kit/node/ui')
+vi.mock('@shopify/cli-kit/node/system')
 vi.mock('../../context/partner-account-info.js')
 vi.mock('../../context.js')
 vi.mock('../select-app.js')
@@ -66,6 +68,7 @@ function buildDeveloperPlatformClient(extraFields: Partial<DeveloperPlatformClie
 
 beforeEach(async () => {
   vi.mocked(fetchAppRemoteConfiguration).mockResolvedValue(DEFAULT_REMOTE_CONFIGURATION)
+  vi.mocked(terminalSupportsPrompting).mockReturnValue(true)
   // Default mock for selectConfigName - tests that need a specific value can override
   vi.mocked(selectConfigName).mockResolvedValue('shopify.app.toml')
 })
@@ -112,6 +115,30 @@ describe('link', () => {
       expect(configFileName).toBe('shopify.app.default-value.toml')
 
       expect(remoteApp).toEqual(mockRemoteApp({developerPlatformClient}))
+    })
+  })
+
+  test('throws in non-TTY when the remote app would require prompting', async () => {
+    await inTemporaryDirectory(async (tmp) => {
+      // Given
+      vi.mocked(terminalSupportsPrompting).mockReturnValue(false)
+      const developerPlatformClient = buildDeveloperPlatformClient()
+      const options: LinkOptions = {
+        directory: tmp,
+        developerPlatformClient,
+      }
+      await mockLoadOpaqueAppWithApp(tmp)
+
+      // When
+      const result = link(options)
+
+      // Then
+      await expect(result).rejects.toMatchObject({
+        formattedMessage: expect.arrayContaining([{command: 'app config link'}]),
+        tryMessage: expect.arrayContaining([{command: expect.stringContaining('--client-id')}]),
+      })
+      expect(fetchOrCreateOrganizationApp).not.toHaveBeenCalled()
+      expect(selectConfigName).not.toHaveBeenCalled()
     })
   })
 
@@ -912,6 +939,33 @@ describe('link', () => {
 
       // Then - should use default filename without prompting
       expect(configFileName).toBe('shopify.app.toml')
+      expect(selectConfigName).not.toHaveBeenCalled()
+    })
+  })
+
+  test('throws in non-TTY when the config file name would require prompting', async () => {
+    await inTemporaryDirectory(async (tmp) => {
+      // Given
+      vi.mocked(terminalSupportsPrompting).mockReturnValue(false)
+      const developerPlatformClient = buildDeveloperPlatformClient()
+      const remoteApp = mockRemoteApp({developerPlatformClient, apiKey: 'new-api-key'})
+      const options: LinkOptions = {
+        directory: tmp,
+        apiKey: remoteApp.apiKey,
+        developerPlatformClient,
+      }
+      writeFileSync(joinPath(tmp, 'shopify.app.toml'), 'client_id = "existing-api-key"')
+      await mockLoadOpaqueAppWithApp(tmp)
+      vi.mocked(appFromIdentifiers).mockResolvedValue(remoteApp)
+
+      // When
+      const result = link(options)
+
+      // Then
+      await expect(result).rejects.toMatchObject({
+        formattedMessage: expect.arrayContaining([{command: 'app config link'}]),
+        tryMessage: expect.arrayContaining([{command: expect.stringContaining('--file-name')}]),
+      })
       expect(selectConfigName).not.toHaveBeenCalled()
     })
   })

--- a/packages/app/src/cli/services/app/config/link.ts
+++ b/packages/app/src/cli/services/app/config/link.ts
@@ -30,6 +30,7 @@ import {fileExists} from '@shopify/cli-kit/node/fs'
 import {joinPath} from '@shopify/cli-kit/node/path'
 import {AbortError} from '@shopify/cli-kit/node/error'
 import {PackageManager} from '@shopify/cli-kit/node/node-package-manager'
+import {terminalSupportsPrompting} from '@shopify/cli-kit/node/system'
 
 export interface LinkOptions {
   directory: string
@@ -94,6 +95,20 @@ export default async function link(options: LinkOptions, shouldRenderSuccess = t
   return {remoteApp, configFileName, configuration: mergedAppConfiguration}
 }
 
+function abortIfLinkPromptCannotRun(missingFlags: string[]) {
+  if (terminalSupportsPrompting() || missingFlags.length === 0) return
+
+  const flags = missingFlags.map((flag) => `--${flag}`).join(' ')
+  throw new AbortError(
+    [{command: 'app config link'}, 'requires additional flags in non-interactive terminal environments.'],
+    [
+      'Run',
+      {command: `shopify app config link ${flags}`},
+      'with the required values, or run the command in an interactive terminal.',
+    ],
+  )
+}
+
 /**
  * Choose or create an app on the platform to link to.
  *
@@ -125,6 +140,7 @@ async function selectOrCreateRemoteAppToLinkTo(options: LinkOptions): Promise<{
     }
   }
 
+  if (!options.organizationId) abortIfLinkPromptCannotRun(['client-id'])
   const remoteApp = await fetchOrCreateOrganizationApp({
     ...creationOptions,
     directory: appDirectory,
@@ -327,6 +343,7 @@ async function loadConfigurationFileName(
   // If no TOML files exist at all, use the default filename without prompting
   if (isEmpty(existingTomls)) return 'shopify.app.toml'
 
+  abortIfLinkPromptCannotRun(['file-name'])
   return selectConfigName(configDirectory, remoteApp.title)
 }
 


### PR DESCRIPTION
### WHY are these changes introduced?

Related to https://github.com/shop/issues-develop/issues/22869

`app config link` can still reach prompt-only paths when a caller has not provided enough information to choose the remote app or local config file name. In non-interactive environments, that should fail with actionable guidance instead of attempting to render prompts.

This is especially important for commands that call linking indirectly: they should surface that the project needs to be linked first with explicit flags, rather than hanging or failing inside prompt rendering.

### WHAT is this pull request doing?

- Adds a shared non-TTY guard before `app config link` prompts for remote app selection.
- Adds the same guard before `app config link` prompts for a new config file name.
- Suggests rerunning `shopify app config link` with the missing required flags, such as `--client-id` or `--file-name`.
- Covers both non-TTY failure paths in the link service tests.

### How to test your changes?

- `CI=1 shopify app config link`
- `CI=1 shopify app config link --client-id new-app`

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible documentation changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing, so I've added a changelog entry with `pnpm changeset add`