### PR TITLE
Add the Business Platform GraphQL data-access layer for store info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -202,6 +202,7 @@ packages/ui-extensions-dev-console/css-transform.js
 packages/ui-extensions-dev-console/dist
 packages/cli-kit/src/cli/api/graphql/*/*_schema.graphql
 packages/organizations/src/cli/api/graphql/*/*_schema.graphql
+packages/store/src/cli/api/graphql/*/*_schema.graphql
 
 .claude/settings.local.json
 

--- a/bin/get-graphql-schemas.js
+++ b/bin/get-graphql-schemas.js
@@ -51,13 +51,17 @@ const schemas = [
     localPaths: [
       './packages/app/src/cli/api/graphql/business-platform-destinations/destinations_schema.graphql',
       './packages/organizations/src/cli/api/graphql/business-platform-destinations/destinations_schema.graphql',
+      './packages/store/src/cli/api/graphql/business-platform-destinations/destinations_schema.graphql',
     ],
   },
   {
     owner: 'shop',
     repo: 'world',
     pathToFile: 'areas/platforms/organizations/db/graphql/organizations_schema.graphql',
-    localPaths: ['./packages/app/src/cli/api/graphql/business-platform-organizations/organizations_schema.graphql'],
+    localPaths: [
+      './packages/app/src/cli/api/graphql/business-platform-organizations/organizations_schema.graphql',
+      './packages/store/src/cli/api/graphql/business-platform-organizations/organizations_schema.graphql',
+    ],
   },
   {
     owner: 'shop',

--- a/graphql.config.ts
+++ b/graphql.config.ts
@@ -86,5 +86,7 @@ export default {
     functions: projectFactory('functions', 'functions_cli_schema.graphql', 'app'),
     adminAsApp: projectFactory('admin', 'admin_schema.graphql'),
     organizationsDestinations: projectFactory('business-platform-destinations', 'destinations_schema.graphql', 'organizations'),
+    storeBusinessPlatformDestinations: projectFactory('business-platform-destinations', 'destinations_schema.graphql', 'store'),
+    storeBusinessPlatformOrganizations: projectFactory('business-platform-organizations', 'organizations_schema.graphql', 'store'),
   },
 }

--- a/package.json
+++ b/package.json
@@ -227,6 +227,24 @@
           ]
         }
       },
+      "packages/store": {
+        "entry": [
+          "**/{commands,hooks}/**/*.ts!",
+          "**/index.ts!"
+        ],
+        "project": "**/*.ts!",
+        "ignore": [
+          "**/graphql/**/generated/*.ts"
+        ],
+        "ignoreDependencies": [
+          "@graphql-typed-document-node/core"
+        ],
+        "vite": {
+          "config": [
+            "vite.config.ts"
+          ]
+        }
+      },
       "packages/cli": {
         "entry": [
           "**/{commands,hooks}/**/*.ts!",

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -39,6 +39,7 @@
     ]
   },
   "dependencies": {
+    "@graphql-typed-document-node/core": "3.2.0",
     "@oclif/core": "4.11.4",
     "@shopify/cli-kit": "4.1.0"
   },

--- a/packages/store/project.json
+++ b/packages/store/project.json
@@ -41,6 +41,69 @@
         "command": "pnpm tsc --noEmit",
         "cwd": "packages/store"
       }
+    },
+    "graphql-codegen": {
+      "executor": "nx:noop",
+      "dependsOn": ["graphql-codegen:formatting"]
+    },
+    "graphql-codegen:formatting": {
+      "executor": "nx:run-commands",
+      "dependsOn": ["graphql-codegen:postfix"],
+      "inputs": [{"dependentTasksOutputFiles": "**/*.ts"}],
+      "outputs": [
+        "{projectRoot}/src/cli/api/graphql/business-platform-destinations/generated/**/*.ts",
+        "{projectRoot}/src/cli/api/graphql/business-platform-organizations/generated/**/*.ts"
+      ],
+      "options": {
+        "commands": [
+          "pnpm eslint 'src/cli/api/graphql/business-platform-destinations/generated/**/*.{ts,tsx}' --fix",
+          "pnpm eslint 'src/cli/api/graphql/business-platform-organizations/generated/**/*.{ts,tsx}' --fix"
+        ],
+        "cwd": "packages/store"
+      }
+    },
+    "graphql-codegen:generate:business-platform-destinations": {
+      "executor": "nx:run-commands",
+      "inputs": [
+        "{workspaceRoot}/graphql.config.ts",
+        "{projectRoot}/src/cli/api/graphql/business-platform-destinations/**/*.graphql"
+      ],
+      "outputs": ["{projectRoot}/src/cli/api/graphql/business-platform-destinations/generated/**/*.ts"],
+      "options": {
+        "commands": ["pnpm exec graphql-codegen --project=storeBusinessPlatformDestinations"],
+        "cwd": "{workspaceRoot}"
+      }
+    },
+    "graphql-codegen:generate:business-platform-organizations": {
+      "executor": "nx:run-commands",
+      "inputs": [
+        "{workspaceRoot}/graphql.config.ts",
+        "{projectRoot}/src/cli/api/graphql/business-platform-organizations/**/*.graphql"
+      ],
+      "outputs": ["{projectRoot}/src/cli/api/graphql/business-platform-organizations/generated/**/*.ts"],
+      "options": {
+        "commands": ["pnpm exec graphql-codegen --project=storeBusinessPlatformOrganizations"],
+        "cwd": "{workspaceRoot}"
+      }
+    },
+    "graphql-codegen:postfix": {
+      "executor": "nx:run-commands",
+      "dependsOn": [
+        "graphql-codegen:generate:business-platform-destinations",
+        "graphql-codegen:generate:business-platform-organizations"
+      ],
+      "inputs": [{"dependentTasksOutputFiles": "**/*.ts"}],
+      "outputs": [
+        "{projectRoot}/src/cli/api/graphql/business-platform-destinations/generated/**/*.ts",
+        "{projectRoot}/src/cli/api/graphql/business-platform-organizations/generated/**/*.ts"
+      ],
+      "options": {
+        "commands": [
+          "find ./packages/store/src/cli/api/graphql/business-platform-destinations/generated/ -type f -name '*.ts' -exec sh -c 'sed -i \"\" \"s|import \\* as Types from '\\''./types'\\'';|import \\* as Types from '\\''./types.js'\\'';|g; s|export const \\([A-Za-z0-9_]*\\)Document =|export const \\1 =|g\" \"$0\"' {} \\;",
+          "find ./packages/store/src/cli/api/graphql/business-platform-organizations/generated/ -type f -name '*.ts' -exec sh -c 'sed -i \"\" \"s|import \\* as Types from '\\''./types'\\'';|import \\* as Types from '\\''./types.js'\\'';|g; s|export const \\([A-Za-z0-9_]*\\)Document =|export const \\1 =|g\" \"$0\"' {} \\;"
+        ],
+        "cwd": "{workspaceRoot}"
+      }
     }
   }
 }

--- a/packages/store/src/cli/api/graphql/business-platform-destinations/generated/store-info-destinations.ts
+++ b/packages/store/src/cli/api/graphql/business-platform-destinations/generated/store-info-destinations.ts
@@ -1,0 +1,83 @@
+/* eslint-disable @typescript-eslint/consistent-type-definitions */
+import * as Types from './types.js'
+
+import {TypedDocumentNode as DocumentNode} from '@graphql-typed-document-node/core'
+
+export type StoreInfoDestinationsQueryVariables = Types.Exact<{
+  search: Types.Scalars['String']['input']
+}>
+
+export type StoreInfoDestinationsQuery = {
+  currentUserAccount?: {
+    destinations: {nodes: {publicId: unknown; primaryDomain?: string | null; webUrl: string}[]}
+  } | null
+}
+
+export const StoreInfoDestinations = {
+  kind: 'Document',
+  definitions: [
+    {
+      kind: 'OperationDefinition',
+      operation: 'query',
+      name: {kind: 'Name', value: 'StoreInfoDestinations'},
+      variableDefinitions: [
+        {
+          kind: 'VariableDefinition',
+          variable: {kind: 'Variable', name: {kind: 'Name', value: 'search'}},
+          type: {kind: 'NonNullType', type: {kind: 'NamedType', name: {kind: 'Name', value: 'String'}}},
+        },
+      ],
+      selectionSet: {
+        kind: 'SelectionSet',
+        selections: [
+          {
+            kind: 'Field',
+            name: {kind: 'Name', value: 'currentUserAccount'},
+            selectionSet: {
+              kind: 'SelectionSet',
+              selections: [
+                {
+                  kind: 'Field',
+                  name: {kind: 'Name', value: 'destinations'},
+                  arguments: [
+                    {
+                      kind: 'Argument',
+                      name: {kind: 'Name', value: 'search'},
+                      value: {kind: 'Variable', name: {kind: 'Name', value: 'search'}},
+                    },
+                    {
+                      kind: 'Argument',
+                      name: {kind: 'Name', value: 'shopsOnly'},
+                      value: {kind: 'BooleanValue', value: true},
+                    },
+                    {kind: 'Argument', name: {kind: 'Name', value: 'first'}, value: {kind: 'IntValue', value: '25'}},
+                  ],
+                  selectionSet: {
+                    kind: 'SelectionSet',
+                    selections: [
+                      {
+                        kind: 'Field',
+                        name: {kind: 'Name', value: 'nodes'},
+                        selectionSet: {
+                          kind: 'SelectionSet',
+                          selections: [
+                            {kind: 'Field', name: {kind: 'Name', value: 'publicId'}},
+                            {kind: 'Field', name: {kind: 'Name', value: 'primaryDomain'}},
+                            {kind: 'Field', name: {kind: 'Name', value: 'webUrl'}},
+                            {kind: 'Field', name: {kind: 'Name', value: '__typename'}},
+                          ],
+                        },
+                      },
+                      {kind: 'Field', name: {kind: 'Name', value: '__typename'}},
+                    ],
+                  },
+                },
+                {kind: 'Field', name: {kind: 'Name', value: '__typename'}},
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<StoreInfoDestinationsQuery, StoreInfoDestinationsQueryVariables>

--- a/packages/store/src/cli/api/graphql/business-platform-destinations/generated/store-info-owning-org.ts
+++ b/packages/store/src/cli/api/graphql/business-platform-destinations/generated/store-info-owning-org.ts
@@ -1,0 +1,64 @@
+/* eslint-disable @typescript-eslint/consistent-type-definitions */
+import * as Types from './types.js'
+
+import {TypedDocumentNode as DocumentNode} from '@graphql-typed-document-node/core'
+
+export type StoreInfoOwningOrgQueryVariables = Types.Exact<{
+  destinationPublicId: Types.Scalars['DestinationPublicID']['input']
+}>
+
+export type StoreInfoOwningOrgQuery = {
+  currentUserAccount?: {organizationForDestination?: {id: string; name: string} | null} | null
+}
+
+export const StoreInfoOwningOrg = {
+  kind: 'Document',
+  definitions: [
+    {
+      kind: 'OperationDefinition',
+      operation: 'query',
+      name: {kind: 'Name', value: 'StoreInfoOwningOrg'},
+      variableDefinitions: [
+        {
+          kind: 'VariableDefinition',
+          variable: {kind: 'Variable', name: {kind: 'Name', value: 'destinationPublicId'}},
+          type: {kind: 'NonNullType', type: {kind: 'NamedType', name: {kind: 'Name', value: 'DestinationPublicID'}}},
+        },
+      ],
+      selectionSet: {
+        kind: 'SelectionSet',
+        selections: [
+          {
+            kind: 'Field',
+            name: {kind: 'Name', value: 'currentUserAccount'},
+            selectionSet: {
+              kind: 'SelectionSet',
+              selections: [
+                {
+                  kind: 'Field',
+                  name: {kind: 'Name', value: 'organizationForDestination'},
+                  arguments: [
+                    {
+                      kind: 'Argument',
+                      name: {kind: 'Name', value: 'destinationPublicId'},
+                      value: {kind: 'Variable', name: {kind: 'Name', value: 'destinationPublicId'}},
+                    },
+                  ],
+                  selectionSet: {
+                    kind: 'SelectionSet',
+                    selections: [
+                      {kind: 'Field', name: {kind: 'Name', value: 'id'}},
+                      {kind: 'Field', name: {kind: 'Name', value: 'name'}},
+                      {kind: 'Field', name: {kind: 'Name', value: '__typename'}},
+                    ],
+                  },
+                },
+                {kind: 'Field', name: {kind: 'Name', value: '__typename'}},
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<StoreInfoOwningOrgQuery, StoreInfoOwningOrgQueryVariables>

--- a/packages/store/src/cli/api/graphql/business-platform-destinations/generated/types.d.ts
+++ b/packages/store/src/cli/api/graphql/business-platform-destinations/generated/types.d.ts
@@ -1,0 +1,24 @@
+/* eslint-disable @typescript-eslint/consistent-type-definitions, @typescript-eslint/naming-convention, @typescript-eslint/no-explicit-any, tsdoc/syntax, @typescript-eslint/no-duplicate-type-constituents, @typescript-eslint/no-redundant-type-constituents, @nx/enforce-module-boundaries  */
+import {JsonMapType} from '@shopify/cli-kit/node/toml'
+export type Maybe<T> = T | null;
+export type InputMaybe<T> = Maybe<T>;
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
+export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
+export type MakeEmpty<T extends { [key: string]: unknown }, K extends keyof T> = { [_ in K]?: never };
+export type Incremental<T> = T | { [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never };
+/** All built-in and custom scalars, mapped to their actual values */
+export type Scalars = {
+  ID: { input: string; output: string; }
+  String: { input: string; output: string; }
+  Boolean: { input: boolean; output: boolean; }
+  Int: { input: number; output: number; }
+  Float: { input: number; output: number; }
+  DestinationID: { input: any; output: any; }
+  DestinationPublicID: { input: any; output: any; }
+  GlobalID: { input: string; output: string; }
+  /** An ISO 8601-encoded datetime */
+  ISO8601DateTime: { input: any; output: any; }
+  /** The ID for a Organization. */
+  OrganizationID: { input: any; output: any; }
+};

--- a/packages/store/src/cli/api/graphql/business-platform-destinations/queries/store-info-destinations.graphql
+++ b/packages/store/src/cli/api/graphql/business-platform-destinations/queries/store-info-destinations.graphql
@@ -1,0 +1,11 @@
+query StoreInfoDestinations($search: String!) {
+  currentUserAccount {
+    destinations(search: $search, shopsOnly: true, first: 25) {
+      nodes {
+        publicId
+        primaryDomain
+        webUrl
+      }
+    }
+  }
+}

--- a/packages/store/src/cli/api/graphql/business-platform-destinations/queries/store-info-owning-org.graphql
+++ b/packages/store/src/cli/api/graphql/business-platform-destinations/queries/store-info-owning-org.graphql
@@ -1,0 +1,8 @@
+query StoreInfoOwningOrg($destinationPublicId: DestinationPublicID!) {
+  currentUserAccount {
+    organizationForDestination(destinationPublicId: $destinationPublicId) {
+      id
+      name
+    }
+  }
+}

--- a/packages/store/src/cli/api/graphql/business-platform-organizations/generated/store-info-shop.ts
+++ b/packages/store/src/cli/api/graphql/business-platform-organizations/generated/store-info-shop.ts
@@ -1,0 +1,115 @@
+/* eslint-disable @typescript-eslint/consistent-type-definitions */
+import * as Types from './types.js'
+
+import {TypedDocumentNode as DocumentNode} from '@graphql-typed-document-node/core'
+
+export type StoreInfoShopQueryVariables = Types.Exact<{
+  search?: Types.InputMaybe<Types.Scalars['String']['input']>
+}>
+
+export type StoreInfoShopQuery = {
+  organization?: {
+    accessibleShops?: {
+      edges: {
+        node: {
+          shopifyShopId?: string | null
+          name: string
+          primaryDomain?: string | null
+          storeType?: Types.Store | null
+          developerPreviewHandle?: string | null
+          planName?: string | null
+          ownerDetails?: {fullName?: string | null; email?: string | null} | null
+        }
+      }[]
+    } | null
+  } | null
+}
+
+export const StoreInfoShop = {
+  kind: 'Document',
+  definitions: [
+    {
+      kind: 'OperationDefinition',
+      operation: 'query',
+      name: {kind: 'Name', value: 'StoreInfoShop'},
+      variableDefinitions: [
+        {
+          kind: 'VariableDefinition',
+          variable: {kind: 'Variable', name: {kind: 'Name', value: 'search'}},
+          type: {kind: 'NamedType', name: {kind: 'Name', value: 'String'}},
+        },
+      ],
+      selectionSet: {
+        kind: 'SelectionSet',
+        selections: [
+          {
+            kind: 'Field',
+            name: {kind: 'Name', value: 'organization'},
+            selectionSet: {
+              kind: 'SelectionSet',
+              selections: [
+                {
+                  kind: 'Field',
+                  name: {kind: 'Name', value: 'accessibleShops'},
+                  arguments: [
+                    {kind: 'Argument', name: {kind: 'Name', value: 'first'}, value: {kind: 'IntValue', value: '5'}},
+                    {
+                      kind: 'Argument',
+                      name: {kind: 'Name', value: 'search'},
+                      value: {kind: 'Variable', name: {kind: 'Name', value: 'search'}},
+                    },
+                  ],
+                  selectionSet: {
+                    kind: 'SelectionSet',
+                    selections: [
+                      {
+                        kind: 'Field',
+                        name: {kind: 'Name', value: 'edges'},
+                        selectionSet: {
+                          kind: 'SelectionSet',
+                          selections: [
+                            {
+                              kind: 'Field',
+                              name: {kind: 'Name', value: 'node'},
+                              selectionSet: {
+                                kind: 'SelectionSet',
+                                selections: [
+                                  {kind: 'Field', name: {kind: 'Name', value: 'shopifyShopId'}},
+                                  {kind: 'Field', name: {kind: 'Name', value: 'name'}},
+                                  {kind: 'Field', name: {kind: 'Name', value: 'primaryDomain'}},
+                                  {kind: 'Field', name: {kind: 'Name', value: 'storeType'}},
+                                  {kind: 'Field', name: {kind: 'Name', value: 'developerPreviewHandle'}},
+                                  {kind: 'Field', name: {kind: 'Name', value: 'planName'}},
+                                  {
+                                    kind: 'Field',
+                                    name: {kind: 'Name', value: 'ownerDetails'},
+                                    selectionSet: {
+                                      kind: 'SelectionSet',
+                                      selections: [
+                                        {kind: 'Field', name: {kind: 'Name', value: 'fullName'}},
+                                        {kind: 'Field', name: {kind: 'Name', value: 'email'}},
+                                        {kind: 'Field', name: {kind: 'Name', value: '__typename'}},
+                                      ],
+                                    },
+                                  },
+                                  {kind: 'Field', name: {kind: 'Name', value: '__typename'}},
+                                ],
+                              },
+                            },
+                            {kind: 'Field', name: {kind: 'Name', value: '__typename'}},
+                          ],
+                        },
+                      },
+                      {kind: 'Field', name: {kind: 'Name', value: '__typename'}},
+                    ],
+                  },
+                },
+                {kind: 'Field', name: {kind: 'Name', value: '__typename'}},
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<StoreInfoShopQuery, StoreInfoShopQueryVariables>

--- a/packages/store/src/cli/api/graphql/business-platform-organizations/generated/types.d.ts
+++ b/packages/store/src/cli/api/graphql/business-platform-organizations/generated/types.d.ts
@@ -1,0 +1,91 @@
+/* eslint-disable @typescript-eslint/consistent-type-definitions, @typescript-eslint/naming-convention, @typescript-eslint/no-explicit-any, tsdoc/syntax, @typescript-eslint/no-duplicate-type-constituents, @typescript-eslint/no-redundant-type-constituents, @nx/enforce-module-boundaries  */
+import {JsonMapType} from '@shopify/cli-kit/node/toml'
+export type Maybe<T> = T | null;
+export type InputMaybe<T> = Maybe<T>;
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
+export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
+export type MakeEmpty<T extends { [key: string]: unknown }, K extends keyof T> = { [_ in K]?: never };
+export type Incremental<T> = T | { [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never };
+/** All built-in and custom scalars, mapped to their actual values */
+export type Scalars = {
+  ID: { input: string; output: string; }
+  String: { input: string; output: string; }
+  Boolean: { input: boolean; output: boolean; }
+  Int: { input: number; output: number; }
+  Float: { input: number; output: number; }
+  AccessRoleAssignee: { input: any; output: any; }
+  /** The ID for a AccessRole. */
+  AccessRoleID: { input: any; output: any; }
+  AccessRoleRecordId: { input: any; output: any; }
+  /** The ID for a ActionAudit. */
+  ActionAuditID: { input: any; output: any; }
+  /** The ID for a Address. */
+  AddressID: { input: any; output: any; }
+  /** The ID for a Attestation. */
+  AttestationID: { input: any; output: any; }
+  /** The ID for a BulkDataOperation. */
+  BulkDataOperationID: { input: any; output: any; }
+  /** The ID for a BusinessUser. */
+  BusinessUserID: { input: any; output: any; }
+  /** The ID for a BusinessUsersImport. */
+  BusinessUsersImportID: { input: any; output: any; }
+  /** A signed decimal number, which supports arbitrary precision and is serialized as a string. */
+  Decimal: { input: any; output: any; }
+  /** The ID for a DocumentAttachment. */
+  DocumentAttachmentID: { input: any; output: any; }
+  /** The ID for a EntitySupportingDocument. */
+  EntitySupportingDocumentID: { input: any; output: any; }
+  GlobalID: { input: string; output: string; }
+  /** The ID for a GovernmentIdentifier. */
+  GovernmentIdentifierID: { input: any; output: any; }
+  /** The ID for a Group. */
+  GroupID: { input: any; output: any; }
+  /** An ISO 8601-encoded date */
+  ISO8601Date: { input: any; output: any; }
+  /** An ISO 8601-encoded datetime */
+  ISO8601DateTime: { input: any; output: any; }
+  /** Represents untyped JSON */
+  JSON: { input: JsonMapType | string; output: JsonMapType; }
+  /** The ID for a LegalEntity. */
+  LegalEntityID: { input: any; output: any; }
+  /** The ID for a OrganizationDomain. */
+  OrganizationDomainID: { input: any; output: any; }
+  /** The ID for a Organization. */
+  OrganizationID: { input: any; output: any; }
+  /** The ID for a OrganizationUser. */
+  OrganizationUserID: { input: any; output: any; }
+  /** The ID for a PersonAlias. */
+  PersonAliasID: { input: any; output: any; }
+  /** The ID for a Person. */
+  PersonID: { input: any; output: any; }
+  /** The ID for a Principal. */
+  PrincipalID: { input: any; output: any; }
+  /** The ID for a Property. */
+  PropertyID: { input: any; output: any; }
+  PropertyId: { input: string; output: string; }
+  PropertyPublicID: { input: string; output: string; }
+  /** The ID for a PropertyTransferRequest. */
+  PropertyTransferRequestID: { input: any; output: any; }
+  /** The ID for a Role. */
+  RoleID: { input: any; output: any; }
+  /** The ID for a Shop. */
+  ShopID: { input: any; output: any; }
+  /** The ID for a ShopifyShop. */
+  ShopifyShopID: { input: any; output: any; }
+  /** The ID for a StoreAdditionRequest. */
+  StoreAdditionRequestID: { input: any; output: any; }
+  SupportedEntityId: { input: any; output: any; }
+  /** The ID for a SupportingDocument. */
+  SupportingDocumentID: { input: any; output: any; }
+  /** An RFC 3986 and RFC 3987 compliant URI string. */
+  URL: { input: string; output: string; }
+};
+
+export type Store =
+  | 'APP_DEVELOPMENT'
+  | 'CLIENT_TRANSFER'
+  | 'COLLABORATOR'
+  | 'DEVELOPMENT'
+  | 'DEVELOPMENT_SUPERSET'
+  | 'PRODUCTION';

--- a/packages/store/src/cli/api/graphql/business-platform-organizations/queries/store-info-shop.graphql
+++ b/packages/store/src/cli/api/graphql/business-platform-organizations/queries/store-info-shop.graphql
@@ -1,0 +1,20 @@
+query StoreInfoShop($search: String) {
+  organization {
+    accessibleShops(first: 5, search: $search) {
+      edges {
+        node {
+          shopifyShopId
+          name
+          primaryDomain
+          storeType
+          developerPreviewHandle
+          planName
+          ownerDetails {
+            fullName
+            email
+          }
+        }
+      }
+    }
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -645,6 +645,9 @@ importers:
 
   packages/store:
     dependencies:
+      '@graphql-typed-document-node/core':
+        specifier: 3.2.0
+        version: 3.2.0(graphql@16.10.0)
       '@oclif/core':
         specifier: 4.11.4
         version: 4.11.4


### PR DESCRIPTION
> 📚 **Part of the `store info` stack** — review/merge bottom-up:
> #7753 gid codec → #7754 url helpers → #7755 shared `--store` flag → **#7756 (this)** → #7660 `store info`

### WHY are these changes introduced?

`store info` reads store metadata from two Business Platform schemas (Destinations + Organizations). This PR adds the **typed GraphQL data-access layer** for that — codegen wiring plus the queries and their generated types — separately from the service/command logic that consumes it (#7660). Splitting it keeps the feature PR focused on behavior, and lets the typed-client layer be reviewed on its own (these queries fetch exactly these fields).

> Note: this can't be split any finer. `graphql-codegen` hard-fails when a configured project matches zero query documents, so the codegen config and the `.graphql` queries are an atomic unit; and the generated `.ts` must be committed alongside the queries or CI's codegen-check sees drift. So the whole layer travels together.

### WHAT is this pull request doing?

- `graphql.config.ts` — registers `storeBusinessPlatformDestinations` and `storeBusinessPlatformOrganizations` codegen projects.
- `packages/store/project.json` — `graphql-codegen` nx targets (generate → postfix → eslint-format), mirroring the other packages.
- `bin/get-graphql-schemas.js` + `.gitignore` — fetch and ignore the store copies of the BP destinations/organizations schemas.
- `packages/store/package.json` (+`@graphql-typed-document-node/core`) and the lockfile entry.
- `package.json` — knip config for the store workspace: ignore the generated files and the `@graphql-typed-document-node/core` dep (only ever type-imported by generated code, so knip can't see it as used), matching the permanent blocks `app`/`organizations`/`cli-kit` already carry.
- Three queries — `store-info-destinations`, `store-info-owning-org` (BP Destinations), `store-info-shop` (BP Organizations) — and their generated `*.ts` + `types.d.ts`.

Nothing imports the generated documents yet (the services land in #7660), so there's **no user-facing surface** and **no changeset**. The generated output is reproducible: `nx graphql-codegen store` regenerates it byte-for-byte; `knip` passes (the block above covers the not-yet-consumed artifacts).

### How to test your changes?

- `bin/get-graphql-schemas.js` to fetch schemas, then `pnpm nx graphql-codegen store --skip-nx-cache` — regenerates the committed `generated/*.ts` with zero diff.
- `pnpm nx run-many --target=type-check,build --projects=store` — the generated layer compiles.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows) — codegen runs in CI; `sed -i ""` postfix matches the repo's existing macOS-oriented targets
- [x] I've considered possible [documentation](https://shopify.dev) changes — no command surface yet
- [x] I've considered analytics changes to measure impact — none
- [ ] The change is user-facing — N/A, no command consumes this yet; no changeset

