### PR TITLE
Handle TOML parse failures as user errors

### DIFF
--- a/packages/cli-kit/src/public/node/environments.test.ts
+++ b/packages/cli-kit/src/public/node/environments.test.ts
@@ -1,5 +1,7 @@
 import * as environments from './environments.js'
 import {encodeToml as tomlEncode} from './toml/codec.js'
+import {TomlFileError} from './toml/toml-file.js'
+import {shouldReportErrorAsUnexpected} from './error.js'
 import {inTemporaryDirectory, writeFile} from './fs.js'
 import {joinPath} from './path.js'
 import {mockAndCaptureOutput} from './testing/output.js'
@@ -80,6 +82,21 @@ describe('loading environments', async () => {
 
       // Then
       expect(loaded).toEqual(environment1)
+    })
+  })
+
+  test('malformed environment files fail as expected user errors', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      const filePath = joinPath(tmpDir, fileName)
+      await writeFile(filePath, 'environments = [invalid')
+
+      // When
+      const error = await environments.loadEnvironment('environment1', fileName, {from: tmpDir}).catch((err) => err)
+
+      // Then
+      expect(error).toBeInstanceOf(TomlFileError)
+      expect(shouldReportErrorAsUnexpected(error)).toBe(false)
     })
   })
 

--- a/packages/cli-kit/src/public/node/toml/toml-file.test.ts
+++ b/packages/cli-kit/src/public/node/toml/toml-file.test.ts
@@ -1,4 +1,5 @@
 import {TomlFile, TomlFileError} from './toml-file.js'
+import {shouldReportErrorAsUnexpected} from '../error.js'
 import {writeFile, readFile, inTemporaryDirectory} from '../fs.js'
 import {joinPath} from '../path.js'
 import {describe, expect, test} from 'vitest'
@@ -35,6 +36,18 @@ describe('TomlFile', () => {
 
         await expect(TomlFile.read(path)).rejects.toThrow(TomlFileError)
         await expect(TomlFile.read(path)).rejects.toThrow(/row.*col/)
+      })
+    })
+
+    test('classifies invalid TOML as an expected user error', async () => {
+      await inTemporaryDirectory(async (dir) => {
+        const path = joinPath(dir, 'bad.toml')
+        await writeFile(path, 'name = [invalid')
+
+        const error = await TomlFile.read(path).catch((err: unknown) => err)
+
+        expect(error).toBeInstanceOf(TomlFileError)
+        expect(shouldReportErrorAsUnexpected(error)).toBe(false)
       })
     })
 

--- a/packages/cli-kit/src/public/node/toml/toml-file.ts
+++ b/packages/cli-kit/src/public/node/toml/toml-file.ts
@@ -1,4 +1,5 @@
 import {JsonMapType, decodeToml, encodeToml} from './codec.js'
+import {AbortError} from '../error.js'
 import {fileExists, readFile, writeFile} from '../fs.js'
 import {updateTomlValues} from '@shopify/toml-patch'
 
@@ -6,9 +7,9 @@ type TomlPatchValue = string | number | boolean | undefined | (string | number |
 
 /**
  * An error on a TOML file — missing or malformed.
- * Extends Error so it can be thrown. Carries path and a clean message suitable for JSON output.
+ * Carries path and a clean message suitable for JSON output.
  */
-export class TomlFileError extends Error {
+export class TomlFileError extends AbortError {
   readonly path: string
 
   constructor(path: string, message: string) {


### PR DESCRIPTION
### Why
Malformed TOML config files were reported as unexpected CLI crashes.

Fixes https://github.com/shop/issues/issues/47669

### What
Classify `TomlFileError` as an expected user error and add regression coverage for TOML/environment parsing.