### PR TITLE
Restore cli-kit root export

### DIFF
--- a/configurations/tsconfig.json
+++ b/configurations/tsconfig.json
@@ -19,6 +19,7 @@
       "noUncheckedIndexedAccess": true,
       "jsx": "react",
       "paths": {
+        "@shopify/cli-kit": ["../packages/cli-kit/src/index"],
         "@shopify/cli-kit/*": ["../packages/cli-kit/src/public/*"],
         "@shopify/theme/*": ["../packages/theme/src/*"],
         "@shopify/cli-kit/typing/*": ["../packages/cli-kit/src/typing/*"],

--- a/docs/cli/testing-strategy.md
+++ b/docs/cli/testing-strategy.md
@@ -40,19 +40,19 @@ pnpm test path/to/my.test.ts
 If the subject under testing does a filesystem I/O operation, we recommend not stubbing that behavior instead of hitting the filesystem. Create a temporary directory whose lifecycle is tied to the lifecycle of the test:
 
 ```ts
-import {file, path} from "@shopify/cli-kit"
+import {exists, inTemporaryDirectory, writeFile} from "@shopify/cli-kit/node/fs"
+import {joinPath} from "@shopify/cli-kit/node/path"
 
 test("writes", async () => {
-    await file.inTemporaryDirectory(async (tmpDir: string) => {
+  await inTemporaryDirectory(async (tmpDir: string) => {
     // Given
-    const outputPath = path.join(tmpDir, "output")
+    const outputPath = joinPath(tmpDir, "output")
 
     // When
-    await file.write(outputPath, "content")
+    await writeFile(outputPath, "content")
 
     // Then
-    const exists = await file.exists(outputPath)
-    expect(exists).toBe(true)
+    expect(await exists(outputPath)).toBe(true)
   })
 })
 ```

--- a/packages/cli-kit/src/index.test.ts
+++ b/packages/cli-kit/src/index.test.ts
@@ -1,0 +1,9 @@
+import {file, path} from './index.js'
+import {describe, expect, test} from 'vitest'
+
+describe('root exports', () => {
+  test('exposes documented filesystem and path helpers', () => {
+    expect(file.inTemporaryDirectory).toBeTypeOf('function')
+    expect(path.joinPath).toBeTypeOf('function')
+  })
+})

--- a/packages/cli-kit/src/index.ts
+++ b/packages/cli-kit/src/index.ts
@@ -1,0 +1,2 @@
+export * as file from './public/node/fs.js'
+export * as path from './public/node/path.js'


### PR DESCRIPTION
## What

Restores the missing `@shopify/cli-kit` root entry by adding `packages/cli-kit/src/index.ts` with the documented `file` and `path` namespaces.

The published `@shopify/cli-kit@4.1.0` package still advertises:

- `exports["."].import = ./dist/index.js`
- `exports["."].types = ./dist/index.d.ts`
- `module = dist/index.js`
- `types = dist/index.d.ts`

but the tarball does not include `dist/index.js` or `dist/index.d.ts`, so `import('@shopify/cli-kit')` fails in a clean install.

This also re-adds the local TS path mapping for the root package and updates the testing-strategy docs sample to use the current filesystem/path helper names.

## Reproduction

```sh
mkdir /tmp/cli-kit-root-repro
cd /tmp/cli-kit-root-repro
npm init -y
npm install --ignore-scripts @shopify/cli-kit@4.1.0
node -e "import('@shopify/cli-kit').catch(e => { console.error(e.code + ': ' + e.message); process.exit(1) })"
```

Current output:

```text
ERR_MODULE_NOT_FOUND: Cannot find module '.../node_modules/@shopify/cli-kit/dist/index.js'
```

## Validation

- `pnpm --filter @shopify/cli-kit vitest src/index.test.ts`
- `pnpm --filter @shopify/cli-kit build`
- `pnpm --filter @shopify/cli-kit lint`
- `git diff --check`
- `npm pack --ignore-scripts --json --pack-destination /tmp/mojobeep-shopify-cli-kit-patched-pack`
- Clean packed-tarball install: `import('@shopify/cli-kit')` exposes `file.inTemporaryDirectory`, `file.writeFile`, and `path.joinPath`
- Clean packed-tarball TypeScript consumer with `skipLibCheck: false` and `@types/react@19` resolves `import {file, path} from '@shopify/cli-kit'`
