### PR TITLE
Add a shared GID codec to cli-kit and adopt it in app and organizations

### DIFF
--- a/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
@@ -159,6 +159,7 @@ import {
   BusinessPlatformRequestOptions,
 } from '@shopify/cli-kit/node/api/business-platform'
 import {CLI_KIT_VERSION} from '@shopify/cli-kit/common/version'
+import {encodeGid, numericIdFromEncodedGid, numericIdFromGid} from '@shopify/cli-kit/common/gid'
 import {versionSatisfies} from '@shopify/cli-kit/node/node-package-manager'
 import {outputDebug} from '@shopify/cli-kit/node/output'
 import {developerDashboardFqdn, normalizeStoreFqdn} from '@shopify/cli-kit/node/context/fqdn'
@@ -1266,7 +1267,7 @@ export function organizationGidForBP(id: string): string {
 
 // 1234 => gid://organization/Organization/1234 => base64
 export function encodedGidFromOrganizationIdForBP(id: string): string {
-  return Buffer.from(organizationGidForBP(id)).toString('base64')
+  return encodeGid(organizationGidForBP(id))
 }
 
 // App Managament uses a different GID format than Business Platform for organizationId.
@@ -1277,20 +1278,26 @@ function gidFromOrganizationIdForShopify(id: string): string {
 
 // 1234 => gid://organization/ShopifyShop/1234 => base64
 export function encodedGidFromShopId(id: string): string {
-  const gid = `gid://organization/ShopifyShop/${id}`
-  return Buffer.from(gid).toString('base64')
+  return encodeGid(`gid://organization/ShopifyShop/${id}`)
 }
 
 // base64 => gid://organization/Organization/1234 => 1234
 function idFromEncodedGid(gid: string): string {
-  const decodedGid = Buffer.from(gid, 'base64').toString('ascii')
-  return numberFromGid(decodedGid).toString()
+  const numeric = numericIdFromEncodedGid(gid)
+  if (numeric === undefined) {
+    throw new Error(`Invalid encoded GID: ${gid}`)
+  }
+  return numeric
 }
 
 // gid://organization/Organization/1234 => 1234
 function numberFromGid(gid: string): number {
   if (gid.startsWith('gid://')) {
-    return Number(gid.match(/^gid.*\/(\d+)$/)![1])
+    const numeric = numericIdFromGid(gid)
+    if (numeric === undefined) {
+      throw new Error(`Invalid GID: ${gid}`)
+    }
+    return Number(numeric)
   }
   return Number(gid)
 }

--- a/packages/cli-kit/src/public/common/gid.test.ts
+++ b/packages/cli-kit/src/public/common/gid.test.ts
@@ -1,0 +1,39 @@
+import {encodeGid, numericIdFromEncodedGid, numericIdFromGid} from './gid.js'
+import {describe, expect, test} from 'vitest'
+
+describe('numericIdFromGid', () => {
+  test('extracts the trailing numeric id from a plain gid', () => {
+    expect(numericIdFromGid('gid://shopify/Product/1234')).toBe('1234')
+    expect(numericIdFromGid('gid://organization/Organization/9876')).toBe('9876')
+  })
+
+  test('returns undefined when there is no trailing /<digits>', () => {
+    expect(numericIdFromGid('gid://shopify/Product/ABC')).toBeUndefined()
+    expect(numericIdFromGid('not-a-gid')).toBeUndefined()
+    expect(numericIdFromGid('1234')).toBeUndefined()
+  })
+})
+
+describe('numericIdFromEncodedGid', () => {
+  test('extracts the trailing numeric id from a base64-encoded gid', () => {
+    const gid = Buffer.from('gid://organization/Organization/1234').toString('base64')
+    expect(numericIdFromEncodedGid(gid)).toBe('1234')
+  })
+
+  test('returns undefined when the decoded string does not end with /<digits>', () => {
+    expect(numericIdFromEncodedGid(Buffer.from('not-a-gid').toString('base64'))).toBeUndefined()
+    expect(numericIdFromEncodedGid('!!!')).toBeUndefined()
+  })
+})
+
+describe('encodeGid', () => {
+  test('base64-encodes a plain gid', () => {
+    expect(encodeGid('gid://organization/Organization/1234')).toBe(
+      Buffer.from('gid://organization/Organization/1234').toString('base64'),
+    )
+  })
+
+  test('round-trips with numericIdFromEncodedGid', () => {
+    expect(numericIdFromEncodedGid(encodeGid('gid://shopify/Product/42'))).toBe('42')
+  })
+})

--- a/packages/cli-kit/src/public/common/gid.ts
+++ b/packages/cli-kit/src/public/common/gid.ts
@@ -1,0 +1,33 @@
+/**
+ * Extracts the trailing numeric id from a plain GraphQL global id like
+ * `gid://shopify/Product/123`.
+ *
+ * @param gid - A plain GraphQL global id string.
+ * @returns The trailing numeric id, or undefined when the string does not end with `/<digits>`.
+ */
+export function numericIdFromGid(gid: string): string | undefined {
+  const match = gid.match(/\/(\d+)$/)
+  return match ? match[1] : undefined
+}
+
+/**
+ * Decodes a base64-encoded GraphQL global id (for example, the form
+ * Business Platform APIs return) and returns the trailing numeric id.
+ *
+ * @param gid - A base64-encoded GraphQL global id.
+ * @returns The trailing numeric id, or undefined when the decoded string does not end with `/<digits>`.
+ */
+export function numericIdFromEncodedGid(gid: string): string | undefined {
+  return numericIdFromGid(Buffer.from(gid, 'base64').toString('utf8'))
+}
+
+/**
+ * Encodes a plain GraphQL global id (`gid://...`) as base64, which is the
+ * form some Business Platform endpoints require.
+ *
+ * @param gid - A plain GraphQL global id string to encode.
+ * @returns The base64-encoded gid.
+ */
+export function encodeGid(gid: string): string {
+  return Buffer.from(gid).toString('base64')
+}

--- a/packages/organizations/src/cli/services/fetch.ts
+++ b/packages/organizations/src/cli/services/fetch.ts
@@ -3,6 +3,7 @@ import {Organization} from '../models/organization.js'
 import {businessPlatformRequestDoc} from '@shopify/cli-kit/node/api/business-platform'
 import {ensureAuthenticatedBusinessPlatform} from '@shopify/cli-kit/node/session'
 import {AbortError} from '@shopify/cli-kit/node/error'
+import {numericIdFromEncodedGid} from '@shopify/cli-kit/common/gid'
 
 export async function fetchOrganizations(): Promise<Organization[]> {
   const token = await ensureAuthenticatedBusinessPlatform()
@@ -25,17 +26,11 @@ export async function fetchOrganizations(): Promise<Organization[]> {
   }
 
   const orgs = result.currentUserAccount.organizationsWithAccessToDestination.nodes
-  return orgs.map((org) => ({
-    id: idFromEncodedGid(org.id),
-    businessName: org.name,
-  }))
-}
-
-function idFromEncodedGid(gid: string): string {
-  const decodedGid = Buffer.from(gid, 'base64').toString('ascii')
-  const match = decodedGid.match(/\/(\d+)$/)
-  if (!match) {
-    throw new AbortError(`Failed to decode organization ID from: ${gid}`)
-  }
-  return match[1]!
+  return orgs.map((org) => {
+    const id = numericIdFromEncodedGid(org.id)
+    if (id === undefined) {
+      throw new AbortError(`Failed to decode organization ID from: ${org.id}`)
+    }
+    return {id, businessName: org.name}
+  })
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Decoding/encoding GraphQL global ids (`gid://shopify/<Type>/<id>`) was open-coded in more than one place — `app`'s `app-management-client` and the `organizations` fetch service each carried their own regex/base64 handling. This is the base of the stack for [`shopify store info`](https://github.com/Shopify/cli/pull/7660), which needs the same decoding for Business Platform ids, so the logic is centralized into one small, tested cli-kit module rather than copied a third time.

### WHAT is this pull request doing?

Adds `@shopify/cli-kit/common/gid` and adopts it at the two existing call sites:

- `numericIdFromGid(gid)` — trailing numeric id from a plain `gid://…/123` (or `undefined`).
- `numericIdFromEncodedGid(gid)` — same, for the base64-encoded form Business Platform APIs return.
- `encodeGid(gid)` — base64-encode a plain gid (the form some BP endpoints require).

`packages/app/.../app-management-client.ts` and `packages/organizations/.../fetch.ts` now call the shared helpers instead of their inline equivalents. Behavior is unchanged — this is a pure, internal refactor with no user-facing surface, so **no changeset** is included (consistent with how other private-package extractions in this repo are handled).

### How to test your changes?

- `pnpm vitest run packages/cli-kit/src/public/common/gid.test.ts` — 6 unit tests cover plain/encoded decoding, the no-trailing-id case, and round-tripping through `encodeGid`.
- `pnpm vitest run packages/app packages/organizations` — existing suites for the adopting call sites still pass.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows) — pure string/base64 operations, no platform-specific behavior
- [x] I've considered possible [documentation](https://shopify.dev) changes — internal helper, no public docs
- [x] I've considered analytics changes to measure impact — none; behavior-preserving
- [ ] The change is user-facing — N/A, internal refactor; no changeset
