### PR TITLE
[Refactor] Use uniq helper in info service

### DIFF
--- a/packages/app/src/cli/services/info.ts
+++ b/packages/app/src/cli/services/info.ts
@@ -16,6 +16,7 @@ import {
 } from '@shopify/cli-kit/node/output'
 import {AlertCustomSection, InlineToken} from '@shopify/cli-kit/node/ui'
 import {CLI_KIT_VERSION} from '@shopify/cli-kit/common/version'
+import {uniq} from '@shopify/cli-kit/common/array'
 
 export type Format = 'json' | 'text'
 export interface InfoOptions {
@@ -230,7 +231,7 @@ class AppInfo {
 
   extensionsSections(): AlertCustomSection[] {
     const extensions = this.app.allExtensions.filter((ext) => ext.isReturnedAsInfo())
-    const types = Array.from(new Set(extensions.map((ext) => ext.type)))
+    const types = uniq(extensions.map((ext) => ext.type))
     return types
       .map((extensionType: string): AlertCustomSection | undefined => {
         const relevantExtensions = extensions.filter((extension: ExtensionInstance) => extension.type === extensionType)


### PR DESCRIPTION
### WHY are these changes introduced?

Standardize array deduplication by using the `uniq` helper instead of native `Array.from(new Set(...))`.

### WHAT is this pull request doing?

Refactors `extensionsSections` in `packages/app/src/cli/services/info.ts` to use the `uniq` helper from `@shopify/cli-kit/common/array`.

### How to test your changes?

shopify app info

### Post-release steps

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [6775837903008228311](https://jules.google.com/task/6775837903008228311) started by @gonzaloriestra*