### PR TITLE
[Performance] Memoize isWsl

### DIFF
--- a/packages/cli-kit/src/public/node/system.test.ts
+++ b/packages/cli-kit/src/public/node/system.test.ts
@@ -1,11 +1,14 @@
 import * as system from './system.js'
 import {execa} from 'execa'
-import {describe, expect, test, vi} from 'vitest'
+import {describe, expect, test, vi, beforeEach} from 'vitest'
 import which from 'which'
 import {Readable} from 'stream'
 
 import * as fs from 'fs'
 
+vi.mock('is-wsl', () => ({
+  default: true,
+}))
 vi.mock('which')
 vi.mock('execa')
 vi.mock('fs', async (importOriginal) => {
@@ -391,5 +394,28 @@ describe('readStdinString', () => {
 
     // Then
     await expect(got).rejects.toThrow('Stdin input exceeded the maximum allowed size.')
+  })
+})
+
+describe('isWsl', () => {
+  beforeEach(() => {
+    system._resetIsWsl()
+  })
+
+  test('returns true when is-wsl is true', async () => {
+    // When
+    const got = await system.isWsl()
+
+    // Then
+    expect(got).toBe(true)
+  })
+
+  test('memoizes the result', () => {
+    // When
+    const firstCall = system.isWsl()
+    const secondCall = system.isWsl()
+
+    // Then
+    expect(firstCall).toBe(secondCall)
   })
 })

--- a/packages/cli-kit/src/public/node/system.ts
+++ b/packages/cli-kit/src/public/node/system.ts
@@ -352,13 +352,24 @@ export function isCI(): boolean {
 }
 
 /**
+ * Memoized value for the WSL check.
+ */
+let memoizedIsWsl: Promise<boolean> | undefined
+
+/**
  * Check if the current environment is a WSL environment.
  *
  * @returns True if the current environment is a WSL environment.
  */
-export async function isWsl(): Promise<boolean> {
-  const wsl = await import('is-wsl')
-  return wsl.default
+export function isWsl(): Promise<boolean> {
+  return (memoizedIsWsl ??= import('is-wsl').then((wsl) => wsl.default))
+}
+
+/**
+ * Resets the memoized value for the WSL check.
+ */
+export function _resetIsWsl(): void {
+  memoizedIsWsl = undefined
 }
 
 /**


### PR DESCRIPTION
This PR optimizes the `isWsl` utility function by memoizing its result. Since the WSL status of an environment does not change during the lifetime of the process, we can safely cache the promise from the dynamic import and return it for all subsequent calls.

Performance Impact:
- Reduces overhead of repeated dynamic imports.
- Returns the same promise instance, allowing for reference equality checks if needed.
- Improves performance in analytics and metadata reporting paths.

Testing:
- Added new unit tests in `packages/cli-kit/src/public/node/system.test.ts`.
- Verified that `isWsl` correctly identifies the environment (mocked).
- Verified that multiple calls return the exact same promise instance.
- Ran full test suite for `@shopify/cli-kit`.


---
*PR created automatically by Jules for task [2044910693505345155](https://jules.google.com/task/2044910693505345155) started by @gonzaloriestra*