### PR TITLE
[Tests] Remove filesystem mocks in dev-session-process.test.ts

### DIFF
--- a/packages/app/src/cli/services/dev/processes/dev-session/dev-session-process.test.ts
+++ b/packages/app/src/cli/services/dev/processes/dev-session/dev-session-process.test.ts
@@ -1,4 +1,4 @@
-import {setupDevSessionProcess, pushUpdatesForDevSession} from './dev-session-process.js'
+import {setupDevSessionProcess, pushUpdatesForDevSession, DevSessionProcessOptions} from './dev-session-process.js'
 import {DevSessionStatusManager} from './dev-session-status-manager.js'
 import {DeveloperPlatformClient} from '../../../../utilities/developer-platform-client.js'
 import {AppLinkedInterface} from '../../../../models/app/app.js'
@@ -15,15 +15,15 @@ import {
 } from '../../../../models/app/app.test-data.js'
 import {getUploadURL, writeManifestToBundle} from '../../../bundle.js'
 import {formData} from '@shopify/cli-kit/node/http'
-import {describe, expect, test, vi, beforeEach, afterEach} from 'vitest'
+import {describe, expect, test, vi} from 'vitest'
 import {AbortSignal, AbortController} from '@shopify/cli-kit/node/abort'
 import {flushPromises} from '@shopify/cli-kit/node/promises'
 import * as outputContext from '@shopify/cli-kit/node/ui/components'
-import {readdir} from '@shopify/cli-kit/node/fs'
+import {inTemporaryDirectory, mkdir} from '@shopify/cli-kit/node/fs'
 import {firstPartyDev} from '@shopify/cli-kit/node/context/local'
 import {SerialBatchProcessor} from '@shopify/cli-kit/node/serial-batch-processor'
+import {joinPath} from '@shopify/cli-kit/node/path'
 
-vi.mock('@shopify/cli-kit/node/fs')
 vi.mock('@shopify/cli-kit/node/archiver')
 vi.mock('@shopify/cli-kit/node/http')
 vi.mock('../../../../utilities/app/app-url.js')
@@ -80,734 +80,889 @@ describe('setupDevSessionProcess', () => {
 })
 
 describe('pushUpdatesForDevSession', () => {
-  let stdout: any
-  let stderr: any
-  let options: any
-  let developerPlatformClient: any
-  let appWatcher: AppEventWatcher
-  let app: AppLinkedInterface
-  let abortController: AbortController
-  let devSessionStatusManager: DevSessionStatusManager
-
-  beforeEach(() => {
-    vi.mocked(formData).mockReturnValue({append: vi.fn(), getHeaders: vi.fn()} as any)
-    stdout = {write: vi.fn()}
-    stderr = {write: vi.fn()}
-    developerPlatformClient = testDeveloperPlatformClient()
-    app = testAppLinked()
-    appWatcher = new AppEventWatcher(app)
-    abortController = new AbortController()
-    devSessionStatusManager = new DevSessionStatusManager()
-    options = {
-      app: {} as AppLinkedInterface,
-      apiKey: 'test-api-key',
-      developerPlatformClient,
-      appWatcher,
-      storeFqdn: 'test.myshopify.com',
-      url: 'https://test.dev',
-      appId: 'app123',
-      organizationId: 'org123',
-      appPreviewURL: 'https://test.preview.url',
-      appLocalProxyURL: 'https://test.local.url',
-      devSessionStatusManager,
-    }
-  })
-
-  afterEach(() => {
-    abortController.abort()
-  })
-
   test('creates a new dev session successfully when receiving the app watcher start event', async () => {
-    // When
-    await pushUpdatesForDevSession({stderr, stdout, abortSignal: abortController.signal}, options)
-    await appWatcher.start({stdout, stderr, signal: abortController.signal})
-    await flushPromises()
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      const {options, stdout, stderr, abortController, appWatcher, developerPlatformClient} = await setup(tmpDir)
 
-    // Then
-    expect(developerPlatformClient.devSessionCreate).toHaveBeenCalled()
-    expect(stdout.write).toHaveBeenCalledWith(expect.stringContaining('Ready'))
+      // When
+      await pushUpdatesForDevSession({stderr, stdout, abortSignal: abortController.signal}, options)
+      await appWatcher.start({stdout, stderr, signal: abortController.signal})
+
+      // Then
+      await vi.waitFor(() => expect(developerPlatformClient.devSessionCreate).toHaveBeenCalled())
+      expect(stdout.write).toHaveBeenCalledWith(expect.stringContaining('Ready'))
+    })
   })
 
   test('updates use the extension handle as the output prefix', async () => {
-    // When
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      const {options, stdout, stderr, abortController, appWatcher, app, devSessionStatusManager} = await setup(tmpDir)
 
-    const spyContext = vi.spyOn(outputContext, 'useConcurrentOutputContext')
-    await pushUpdatesForDevSession({stderr, stdout, abortSignal: abortController.signal}, options)
-    await appWatcher.start({stdout, stderr, signal: abortController.signal})
-    await flushPromises()
+      const spyContext = vi.spyOn(outputContext, 'useConcurrentOutputContext')
+      await pushUpdatesForDevSession({stderr, stdout, abortSignal: abortController.signal}, options)
+      await appWatcher.start({stdout, stderr, signal: abortController.signal})
 
-    const extension = await testUIExtension()
-    appWatcher.emit('all', {app, extensionEvents: [{type: 'updated', extension}]})
-    await flushPromises()
+      const extension = await testUIExtension()
+      await vi.waitFor(() => expect(devSessionStatusManager.status.isReady).toBe(true))
+      appWatcher.emit('all', {app, extensionEvents: [{type: 'updated', extension}]})
 
-    // Then
-    expect(stdout.write).toHaveBeenCalledWith(expect.stringContaining('Updated dev preview on test.myshopify.com'))
-    expect(spyContext).toHaveBeenCalledWith({outputPrefix: 'test-ui-extension', stripAnsi: false}, expect.anything())
+      // Then
+      await vi.waitFor(() =>
+        expect(stdout.write).toHaveBeenCalledWith(expect.stringContaining('Updated dev preview on test.myshopify.com')),
+      )
+      expect(spyContext).toHaveBeenCalledWith({outputPrefix: 'test-ui-extension', stripAnsi: false}, expect.anything())
 
-    // In theory this shouldn't be necessary, but vitest doesn't restore spies automatically.
-    // eslint-disable-next-line @shopify/cli/no-vi-manual-mock-clear
-    vi.restoreAllMocks()
+      // In theory this shouldn't be necessary, but vitest doesn't restore spies automatically.
+      // eslint-disable-next-line @shopify/cli/no-vi-manual-mock-clear
+      vi.restoreAllMocks()
+    })
   })
 
   test('handles user errors from dev session creation', async () => {
-    // Given
-    const userErrors = [{message: 'Test error', category: 'test'}]
-    developerPlatformClient.devSessionCreate = vi.fn().mockResolvedValue({devSessionCreate: {userErrors}})
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      const {options, stdout, stderr, appWatcher, developerPlatformClient} = await setup(tmpDir)
 
-    // When
-    await appWatcher.start({stdout, stderr, signal: abortController.signal})
-    await pushUpdatesForDevSession({stderr, stdout, abortSignal: new AbortSignal()}, options)
-    await flushPromises()
+      const userErrors = [{message: 'Test error', category: 'test'}]
+      developerPlatformClient.devSessionCreate = vi.fn().mockResolvedValue({devSessionCreate: {userErrors}})
 
-    // Then
-    expect(stdout.write).toHaveBeenCalledWith(expect.stringContaining('Error'))
-    expect(stdout.write).toHaveBeenCalledWith(expect.stringContaining('Test error'))
+      // When
+      await pushUpdatesForDevSession({stderr, stdout, abortSignal: new AbortSignal()}, options)
+      await appWatcher.start({stdout, stderr, signal: new AbortController().signal})
+
+      // Then
+      await vi.waitFor(() => {
+        expect(stdout.write).toHaveBeenCalledWith(expect.stringContaining('Error'))
+        expect(stdout.write).toHaveBeenCalledWith(expect.stringContaining('Test error'))
+      })
+    })
   })
 
   test('handles receiving an event before session is ready', async () => {
-    // When
-    await pushUpdatesForDevSession({stderr, stdout, abortSignal: abortController.signal}, options)
-    appWatcher.emit('all', {app, extensionEvents: [{type: 'updated', extension: await testWebhookExtensions()}]})
-    await flushPromises()
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      const {options, stdout, stderr, abortController, appWatcher, app, developerPlatformClient} = await setup(tmpDir)
 
-    // Then
-    expect(stdout.write).toHaveBeenCalledWith(
-      expect.stringContaining('Change detected, but dev preview is not ready yet.'),
-    )
-    expect(developerPlatformClient.devSessionCreate).not.toHaveBeenCalled()
-    expect(developerPlatformClient.devSessionUpdate).not.toHaveBeenCalled()
+      // When
+      await pushUpdatesForDevSession({stderr, stdout, abortSignal: abortController.signal}, options)
+      appWatcher.emit('all', {app, extensionEvents: [{type: 'updated', extension: await testWebhookExtensions()}]})
+      await flushPromises()
+
+      // Then
+      expect(stdout.write).toHaveBeenCalledWith(
+        expect.stringContaining('Change detected, but dev preview is not ready yet.'),
+      )
+      expect(developerPlatformClient.devSessionCreate).not.toHaveBeenCalled()
+      expect(developerPlatformClient.devSessionUpdate).not.toHaveBeenCalled()
+    })
   })
 
   test('handles user errors from dev session update', async () => {
-    // Given
-    const userErrors = [{message: 'Update error', category: 'test'}]
-    developerPlatformClient.devSessionUpdate = vi.fn().mockResolvedValue({devSessionUpdate: {userErrors}})
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      const {
+        options,
+        stdout,
+        stderr,
+        abortController,
+        appWatcher,
+        app,
+        developerPlatformClient,
+        devSessionStatusManager,
+      } = await setup(tmpDir)
 
-    // When
-    await pushUpdatesForDevSession({stderr, stdout, abortSignal: abortController.signal}, options)
-    await appWatcher.start({stdout, stderr, signal: abortController.signal})
-    await flushPromises()
-    appWatcher.emit('all', {app, extensionEvents: [{type: 'updated', extension: await testWebhookExtensions()}]})
-    await flushPromises()
+      const userErrors = [{message: 'Update error', category: 'test'}]
+      developerPlatformClient.devSessionUpdate = vi.fn().mockResolvedValue({devSessionUpdate: {userErrors}})
 
-    // Then
-    expect(stdout.write).toHaveBeenCalledWith(expect.stringContaining('Error'))
-    expect(stdout.write).toHaveBeenCalledWith(expect.stringContaining('Update error'))
+      // When
+      await pushUpdatesForDevSession({stderr, stdout, abortSignal: abortController.signal}, options)
+      await appWatcher.start({stdout, stderr, signal: abortController.signal})
+      await vi.waitFor(() => expect(devSessionStatusManager.status.isReady).toBe(true))
+      appWatcher.emit('all', {app, extensionEvents: [{type: 'updated', extension: await testWebhookExtensions()}]})
+
+      // Then
+      await vi.waitFor(() => {
+        expect(stdout.write).toHaveBeenCalledWith(expect.stringContaining('Error'))
+        expect(stdout.write).toHaveBeenCalledWith(expect.stringContaining('Update error'))
+      })
+    })
   })
 
   test('handles scope changes and displays updated message', async () => {
-    // Given
-    vi.mocked(buildAppURLForWeb).mockResolvedValue('https://test.myshopify.com/admin/apps/test')
-    const appAccess = await testAppAccessConfigExtension(false, undefined, false)
-    const event = {extensionEvents: [{type: 'updated', extension: appAccess}], app}
-    const contextSpy = vi.spyOn(outputContext, 'useConcurrentOutputContext')
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      const {options, stdout, stderr, abortController, appWatcher, app, devSessionStatusManager} = await setup(tmpDir)
 
-    // When
-    await pushUpdatesForDevSession({stderr, stdout, abortSignal: abortController.signal}, options)
-    await appWatcher.start({stdout, stderr, signal: abortController.signal})
-    await flushPromises()
-    appWatcher.emit('all', event)
-    await flushPromises()
+      vi.mocked(buildAppURLForWeb).mockResolvedValue('https://test.myshopify.com/admin/apps/test')
+      const appAccess = await testAppAccessConfigExtension(false, undefined, false)
+      const event = {extensionEvents: [{type: 'updated', extension: appAccess}], app}
+      const contextSpy = vi.spyOn(outputContext, 'useConcurrentOutputContext')
 
-    // Then
-    expect(stdout.write).toHaveBeenCalledWith(expect.stringContaining('Updated dev preview on test.myshopify.com'))
-    expect(stdout.write).toHaveBeenCalledWith(
-      expect.stringContaining('Access scopes auto-granted: read_products, write_products'),
-    )
+      // When
+      await pushUpdatesForDevSession({stderr, stdout, abortSignal: abortController.signal}, options)
+      await appWatcher.start({stdout, stderr, signal: abortController.signal})
+      await vi.waitFor(() => expect(devSessionStatusManager.status.isReady).toBe(true))
+      appWatcher.emit('all', event)
 
-    expect(contextSpy).toHaveBeenCalledWith({outputPrefix: 'app-preview', stripAnsi: false}, expect.anything())
-    contextSpy.mockRestore()
+      // Then
+      await vi.waitFor(() => {
+        expect(stdout.write).toHaveBeenCalledWith(expect.stringContaining('Updated dev preview on test.myshopify.com'))
+        expect(stdout.write).toHaveBeenCalledWith(
+          expect.stringContaining('Access scopes auto-granted: read_products, write_products'),
+        )
+      })
+
+      expect(contextSpy).toHaveBeenCalledWith({outputPrefix: 'app-preview', stripAnsi: false}, expect.anything())
+      contextSpy.mockRestore()
+    })
   })
 
   test('updates preview URL to appPreviewURL by default (local dev console only for 1P devs)', async () => {
-    // Given - dev console is NOT shown by default (only for 1P devs)
-    vi.mocked(firstPartyDev).mockReturnValue(false)
-    const extension = await testUIExtension({type: 'ui_extension'})
-    const newApp = testAppLinked({allExtensions: [extension]})
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given - dev console is NOT shown by default (only for 1P devs)
+      const {options, stdout, stderr, abortController, appWatcher, devSessionStatusManager} = await setup(tmpDir)
 
-    // When
-    await pushUpdatesForDevSession({stderr, stdout, abortSignal: abortController.signal}, options)
-    await appWatcher.start({stdout, stderr, signal: abortController.signal})
-    await flushPromises()
-    appWatcher.emit('all', {app: newApp, extensionEvents: [{type: 'updated', extension}]})
-    await flushPromises()
+      vi.mocked(firstPartyDev).mockReturnValue(false)
+      const extension = await testUIExtension({type: 'ui_extension'})
+      const newApp = testAppLinked({allExtensions: [extension]})
 
-    // Then
-    expect(devSessionStatusManager.status.previewURL).toBe(options.appPreviewURL)
+      // When
+      await pushUpdatesForDevSession({stderr, stdout, abortSignal: abortController.signal}, options)
+      await appWatcher.start({stdout, stderr, signal: abortController.signal})
+      await vi.waitFor(() => expect(devSessionStatusManager.status.isReady).toBe(true))
+      appWatcher.emit('all', {app: newApp, extensionEvents: [{type: 'updated', extension}]})
+
+      // Then
+      await vi.waitFor(() => expect(devSessionStatusManager.status.previewURL).toBe(options.appPreviewURL))
+    })
   })
 
   test('updates preview URL to appLocalProxyURL when 1P dev has previewable extensions', async () => {
-    // Given - dev console is shown for 1P devs with previewable extensions
-    vi.mocked(firstPartyDev).mockReturnValue(true)
-    const extension = await testUIExtension({type: 'ui_extension'})
-    const newApp = testAppLinked({allExtensions: [extension]})
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given - dev console is shown for 1P devs with previewable extensions
+      const {options, stdout, stderr, abortController, appWatcher, devSessionStatusManager} = await setup(tmpDir)
 
-    // When
-    await pushUpdatesForDevSession({stderr, stdout, abortSignal: abortController.signal}, options)
-    await appWatcher.start({stdout, stderr, signal: abortController.signal})
-    await flushPromises()
-    appWatcher.emit('all', {app: newApp, extensionEvents: [{type: 'updated', extension}]})
-    await flushPromises()
+      vi.mocked(firstPartyDev).mockReturnValue(true)
+      const extension = await testUIExtension({type: 'ui_extension'})
+      const newApp = testAppLinked({allExtensions: [extension]})
 
-    // Then
-    expect(devSessionStatusManager.status.previewURL).toBe(options.appLocalProxyURL)
-    vi.mocked(firstPartyDev).mockReturnValue(false)
+      // When
+      await pushUpdatesForDevSession({stderr, stdout, abortSignal: abortController.signal}, options)
+      await appWatcher.start({stdout, stderr, signal: abortController.signal})
+      await vi.waitFor(() => expect(devSessionStatusManager.status.isReady).toBe(true))
+      appWatcher.emit('all', {app: newApp, extensionEvents: [{type: 'updated', extension}]})
+
+      // Then
+      await vi.waitFor(() => expect(devSessionStatusManager.status.previewURL).toBe(options.appLocalProxyURL))
+      vi.mocked(firstPartyDev).mockReturnValue(false)
+    })
   })
 
   test('updates preview URL to appPreviewURL when no previewable extensions', async () => {
-    // Given
-    const extension = await testFlowActionExtension()
-    const newApp = testAppLinked({allExtensions: [extension]})
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      const {options, stdout, stderr, abortController, appWatcher, devSessionStatusManager} = await setup(tmpDir)
 
-    // When
-    await pushUpdatesForDevSession({stderr, stdout, abortSignal: abortController.signal}, options)
-    await appWatcher.start({stdout, stderr, signal: abortController.signal})
-    await flushPromises()
-    appWatcher.emit('all', {app: newApp, extensionEvents: [{type: 'updated', extension}]})
-    await flushPromises()
+      const extension = await testFlowActionExtension()
+      const newApp = testAppLinked({allExtensions: [extension]})
 
-    // Then
-    expect(devSessionStatusManager.status.previewURL).toBe(options.appPreviewURL)
+      // When
+      await pushUpdatesForDevSession({stderr, stdout, abortSignal: abortController.signal}, options)
+      await appWatcher.start({stdout, stderr, signal: abortController.signal})
+      await vi.waitFor(() => expect(devSessionStatusManager.status.isReady).toBe(true))
+      appWatcher.emit('all', {app: newApp, extensionEvents: [{type: 'updated', extension}]})
+
+      // Then
+      await vi.waitFor(() => expect(devSessionStatusManager.status.previewURL).toBe(options.appPreviewURL))
+    })
   })
 
   test('resets dev session status when calling resetDevSessionStatus', async () => {
-    // Given
-    const extension = await testUIExtension({type: 'ui_extension'})
-    const newApp = testAppLinked({allExtensions: [extension]})
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      const {options, stdout, stderr, abortController, appWatcher, devSessionStatusManager} = await setup(tmpDir)
 
-    // When
-    await pushUpdatesForDevSession({stderr, stdout, abortSignal: abortController.signal}, options)
-    await appWatcher.start({stdout, stderr, signal: abortController.signal})
-    await flushPromises()
-    appWatcher.emit('all', {app: newApp, extensionEvents: [{type: 'updated', extension}]})
-    await flushPromises()
+      const extension = await testUIExtension({type: 'ui_extension'})
+      const newApp = testAppLinked({allExtensions: [extension]})
 
-    // Then
-    expect(devSessionStatusManager.status.isReady).toBe(true)
-    expect(devSessionStatusManager.status.previewURL).toBeDefined()
+      // When
+      await pushUpdatesForDevSession({stderr, stdout, abortSignal: abortController.signal}, options)
+      await appWatcher.start({stdout, stderr, signal: abortController.signal})
+      await vi.waitFor(() => expect(devSessionStatusManager.status.isReady).toBe(true))
+      appWatcher.emit('all', {app: newApp, extensionEvents: [{type: 'updated', extension}]})
 
-    // When
-    devSessionStatusManager.reset()
+      // Then
+      await vi.waitFor(() => expect(devSessionStatusManager.status.previewURL).toBeDefined())
 
-    // Then
-    expect(devSessionStatusManager.status.isReady).toBe(false)
-    expect(devSessionStatusManager.status.previewURL).toBeUndefined()
+      // When
+      devSessionStatusManager.reset()
+
+      // Then
+      expect(devSessionStatusManager.status.isReady).toBe(false)
+      expect(devSessionStatusManager.status.previewURL).toBeUndefined()
+    })
   })
 
   test('handles error events from the app watcher', async () => {
-    // Given
-    const testError = new Error('Watcher error')
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      const {options, stdout, stderr, abortController, appWatcher} = await setup(tmpDir)
 
-    // When
-    await pushUpdatesForDevSession({stderr, stdout, abortSignal: abortController.signal}, options)
-    appWatcher.emit('error', testError)
-    await flushPromises()
+      const testError = new Error('Watcher error')
 
-    // Then
-    expect(stdout.write).toHaveBeenCalledWith(expect.stringContaining('Error'))
-    expect(stdout.write).toHaveBeenCalledWith(expect.stringContaining('Watcher error'))
+      // When
+      await pushUpdatesForDevSession({stderr, stdout, abortSignal: abortController.signal}, options)
+      appWatcher.emit('error', testError)
+      await flushPromises()
+
+      // Then
+      expect(stdout.write).toHaveBeenCalledWith(expect.stringContaining('Error'))
+      expect(stdout.write).toHaveBeenCalledWith(expect.stringContaining('Watcher error'))
+    })
   })
 
   test('sets correct status messages during dev session lifecycle', async () => {
-    // When
-    await pushUpdatesForDevSession({stderr, stdout, abortSignal: abortController.signal}, options)
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      const {options, stdout, stderr, abortController, appWatcher, app, devSessionStatusManager} = await setup(tmpDir)
 
-    expect(stdout.write).toHaveBeenCalledWith(expect.stringContaining(`Preparing dev preview on ${options.storeFqdn}`))
+      // When
+      await pushUpdatesForDevSession({stderr, stdout, abortSignal: abortController.signal}, options)
 
-    const statusSpy = vi.spyOn(devSessionStatusManager, 'setMessage')
+      expect(stdout.write).toHaveBeenCalledWith(
+        expect.stringContaining(`Preparing dev preview on ${options.storeFqdn}`),
+      )
 
-    // Then - Initial loading state
-    expect(devSessionStatusManager.status.statusMessage).toEqual({
-      message: 'Preparing dev preview',
-      type: 'loading',
+      const statusSpy = vi.spyOn(devSessionStatusManager, 'setMessage')
+
+      // Then - Initial loading state
+      expect(devSessionStatusManager.status.statusMessage).toEqual({
+        message: 'Preparing dev preview',
+        type: 'loading',
+      })
+
+      // When - Start the session
+      await appWatcher.start({stdout, stderr, signal: abortController.signal})
+
+      // Then - Ready state
+      await vi.waitFor(() => expect(statusSpy).toHaveBeenCalledWith('READY'))
+
+      // When - Emit an update event
+      const extension = await testUIExtension()
+      appWatcher.emit('all', {app, extensionEvents: [{type: 'updated', extension}]})
+
+      // Then - Loading state during update
+      await vi.waitFor(() => expect(statusSpy).toHaveBeenCalledWith('CHANGE_DETECTED'))
+      // Then - Updated state after successful update
+      await vi.waitFor(() => expect(statusSpy).toHaveBeenCalledWith('UPDATED'))
+      statusSpy.mockRestore()
     })
-
-    // When - Start the session
-    await appWatcher.start({stdout, stderr, signal: abortController.signal})
-    await flushPromises()
-
-    // Then - Ready state
-    expect(statusSpy).toHaveBeenCalledWith('READY')
-
-    // When - Emit an update event
-    const extension = await testUIExtension()
-    appWatcher.emit('all', {app, extensionEvents: [{type: 'updated', extension}]})
-    await flushPromises()
-
-    // Then - Loading state during update
-    expect(statusSpy).toHaveBeenCalledWith('CHANGE_DETECTED')
-    // Then - Updated state after successful update
-    expect(statusSpy).toHaveBeenCalledWith('UPDATED')
-    statusSpy.mockRestore()
   })
 
   test('sets error status message on build error', async () => {
-    // Given
-    const extension = await testUIExtension()
-    const errorEvent = {
-      app,
-      extensionEvents: [
-        {
-          type: 'updated',
-          extension,
-          buildResult: {status: 'error'},
-        },
-      ],
-    }
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      const {options, stdout, stderr, abortController, appWatcher, app, devSessionStatusManager} = await setup(tmpDir)
 
-    // When
-    await pushUpdatesForDevSession({stderr, stdout, abortSignal: abortController.signal}, options)
-    await appWatcher.start({stdout, stderr, signal: abortController.signal})
-    await flushPromises()
-    appWatcher.emit('all', errorEvent)
-    await flushPromises()
+      const extension = await testUIExtension()
+      const errorEvent = {
+        app,
+        extensionEvents: [
+          {
+            type: 'updated',
+            extension,
+            buildResult: {status: 'error'},
+          },
+        ],
+      }
 
-    // Then
-    expect(devSessionStatusManager.status.statusMessage).toEqual({
-      message: 'Build error. Please review your code and try again',
-      type: 'error',
+      // When
+      await pushUpdatesForDevSession({stderr, stdout, abortSignal: abortController.signal}, options)
+      await appWatcher.start({stdout, stderr, signal: abortController.signal})
+      await vi.waitFor(() => expect(devSessionStatusManager.status.isReady).toBe(true))
+      appWatcher.emit('all', errorEvent)
+
+      // Then
+      await vi.waitFor(() =>
+        expect(devSessionStatusManager.status.statusMessage).toEqual({
+          message: 'Build error. Please review your code and try again',
+          type: 'error',
+        }),
+      )
     })
   })
 
   test('sets error status message on remote error', async () => {
-    // Given
-    const userErrors = [{message: 'Update error', category: 'test'}]
-    developerPlatformClient.devSessionUpdate = vi.fn().mockResolvedValue({devSessionUpdate: {userErrors}})
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      const {
+        options,
+        stdout,
+        stderr,
+        abortController,
+        appWatcher,
+        app,
+        developerPlatformClient,
+        devSessionStatusManager,
+      } = await setup(tmpDir)
 
-    // When
-    await pushUpdatesForDevSession({stderr, stdout, abortSignal: abortController.signal}, options)
-    await appWatcher.start({stdout, stderr, signal: abortController.signal})
-    await flushPromises()
-    appWatcher.emit('all', {app, extensionEvents: [{type: 'updated', extension: await testWebhookExtensions()}]})
-    await flushPromises()
+      const userErrors = [{message: 'Update error', category: 'test'}]
+      developerPlatformClient.devSessionUpdate = vi.fn().mockResolvedValue({devSessionUpdate: {userErrors}})
 
-    // Then
-    expect(devSessionStatusManager.status.statusMessage).toEqual({
-      message: 'Error updating dev preview',
-      type: 'error',
+      // When
+      await pushUpdatesForDevSession({stderr, stdout, abortSignal: abortController.signal}, options)
+      await appWatcher.start({stdout, stderr, signal: abortController.signal})
+      await vi.waitFor(() => expect(devSessionStatusManager.status.isReady).toBe(true))
+      appWatcher.emit('all', {app, extensionEvents: [{type: 'updated', extension: await testWebhookExtensions()}]})
+
+      // Then
+      await vi.waitFor(() =>
+        expect(devSessionStatusManager.status.statusMessage).toEqual({
+          message: 'Error updating dev preview',
+          type: 'error',
+        }),
+      )
     })
   })
 
   test('sets validation error status message when error cause is validation-error', async () => {
-    // Given
-    const validationError = new Error('Validation failed')
-    ;(validationError as Error & {cause: string}).cause = 'validation-error'
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      const {options, stdout, stderr, abortController, appWatcher, devSessionStatusManager} = await setup(tmpDir)
 
-    // When
-    await pushUpdatesForDevSession({stderr, stdout, abortSignal: abortController.signal}, options)
-    await appWatcher.start({stdout, stderr, signal: abortController.signal})
-    await flushPromises()
-    appWatcher.emit('error', validationError)
-    await flushPromises()
+      const validationError = new Error('Validation failed')
+      ;(validationError as Error & {cause: string}).cause = 'validation-error'
 
-    // Then
-    expect(devSessionStatusManager.status.statusMessage).toEqual({
-      message: 'Validation error in your app configuration',
-      type: 'error',
+      // When
+      await pushUpdatesForDevSession({stderr, stdout, abortSignal: abortController.signal}, options)
+      await appWatcher.start({stdout, stderr, signal: abortController.signal})
+      await vi.waitFor(() => expect(devSessionStatusManager.status.isReady).toBe(true))
+      appWatcher.emit('error', validationError)
+
+      // Then
+      await vi.waitFor(() =>
+        expect(devSessionStatusManager.status.statusMessage).toEqual({
+          message: 'Validation error in your app configuration',
+          type: 'error',
+        }),
+      )
     })
   })
 
   test('manifest sent in update payload only includes affected extensions', async () => {
-    // Given
-    vi.mocked(readdir).mockResolvedValue(['assets', 'assets/updated-extension'])
-    vi.mocked(getUploadURL).mockResolvedValue('https://gcs.url')
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      const {options, stdout, stderr, abortController, appWatcher, developerPlatformClient, devSessionStatusManager} =
+        await setup(tmpDir)
 
-    const updatedExtension = await testUIExtension()
-    updatedExtension.deployConfig = vi.fn().mockResolvedValue({})
-    const unaffectedExtension = await testThemeExtensions()
-    const appWithMultipleExtensions = testAppLinked({
-      allExtensions: [updatedExtension, unaffectedExtension],
-    })
+      vi.mocked(getUploadURL).mockResolvedValue('https://gcs.url')
 
-    // When
-    await pushUpdatesForDevSession({stderr, stdout, abortSignal: abortController.signal}, options)
-    await appWatcher.start({stdout, stderr, signal: abortController.signal})
-    await flushPromises()
-    appWatcher.emit('all', {
-      app: appWithMultipleExtensions,
-      extensionEvents: [{type: 'updated', extension: updatedExtension}],
-    })
-    await flushPromises()
+      const updatedExtension = await testUIExtension()
+      updatedExtension.deployConfig = vi.fn().mockResolvedValue({})
+      const unaffectedExtension = await testThemeExtensions()
+      const appWithMultipleExtensions = testAppLinked({
+        allExtensions: [updatedExtension, unaffectedExtension],
+      })
 
-    // Then
-    expect(developerPlatformClient.devSessionUpdate).toHaveBeenCalledWith({
-      shopFqdn: 'test.myshopify.com',
-      appId: 'app123',
-      // Assets URL is empty because the affected extension has no assets
-      assetsUrl: undefined,
-      manifest: {
-        name: 'App',
-        handle: '',
-        modules: [
-          {
-            uid: 'test-ui-extension-uid',
-            uuid: undefined,
-            assets: 'test-ui-extension-uid',
-            handle: updatedExtension.handle,
-            type: updatedExtension.externalType,
-            target: updatedExtension.contextValue,
-            config: {},
+      // When
+      await pushUpdatesForDevSession({stderr, stdout, abortSignal: abortController.signal}, options)
+      await appWatcher.start({stdout, stderr, signal: abortController.signal})
+      await vi.waitFor(() => expect(devSessionStatusManager.status.isReady).toBe(true))
+      appWatcher.emit('all', {
+        app: appWithMultipleExtensions,
+        extensionEvents: [{type: 'updated', extension: updatedExtension}],
+      })
+
+      // Then
+      await vi.waitFor(() =>
+        expect(developerPlatformClient.devSessionUpdate).toHaveBeenCalledWith({
+          shopFqdn: 'test.myshopify.com',
+          appId: 'app123',
+          // Assets URL is empty because the affected extension has no assets
+          assetsUrl: undefined,
+          manifest: {
+            name: 'App',
+            handle: '',
+            modules: [
+              {
+                uid: 'test-ui-extension-uid',
+                uuid: undefined,
+                assets: 'test-ui-extension-uid',
+                handle: updatedExtension.handle,
+                type: updatedExtension.externalType,
+                target: updatedExtension.contextValue,
+                config: {},
+              },
+            ],
           },
-        ],
-      },
-      // The unaffected extension is listed in inheritedModuleUids
-      inheritedModuleUids: [unaffectedExtension.uid],
+          // The unaffected extension is listed in inheritedModuleUids
+          inheritedModuleUids: [unaffectedExtension.uid],
+        }),
+      )
     })
   })
 
   test('writes full manifest to bundle on session update, not just create', async () => {
-    // Given
-    vi.mocked(readdir).mockResolvedValue([])
-    vi.mocked(getUploadURL).mockResolvedValue('https://gcs.url')
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      const {options, stdout, stderr, abortController, appWatcher, devSessionStatusManager} = await setup(tmpDir)
 
-    const updatedExtension = await testUIExtension({handle: 'updated-ext', uid: 'updated-uid'})
-    updatedExtension.deployConfig = vi.fn().mockResolvedValue({})
-    const existingExtension = await testUIExtension({handle: 'existing-ext', uid: 'existing-uid'})
-    existingExtension.deployConfig = vi.fn().mockResolvedValue({})
-    const appWithMultipleExtensions = testAppLinked({
-      allExtensions: [updatedExtension, existingExtension],
+      vi.mocked(getUploadURL).mockResolvedValue('https://gcs.url')
+
+      const updatedExtension = await testUIExtension({handle: 'updated-ext', uid: 'updated-uid'})
+      updatedExtension.deployConfig = vi.fn().mockResolvedValue({})
+      const existingExtension = await testUIExtension({handle: 'existing-ext', uid: 'existing-uid'})
+      existingExtension.deployConfig = vi.fn().mockResolvedValue({})
+      const appWithMultipleExtensions = testAppLinked({
+        allExtensions: [updatedExtension, existingExtension],
+      })
+
+      // When
+      await pushUpdatesForDevSession({stderr, stdout, abortSignal: abortController.signal}, options)
+      await appWatcher.start({stdout, stderr, signal: abortController.signal})
+      await vi.waitFor(() => expect(devSessionStatusManager.status.isReady).toBe(true))
+
+      // Capture manifests at call time (the object is mutated after writeManifestToBundle)
+      const capturedManifests: any[] = []
+      vi.mocked(writeManifestToBundle).mockImplementation(async (manifest: any) => {
+        capturedManifests.push(structuredClone(manifest))
+      })
+
+      // Emit UPDATE event with only one extension changed
+      appWatcher.emit('all', {
+        app: appWithMultipleExtensions,
+        extensionEvents: [{type: 'updated', extension: updatedExtension}],
+      })
+
+      // Then - writeManifestToBundle should have been called with ALL modules, not just the updated one
+      await vi.waitFor(() => expect(capturedManifests).toHaveLength(1))
+      const moduleUids = capturedManifests[0].modules.map((mod: any) => mod.uid)
+      expect(moduleUids).toContain(updatedExtension.uid)
+      expect(moduleUids).toContain(existingExtension.uid)
+      expect(moduleUids.length).toBeGreaterThanOrEqual(2)
     })
-
-    // When
-    await pushUpdatesForDevSession({stderr, stdout, abortSignal: abortController.signal}, options)
-    await appWatcher.start({stdout, stderr, signal: abortController.signal})
-    await flushPromises()
-
-    // Capture manifests at call time (the object is mutated after writeManifestToBundle)
-    const capturedManifests: any[] = []
-    vi.mocked(writeManifestToBundle).mockImplementation(async (manifest: any) => {
-      capturedManifests.push(structuredClone(manifest))
-    })
-
-    // Emit UPDATE event with only one extension changed
-    appWatcher.emit('all', {
-      app: appWithMultipleExtensions,
-      extensionEvents: [{type: 'updated', extension: updatedExtension}],
-    })
-    await flushPromises()
-
-    // Then - writeManifestToBundle should have been called with ALL modules, not just the updated one
-    expect(capturedManifests).toHaveLength(1)
-    const moduleUids = capturedManifests[0].modules.map((mod: any) => mod.uid)
-    expect(moduleUids).toContain(updatedExtension.uid)
-    expect(moduleUids).toContain(existingExtension.uid)
-    expect(moduleUids.length).toBeGreaterThanOrEqual(2)
   })
 
   test('writes full manifest including new extension on created event', async () => {
-    // Given
-    vi.mocked(readdir).mockResolvedValue([])
-    vi.mocked(getUploadURL).mockResolvedValue('https://gcs.url')
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      const {options, stdout, stderr, abortController, appWatcher, devSessionStatusManager} = await setup(tmpDir)
 
-    const existingExtension = await testUIExtension({handle: 'existing-ext', uid: 'existing-uid'})
-    existingExtension.deployConfig = vi.fn().mockResolvedValue({})
-    const newExtension = await testUIExtension({handle: 'new-ext', uid: 'new-uid'})
-    newExtension.deployConfig = vi.fn().mockResolvedValue({})
+      vi.mocked(getUploadURL).mockResolvedValue('https://gcs.url')
 
-    // The app after reload includes both the existing and newly created extension
-    const appAfterReload = testAppLinked({
-      allExtensions: [existingExtension, newExtension],
+      const existingExtension = await testUIExtension({handle: 'existing-ext', uid: 'existing-uid'})
+      existingExtension.deployConfig = vi.fn().mockResolvedValue({})
+      const newExtension = await testUIExtension({handle: 'new-ext', uid: 'new-uid'})
+      newExtension.deployConfig = vi.fn().mockResolvedValue({})
+
+      // The app after reload includes both the existing and newly created extension
+      const appAfterReload = testAppLinked({
+        allExtensions: [existingExtension, newExtension],
+      })
+
+      // When
+      await pushUpdatesForDevSession({stderr, stdout, abortSignal: abortController.signal}, options)
+      await appWatcher.start({stdout, stderr, signal: abortController.signal})
+      await vi.waitFor(() => expect(devSessionStatusManager.status.isReady).toBe(true))
+
+      // Capture manifests at call time (the object is mutated after writeManifestToBundle)
+      const capturedManifests: any[] = []
+      vi.mocked(writeManifestToBundle).mockImplementation(async (manifest: any) => {
+        capturedManifests.push(structuredClone(manifest))
+      })
+
+      // Emit event with a new extension created mid-dev (simulates generate extension)
+      appWatcher.emit('all', {
+        app: appAfterReload,
+        extensionEvents: [{type: 'created', extension: newExtension}],
+      })
+
+      // Then - writeManifestToBundle should include ALL modules (existing + new)
+      await vi.waitFor(() => expect(capturedManifests).toHaveLength(1))
+      const moduleUids = capturedManifests[0].modules.map((mod: any) => mod.uid)
+      expect(moduleUids).toContain(existingExtension.uid)
+      expect(moduleUids).toContain(newExtension.uid)
+      expect(moduleUids.length).toBeGreaterThanOrEqual(2)
     })
-
-    // When
-    await pushUpdatesForDevSession({stderr, stdout, abortSignal: abortController.signal}, options)
-    await appWatcher.start({stdout, stderr, signal: abortController.signal})
-    await flushPromises()
-
-    // Capture manifests at call time (the object is mutated after writeManifestToBundle)
-    const capturedManifests: any[] = []
-    vi.mocked(writeManifestToBundle).mockImplementation(async (manifest: any) => {
-      capturedManifests.push(structuredClone(manifest))
-    })
-
-    // Emit event with a new extension created mid-dev (simulates generate extension)
-    appWatcher.emit('all', {
-      app: appAfterReload,
-      extensionEvents: [{type: 'created', extension: newExtension}],
-    })
-    await flushPromises()
-
-    // Then - writeManifestToBundle should include ALL modules (existing + new)
-    expect(capturedManifests).toHaveLength(1)
-    const moduleUids = capturedManifests[0].modules.map((mod: any) => mod.uid)
-    expect(moduleUids).toContain(existingExtension.uid)
-    expect(moduleUids).toContain(newExtension.uid)
-    expect(moduleUids.length).toBeGreaterThanOrEqual(2)
   })
 
   test('assetsURL is only generated if affected extensions have assets', async () => {
-    // Given
-    vi.mocked(formData).mockReturnValue({append: vi.fn(), getHeaders: vi.fn()} as any)
-    // Mock readdir to return that a folder for the extension assets exists
-    vi.mocked(readdir).mockResolvedValue(['other-folders', 'ui-extension-uid'])
-    vi.mocked(getUploadURL).mockResolvedValue('https://gcs.url')
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      const {options, stdout, stderr, abortController, appWatcher, developerPlatformClient, devSessionStatusManager} =
+        await setup(tmpDir)
 
-    const extensionWithAssets = await testUIExtension({handle: 'ui-extension-handle', uid: 'ui-extension-uid'})
-    extensionWithAssets.deployConfig = vi.fn().mockResolvedValue({})
-    const app = testAppLinked({allExtensions: [extensionWithAssets]})
+      vi.mocked(formData).mockReturnValue({append: vi.fn(), getHeaders: vi.fn()} as any)
 
-    // When
-    await pushUpdatesForDevSession({stderr, stdout, abortSignal: abortController.signal}, options)
-    await appWatcher.start({stdout, stderr, signal: abortController.signal})
-    await flushPromises()
-    appWatcher.emit('all', {
-      app,
-      extensionEvents: [{type: 'updated', extension: extensionWithAssets}],
-    })
-    await flushPromises()
+      const extensionWithAssets = await testUIExtension({handle: 'ui-extension-handle', uid: 'ui-extension-uid'})
+      extensionWithAssets.deployConfig = vi.fn().mockResolvedValue({})
+      const app = testAppLinked({allExtensions: [extensionWithAssets]})
 
-    // Then
-    expect(developerPlatformClient.devSessionUpdate).toHaveBeenCalledWith({
-      shopFqdn: 'test.myshopify.com',
-      appId: 'app123',
-      assetsUrl: 'https://gcs.url',
-      manifest: expect.any(Object),
-      inheritedModuleUids: [],
+      vi.mocked(getUploadURL).mockResolvedValue('https://gcs.url')
+
+      // When
+      await pushUpdatesForDevSession({stderr, stdout, abortSignal: abortController.signal}, options)
+      await appWatcher.start({stdout, stderr, signal: abortController.signal})
+      await vi.waitFor(() => expect(devSessionStatusManager.status.isReady).toBe(true))
+
+      // Mock the asset directory creation AFTER appWatcher.start so it doesn't get deleted
+      await mkdir(joinPath(options.appWatcher.buildOutputPath, 'ui-extension-uid'))
+      appWatcher.emit('all', {
+        app,
+        extensionEvents: [{type: 'updated', extension: extensionWithAssets}],
+      })
+
+      // Then
+      await vi.waitFor(() =>
+        expect(developerPlatformClient.devSessionUpdate).toHaveBeenCalledWith({
+          shopFqdn: 'test.myshopify.com',
+          appId: 'app123',
+          assetsUrl: 'https://gcs.url',
+          manifest: expect.any(Object),
+          inheritedModuleUids: [],
+        }),
+      )
     })
   })
 
   test('assetsURL is always generated for create, even if there are no assets', async () => {
-    // Given
-    vi.mocked(formData).mockReturnValue({append: vi.fn(), getHeaders: vi.fn()} as any)
-    vi.mocked(getUploadURL).mockResolvedValue('https://gcs.url')
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      const {options, stdout, stderr, abortController, appWatcher, developerPlatformClient} = await setup(tmpDir)
 
-    // When
-    await pushUpdatesForDevSession({stderr, stdout, abortSignal: abortController.signal}, options)
-    await appWatcher.start({stdout, stderr, signal: abortController.signal})
-    await flushPromises()
+      vi.mocked(formData).mockReturnValue({append: vi.fn(), getHeaders: vi.fn()} as any)
+      vi.mocked(getUploadURL).mockResolvedValue('https://gcs.url')
 
-    // Then
-    expect(developerPlatformClient.devSessionCreate).toHaveBeenCalledWith({
-      shopFqdn: 'test.myshopify.com',
-      appId: 'app123',
-      assetsUrl: 'https://gcs.url',
-      websocketUrl: 'wss://test.dev/extensions',
+      // When
+      await pushUpdatesForDevSession({stderr, stdout, abortSignal: abortController.signal}, options)
+      await appWatcher.start({stdout, stderr, signal: abortController.signal})
+
+      // Then
+      await vi.waitFor(() =>
+        expect(developerPlatformClient.devSessionCreate).toHaveBeenCalledWith({
+          shopFqdn: 'test.myshopify.com',
+          appId: 'app123',
+          assetsUrl: 'https://gcs.url',
+          websocketUrl: 'wss://test.dev/extensions',
+        }),
+      )
     })
   })
 
   test('multiple updates to different extensions are consolidated if a request is in progress', async () => {
-    vi.mocked(getUploadURL).mockResolvedValue('https://gcs.url')
-    vi.mocked(readdir).mockResolvedValue([])
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      const {options, stdout, stderr, abortController, appWatcher, developerPlatformClient, devSessionStatusManager} =
+        await setup(tmpDir)
 
-    const extension1 = await testUIExtension({type: 'ui_extension'})
-    extension1.uid = 'ext1'
-    extension1.handle = 'ext1-handle'
-    extension1.deployConfig = vi.fn().mockResolvedValue({config1: 'val1'})
+      vi.mocked(getUploadURL).mockResolvedValue('https://gcs.url')
 
-    const extension2 = await testWebhookExtensions()
-    extension2.uid = 'ext2'
-    extension2.handle = 'ext2-handle'
-    extension2.deployConfig = vi.fn().mockResolvedValue({config2: 'val2'})
+      const extension1 = await testUIExtension({type: 'ui_extension'})
+      extension1.uid = 'ext1'
+      extension1.handle = 'ext1-handle'
+      extension1.deployConfig = vi.fn().mockResolvedValue({config1: 'val1'})
 
-    app = testAppLinked({allExtensions: [extension1, extension2]})
+      const extension2 = await testWebhookExtensions()
+      extension2.uid = 'ext2'
+      extension2.handle = 'ext2-handle'
+      extension2.deployConfig = vi.fn().mockResolvedValue({config2: 'val2'})
 
-    await pushUpdatesForDevSession({stderr, stdout, abortSignal: abortController.signal}, options)
-    await options.appWatcher.start({stdout, stderr, signal: abortController.signal})
-    await flushPromises()
+      const app = testAppLinked({allExtensions: [extension1, extension2]})
 
-    // First event is processed immediat
-    options.appWatcher.emit('all', {app, extensionEvents: [{type: 'updated', extension: extension1}]})
+      await pushUpdatesForDevSession({stderr, stdout, abortSignal: abortController.signal}, options)
+      await appWatcher.start({stdout, stderr, signal: abortController.signal})
+      await vi.waitFor(() => expect(devSessionStatusManager.status.isReady).toBe(true))
 
-    // second and third event will be queued and processed together in a consolidated event.
-    options.appWatcher.emit('all', {app, extensionEvents: [{type: 'updated', extension: extension2}]})
-    options.appWatcher.emit('all', {app, extensionEvents: [{type: 'updated', extension: extension1}]})
+      // First event is processed immediat
+      appWatcher.emit('all', {app, extensionEvents: [{type: 'updated', extension: extension1}]})
 
-    await flushPromises()
+      // second and third event will be queued and processed together in a consolidated event.
+      appWatcher.emit('all', {app, extensionEvents: [{type: 'updated', extension: extension2}]})
+      appWatcher.emit('all', {app, extensionEvents: [{type: 'updated', extension: extension1}]})
 
-    expect(developerPlatformClient.devSessionUpdate).toHaveBeenCalledTimes(2)
-    const calls = developerPlatformClient.devSessionUpdate.mock.calls
+      await vi.waitFor(() => expect(developerPlatformClient.devSessionUpdate).toHaveBeenCalledTimes(2))
+      const calls = (developerPlatformClient.devSessionUpdate as any).mock.calls
 
-    // First call only has the first event
-    const manifestModules = calls[0][0].manifest.modules
-    expect(manifestModules).toEqual(
-      expect.arrayContaining([expect.objectContaining({uid: 'ext1', config: {config1: 'val1'}})]),
-    )
-    expect(manifestModules.length).toBe(1)
+      // First call only has the first event
+      const manifestModules = calls[0][0].manifest.modules
+      expect(manifestModules).toEqual(
+        expect.arrayContaining([expect.objectContaining({uid: 'ext1', config: {config1: 'val1'}})]),
+      )
+      expect(manifestModules.length).toBe(1)
 
-    // Second call has the second and third event
-    const manifestModules2 = calls[1][0].manifest.modules
-    expect(manifestModules2).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({uid: 'ext1', config: {config1: 'val1'}}),
-        expect.objectContaining({uid: 'ext2', config: {config2: 'val2'}}),
-      ]),
-    )
-    expect(manifestModules2.length).toBe(2)
+      // Second call has the second and third event
+      const manifestModules2 = calls[1][0].manifest.modules
+      expect(manifestModules2).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({uid: 'ext1', config: {config1: 'val1'}}),
+          expect.objectContaining({uid: 'ext2', config: {config2: 'val2'}}),
+        ]),
+      )
+      expect(manifestModules2.length).toBe(2)
+    })
   })
 
   test('displays SESSION_TAKEOVER warning from devSessionCreate response', async () => {
-    // Given
-    developerPlatformClient.devSessionCreate = vi.fn().mockResolvedValue({
-      devSessionCreate: {
-        userErrors: [],
-        warnings: [{message: "You took over another user's session", code: 'SESSION_TAKEOVER'}],
-        devSession: {
-          websocketUrl: 'wss://test.dev/extensions',
-          updatedAt: '2024-01-01T00:00:00Z',
-          user: {id: 'user1', email: 'user1@test.com'},
-          app: {id: 'app1', key: 'key1'},
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      const {options, stdout, stderr, abortController, appWatcher, developerPlatformClient} = await setup(tmpDir)
+
+      developerPlatformClient.devSessionCreate = vi.fn().mockResolvedValue({
+        devSessionCreate: {
+          userErrors: [],
+          warnings: [{message: "You took over another user's session", code: 'SESSION_TAKEOVER'}],
+          devSession: {
+            websocketUrl: 'wss://test.dev/extensions',
+            updatedAt: '2024-01-01T00:00:00Z',
+            user: {id: 'user1', email: 'user1@test.com'},
+            app: {id: 'app1', key: 'key1'},
+          },
         },
-      },
+      })
+
+      // When
+      await pushUpdatesForDevSession({stderr, stdout, abortSignal: abortController.signal}, options)
+      await appWatcher.start({stdout, stderr, signal: abortController.signal})
+
+      // Then
+      await vi.waitFor(() => {
+        expect(stdout.write).toHaveBeenCalledWith(expect.stringContaining("⚠️  You took over another user's session"))
+        expect(stdout.write).toHaveBeenCalledWith(expect.stringContaining('Ready'))
+      })
     })
-
-    // When
-    await pushUpdatesForDevSession({stderr, stdout, abortSignal: abortController.signal}, options)
-    await appWatcher.start({stdout, stderr, signal: abortController.signal})
-    await flushPromises()
-
-    // Then
-    expect(stdout.write).toHaveBeenCalledWith(expect.stringContaining("⚠️  You took over another user's session"))
-    expect(stdout.write).toHaveBeenCalledWith(expect.stringContaining('Ready'))
   })
 
   test('detects session takeover during update when user ID changes', async () => {
-    // The session takeover detection throws an AbortError that propagates as an unhandled
-    // rejection through the SerialBatchProcessor (due to a missing await in bundleExtensionsAndUpload).
-    // Attach a .catch() to the processing promise to prevent the unhandled rejection.
-    const originalEnqueue = SerialBatchProcessor.prototype.enqueue
-    const enqueueSpy = vi.spyOn(SerialBatchProcessor.prototype, 'enqueue').mockImplementation(function (
-      this: any,
-      ...args: [any]
-    ) {
-      originalEnqueue.apply(this, args)
-      this.processingPromise?.catch(() => {})
-    })
+    await inTemporaryDirectory(async (tmpDir) => {
+      // The session takeover detection throws an AbortError that propagates as an unhandled
+      // rejection through the SerialBatchProcessor (due to a missing await in bundleExtensionsAndUpload).
+      // Attach a .catch() to the processing promise to prevent the unhandled rejection.
+      const originalEnqueue = SerialBatchProcessor.prototype.enqueue
+      const enqueueSpy = vi.spyOn(SerialBatchProcessor.prototype, 'enqueue').mockImplementation(function (
+        this: any,
+        ...args: [any]
+      ) {
+        originalEnqueue.apply(this, args)
+        this.processingPromise?.catch(() => {})
+      })
 
-    // Given - Create with initial session state
-    developerPlatformClient.devSessionCreate = vi.fn().mockResolvedValue({
-      devSessionCreate: {
-        userErrors: [],
-        devSession: {
-          websocketUrl: 'wss://test.dev/extensions',
-          updatedAt: '2024-01-01T00:00:00Z',
-          user: {id: 'user1', email: 'user1@test.com'},
-          app: {id: 'app1', key: 'key1'},
+      // Given
+      const {
+        options,
+        stdout,
+        stderr,
+        abortController,
+        appWatcher,
+        app,
+        developerPlatformClient,
+        devSessionStatusManager,
+      } = await setup(tmpDir)
+
+      // Create with initial session state
+      developerPlatformClient.devSessionCreate = vi.fn().mockResolvedValue({
+        devSessionCreate: {
+          userErrors: [],
+          devSession: {
+            websocketUrl: 'wss://test.dev/extensions',
+            updatedAt: '2024-01-01T00:00:00Z',
+            user: {id: 'user1', email: 'user1@test.com'},
+            app: {id: 'app1', key: 'key1'},
+          },
         },
-      },
-    })
+      })
 
-    // Update returns a different user (session takeover)
-    developerPlatformClient.devSessionUpdate = vi.fn().mockResolvedValue({
-      devSessionUpdate: {
-        userErrors: [],
-        devSession: {
-          websocketUrl: 'wss://test.dev/extensions',
-          updatedAt: '2024-01-01T00:01:00Z',
-          user: {id: 'user2', email: 'user2@test.com'},
-          app: {id: 'app1', key: 'key1'},
+      // Update returns a different user (session takeover)
+      developerPlatformClient.devSessionUpdate = vi.fn().mockResolvedValue({
+        devSessionUpdate: {
+          userErrors: [],
+          devSession: {
+            websocketUrl: 'wss://test.dev/extensions',
+            updatedAt: '2024-01-01T00:01:00Z',
+            user: {id: 'user2', email: 'user2@test.com'},
+            app: {id: 'app1', key: 'key1'},
+          },
         },
-      },
+      })
+
+      // When
+      await pushUpdatesForDevSession({stderr, stdout, abortSignal: abortController.signal}, options)
+      await appWatcher.start({stdout, stderr, signal: abortController.signal})
+      await vi.waitFor(() => expect(devSessionStatusManager.status.isReady).toBe(true))
+      appWatcher.emit('all', {app, extensionEvents: [{type: 'updated', extension: await testWebhookExtensions()}]})
+
+      // Then
+      await vi.waitFor(() => {
+        expect(stdout.write).toHaveBeenCalledWith(expect.stringContaining('Another developer'))
+        expect(stdout.write).toHaveBeenCalledWith(expect.stringContaining('user2@test.com'))
+        expect(stdout.write).toHaveBeenCalledWith(expect.stringContaining('taken ownership of this dev preview'))
+      })
+
+      enqueueSpy.mockRestore()
     })
-
-    // When
-    await pushUpdatesForDevSession({stderr, stdout, abortSignal: abortController.signal}, options)
-    await appWatcher.start({stdout, stderr, signal: abortController.signal})
-    await flushPromises()
-    appWatcher.emit('all', {app, extensionEvents: [{type: 'updated', extension: await testWebhookExtensions()}]})
-    await flushPromises()
-
-    // Then
-    expect(stdout.write).toHaveBeenCalledWith(expect.stringContaining('Another developer'))
-    expect(stdout.write).toHaveBeenCalledWith(expect.stringContaining('user2@test.com'))
-    expect(stdout.write).toHaveBeenCalledWith(expect.stringContaining('taken ownership of this dev preview'))
-
-    enqueueSpy.mockRestore()
   })
 
   test('does not detect session takeover when session state matches during update', async () => {
-    // Given - Create and update return the same user/websocket
-    developerPlatformClient.devSessionCreate = vi.fn().mockResolvedValue({
-      devSessionCreate: {
-        userErrors: [],
-        devSession: {
-          websocketUrl: 'wss://test.dev/extensions',
-          updatedAt: '2024-01-01T00:00:00Z',
-          user: {id: 'user1', email: 'user1@test.com'},
-          app: {id: 'app1', key: 'key1'},
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      const {
+        options,
+        stdout,
+        stderr,
+        abortController,
+        appWatcher,
+        app,
+        developerPlatformClient,
+        devSessionStatusManager,
+      } = await setup(tmpDir)
+
+      // Create and update return the same user/websocket
+      developerPlatformClient.devSessionCreate = vi.fn().mockResolvedValue({
+        devSessionCreate: {
+          userErrors: [],
+          devSession: {
+            websocketUrl: 'wss://test.dev/extensions',
+            updatedAt: '2024-01-01T00:00:00Z',
+            user: {id: 'user1', email: 'user1@test.com'},
+            app: {id: 'app1', key: 'key1'},
+          },
         },
-      },
-    })
+      })
 
-    developerPlatformClient.devSessionUpdate = vi.fn().mockResolvedValue({
-      devSessionUpdate: {
-        userErrors: [],
-        devSession: {
-          websocketUrl: 'wss://test.dev/extensions',
-          updatedAt: '2024-01-01T00:01:00Z',
-          user: {id: 'user1', email: 'user1@test.com'},
-          app: {id: 'app1', key: 'key1'},
+      developerPlatformClient.devSessionUpdate = vi.fn().mockResolvedValue({
+        devSessionUpdate: {
+          userErrors: [],
+          devSession: {
+            websocketUrl: 'wss://test.dev/extensions',
+            updatedAt: '2024-01-01T00:01:00Z',
+            user: {id: 'user1', email: 'user1@test.com'},
+            app: {id: 'app1', key: 'key1'},
+          },
         },
-      },
+      })
+
+      // When
+      await pushUpdatesForDevSession({stderr, stdout, abortSignal: abortController.signal}, options)
+      await appWatcher.start({stdout, stderr, signal: abortController.signal})
+      await vi.waitFor(() => expect(devSessionStatusManager.status.isReady).toBe(true))
+      appWatcher.emit('all', {app, extensionEvents: [{type: 'updated', extension: await testWebhookExtensions()}]})
+
+      // Then - Should succeed normally without takeover error
+      await vi.waitFor(() =>
+        expect(stdout.write).toHaveBeenCalledWith(expect.stringContaining('Updated dev preview on test.myshopify.com')),
+      )
+      expect(stdout.write).not.toHaveBeenCalledWith(expect.stringContaining('Another developer'))
+      expect(stdout.write).not.toHaveBeenCalledWith(expect.stringContaining('taken ownership of this dev preview'))
     })
-
-    // When
-    await pushUpdatesForDevSession({stderr, stdout, abortSignal: abortController.signal}, options)
-    await appWatcher.start({stdout, stderr, signal: abortController.signal})
-    await flushPromises()
-    appWatcher.emit('all', {app, extensionEvents: [{type: 'updated', extension: await testWebhookExtensions()}]})
-    await flushPromises()
-
-    // Then - Should succeed normally without takeover error
-    expect(stdout.write).toHaveBeenCalledWith(expect.stringContaining('Updated dev preview on test.myshopify.com'))
-    expect(stdout.write).not.toHaveBeenCalledWith(expect.stringContaining('Another developer'))
-    expect(stdout.write).not.toHaveBeenCalledWith(expect.stringContaining('taken ownership of this dev preview'))
   })
 
   test('retries failed events along with newly received events', async () => {
-    vi.mocked(getUploadURL).mockResolvedValue('https://gcs.url')
-    vi.mocked(readdir).mockResolvedValue([])
-    // Setup test extensions
-    const extension1 = await testUIExtension()
-    extension1.uid = 'ext1-uid'
-    extension1.handle = 'ext1-handle'
-    extension1.deployConfig = vi.fn().mockResolvedValue({config1: 'val1'})
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      const {options, stdout, stderr, abortController, appWatcher, developerPlatformClient, devSessionStatusManager} =
+        await setup(tmpDir)
 
-    const extension2 = await testWebhookExtensions()
-    extension2.uid = 'ext2-uid'
-    extension2.handle = 'ext2-handle'
-    extension2.deployConfig = vi.fn().mockResolvedValue({config2: 'val2'})
+      vi.mocked(getUploadURL).mockResolvedValue('https://gcs.url')
 
-    app = testAppLinked({allExtensions: [extension1, extension2]})
+      // Setup test extensions
+      const extension1 = await testUIExtension()
+      extension1.uid = 'ext1-uid'
+      extension1.handle = 'ext1-handle'
+      extension1.deployConfig = vi.fn().mockResolvedValue({config1: 'val1'})
 
-    // Mock devSessionUpdate to fail on first call and succeed on second
-    developerPlatformClient.devSessionUpdate = vi
-      .fn()
-      .mockResolvedValueOnce({devSessionUpdate: {userErrors: [{message: 'Simulated failure', category: 'remote'}]}})
-      .mockResolvedValueOnce({devSessionUpdate: {userErrors: []}})
+      const extension2 = await testWebhookExtensions()
+      extension2.uid = 'ext2-uid'
+      extension2.handle = 'ext2-handle'
+      extension2.deployConfig = vi.fn().mockResolvedValue({config2: 'val2'})
 
-    // Start the dev session
-    await pushUpdatesForDevSession({stderr, stdout, abortSignal: abortController.signal}, options)
-    await appWatcher.start({stdout, stderr, signal: abortController.signal})
-    await flushPromises()
+      const app = testAppLinked({allExtensions: [extension1, extension2]})
 
-    // First event (will fail)
-    appWatcher.emit('all', {app, extensionEvents: [{type: 'updated', extension: extension1}]})
-    await flushPromises()
+      // Mock devSessionUpdate to fail on first call and succeed on second
+      developerPlatformClient.devSessionUpdate = vi
+        .fn()
+        .mockResolvedValueOnce({devSessionUpdate: {userErrors: [{message: 'Simulated failure', category: 'remote'}]}})
+        .mockResolvedValueOnce({devSessionUpdate: {userErrors: []}})
 
-    // Verify the update was attempted and failed
-    expect(developerPlatformClient.devSessionUpdate).toHaveBeenCalledTimes(1)
-    expect(stdout.write).toHaveBeenCalledWith(expect.stringContaining('Simulated failure'))
-    expect(devSessionStatusManager.status.statusMessage?.message).toBe('Error updating dev preview')
+      // Start the dev session
+      await pushUpdatesForDevSession({stderr, stdout, abortSignal: abortController.signal}, options)
+      await appWatcher.start({stdout, stderr, signal: abortController.signal})
+      await vi.waitFor(() => expect(devSessionStatusManager.status.isReady).toBe(true))
 
-    // Second event (should include retry of first failed event)
-    appWatcher.emit('all', {app, extensionEvents: [{type: 'updated', extension: extension2}]})
-    await flushPromises()
+      // First event (will fail)
+      appWatcher.emit('all', {app, extensionEvents: [{type: 'updated', extension: extension1}]})
 
-    // Verify a second update attempt was made
-    expect(developerPlatformClient.devSessionUpdate).toHaveBeenCalledTimes(2)
+      // Verify the update was attempted and failed
+      await vi.waitFor(() => expect(developerPlatformClient.devSessionUpdate).toHaveBeenCalledTimes(1))
+      expect(stdout.write).toHaveBeenCalledWith(expect.stringContaining('Simulated failure'))
+      expect(devSessionStatusManager.status.statusMessage?.message).toBe('Error updating dev preview')
 
-    // Verify the second update attempt included both extensions
-    const secondCallPayload = developerPlatformClient.devSessionUpdate.mock.calls[1][0]
-    expect(secondCallPayload.manifest.modules).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({uid: 'ext1-uid', handle: 'ext1-handle', config: {config1: 'val1'}}),
-        expect.objectContaining({uid: 'ext2-uid', handle: 'ext2-handle', config: {config2: 'val2'}}),
-      ]),
-    )
-    expect(secondCallPayload.manifest.modules.length).toBe(2)
+      // Second event (should include retry of first failed event)
+      appWatcher.emit('all', {app, extensionEvents: [{type: 'updated', extension: extension2}]})
 
-    // Verify success status was set
-    expect(stdout.write).toHaveBeenCalledWith(expect.stringContaining('Updated dev preview on test.myshopify.com'))
-    expect(devSessionStatusManager.status.statusMessage?.message).toBe('Updated')
+      // Verify a second update attempt was made
+      await vi.waitFor(() => expect(developerPlatformClient.devSessionUpdate).toHaveBeenCalledTimes(2))
+
+      // Verify the second update attempt included both extensions
+      const secondCallPayload = (developerPlatformClient.devSessionUpdate as any).mock.calls[1][0]
+      expect(secondCallPayload.manifest.modules).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({uid: 'ext1-uid', handle: 'ext1-handle', config: {config1: 'val1'}}),
+          expect.objectContaining({uid: 'ext2-uid', handle: 'ext2-handle', config: {config2: 'val2'}}),
+        ]),
+      )
+      expect(secondCallPayload.manifest.modules.length).toBe(2)
+
+      // Verify success status was set
+      expect(stdout.write).toHaveBeenCalledWith(expect.stringContaining('Updated dev preview on test.myshopify.com'))
+      expect(devSessionStatusManager.status.statusMessage?.message).toBe('Updated')
+    })
   })
 })
+
+async function setup(tmpDir: string) {
+  vi.mocked(formData).mockReturnValue({append: vi.fn(), getHeaders: vi.fn()} as any)
+  vi.mocked(getUploadURL).mockResolvedValue('https://gcs.url')
+  const stdout = {write: vi.fn()} as any
+  const stderr = {write: vi.fn()} as any
+  const developerPlatformClient = testDeveloperPlatformClient()
+  const app = testAppLinked({directory: tmpDir})
+  app.manifest = vi.fn().mockResolvedValue({
+    name: 'App',
+    handle: '',
+    modules: [],
+  })
+
+  const buildOutputPath = joinPath(tmpDir, '.shopify', 'dev-bundle')
+  await mkdir(buildOutputPath)
+  const appWatcher = new AppEventWatcher(app, undefined, buildOutputPath)
+  // Disable initial build as we are mocking extensions and don't want to deal with esbuild/build failures
+  const originalStart = appWatcher.start.bind(appWatcher)
+  appWatcher.start = (options?: any) => originalStart(options, false)
+
+  const abortController = new AbortController()
+  const devSessionStatusManager = new DevSessionStatusManager()
+  const options: DevSessionProcessOptions = {
+    app,
+    apiKey: 'test-api-key',
+    developerPlatformClient,
+    appWatcher,
+    storeFqdn: 'test.myshopify.com',
+    url: 'https://test.dev',
+    appId: 'app123',
+    organizationId: 'org123',
+    appPreviewURL: 'https://test.preview.url',
+    appLocalProxyURL: 'https://test.local.url',
+    devSessionStatusManager,
+  }
+  return {
+    options,
+    stdout,
+    stderr,
+    developerPlatformClient,
+    appWatcher,
+    app,
+    abortController,
+    devSessionStatusManager,
+  }
+}


### PR DESCRIPTION
This PR refactors the unit tests for the dev session process to follow the project's testing guidelines by using a real filesystem instead of mocks.

### Key Changes:
- Removed `vi.mock('@shopify/cli-kit/node/fs')`.
- Wrapped tests in `inTemporaryDirectory` to ensure isolation and clean up after execution.
- Replaced brittle `flushPromises()` calls with `vi.waitFor()` to correctly synchronize with asynchronous status changes in the `DevSession`.
- Refactored test setup to eliminate `beforeEach`/`afterEach` shared state, moving it into a dedicated `setup` helper called within each test block.
- Updated asset detection tests to create actual directories in the temporary bundle path.

### How to test your changes?
CI

---
*PR created automatically by Jules for task [3550839542173712765](https://jules.google.com/task/3550839542173712765) started by @gonzaloriestra*