### PR TITLE
Add CLI docs search and GraphQL validation

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -54,6 +54,7 @@
   "dependencies": {
     "@ast-grep/napi": "0.33.0",
     "esbuild": "0.28.0",
+    "graphql": "16.10.0",
     "global-agent": "3.0.0"
   },
   "devDependencies": {
@@ -99,6 +100,12 @@
       },
       "theme": {
         "description": "Build Liquid themes."
+      },
+      "docs": {
+        "description": "Search and generate Shopify developer documentation."
+      },
+      "validate": {
+        "description": "Validate Shopify project artifacts."
       },
       "app": {
         "description": "Build Shopify apps."

--- a/packages/cli/src/cli/commands/docs/search.test.ts
+++ b/packages/cli/src/cli/commands/docs/search.test.ts
@@ -1,0 +1,19 @@
+import DocsSearch from './search.js'
+import {searchShopifyDevDocs} from '../../services/docs/search.js'
+import {mockAndCaptureOutput} from '@shopify/cli-kit/node/testing/output'
+import {describe, expect, test, vi} from 'vitest'
+
+vi.mock('../../services/docs/search.js')
+
+describe('DocsSearch', () => {
+  test('outputs search results as JSON', async () => {
+    const outputMock = mockAndCaptureOutput()
+    outputMock.clear()
+    vi.mocked(searchShopifyDevDocs).mockResolvedValue({results: [{title: 'Inventory'}]})
+
+    await DocsSearch.run(['inventory scopes', '--api', 'admin', '--json'], import.meta.url)
+
+    expect(searchShopifyDevDocs).toHaveBeenCalledWith({query: 'inventory scopes', apiName: 'admin'})
+    expect(JSON.parse(outputMock.output())).toEqual({results: [{title: 'Inventory'}]})
+  })
+})

--- a/packages/cli/src/cli/commands/docs/search.ts
+++ b/packages/cli/src/cli/commands/docs/search.ts
@@ -1,0 +1,43 @@
+import {searchShopifyDevDocs} from '../../services/docs/search.js'
+import Command from '@shopify/cli-kit/node/base-command'
+import {globalFlags, jsonFlag} from '@shopify/cli-kit/node/cli'
+import {outputInfo, outputResult} from '@shopify/cli-kit/node/output'
+import {Args, Flags} from '@oclif/core'
+
+export default class DocsSearch extends Command {
+  static summary = 'Search Shopify developer documentation.'
+
+  static descriptionWithMarkdown = `Searches Shopify developer documentation using the same Shopify.dev assistant endpoint used by generated agent skills.`
+
+  static description = this.descriptionWithoutMarkdown()
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %> "inventorySetQuantities required scopes" --api admin --json',
+    '<%= config.bin %> <%= command.id %> "checkout UI extension buyer journey intercept" --json',
+  ]
+
+  static args = {
+    query: Args.string({description: 'Search query.', required: true}),
+  }
+
+  static flags = {
+    ...globalFlags,
+    ...jsonFlag,
+    api: Flags.string({
+      description: 'Optional Shopify API/topic name to scope results, matching ai-toolkit api_name.',
+      env: 'SHOPIFY_FLAG_API',
+    }),
+  }
+
+  async run(): Promise<void> {
+    const {args, flags} = await this.parse(DocsSearch)
+    const result = await searchShopifyDevDocs({query: args.query, apiName: flags.api})
+
+    if (flags.json) {
+      outputResult(JSON.stringify(result, null, 2))
+      return
+    }
+
+    outputInfo(typeof result === 'string' ? result : JSON.stringify(result, null, 2))
+  }
+}

--- a/packages/cli/src/cli/commands/validate/graphql.test.ts
+++ b/packages/cli/src/cli/commands/validate/graphql.test.ts
@@ -1,0 +1,31 @@
+import ValidateGraphQL from './graphql.js'
+import {mockAndCaptureOutput} from '@shopify/cli-kit/node/testing/output'
+import {describe, expect, test} from 'vitest'
+
+describe('ValidateGraphQL', () => {
+  test('outputs JSON validation results', async () => {
+    const outputMock = mockAndCaptureOutput()
+    outputMock.clear()
+
+    await ValidateGraphQL.run(['--query', 'query { shop { name } }', '--json'], import.meta.url)
+
+    const output = JSON.parse(outputMock.output())
+    expect(output).toMatchObject({
+      valid: true,
+      issues: [],
+      operation: {type: 'query'},
+      schema: {source: 'none', validation: 'skipped'},
+    })
+  })
+
+  test('exits silently after outputting invalid JSON results', async () => {
+    const outputMock = mockAndCaptureOutput()
+    outputMock.clear()
+
+    await expect(ValidateGraphQL.run(['--query', 'query {', '--json'], import.meta.url)).rejects.toThrow()
+
+    const output = JSON.parse(outputMock.output())
+    expect(output.valid).toBe(false)
+    expect(output.issues).toEqual([expect.objectContaining({stage: 'syntax'})])
+  })
+})

--- a/packages/cli/src/cli/commands/validate/graphql.ts
+++ b/packages/cli/src/cli/commands/validate/graphql.ts
@@ -1,0 +1,90 @@
+import {validateGraphQL} from '../../services/validation/graphql.js'
+import Command from '@shopify/cli-kit/node/base-command'
+import {globalFlags, jsonFlag} from '@shopify/cli-kit/node/cli'
+import {AbortSilentError} from '@shopify/cli-kit/node/error'
+import {outputInfo, outputResult} from '@shopify/cli-kit/node/output'
+import {resolvePath} from '@shopify/cli-kit/node/path'
+import {Flags} from '@oclif/core'
+
+export default class ValidateGraphQL extends Command {
+  static summary = 'Validate a GraphQL query or mutation.'
+
+  static descriptionWithMarkdown = `Validates a GraphQL document for agent and automation workflows.
+
+By default this command checks GraphQL syntax, confirms there is exactly one operation, and validates variable JSON. Pass \`--schema-file\` to also validate fields, arguments, and variable values against a GraphQL schema. Schema files can be SDL (\`.graphql\`) or introspection JSON.`
+
+  static description = this.descriptionWithoutMarkdown()
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %> --query "query { shop { name } }" --json',
+    '<%= config.bin %> <%= command.id %> --query-file ./operation.graphql --schema-file ./schema.graphql --json',
+    `<%= config.bin %> <%= command.id %> --query 'query Product($id: ID!) { product(id: $id) { title } }' --variables '{"id":"gid://shopify/Product/1"}' --schema-file ./schema.graphql --json`,
+  ]
+
+  static flags = {
+    ...globalFlags,
+    ...jsonFlag,
+    query: Flags.string({
+      char: 'q',
+      description: 'The GraphQL query or mutation to validate.',
+      env: 'SHOPIFY_FLAG_QUERY',
+      exactlyOne: ['query', 'query-file'],
+    }),
+    'query-file': Flags.string({
+      description: "Path to a file containing the GraphQL query or mutation. Can't be used with --query.",
+      env: 'SHOPIFY_FLAG_QUERY_FILE',
+      parse: async (input) => resolvePath(input),
+      exactlyOne: ['query', 'query-file'],
+    }),
+    variables: Flags.string({
+      char: 'v',
+      description: 'The values for any GraphQL variables in your query or mutation, in JSON format.',
+      env: 'SHOPIFY_FLAG_VARIABLES',
+      exclusive: ['variable-file'],
+    }),
+    'variable-file': Flags.string({
+      description: "Path to a file containing GraphQL variables in JSON format. Can't be used with --variables.",
+      env: 'SHOPIFY_FLAG_VARIABLE_FILE',
+      parse: async (input) => resolvePath(input),
+      exclusive: ['variables'],
+    }),
+    'schema-file': Flags.string({
+      description: 'Path to a GraphQL schema file, as SDL or introspection JSON. Enables schema validation.',
+      env: 'SHOPIFY_FLAG_SCHEMA_FILE',
+      parse: async (input) => resolvePath(input),
+    }),
+    surface: Flags.string({
+      description: 'Shopify API surface to validate against. Prototype only; pass --schema-file for schema validation.',
+      env: 'SHOPIFY_FLAG_SURFACE',
+      options: ['admin'],
+    }),
+  }
+
+  async run(): Promise<void> {
+    const {flags} = await this.parse(ValidateGraphQL)
+    const result = await validateGraphQL({
+      query: flags.query,
+      queryFile: flags['query-file'],
+      variables: flags.variables,
+      variablesFile: flags['variable-file'],
+      schemaFile: flags['schema-file'],
+    })
+
+    if (flags.json) {
+      outputResult(JSON.stringify(result, null, 2))
+    } else if (result.valid) {
+      const schemaStatus = result.schema?.validation === 'checked' ? 'schema checked' : 'syntax checked'
+      outputInfo(`GraphQL document is valid (${schemaStatus}).`)
+    } else {
+      outputInfo(formatIssues(result.issues))
+    }
+
+    if (!result.valid) {
+      throw new AbortSilentError()
+    }
+  }
+}
+
+function formatIssues(issues: {message: string; stage: string}[]): string {
+  return ['GraphQL document is invalid:', ...issues.map((issue) => `  • [${issue.stage}] ${issue.message}`)].join('\n')
+}

--- a/packages/cli/src/cli/services/docs/search.test.ts
+++ b/packages/cli/src/cli/services/docs/search.test.ts
@@ -1,0 +1,46 @@
+import {resolveShopifyDevBaseUrl, searchShopifyDevDocs} from './search.js'
+import {fetch as cliFetch} from '@shopify/cli-kit/node/http'
+import {describe, expect, test, vi} from 'vitest'
+
+describe('resolveShopifyDevBaseUrl', () => {
+  test('uses production by default', () => {
+    expect(resolveShopifyDevBaseUrl({})).toEqual({url: 'https://shopify.dev/', headers: {}})
+  })
+
+  test('uses shopify-dev when DEV is set', () => {
+    expect(resolveShopifyDevBaseUrl({DEV: 'true'})).toEqual({url: 'https://shopify-dev.shop.dev/', headers: {}})
+  })
+
+  test('uses staging with Minerva token', () => {
+    expect(resolveShopifyDevBaseUrl({SHOPIFY_DEV_STAGING_SERVER_NUMBER: '2', MINERVA_TOKEN: 'token'})).toEqual({
+      url: 'https://shopify-dev-staging2.shopifycloud.com/',
+      headers: {Cookie: 'MINERVA_TOKEN=token'},
+    })
+  })
+})
+
+describe('searchShopifyDevDocs', () => {
+  test('posts to the assistant search endpoint', async () => {
+    const response = {
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({results: [{title: 'Inventory'}]}),
+    } as Awaited<ReturnType<typeof cliFetch>>
+    const fetch = vi.fn<typeof cliFetch>(async () => response)
+
+    const result = await searchShopifyDevDocs({query: 'inventory scopes', apiName: 'admin', env: {}, fetch})
+
+    expect(result).toEqual({results: [{title: 'Inventory'}]})
+    expect(fetch).toHaveBeenCalledWith(
+      'https://shopify.dev/assistant/search',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          'Content-Type': 'application/json',
+          'X-Shopify-Surface': 'cli',
+        }),
+        body: JSON.stringify({query: 'inventory scopes', api_name: 'admin'}),
+      }),
+    )
+  })
+})

--- a/packages/cli/src/cli/services/docs/search.ts
+++ b/packages/cli/src/cli/services/docs/search.ts
@@ -1,0 +1,86 @@
+import {AbortError} from '@shopify/cli-kit/node/error'
+import {fetch as cliFetch} from '@shopify/cli-kit/node/http'
+
+const PROD_BASE_URL = 'https://shopify.dev/'
+const SHOP_DEV_BASE_URL = 'https://shopify-dev.shop.dev/'
+
+function stagingHost(serverNumber: number): string {
+  return `https://shopify-dev-staging${serverNumber}.shopifycloud.com/`
+}
+
+export function resolveShopifyDevBaseUrl(env: NodeJS.ProcessEnv = process.env): {
+  url: string
+  headers: Record<string, string>
+} {
+  const stagingRaw = env.SHOPIFY_DEV_STAGING_SERVER_NUMBER?.trim()
+
+  if (stagingRaw) {
+    if (!/^\d+$/.test(stagingRaw)) {
+      throw new AbortError(`SHOPIFY_DEV_STAGING_SERVER_NUMBER must be a positive integer; got: "${stagingRaw}"`)
+    }
+
+    const serverNumber = Number(stagingRaw)
+    if (!Number.isSafeInteger(serverNumber) || serverNumber <= 0) {
+      throw new AbortError(`SHOPIFY_DEV_STAGING_SERVER_NUMBER must be a positive integer; got: "${stagingRaw}"`)
+    }
+
+    const token = env.MINERVA_TOKEN
+    if (!token) {
+      const audience = stagingHost(serverNumber).replace(/\/$/, '')
+      throw new AbortError(
+        `SHOPIFY_DEV_STAGING_SERVER_NUMBER=${serverNumber} is set but no Minerva token is available.`,
+        `Get a token via: export MINERVA_TOKEN=$(devx minerva-auth --client-id 0oa1bphetnkOusboI0x8 --audience ${audience})`,
+      )
+    }
+
+    return {
+      url: stagingHost(serverNumber),
+      headers: {Cookie: `MINERVA_TOKEN=${token}`},
+    }
+  }
+
+  if (env.DEV && env.DEV !== 'false') {
+    return {url: SHOP_DEV_BASE_URL, headers: {}}
+  }
+
+  return {url: PROD_BASE_URL, headers: {}}
+}
+
+export interface SearchShopifyDevDocsOptions {
+  query: string
+  apiName?: string
+  env?: NodeJS.ProcessEnv
+  fetch?: typeof cliFetch
+}
+
+export async function searchShopifyDevDocs(options: SearchShopifyDevDocsOptions): Promise<unknown> {
+  const resolved = resolveShopifyDevBaseUrl(options.env)
+  const url = new URL('/assistant/search', resolved.url)
+  const body: Record<string, unknown> = {query: options.query}
+  if (options.apiName) body.api_name = options.apiName
+
+  const fetch = options.fetch ?? cliFetch
+  const response = await fetch(url.toString(), {
+    method: 'POST',
+    headers: {
+      Accept: 'application/json',
+      'Cache-Control': 'no-cache',
+      'Content-Type': 'application/json',
+      'X-Shopify-Surface': 'cli',
+      ...resolved.headers,
+    },
+    body: JSON.stringify(body),
+  })
+
+  const responseText = await response.text()
+  if (!response.ok) {
+    throw new AbortError(`Shopify.dev search failed with HTTP ${response.status}.`, responseText)
+  }
+
+  try {
+    return JSON.parse(responseText) as unknown
+    // eslint-disable-next-line no-catch-all/no-catch-all -- Search endpoint can return text during prototype/staging failures.
+  } catch {
+    return responseText
+  }
+}

--- a/packages/cli/src/cli/services/validation/graphql.test.ts
+++ b/packages/cli/src/cli/services/validation/graphql.test.ts
@@ -1,0 +1,120 @@
+import {validateGraphQL} from './graphql.js'
+import {inTemporaryDirectory, writeFile} from '@shopify/cli-kit/node/fs'
+import {joinPath} from '@shopify/cli-kit/node/path'
+import {describe, expect, test} from 'vitest'
+
+// eslint-disable-next-line @shopify/cli/no-inline-graphql -- Local schema fixture keeps validation tests self-contained.
+const schema = `
+  schema {
+    query: Query
+    mutation: Mutation
+  }
+
+  type Query {
+    shop: Shop!
+    product(id: ID!): Product
+  }
+
+  type Mutation {
+    productCreate(title: String!): Product
+  }
+
+  type Shop {
+    name: String!
+  }
+
+  type Product {
+    title: String!
+  }
+`
+
+describe('validateGraphQL', () => {
+  test('validates syntax without a schema file', async () => {
+    const result = await validateGraphQL({query: 'query { shop { name } }'})
+
+    expect(result).toMatchObject({
+      valid: true,
+      issues: [],
+      operation: {type: 'query'},
+      schema: {source: 'none', validation: 'skipped'},
+    })
+  })
+
+  test('validates fields against a schema file', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      const schemaFile = joinPath(tmpDir, 'schema.graphql')
+      await writeFile(schemaFile, schema)
+
+      const result = await validateGraphQL({query: 'query { shop { name } }', schemaFile})
+
+      expect(result).toMatchObject({
+        valid: true,
+        issues: [],
+        operation: {type: 'query'},
+        schema: {source: 'file', path: schemaFile, validation: 'checked'},
+      })
+    })
+  })
+
+  test('returns schema issues for invalid fields', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      const schemaFile = joinPath(tmpDir, 'schema.graphql')
+      await writeFile(schemaFile, schema)
+
+      const result = await validateGraphQL({query: 'query { shop { missingField } }', schemaFile})
+
+      expect(result.valid).toBe(false)
+      expect(result.issues).toEqual([
+        expect.objectContaining({
+          stage: 'schema',
+          message: expect.stringContaining('Cannot query field "missingField" on type "Shop"'),
+        }),
+      ])
+    })
+  })
+
+  test('returns variable coercion issues when schema is available', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      const schemaFile = joinPath(tmpDir, 'schema.graphql')
+      await writeFile(schemaFile, schema)
+
+      const result = await validateGraphQL({
+        query: 'query Product($id: ID!) { product(id: $id) { title } }',
+        variables: '{}',
+        schemaFile,
+      })
+
+      expect(result.valid).toBe(false)
+      expect(result.issues).toEqual([
+        expect.objectContaining({
+          stage: 'variables',
+          message: expect.stringContaining('Variable "$id" of required type "ID!" was not provided'),
+        }),
+      ])
+    })
+  })
+
+  test('returns syntax issues for invalid GraphQL', async () => {
+    const result = await validateGraphQL({query: 'query {'})
+
+    expect(result.valid).toBe(false)
+    expect(result.issues).toEqual([
+      expect.objectContaining({
+        stage: 'syntax',
+        message: expect.stringContaining('Syntax Error'),
+      }),
+    ])
+  })
+
+  test('returns variable issues for invalid JSON', async () => {
+    const result = await validateGraphQL({query: 'query { shop { name } }', variables: '{'})
+
+    expect(result.valid).toBe(false)
+    expect(result.issues).toEqual([
+      expect.objectContaining({
+        stage: 'variables',
+        message: expect.stringContaining('Invalid variables JSON'),
+      }),
+    ])
+  })
+})

--- a/packages/cli/src/cli/services/validation/graphql.ts
+++ b/packages/cli/src/cli/services/validation/graphql.ts
@@ -1,0 +1,209 @@
+/* eslint-disable @shopify/typescript-prefer-build-client-schema -- PoC accepts local SDL schema files. */
+import {fileExists, readFile} from '@shopify/cli-kit/node/fs'
+import {AbortError} from '@shopify/cli-kit/node/error'
+import {
+  buildClientSchema,
+  buildSchema,
+  getOperationAST,
+  getVariableValues,
+  GraphQLError,
+  GraphQLSchema,
+  IntrospectionQuery,
+  OperationDefinitionNode,
+  parse,
+  specifiedRules,
+  validate,
+} from 'graphql'
+
+export interface GraphQLValidationIssue {
+  message: string
+  stage: 'input' | 'syntax' | 'schema' | 'variables'
+  locations?: {line: number; column: number}[]
+  path?: ReadonlyArray<string | number>
+  code?: string
+}
+
+export interface GraphQLValidationResult {
+  valid: boolean
+  issues: GraphQLValidationIssue[]
+  operation?: {
+    type: 'query' | 'mutation' | 'subscription'
+    name?: string
+  }
+  schema?: {
+    source: 'file' | 'none'
+    path?: string
+    validation: 'checked' | 'skipped'
+  }
+}
+
+export interface ValidateGraphQLOptions {
+  query?: string
+  queryFile?: string
+  variables?: string
+  variablesFile?: string
+  schemaFile?: string
+}
+
+async function readRequiredFile(path: string, label: string): Promise<string> {
+  if (!(await fileExists(path))) {
+    throw new AbortError(`${label} file not found at ${path}. Please check the path and try again.`)
+  }
+
+  return readFile(path, {encoding: 'utf8'})
+}
+
+async function readQuery(options: Pick<ValidateGraphQLOptions, 'query' | 'queryFile'>): Promise<string> {
+  if (options.query !== undefined) {
+    return options.query
+  }
+
+  if (options.queryFile) {
+    return readRequiredFile(options.queryFile, 'GraphQL query')
+  }
+
+  throw new AbortError('Provide a GraphQL document with --query or --query-file.')
+}
+
+async function readVariables(options: Pick<ValidateGraphQLOptions, 'variables' | 'variablesFile'>): Promise<unknown> {
+  if (options.variables !== undefined) {
+    return JSON.parse(options.variables)
+  }
+
+  if (options.variablesFile) {
+    return JSON.parse(await readRequiredFile(options.variablesFile, 'Variables'))
+  }
+
+  return undefined
+}
+
+async function readSchema(schemaFile?: string): Promise<GraphQLSchema | undefined> {
+  if (!schemaFile) return undefined
+
+  const schemaSource = await readRequiredFile(schemaFile, 'GraphQL schema')
+  const trimmedSchema = schemaSource.trim()
+  if (trimmedSchema.startsWith('{')) {
+    const parsedSchema = JSON.parse(trimmedSchema) as {data?: IntrospectionQuery} | IntrospectionQuery
+    const introspection = 'data' in parsedSchema && parsedSchema.data ? parsedSchema.data : parsedSchema
+    return buildClientSchema(introspection as IntrospectionQuery)
+  }
+
+  return buildSchema(schemaSource)
+}
+
+function issueFromGraphQLError(error: GraphQLError, stage: GraphQLValidationIssue['stage']): GraphQLValidationIssue {
+  const code = typeof error.extensions?.code === 'string' ? error.extensions.code : undefined
+  return {
+    message: error.message,
+    stage,
+    locations: error.locations?.map(({line, column}) => ({line, column})),
+    path: error.path,
+    code,
+  }
+}
+
+function isVariablesObject(variables: unknown): variables is {[key: string]: unknown} {
+  return typeof variables === 'object' && variables !== null && !Array.isArray(variables)
+}
+
+function getSingleOperation(document: ReturnType<typeof parse>): OperationDefinitionNode | undefined {
+  const operationDefinitions = document.definitions.filter(
+    (definition): definition is OperationDefinitionNode => definition.kind === 'OperationDefinition',
+  )
+
+  if (operationDefinitions.length !== 1) {
+    return undefined
+  }
+
+  return getOperationAST(document, operationDefinitions[0]?.name?.value) ?? undefined
+}
+
+export async function validateGraphQL(options: ValidateGraphQLOptions): Promise<GraphQLValidationResult> {
+  const issues: GraphQLValidationIssue[] = []
+  const query = await readQuery(options)
+
+  if (!query.trim()) {
+    return {
+      valid: false,
+      issues: [{message: 'GraphQL document is empty.', stage: 'input'}],
+      schema: {source: options.schemaFile ? 'file' : 'none', path: options.schemaFile, validation: 'skipped'},
+    }
+  }
+
+  let variables: unknown
+  try {
+    variables = await readVariables(options)
+    // eslint-disable-next-line no-catch-all/no-catch-all -- Validation returns JSON issues instead of throwing parse errors.
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown JSON parse error'
+    return {
+      valid: false,
+      issues: [{message: `Invalid variables JSON: ${message}`, stage: 'variables'}],
+      schema: {source: options.schemaFile ? 'file' : 'none', path: options.schemaFile, validation: 'skipped'},
+    }
+  }
+
+  let document
+  try {
+    document = parse(query)
+    // eslint-disable-next-line no-catch-all/no-catch-all -- Validation returns JSON issues instead of throwing parse errors.
+  } catch (error) {
+    const issue =
+      error instanceof GraphQLError
+        ? issueFromGraphQLError(error, 'syntax')
+        : {message: String(error), stage: 'syntax' as const}
+    return {
+      valid: false,
+      issues: [issue],
+      schema: {source: options.schemaFile ? 'file' : 'none', path: options.schemaFile, validation: 'skipped'},
+    }
+  }
+
+  const operation = getSingleOperation(document)
+  if (!operation) {
+    issues.push({
+      message: 'GraphQL document must contain exactly one operation definition. Multiple operations are not supported.',
+      stage: 'syntax',
+    })
+  }
+
+  let schema: GraphQLSchema | undefined
+  try {
+    schema = await readSchema(options.schemaFile)
+    // eslint-disable-next-line no-catch-all/no-catch-all -- Validation returns JSON issues instead of throwing schema errors.
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    issues.push({message: `Invalid GraphQL schema: ${message}`, stage: 'schema'})
+  }
+
+  if (schema) {
+    issues.push(...validate(schema, document, specifiedRules).map((error) => issueFromGraphQLError(error, 'schema')))
+
+    if (operation?.variableDefinitions?.length && variables !== undefined) {
+      if (isVariablesObject(variables)) {
+        const variableValues = getVariableValues(schema, operation.variableDefinitions, variables)
+        if (variableValues.errors) {
+          issues.push(...variableValues.errors.map((error) => issueFromGraphQLError(error, 'variables')))
+        }
+      } else {
+        issues.push({message: 'Variables JSON must be an object.', stage: 'variables'})
+      }
+    }
+  }
+
+  return {
+    valid: issues.length === 0,
+    issues,
+    operation: operation
+      ? {
+          type: operation.operation,
+          name: operation.name?.value,
+        }
+      : undefined,
+    schema: {
+      source: schema ? 'file' : 'none',
+      path: options.schemaFile,
+      validation: schema ? 'checked' : 'skipped',
+    },
+  }
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -11,6 +11,7 @@ import KitchenSink from './cli/commands/kitchen-sink/index.js'
 import Doctor from './cli/commands/doctor-release/doctor-release.js'
 import DoctorTheme from './cli/commands/doctor-release/theme/index.js'
 import DocsGenerate from './cli/commands/docs/generate.js'
+import DocsSearch from './cli/commands/docs/search.js'
 import HelpCommand from './cli/commands/help.js'
 import List from './cli/commands/notifications/list.js'
 import Generate from './cli/commands/notifications/generate.js'
@@ -19,6 +20,7 @@ import AutoupgradeOff from './cli/commands/config/autoupgrade/off.js'
 import AutoupgradeOn from './cli/commands/config/autoupgrade/on.js'
 import AutoupgradeStatus from './cli/commands/config/autoupgrade/status.js'
 import AgentSessionStart from './cli/commands/agent/session/start.js'
+import ValidateGraphQL from './cli/commands/validate/graphql.js'
 import {createGlobalProxyAgent} from 'global-agent'
 import StoreCommands from '@shopify/store'
 import ThemeCommands from '@shopify/theme'
@@ -159,6 +161,7 @@ export const COMMANDS: any = {
   'doctor-release': Doctor,
   'doctor-release:theme': DoctorTheme,
   'docs:generate': DocsGenerate,
+  'docs:search': DocsSearch,
   'notifications:list': List,
   'notifications:generate': Generate,
   'cache:clear': ClearCache,
@@ -166,6 +169,7 @@ export const COMMANDS: any = {
   'config:autoupgrade:on': AutoupgradeOn,
   'config:autoupgrade:status': AutoupgradeStatus,
   'agent:session:start': AgentSessionStart,
+  'validate:graphql': ValidateGraphQL,
 }
 
 export default runShopifyCLI

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -251,6 +251,9 @@ importers:
       global-agent:
         specifier: 3.0.0
         version: 3.0.0
+      graphql:
+        specifier: 16.10.0
+        version: 16.10.0
     devDependencies:
       '@oclif/core':
         specifier: 4.5.3


### PR DESCRIPTION
## What changed

This PR adds two CLI-owned primitives for agent workflows, stacked on top of `shopify agent session start` from the base PR.

| Command | Purpose |
|---|---|
| `shopify docs search <query> --api <api-name> --json` | Query Shopify.dev docs through the same `/assistant/search` endpoint used by generated ai-toolkit skills. |
| `shopify validate graphql --query/--query-file ... --schema-file ... --variables/--variable-file ... --json` | Validate GraphQL syntax, operation shape, variables, and schema compatibility before execution. |

It also registers `docs:search` and `validate:graphql`, and adds `graphql` as a direct `@shopify/cli` dependency.

## Why

The base PR proves CLI-owned agent session state. This PR proves the next deterministic agent steps can also move into Shopify CLI:

```text
agent session → docs search → GraphQL validation → store execute
```

That reduces one-off `ai-toolkit-source` script glue while keeping Shopify.dev as the docs source of truth.

## Architecture context

- [Current state](https://arch-diagrams.quick.shopify.io/d/31c73577-fcfd-4a88-a388-00321f8250f6)
- [Proposed architecture](https://arch-diagrams.quick.shopify.io/d/d55c3503-598a-4c29-a3b6-d9d7d8bb9af5)

## Demo

Watch at 2x speed:

https://github.com/user-attachments/assets/f1357c78-3378-4a4e-8d51-ec7304f500b3

The video uses a natural agent prompt (“Can you confirm my demo store identity through Admin GraphQL?”). The skill/prompting is local demo harness; the product behavior under review is the CLI command path and JSON contracts below.

## Command behavior

| Area | Details |
|---|---|
| Docs endpoint | `POST /assistant/search` |
| Docs request body | `{ "query": "...", "api_name": "admin" }` |
| Docs surface header | `X-Shopify-Surface: cli` |
| Shopify.dev routing | default `https://shopify.dev/`; `DEV=true` uses `https://shopify-dev.shop.dev/`; staging uses `SHOPIFY_DEV_STAGING_SERVER_NUMBER` + `MINERVA_TOKEN` |
| Validation inputs | inline query or query file; inline variables or variable file; optional schema file |
| Schema formats | SDL `.graphql` or introspection JSON |
| Invalid result behavior | print structured JSON, then exit non-zero with `AbortSilentError` |

Example invalid validation result:

```json
{
  "valid": false,
  "issues": [
    {
      "message": "Cannot query field ...",
      "stage": "schema",
      "locations": [{"line": 1, "column": 9}]
    }
  ],
  "operation": {"type": "query"},
  "schema": {"source": "file", "validation": "checked"}
}
```

## Manual smoke test

These commands reproduce the demo path against a real store without requiring the agent harness.

### Preflight

```bash
cd /Users/donald/src/github.com/Shopify/cli-worktree-agent-session-poc
git switch donald/agent-session-docs-validate-poc

shadowenv exec -- pnpm --filter @shopify/cli build

if [ ! -s packages/cli-kit/src/cli/api/graphql/admin/admin_schema.graphql ]; then
  shadowenv exec -- pnpm graphql-codegen:get-graphql-schemas
fi
export SHOPIFY_ADMIN_SCHEMA_FILE="$PWD/packages/cli-kit/src/cli/api/graphql/admin/admin_schema.graphql"
test -s "$SHOPIFY_ADMIN_SCHEMA_FILE"

cd packages/cli
shadowenv exec -- pnpm exec oclif manifest
cd ../..

mkdir -p .demo-bin
cat > .demo-bin/shopify <<'SH'
#!/usr/bin/env bash
set -euo pipefail
cd /Users/donald/src/github.com/Shopify/cli-worktree-agent-session-poc
exec shadowenv exec -- node packages/cli/bin/dev.js "$@"
SH
chmod +x .demo-bin/shopify
export PATH="$PWD/.demo-bin:$PATH"

command -v shopify
shopify docs search --help >/dev/null
shopify validate graphql --help >/dev/null
```

Authenticate the target store once if needed:

```bash
export SHOPIFY_STORE=example.myshopify.com
shopify store auth --store "$SHOPIFY_STORE"
```

### Flow

```bash
work_dir="$(mktemp -d)"

shopify agent session start \
  --agent pi \
  --agent-version 1.0.0 \
  --provider shopify \
  --metrics on \
  --default-non-interactive \
  --json

shopify docs search \
  "GraphQL Admin shop query myshopifyDomain" \
  --api admin \
  --json

cat > "$work_dir/shop-query.graphql" <<'GRAPHQL'
query ShopInfo {
  shop {
    id
    name
    myshopifyDomain
  }
}
GRAPHQL

shopify validate graphql \
  --query-file "$work_dir/shop-query.graphql" \
  --schema-file "$SHOPIFY_ADMIN_SCHEMA_FILE" \
  --json

shopify store execute \
  --store "$SHOPIFY_STORE" \
  --query-file "$work_dir/shop-query.graphql" \
  --json
```

Expected validation result:

```json
{
  "valid": true,
  "issues": [],
  "operation": {"type": "query", "name": "ShopInfo"},
  "schema": {
    "source": "file",
    "path": ".../packages/cli-kit/src/cli/api/graphql/admin/admin_schema.graphql",
    "validation": "checked"
  }
}
```

Expected store result shape:

```json
{
  "shop": {
    "id": "gid://shopify/Shop/...",
    "name": "...",
    "myshopifyDomain": "example.myshopify.com"
  }
}
```

The same session in the demo also handled “Let’s check products on that store” by repeating the path with a `products(first: 10)` read-only query. That shows the flow is not hardcoded to the identity query.

## Boundaries

This PR does not yet:

- resolve/cache Admin schemas via `shopify validate graphql --surface admin --version unstable`
- infer required OAuth scopes from GraphQL validation
- replace every ai-toolkit validator
- make `/assistant/search` a public Shopify.dev API contract

The likely next product step is schema resolution in the CLI:

```bash
shopify validate graphql \
  --surface admin \
  --version unstable \
  --query-file ./operation.graphql \
  --json
```
