### PR TITLE
[Performance] Memoize username

### DIFF
--- a/packages/cli-kit/src/public/node/os.test.ts
+++ b/packages/cli-kit/src/public/node/os.test.ts
@@ -1,16 +1,8 @@
-import {platformAndArch, username} from './os.js'
+import {platformAndArch, username, _resetUsernameCache} from './os.js'
 import {describe, test, expect, vi, beforeEach} from 'vitest'
 import {execa} from 'execa'
 import {userInfo as osUserInfo} from 'os'
 
-vi.mock('node:process', () => ({
-  default: {
-    platform: 'linux',
-    arch: 'x64',
-    env: {},
-    argv: [],
-  },
-}))
 vi.mock('execa')
 vi.mock('os', async (importOriginal) => {
   const original = (await importOriginal()) as any
@@ -22,6 +14,7 @@ vi.mock('os', async (importOriginal) => {
 
 describe('username', () => {
   beforeEach(() => {
+    _resetUsernameCache()
     vi.mocked(execa).mockClear()
     vi.mocked(osUserInfo).mockReturnValue({} as any)
     vi.stubEnv('USER', '')
@@ -34,31 +27,50 @@ describe('username', () => {
 
   test('memoizes the result when platform matches process.platform', async () => {
     // Given
-    vi.mocked(execa).mockResolvedValue({stdout: '123'} as any)
-    // First call to id -u, second to id -un 123
-    vi.mocked(execa).mockResolvedValueOnce({stdout: '123'} as any)
-    vi.mocked(execa).mockResolvedValueOnce({stdout: 'user'} as any)
+    if (process.platform === 'win32') {
+      vi.mocked(execa).mockResolvedValue({stdout: 'domain\\user'} as any)
+    } else {
+      vi.mocked(execa).mockResolvedValueOnce({stdout: '123'} as any)
+      vi.mocked(execa).mockResolvedValueOnce({stdout: 'user'} as any)
+    }
 
     // When
-    const firstResult = await username('linux')
-    const secondResult = await username('linux')
+    const firstResult = await username()
+    const secondResult = await username()
 
     // Then
     expect(firstResult).toBe('user')
     expect(secondResult).toBe('user')
-    expect(execa).toHaveBeenCalledTimes(2)
+    if (process.platform === 'win32') {
+      expect(execa).toHaveBeenCalledTimes(1)
+      expect(execa).toHaveBeenCalledWith('whoami')
+    } else {
+      expect(execa).toHaveBeenCalledTimes(2)
+      expect(execa).toHaveBeenNthCalledWith(1, 'id', ['-u'])
+      expect(execa).toHaveBeenNthCalledWith(2, 'id', ['-un', '123'])
+    }
   })
 
   test('does not memoize the result when platform does not match process.platform', async () => {
     // Given
-    vi.mocked(execa).mockResolvedValue({stdout: 'user'} as any)
+    const otherPlatform = process.platform === 'win32' ? 'linux' : 'win32'
+    if (otherPlatform === 'win32') {
+      vi.mocked(execa).mockResolvedValue({stdout: 'domain\\user'} as any)
+    } else {
+      vi.mocked(execa).mockResolvedValue({stdout: 'user'} as any)
+    }
 
     // When
-    await username('win32')
-    await username('win32')
+    await username(otherPlatform)
+    await username(otherPlatform)
 
     // Then
-    expect(execa).toHaveBeenCalledTimes(2)
+    if (otherPlatform === 'win32') {
+      expect(execa).toHaveBeenCalledTimes(2)
+    } else {
+      // id -u is called each time, and potentially id -un
+      expect(execa).toHaveBeenCalledTimes(4)
+    }
   })
 })
 

--- a/packages/cli-kit/src/public/node/os.test.ts
+++ b/packages/cli-kit/src/public/node/os.test.ts
@@ -1,7 +1,66 @@
-import {platformAndArch} from './os.js'
-import {describe, test, expect, vi} from 'vitest'
+import {platformAndArch, username} from './os.js'
+import {describe, test, expect, vi, beforeEach} from 'vitest'
+import {execa} from 'execa'
+import {userInfo as osUserInfo} from 'os'
 
-vi.mock('node:process')
+vi.mock('node:process', () => ({
+  default: {
+    platform: 'linux',
+    arch: 'x64',
+    env: {},
+    argv: [],
+  },
+}))
+vi.mock('execa')
+vi.mock('os', async (importOriginal) => {
+  const original = (await importOriginal()) as any
+  return {
+    ...original,
+    userInfo: vi.fn(),
+  }
+})
+
+describe('username', () => {
+  beforeEach(() => {
+    vi.mocked(execa).mockClear()
+    vi.mocked(osUserInfo).mockReturnValue({} as any)
+    vi.stubEnv('USER', '')
+    vi.stubEnv('SUDO_USER', '')
+    vi.stubEnv('C9_USER', '')
+    vi.stubEnv('LOGNAME', '')
+    vi.stubEnv('LNAME', '')
+    vi.stubEnv('USERNAME', '')
+  })
+
+  test('memoizes the result when platform matches process.platform', async () => {
+    // Given
+    vi.mocked(execa).mockResolvedValue({stdout: '123'} as any)
+    // First call to id -u, second to id -un 123
+    vi.mocked(execa).mockResolvedValueOnce({stdout: '123'} as any)
+    vi.mocked(execa).mockResolvedValueOnce({stdout: 'user'} as any)
+
+    // When
+    const firstResult = await username('linux')
+    const secondResult = await username('linux')
+
+    // Then
+    expect(firstResult).toBe('user')
+    expect(secondResult).toBe('user')
+    expect(execa).toHaveBeenCalledTimes(2)
+  })
+
+  test('does not memoize the result when platform does not match process.platform', async () => {
+    // Given
+    vi.mocked(execa).mockResolvedValue({stdout: 'user'} as any)
+
+    // When
+    await username('win32')
+    await username('win32')
+
+    // Then
+    expect(execa).toHaveBeenCalledTimes(2)
+  })
+})
 
 describe('platformAndArch', () => {
   test("returns the right architecture when it's x64", () => {

--- a/packages/cli-kit/src/public/node/os.ts
+++ b/packages/cli-kit/src/public/node/os.ts
@@ -6,10 +6,22 @@ import {userInfo as osUserInfo} from 'os'
 // because adding it as a transtive dependency causes conflicts with other
 // packages that haven't been yet migrated to the latest version.
 /**
+ * Memoized value for the username.
+ */
+let memoizedUsername: Promise<string | null> | undefined
+
+/**
  * @param platform - The platform to get the username for. Defaults to the current platform.
  * @returns The username of the current user.
  */
-export async function username(platform: typeof process.platform = process.platform): Promise<string | null> {
+export function username(platform: typeof process.platform = process.platform): Promise<string | null> {
+  if (platform !== process.platform) {
+    return fetchUsername(platform)
+  }
+  return (memoizedUsername ??= fetchUsername(platform))
+}
+
+async function fetchUsername(platform: typeof process.platform = process.platform): Promise<string | null> {
   outputDebug(outputContent`Obtaining user name...`)
   const environmentVariable = getEnvironmentVariable()
   if (environmentVariable) {

--- a/packages/cli-kit/src/public/node/os.ts
+++ b/packages/cli-kit/src/public/node/os.ts
@@ -21,6 +21,13 @@ export function username(platform: typeof process.platform = process.platform): 
   return (memoizedUsername ??= fetchUsername(platform))
 }
 
+/**
+ * Resets the memoized username.
+ */
+export function _resetUsernameCache(): void {
+  memoizedUsername = undefined
+}
+
 async function fetchUsername(platform: typeof process.platform = process.platform): Promise<string | null> {
   outputDebug(outputContent`Obtaining user name...`)
   const environmentVariable = getEnvironmentVariable()


### PR DESCRIPTION
### WHY are these changes introduced?

Obtaining the username can be an expensive operation, involving system calls like `whoami` on Windows or `id` on Linux/macOS. Since the username is unlikely to change during the execution of a CLI command, memoizing it improves performance for subsequent calls.

### WHAT is this pull request doing?

This PR memoizes the result of the `username` function in `packages/cli-kit/src/public/node/os.ts`. 
- Introduced a `memoizedUsername` variable to store the Promise.
- The cache is only used when the requested platform matches the current process platform to ensure correctness.
- Added comprehensive unit tests in `packages/cli-kit/src/public/node/os.test.ts` to verify memoization behavior.

### How to test your changes?

CI

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [7917733068613054796](https://jules.google.com/task/7917733068613054796) started by @gonzaloriestra*