### PR TITLE
[Security] Harden downloadFile with response validation

### DIFF
--- a/packages/cli-kit/src/public/node/http.test.ts
+++ b/packages/cli-kit/src/public/node/http.test.ts
@@ -292,6 +292,24 @@ describe('downloadFile', () => {
       await expect(fileExists(to)).resolves.toBe(false)
     })
   })
+
+  test('Fails and cleans up if server returns 500', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      const url = 'https://shopify.example/500.txt'
+      const filename = '/bin/500.txt'
+      const to = joinPath(tmpDir, filename)
+
+      // When
+      const result = downloadFile(url, to)
+
+      // Then
+      await expect(result).rejects.toThrow(
+        'Failed to download file from https://shopify.example/500.txt: 500 Internal Server Error',
+      )
+      await expect(fileExists(to)).resolves.toBe(false)
+    })
+  })
 })
 
 describe('requestMode', () => {

--- a/packages/cli-kit/src/public/node/http.ts
+++ b/packages/cli-kit/src/public/node/http.ts
@@ -226,46 +226,52 @@ export function downloadFile(url: string, to: string): Promise<string> {
 
   return runWithTimer('cmd_all_timing_network_ms')(() => {
     return new Promise<string>((resolve, reject) => {
-      if (!fileExistsSync(dirname(to))) {
-        mkdirSync(dirname(to))
-      }
-
-      const file = createFileWriteStream(to)
-
-      // if we can't remove the file for some reason (seen on windows), that's ok -- it's in a temporary directory
-      const tryToRemoveFile = () => {
-        try {
-          unlinkFileSync(to)
-          // eslint-disable-next-line no-catch-all/no-catch-all
-        } catch (err: unknown) {
-          outputDebug(outputContent`Failed to remove file ${outputToken.path(to)}: ${outputToken.raw(String(err))}`)
-        }
-      }
-
-      file.on('finish', () => {
-        file.close()
-        resolve(to)
-      })
-
-      file.on('error', (err) => {
-        tryToRemoveFile()
-        reject(err)
-      })
-
       nodeFetch(url, {redirect: 'follow'})
         .then((res) => {
           if (!res.ok) {
-            tryToRemoveFile()
             return reject(new Error(`Failed to download file from ${sanitizedUrl}: ${res.status} ${res.statusText}`))
           }
           if (!res.body) {
-            tryToRemoveFile()
             return reject(new Error(`Failed to download file from ${sanitizedUrl}: Empty response body`))
           }
+
+          if (!fileExistsSync(dirname(to))) {
+            mkdirSync(dirname(to))
+          }
+
+          const file = createFileWriteStream(to)
+
+          // if we can't remove the file for some reason (seen on windows), that's ok -- it's in a temporary directory
+          const tryToRemoveFile = () => {
+            try {
+              if (!file.destroyed) {
+                file.destroy()
+              }
+              unlinkFileSync(to)
+              // eslint-disable-next-line no-catch-all/no-catch-all
+            } catch (err: unknown) {
+              outputDebug(outputContent`Failed to remove file ${outputToken.path(to)}: ${outputToken.raw(String(err))}`)
+            }
+          }
+
+          file.on('finish', () => {
+            file.close()
+            resolve(to)
+          })
+
+          file.on('error', (err) => {
+            tryToRemoveFile()
+            reject(err instanceof Error ? err : new Error(String(err)))
+          })
+
+          res.body.on('error', (err) => {
+            tryToRemoveFile()
+            reject(err instanceof Error ? err : new Error(String(err)))
+          })
+
           res.body.pipe(file)
         })
         .catch((err) => {
-          tryToRemoveFile()
           reject(err instanceof Error ? err : new Error(String(err)))
         })
     })

--- a/packages/cli-kit/src/public/node/http.ts
+++ b/packages/cli-kit/src/public/node/http.ts
@@ -254,7 +254,15 @@ export function downloadFile(url: string, to: string): Promise<string> {
 
       nodeFetch(url, {redirect: 'follow'})
         .then((res) => {
-          res.body?.pipe(file)
+          if (!res.ok) {
+            tryToRemoveFile()
+            return reject(new Error(`Failed to download file from ${sanitizedUrl}: ${res.status} ${res.statusText}`))
+          }
+          if (!res.body) {
+            tryToRemoveFile()
+            return reject(new Error(`Failed to download file from ${sanitizedUrl}: Empty response body`))
+          }
+          res.body.pipe(file)
         })
         .catch((err) => {
           tryToRemoveFile()


### PR DESCRIPTION
### WHY are these changes introduced?

Context about the problem that's being addressed:
The `downloadFile` function did not validate the HTTP response status, potentially leading to cases where an error page (e.g., 404 or 500) was saved to disk as if it were the intended file.

### WHAT is this pull request doing?

Summary of the changes committed:
Hardened `downloadFile` in `packages/cli-kit/src/public/node/http.ts` by adding checks for `res.ok` and `res.body`. If these checks fail, the partially downloaded file is removed and the promise is rejected with a descriptive error message. Added a regression test in `packages/cli-kit/src/public/node/http.test.ts`.

### How to test your changes?

CI

### Post-release steps

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [1835591128841729605](https://jules.google.com/task/1835591128841729605) started by @gonzaloriestra*