### PR TITLE
[Feature] Extend ExtensionInstance.deployConfig to include app config info

### DIFF
--- a/packages/app/src/cli/models/extensions/extension-instance.test.ts
+++ b/packages/app/src/cli/models/extensions/extension-instance.test.ts
@@ -218,6 +218,30 @@ describe('deployConfig', async () => {
     expect(got).toMatchObject({theme_extension: {files: {}}})
   })
 
+  test('passes app configuration context to deployConfig', async () => {
+    const extensionInstance = await testThemeExtensions()
+    const originalDeployConfig = extensionInstance.specification.deployConfig
+    const deployConfig = vi.fn().mockResolvedValue({theme_extension: {files: {}}})
+    extensionInstance.specification.deployConfig = deployConfig
+
+    try {
+      await extensionInstance.deployConfig({
+        apiKey: 'apiKey',
+        appConfiguration: placeholderAppConfiguration,
+      })
+
+      expect(deployConfig).toHaveBeenCalledWith(
+        extensionInstance.configuration,
+        extensionInstance.directory,
+        'apiKey',
+        undefined,
+        {appConfiguration: placeholderAppConfiguration},
+      )
+    } finally {
+      extensionInstance.specification.deployConfig = originalDeployConfig
+    }
+  })
+
   test('returns transformed config when defined', async () => {
     const extensionInstance = await testAppConfigExtensions()
 

--- a/packages/app/src/cli/models/extensions/extension-instance.ts
+++ b/packages/app/src/cli/models/extensions/extension-instance.ts
@@ -199,7 +199,15 @@ export class ExtensionInstance<TConfiguration extends BaseConfigType = BaseConfi
     apiKey,
     appConfiguration,
   }: ExtensionDeployConfigOptions): Promise<{[key: string]: unknown} | undefined> {
-    const deployConfig = await this.specification.deployConfig?.(this.configuration, this.directory, apiKey, undefined)
+    const deployConfig = await this.specification.deployConfig?.(
+      this.configuration,
+      this.directory,
+      apiKey,
+      undefined,
+      {
+        appConfiguration,
+      },
+    )
     const transformedConfig = this.specification.transformLocalToRemote?.(this.configuration, appConfiguration) as
       | {[key: string]: unknown}
       | undefined

--- a/packages/app/src/cli/models/extensions/specification.ts
+++ b/packages/app/src/cli/models/extensions/specification.ts
@@ -57,6 +57,10 @@ export interface BuildAsset {
   static?: boolean
 }
 
+interface ExtensionDeployConfigContext {
+  appConfiguration: AppConfiguration
+}
+
 /**
  * Extension specification with all the needed properties and methods to load an extension.
  */
@@ -80,6 +84,7 @@ export interface ExtensionSpecification<TConfiguration extends BaseConfigType = 
     directory: string,
     apiKey: string,
     moduleId?: string,
+    context?: ExtensionDeployConfigContext,
   ) => Promise<Record<string, unknown> | undefined>
   validate?: (config: TConfiguration, configPath: string, directory: string) => Promise<Result<unknown, string>>
   preDeployValidation?: (extension: ExtensionInstance<TConfiguration>) => Promise<void>


### PR DESCRIPTION
### WHY are these changes introduced?

Part of https://github.com/Shopify/flow/issues/21604, allows app extensions, such as Flow actions, to access application configuration data such as the application url.

### WHAT is this pull request doing?

This PR extends the `ExtensionInstance.deployConfig` method to allow it to accept an optional `context` object (currently only contains `appConfiguration`) which is obtained from the callsite in `extension-instance.ts`. Extensions can now extend their implementation of `deployConfig` in their `createExtensionSpecification` functions to use the properties of this new `context` object.

### How to test your changes?

This PR is an enabling change and is not currently used by any app extension. I added unit coverage in `extension-instance.test.ts` verifying that `ExtensionInstance.deployConfig` passes `{appConfiguration}` to specification-level `deployConfig`. The Flow action consumer change is in #7715 .

### Post-release steps

None

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`