### PR TITLE
Add extractHost and extractMyshopifyHandle to cli-kit/common/url

### DIFF
--- a/packages/cli-kit/src/public/common/url.test.ts
+++ b/packages/cli-kit/src/public/common/url.test.ts
@@ -1,4 +1,4 @@
-import {isValidURL, safeParseURL} from './url.js'
+import {extractHost, extractMyshopifyHandle, isValidURL, safeParseURL} from './url.js'
 import {describe, expect, test} from 'vitest'
 
 describe('isValidURL', () => {
@@ -55,5 +55,36 @@ describe('safeParseURL', () => {
     const result = safeParseURL('')
 
     expect(result).toBeUndefined()
+  })
+})
+
+describe('extractHost', () => {
+  test('returns the hostname for a full URL', () => {
+    expect(extractHost('https://Shop.MyShopify.com/admin')).toBe('shop.myshopify.com')
+  })
+
+  test('strips the scheme and path for a bare host string', () => {
+    expect(extractHost('shop.myshopify.com/admin')).toBe('shop.myshopify.com')
+  })
+
+  test('returns undefined for null/undefined/empty input', () => {
+    expect(extractHost(null)).toBeUndefined()
+    expect(extractHost(undefined)).toBeUndefined()
+    expect(extractHost('')).toBeUndefined()
+  })
+})
+
+describe('extractMyshopifyHandle', () => {
+  test('extracts the subdomain from a myshopify.com URL', () => {
+    expect(extractMyshopifyHandle('https://my-shop.myshopify.com')).toBe('my-shop')
+  })
+
+  test('returns undefined when the host is not a myshopify.com domain', () => {
+    expect(extractMyshopifyHandle('https://example.com')).toBeUndefined()
+  })
+
+  test('returns undefined for null/undefined input', () => {
+    expect(extractMyshopifyHandle(null)).toBeUndefined()
+    expect(extractMyshopifyHandle(undefined)).toBeUndefined()
   })
 })

--- a/packages/cli-kit/src/public/common/url.ts
+++ b/packages/cli-kit/src/public/common/url.ts
@@ -28,3 +28,32 @@ export function safeParseURL(url: string): URL | undefined {
     return undefined
   }
 }
+
+/**
+ * Extracts the lowercased hostname from a URL-shaped string. Tolerates
+ * bare hosts (without a scheme) and inputs that come back from APIs as
+ * either `https://shop.myshopify.com` or `shop.myshopify.com`.
+ *
+ * @param value - A URL or bare host string, possibly null/undefined.
+ * @returns The lowercased hostname, or undefined when the input is empty.
+ */
+export function extractHost(value: string | null | undefined): string | undefined {
+  if (!value) return undefined
+  const lowered = value.toLowerCase()
+  const parsed = safeParseURL(lowered)
+  if (parsed) return parsed.hostname
+  return lowered.replace(/^https?:\/\//, '').split('/')[0]
+}
+
+/**
+ * Extracts the subdomain handle from a `*.myshopify.com` URL or host.
+ *
+ * @param value - A URL or host string, possibly null/undefined.
+ * @returns The myshopify subdomain handle, or undefined when the input isn't a `*.myshopify.com` URL.
+ */
+export function extractMyshopifyHandle(value: string | null | undefined): string | undefined {
+  const host = extractHost(value)
+  if (!host) return undefined
+  const match = host.match(/^([^.]+)\.myshopify\.com$/)
+  return match ? match[1] : undefined
+}


### PR DESCRIPTION
### WHY are these changes introduced?

`shopify store info` (top of this stack, [#7660](https://github.com/Shopify/cli/pull/7660)) needs to (a) normalize a store host out of values that arrive as either `https://shop.myshopify.com` or a bare `shop.myshopify.com`, and (b) pull the subdomain handle out of a `*.myshopify.com` domain to build an admin URL. Both are generic URL operations that belong alongside the existing helpers in `cli-kit/common/url` rather than inside a command-specific module. This base PR adds them so the store PR can simply import them.

### WHAT is this pull request doing?

Adds two helpers to `@shopify/cli-kit/common/url`:

- `extractHost(value)` — lowercased hostname from a URL or bare-host string; tolerates a missing scheme and `null`/`undefined`.
- `extractMyshopifyHandle(value)` — the `<handle>` from a `*.myshopify.com` URL or host; `undefined` for anything that isn't a myshopify domain.

`extractMyshopifyHandle` is built on `extractHost`, so the scheme-tolerance and null-handling are shared. No existing exports change; this is purely additive. Internal refactor with no user-facing surface, so **no changeset**.

### How to test your changes?

- `pnpm vitest run packages/cli-kit/src/public/common/url.test.ts` — added cases cover scheme/no-scheme, casing, trailing path, non-myshopify hosts, and empty input.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows) — pure string/`URL` parsing
- [x] I've considered possible [documentation](https://shopify.dev) changes — internal helpers, no public docs
- [x] I've considered analytics changes to measure impact — none
- [ ] The change is user-facing — N/A, internal refactor; no changeset
