### PR TITLE
[Security] Harden URL sanitization

### DIFF
--- a/packages/cli-kit/src/private/node/api/urls.test.ts
+++ b/packages/cli-kit/src/private/node/api/urls.test.ts
@@ -56,6 +56,11 @@ describe('sanitizeURL', () => {
     'client_secret',
     'code',
     'token',
+    'api_key',
+    'secret',
+    'password',
+    'sig',
+    'signature',
   ])('sanitizes %s query parameter', (param) => {
     // Given
     const url = `https://example.com?${param}=secret-value`
@@ -78,5 +83,49 @@ describe('sanitizeURL', () => {
     expect(sanitizedUrl).toBe(
       'https://example.com/?access_token=****&refresh_token=****&device_code=****&subject_token=****&other=keep',
     )
+  })
+
+  test('sanitizes query parameters case-insensitively', () => {
+    // Given
+    const url = 'https://example.com?TOKEN=abc123&Access_Token=def456'
+
+    // When
+    const sanitizedUrl = sanitizeURL(url)
+
+    // Then
+    expect(sanitizedUrl).toBe('https://example.com/?TOKEN=****&Access_Token=****')
+  })
+
+  test('sanitizes username and password in the URL', () => {
+    // Given
+    const url = 'https://user:pass@example.com/path?token=abc123'
+
+    // When
+    const sanitizedUrl = sanitizeURL(url)
+
+    // Then
+    expect(sanitizedUrl).toBe('https://****:****@example.com/path?token=****')
+  })
+
+  test('sanitizes only password in the URL', () => {
+    // Given
+    const url = 'https://:pass@example.com/path'
+
+    // When
+    const sanitizedUrl = sanitizeURL(url)
+
+    // Then
+    expect(sanitizedUrl).toBe('https://:****@example.com/path')
+  })
+
+  test('sanitizes only username in the URL', () => {
+    // Given
+    const url = 'https://user@example.com/path'
+
+    // When
+    const sanitizedUrl = sanitizeURL(url)
+
+    // Then
+    expect(sanitizedUrl).toBe('https://****@example.com/path')
   })
 })

--- a/packages/cli-kit/src/private/node/api/urls.ts
+++ b/packages/cli-kit/src/private/node/api/urls.ts
@@ -12,6 +12,11 @@ const SENSITIVE_QUERY_PARAMS = [
   'client_secret',
   'code',
   'token',
+  'api_key',
+  'secret',
+  'password',
+  'sig',
+  'signature',
 ]
 
 /**
@@ -21,10 +26,20 @@ const SENSITIVE_QUERY_PARAMS = [
  */
 export function sanitizeURL(url: string): string {
   const parsedUrl = new URL(url)
-  for (const param of SENSITIVE_QUERY_PARAMS) {
-    if (parsedUrl.searchParams.has(param)) {
-      parsedUrl.searchParams.set(param, '****')
+
+  if (parsedUrl.username) {
+    parsedUrl.username = '****'
+  }
+  if (parsedUrl.password) {
+    parsedUrl.password = '****'
+  }
+
+  const keys = Array.from(parsedUrl.searchParams.keys())
+  for (const key of keys) {
+    if (SENSITIVE_QUERY_PARAMS.includes(key.toLowerCase())) {
+      parsedUrl.searchParams.set(key, '****')
     }
   }
+
   return parsedUrl.toString()
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Hardens URL sanitization to prevent leakage of sensitive credentials and tokens in logs or analytics.

### WHAT is this pull request doing?

Implements redaction of URL credentials (username/password) and expands the list of sensitive query parameters to include common secret keys. The sanitization logic is also updated to be case-insensitive for search parameters.

### How to test your changes?

CI

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [11338822784890241915](https://jules.google.com/task/11338822784890241915) started by @gonzaloriestra*