### PR TITLE
Scope cached signed upload URL per app and command

### DIFF
--- a/.changeset/river-fix-parallel-deploy-cache-key.md
+++ b/.changeset/river-fix-parallel-deploy-cache-key.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Fix `app deploy` cross-contaminating bundles between concurrent deploys of different apps in the same organization. The App Management `generateSignedUploadUrl` response was cached for 59 minutes using only the organization ID, so parallel `shopify app deploy --path=...` invocations would receive the same signed upload URL and overwrite each other's bundles. The cache key now also includes the app's API key and the current command, preserving the cache's benefit for `dev` hot-reload while keeping per-app deploys isolated.

--- a/.changeset/river-fix-parallel-deploy-cache-key.md
+++ b/.changeset/river-fix-parallel-deploy-cache-key.md
@@ -2,4 +2,4 @@
 '@shopify/app': patch
 ---
 
-Fix `app deploy` cross-contaminating bundles between concurrent deploys of different apps in the same organization. The App Management `generateSignedUploadUrl` response was cached for 59 minutes using only the organization ID, so parallel `shopify app deploy --path=...` invocations would receive the same signed upload URL and overwrite each other's bundles. The cache key now also includes the app's API key and the current command, preserving the cache's benefit for `dev` hot-reload while keeping per-app deploys isolated.
+Fix `app deploy` reusing signed upload URLs across apps in the same organization.

--- a/packages/app/src/cli/utilities/developer-platform-client/app-management-client.test.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/app-management-client.test.ts
@@ -50,6 +50,7 @@ import {
   businessPlatformRequestDoc,
 } from '@shopify/cli-kit/node/api/business-platform'
 import {appManagementRequestDoc} from '@shopify/cli-kit/node/api/app-management'
+import {setCurrentCommandId} from '@shopify/cli-kit/node/global-context'
 import {BugError} from '@shopify/cli-kit/node/error'
 import {randomUUID} from '@shopify/cli-kit/node/crypto'
 import {webhooksRequestDoc} from '@shopify/cli-kit/node/api/webhooks'
@@ -1212,7 +1213,7 @@ describe('deploy', () => {
 
 describe('AppManagementClient', () => {
   describe('generateSignedUploadUrl', () => {
-    test('passes Brotli format for uploads', async () => {
+    test('passes Brotli format for uploads and scopes the cache key to the app and command', async () => {
       // Given
       const client = AppManagementClient.getInstance()
       const mockResponse = {
@@ -1224,6 +1225,7 @@ describe('AppManagementClient', () => {
 
       // Mock the app management request
       vi.mocked(appManagementRequestDoc).mockResolvedValueOnce(mockResponse)
+      setCurrentCommandId('app:deploy')
 
       const app: MinimalAppIdentifiers = {
         apiKey: 'test-api-key',
@@ -1249,8 +1251,44 @@ describe('AppManagementClient', () => {
         },
         cacheOptions: {
           cacheTTL: {minutes: 59},
+          cacheExtraKey: 'test-api-key-app:deploy',
         },
       })
+    })
+
+    test('produces different cache keys for different apps in the same organization', async () => {
+      // Given
+      const client = AppManagementClient.getInstance()
+      const mockResponse = {
+        appRequestSourceUploadUrl: {
+          sourceUploadUrl: 'https://example.com/upload-url',
+          userErrors: [],
+        },
+      }
+      vi.mocked(appManagementRequestDoc).mockResolvedValue(mockResponse)
+      setCurrentCommandId('app:deploy')
+
+      const appOne: MinimalAppIdentifiers = {
+        apiKey: 'app-one-api-key',
+        organizationId: '213141',
+        id: 'app-one-id',
+      }
+      const appTwo: MinimalAppIdentifiers = {
+        apiKey: 'app-two-api-key',
+        organizationId: '213141',
+        id: 'app-two-id',
+      }
+
+      // When
+      client.token = () => Promise.resolve('token')
+      await client.generateSignedUploadUrl(appOne)
+      await client.generateSignedUploadUrl(appTwo)
+
+      // Then
+      const calls = vi.mocked(appManagementRequestDoc).mock.calls.map(
+        ([options]) => (options as {cacheOptions?: {cacheExtraKey?: string}}).cacheOptions?.cacheExtraKey,
+      )
+      expect(calls).toEqual(['app-one-api-key-app:deploy', 'app-two-api-key-app:deploy'])
     })
   })
 

--- a/packages/app/src/cli/utilities/developer-platform-client/app-management-client.test.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/app-management-client.test.ts
@@ -62,8 +62,9 @@ vi.mock('@shopify/organizations')
 vi.mock('@shopify/cli-kit/node/api/webhooks')
 
 beforeEach(() => {
-  // Reset the singleton instance before each test
   AppManagementClient.resetInstance()
+  setCurrentCommandId('')
+  delete process.env.COMMAND_RUN_ID
 })
 
 const extensionA = await testUIExtension({uid: 'extension-a-uuid'})
@@ -1213,7 +1214,7 @@ describe('deploy', () => {
 
 describe('AppManagementClient', () => {
   describe('generateSignedUploadUrl', () => {
-    test('passes Brotli format for uploads and scopes the cache key to the app and command', async () => {
+    test('passes Brotli format for uploads and scopes the cache key to the app and command run', async () => {
       // Given
       const client = AppManagementClient.getInstance()
       const mockResponse = {
@@ -1225,7 +1226,7 @@ describe('AppManagementClient', () => {
 
       // Mock the app management request
       vi.mocked(appManagementRequestDoc).mockResolvedValueOnce(mockResponse)
-      setCurrentCommandId('app:deploy')
+      process.env.COMMAND_RUN_ID = 'test-run-id'
 
       const app: MinimalAppIdentifiers = {
         apiKey: 'test-api-key',
@@ -1251,7 +1252,7 @@ describe('AppManagementClient', () => {
         },
         cacheOptions: {
           cacheTTL: {minutes: 59},
-          cacheExtraKey: 'test-api-key-app:deploy',
+          cacheExtraKey: 'test-api-key-test-run-id',
         },
       })
     })
@@ -1265,8 +1266,8 @@ describe('AppManagementClient', () => {
           userErrors: [],
         },
       }
-      vi.mocked(appManagementRequestDoc).mockResolvedValue(mockResponse)
-      setCurrentCommandId('app:deploy')
+      vi.mocked(appManagementRequestDoc).mockResolvedValueOnce(mockResponse).mockResolvedValueOnce(mockResponse)
+      process.env.COMMAND_RUN_ID = 'test-run-id'
 
       const appOne: MinimalAppIdentifiers = {
         apiKey: 'app-one-api-key',
@@ -1285,10 +1286,12 @@ describe('AppManagementClient', () => {
       await client.generateSignedUploadUrl(appTwo)
 
       // Then
-      const calls = vi.mocked(appManagementRequestDoc).mock.calls.map(
-        ([options]) => (options as {cacheOptions?: {cacheExtraKey?: string}}).cacheOptions?.cacheExtraKey,
-      )
-      expect(calls).toEqual(['app-one-api-key-app:deploy', 'app-two-api-key-app:deploy'])
+      const calls = vi
+        .mocked(appManagementRequestDoc)
+        .mock.calls.map(
+          ([options]) => (options as {cacheOptions?: {cacheExtraKey?: string}}).cacheOptions?.cacheExtraKey,
+        )
+      expect(calls).toEqual(['app-one-api-key-test-run-id', 'app-two-api-key-test-run-id'])
     })
   })
 

--- a/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
@@ -161,6 +161,7 @@ import {
 import {CLI_KIT_VERSION} from '@shopify/cli-kit/common/version'
 import {versionSatisfies} from '@shopify/cli-kit/node/node-package-manager'
 import {outputDebug} from '@shopify/cli-kit/node/output'
+import {getCurrentCommandId} from '@shopify/cli-kit/node/global-context'
 import {developerDashboardFqdn, normalizeStoreFqdn} from '@shopify/cli-kit/node/context/fqdn'
 import {TokenItem} from '@shopify/cli-kit/node/ui'
 import {functionsRequestDoc, FunctionsRequestOptions} from '@shopify/cli-kit/node/api/functions'
@@ -718,7 +719,7 @@ export class AppManagementClient implements DeveloperPlatformClient {
     }
   }
 
-  async generateSignedUploadUrl({organizationId}: MinimalAppIdentifiers): Promise<AssetUrlSchema> {
+  async generateSignedUploadUrl({apiKey, organizationId}: MinimalAppIdentifiers): Promise<AssetUrlSchema> {
     const variables = {
       sourceExtension: 'BR' as SourceExtension,
       organizationId: gidFromOrganizationIdForShopify(organizationId),
@@ -726,7 +727,17 @@ export class AppManagementClient implements DeveloperPlatformClient {
     const result = await this.appManagementRequest({
       query: CreateAssetUrl,
       variables,
-      cacheOptions: {cacheTTL: {minutes: 59}},
+      cacheOptions: {
+        cacheTTL: {minutes: 59},
+        // Scope the cached signed upload URL to this specific app and command
+        // run. Without this, concurrent deploys of different apps in the same
+        // organization can share a single cached signed upload URL — each
+        // process uploads its own bundle to the same destination and whichever
+        // upload App Management reads last gets used for every concurrent
+        // appVersionCreate, cross-contaminating app bundles.
+        // See https://github.com/Shopify/cli/issues/7696.
+        cacheExtraKey: `${apiKey}-${getCurrentCommandId()}`,
+      },
     })
     return {
       assetUrl: result.appRequestSourceUploadUrl.sourceUploadUrl,

--- a/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
@@ -729,8 +729,8 @@ export class AppManagementClient implements DeveloperPlatformClient {
       variables,
       cacheOptions: {
         cacheTTL: {minutes: 59},
-        // Avoid reusing signed upload URLs across apps or commands.
-        cacheExtraKey: `${apiKey}-${getCurrentCommandId()}`,
+        // Avoid reusing signed upload URLs across apps or command runs.
+        cacheExtraKey: `${apiKey}-${process.env.COMMAND_RUN_ID ?? getCurrentCommandId()}`,
       },
     })
     return {

--- a/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
@@ -729,13 +729,7 @@ export class AppManagementClient implements DeveloperPlatformClient {
       variables,
       cacheOptions: {
         cacheTTL: {minutes: 59},
-        // Scope the cached signed upload URL to this specific app and command
-        // run. Without this, concurrent deploys of different apps in the same
-        // organization can share a single cached signed upload URL — each
-        // process uploads its own bundle to the same destination and whichever
-        // upload App Management reads last gets used for every concurrent
-        // appVersionCreate, cross-contaminating app bundles.
-        // See https://github.com/Shopify/cli/issues/7696.
+        // Avoid reusing signed upload URLs across apps or commands.
         cacheExtraKey: `${apiKey}-${getCurrentCommandId()}`,
       },
     })


### PR DESCRIPTION
The App Management client caches generateSignedUploadUrl responses for 59 minutes using only the organization ID as the cache key. When two `shopify app deploy --path=...` processes run concurrently for different apps in the same organization, both retrieve the same cached signed upload URL and upload their bundles to the same destination. App Management then reads whichever upload arrived last when each appVersionCreate is called, so apps end up with the wrong bundles.

Add the app's apiKey and the current command id to cacheExtraKey so the cache remains useful for repeated dev hot-reload uploads of the same app, while concurrent deploys of different apps in the same org no longer share a signed upload destination.

Fixes #7696.

<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it's a work in progress
-->

### WHY are these changes introduced?

Fixes #0000 <!-- link to issue if one exists -->

<!--
  Context about the problem that's being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
  You can post a comment with `/snapit` to generate a snapshot of the changes to be tested.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`
