### PR TITLE
Add `requiredIfNonInteractive` flag factory and apply to `app init --template`

### DIFF
--- a/packages/app/src/cli/commands/app/init.ts
+++ b/packages/app/src/cli/commands/app/init.ts
@@ -10,7 +10,7 @@ import {appNamePrompt, createAsNewAppPrompt, selectAppPrompt} from '../../prompt
 import {searchForAppsByNameFactory} from '../../services/dev/prompt-helpers.js'
 import {isValidName} from '../../models/app/validation/common.js'
 import {Flags} from '@oclif/core'
-import {globalFlags} from '@shopify/cli-kit/node/cli'
+import {globalFlags, requiredIfNonInteractive} from '@shopify/cli-kit/node/cli'
 import {resolvePath, cwd} from '@shopify/cli-kit/node/path'
 import {addPublicMetadata} from '@shopify/cli-kit/node/metadata'
 
@@ -38,12 +38,14 @@ export default class Init extends AppLinkedCommand {
       default: async () => cwd(),
       hidden: false,
     }),
-    template: Flags.string({
-      description: `The app template. Accepts one of the following:
+    template: requiredIfNonInteractive(
+      Flags.string({
+        description: `The app template. Accepts one of the following:
        - <${visibleTemplates.join('|')}>
        - Any GitHub repo with optional branch and subpath, e.g., https://github.com/Shopify/<repository>/[subpath]#[branch]`,
-      env: 'SHOPIFY_FLAG_TEMPLATE',
-    }),
+        env: 'SHOPIFY_FLAG_TEMPLATE',
+      }),
+    ),
     flavor: Flags.string({
       description: 'Which flavor of the given template to use.',
       env: 'SHOPIFY_FLAG_TEMPLATE_FLAVOR',

--- a/packages/cli-kit/src/public/node/base-command.ts
+++ b/packages/cli-kit/src/public/node/base-command.ts
@@ -105,6 +105,7 @@ abstract class BaseCommand extends Command {
     let result = await super.parse<TFlags, TGlobalFlags, TArgs>(options, argv)
     result = await this.resultWithEnvironment<TFlags, TGlobalFlags, TArgs>(result, options, argv)
     await addFromParsedFlags(result.flags)
+    this.failMissingNonTTYFlags(result.flags, this.nonInteractiveRequiredFlags())
     return {...result, ...{argv: result.argv as string[]}}
   }
 
@@ -128,6 +129,17 @@ This flag is required in non-interactive terminal environments, such as a CI env
         )
       }
     })
+  }
+
+  // Collects the names of flags marked with the `requiredIfNonInteractive` factory (see
+  // `requiredIfNonInteractive` in `cli.ts`). The custom property is read from the live command class
+  // rather than the cached manifest, where it would have been stripped.
+  private nonInteractiveRequiredFlags(): string[] {
+    const ctor = this.constructor as unknown as {flags?: FlagInput; baseFlags?: FlagInput}
+    const allFlags = {...ctor.baseFlags, ...ctor.flags}
+    return Object.entries(allFlags)
+      .filter(([, flag]) => Boolean((flag as {requiredIfNonInteractive?: boolean}).requiredIfNonInteractive))
+      .map(([name]) => name)
   }
 
   private async resultWithEnvironment<

--- a/packages/cli-kit/src/public/node/cli.ts
+++ b/packages/cli-kit/src/public/node/cli.ts
@@ -167,6 +167,32 @@ export const portFlag = (options: {description?: string; env?: string; hidden?: 
 }
 
 /**
+ * Marks a flag as required when the CLI runs in a non-interactive terminal (e.g. CI, or piped input).
+ *
+ * The flag stays optional in interactive sessions, where the command can prompt for the value. In
+ * non-interactive sessions `BaseCommand` fails with a clear error if the flag is missing. The factory
+ * also prepends `(required if non-interactive)` to the flag's description so the requirement shows up
+ * in `--help`, mirroring how oclif renders `(required)`.
+ *
+ * Wrap any oclif flag definition with it, for example:
+ *
+ * ```
+ *   template: requiredIfNonInteractive(Flags.string({description: 'The app template.'}))
+ * ```
+ * @param flag - A flag definition created with `Flags.string`, `Flags.boolean`, etc.
+ * @returns The same flag definition, annotated for non-interactive validation and help rendering.
+ */
+export function requiredIfNonInteractive<TFlag extends {description?: string}>(flag: TFlag): TFlag {
+  // Mutate the freshly-built flag in place: this keeps the original flag type intact (so command
+  // flag typings are unchanged) while attaching a custom property the parser ignores but
+  // `BaseCommand` reads from the live command class at parse time.
+  const annotated = flag as TFlag & {requiredIfNonInteractive?: boolean}
+  annotated.requiredIfNonInteractive = true
+  annotated.description = ['(required if non-interactive)', flag.description].filter(Boolean).join(' ')
+  return annotated
+}
+
+/**
  * Clear the CLI cache, used to store some API responses and handle notifications status
  */
 export async function clearCache(): Promise<void> {

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -852,7 +852,8 @@ FLAGS
       --no-color                  [env: SHOPIFY_FLAG_NO_COLOR] Disable color output.
       --organization-id=<value>   [env: SHOPIFY_FLAG_ORGANIZATION_ID] The organization ID. Your organization ID can be
                                   found in your Dev Dashboard URL: https://dev.shopify.com/dashboard/<organization-id>
-      --template=<value>          [env: SHOPIFY_FLAG_TEMPLATE] The app template. Accepts one of the following:
+      --template=<value>          [env: SHOPIFY_FLAG_TEMPLATE] (required if non-interactive) The app template. Accepts
+                                  one of the following:
                                   - <reactRouter|none>
                                   - Any GitHub repo with optional branch and subpath, e.g.,
                                   https://github.com/Shopify/<repository>/[subpath]#[branch]

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -2499,7 +2499,7 @@
           "type": "option"
         },
         "template": {
-          "description": "The app template. Accepts one of the following:\n       - <reactRouter|none>\n       - Any GitHub repo with optional branch and subpath, e.g., https://github.com/Shopify/<repository>/[subpath]#[branch]",
+          "description": "(required if non-interactive) The app template. Accepts one of the following:\n       - <reactRouter|none>\n       - Any GitHub repo with optional branch and subpath, e.g., https://github.com/Shopify/<repository>/[subpath]#[branch]",
           "env": "SHOPIFY_FLAG_TEMPLATE",
           "hasDynamicHelp": false,
           "multiple": false,

--- a/packages/create-app/oclif.manifest.json
+++ b/packages/create-app/oclif.manifest.json
@@ -90,7 +90,7 @@
           "type": "option"
         },
         "template": {
-          "description": "The app template. Accepts one of the following:\n       - <reactRouter|none>\n       - Any GitHub repo with optional branch and subpath, e.g., https://github.com/Shopify/<repository>/[subpath]#[branch]",
+          "description": "(required if non-interactive) The app template. Accepts one of the following:\n       - <reactRouter|none>\n       - Any GitHub repo with optional branch and subpath, e.g., https://github.com/Shopify/<repository>/[subpath]#[branch]",
           "env": "SHOPIFY_FLAG_TEMPLATE",
           "hasDynamicHelp": false,
           "multiple": false,


### PR DESCRIPTION
### WHY are these changes introduced?

Related to https://github.com/shop/issues-develop/issues/22928

Some flags shouldn't be strictly `required` (the command can prompt for them in an interactive session), but they *must* be supplied when the CLI runs non-interactively (CI, or piped input). Today `BaseCommand` already has `failMissingNonTTYFlags()`, but each command has to pass a hardcoded list of flag names, and there's no way to surface the requirement in `--help`.

### WHAT is this pull request doing?

Introduces a `requiredIfNonInteractive` flag factory in cli-kit and wires it into the base command, and applies it to `app init --template` as the first usage.

#### Design note

The custom `requiredIfNonInteractive` property is read from the live command class at parse time, because it is **stripped from the cached oclif manifest** (`cacheFlags` only copies an allowlist of known properties). The help annotation instead lives in `description` — a cached field — so it survives manifest generation. This is why the manifest diff shows the new description but not the custom property.

### How to test your changes?

In a non-interactive shell (no TTY / CI):

```
$ shopify app init --path /tmp/new-app
#  ✖ Flag not specified: template
#    This flag is required in non-interactive terminal environments...
```

`shopify app init --help` shows:

```
--template=<value>
    (required if non-interactive) The app template. Accepts one of the following:
    ...
```

In an interactive terminal, `app init` still prompts for the template as before.

### Measuring impact

- [x] No impact on usage metrics

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've added a changeset if changes are user-facing
- [ ] I've added a test to cover my changes, if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)