### PR TITLE
[Performance] Memoize isWsl

### DIFF
--- a/packages/cli-kit/src/public/node/system.test.ts
+++ b/packages/cli-kit/src/public/node/system.test.ts
@@ -393,3 +393,26 @@ describe('readStdinString', () => {
     await expect(got).rejects.toThrow('Stdin input exceeded the maximum allowed size.')
   })
 })
+
+describe('isWsl', () => {
+  test('memoizes the result', async () => {
+    // Given
+    vi.doMock('is-wsl', () => ({default: true}))
+
+    // When
+    const firstCall = await system.isWsl()
+
+    // Then
+    expect(firstCall).toBe(true)
+
+    // Given
+    // We change the mock value. If it's memoized, it should still return the first value.
+    vi.doMock('is-wsl', () => ({default: false}))
+
+    // When
+    const secondCall = await system.isWsl()
+
+    // Then
+    expect(secondCall).toBe(true)
+  })
+})

--- a/packages/cli-kit/src/public/node/system.ts
+++ b/packages/cli-kit/src/public/node/system.ts
@@ -352,13 +352,17 @@ export function isCI(): boolean {
 }
 
 /**
+ * Memoized value for the WSL check.
+ */
+let memoizedIsWsl: Promise<boolean> | undefined
+
+/**
  * Check if the current environment is a WSL environment.
  *
  * @returns True if the current environment is a WSL environment.
  */
 export async function isWsl(): Promise<boolean> {
-  const wsl = await import('is-wsl')
-  return wsl.default
+  return (memoizedIsWsl ??= import('is-wsl').then((wsl) => wsl.default))
 }
 
 /**


### PR DESCRIPTION
### WHY are these changes introduced?

The `isWsl` function is called during analytics generation and other environment-sensitive paths. Each call triggers a dynamic import of the `is-wsl` package and repeated environment/filesystem checks.

### WHAT is this pull request doing?

This PR memoizes the `isWsl` function by caching the Promise of the dynamic import in a module-level variable. This ensures the import and environment check happen only once per process execution.

### How to test your changes?

CI

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [13826024206793621349](https://jules.google.com/task/13826024206793621349) started by @gonzaloriestra*