### PR TITLE
[Security] Redact secrets in app env pull output

### DIFF
--- a/packages/app/src/cli/services/app/env/pull.test.ts
+++ b/packages/app/src/cli/services/app/env/pull.test.ts
@@ -40,7 +40,7 @@ describe('env pull', () => {
       "Created ${filePath}:
 
       SHOPIFY_API_KEY=api-key
-      SHOPIFY_API_SECRET=api-secret
+      SHOPIFY_API_SECRET=****
       SCOPES=my-scope
       "
       `)
@@ -66,15 +66,14 @@ describe('env pull', () => {
       "Updated ${filePath} to be:
 
       SHOPIFY_API_KEY=api-key
-      SHOPIFY_API_SECRET=api-secret
+      SHOPIFY_API_SECRET=****
       SCOPES=my-scope
 
       Here's what changed:
 
       - SHOPIFY_API_KEY=ABC
-      - SHOPIFY_API_SECRET=XYZ
       + SHOPIFY_API_KEY=api-key
-      + SHOPIFY_API_SECRET=api-secret
+      SHOPIFY_API_SECRET=****
       SCOPES=my-scope
         "
       `)

--- a/packages/app/src/cli/services/app/env/pull.ts
+++ b/packages/app/src/cli/services/app/env/pull.ts
@@ -24,6 +24,11 @@ export async function pullEnv({app, remoteApp, organization, envFile}: PullEnvOp
     SCOPES: getAppScopes(app.configuration),
   }
 
+  const redactedValues = {
+    ...updatedValues,
+    SHOPIFY_API_SECRET: '****',
+  }
+
   if (await fileExists(envFile)) {
     const envFileContent = await readFile(envFile)
     const updatedEnvFileContent = patchEnvFile(envFileContent, updatedValues)
@@ -33,10 +38,12 @@ export async function pullEnv({app, remoteApp, organization, envFile}: PullEnvOp
     } else {
       await writeFile(envFile, updatedEnvFileContent)
 
-      const diff = diffLines(envFileContent ?? '', updatedEnvFileContent)
+      const redactedOldEnvFileContent = patchEnvFile(envFileContent, {SHOPIFY_API_SECRET: '****'})
+      const redactedEnvFileContent = patchEnvFile(envFileContent, redactedValues)
+      const diff = diffLines(redactedOldEnvFileContent, redactedEnvFileContent)
       return outputContent`Updated ${outputToken.path(envFile)} to be:
 
-${updatedEnvFileContent}
+${redactedEnvFileContent}
 
 Here's what changed:
 
@@ -45,12 +52,13 @@ ${outputToken.linesDiff(diff)}
     }
   } else {
     const newEnvFileContent = patchEnvFile(null, updatedValues)
+    const redactedEnvFileContent = patchEnvFile(null, redactedValues)
 
     await writeFile(envFile, newEnvFileContent)
 
     return outputContent`Created ${outputToken.path(envFile)}:
 
-${newEnvFileContent}
+${redactedEnvFileContent}
 `
   }
 }


### PR DESCRIPTION
Redact sensitive secrets (SHOPIFY_API_SECRET) from the console output and diffs generated by the `shopify app env pull` command. This improvement prevents secrets from being leaked in terminal logs, history, or screen-sharing sessions, while maintaining the full secret in the actual `.env` file on disk.

---
*PR created automatically by Jules for task [5069231579065351227](https://jules.google.com/task/5069231579065351227) started by @gonzaloriestra*