### PR TITLE
Upgrade deprecated actions

### DIFF
--- a/.github/actions/setup-cli-deps/action.yml
+++ b/.github/actions/setup-cli-deps/action.yml
@@ -13,12 +13,12 @@ runs:
         git config --global user.name "App Management"
       shell: bash
     - name: Install pnpm
-      uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
+      uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
       with:
         version: ${{ env.PNPM_VERSION }}
         run_install: false
     - name: Install Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ inputs.node-version }}
         registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -55,11 +55,11 @@ jobs:
           # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3
+        uses: github/codeql-action/init@d77b13a0df3134d64a457ea9003f600b09fa1c8a # v3
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -87,6 +87,6 @@ jobs:
           exit 1
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3
+        uses: github/codeql-action/analyze@d77b13a0df3134d64a457ea9003f600b09fa1c8a # v3
         with:
           category: "/language:${{matrix.language}}"

--- a/.github/workflows/gardener-investigate-issue.yml
+++ b/.github/workflows/gardener-investigate-issue.yml
@@ -24,7 +24,7 @@ jobs:
       github.event.label.name == 'devtools-investigate-for-gardener'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           # GITHUB_TOKEN won't trigger CI on PRs it creates (GitHub's loop-prevention).
@@ -71,7 +71,7 @@ jobs:
       - name: Investigate issue
         id: investigate
         timeout-minutes: 30
-        uses: anthropics/claude-code-action@b47fd721da662d48c5680e154ad16a73ed74d2e0 # v1
+        uses: anthropics/claude-code-action@36a69b6a90b850823f86de06fdfd56264772ad98 # v1
         env:
           ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
         with:

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -17,7 +17,7 @@ jobs:
       pull-requests: write
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup deps
         uses: ./.github/actions/setup-cli-deps
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
       # WARNING: DO NOT RUN ANY CUSTOM LOCAL SCRIPT BEFORE RUNNING THE SNAPIT ACTION
       # This action can be executed by 3rd party users and it should not be able to run arbitrary code from a PR.
       - name: Checkout current branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Setup deps
@@ -89,7 +89,7 @@ jobs:
       pull-requests: write
       id-token: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
         # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
         with:
           fetch-depth: 0
@@ -99,7 +99,7 @@ jobs:
           node-version: 24.12.0
       - name: Create Release Pull Request
         id: changesets
-        uses: changesets/action@6a0a831ff30acef54f2c6aa1cbbc1096b066edaf # v1
+        uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1
         with:
           version: pnpm changeset-manifests
           title: Version Packages - ${{ github.ref_name }}
@@ -180,7 +180,7 @@ jobs:
       pull-requests: write
       id-token: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
         # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
         with:
           fetch-depth: 0

--- a/.github/workflows/shopify-dev-preview-automation.yml
+++ b/.github/workflows/shopify-dev-preview-automation.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - name: Checkout repository
         if: github.event.action != 'closed'
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/tests-main.yml
+++ b/.github/workflows/tests-main.yml
@@ -34,7 +34,7 @@ jobs:
         os: [ 'ubuntu-latest', 'windows-latest', 'macos-latest' ]
         node: [ '22.12.0', '24.1.0', '26.1.0' ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
         name: Checkout [${{ github.ref_name }}]
         with:
           fetch-depth: 1

--- a/.github/workflows/tests-manual.yml
+++ b/.github/workflows/tests-manual.yml
@@ -50,7 +50,7 @@ jobs:
     runs-on: ${{ inputs.os }}
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.branch-name }}
           fetch-depth: 1
@@ -62,6 +62,6 @@ jobs:
         run: pnpm test --output-style=stream
       - name: Setup tmate session
         if: ${{ failure() && inputs.debug-enabled }}
-        uses: mxschmitt/action-tmate@c0afd6f790e3a5564914980036ebf83216678101 # v3
+        uses: mxschmitt/action-tmate@35b54afac29c97fb54faba5b513f8fbd1882f113 # v3
         with:
           limit-access-to-actor: true

--- a/.github/workflows/tests-pr.yml
+++ b/.github/workflows/tests-pr.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name || github.event.repository.full_name }}
           ref: ${{ github.event.pull_request.head.ref || github.event.merge_group.head_ref }}
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name || github.event.repository.full_name }}
           ref: ${{ github.event.pull_request.head.ref || github.event.merge_group.head_ref }}
@@ -59,7 +59,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name || github.event.repository.full_name }}
           ref: ${{ github.event.pull_request.head.ref || github.event.merge_group.head_ref }}
@@ -78,7 +78,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name || github.event.repository.full_name }}
           ref: ${{ github.event.pull_request.head.ref || github.event.merge_group.head_ref }}
@@ -99,7 +99,7 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name || github.event.repository.full_name }}
           ref: ${{ github.event.pull_request.head.ref || github.event.merge_group.head_ref }}
@@ -122,7 +122,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name || github.event.repository.full_name }}
           ref: ${{ github.event.pull_request.head.ref || github.event.merge_group.head_ref }}
@@ -191,7 +191,7 @@ jobs:
             node: '26.1.0'
             shard: ''
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name || github.event.repository.full_name }}
           ref: ${{ github.event.pull_request.head.ref || github.event.merge_group.head_ref }}
@@ -230,7 +230,7 @@ jobs:
       matrix:
         shard: ['1/2', '2/2']
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name || github.event.repository.full_name }}
           ref: ${{ github.event.pull_request.head.ref || github.event.merge_group.head_ref }}
@@ -275,7 +275,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
         name: Checkout [main]
         with:
           fetch-depth: 1
@@ -304,7 +304,7 @@ jobs:
     outputs:
       has_breaking_changes: ${{ steps.check.outputs.has_breaking_changes }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name || github.event.repository.full_name }}
           ref: ${{ github.event.pull_request.head.ref || github.event.merge_group.head_ref }}

--- a/.github/workflows/update-graphql-deps.yml
+++ b/.github/workflows/update-graphql-deps.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: macos-latest # Codegen uses a find command that needs to work on CI and macOS; using the same env keeps this simple
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
       - name: Checkout a new branch


### PR DESCRIPTION
### WHY are these changes introduced?

Some GitHub Actions use Node.js 20 and it's deprecated.

[Example](https://github.com/Shopify/cli/actions/runs/26871719308):

<img width="1270" height="275" alt="03-12-ftq7w-hva23" src="https://github.com/user-attachments/assets/934f35d9-8ab0-4d11-a416-7143ed10d441" />

### WHAT is this pull request doing?

Updates GitHub Actions references to Node 24-compatible versions:

- `actions/checkout@v6`
- `actions/setup-node@v6`
- `pnpm/action-setup@v6`

Also pins applicable third-party action refs with `bin/pin-github-actions.js`.

### How to test your changes?

CI

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`