### PR TITLE
[Performance] Memoize username

### DIFF
--- a/packages/cli-kit/src/public/node/os.test.ts
+++ b/packages/cli-kit/src/public/node/os.test.ts
@@ -1,7 +1,45 @@
-import {platformAndArch} from './os.js'
-import {describe, test, expect, vi} from 'vitest'
+import {platformAndArch, username} from './os.js'
+import {describe, test, expect, vi, beforeEach, afterEach} from 'vitest'
+import {userInfo} from 'os'
 
 vi.mock('node:process')
+vi.mock('os', async (importOriginal) => {
+  const original: any = await importOriginal()
+  return {
+    ...original,
+    userInfo: vi.fn(),
+  }
+})
+
+describe('username', () => {
+  beforeEach(() => {
+    vi.mocked(userInfo).mockReturnValue({
+      username: 'test-user',
+      uid: 1,
+      gid: 1,
+      shell: 'sh',
+      homedir: '/home/test-user',
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  test('returns the username and memoizes it', async () => {
+    // Given
+    vi.stubEnv('SUDO_USER', 'test-user')
+
+    // When
+    const result1 = await username()
+    const result2 = await username()
+
+    // Then
+    expect(result1).toBe('test-user')
+    expect(result2).toBe('test-user')
+    expect(username()).toBe(username())
+  })
+})
 
 describe('platformAndArch', () => {
   test("returns the right architecture when it's x64", () => {

--- a/packages/cli-kit/src/public/node/os.ts
+++ b/packages/cli-kit/src/public/node/os.ts
@@ -5,11 +5,24 @@ import {userInfo as osUserInfo} from 'os'
 // This code has been vendored from https://github.com/sindresorhus/username
 // because adding it as a transtive dependency causes conflicts with other
 // packages that haven't been yet migrated to the latest version.
+
+/**
+ * Memoized value for the username.
+ */
+let memoizedUsername: Promise<string | null> | undefined
+
 /**
  * @param platform - The platform to get the username for. Defaults to the current platform.
  * @returns The username of the current user.
  */
-export async function username(platform: typeof process.platform = process.platform): Promise<string | null> {
+export function username(platform: typeof process.platform = process.platform): Promise<string | null> {
+  if (platform === process.platform) {
+    return (memoizedUsername ??= getUsername(platform))
+  }
+  return getUsername(platform)
+}
+
+async function getUsername(platform: typeof process.platform): Promise<string | null> {
   outputDebug(outputContent`Obtaining user name...`)
   const environmentVariable = getEnvironmentVariable()
   if (environmentVariable) {


### PR DESCRIPTION
### WHY are these changes introduced?

The `username` function performs environment lookups, `os.userInfo()` calls, and potential `execa` calls which are expensive. Since the username is static during the CLI execution, memoizing the result improves efficiency.

### WHAT is this pull request doing?

This PR implements memoization for the `username` function in `packages/cli-kit/src/public/node/os.ts` by caching the resulting Promise in a module-level variable.

### How to test your changes?

CI

### Post-release steps

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`


---
*PR created automatically by Jules for task [5748205486080182555](https://jules.google.com/task/5748205486080182555) started by @gonzaloriestra*