### PR TITLE
[Refactor] Use uniq helper in app management client

### DIFF
--- a/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
@@ -158,6 +158,7 @@ import {
   businessPlatformRequestDoc,
   BusinessPlatformRequestOptions,
 } from '@shopify/cli-kit/node/api/business-platform'
+import {uniq} from '@shopify/cli-kit/common/array'
 import {CLI_KIT_VERSION} from '@shopify/cli-kit/common/version'
 import {versionSatisfies} from '@shopify/cli-kit/node/node-package-manager'
 import {outputDebug} from '@shopify/cli-kit/node/output'
@@ -1336,8 +1337,8 @@ export async function allowedTemplates(
   version: string = CLI_KIT_VERSION,
 ): Promise<GatedExtensionTemplate[]> {
   // Extract both types of flags from templates
-  const allBetaFlags = Array.from(new Set(templates.map((ext) => ext.organizationBetaFlags ?? []).flat()))
-  const allExpFlags = Array.from(new Set(templates.map((ext) => ext.organizationExpFlags ?? []).flat()))
+  const allBetaFlags = uniq(templates.map((ext) => ext.organizationBetaFlags ?? []).flat())
+  const allExpFlags = uniq(templates.map((ext) => ext.organizationExpFlags ?? []).flat())
 
   // Fetch both flag types in parallel
   const [enabledBetaFlags, enabledExpFlags] = await Promise.all([


### PR DESCRIPTION
### WHY are these changes introduced?

This refactor replaces manual `Array.from(new Set(...))` deduplication logic with the standardized `uniq` helper from `@shopify/cli-kit/common/array`. This improves code consistency and readability by using existing project utilities.

### WHAT is this pull request doing?

- Imports the `uniq` helper in `packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts`.
- Replaces manual Set-based deduplication for `allBetaFlags` and `allExpFlags` in the `allowedTemplates` function with the `uniq` utility.

### How to test your changes?

CI

### Post-release steps

None.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [11757100007447729076](https://jules.google.com/task/11757100007447729076) started by @gonzaloriestra*