### PR TITLE
[Performance] Memoize isShopify

### DIFF
--- a/packages/cli-kit/src/public/node/context/local.test.ts
+++ b/packages/cli-kit/src/public/node/context/local.test.ts
@@ -3,6 +3,7 @@ import {
   hasGit,
   isDevelopment,
   isShopify,
+  _resetIsShopifyMemo,
   isTerminalInteractive,
   isUnitTest,
   analyticsDisabled,
@@ -14,7 +15,7 @@ import {
 import {fileExists} from '../fs.js'
 import {exec} from '../system.js'
 
-import {afterEach, expect, describe, vi, test} from 'vitest'
+import {afterEach, beforeEach, expect, describe, vi, test} from 'vitest'
 
 vi.mock('../fs.js')
 vi.mock('../system.js')
@@ -97,6 +98,10 @@ describe('isDevelopment', () => {
 })
 
 describe('isShopify', () => {
+  beforeEach(() => {
+    _resetIsShopifyMemo()
+  })
+
   test('returns false when the SHOPIFY_RUN_AS_USER env. variable is truthy', async () => {
     // Given
     const env = {SHOPIFY_RUN_AS_USER: '1'}
@@ -119,6 +124,21 @@ describe('isShopify', () => {
 
     // When
     await expect(isShopify()).resolves.toBe(true)
+  })
+
+  test('memoizes the result when called with the same env', async () => {
+    // Given
+    vi.mocked(fileExists).mockResolvedValue(true)
+
+    // When
+    const first = isShopify()
+    const second = isShopify()
+
+    // Then
+    await expect(first).resolves.toBe(true)
+    await expect(second).resolves.toBe(true)
+    expect(first).toBe(second)
+    expect(fileExists).toHaveBeenCalledTimes(1)
   })
 })
 

--- a/packages/cli-kit/src/public/node/context/local.ts
+++ b/packages/cli-kit/src/public/node/context/local.ts
@@ -45,6 +45,11 @@ let memoizedIsVerbose: boolean | undefined
 let memoizedIsUnitTest: boolean | undefined
 
 /**
+ * Memoized value for the Shopify check.
+ */
+let memoizedIsShopify: Promise<boolean> | undefined
+
+/**
  * Returns true if the CLI is running in debug mode.
  *
  * @param env - The environment variables from the environment of the current process.
@@ -76,12 +81,33 @@ export function isVerbose(env = process.env): boolean {
  * @param env - The environment variables from the environment of the current process.
  * @returns True if the CLI is used in a Shopify environment.
  */
-export async function isShopify(env = process.env): Promise<boolean> {
-  if (Object.prototype.hasOwnProperty.call(env, environmentVariables.runAsUser)) {
-    return !isTruthy(env[environmentVariables.runAsUser])
+export function isShopify(env = process.env): Promise<boolean> {
+  if (env === process.env && memoizedIsShopify !== undefined) {
+    // Memoize the result to avoid repeated filesystem checks for the presence of the dev binary.
+    return memoizedIsShopify
   }
-  const devInstalled = await lazyFileExists(pathConstants.executables.dev)
-  return devInstalled
+
+  const resultPromise = (async () => {
+    if (Object.prototype.hasOwnProperty.call(env, environmentVariables.runAsUser)) {
+      return !isTruthy(env[environmentVariables.runAsUser])
+    }
+    const devInstalled = await lazyFileExists(pathConstants.executables.dev)
+    return devInstalled
+  })()
+
+  if (env === process.env) {
+    memoizedIsShopify = resultPromise
+  }
+
+  return resultPromise
+}
+
+/**
+ * Resets the memoized value for the Shopify check.
+ * This is only used for testing purposes.
+ */
+export function _resetIsShopifyMemo(): void {
+  memoizedIsShopify = undefined
 }
 
 /**


### PR DESCRIPTION
### WHY are these changes introduced?

The `isShopify` function is called frequently, including during analytics generation for every command. It performs an asynchronous filesystem check for the presence of the `dev` binary. Since the environment and installation status are static during a single CLI execution, this check can be safely memoized to improve efficiency.

### WHAT is this pull request doing?

- Memoizes the `isShopify` result when called with the default `process.env`.
- Caches the `Promise` directly to ensure concurrent calls await the same operation.
- Introduced a internal `_resetIsShopifyMemo` utility to maintain test isolation.
- Added a new unit test to verify that the filesystem is only queried once.

### How to test your changes?

`pnpm --filter @shopify/cli-kit vitest run src/public/node/context/local.test.ts`

### Post-release steps

None.

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [14669418771078202875](https://jules.google.com/task/14669418771078202875) started by @gonzaloriestra*