### PR TITLE
Fix app env pull absolute env-file paths

### DIFF
--- a/.changeset/fix-app-env-pull-absolute-path.md
+++ b/.changeset/fix-app-env-pull-absolute-path.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Fix `app env pull --env-file` with absolute paths.

--- a/packages/app/src/cli/commands/app/env/pull.test.ts
+++ b/packages/app/src/cli/commands/app/env/pull.test.ts
@@ -1,0 +1,61 @@
+import EnvPull from './pull.js'
+import {linkedAppContext} from '../../../services/app-context.js'
+import {pullEnv} from '../../../services/app/env/pull.js'
+import {testAppLinked, testOrganization, testOrganizationApp} from '../../../models/app/app.test-data.js'
+import {outputResult} from '@shopify/cli-kit/node/output'
+import {joinPath, resolvePath} from '@shopify/cli-kit/node/path'
+import {describe, expect, test, vi} from 'vitest'
+
+vi.mock('../../../services/app-context.js')
+vi.mock('../../../services/app/env/pull.js')
+vi.mock('@shopify/cli-kit/node/output', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@shopify/cli-kit/node/output')>()
+  return {...actual, outputResult: vi.fn()}
+})
+
+describe('app env pull command', () => {
+  test('uses absolute --env-file paths as-is', async () => {
+    const app = testAppLinked({
+      directory: joinPath('F:', 'Project', 'cherhomeliving.shopify', 'shopify-app'),
+      configPath: joinPath('F:', 'Project', 'cherhomeliving.shopify', 'shopify-app', 'shopify.app.toml'),
+    })
+    const remoteApp = testOrganizationApp()
+    const organization = testOrganization()
+    const envFile = joinPath(app.directory, '.env')
+
+    vi.mocked(linkedAppContext).mockResolvedValue({app, remoteApp, organization} as Awaited<
+      ReturnType<typeof linkedAppContext>
+    >)
+    vi.mocked(pullEnv).mockResolvedValue('Created env file')
+
+    await EnvPull.run(['--path', app.directory, '--env-file', envFile], import.meta.url)
+
+    expect(pullEnv).toHaveBeenCalledWith({
+      app,
+      remoteApp,
+      organization,
+      envFile,
+    })
+    expect(outputResult).toHaveBeenCalledWith('Created env file')
+  })
+
+  test('resolves relative --env-file paths from the app directory', async () => {
+    const app = testAppLinked({directory: '/tmp/my-app', configPath: '/tmp/my-app/shopify.app.toml'})
+    const remoteApp = testOrganizationApp()
+    const organization = testOrganization()
+
+    vi.mocked(linkedAppContext).mockResolvedValue({app, remoteApp, organization} as Awaited<
+      ReturnType<typeof linkedAppContext>
+    >)
+    vi.mocked(pullEnv).mockResolvedValue('Created env file')
+
+    await EnvPull.run(['--path', app.directory, '--env-file', 'config/.env'], import.meta.url)
+
+    expect(pullEnv).toHaveBeenCalledWith({
+      app,
+      remoteApp,
+      organization,
+      envFile: resolvePath(app.directory, 'config/.env'),
+    })
+  })
+})

--- a/packages/app/src/cli/commands/app/env/pull.ts
+++ b/packages/app/src/cli/commands/app/env/pull.ts
@@ -6,7 +6,7 @@ import {linkedAppContext} from '../../../services/app-context.js'
 import {Flags} from '@oclif/core'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
 import {outputResult} from '@shopify/cli-kit/node/output'
-import {joinPath} from '@shopify/cli-kit/node/path'
+import {resolvePath} from '@shopify/cli-kit/node/path'
 
 export default class EnvPull extends AppLinkedCommand {
   static summary = 'Pull app and extensions environment variables.'
@@ -36,7 +36,7 @@ export default class EnvPull extends AppLinkedCommand {
       forceRelink: flags.reset,
       userProvidedConfigName: flags.config,
     })
-    const envFile = joinPath(app.directory, flags['env-file'] ?? getDotEnvFileName(app.configPath))
+    const envFile = resolvePath(app.directory, flags['env-file'] ?? getDotEnvFileName(app.configPath))
     outputResult(await pullEnv({app, remoteApp, organization, envFile}))
     return {app}
   }


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/shop/issues/issues/47828

`app env pull --env-file` doubled absolute paths because it joined the supplied file path onto the app directory, causing ENOENT errors on Windows-style paths.

### WHAT is this pull request doing?

Uses `resolvePath` for the env file path so absolute paths are preserved and relative paths still resolve from the app directory. Adds command-level regression coverage and a patch changeset.

### How to test your changes?

- `pnpm vitest run packages/app/src/cli/commands/app/env/pull.test.ts packages/app/src/cli/services/app/env/pull.test.ts`
- `git diff --check`

`pnpm nx type-check app` was attempted, but failed before app type-check in the dependent `organizations:build` task due unresolved `@shopify/cli-kit` / `@graphql-typed-document-node/core` imports.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible documentation changes
- [x] I've considered analytics changes to measure impact
- [x] The change is user-facing — patch changeset added