### PR TITLE
Add local store auth summary API

### DIFF
--- a/packages/store/src/cli/services/store/auth/index.ts
+++ b/packages/store/src/cli/services/store/auth/index.ts
@@ -13,6 +13,8 @@ import {outputContent, outputDebug, outputToken} from '@shopify/cli-kit/node/out
 import {AbortError} from '@shopify/cli-kit/node/error'
 import {normalizeStoreFqdn} from '@shopify/cli-kit/node/context/fqdn'
 
+export {listStoredStoreAuthSummaries, type StoredStoreAuthSummary} from './stored-auth.js'
+
 interface StoreAuthInput {
   store: string
   scopes: string

--- a/packages/store/src/cli/services/store/auth/session-store.ts
+++ b/packages/store/src/cli/services/store/auth/session-store.ts
@@ -1,5 +1,6 @@
 import {STORE_AUTH_APP_CLIENT_ID, storeAuthSessionKey} from './config.js'
 import {LocalStorage} from '@shopify/cli-kit/node/local-storage'
+import {type JsonMapType} from '@shopify/cli-kit/node/toml'
 
 /**
  * Discriminator for a stored store auth session.
@@ -61,6 +62,8 @@ interface StoredStoreAppSessionBucket {
 interface StoreSessionSchema {
   [key: string]: StoredStoreAppSessionBucket
 }
+
+type RawStoreSessionStorage = JsonMapType
 
 let _storeSessionStorage: LocalStorage<StoreSessionSchema> | undefined
 
@@ -205,8 +208,8 @@ function readStoredStoreAppSessionBucket(
 // `conf` persists dotted keys as nested objects. Store-auth callers should not
 // learn that layout directly; this helper keeps the current traversal private to
 // the persistence seam while higher-level code projects summaries instead.
-function readRawStoreSessionStorage(storage: LocalStorage<StoreSessionSchema>): Record<string, unknown> {
-  return (storage as unknown as {config: {store: Record<string, unknown>}}).config.store ?? {}
+function readRawStoreSessionStorage(storage: LocalStorage<StoreSessionSchema>): RawStoreSessionStorage {
+  return (storage as unknown as {config?: {store?: RawStoreSessionStorage}}).config?.store ?? {}
 }
 
 function collectCurrentStoredStoreAppSessions(
@@ -224,7 +227,7 @@ function collectCurrentStoredStoreAppSessions(
     return
   }
 
-  for (const [childKey, childValue] of Object.entries(value as Record<string, unknown>)) {
+  for (const [childKey, childValue] of Object.entries(value as RawStoreSessionStorage)) {
     collectCurrentStoredStoreAppSessions(storage, `${store}.${childKey}`, childValue, sessions)
   }
 }

--- a/packages/store/src/cli/services/store/auth/session-store.ts
+++ b/packages/store/src/cli/services/store/auth/session-store.ts
@@ -1,4 +1,4 @@
-import {storeAuthSessionKey} from './config.js'
+import {STORE_AUTH_APP_CLIENT_ID, storeAuthSessionKey} from './config.js'
 import {LocalStorage} from '@shopify/cli-kit/node/local-storage'
 
 /**
@@ -120,6 +120,8 @@ function sanitizeStoredStoreAppSession(value: unknown): StoredStoreAppSession | 
     return undefined
   }
 
+  const associatedUser = sanitizeAssociatedUser(session.associatedUser)
+
   // Discriminator is optional for back-compat: sessions written before this field existed
   // are read back as 'standard'. Unknown values are coerced to 'standard' and the field is
   // omitted from the result so it doesn't pollute legacy buckets.
@@ -140,23 +142,24 @@ function sanitizeStoredStoreAppSession(value: unknown): StoredStoreAppSession | 
     ...(isString(session.refreshToken) ? {refreshToken: session.refreshToken} : {}),
     ...(isString(session.expiresAt) ? {expiresAt: session.expiresAt} : {}),
     ...(isString(session.refreshTokenExpiresAt) ? {refreshTokenExpiresAt: session.refreshTokenExpiresAt} : {}),
-    ...(sanitizeAssociatedUser(session.associatedUser)
-      ? {associatedUser: sanitizeAssociatedUser(session.associatedUser)}
-      : {}),
+    ...(associatedUser ? {associatedUser} : {}),
     ...(kind === 'preview' ? {kind} : {}),
     ...(preview ? {preview} : {}),
   }
 }
 
-function readStoredStoreAppSessionBucket(
+function sanitizeStoredStoreAppSessionBucket(
   store: string,
+  storedBucket: unknown,
   storage: LocalStorage<StoreSessionSchema>,
 ): StoredStoreAppSessionBucket | undefined {
-  const key = storeAuthSessionKey(store)
-  const storedBucket = storage.get(key)
   if (!storedBucket || typeof storedBucket !== 'object') return undefined
 
   const {sessionsByUserId, currentUserId} = storedBucket as Partial<StoredStoreAppSessionBucket>
+  const looksLikeBucket = sessionsByUserId !== undefined || currentUserId !== undefined
+  if (!looksLikeBucket) return undefined
+
+  const key = storeAuthSessionKey(store)
   if (
     !sessionsByUserId ||
     typeof sessionsByUserId !== 'object' ||
@@ -190,6 +193,58 @@ function readStoredStoreAppSessionBucket(
     currentUserId,
     sessionsByUserId: sanitizedSessionsByUserId,
   }
+}
+
+function readStoredStoreAppSessionBucket(
+  store: string,
+  storage: LocalStorage<StoreSessionSchema>,
+): StoredStoreAppSessionBucket | undefined {
+  return sanitizeStoredStoreAppSessionBucket(store, storage.get(storeAuthSessionKey(store)), storage)
+}
+
+// `conf` persists dotted keys as nested objects. Store-auth callers should not
+// learn that layout directly; this helper keeps the current traversal private to
+// the persistence seam while higher-level code projects summaries instead.
+function readRawStoreSessionStorage(storage: LocalStorage<StoreSessionSchema>): Record<string, unknown> {
+  return (storage as unknown as {config: {store: Record<string, unknown>}}).config.store ?? {}
+}
+
+function collectCurrentStoredStoreAppSessions(
+  storage: LocalStorage<StoreSessionSchema>,
+  store: string,
+  value: unknown,
+  sessions: StoredStoreAppSession[],
+): void {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return
+
+  const bucket = sanitizeStoredStoreAppSessionBucket(store, value, storage)
+  if (bucket) {
+    const session = bucket.sessionsByUserId[bucket.currentUserId]
+    if (session) sessions.push(session)
+    return
+  }
+
+  for (const [childKey, childValue] of Object.entries(value as Record<string, unknown>)) {
+    collectCurrentStoredStoreAppSessions(storage, `${store}.${childKey}`, childValue, sessions)
+  }
+}
+
+/**
+ * Internal persistence helper for projecting the current session for every
+ * store that has locally stored store auth.
+ */
+export function listCurrentStoredStoreAppSessions(
+  storage: LocalStorage<StoreSessionSchema> = storeSessionStorage(),
+): StoredStoreAppSession[] {
+  const sessions: StoredStoreAppSession[] = []
+  const keyPrefix = `${STORE_AUTH_APP_CLIENT_ID}::`
+
+  for (const [key, value] of Object.entries(readRawStoreSessionStorage(storage))) {
+    if (!key.startsWith(keyPrefix)) continue
+    collectCurrentStoredStoreAppSessions(storage, key.slice(keyPrefix.length), value, sessions)
+  }
+
+  return sessions
 }
 
 export function getCurrentStoredStoreAppSession(

--- a/packages/store/src/cli/services/store/auth/stored-auth.test.ts
+++ b/packages/store/src/cli/services/store/auth/stored-auth.test.ts
@@ -27,17 +27,25 @@ describe('listStoredStoreAuthSummaries', () => {
     })
   })
 
-  test('returns one summary per store sorted by store using the current user session', async () => {
+  test('returns one summary per store sorted by newest auth using the current user session', async () => {
     await inTemporaryDirectory((cwd) => {
       const storage = new LocalStorage<Record<string, unknown>>({cwd})
 
-      setStoredStoreAppSession(buildSession({store: 'b-shop.myshopify.com'}), storage as any)
+      setStoredStoreAppSession(
+        buildSession({store: 'b-shop.myshopify.com', acquiredAt: '2026-03-27T00:00:00.000Z'}),
+        storage as any,
+      )
       setStoredStoreAppSession(
         buildSession({store: 'a-shop.myshopify.com', userId: '41', accessToken: 'token-41'}),
         storage as any,
       )
       setStoredStoreAppSession(
-        buildSession({store: 'a-shop.myshopify.com', userId: '84', accessToken: 'token-84'}),
+        buildSession({
+          store: 'a-shop.myshopify.com',
+          userId: '84',
+          accessToken: 'token-84',
+          acquiredAt: '2026-03-28T00:00:00.000Z',
+        }),
         storage as any,
       )
 
@@ -46,7 +54,7 @@ describe('listStoredStoreAuthSummaries', () => {
           store: 'a-shop.myshopify.com',
           userId: '84',
           scopes: ['read_products'],
-          acquiredAt: '2026-03-27T00:00:00.000Z',
+          acquiredAt: '2026-03-28T00:00:00.000Z',
         },
         {
           store: 'b-shop.myshopify.com',

--- a/packages/store/src/cli/services/store/auth/stored-auth.test.ts
+++ b/packages/store/src/cli/services/store/auth/stored-auth.test.ts
@@ -1,0 +1,140 @@
+import {STORE_AUTH_APP_CLIENT_ID, storeAuthSessionKey} from './config.js'
+import {setStoredStoreAppSession, type StoredStoreAppSession} from './session-store.js'
+import {listStoredStoreAuthSummaries} from './stored-auth.js'
+import {inTemporaryDirectory} from '@shopify/cli-kit/node/fs'
+import {LocalStorage} from '@shopify/cli-kit/node/local-storage'
+import {describe, expect, test} from 'vitest'
+
+function buildSession(overrides: Partial<StoredStoreAppSession> = {}): StoredStoreAppSession {
+  return {
+    store: 'shop.myshopify.com',
+    clientId: STORE_AUTH_APP_CLIENT_ID,
+    userId: '42',
+    accessToken: 'token-1',
+    refreshToken: 'refresh-token-1',
+    scopes: ['read_products'],
+    acquiredAt: '2026-03-27T00:00:00.000Z',
+    ...overrides,
+  }
+}
+
+describe('listStoredStoreAuthSummaries', () => {
+  test('returns an empty array when no store auth is persisted', async () => {
+    await inTemporaryDirectory((cwd) => {
+      const storage = new LocalStorage<Record<string, unknown>>({cwd})
+
+      expect(listStoredStoreAuthSummaries(storage as any)).toEqual([])
+    })
+  })
+
+  test('returns one summary per store sorted by store using the current user session', async () => {
+    await inTemporaryDirectory((cwd) => {
+      const storage = new LocalStorage<Record<string, unknown>>({cwd})
+
+      setStoredStoreAppSession(buildSession({store: 'b-shop.myshopify.com'}), storage as any)
+      setStoredStoreAppSession(
+        buildSession({store: 'a-shop.myshopify.com', userId: '41', accessToken: 'token-41'}),
+        storage as any,
+      )
+      setStoredStoreAppSession(
+        buildSession({store: 'a-shop.myshopify.com', userId: '84', accessToken: 'token-84'}),
+        storage as any,
+      )
+
+      expect(listStoredStoreAuthSummaries(storage as any)).toEqual([
+        {
+          store: 'a-shop.myshopify.com',
+          userId: '84',
+          scopes: ['read_products'],
+          acquiredAt: '2026-03-27T00:00:00.000Z',
+        },
+        {
+          store: 'b-shop.myshopify.com',
+          userId: '42',
+          scopes: ['read_products'],
+          acquiredAt: '2026-03-27T00:00:00.000Z',
+        },
+      ])
+    })
+  })
+
+  test('projects associated user metadata without exposing tokens', async () => {
+    await inTemporaryDirectory((cwd) => {
+      const storage = new LocalStorage<Record<string, unknown>>({cwd})
+
+      setStoredStoreAppSession(
+        buildSession({
+          expiresAt: '2026-03-28T00:00:00.000Z',
+          refreshTokenExpiresAt: '2026-04-28T00:00:00.000Z',
+          associatedUser: {
+            id: 42,
+            email: 'merchant@example.com',
+            firstName: 'Merchant',
+            lastName: 'User',
+            accountOwner: true,
+          },
+        }),
+        storage as any,
+      )
+
+      const [summary] = listStoredStoreAuthSummaries(storage as any)
+
+      expect(summary).toEqual({
+        store: 'shop.myshopify.com',
+        userId: '42',
+        scopes: ['read_products'],
+        acquiredAt: '2026-03-27T00:00:00.000Z',
+        expiresAt: '2026-03-28T00:00:00.000Z',
+        refreshTokenExpiresAt: '2026-04-28T00:00:00.000Z',
+        associatedUser: {
+          id: 42,
+          email: 'merchant@example.com',
+          firstName: 'Merchant',
+          lastName: 'User',
+          accountOwner: true,
+        },
+      })
+      expect(summary).not.toHaveProperty('accessToken')
+      expect(summary).not.toHaveProperty('refreshToken')
+    })
+  })
+
+  test('drops malformed sibling sessions while preserving the current session', async () => {
+    await inTemporaryDirectory((cwd) => {
+      const storage = new LocalStorage<Record<string, unknown>>({cwd})
+      const key = storeAuthSessionKey('shop.myshopify.com')
+      storage.set(key, {
+        currentUserId: '42',
+        sessionsByUserId: {
+          '41': {userId: '41'},
+          '42': buildSession(),
+        },
+      })
+
+      expect(listStoredStoreAuthSummaries(storage as any)).toEqual([
+        {
+          store: 'shop.myshopify.com',
+          userId: '42',
+          scopes: ['read_products'],
+          acquiredAt: '2026-03-27T00:00:00.000Z',
+        },
+      ])
+      expect(Object.keys((storage.get(key) as any).sessionsByUserId)).toEqual(['42'])
+    })
+  })
+
+  test('skips malformed persisted buckets while listing summaries', async () => {
+    await inTemporaryDirectory((cwd) => {
+      const storage = new LocalStorage<Record<string, unknown>>({cwd})
+      storage.set(storeAuthSessionKey('broken-shop.myshopify.com'), {
+        currentUserId: '42',
+        sessionsByUserId: {
+          '42': {userId: '42'},
+        },
+      })
+
+      expect(listStoredStoreAuthSummaries(storage as any)).toEqual([])
+      expect(storage.get(storeAuthSessionKey('broken-shop.myshopify.com'))).toBeUndefined()
+    })
+  })
+})

--- a/packages/store/src/cli/services/store/auth/stored-auth.test.ts
+++ b/packages/store/src/cli/services/store/auth/stored-auth.test.ts
@@ -66,6 +66,21 @@ describe('listStoredStoreAuthSummaries', () => {
     })
   })
 
+  test('sorts stores alphabetically when auth timestamps match', async () => {
+    await inTemporaryDirectory((cwd) => {
+      const storage = new LocalStorage<Record<string, unknown>>({cwd})
+      const acquiredAt = '2026-03-27T00:00:00.000Z'
+
+      setStoredStoreAppSession(buildSession({store: 'b-shop.myshopify.com', acquiredAt}), storage as any)
+      setStoredStoreAppSession(buildSession({store: 'a-shop.myshopify.com', acquiredAt}), storage as any)
+
+      expect(listStoredStoreAuthSummaries(storage as any).map((summary) => summary.store)).toEqual([
+        'a-shop.myshopify.com',
+        'b-shop.myshopify.com',
+      ])
+    })
+  })
+
   test('projects associated user metadata without exposing tokens', async () => {
     await inTemporaryDirectory((cwd) => {
       const storage = new LocalStorage<Record<string, unknown>>({cwd})

--- a/packages/store/src/cli/services/store/auth/stored-auth.ts
+++ b/packages/store/src/cli/services/store/auth/stored-auth.ts
@@ -23,5 +23,5 @@ export function listStoredStoreAuthSummaries(storage?: StoreSessionStorage): Sto
       ...(session.refreshTokenExpiresAt ? {refreshTokenExpiresAt: session.refreshTokenExpiresAt} : {}),
       ...(session.associatedUser ? {associatedUser: session.associatedUser} : {}),
     }))
-    .sort((left, right) => left.store.localeCompare(right.store))
+    .sort((left, right) => right.acquiredAt.localeCompare(left.acquiredAt) || left.store.localeCompare(right.store))
 }

--- a/packages/store/src/cli/services/store/auth/stored-auth.ts
+++ b/packages/store/src/cli/services/store/auth/stored-auth.ts
@@ -1,0 +1,27 @@
+import {listCurrentStoredStoreAppSessions, type StoredStoreAppSession} from './session-store.js'
+
+export interface StoredStoreAuthSummary {
+  store: string
+  userId: string
+  scopes: string[]
+  acquiredAt: string
+  expiresAt?: string
+  refreshTokenExpiresAt?: string
+  associatedUser?: StoredStoreAppSession['associatedUser']
+}
+
+type StoreSessionStorage = Parameters<typeof listCurrentStoredStoreAppSessions>[0]
+
+export function listStoredStoreAuthSummaries(storage?: StoreSessionStorage): StoredStoreAuthSummary[] {
+  return listCurrentStoredStoreAppSessions(storage)
+    .map((session) => ({
+      store: session.store,
+      userId: session.userId,
+      scopes: session.scopes,
+      acquiredAt: session.acquiredAt,
+      ...(session.expiresAt ? {expiresAt: session.expiresAt} : {}),
+      ...(session.refreshTokenExpiresAt ? {refreshTokenExpiresAt: session.refreshTokenExpiresAt} : {}),
+      ...(session.associatedUser ? {associatedUser: session.associatedUser} : {}),
+    }))
+    .sort((left, right) => left.store.localeCompare(right.store))
+}


### PR DESCRIPTION
## Summary

Introduce a local store-auth summary API without changing command behavior yet.

## Scope

- add `StoredStoreAuthSummary`
- add `listStoredStoreAuthSummaries()` under `services/store/auth`
- keep token-bearing session buckets as the current persistence source of truth
- keep `conf` traversal and bucket cleanup in `session-store.ts`
- re-export the summary API from `services/store/auth/index.ts`
- sort summaries newest-auth-first for the “return to the store I was working on” use case

## Why this split exists

The next PR needs one narrow question answered first:

- what directly authenticated store auth exists on this machine?

This PR answers that without taking on product behavior:

- no auth-listing command yet
- no persistence migration
- no access-token exposure

That keeps the behavior PR focused on command policy and output, not on storage traversal.

## Boundary this PR is trying to establish

- persistence details stay in `session-store.ts`
- callers see `StoredStoreAuthSummary[]`
- callers do not need token-bearing session buckets or `conf` layout knowledge

## Not changed / deferred

- Did not add the `shopify auth list` command in this PR. This PR is only the storage projection; command behavior lands upstack.
- Did not expose access tokens or refresh tokens. The summary API is deliberately safe for display/automation consumers.
- Did not migrate the persisted store-auth schema or add an index key for known stores. This keeps existing auth sessions compatible and avoids making a storage migration part of this stack.
- Did not add a public `LocalStorage.entries()` / enumeration API in cli-kit. Follow-through review correctly noted that `session-store.ts` still relies on the underlying `conf` layout to discover existing buckets; fixing that should be a focused storage follow-up before adding more local-auth inventory features.
