### PR TITLE
Add sidekick summaries to E2E staging configs

### DIFF
--- a/packages/e2e/tests/multi-config-dev.spec.ts
+++ b/packages/e2e/tests/multi-config-dev.spec.ts
@@ -52,6 +52,9 @@ api_version = "2025-01"
 [build]
 automatically_update_urls_on_dev = true
 include_config_on_deploy = true
+
+[sidekick]
+extensions_summary = "E2E staging app extensions"
 `.trimStart()
 
       fs.writeFileSync(path.join(appDir, 'shopify.app.staging.toml'), stagingToml)
@@ -128,6 +131,9 @@ redirect_urls = ["https://example.com/auth/callback"]
 
 [webhooks]
 api_version = "2025-01"
+
+[sidekick]
+extensions_summary = "E2E staging app extensions"
 `.trimStart()
 
       fs.writeFileSync(path.join(appDir, 'shopify.app.staging.toml'), stagingToml)


### PR DESCRIPTION
### WHY are these changes introduced?

The multi-config `app dev` E2E tests create a synthetic `shopify.app.staging.toml` fixture that no longer matches the required app config shape used by `app dev`.

The default fixture already includes Sidekick metadata, but the in-test staging config did not. That made the E2E scenario fail before it could validate the actual behavior under test: selecting the correct app config with and without `-c`.

### WHAT is this pull request doing?

Adds a minimal `[sidekick]` section with `extensions_summary` to the generated staging TOML in `packages/e2e/tests/multi-config-dev.spec.ts` for both multi-config E2E cases.

This keeps the staging config aligned with the valid app fixture while preserving the test intent:

- `app dev -c staging` loads `shopify.app.staging.toml`
- `app dev` without `-c` continues to load `shopify.app.toml`

### How to test your changes?

Run the affected E2E spec:

```sh
pnpm --filter e2e test tests/multi-config-dev.spec.ts
```

Or run the E2E workflow/check that covers multi-config app dev.

### Post-release steps

None.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows) — test fixture TOML only.
- [x] I've considered possible [documentation](https://shopify.dev) changes — none needed.
- [x] I've considered analytics changes to measure impact — none.
- [ ] The change is not user-facing — no changeset required.
