### PR TITLE
Remove minimatch from cli-kit; consolidate path helpers via path.ts (pathe 2.0.3)

### DIFF
--- a/.changeset/remove-cli-kit-minimatch.md
+++ b/.changeset/remove-cli-kit-minimatch.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': patch
+---
+
+Remove the minimatch dependency from cli-kit glob matching.

--- a/.changeset/remove-cli-kit-minimatch.md
+++ b/.changeset/remove-cli-kit-minimatch.md
@@ -1,5 +1,0 @@
----
-'@shopify/cli-kit': patch
----
-
-Remove the minimatch dependency from cli-kit glob matching.

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "nx": "22.7.0",
     "oclif": "4.23.0",
     "octokit-plugin-create-pull-request": "^3.12.2",
-    "pathe": "1.1.1",
+    "pathe": "2.0.3",
     "pin-github-action": "^3.3.1",
     "rimraf": "^6.1.3",
     "ts-node": "^10.9.1",

--- a/packages/cli-kit/package.json
+++ b/packages/cli-kit/package.json
@@ -148,7 +148,7 @@
     "node-abort-controller": "3.1.1",
     "node-fetch": "3.3.2",
     "open": "8.4.2",
-    "pathe": "1.1.2",
+    "pathe": "2.0.3",
     "react": "19.2.4",
     "semver": "7.6.3",
     "stacktracey": "2.1.8",

--- a/packages/cli-kit/package.json
+++ b/packages/cli-kit/package.json
@@ -143,7 +143,6 @@
     "liquidjs": "10.26.0",
     "lodash": "4.17.23",
     "macaddress": "0.5.3",
-    "minimatch": "9.0.8",
     "mrmime": "1.0.1",
     "network-interfaces": "1.1.0",
     "node-abort-controller": "3.1.1",

--- a/packages/cli-kit/src/public/node/fs.test.ts
+++ b/packages/cli-kit/src/public/node/fs.test.ts
@@ -22,6 +22,7 @@ import {
   copyDirectoryContents,
   symlink,
   fileRealPath,
+  matchGlob,
 } from './fs.js'
 import {joinPath, normalizePath} from './path.js'
 import * as array from '../common/array.js'
@@ -316,6 +317,41 @@ describe('glob', () => {
       expect(got.map((path) => normalizePath(path))).toContain(normalizePath(filePath))
       expect(got.map((path) => normalizePath(path))).not.toContain(normalizePath(dotFilePath))
     })
+  })
+})
+
+describe('matchGlob', () => {
+  test('matches liquid file patterns with native Node glob semantics', () => {
+    expect(matchGlob('theme.liquid', '*.liquid')).toBe(true)
+    expect(matchGlob('layout/theme.liquid', '*.liquid')).toBe(false)
+    expect(matchGlob('layout/theme.liquid', '**/*.liquid')).toBe(true)
+    expect(matchGlob('assets/theme.css', '*.liquid')).toBe(false)
+  })
+
+  test('matches watch-style globs used by extension file watching', () => {
+    expect(matchGlob('src/main.rs', 'src/**/*.rs')).toBe(true)
+    expect(matchGlob('src/lib/main.rs', 'src/**/*.rs')).toBe(true)
+    expect(matchGlob('src/main.ts', 'src/**/*.rs')).toBe(false)
+    expect(matchGlob('/tmp/my-function/src/main.rs', '/tmp/my-function/src/**/*.rs')).toBe(true)
+    expect(matchGlob('/tmp/my-function/src/lib/main.rs', '/tmp/my-function/src/**/*.rs')).toBe(true)
+  })
+
+  test('matches project config selection globs', () => {
+    expect(matchGlob('extensions/my-ext/shopify.extension.toml', 'extensions/*/*.extension.toml')).toBe(true)
+    expect(matchGlob('extensions/nested/my-ext/shopify.extension.toml', 'extensions/*/*.extension.toml')).toBe(false)
+    expect(matchGlob('web/shopify.web.toml', '**/shopify.web.toml')).toBe(true)
+  })
+
+  test('supports matchBase for theme ignore patterns', () => {
+    expect(matchGlob('assets/theme.css', '*.css', {matchBase: true, noglobstar: true})).toBe(true)
+    expect(matchGlob('assets/theme.css', '*.liquid', {matchBase: true, noglobstar: true})).toBe(false)
+  })
+
+  test('supports noglobstar for theme ignore patterns', () => {
+    expect(
+      matchGlob('templates/customers/account.json', 'templates/**/*.json', {matchBase: true, noglobstar: true}),
+    ).toBe(true)
+    expect(matchGlob('templates/404.json', 'templates/**/*.json', {matchBase: true, noglobstar: true})).toBe(false)
   })
 })
 

--- a/packages/cli-kit/src/public/node/fs.ts
+++ b/packages/cli-kit/src/public/node/fs.ts
@@ -16,8 +16,9 @@ import {
 
 import {sep, join} from 'pathe'
 import {findUp as internalFindUp, findUpSync as internalFindUpSync} from 'find-up'
-import {minimatch} from 'minimatch'
 import fastGlobLib from 'fast-glob'
+// eslint-disable-next-line no-restricted-imports -- Node 22 native glob matching is not wrapped by cli-kit path helpers.
+import * as nodePath from 'node:path'
 import {
   mkdirSync as fsMkdirSync,
   readFileSync as fsReadFileSync,
@@ -688,9 +689,11 @@ export function findPathUpSync(
 }
 
 export interface MatchGlobOptions {
-  matchBase: boolean
-  noglobstar: boolean
+  matchBase?: boolean
+  noglobstar?: boolean
 }
+
+const {matchesGlob} = nodePath as typeof nodePath & {matchesGlob(path: string, pattern: string): boolean}
 
 /**
  * Matches a key against a glob pattern.
@@ -699,8 +702,31 @@ export interface MatchGlobOptions {
  * @param options - The options to refine the matching approach.
  * @returns true if the key matches the pattern, false otherwise.
  */
-export function matchGlob(key: string, pattern: string, options?: MatchGlobOptions): boolean {
-  return minimatch(key, pattern, options)
+export function matchGlob(key: string, pattern: string, options: MatchGlobOptions = {}): boolean {
+  const effectivePattern = options.noglobstar ? patternWithoutGlobstars(pattern) : pattern
+
+  if (matchesGlob(key, effectivePattern)) return true
+
+  if (options.matchBase && !hasPathSeparator(effectivePattern)) {
+    return matchesGlob(baseName(key), effectivePattern)
+  }
+
+  return false
+}
+
+function patternWithoutGlobstars(pattern: string): string {
+  return pattern
+    .split(/([/\\])/)
+    .map((part) => (part === '**' ? '*' : part))
+    .join('')
+}
+
+function hasPathSeparator(path: string): boolean {
+  return path.includes('/') || path.includes('\\')
+}
+
+function baseName(path: string): string {
+  return path.split(/[/\\]/).pop() ?? path
 }
 
 /**

--- a/packages/cli-kit/src/public/node/fs.ts
+++ b/packages/cli-kit/src/public/node/fs.ts
@@ -1,5 +1,5 @@
 import {outputContent, outputToken, outputDebug} from './output.js'
-import {joinPath, normalizePath, resolvePath} from './path.js'
+import {basename, joinPath, matchesGlob, normalizePath, resolvePath, sep} from './path.js'
 import {OverloadParameters} from '../../private/common/ts/overloaded-parameters.js'
 import {getRandomName, RandomNameFamily} from '../common/string.js'
 import {systemTempDir} from '../../private/node/temp-dir.js'
@@ -14,11 +14,8 @@ import {
   // @ts-ignore
 } from 'fs-extra/esm'
 
-import {sep, join} from 'pathe'
 import {findUp as internalFindUp, findUpSync as internalFindUpSync} from 'find-up'
 import fastGlobLib from 'fast-glob'
-// eslint-disable-next-line no-restricted-imports -- Node 22 native glob matching is not wrapped by cli-kit path helpers.
-import * as nodePath from 'node:path'
 import {
   mkdirSync as fsMkdirSync,
   readFileSync as fsReadFileSync,
@@ -68,7 +65,7 @@ import type {Pattern, Options as GlobOptions} from 'fast-glob'
  */
 export function stripUpPath(path: string, strip: number): string {
   const parts = path.split(sep)
-  return join(...parts.slice(strip))
+  return joinPath(...parts.slice(strip))
 }
 
 /**
@@ -77,7 +74,7 @@ export function stripUpPath(path: string, strip: number): string {
  * @param callback - The callback that receives the temporary directory.
  */
 export async function inTemporaryDirectory<T>(callback: (tmpDir: string) => T | Promise<T>): Promise<T> {
-  const tmpDir = await fsMkdtemp(join(systemTempDir, 'tmp-'))
+  const tmpDir = await fsMkdtemp(joinPath(systemTempDir, 'tmp-'))
   try {
     return await callback(tmpDir)
   } finally {
@@ -90,7 +87,7 @@ export async function inTemporaryDirectory<T>(callback: (tmpDir: string) => T | 
  * @returns - The path to the temporary directory.
  */
 export function tempDirectory(): string {
-  return fsMkdtempSync(join(systemTempDir, 'tmp-'))
+  return fsMkdtempSync(joinPath(systemTempDir, 'tmp-'))
 }
 
 /**
@@ -693,8 +690,6 @@ export interface MatchGlobOptions {
   noglobstar?: boolean
 }
 
-const {matchesGlob} = nodePath as typeof nodePath & {matchesGlob(path: string, pattern: string): boolean}
-
 /**
  * Matches a key against a glob pattern.
  * @param key - The key to match.
@@ -708,7 +703,7 @@ export function matchGlob(key: string, pattern: string, options: MatchGlobOption
   if (matchesGlob(key, effectivePattern)) return true
 
   if (options.matchBase && !hasPathSeparator(effectivePattern)) {
-    return matchesGlob(baseName(key), effectivePattern)
+    return matchesGlob(basename(key), effectivePattern)
   }
 
   return false
@@ -723,10 +718,6 @@ function patternWithoutGlobstars(pattern: string): string {
 
 function hasPathSeparator(path: string): boolean {
   return path.includes('/') || path.includes('\\')
-}
-
-function baseName(path: string): string {
-  return path.split(/[/\\]/).pop() ?? path
 }
 
 /**

--- a/packages/cli-kit/src/public/node/path.ts
+++ b/packages/cli-kit/src/public/node/path.ts
@@ -8,6 +8,8 @@ import {
   extname as extnamePathe,
   parse,
   isAbsolute,
+  matchesGlob as matchesGlobPathe,
+  sep as patheSep,
 } from 'pathe'
 import {fileURLToPath} from 'url'
 // eslint-disable-next-line n/prefer-global/url
@@ -93,6 +95,22 @@ export function basename(path: string, ext?: string): string {
  */
 export function extname(path: string): string {
   return extnamePathe(path)
+}
+
+/**
+ * The platform-agnostic path segment separator (always `/`, via pathe).
+ */
+export const sep = patheSep
+
+/**
+ * Determines whether a path matches a glob pattern.
+ *
+ * @param path - The path to match.
+ * @param pattern - The glob pattern (or patterns) to match against.
+ * @returns Whether the path matches the pattern.
+ */
+export function matchesGlob(path: string, pattern: string | string[]): boolean {
+  return matchesGlobPathe(path, pattern)
 }
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -420,9 +420,6 @@ importers:
       macaddress:
         specifier: 0.5.3
         version: 0.5.3
-      minimatch:
-        specifier: 9.0.8
-        version: 9.0.8
       mrmime:
         specifier: 1.0.1
         version: 1.0.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -122,8 +122,8 @@ importers:
         specifier: ^3.12.2
         version: 3.13.1
       pathe:
-        specifier: 1.1.1
-        version: 1.1.1
+        specifier: 2.0.3
+        version: 2.0.3
       pin-github-action:
         specifier: ^3.3.1
         version: 3.4.0
@@ -436,8 +436,8 @@ importers:
         specifier: 8.4.2
         version: 8.4.2
       pathe:
-        specifier: 1.1.2
-        version: 1.1.2
+        specifier: 2.0.3
+        version: 2.0.3
       react:
         specifier: 19.2.4
         version: 19.2.4
@@ -7669,14 +7669,8 @@ packages:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
 
-  pathe@1.1.1:
-    resolution: {integrity: sha512-d+RQGp0MAYTIaDBIMmOfMwz3E+LOZnxx1HZd5R18mmCZY0QBlK0LDZfPc8FW8Ed2DlvsuE6PRjroDY+wg4+j/Q==}
-
-  pathe@1.1.2:
-    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
-
   pathe@2.0.3:
-    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==, tarball: https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz}
 
   pathval@2.0.1:
     resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
@@ -17666,10 +17660,6 @@ snapshots:
   path-to-regexp@6.3.0: {}
 
   path-type@4.0.0: {}
-
-  pathe@1.1.1: {}
-
-  pathe@1.1.2: {}
 
   pathe@2.0.3: {}
 


### PR DESCRIPTION
## What
Removes the `minimatch` dependency from `@shopify/cli-kit`, replacing its glob matching with `pathe`'s `matchesGlob`, and routes all of `fs.ts`'s path operations through the `path.ts` wrapper. Also upgrades `pathe` `1.1.x → 2.0.3`.

## Why
Reduce Dependabot churn — `minimatch` saw **~58 version bumps in 24 months**. Part of an automated CLI dependency-removal initiative.

While here: `fs.ts` had been importing `sep`/`join`/`basename` from `pathe` and `matchesGlob` from `node:path` directly, bypassing the `path.ts` wrapper that exists to give us a single, cross-env source of truth (`pathe` normalizes separators across dev environments). `pathe` 2.0.3 adds a native, typed, cross-env `matchesGlob`, so `path.ts` can wrap it too — `fs.ts` no longer touches `node:path` or `pathe` directly.

## How
- `path.ts` now also wraps `matchesGlob` and `sep` — it is the single place that touches the underlying path library.
- `matchGlob()` in `fs.ts` uses `path.ts`'s `matchesGlob`; the hand-rolled `baseName` is replaced by `pathe`'s cross-env `basename`; `join` → `joinPath`.
- ⚠️ **Reviewer note:** the original audit assumed `MatchGlobOptions` (`matchBase`/`noglobstar`) was unused, but a real caller passes them. `matchesGlob` takes no options, so they are emulated:
  - `noglobstar`: rewrite `**` → `*` in the pattern.
  - `matchBase`: when the pattern has no path separator, also match against the basename.
- Added parity tests in `fs.test.ts`.
- Side effect of the bump: `pathe` 2 fixes the Windows `PATH` delimiter (`:` → `;`) used by `system.ts`'s binary safety check.
- No changeset — the change is transparent to users (glob semantics preserved; internal dependency swap).

## Validation
`type-check` ✅ · `lint` ✅ · full `cli-kit` suite ✅ (1417 passed / 2 skipped, incl. glob parity tests).

🤖 Automated dependency-removal initiative — AI-generated draft, **needs human review**. Please double-check glob-semantics parity (dotfiles / negation / braces) and the `matchBase`/`noglobstar` emulation.
