### PR TITLE
Remove jose from cli-kit (inline guarded JWT decode)

### DIFF
--- a/.changeset/remove-cli-kit-jose.md
+++ b/.changeset/remove-cli-kit-jose.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': patch
+---
+
+Removed the `jose` dependency from `@shopify/cli-kit` by inlining guarded JWT payload decoding for session user ID extraction. The session exchange path now validates token structure and payload shape before reading `sub`, including malformed-token handling in tests.

--- a/packages/cli-kit/package.json
+++ b/packages/cli-kit/package.json
@@ -138,7 +138,6 @@
     "ink": "6.8.0",
     "is-executable": "2.0.1",
     "is-wsl": "3.1.0",
-    "jose": "5.9.6",
     "latest-version": "7.0.0",
     "liquidjs": "10.26.0",
     "lodash": "4.17.23",

--- a/packages/cli-kit/src/private/node/session/exchange.test.ts
+++ b/packages/cli-kit/src/private/node/session/exchange.test.ts
@@ -1,5 +1,6 @@
 import {
   exchangeAccessForApplicationTokens,
+  exchangeDeviceCodeForAccessToken,
   exchangeCustomPartnerToken,
   exchangeAppAutomationTokenForAppManagementAccessToken,
   exchangeAppAutomationTokenForBusinessPlatformAccessToken,
@@ -234,6 +235,58 @@ describe('refresh access tokens', () => {
     expect(result.userId).toBe('1234-5678')
     // Alias is preserved
     expect(result.alias).toBe('my-custom-alias')
+  })
+})
+
+describe('exchange device code for access token', () => {
+  test('extracts sub from id_token when existingUserId is absent', async () => {
+    vi.mocked(shopifyFetch).mockResolvedValue(new Response(JSON.stringify(data)))
+
+    const result = await exchangeDeviceCodeForAccessToken('device-code')
+
+    expect(result.isErr()).toBe(false)
+    expect(result.valueOrBug()).toEqual({
+      accessToken: data.access_token,
+      refreshToken: data.refresh_token,
+      expiresAt: expiredDate,
+      scopes: data.scope.split(' '),
+      userId: '1234-5678',
+      alias: undefined,
+    })
+  })
+
+  test.each([
+    {
+      title: 'JWT does not have exactly 3 segments',
+      idToken: 'not-a-jwt',
+      expectedMessage: 'Invalid id_token: expected JWT with exactly 3 segments.',
+    },
+    {
+      title: 'payload is not base64url-encoded JSON',
+      idToken: 'header.invalid-payload.signature',
+      expectedMessage: 'Invalid id_token: payload must be base64url-encoded JSON.',
+    },
+    {
+      title: 'payload is a JSON string',
+      idToken: 'header.InN0cmluZyI.signature',
+      expectedMessage: 'Invalid id_token: payload must be a non-empty JSON object.',
+    },
+    {
+      title: 'payload is an empty object',
+      idToken: 'header.e30.signature',
+      expectedMessage: 'Invalid id_token: payload must be a non-empty JSON object.',
+    },
+  ])('throws when $title', async ({idToken, expectedMessage}) => {
+    vi.mocked(shopifyFetch).mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          ...data,
+          id_token: idToken,
+        }),
+      ),
+    )
+
+    await expect(exchangeDeviceCodeForAccessToken('device-code')).rejects.toThrow(expectedMessage)
   })
 })
 

--- a/packages/cli-kit/src/private/node/session/exchange.ts
+++ b/packages/cli-kit/src/private/node/session/exchange.ts
@@ -9,8 +9,6 @@ import {AbortError, BugError, ExtendableError} from '../../../public/node/error.
 import {setLastSeenAuthMethod, setLastSeenUserIdAfterAuth} from '../session.js'
 import {nonRandomUUID} from '../../../public/node/crypto.js'
 
-import * as jose from 'jose'
-
 export class InvalidGrantError extends ExtendableError {}
 export class InvalidRequestError extends ExtendableError {}
 class InvalidTargetError extends AbortError {}
@@ -262,7 +260,7 @@ function buildIdentityToken(
   existingUserId?: string,
   existingAlias?: string,
 ): IdentityToken {
-  const userId = existingUserId ?? (result.id_token ? jose.decodeJwt(result.id_token).sub! : undefined)
+  const userId = existingUserId ?? (result.id_token ? getJwtSubject(result.id_token) : undefined)
 
   if (!userId) {
     throw new BugError('Error setting userId for session. No id_token or pre-existing user ID provided.')
@@ -284,4 +282,31 @@ function buildApplicationToken(result: TokenRequestResult): ApplicationToken {
     expiresAt: new Date(Date.now() + result.expires_in * 1000),
     scopes: result.scope.split(' '),
   }
+}
+
+function getJwtSubject(idToken: string): string | undefined {
+  const segments = idToken.split('.')
+
+  if (segments.length !== 3) {
+    throw new BugError('Invalid id_token: expected JWT with exactly 3 segments.')
+  }
+
+  const payload = segments[1] as string
+
+  let parsedPayload: unknown
+  try {
+    parsedPayload = JSON.parse(Buffer.from(payload, 'base64url').toString('utf8'))
+  } catch {
+    throw new BugError('Invalid id_token: payload must be base64url-encoded JSON.')
+  }
+
+  if (!parsedPayload || typeof parsedPayload !== 'object' || Array.isArray(parsedPayload)) {
+    throw new BugError('Invalid id_token: payload must be a non-empty JSON object.')
+  }
+
+  if (Object.keys(parsedPayload).length === 0) {
+    throw new BugError('Invalid id_token: payload must be a non-empty JSON object.')
+  }
+
+  return (parsedPayload as {sub?: string}).sub
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -405,9 +405,6 @@ importers:
       is-wsl:
         specifier: 3.1.0
         version: 3.1.0
-      jose:
-        specifier: 5.9.6
-        version: 5.9.6
       latest-version:
         specifier: 7.0.0
         version: 7.0.0
@@ -6755,9 +6752,6 @@ packages:
 
   jju@1.4.0:
     resolution: {integrity: sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==}
-
-  jose@5.9.6:
-    resolution: {integrity: sha512-AMlnetc9+CV9asI19zHmrgS/WYsWUwCn2R7RzlbJWD7F9eWYUTGyBmU9o6PxngtLGOiDGPRu+Uc4fhKzbpteZQ==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -16595,8 +16589,6 @@ snapshots:
   jiti@2.6.1: {}
 
   jju@1.4.0: {}
-
-  jose@5.9.6: {}
 
   js-tokens@4.0.0: {}
 


### PR DESCRIPTION
## Remove `jose` from `@shopify/cli-kit`

**Why:** Part of an initiative to cut low-value dependency churn (**13 Dependabot bumps / 24 months**). Notably, this code path only ever **decoded** an `id_token` payload — it never verified signatures, so the full `jose` library was overkill.

**Replacement:** A guarded inline base64url JWT-payload decoder.
- Sole site: `packages/cli-kit/src/private/node/session/exchange.ts` — `jose.decodeJwt(result.id_token).sub` → `getJwtSubject(idToken)`.
- **Guards (security-relevant):** requires exactly 3 JWT segments; decodes the payload with `Buffer.from(payload, 'base64url')` (engines.node ≥ 22.12); `JSON.parse` wrapped in try/catch; **rejects non-object / array / empty-object payloads before reading `.sub`** (avoids the `String.prototype.sub` hazard a string payload would trigger).
- Returns `string | undefined`; the existing caller's `if (!userId) throw new BugError(...)` already handles a missing subject — safer than the prior `.sub!` non-null assertion.

**Tests:** The decode path was **previously untested**. Added coverage in `exchange.test.ts` for `exchangeDeviceCodeForAccessToken` without an `existingUserId` (the path that triggers the decode) plus malformed-token guard cases.

**Validation:** `type-check` ✅, `lint` ✅, `vitest` ✅ (1 file, 19 tests, 0 failed).

🤖 AI-generated draft — needs human review before merge.
