### PR TITLE
[Security] Harden dev console assets middleware against path traversal

### DIFF
--- a/packages/app/src/cli/services/dev/extension/server/middlewares.test.ts
+++ b/packages/app/src/cli/services/dev/extension/server/middlewares.test.ts
@@ -6,6 +6,7 @@ import {
   noCacheMiddleware,
   redirectToDevConsoleMiddleware,
   getExtensionPointMiddleware,
+  devConsoleAssetsMiddleware,
 } from './middlewares.js'
 import * as utilities from './utilities.js'
 import {GetExtensionsMiddlewareOptions} from './models.js'
@@ -15,6 +16,7 @@ import {UIExtensionPayload} from '../payload/models.js'
 import {testUIExtension} from '../../../../models/app/app.test-data.js'
 import {AppEventWatcher} from '../../app-events/app-event-watcher.js'
 import {copyConfigKeyEntry} from '../../../build/steps/include-assets/copy-config-key-entry.js'
+import * as fs from '@shopify/cli-kit/node/fs'
 import {describe, expect, vi, test} from 'vitest'
 import {inTemporaryDirectory, mkdir, touchFile, writeFile} from '@shopify/cli-kit/node/fs'
 import * as h3 from 'h3'
@@ -686,6 +688,31 @@ describe('getExtensionPayloadMiddleware()', () => {
         extension: {
           mock: 'extension payload',
         },
+      })
+    })
+  })
+})
+
+describe('devConsoleAssetsMiddleware()', () => {
+  test('returns 404 for path traversal attempts', async () => {
+    await inTemporaryDirectory(async (tmpDir: string) => {
+      vi.spyOn(utilities, 'sendError').mockImplementation(() => ({}) as any)
+      vi.spyOn(fs, 'findPathUp').mockResolvedValue(joinPath(tmpDir, 'assets'))
+
+      await fs.mkdir(joinPath(tmpDir, 'assets'))
+      await writeFile(joinPath(tmpDir, 'secret.txt'), 'secret')
+
+      const event = getMockEvent({
+        params: {
+          assetPath: '../secret.txt',
+        },
+      })
+
+      await devConsoleAssetsMiddleware(event)
+
+      expect(utilities.sendError).toHaveBeenCalledWith(event, {
+        statusCode: 404,
+        statusMessage: 'Not Found',
       })
     })
   })

--- a/packages/app/src/cli/services/dev/extension/server/middlewares.ts
+++ b/packages/app/src/cli/services/dev/extension/server/middlewares.ts
@@ -146,8 +146,13 @@ export const devConsoleAssetsMiddleware = defineEventHandler(async (event) => {
     })
   }
 
+  const candidate = resolvePath(joinPath(rootDirectory, assetPath))
+  if (!isSubpath(rootDirectory, candidate)) {
+    return sendError(event, {statusCode: 404, statusMessage: 'Not Found'})
+  }
+
   return fileServerMiddleware(event, {
-    filePath: joinPath(rootDirectory, assetPath),
+    filePath: candidate,
   })
 })
 


### PR DESCRIPTION
### WHY are these changes introduced?

This PR addresses a potential path traversal vulnerability in the dev console assets middleware.

### WHAT is this pull request doing?

It ensures that requested asset paths are contained within the expected root directory by using a subpath check.

### How to test your changes?

CI

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [15539787141918695569](https://jules.google.com/task/15539787141918695569) started by @gonzaloriestra*