### PR TITLE
[Performance] Memoize isWsl

### DIFF
--- a/packages/cli-kit/src/public/node/system.test.ts
+++ b/packages/cli-kit/src/public/node/system.test.ts
@@ -393,3 +393,15 @@ describe('readStdinString', () => {
     await expect(got).rejects.toThrow('Stdin input exceeded the maximum allowed size.')
   })
 })
+
+describe('isWsl', () => {
+  test('memoizes the result', async () => {
+    // When
+    const firstCall = system.isWsl()
+    const secondCall = system.isWsl()
+
+    // Then
+    expect(firstCall).toBe(secondCall)
+    await expect(firstCall).resolves.toBe(await secondCall)
+  })
+})

--- a/packages/cli-kit/src/public/node/system.ts
+++ b/packages/cli-kit/src/public/node/system.ts
@@ -98,9 +98,9 @@ export interface CaptureOutputResult {
  * @example
  * ```typescript
  * const result = await captureOutputWithExitCode('ls', ['-la'])
- * if (result.exitCode !== 0) \{
+ * if (result.exitCode !== 0) {
  *   console.error('Command failed:', result.stderr)
- * \}
+ * }
  * ```
  */
 export async function captureOutputWithExitCode(
@@ -352,13 +352,22 @@ export function isCI(): boolean {
 }
 
 /**
+ * Memoized value for the WSL check.
+ */
+let memoizedIsWsl: Promise<boolean> | undefined
+
+/**
  * Check if the current environment is a WSL environment.
  *
  * @returns True if the current environment is a WSL environment.
  */
-export async function isWsl(): Promise<boolean> {
-  const wsl = await import('is-wsl')
-  return wsl.default
+export function isWsl(): Promise<boolean> {
+  // Memoize the promise to avoid redundant dynamic imports and filesystem/environment checks.
+  // This is checked frequently during analytics generation.
+  return (memoizedIsWsl ??= (async () => {
+    const wsl = await import('is-wsl')
+    return wsl.default
+  })())
 }
 
 /**


### PR DESCRIPTION
### Why is this change necessary?
The \`isWsl\` function performs a dynamic import and checks environment variables/filesystem to determine if the environment is WSL. This check is performed frequently, particularly during analytics generation.

### Performance Impact
Memoizing the result avoids redundant dynamic imports and system probes after the first call, reducing CPU and I/O overhead in high-frequency execution paths.

### How to test your changes?
CI

---
*PR created automatically by Jules for task [3156475889461505530](https://jules.google.com/task/3156475889461505530) started by @gonzaloriestra*