### PR TITLE
Add is_first_party label to CLI command metrics

### DIFF
--- a/.changeset/first-party-cli-metrics-label.md
+++ b/.changeset/first-party-cli-metrics-label.md
@@ -1,5 +1,0 @@
----
-'@shopify/cli-kit': patch
----
-
-Add an `is_first_party` label to the CLI command metrics (`cli_commands_total`, `cli_commands_duration_ms`, `cli_commands_wall_clock_elapsed_ms`) so first-party (1P) Shopify developer usage can be distinguished from third-party usage in observability dashboards. The label is keyed off the 1P dev path (`SHOPIFY_CLI_1P_DEV`), the same signal that sets the `X-Shopify-Cli-Employee` header.

--- a/.changeset/first-party-cli-metrics-label.md
+++ b/.changeset/first-party-cli-metrics-label.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': patch
+---
+
+Add an `is_first_party` label to the CLI command metrics (`cli_commands_total`, `cli_commands_duration_ms`, `cli_commands_wall_clock_elapsed_ms`) so first-party (1P) Shopify developer usage can be distinguished from third-party usage in observability dashboards. The label is keyed off the 1P dev path (`SHOPIFY_CLI_1P_DEV`), the same signal that sets the `X-Shopify-Cli-Employee` header.

--- a/packages/cli-kit/src/private/node/__snapshots__/otel-metrics.test.ts.snap
+++ b/packages/cli-kit/src/private/node/__snapshots__/otel-metrics.test.ts.snap
@@ -8,6 +8,7 @@ exports[`otel-metrics > logs metrics when activated 1`] = `
     {
       "cli_version": "pre",
       "exit": "ok",
+      "is_first_party": "false",
       "job": "@shopify/app::app dev",
     },
   ],
@@ -17,6 +18,7 @@ exports[`otel-metrics > logs metrics when activated 1`] = `
     {
       "cli_version": "pre",
       "exit": "ok",
+      "is_first_party": "false",
       "job": "@shopify/app::app dev",
     },
   ],
@@ -26,6 +28,7 @@ exports[`otel-metrics > logs metrics when activated 1`] = `
     {
       "cli_version": "pre",
       "exit": "ok",
+      "is_first_party": "false",
       "job": "@shopify/app::app dev",
       "stage": "active",
     },
@@ -36,6 +39,7 @@ exports[`otel-metrics > logs metrics when activated 1`] = `
     {
       "cli_version": "pre",
       "exit": "ok",
+      "is_first_party": "false",
       "job": "@shopify/app::app dev",
       "stage": "network",
     },
@@ -46,6 +50,7 @@ exports[`otel-metrics > logs metrics when activated 1`] = `
     {
       "cli_version": "pre",
       "exit": "ok",
+      "is_first_party": "false",
       "job": "@shopify/app::app dev",
       "stage": "prompt",
     },
@@ -58,14 +63,16 @@ exports[`otel-metrics > outputs debug information when deactivated 1`] = `
   "labels": {
     "exit": "ok",
     "job": "@shopify/app::app dev",
-    "cli_version": "nightly"
+    "cli_version": "nightly",
+    "is_first_party": "false"
   }
 }
 [OTEL] record cli_commands_duration_ms histogram 10ms {
   "labels": {
     "exit": "ok",
     "job": "@shopify/app::app dev",
-    "cli_version": "nightly"
+    "cli_version": "nightly",
+    "is_first_party": "false"
   }
 }
 [OTEL] record cli_commands_wall_clock_elapsed_ms histogram stage="active" 10ms

--- a/packages/cli-kit/src/private/node/otel-metrics.test.ts
+++ b/packages/cli-kit/src/private/node/otel-metrics.test.ts
@@ -1,8 +1,12 @@
 import {recordMetrics} from './otel-metrics.js'
 import {mockAndCaptureOutput} from '../../public/node/testing/output.js'
-import {describe, expect, test, vi} from 'vitest'
+import {afterEach, describe, expect, test, vi} from 'vitest'
 
 describe('otel-metrics', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
   test('outputs debug information when deactivated', async () => {
     const outputMock = mockAndCaptureOutput()
 
@@ -52,5 +56,39 @@ describe('otel-metrics', () => {
 
     expect(mockOtelCreator).toHaveBeenCalledOnce()
     expect(mockOtelRecorder.mock.calls).toMatchSnapshot()
+  })
+
+  test('labels metrics as first-party when the 1P dev path is enabled', async () => {
+    vi.stubEnv('SHOPIFY_CLI_1P_DEV', '1')
+    const mockOtelRecorder = vi.fn()
+    const mockOtelCreator = vi.fn()
+    mockOtelCreator.mockReturnValue({
+      type: 'otel',
+      otel: {
+        record: mockOtelRecorder,
+      },
+    })
+
+    await recordMetrics(
+      {
+        skipMetricAnalytics: false,
+        cliVersion: '3.49.1-pre.0',
+        owningPlugin: '@shopify/app',
+        command: 'app dev',
+        exitMode: 'ok',
+      },
+      {
+        active: 10,
+        network: 20,
+        prompt: 30,
+      },
+      mockOtelCreator,
+    )
+
+    const recordedLabels = mockOtelRecorder.mock.calls.map((call) => call[2])
+    expect(recordedLabels.length).toBeGreaterThan(0)
+    recordedLabels.forEach((labels) => {
+      expect(labels).toMatchObject({is_first_party: 'true'})
+    })
   })
 })

--- a/packages/cli-kit/src/private/node/otel-metrics.ts
+++ b/packages/cli-kit/src/private/node/otel-metrics.ts
@@ -4,7 +4,7 @@ import {
   DefaultOtelService,
   DefaultOtelServiceOptions,
 } from '../../public/node/vendor/otel-js/service/DefaultOtelService/DefaultOtelService.js'
-import {isUnitTest, opentelemetryDomain} from '../../public/node/context/local.js'
+import {firstPartyDev, isUnitTest, opentelemetryDomain} from '../../public/node/context/local.js'
 import {ValueType, diag} from '@opentelemetry/api'
 
 type MetricRecorder =
@@ -20,6 +20,7 @@ type Labels = {
   exit: string
   job: string
   cli_version: string
+  is_first_party: string
 }
 
 interface Timing {
@@ -76,6 +77,10 @@ export async function recordMetrics(
     exit: options.exitMode,
     job: `${options.owningPlugin}::${options.command}`,
     cli_version: regularisedCliVersion,
+    // Distinguishes Shopify first-party (1P) developers from third-party developers so the
+    // CLI guardrail dashboards can be scoped to 1P. Keyed off the 1P dev path
+    // (SHOPIFY_CLI_1P_DEV), the same signal that sets the X-Shopify-Cli-Employee header.
+    is_first_party: firstPartyDev() ? 'true' : 'false',
   }
 
   recordCommandCounter(recorder, labels)


### PR DESCRIPTION
### WHY are these changes introduced?

closes: https://github.com/shop/issues-develop/issues/22933

Part of the 1P org migration observability work (GSD #50881). "1P CI/CD pipelines function without breakage after cutover" is a named guardrail on the **[Dev Platform] 1P Orgs Migration** dashboard (Observe `si2kjvt`), but today it can't be measured: `cli_commands_total` (and the companion duration/elapsed metrics) carry only `cli_version`, `exit`, and `job` labels — no org / 1P dimension — so the CLI guardrail panels blend 1P + 3P + all external developers.

### WHAT is this pull request doing?

Adds an `is_first_party` label to the CLI command metrics emitted from `cli-kit`:

- `cli_commands_total`
- `cli_commands_duration_ms`
- `cli_commands_wall_clock_elapsed_ms`

The label is keyed off the 1P dev path via `firstPartyDev()` (the `SHOPIFY_CLI_1P_DEV` env var), which is the same signal that sets the `X-Shopify-Cli-Employee` header. Values are the strings `"true"` / `"false"`, keeping cardinality low.

This lets the dashboard's CLI guardrail panels filter to 1P, so we get a 1P-scoped success/failure signal for commands like `app dev`, `app dev clean`, and `generate extension` after cutover.

**Files changed:**

- `packages/cli-kit/src/private/node/otel-metrics.ts` — added `is_first_party` to the `Labels` type and populated it from `firstPartyDev()` in `recordMetrics`; imported `firstPartyDev` from `context/local`.
- `packages/cli-kit/src/private/node/otel-metrics.test.ts` — added a test asserting all recorded metrics carry `is_first_party: "true"` when `SHOPIFY_CLI_1P_DEV` is set; added `afterEach` env cleanup.
- `packages/cli-kit/src/private/node/__snapshots__/otel-metrics.test.ts.snap` — regenerated to include the new label (`"false"` when the 1P dev path is off).
- `.changeset/first-party-cli-metrics-label.md` — `@shopify/cli-kit` patch changeset.

### How to test your changes?

1. From the repo root, run the unit tests for the metrics module:
   ```
   pnpm --filter @shopify/cli-kit vitest run src/private/node/otel-metrics.test.ts
   ```
   All three tests should pass, including `labels metrics as first-party when the 1P dev path is enabled`.
2. Manually verify the label is emitted. With metrics debug output enabled, run a CLI command as a third-party developer and confirm `cli_commands_total` records `is_first_party: "false"`.
3. Re-run the same command with the 1P dev path enabled (`SHOPIFY_CLI_1P_DEV=1 shopify app dev`) and confirm the metric records `is_first_party: "true"`.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [x] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`
