### PR TITLE
[Security] Harden downloadFile to check for non-2xx status codes

### DIFF
--- a/packages/cli-kit/src/public/node/http.test.ts
+++ b/packages/cli-kit/src/public/node/http.test.ts
@@ -276,6 +276,24 @@ describe('downloadFile', () => {
     })
   })
 
+  test('Fails if the server returns a 500 error', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      const url = 'https://shopify.example/500.txt'
+      const filename = '/bin/500.txt'
+      const to = joinPath(tmpDir, filename)
+
+      // When
+      const result = downloadFile(url, to)
+
+      // Then
+      await expect(result).rejects.toThrow(
+        /Failed to download file from https:\/\/shopify.example\/500.txt. Status: 500/,
+      )
+      await expect(fileExists(to)).resolves.toBe(false)
+    })
+  })
+
   const runningOnWindows = platformAndArch().platform === 'windows'
 
   test.skipIf(runningOnWindows)('Cleans up if download fails', async () => {

--- a/packages/cli-kit/src/public/node/http.ts
+++ b/packages/cli-kit/src/public/node/http.ts
@@ -254,7 +254,13 @@ export function downloadFile(url: string, to: string): Promise<string> {
 
       nodeFetch(url, {redirect: 'follow'})
         .then((res) => {
-          res.body?.pipe(file)
+          if (res.ok) {
+            res.body?.pipe(file)
+          } else {
+            file.destroy()
+            tryToRemoveFile()
+            reject(new Error(`Failed to download file from ${sanitizedUrl}. Status: ${res.status}`))
+          }
         })
         .catch((err) => {
           tryToRemoveFile()


### PR DESCRIPTION
### WHY are these changes introduced?

The `downloadFile` function previously did not check the response status code, which could result in error pages being saved as files and the promise resolving successfully even on failure.

### WHAT is this pull request doing?

Hardens `downloadFile` in `packages/cli-kit/src/public/node/http.ts` by validating `res.ok` before piping the response body. If the response is not successful, it destroys the file stream, removes the partial file, and rejects the promise with an error message containing the status code.

### How to test your changes?

CI

### Post-release steps

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [490676649903503427](https://jules.google.com/task/490676649903503427) started by @gonzaloriestra*