### PR TITLE
[Refactor] Use uniq helper in theme check

### DIFF
--- a/packages/theme/src/cli/services/check.ts
+++ b/packages/theme/src/cli/services/check.ts
@@ -2,6 +2,7 @@ import {fileExists, readFileSync, writeFile} from '@shopify/cli-kit/node/fs'
 import {outputResult, outputInfo, outputSuccess} from '@shopify/cli-kit/node/output'
 import {joinPath} from '@shopify/cli-kit/node/path'
 import {renderInfo} from '@shopify/cli-kit/node/ui'
+import {uniq} from '@shopify/cli-kit/common/array'
 import {
   Severity,
   applyFixToString,
@@ -292,7 +293,7 @@ export async function outputActiveConfig(themeRoot: string, configPath?: string,
 
     // Depending on how the configs were merged during loadConfig, there may be
     // duplicate patterns to ignore. We can clean them before outputting.
-    ignore: [...new Set(ignore)],
+    ignore: uniq(ignore ?? []),
 
     rootUri,
 
@@ -307,7 +308,7 @@ export async function outputActiveChecks(root: string, configPath?: string, envi
   const {settings, ignore, checks} = await loadConfig(configPath, root)
   // Depending on how the configs were merged during loadConfig, there may be
   // duplicate patterns to ignore. We can clean them before outputting.
-  const ignorePatterns = [...new Set(ignore)]
+  const ignorePatterns = uniq(ignore ?? [])
 
   const checkCodes = Object.keys(settings)
 


### PR DESCRIPTION
### WHY are these changes introduced?

Refactor the codebase to use the centralized `uniq` utility function from `@shopify/cli-kit/common/array` instead of manual `[...new Set()]` spreads, improving consistency and readability.

### WHAT is this pull request doing?

- Imports `uniq` from `@shopify/cli-kit/common/array` in `packages/theme/src/cli/services/check.ts`.
- Replaces two instances of `[...new Set(ignore)]` with `uniq(ignore ?? [])` in `outputActiveConfig` and `outputActiveChecks`.
- Uses the nullish coalescing operator `?? []` to handle cases where `ignore` might be undefined, satisfying TypeScript requirements.

### How to test your changes?

CI

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [12210410227757153211](https://jules.google.com/task/12210410227757153211) started by @gonzaloriestra*