### PR TITLE
[Refactor] Use uniq helper in type generation

### DIFF
--- a/packages/app/src/cli/models/extensions/specifications/type-generation.ts
+++ b/packages/app/src/cli/models/extensions/specifications/type-generation.ts
@@ -3,6 +3,7 @@ import {dirname, joinPath, relativizePath, resolvePath} from '@shopify/cli-kit/n
 import {AbortError} from '@shopify/cli-kit/node/error'
 import {compile} from 'json-schema-to-typescript'
 import {pascalize} from '@shopify/cli-kit/common/string'
+import {uniq} from '@shopify/cli-kit/common/array'
 import {zod} from '@shopify/cli-kit/node/schema'
 import {createRequire} from 'module'
 import type ts from 'typescript'
@@ -186,7 +187,7 @@ export async function findAllImportedFiles(filePath: string, visited = new Set<s
     allFiles.push(...nestedImports)
   }
 
-  return [...new Set(allFiles)]
+  return uniq(allFiles)
 }
 
 interface CreateTypeDefinitionOptions {


### PR DESCRIPTION
### WHY are these changes introduced?

Follows the project convention of using the `uniq` helper from `@shopify/cli-kit/common/array` for array deduplication instead of manual `Set` spreads.

### WHAT is this pull request doing?

Refactors `packages/app/src/cli/models/extensions/specifications/type-generation.ts` to use `uniq` in `findAllImportedFiles`.

### How to test your changes?

CI

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [9236563226462253352](https://jules.google.com/task/9236563226462253352) started by @gonzaloriestra*