### PR TITLE
feature/add shopify app get-review-requirements command

### DIFF
--- a/.changeset/app-get-review-requirements.md
+++ b/.changeset/app-get-review-requirements.md
@@ -1,0 +1,6 @@
+---
+'@shopify/app': minor
+'@shopify/cli-kit': patch
+---
+
+Add `shopify app get-review-requirements`, a new command that prints the [App Store review requirements](https://shopify.dev/docs/apps/launch/app-store-review/app-store-ai-self-review-requirements), with agent verification guidance, as markdown. Designed to be invoked by the `/shopify-app-review` agent skill in the Shopify AI Toolkit to power a local pre-submission compliance check against an app's codebase.

--- a/packages/app/src/cli/commands/app/get-review-requirements.ts
+++ b/packages/app/src/cli/commands/app/get-review-requirements.ts
@@ -1,0 +1,32 @@
+import {getReviewRequirements} from '../../services/app/get-review-requirements.js'
+import {appFlags} from '../../flags.js'
+import BaseCommand from '@shopify/cli-kit/node/base-command'
+import {globalFlags} from '@shopify/cli-kit/node/cli'
+import {outputResult} from '@shopify/cli-kit/node/output'
+
+export default class AppGetReviewRequirements extends BaseCommand {
+  static summary = 'Print the App Store self-review requirements as markdown.'
+
+  static descriptionWithMarkdown = `Prints the [App Store review requirements](https://shopify.dev/docs/apps/launch/app-store-review/app-store-ai-self-review-requirements) to stdout as markdown, including the agent verification guidance an AI agent needs to evaluate each requirement against a local codebase.
+
+  Designed to be invoked by the \`shopify-app-review\` agent skill from the Shopify AI Toolkit as part of a local pre-submission compliance check, but you can also run it yourself to read the latest locally checkable requirements.`
+
+  static description = this.descriptionWithoutMarkdown()
+
+  static flags = {
+    ...globalFlags,
+    path: appFlags.path,
+    config: appFlags.config,
+  }
+
+  public async run(): Promise<void> {
+    const {flags} = await this.parse(AppGetReviewRequirements)
+
+    const markdown = await getReviewRequirements({
+      directory: flags.path,
+      configName: flags.config,
+    })
+
+    outputResult(markdown)
+  }
+}

--- a/packages/app/src/cli/index.ts
+++ b/packages/app/src/cli/index.ts
@@ -20,6 +20,7 @@ import FetchSchema from './commands/app/function/schema.js'
 import FunctionTypegen from './commands/app/function/typegen.js'
 import AppGenerateExtension from './commands/app/generate/extension.js'
 import ImportExtensions from './commands/app/import-extensions.js'
+import AppGetReviewRequirements from './commands/app/get-review-requirements.js'
 import AppInfo from './commands/app/info.js'
 import Init from './commands/app/init.js'
 import ConfigValidate from './commands/app/config/validate.js'
@@ -70,6 +71,7 @@ export const commands: {[key: string]: typeof AppLinkedCommand | typeof AppUnlin
   'app:function:schema': FetchSchema,
   'app:function:typegen': FunctionTypegen,
   'app:generate:extension': AppGenerateExtension,
+  'app:get-review-requirements': AppGetReviewRequirements,
   'app:versions:list': VersionsList,
   'app:webhook:trigger': WebhookTrigger,
   'demo:watcher': DemoWatcher,

--- a/packages/app/src/cli/services/app/get-review-requirements.ts
+++ b/packages/app/src/cli/services/app/get-review-requirements.ts
@@ -1,0 +1,88 @@
+import {loadApp} from '../../models/app/loader.js'
+import {loadLocalExtensionsSpecifications} from '../../models/extensions/load-specifications.js'
+import metadata from '../../metadata.js'
+import {fetch} from '@shopify/cli-kit/node/http'
+import {outputDebug} from '@shopify/cli-kit/node/output'
+import {AbortError} from '@shopify/cli-kit/node/error'
+import {CLI_KIT_VERSION} from '@shopify/cli-kit/common/version'
+
+const REQUIREMENTS_URL = 'https://shopify.dev/docs/apps/launch/app-store-review/app-store-ai-self-review-requirements'
+
+export interface GetReviewRequirementsOptions {
+  directory: string
+  configName?: string
+}
+
+/**
+ * Fetches the canonical App Store self-review requirements markdown from
+ * shopify.dev and returns it as a string. Best-effort loads the local app so
+ * the auto-emitted Monorail event carries app-level attribution (api_key,
+ * app_path_hash, app_scopes, etc.).
+ *
+ * Designed to be invoked by the `shopify-app-review` agent skill in the
+ * Shopify AI Toolkit: the skill shells out to
+ * `shopify app get-review-requirements`, captures stdout, and uses it as the
+ * live list of requirements to evaluate the codebase against.
+ */
+export async function getReviewRequirements(options: GetReviewRequirementsOptions): Promise<string> {
+  await loadAppForAttribution(options)
+
+  const markdown = await fetchRequirementsMarkdown()
+  return markdown
+}
+
+async function loadAppForAttribution(options: GetReviewRequirementsOptions): Promise<void> {
+  try {
+    const app = await loadApp({
+      directory: options.directory,
+      userProvidedConfigName: options.configName,
+      specifications: await loadLocalExtensionsSpecifications(),
+      remoteFlags: undefined,
+      skipPrompts: true,
+    })
+
+    if (app.configuration.client_id) {
+      await metadata.addPublicMetadata(() => ({
+        api_key: String(app.configuration.client_id),
+      }))
+    }
+    // eslint-disable-next-line no-catch-all/no-catch-all
+  } catch (error) {
+    outputDebug(
+      `Skipping app attribution for review-requirements fetch: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    )
+  }
+}
+
+async function fetchRequirementsMarkdown(): Promise<string> {
+  const response = await fetch(
+    REQUIREMENTS_URL,
+    {
+      headers: {
+        Accept: 'text/markdown, text/plain;q=0.9, */*;q=0.1',
+        'User-Agent': `Shopify CLI/${CLI_KIT_VERSION} (app get-review-requirements)`,
+      },
+    },
+    'non-blocking',
+  )
+
+  if (!response.ok) {
+    await metadata.addPublicMetadata(() => ({
+      cmd_app_review_requirements_fetch_status: response.status,
+    }))
+    throw new AbortError(
+      `Failed to fetch App Store self-review requirements from shopify.dev (HTTP ${response.status} ${response.statusText}).`,
+      `Check your network connection and try again, or visit ${REQUIREMENTS_URL} directly.`,
+    )
+  }
+
+  const body = await response.text()
+
+  await metadata.addPublicMetadata(() => ({
+    cmd_app_review_requirements_fetch_status: response.status,
+  }))
+
+  return body
+}

--- a/packages/cli-kit/src/public/node/monorail.ts
+++ b/packages/cli-kit/src/public/node/monorail.ts
@@ -100,6 +100,7 @@ export interface Schemas {
       cmd_app_validate_valid?: Optional<boolean>
       cmd_app_validate_issue_count?: Optional<number>
       cmd_app_validate_file_count?: Optional<number>
+      cmd_app_review_requirements_fetch_status?: Optional<number>
 
       // Dev related commands
       cmd_dev_tunnel_type?: Optional<string>

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -21,6 +21,7 @@
 * [`shopify app function schema`](#shopify-app-function-schema)
 * [`shopify app function typegen`](#shopify-app-function-typegen)
 * [`shopify app generate extension`](#shopify-app-generate-extension)
+* [`shopify app get-review-requirements`](#shopify-app-get-review-requirements)
 * [`shopify app import-custom-data-definitions`](#shopify-app-import-custom-data-definitions)
 * [`shopify app import-extensions`](#shopify-app-import-extensions)
 * [`shopify app info`](#shopify-app-info)
@@ -747,6 +748,31 @@ DESCRIPTION
   Each new app extension is created in a folder under `extensions/`. To learn more about the extensions file structure,
   refer to "App structure" (https://shopify.dev/docs/apps/build/cli-for-apps/app-structure) and the documentation for
   your extension.
+```
+
+## `shopify app get-review-requirements`
+
+Print the App Store self-review requirements as markdown.
+
+```
+USAGE
+  $ shopify app get-review-requirements [-c <value>] [--no-color] [--path <value>] [--verbose]
+
+FLAGS
+  -c, --config=<value>  [env: SHOPIFY_FLAG_APP_CONFIG] The name of the app configuration.
+      --no-color        [env: SHOPIFY_FLAG_NO_COLOR] Disable color output.
+      --path=<value>    [env: SHOPIFY_FLAG_PATH] The path to your app directory.
+      --verbose         [env: SHOPIFY_FLAG_VERBOSE] Increase the verbosity of the output.
+
+DESCRIPTION
+  Print the App Store self-review requirements as markdown.
+
+  Prints the "App Store review requirements"
+  (https://shopify.dev/docs/apps/launch/app-store-review/app-store-ai-self-review-requirements) to stdout as markdown,
+  including the agent verification guidance an AI agent needs to evaluate each requirement against a local codebase.
+
+  Designed to be invoked by the `shopify-app-review` agent skill from the Shopify AI Toolkit  as part of a local
+  pre-submission compliance check, but you can also run it yourself to read the latest locally checkable requirements.
 ```
 
 ## `shopify app import-custom-data-definitions`

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -2143,6 +2143,62 @@
       "strict": true,
       "summary": "Generate a new app Extension."
     },
+    "app:get-review-requirements": {
+      "aliases": [
+      ],
+      "args": {
+      },
+      "customPluginName": "@shopify/app",
+      "description": "Prints the \"App Store review requirements\" (https://shopify.dev/docs/apps/launch/app-store-review/app-store-ai-self-review-requirements) to stdout as markdown, including the agent verification guidance an AI agent needs to evaluate each requirement against a local codebase.\n\n  Designed to be invoked by the `shopify-app-review` agent skill from the Shopify AI Toolkit as part of a local pre-submission compliance check, but you can also run it yourself to read the latest locally checkable requirements.",
+      "descriptionWithMarkdown": "Prints the [App Store review requirements](https://shopify.dev/docs/apps/launch/app-store-review/app-store-ai-self-review-requirements) to stdout as markdown, including the agent verification guidance an AI agent needs to evaluate each requirement against a local codebase.\n\n  Designed to be invoked by the `shopify-app-review` agent skill from the Shopify AI Toolkit as part of a local pre-submission compliance check, but you can also run it yourself to read the latest locally checkable requirements.",
+      "enableJsonFlag": false,
+      "flags": {
+        "config": {
+          "char": "c",
+          "description": "The name of the app configuration.",
+          "env": "SHOPIFY_FLAG_APP_CONFIG",
+          "hasDynamicHelp": false,
+          "hidden": false,
+          "multiple": false,
+          "name": "config",
+          "type": "option"
+        },
+        "no-color": {
+          "allowNo": false,
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
+          "type": "boolean"
+        },
+        "path": {
+          "description": "The path to your app directory.",
+          "env": "SHOPIFY_FLAG_PATH",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "path",
+          "noCacheDefault": true,
+          "type": "option"
+        },
+        "verbose": {
+          "allowNo": false,
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [
+      ],
+      "id": "app:get-review-requirements",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "summary": "Print the App Store self-review requirements as markdown."
+    },
     "app:import-custom-data-definitions": {
       "aliases": [
       ],


### PR DESCRIPTION
> [!WARNING]
> We'll need an actual monorail event created before this can be reviewed and merged.

### WHY are these changes introduced?

The AI Toolkit ships a `shopify-app-review` agent skill that walks a
developer's local codebase against the App Store review requirements before
they submit. Today the skill instructs the agent to web-fetch the
requirements directly from
https://shopify.dev/docs/apps/launch/app-store-review/app-store-ai-self-review-requirements.

That works, but it gives us no signal about which apps have actually
attempted a local self-review. We'd like that signal so we can:

- track adoption of the skill,
- potentially use it as a trust input when ranking apps for human review.

Since developers building for the App Store already have the Shopify CLI
installed, routing the requirements fetch through a CLI command gives us
the auto-emitted Monorail event (with local app attribution and the
standard analytics opt-out) for free.

### WHAT is this pull request doing?

Adds a new command:

```
shopify app get-review-requirements
```

It fetches the canonical App Store review requirements (including the agent
verification guidance) from shopify.dev and prints them to stdout as
markdown — the format the agent skill needs to evaluate the codebase.

Key behaviors:

- Extends `BaseCommand` (not `AppLinkedCommand`) — no auth, no remote
  linking, works inside or outside an app directory so agents and humans
  can call it freely.
- When run inside an app directory, the local `shopify.app.toml` is loaded
  best-effort so the Monorail event carries app-level attribution
  (`api_key` from the local `client_id`, `app_name_hash`, `app_path_hash`,
  `app_scopes`, `project_type`, …). Outside an app dir the event is still
  emitted, just without `app_*` fields.
- One new public Monorail field, `cmd_app_review_requirements_fetch_status`,
  so we can distinguish successful fetches from network/HTTP failures
  without parsing error messages.
- Standard CLI analytics opt-out (`SHOPIFY_CLI_NO_ANALYTICS` /
  `OPT_OUT_INSTRUMENTATION`) applies.

Not in this PR: updating the `shopify-app-review` skill in
`Shopify/ai-toolkit-source` to shell out to this command instead of
web-fetching directly. That'll be a follow-up once this lands and is
released.

Files of interest:

- `packages/app/src/cli/commands/app/get-review-requirements.ts` — command
- `packages/app/src/cli/services/app/get-review-requirements.ts` — fetch + best-effort local app load
- `packages/cli-kit/src/public/node/monorail.ts` — new schema field
- `packages/app/src/cli/index.ts` — command registration

### How to test your changes?

From inside an app directory:

```sh
shopify app get-review-requirements | head -20
```

You should see the requirements markdown printed to stdout, starting with
`Section 1. Policy`.

To verify the Monorail payload locally:

```sh
SHOPIFY_CLI_ALWAYS_LOG_ANALYTICS=true OPT_OUT_INSTRUMENTATION=true \
  shopify app get-review-requirements --verbose 2>&1 >/dev/null \
  | awk '/Analytics event sent/,/^}/'
```

Inside a linked app dir you should see `api_key`, `app_name_hash`,
`app_path_hash`, `app_scopes`, `project_type` and
`cmd_app_review_requirements_fetch_status: 200` in the payload. From a
non-app directory the same command runs cleanly but emits the event
without the `app_*` fields.

Opt-out:

```sh
OPT_OUT_INSTRUMENTATION=true shopify app get-review-requirements --verbose 2>&1 \
  | grep "Skipping command analytics"
```

### Post-release steps

Open a follow-up PR in `Shopify/ai-toolkit-source` to update the
`shopify-app-review` skill to invoke `shopify app
get-review-requirements` instead of fetching the requirements page
directly.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [x] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`