### PR TITLE
Extract the shared --store flag out of the store auth and execute commands

### DIFF
--- a/docs-shopify.dev/commands/interfaces/store-auth.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/store-auth.interface.ts
@@ -23,7 +23,7 @@ export interface storeauth {
   '--scopes <value>': string
 
   /**
-   * The myshopify.com domain of the store to authenticate against.
+   * The myshopify.com domain of the store.
    * @environment SHOPIFY_FLAG_STORE
    */
   '-s, --store <value>': string

--- a/docs-shopify.dev/commands/interfaces/store-execute.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/store-execute.interface.ts
@@ -41,7 +41,7 @@ export interface storeexecute {
   '--query-file <value>'?: string
 
   /**
-   * The myshopify.com domain of the store to execute against.
+   * The myshopify.com domain of the store.
    * @environment SHOPIFY_FLAG_STORE
    */
   '-s, --store <value>': string

--- a/docs-shopify.dev/generated/generated_docs_data_v2.json
+++ b/docs-shopify.dev/generated/generated_docs_data_v2.json
@@ -4177,11 +4177,11 @@
           "syntaxKind": "PropertySignature",
           "name": "-s, --store <value>",
           "value": "string",
-          "description": "The myshopify.com domain of the store to authenticate against.",
+          "description": "The myshopify.com domain of the store.",
           "environmentValue": "SHOPIFY_FLAG_STORE"
         }
       ],
-      "value": "export interface storeauth {\n  /**\n   * Output the result as JSON. Automatically disables color output.\n   * @environment SHOPIFY_FLAG_JSON\n   */\n  '-j, --json'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Comma-separated Admin API scopes to request for the app.\n   * @environment SHOPIFY_FLAG_SCOPES\n   */\n  '--scopes <value>': string\n\n  /**\n   * The myshopify.com domain of the store to authenticate against.\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>': string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+      "value": "export interface storeauth {\n  /**\n   * Output the result as JSON. Automatically disables color output.\n   * @environment SHOPIFY_FLAG_JSON\n   */\n  '-j, --json'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Comma-separated Admin API scopes to request for the app.\n   * @environment SHOPIFY_FLAG_SCOPES\n   */\n  '--scopes <value>': string\n\n  /**\n   * The myshopify.com domain of the store.\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>': string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
     }
   },
   "storeexecute": {
@@ -4277,7 +4277,7 @@
           "syntaxKind": "PropertySignature",
           "name": "-s, --store <value>",
           "value": "string",
-          "description": "The myshopify.com domain of the store to execute against.",
+          "description": "The myshopify.com domain of the store.",
           "environmentValue": "SHOPIFY_FLAG_STORE"
         },
         {
@@ -4290,7 +4290,7 @@
           "environmentValue": "SHOPIFY_FLAG_VARIABLES"
         }
       ],
-      "value": "export interface storeexecute {\n  /**\n   * Allow GraphQL mutations to run against the target store.\n   * @environment SHOPIFY_FLAG_ALLOW_MUTATIONS\n   */\n  '--allow-mutations'?: ''\n\n  /**\n   * Output the result as JSON. Automatically disables color output.\n   * @environment SHOPIFY_FLAG_JSON\n   */\n  '-j, --json'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The file name where results should be written, instead of STDOUT.\n   * @environment SHOPIFY_FLAG_OUTPUT_FILE\n   */\n  '--output-file <value>'?: string\n\n  /**\n   * The GraphQL query or mutation, as a string.\n   * @environment SHOPIFY_FLAG_QUERY\n   */\n  '-q, --query <value>'?: string\n\n  /**\n   * Path to a file containing the GraphQL query or mutation. Can't be used with --query.\n   * @environment SHOPIFY_FLAG_QUERY_FILE\n   */\n  '--query-file <value>'?: string\n\n  /**\n   * The myshopify.com domain of the store to execute against.\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>': string\n\n  /**\n   * Path to a file containing GraphQL variables in JSON format. Can't be used with --variables.\n   * @environment SHOPIFY_FLAG_VARIABLE_FILE\n   */\n  '--variable-file <value>'?: string\n\n  /**\n   * The values for any GraphQL variables in your query or mutation, in JSON format.\n   * @environment SHOPIFY_FLAG_VARIABLES\n   */\n  '-v, --variables <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n\n  /**\n   * The API version to use for the query or mutation. Defaults to the latest stable version.\n   * @environment SHOPIFY_FLAG_VERSION\n   */\n  '--version <value>'?: string\n}"
+      "value": "export interface storeexecute {\n  /**\n   * Allow GraphQL mutations to run against the target store.\n   * @environment SHOPIFY_FLAG_ALLOW_MUTATIONS\n   */\n  '--allow-mutations'?: ''\n\n  /**\n   * Output the result as JSON. Automatically disables color output.\n   * @environment SHOPIFY_FLAG_JSON\n   */\n  '-j, --json'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The file name where results should be written, instead of STDOUT.\n   * @environment SHOPIFY_FLAG_OUTPUT_FILE\n   */\n  '--output-file <value>'?: string\n\n  /**\n   * The GraphQL query or mutation, as a string.\n   * @environment SHOPIFY_FLAG_QUERY\n   */\n  '-q, --query <value>'?: string\n\n  /**\n   * Path to a file containing the GraphQL query or mutation. Can't be used with --query.\n   * @environment SHOPIFY_FLAG_QUERY_FILE\n   */\n  '--query-file <value>'?: string\n\n  /**\n   * The myshopify.com domain of the store.\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>': string\n\n  /**\n   * Path to a file containing GraphQL variables in JSON format. Can't be used with --variables.\n   * @environment SHOPIFY_FLAG_VARIABLE_FILE\n   */\n  '--variable-file <value>'?: string\n\n  /**\n   * The values for any GraphQL variables in your query or mutation, in JSON format.\n   * @environment SHOPIFY_FLAG_VARIABLES\n   */\n  '-v, --variables <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n\n  /**\n   * The API version to use for the query or mutation. Defaults to the latest stable version.\n   * @environment SHOPIFY_FLAG_VERSION\n   */\n  '--version <value>'?: string\n}"
     }
   },
   "themecheck": {

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -2111,8 +2111,7 @@ USAGE
 
 FLAGS
   -j, --json            [env: SHOPIFY_FLAG_JSON] Output the result as JSON. Automatically disables color output.
-  -s, --store=<value>   (required) [env: SHOPIFY_FLAG_STORE] The myshopify.com domain of the store to authenticate
-                        against.
+  -s, --store=<value>   (required) [env: SHOPIFY_FLAG_STORE] The myshopify.com domain of the store.
       --no-color        [env: SHOPIFY_FLAG_NO_COLOR] Disable color output.
       --scopes=<value>  (required) [env: SHOPIFY_FLAG_SCOPES] Comma-separated Admin API scopes to request for the app.
       --verbose         [env: SHOPIFY_FLAG_VERBOSE] Increase the verbosity of the output.
@@ -2143,8 +2142,7 @@ USAGE
 FLAGS
   -j, --json                   [env: SHOPIFY_FLAG_JSON] Output the result as JSON. Automatically disables color output.
   -q, --query=<value>          [env: SHOPIFY_FLAG_QUERY] The GraphQL query or mutation, as a string.
-  -s, --store=<value>          (required) [env: SHOPIFY_FLAG_STORE] The myshopify.com domain of the store to execute
-                               against.
+  -s, --store=<value>          (required) [env: SHOPIFY_FLAG_STORE] The myshopify.com domain of the store.
   -v, --variables=<value>      [env: SHOPIFY_FLAG_VARIABLES] The values for any GraphQL variables in your query or
                                mutation, in JSON format.
       --allow-mutations        [env: SHOPIFY_FLAG_ALLOW_MUTATIONS] Allow GraphQL mutations to run against the target

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -5710,7 +5710,7 @@
         },
         "store": {
           "char": "s",
-          "description": "The myshopify.com domain of the store to authenticate against.",
+          "description": "The myshopify.com domain of the store.",
           "env": "SHOPIFY_FLAG_STORE",
           "hasDynamicHelp": false,
           "multiple": false,
@@ -5804,7 +5804,7 @@
         },
         "store": {
           "char": "s",
-          "description": "The myshopify.com domain of the store to execute against.",
+          "description": "The myshopify.com domain of the store.",
           "env": "SHOPIFY_FLAG_STORE",
           "hasDynamicHelp": false,
           "multiple": false,

--- a/packages/store/src/cli/commands/store/auth.ts
+++ b/packages/store/src/cli/commands/store/auth.ts
@@ -1,8 +1,8 @@
 import {authenticateStoreWithApp} from '../../services/store/auth/index.js'
 import {createStoreAuthPresenter} from '../../services/store/auth/result.js'
 import StoreCommand from '../../utilities/store-command.js'
+import {storeFlags} from '../../flags.js'
 import {globalFlags, jsonFlag} from '@shopify/cli-kit/node/cli'
-import {normalizeStoreFqdn} from '@shopify/cli-kit/node/context/fqdn'
 import {Flags} from '@oclif/core'
 
 export default class StoreAuth extends StoreCommand {
@@ -22,13 +22,7 @@ Re-run this command if the stored token is missing, expires, or no longer has th
   static flags = {
     ...globalFlags,
     ...jsonFlag,
-    store: Flags.string({
-      char: 's',
-      description: 'The myshopify.com domain of the store to authenticate against.',
-      env: 'SHOPIFY_FLAG_STORE',
-      parse: async (input) => normalizeStoreFqdn(input),
-      required: true,
-    }),
+    store: storeFlags.store,
     scopes: Flags.string({
       description: 'Comma-separated Admin API scopes to request for the app.',
       env: 'SHOPIFY_FLAG_SCOPES',

--- a/packages/store/src/cli/commands/store/execute.ts
+++ b/packages/store/src/cli/commands/store/execute.ts
@@ -1,8 +1,8 @@
 import {executeStoreOperation} from '../../services/store/execute/index.js'
 import {writeOrOutputStoreExecuteResult} from '../../services/store/execute/result.js'
 import StoreCommand from '../../utilities/store-command.js'
+import {storeFlags} from '../../flags.js'
 import {globalFlags, jsonFlag} from '@shopify/cli-kit/node/cli'
-import {normalizeStoreFqdn} from '@shopify/cli-kit/node/context/fqdn'
 import {resolvePath} from '@shopify/cli-kit/node/path'
 import {Flags} from '@oclif/core'
 
@@ -52,13 +52,7 @@ Mutations are disabled by default. Re-run with \`--allow-mutations\` if you inte
       parse: async (input) => resolvePath(input),
       exclusive: ['variables'],
     }),
-    store: Flags.string({
-      char: 's',
-      description: 'The myshopify.com domain of the store to execute against.',
-      env: 'SHOPIFY_FLAG_STORE',
-      parse: async (input) => normalizeStoreFqdn(input),
-      required: true,
-    }),
+    store: storeFlags.store,
     version: Flags.string({
       description: 'The API version to use for the query or mutation. Defaults to the latest stable version.',
       env: 'SHOPIFY_FLAG_VERSION',

--- a/packages/store/src/cli/flags.ts
+++ b/packages/store/src/cli/flags.ts
@@ -1,0 +1,12 @@
+import {normalizeStoreFqdn} from '@shopify/cli-kit/node/context/fqdn'
+import {Flags} from '@oclif/core'
+
+export const storeFlags = {
+  store: Flags.string({
+    char: 's',
+    description: 'The myshopify.com domain of the store.',
+    env: 'SHOPIFY_FLAG_STORE',
+    parse: async (input) => normalizeStoreFqdn(input),
+    required: true,
+  }),
+}


### PR DESCRIPTION
> 📚 **Part of the `store info` stack** — review/merge bottom-up:
> #7753 gid codec → #7754 url helpers → **#7755 (this)** → #7756 GraphQL layer → #7660 `store info`

### WHY are these changes introduced?

`store auth` and `store execute` each defined their own `--store` flag inline — identical except for the trailing words of the help text. `store info` (top of this stack) needs the same flag, so rather than copy it a third time, consolidate the shared definition. Pulling it into its own PR keeps the two pre-existing commands' churn out of the feature PR — a reviewer of `store info` shouldn't have to reason about why `auth`/`execute` changed.

### WHAT is this pull request doing?

Adds `packages/store/src/cli/flags.ts` exporting `storeFlags.store` (char `s`, `SHOPIFY_FLAG_STORE`, normalized via `normalizeStoreFqdn`, required) and converts `store auth` and `store execute` to consume it.

Behavior-preserving except the flag's help text is now the generic **"The myshopify.com domain of the store."** — previously each command appended its own suffix (`"…to authenticate against."` / `"…to execute against."`). The manifest, README, and reference docs are regenerated to match. No user-facing behavior change, so **no changeset** (the help-text normalization is cosmetic; consistent with the other base PRs in this stack).

### How to test your changes?

- `pnpm vitest run packages/store` — `auth`/`execute` suites still pass.
- `shopify store auth --help` / `shopify store execute --help` show the normalized `--store` description.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows) — no platform-specific behavior
- [x] I've considered possible [documentation](https://shopify.dev) changes — manifest/README/reference docs regenerated
- [x] I've considered analytics changes to measure impact — none
- [ ] The change is user-facing — N/A beyond a cosmetic help-text tweak; no changeset
