### PR TITLE
Add production preview store create command

### DIFF
--- a/.changeset/preview-store-create-production.md
+++ b/.changeset/preview-store-create-production.md
@@ -1,0 +1,6 @@
+---
+'@shopify/cli': minor
+'@shopify/store': minor
+---
+
+Add `shopify store create preview` to create preview stores and persist their Admin API token in local store auth.

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -5812,6 +5812,75 @@
       "strict": true,
       "summary": "Create a new development store."
     },
+    "store:create:preview": {
+      "aliases": [
+      ],
+      "args": {
+      },
+      "customPluginName": "@shopify/store",
+      "description": "Creates a new Shopify store, with no need for an existing account.",
+      "descriptionWithMarkdown": "Creates a new Shopify store, with no need for an existing account.",
+      "examples": [
+        "<%= config.bin %> <%= command.id %> --name \"Lavender Candles\"",
+        "<%= config.bin %> <%= command.id %> --name \"Lavender Candles\" --country US",
+        "<%= config.bin %> <%= command.id %> --name \"Lavender Candles\" --json"
+      ],
+      "flags": {
+        "country": {
+          "description": "Two-letter country code for the store, such as US, CA, or GB.",
+          "env": "SHOPIFY_FLAG_PREVIEW_STORE_COUNTRY",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "country",
+          "required": false,
+          "type": "option"
+        },
+        "json": {
+          "allowNo": false,
+          "char": "j",
+          "description": "Output the result as JSON. Automatically disables color output.",
+          "env": "SHOPIFY_FLAG_JSON",
+          "hidden": false,
+          "name": "json",
+          "type": "boolean"
+        },
+        "name": {
+          "description": "The name of the store.",
+          "env": "SHOPIFY_FLAG_PREVIEW_STORE_NAME",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "name",
+          "required": false,
+          "type": "option"
+        },
+        "no-color": {
+          "allowNo": false,
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
+          "type": "boolean"
+        },
+        "verbose": {
+          "allowNo": false,
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hidden": true,
+      "hiddenAliases": [
+      ],
+      "id": "store:create:preview",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "summary": "Create a preview Shopify store."
+    },
     "store:execute": {
       "aliases": [
       ],

--- a/packages/store/src/cli/commands/store/create/preview.test.ts
+++ b/packages/store/src/cli/commands/store/create/preview.test.ts
@@ -1,0 +1,48 @@
+import StoreCreatePreview from './preview.js'
+import {createPreviewStoreCommand} from '../../../services/store/create/preview/index.js'
+import {writeCreatePreviewStoreResult} from '../../../services/store/create/preview/result.js'
+import {renderSingleTask} from '@shopify/cli-kit/node/ui'
+import {describe, expect, test, vi} from 'vitest'
+
+vi.mock('../../../services/store/create/preview/index.js')
+vi.mock('../../../services/store/create/preview/result.js')
+vi.mock('@shopify/cli-kit/node/ui', async () => {
+  const actual = await vi.importActual<typeof import('@shopify/cli-kit/node/ui')>('@shopify/cli-kit/node/ui')
+  return {...actual, renderSingleTask: vi.fn(async ({task}) => task())}
+})
+
+describe('store create preview command', () => {
+  test('is hidden until preview store creation is generally available', () => {
+    expect(StoreCreatePreview.hidden).toBe(true)
+  })
+
+  test('passes parsed flags through to the service', async () => {
+    const result = {
+      status: 'success' as const,
+      message: 'Your Shopify store is ready.',
+      store: {
+        id: '123',
+        name: 'Lavender Candles',
+        subdomain: 'x.myshopify.com',
+        country: 'US',
+        storefrontUrl: 'https://x.myshopify.com',
+      },
+    }
+    vi.mocked(createPreviewStoreCommand).mockResolvedValueOnce(result)
+
+    await StoreCreatePreview.run(['--name', 'Lavender Candles', '--country', 'us', '--json'])
+
+    expect(renderSingleTask).toHaveBeenCalledWith({
+      title: expect.objectContaining({value: 'Creating store…'}),
+      task: expect.any(Function),
+    })
+    expect(createPreviewStoreCommand).toHaveBeenCalledWith({name: 'Lavender Candles', country: 'US'})
+    expect(writeCreatePreviewStoreResult).toHaveBeenCalledWith(result, 'json')
+  })
+
+  test('rejects invalid country codes before calling the service', async () => {
+    await expect(StoreCreatePreview.run(['--country', 'USA'])).rejects.toThrow('process.exit unexpectedly called')
+
+    expect(createPreviewStoreCommand).not.toHaveBeenCalled()
+  })
+})

--- a/packages/store/src/cli/commands/store/create/preview.ts
+++ b/packages/store/src/cli/commands/store/create/preview.ts
@@ -1,0 +1,50 @@
+import {isCountryCode, previewStoreFlags} from '../../../flags.js'
+import {type CreatePreviewStoreResult, createPreviewStoreCommand} from '../../../services/store/create/preview/index.js'
+import {writeCreatePreviewStoreResult} from '../../../services/store/create/preview/result.js'
+import StoreCommand from '../../../utilities/store-command.js'
+import {globalFlags, jsonFlag} from '@shopify/cli-kit/node/cli'
+import {outputContent} from '@shopify/cli-kit/node/output'
+import {renderSingleTask} from '@shopify/cli-kit/node/ui'
+import {Flags} from '@oclif/core'
+
+export default class StoreCreatePreview extends StoreCommand {
+  static hidden = true
+
+  static summary = 'Create a preview Shopify store.'
+
+  static descriptionWithMarkdown = `Creates a new Shopify store, with no need for an existing account.`
+
+  static description = this.descriptionWithoutMarkdown()
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %> --name "Lavender Candles"',
+    '<%= config.bin %> <%= command.id %> --name "Lavender Candles" --country US',
+    '<%= config.bin %> <%= command.id %> --name "Lavender Candles" --json',
+  ]
+
+  static flags = {
+    ...globalFlags,
+    ...jsonFlag,
+    name: Flags.string({
+      description: 'The name of the store.',
+      env: 'SHOPIFY_FLAG_PREVIEW_STORE_NAME',
+      required: false,
+    }),
+    country: previewStoreFlags.country,
+  }
+
+  public async run(): Promise<void> {
+    const {flags} = await this.parse(StoreCreatePreview)
+
+    if (flags.country !== undefined && !isCountryCode(flags.country)) {
+      this.error('Country must be a two-letter country code, for example: US.')
+    }
+
+    const result = await renderSingleTask<CreatePreviewStoreResult>({
+      title: outputContent`Creating store…`,
+      task: async () => createPreviewStoreCommand({name: flags.name, country: flags.country}),
+    })
+
+    writeCreatePreviewStoreResult(result, flags.json ? 'json' : 'text')
+  }
+}

--- a/packages/store/src/cli/flags.ts
+++ b/packages/store/src/cli/flags.ts
@@ -1,6 +1,23 @@
 import {normalizeStoreFqdn} from '@shopify/cli-kit/node/context/fqdn'
 import {Flags} from '@oclif/core'
 
+function countryFlag(env: string) {
+  return Flags.string({
+    description: 'Two-letter country code for the store, such as US, CA, or GB.',
+    env,
+    required: false,
+    parse: async (value) => value.trim().toUpperCase(),
+  })
+}
+
+export function isCountryCode(value: string): boolean {
+  return /^[A-Z]{2}$/.test(value)
+}
+
+export const previewStoreFlags = {
+  country: countryFlag('SHOPIFY_FLAG_PREVIEW_STORE_COUNTRY'),
+}
+
 export const storeFlags = {
   store: Flags.string({
     char: 's',

--- a/packages/store/src/cli/services/store/auth/session-store.test.ts
+++ b/packages/store/src/cli/services/store/auth/session-store.test.ts
@@ -144,6 +144,42 @@ describe('store session storage', () => {
     })
   })
 
+  test('round-trips preview store session metadata', () => {
+    const storage = inMemoryStorage()
+    const previewSession = buildSession({
+      userId: 'preview:placeholder-uuid',
+      scopes: [],
+      kind: 'preview',
+      preview: {
+        placeholderAccountUuid: 'placeholder-uuid',
+        shopId: '123',
+        name: 'Lavender Candles',
+        country: 'US',
+        createdAt: '2026-06-08T12:00:00.000Z',
+      },
+    })
+
+    setStoredStoreAppSession(previewSession, storage as any)
+
+    expect(getCurrentStoredStoreAppSession('shop.myshopify.com', storage as any)).toEqual(previewSession)
+  })
+
+  test('rejects preview store sessions with malformed metadata', () => {
+    const storage = inMemoryStorage()
+    storage.set(storeAuthSessionKey('shop.myshopify.com'), {
+      currentUserId: 'preview:placeholder-uuid',
+      sessionsByUserId: {
+        'preview:placeholder-uuid': {
+          ...buildSession({userId: 'preview:placeholder-uuid', kind: 'preview'}),
+          preview: {placeholderAccountUuid: 'placeholder-uuid'},
+        },
+      },
+    })
+
+    expect(getCurrentStoredStoreAppSession('shop.myshopify.com', storage as any)).toBeUndefined()
+    expect(storage.get(storeAuthSessionKey('shop.myshopify.com'))).toBeUndefined()
+  })
+
   test('overwrites a malformed bucket when writing a new session', () => {
     const storage = inMemoryStorage()
     storage.set(storeAuthSessionKey('shop.myshopify.com'), {

--- a/packages/store/src/cli/services/store/auth/session-store.ts
+++ b/packages/store/src/cli/services/store/auth/session-store.ts
@@ -1,6 +1,32 @@
 import {storeAuthSessionKey} from './config.js'
 import {LocalStorage} from '@shopify/cli-kit/node/local-storage'
 
+/**
+ * Discriminator for a stored store auth session.
+ *
+ * - 'standard': created via `shopify store auth`.
+ * - 'preview': created via `shopify store create preview`; backed by a server-issued Admin API token.
+ *
+ * Stored sessions written before this discriminator existed have no `kind` field and are
+ * read back as 'standard'.
+ */
+type StoredStoreSessionKind = 'standard' | 'preview'
+
+interface StoredPreviewStoreMetadata {
+  /** Placeholder account UUID returned by the preview-store backend when available. */
+  placeholderAccountUuid?: string
+  /** Numeric shop id returned by the preview-store backend. */
+  shopId: string
+  /** Store name returned by the preview-store backend. */
+  name: string
+  /** ISO country code requested for the store, when provided by the caller. */
+  country?: string
+  /** ISO timestamp for when the preview store was created locally. */
+  createdAt: string
+  /** Access URL returned by the preview-store backend. */
+  accessUrl?: string
+}
+
 export interface StoredStoreAppSession {
   store: string
   clientId: string
@@ -18,6 +44,13 @@ export interface StoredStoreAppSession {
     lastName?: string
     accountOwner?: boolean
   }
+  /**
+   * Discriminator. Optional in storage for back-compat with sessions written before the
+   * field existed; `sessionKind()` resolves missing values to 'standard'.
+   */
+  kind?: StoredStoreSessionKind
+  /** Preview-store-only metadata. Set iff `kind === 'preview'`. */
+  preview?: StoredPreviewStoreMetadata
 }
 
 interface StoredStoreAppSessionBucket {
@@ -55,6 +88,22 @@ function sanitizeAssociatedUser(value: unknown): StoredStoreAppSession['associat
   }
 }
 
+function sanitizePreviewMetadata(value: unknown): StoredPreviewStoreMetadata | undefined {
+  if (!value || typeof value !== 'object') return undefined
+
+  const metadata = value as Record<string, unknown>
+  if (!isString(metadata.shopId) || !isString(metadata.name) || !isString(metadata.createdAt)) return undefined
+
+  return {
+    shopId: metadata.shopId,
+    name: metadata.name,
+    createdAt: metadata.createdAt,
+    ...(isString(metadata.placeholderAccountUuid) ? {placeholderAccountUuid: metadata.placeholderAccountUuid} : {}),
+    ...(isString(metadata.country) ? {country: metadata.country} : {}),
+    ...(isString(metadata.accessUrl) ? {accessUrl: metadata.accessUrl} : {}),
+  }
+}
+
 function sanitizeStoredStoreAppSession(value: unknown): StoredStoreAppSession | undefined {
   if (!value || typeof value !== 'object') return undefined
 
@@ -71,6 +120,16 @@ function sanitizeStoredStoreAppSession(value: unknown): StoredStoreAppSession | 
     return undefined
   }
 
+  // Discriminator is optional for back-compat: sessions written before this field existed
+  // are read back as 'standard'. Unknown values are coerced to 'standard' and the field is
+  // omitted from the result so it doesn't pollute legacy buckets.
+  const kind: StoredStoreSessionKind = session.kind === 'preview' ? 'preview' : 'standard'
+  const preview = kind === 'preview' ? sanitizePreviewMetadata(session.preview) : undefined
+
+  // A session declared as 'preview' but missing/malformed metadata is rejected outright,
+  // because store-list fallback and future re-mint/claim flows rely on this metadata.
+  if (kind === 'preview' && !preview) return undefined
+
   return {
     store: session.store,
     clientId: session.clientId,
@@ -84,6 +143,8 @@ function sanitizeStoredStoreAppSession(value: unknown): StoredStoreAppSession | 
     ...(sanitizeAssociatedUser(session.associatedUser)
       ? {associatedUser: sanitizeAssociatedUser(session.associatedUser)}
       : {}),
+    ...(kind === 'preview' ? {kind} : {}),
+    ...(preview ? {preview} : {}),
   }
 }
 

--- a/packages/store/src/cli/services/store/create/preview/client.test.ts
+++ b/packages/store/src/cli/services/store/create/preview/client.test.ts
@@ -1,0 +1,180 @@
+import {
+  CLI_INSTANCE_HEADER,
+  CLI_VERSION_HEADER,
+  createPreviewStore,
+  getOrCreateCliInstanceId,
+  previewStoreCreateHeaders,
+} from './client.js'
+import {shopifyFetch} from '@shopify/cli-kit/node/http'
+import {LocalStorage} from '@shopify/cli-kit/node/local-storage'
+import {CLI_KIT_VERSION} from '@shopify/cli-kit/common/version'
+import {describe, expect, test, vi} from 'vitest'
+
+vi.mock('@shopify/cli-kit/node/http')
+vi.mock('@shopify/cli-kit/node/context/fqdn', async () => {
+  const actual = await vi.importActual<typeof import('@shopify/cli-kit/node/context/fqdn')>(
+    '@shopify/cli-kit/node/context/fqdn',
+  )
+  return {...actual, appManagementFqdn: vi.fn(async () => 'app.shopify.com')}
+})
+vi.mock('@shopify/cli-kit/node/crypto', async () => {
+  const actual = await vi.importActual<typeof import('@shopify/cli-kit/node/crypto')>('@shopify/cli-kit/node/crypto')
+  return {...actual, randomUUID: vi.fn(() => 'cli-install-id')}
+})
+
+function response(status: number, body: unknown) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    text: async () => (typeof body === 'string' ? body : JSON.stringify(body)),
+  } as Awaited<ReturnType<typeof shopifyFetch>>
+}
+
+function inMemoryStorage(initial?: string) {
+  const values = new Map<string, unknown>()
+  if (initial) values.set('cliInstanceId', initial)
+  return {
+    get: vi.fn((key: string) => values.get(key) as any),
+    set: vi.fn((key: string, value: unknown) => values.set(key, value)),
+    delete: vi.fn((key: string) => values.delete(key)),
+  } as unknown as LocalStorage<{cliInstanceId?: string}>
+}
+
+describe('preview store client', () => {
+  test('persists and reuses a stable CLI instance id', () => {
+    const storage = inMemoryStorage()
+
+    expect(getOrCreateCliInstanceId(storage)).toBe('cli-install-id')
+    expect(getOrCreateCliInstanceId(storage)).toBe('cli-install-id')
+    expect(storage.set).toHaveBeenCalledTimes(1)
+  })
+
+  test('builds production request headers', () => {
+    expect(previewStoreCreateHeaders('instance-1')).toEqual({
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+      'User-Agent': `Shopify CLI; v=${CLI_KIT_VERSION}`,
+      [CLI_INSTANCE_HEADER]: 'instance-1',
+      [CLI_VERSION_HEADER]: CLI_KIT_VERSION,
+    })
+  })
+
+  test('POSTs to /services/preview-stores with optional name and country variables and no authorization', async () => {
+    vi.mocked(shopifyFetch).mockResolvedValueOnce(
+      response(201, {
+        shop: {id: 123, name: 'Lavender Candles', domain: 'x12y45z.myshopify.com'},
+        placeholder_account_uuid: 'placeholder-uuid',
+        admin_api_token: 'shpat_token',
+        access_url: 'https://app.shopify.com/auth/preview-store?token=access-token',
+      }),
+    )
+
+    const got = await createPreviewStore(
+      {name: 'Lavender Candles', country: 'US'},
+      {storage: inMemoryStorage('instance-1')},
+    )
+
+    expect(shopifyFetch).toHaveBeenCalledWith('https://app.shopify.com/services/preview-stores', {
+      method: 'POST',
+      headers: expect.objectContaining({
+        [CLI_INSTANCE_HEADER]: 'instance-1',
+        [CLI_VERSION_HEADER]: CLI_KIT_VERSION,
+        'User-Agent': `Shopify CLI; v=${CLI_KIT_VERSION}`,
+      }),
+      body: JSON.stringify({
+        name: 'Lavender Candles',
+        variables: {storeCreatePayload: {country: 'US'}},
+      }),
+    })
+    expect((vi.mocked(shopifyFetch).mock.calls[0]![1]!.headers as Record<string, string>).Authorization).toBeUndefined()
+    expect(got).toEqual({
+      shop: {id: '123', name: 'Lavender Candles', domain: 'x12y45z.myshopify.com'},
+      placeholderAccountUuid: 'placeholder-uuid',
+      adminApiToken: 'shpat_token',
+      accessUrl: 'https://app.shopify.com/auth/preview-store?token=access-token',
+    })
+  })
+
+  test('omits name and country variables when absent', async () => {
+    vi.mocked(shopifyFetch).mockResolvedValueOnce(
+      response(201, {
+        shop: {id: 123, name: 'My Store', domain: 'x.myshopify.com'},
+        admin_api_token: 'shpat_token',
+        access_url: 'https://app.shopify.com/auth/preview-store?token=access-token',
+      }),
+    )
+
+    await createPreviewStore({}, {storage: inMemoryStorage('instance-1')})
+
+    expect(vi.mocked(shopifyFetch).mock.calls[0]![1]!.body).toBe('{}')
+  })
+
+  test.each([
+    ['service_unavailable', 503, 'Preview store creation is temporarily unavailable.'],
+    ['not_in_rollout', 503, 'Preview store creation is not enabled yet.'],
+    ['rate_limited', 429, 'Too many preview store creation requests.'],
+    ['preview_store_create_failed', 422, 'Preview store creation failed.'],
+    ['preview_store_create_failed', 500, 'Preview store creation failed.'],
+    ['shop_name_invalid', 422, 'The preview store name was rejected.'],
+    ['shop_name_banned_keyword', 422, 'The preview store name was rejected.'],
+    ['country_invalid', 422, 'The preview store country was rejected.'],
+  ])('maps %s errors', async (errorCode, status, message) => {
+    vi.mocked(shopifyFetch).mockResolvedValueOnce(response(status, {error_code: errorCode, message: 'server message'}))
+
+    await expect(createPreviewStore({}, {storage: inMemoryStorage('instance-1')})).rejects.toThrow(message)
+  })
+
+  test('rejects malformed success responses without leaking the admin API token or access URL', async () => {
+    vi.mocked(shopifyFetch).mockResolvedValueOnce(
+      response(201, {
+        shop: {id: 123},
+        admin_api_token: 'shpat_token',
+        access_url: 'https://app.shopify.com/auth/preview-store?token=access-token',
+      }),
+    )
+
+    await expect(createPreviewStore({}, {storage: inMemoryStorage('instance-1')})).rejects.toMatchObject({
+      message: 'Preview store creation response is missing required fields.',
+      tryMessage: expect.stringMatching(/"admin_api_token":"\[REDACTED\]".*"access_url":"\[REDACTED\]"/),
+    })
+  })
+
+  test('rejects non-JSON success responses without leaking the admin API token or access URL', async () => {
+    vi.mocked(shopifyFetch).mockResolvedValueOnce(
+      response(
+        201,
+        '{"shop":{"id":123},"admin_api_token":"shpat_token","access_url":"https://app.shopify.com/auth/preview-store?token=access-token"',
+      ),
+    )
+
+    const error = (await createPreviewStore({}, {storage: inMemoryStorage('instance-1')}).catch(
+      (caught: unknown) => caught,
+    )) as {tryMessage: string}
+
+    expect(error).toMatchObject({
+      message: 'Preview store creation returned a non-JSON response.',
+      tryMessage: expect.stringContaining('"admin_api_token":"[REDACTED]"'),
+    })
+    expect(error.tryMessage).not.toContain('shpat_token')
+    expect(error.tryMessage).not.toContain('access-token')
+  })
+
+  test('redacts raw response fallback diagnostics', async () => {
+    vi.mocked(shopifyFetch).mockResolvedValueOnce(
+      response(
+        500,
+        'Preview store failed after creating https://app.shopify.com/auth/preview-store?token=access-token with admin_api_token: "shpat_token"',
+      ),
+    )
+
+    const error = (await createPreviewStore({}, {storage: inMemoryStorage('instance-1')}).catch(
+      (caught: unknown) => caught,
+    )) as {tryMessage: string}
+
+    expect(error).toMatchObject({
+      message: 'Preview store creation failed with HTTP 500.',
+    })
+    expect(error.tryMessage).not.toContain('access-token')
+    expect(error.tryMessage).not.toContain('shpat_token')
+  })
+})

--- a/packages/store/src/cli/services/store/create/preview/client.ts
+++ b/packages/store/src/cli/services/store/create/preview/client.ts
@@ -1,0 +1,224 @@
+import {appManagementFqdn, normalizeStoreFqdn} from '@shopify/cli-kit/node/context/fqdn'
+import {randomUUID} from '@shopify/cli-kit/node/crypto'
+import {AbortError} from '@shopify/cli-kit/node/error'
+import {shopifyFetch} from '@shopify/cli-kit/node/http'
+import {LocalStorage} from '@shopify/cli-kit/node/local-storage'
+import {CLI_KIT_VERSION} from '@shopify/cli-kit/common/version'
+
+export const CLI_INSTANCE_HEADER = 'X-Shopify-CLI-Instance'
+export const CLI_VERSION_HEADER = 'X-Shopify-CLI-Version'
+
+interface PreviewStoreClientStorageSchema {
+  cliInstanceId?: string
+}
+
+let _clientStorage: LocalStorage<PreviewStoreClientStorageSchema> | undefined
+
+function clientStorage() {
+  _clientStorage ??= new LocalStorage<PreviewStoreClientStorageSchema>({projectName: 'shopify-cli-store'})
+  return _clientStorage
+}
+
+export interface PreviewStoreClientOptions {
+  storage?: LocalStorage<PreviewStoreClientStorageSchema>
+}
+
+interface PreviewStoreCreateRequest {
+  name?: string
+  country?: string
+}
+
+interface PreviewStoreResponseShop {
+  id: string
+  name: string
+  domain: string
+}
+
+export interface PreviewStoreCreateResponse {
+  shop: PreviewStoreResponseShop
+  placeholderAccountUuid?: string
+  adminApiToken: string
+  accessUrl: string
+}
+
+interface RawPreviewStoreResponseShop {
+  id?: unknown
+  name?: unknown
+  domain?: unknown
+}
+
+interface RawPreviewStoreCreateResponse {
+  shop?: RawPreviewStoreResponseShop
+  placeholder_account_uuid?: unknown
+  admin_api_token?: unknown
+  access_url?: unknown
+}
+
+interface RawPreviewStoreErrorResponse {
+  error_code?: string
+  message?: string
+}
+
+export function getOrCreateCliInstanceId(
+  storage: LocalStorage<PreviewStoreClientStorageSchema> = clientStorage(),
+): string {
+  const existing = storage.get('cliInstanceId')
+  if (typeof existing === 'string' && existing.length > 0) return existing
+
+  const next = randomUUID()
+  storage.set('cliInstanceId', next)
+  return next
+}
+
+export function previewStoreCreateHeaders(cliInstanceId: string): Record<string, string> {
+  return {
+    Accept: 'application/json',
+    'Content-Type': 'application/json',
+    'User-Agent': `Shopify CLI; v=${CLI_KIT_VERSION}`,
+    [CLI_INSTANCE_HEADER]: cliInstanceId,
+    [CLI_VERSION_HEADER]: CLI_KIT_VERSION,
+  }
+}
+
+export async function createPreviewStore(
+  request: PreviewStoreCreateRequest,
+  options: PreviewStoreClientOptions = {},
+): Promise<PreviewStoreCreateResponse> {
+  const fqdn = await appManagementFqdn()
+  const url = `https://${fqdn}/services/preview-stores`
+  const body = JSON.stringify({
+    ...(request.name ? {name: request.name} : {}),
+    ...(request.country
+      ? {
+          variables: {
+            storeCreatePayload: {
+              country: request.country,
+            },
+          },
+        }
+      : {}),
+  })
+
+  const response = await shopifyFetch(url, {
+    method: 'POST',
+    headers: previewStoreCreateHeaders(getOrCreateCliInstanceId(options.storage)),
+    body,
+  })
+
+  const rawText = await response.text()
+  if (!response.ok) {
+    const error = previewStoreError(response.status, rawText)
+    throw new AbortError(error.message, error.tryMessage)
+  }
+
+  let parsed: RawPreviewStoreCreateResponse
+  try {
+    parsed = JSON.parse(rawText) as RawPreviewStoreCreateResponse
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error'
+    throw new AbortError(
+      'Preview store creation returned a non-JSON response.',
+      `Parse error: ${message}. Body (truncated): ${redactPreviewStoreRawText(rawText).slice(0, 500)}`,
+    )
+  }
+
+  return narrowResponse(parsed)
+}
+
+function previewStoreError(status: number, rawText: string): {message: string; tryMessage?: string} {
+  const parsed = parseErrorBody(rawText)
+  const errorCode = parsed.error_code
+  const message = parsed.message
+
+  if (errorCode === 'not_in_rollout') {
+    return {
+      message: 'Preview store creation is not enabled yet.',
+      tryMessage: 'Try again later.',
+    }
+  }
+
+  if (errorCode === 'service_unavailable') {
+    return {message: 'Preview store creation is temporarily unavailable.', tryMessage: 'Try again later.'}
+  }
+
+  if (errorCode === 'rate_limited') {
+    return {message: 'Too many preview store creation requests.', tryMessage: 'Try again later.'}
+  }
+
+  if (errorCode === 'preview_store_create_failed') {
+    return {message: 'Preview store creation failed.', tryMessage: 'Try again later.'}
+  }
+
+  if (errorCode === 'shop_name_banned_keyword' || errorCode === 'shop_name_invalid') {
+    return {message: 'The preview store name was rejected.', tryMessage: 'Use a different store name and try again.'}
+  }
+
+  if (errorCode === 'country_invalid') {
+    return {message: 'The preview store country was rejected.', tryMessage: 'Use a different country and try again.'}
+  }
+
+  const redactedRawText = redactPreviewStoreRawText(rawText)
+
+  return {
+    message: `Preview store creation failed with HTTP ${status}.`,
+    tryMessage: message ?? (redactedRawText.length > 0 ? redactedRawText.slice(0, 1000) : 'No response body returned.'),
+  }
+}
+
+function parseErrorBody(rawText: string): RawPreviewStoreErrorResponse {
+  if (rawText.length === 0) return {}
+
+  try {
+    const parsed: unknown = JSON.parse(rawText)
+    if (!parsed || typeof parsed !== 'object') return {}
+
+    const body = parsed as Record<string, unknown>
+    return {
+      ...(typeof body.error_code === 'string' ? {error_code: body.error_code} : {}),
+      ...(typeof body.message === 'string' ? {message: body.message} : {}),
+    }
+  } catch (error) {
+    if (error instanceof SyntaxError) return {}
+    throw error
+  }
+}
+
+function narrowResponse(parsed: RawPreviewStoreCreateResponse): PreviewStoreCreateResponse {
+  const shop = parsed.shop
+  const id = typeof shop?.id === 'string' || typeof shop?.id === 'number' ? String(shop.id) : undefined
+  const name = typeof shop?.name === 'string' ? shop.name : undefined
+  const domain = typeof shop?.domain === 'string' ? normalizeStoreFqdn(shop.domain) : undefined
+  const adminApiToken = typeof parsed.admin_api_token === 'string' ? parsed.admin_api_token : undefined
+  const accessUrl = typeof parsed.access_url === 'string' ? parsed.access_url : undefined
+  const placeholderAccountUuid =
+    typeof parsed.placeholder_account_uuid === 'string' ? parsed.placeholder_account_uuid : undefined
+
+  if (!id || !name || !domain || !adminApiToken || !accessUrl) {
+    throw new AbortError(
+      'Preview store creation response is missing required fields.',
+      `Got: ${JSON.stringify(redactPreviewStoreResponse(parsed)).slice(0, 500)}`,
+    )
+  }
+
+  return {
+    shop: {id, name, domain},
+    adminApiToken,
+    accessUrl,
+    ...(placeholderAccountUuid ? {placeholderAccountUuid} : {}),
+  }
+}
+
+function redactPreviewStoreResponse(parsed: RawPreviewStoreCreateResponse): RawPreviewStoreCreateResponse {
+  return {
+    ...parsed,
+    ...(parsed.admin_api_token ? {admin_api_token: '[REDACTED]'} : {}),
+    ...(parsed.access_url ? {access_url: '[REDACTED]'} : {}),
+  }
+}
+
+function redactPreviewStoreRawText(rawText: string): string {
+  return rawText
+    .replace(/(["']?(?:admin_api_token|adminApiToken)["']?\s*:\s*["'])[^"']+/gi, '$1[REDACTED]')
+    .replace(/(["']?(?:access_url|accessUrl)["']?\s*:\s*["'])[^"']+/gi, '$1[REDACTED]')
+    .replace(/([?&](?:token|access_token)=)[^&\s"'<>]+/gi, '$1[REDACTED]')
+}

--- a/packages/store/src/cli/services/store/create/preview/index.test.ts
+++ b/packages/store/src/cli/services/store/create/preview/index.test.ts
@@ -1,0 +1,139 @@
+import {PREVIEW_USER_ID_PREFIX, createPreviewStoreCommand} from './index.js'
+import {STORE_AUTH_APP_CLIENT_ID} from '../../auth/config.js'
+import {describe, expect, test, vi} from 'vitest'
+
+describe('preview store create service', () => {
+  test('persists the created preview store in the store-auth cache', async () => {
+    const setStoredStoreAppSession = vi.fn()
+    const recordStoreFqdnMetadata = vi.fn()
+    const setLastSeenUserId = vi.fn()
+
+    const result = await createPreviewStoreCommand(
+      {name: 'Lavender Candles', country: 'US'},
+      {
+        createPreviewStore: vi.fn(async () => ({
+          shop: {id: '123', name: 'Lavender Candles', domain: 'x12y45z.myshopify.com'},
+          placeholderAccountUuid: 'placeholder-uuid',
+          adminApiToken: 'shpat_token',
+          accessUrl: 'https://app.shopify.com/auth/preview-store?token=access-token',
+        })),
+        setStoredStoreAppSession,
+        recordStoreFqdnMetadata,
+        setLastSeenUserId,
+        now: () => new Date('2026-06-08T12:00:00.000Z'),
+      },
+    )
+
+    expect(setStoredStoreAppSession).toHaveBeenCalledWith({
+      store: 'x12y45z.myshopify.com',
+      clientId: STORE_AUTH_APP_CLIENT_ID,
+      userId: `${PREVIEW_USER_ID_PREFIX}placeholder-uuid`,
+      accessToken: 'shpat_token',
+      scopes: [],
+      acquiredAt: '2026-06-08T12:00:00.000Z',
+      kind: 'preview',
+      preview: {
+        shopId: '123',
+        name: 'Lavender Candles',
+        placeholderAccountUuid: 'placeholder-uuid',
+        country: 'US',
+        createdAt: '2026-06-08T12:00:00.000Z',
+        accessUrl: 'https://app.shopify.com/auth/preview-store?token=access-token',
+      },
+    })
+    expect(recordStoreFqdnMetadata).toHaveBeenCalledOnce()
+    expect(recordStoreFqdnMetadata).toHaveBeenCalledWith('x12y45z.myshopify.com', true)
+    expect(setLastSeenUserId).toHaveBeenCalledWith(`${PREVIEW_USER_ID_PREFIX}placeholder-uuid`)
+    expect(result).toEqual({
+      status: 'success',
+      message:
+        'Your Shopify store is ready. This store is temporary. Create a free Shopify account to save it and start selling.',
+      store: {
+        id: '123',
+        name: 'Lavender Candles',
+        subdomain: 'x12y45z.myshopify.com',
+        country: 'US',
+        storefrontUrl: 'https://app.shopify.com/auth/preview-store?token=access-token',
+      },
+    })
+  })
+
+  test('uses the shop id as the preview user id when no placeholder account uuid is returned', async () => {
+    const setStoredStoreAppSession = vi.fn()
+    const setLastSeenUserId = vi.fn()
+
+    await createPreviewStoreCommand(
+      {name: 'Lavender Candles'},
+      {
+        createPreviewStore: vi.fn(async () => ({
+          shop: {id: '123', name: 'Lavender Candles', domain: 'x12y45z.myshopify.com'},
+          adminApiToken: 'shpat_token',
+          accessUrl: 'https://app.shopify.com/auth/preview-store?token=access-token',
+        })),
+        setStoredStoreAppSession,
+        recordStoreFqdnMetadata: vi.fn(),
+        setLastSeenUserId,
+        now: () => new Date('2026-06-08T12:00:00.000Z'),
+      },
+    )
+
+    expect(setStoredStoreAppSession).toHaveBeenCalledWith(
+      expect.objectContaining({userId: `${PREVIEW_USER_ID_PREFIX}123`}),
+    )
+    expect(setLastSeenUserId).toHaveBeenCalledWith(`${PREVIEW_USER_ID_PREFIX}123`)
+  })
+
+  test('persists a store session and returns success when recording store metadata fails', async () => {
+    const setStoredStoreAppSession = vi.fn()
+    const recordStoreFqdnMetadata = vi.fn(async () => {
+      throw new Error('Metadata failed.')
+    })
+    const setLastSeenUserId = vi.fn()
+
+    const result = await createPreviewStoreCommand(
+      {name: 'Lavender Candles'},
+      {
+        createPreviewStore: vi.fn(async () => ({
+          shop: {id: '123', name: 'Lavender Candles', domain: 'x12y45z.myshopify.com'},
+          adminApiToken: 'shpat_token',
+          accessUrl: 'https://app.shopify.com/auth/preview-store?token=access-token',
+        })),
+        setStoredStoreAppSession,
+        recordStoreFqdnMetadata,
+        setLastSeenUserId,
+        now: () => new Date('2026-06-08T12:00:00.000Z'),
+      },
+    )
+
+    expect(setStoredStoreAppSession).toHaveBeenCalledOnce()
+    expect(setLastSeenUserId).toHaveBeenCalledWith(`${PREVIEW_USER_ID_PREFIX}123`)
+    expect(recordStoreFqdnMetadata).toHaveBeenCalledOnce()
+    expect(recordStoreFqdnMetadata).toHaveBeenCalledWith('x12y45z.myshopify.com', true)
+    expect(result.status).toBe('success')
+  })
+
+  test('does not persist a store session when preview store creation fails', async () => {
+    const setStoredStoreAppSession = vi.fn()
+    const recordStoreFqdnMetadata = vi.fn()
+    const setLastSeenUserId = vi.fn()
+
+    await expect(
+      createPreviewStoreCommand(
+        {name: 'Lavender Candles'},
+        {
+          createPreviewStore: vi.fn(async () => {
+            throw new Error('Preview store creation failed.')
+          }),
+          setStoredStoreAppSession,
+          recordStoreFqdnMetadata,
+          setLastSeenUserId,
+          now: () => new Date('2026-06-08T12:00:00.000Z'),
+        },
+      ),
+    ).rejects.toThrow('Preview store creation failed.')
+
+    expect(setStoredStoreAppSession).not.toHaveBeenCalled()
+    expect(recordStoreFqdnMetadata).not.toHaveBeenCalled()
+    expect(setLastSeenUserId).not.toHaveBeenCalled()
+  })
+})

--- a/packages/store/src/cli/services/store/create/preview/index.ts
+++ b/packages/store/src/cli/services/store/create/preview/index.ts
@@ -1,0 +1,108 @@
+import {PreviewStoreClientOptions, PreviewStoreCreateResponse, createPreviewStore} from './client.js'
+import {STORE_AUTH_APP_CLIENT_ID} from '../../auth/config.js'
+import {setStoredStoreAppSession} from '../../auth/session-store.js'
+import {recordStoreFqdnMetadata} from '../../attribution.js'
+import {setLastSeenUserId} from '@shopify/cli-kit/node/session'
+
+export const PREVIEW_USER_ID_PREFIX = 'preview:'
+
+interface CreatePreviewStoreInput {
+  name?: string
+  country?: string
+  client?: PreviewStoreClientOptions
+}
+
+interface CreatePreviewStoreDependencies {
+  createPreviewStore: typeof createPreviewStore
+  setStoredStoreAppSession: typeof setStoredStoreAppSession
+  recordStoreFqdnMetadata: typeof recordStoreFqdnMetadata
+  setLastSeenUserId: typeof setLastSeenUserId
+  now: () => Date
+}
+
+export interface CreatePreviewStoreResult {
+  status: 'success'
+  message: string
+  store: {
+    id: string
+    name: string
+    subdomain: string
+    country?: string
+    storefrontUrl: string
+  }
+}
+
+const defaultDependencies: CreatePreviewStoreDependencies = {
+  createPreviewStore,
+  setStoredStoreAppSession,
+  recordStoreFqdnMetadata,
+  setLastSeenUserId,
+  now: () => new Date(),
+}
+
+export async function createPreviewStoreCommand(
+  input: CreatePreviewStoreInput,
+  dependencies: Partial<CreatePreviewStoreDependencies> = {},
+): Promise<CreatePreviewStoreResult> {
+  const resolvedDependencies = {...defaultDependencies, ...dependencies}
+  const response = await resolvedDependencies.createPreviewStore(
+    {
+      name: input.name,
+      country: input.country,
+    },
+    input.client,
+  )
+
+  return persistPreviewStoreSession(response, input.country, resolvedDependencies)
+}
+
+function previewUserId(response: PreviewStoreCreateResponse): string {
+  return `${PREVIEW_USER_ID_PREFIX}${response.placeholderAccountUuid ?? response.shop.id}`
+}
+
+async function persistPreviewStoreSession(
+  response: PreviewStoreCreateResponse,
+  country: string | undefined,
+  dependencies: CreatePreviewStoreDependencies,
+): Promise<CreatePreviewStoreResult> {
+  const acquiredAt = dependencies.now().toISOString()
+  const userId = previewUserId(response)
+
+  dependencies.setStoredStoreAppSession({
+    store: response.shop.domain,
+    clientId: STORE_AUTH_APP_CLIENT_ID,
+    userId,
+    accessToken: response.adminApiToken,
+    scopes: [],
+    acquiredAt,
+    kind: 'preview',
+    preview: {
+      shopId: response.shop.id,
+      name: response.shop.name,
+      createdAt: acquiredAt,
+      ...(response.placeholderAccountUuid ? {placeholderAccountUuid: response.placeholderAccountUuid} : {}),
+      ...(country ? {country} : {}),
+      accessUrl: response.accessUrl,
+    },
+  })
+  dependencies.setLastSeenUserId(userId)
+  try {
+    await dependencies.recordStoreFqdnMetadata(response.shop.domain, true)
+    // eslint-disable-next-line no-catch-all/no-catch-all
+  } catch {
+    // Store metadata is best-effort; credentials and access URL are already persisted.
+  }
+
+  return {
+    status: 'success',
+    message:
+      'Your Shopify store is ready. This store is temporary. Create a free Shopify account to save it and start selling.',
+    store: {
+      id: response.shop.id,
+      name: response.shop.name,
+      subdomain: response.shop.domain,
+      ...(country ? {country} : {}),
+      storefrontUrl: response.accessUrl,
+    },
+  }
+}

--- a/packages/store/src/cli/services/store/create/preview/result.test.ts
+++ b/packages/store/src/cli/services/store/create/preview/result.test.ts
@@ -1,0 +1,107 @@
+import {writeCreatePreviewStoreResult} from './result.js'
+import {outputResult} from '@shopify/cli-kit/node/output'
+import {renderSuccess} from '@shopify/cli-kit/node/ui'
+import {describe, expect, test, vi} from 'vitest'
+
+vi.mock('@shopify/cli-kit/node/output', async () => {
+  const actual = await vi.importActual<typeof import('@shopify/cli-kit/node/output')>('@shopify/cli-kit/node/output')
+  return {...actual, outputResult: vi.fn()}
+})
+vi.mock('@shopify/cli-kit/node/ui', async () => {
+  const actual = await vi.importActual<typeof import('@shopify/cli-kit/node/ui')>('@shopify/cli-kit/node/ui')
+  return {...actual, renderSuccess: vi.fn()}
+})
+
+const result = {
+  status: 'success' as const,
+  message:
+    'Your Shopify store is ready. This store is temporary. Create a free Shopify account to save it and start selling.',
+  store: {
+    id: '123',
+    name: 'Lavender Candles',
+    subdomain: 'x12y45z.myshopify.com',
+    country: 'US',
+    storefrontUrl: 'https://x12y45z.myshopify.com/?foo=bar',
+  },
+}
+
+describe('preview store create result presenter', () => {
+  test('writes JSON output with the storefront URL and no save URL', () => {
+    writeCreatePreviewStoreResult(result, 'json')
+
+    expect(outputResult).toHaveBeenCalledWith(
+      JSON.stringify(
+        {
+          status: 'success',
+          message:
+            'Your Shopify store is ready. This store is temporary. Create a free Shopify account to save it and start selling.',
+          store: {
+            id: '123',
+            name: 'Lavender Candles',
+            subdomain: 'x12y45z.myshopify.com',
+            country: 'US',
+            storefrontUrl: 'https://x12y45z.myshopify.com/?foo=bar',
+          },
+          next_steps: [
+            'Open your store (https://x12y45z.myshopify.com/?foo=bar) to preview the storefront.',
+            'Use `shopify store execute` to add products, collections, pages, and more.',
+            'Use `shopify theme pull` and `shopify theme push` to edit your store design.',
+          ],
+        },
+        null,
+        2,
+      ),
+    )
+  })
+
+  test('renders text output with store details and next steps', () => {
+    writeCreatePreviewStoreResult(result, 'text')
+
+    expect(renderSuccess).toHaveBeenCalledWith(
+      expect.objectContaining({
+        headline: 'Store created',
+        customSections: [
+          {
+            body: {
+              tabularData: [
+                ['Name', 'Lavender Candles'],
+                ['Domain', 'x12y45z.myshopify.com'],
+              ],
+              firstColumnSubdued: true,
+            },
+          },
+          {
+            body: 'Your Shopify store is ready. This store is temporary. Create a free Shopify account to save it and start selling.',
+          },
+          {
+            title: 'Next steps',
+            body: {
+              list: {
+                items: [
+                  [
+                    'Open ',
+                    {
+                      link: {
+                        label: 'your store',
+                        url: 'https://x12y45z.myshopify.com/?foo=bar',
+                      },
+                    },
+                    ' to preview the storefront.',
+                  ],
+                  ['Use ', {command: 'shopify store execute'}, ' to add products, collections, pages, and more.'],
+                  [
+                    'Use ',
+                    {command: 'shopify theme pull'},
+                    ' and ',
+                    {command: 'shopify theme push'},
+                    ' to edit your store design.',
+                  ],
+                ],
+              },
+            },
+          },
+        ],
+      }),
+    )
+  })
+})

--- a/packages/store/src/cli/services/store/create/preview/result.ts
+++ b/packages/store/src/cli/services/store/create/preview/result.ts
@@ -1,0 +1,83 @@
+import {type CreatePreviewStoreResult} from './index.js'
+import {outputResult} from '@shopify/cli-kit/node/output'
+import {renderSuccess, type InlineToken, type TokenItem} from '@shopify/cli-kit/node/ui'
+
+type CreatePreviewStoreOutputFormat = 'text' | 'json'
+interface PreviewStoreNextStep {
+  json: string
+  text: TokenItem<InlineToken>
+}
+
+export function writeCreatePreviewStoreResult(
+  result: CreatePreviewStoreResult,
+  format: CreatePreviewStoreOutputFormat,
+): void {
+  if (format === 'json') {
+    outputResult(JSON.stringify(serializeAsJson(result), null, 2))
+    return
+  }
+
+  renderTextResult(result)
+}
+
+function serializeAsJson(result: CreatePreviewStoreResult) {
+  return {
+    status: result.status,
+    message: result.message,
+    store: result.store,
+    next_steps: previewStoreNextSteps(result).map((step) => step.json),
+  }
+}
+
+function previewStoreNextSteps(result: CreatePreviewStoreResult): PreviewStoreNextStep[] {
+  return [
+    {
+      json: `Open your store (${result.store.storefrontUrl}) to preview the storefront.`,
+      text: ['Open ', {link: {label: 'your store', url: result.store.storefrontUrl}}, ' to preview the storefront.'],
+    },
+    {
+      json: 'Use `shopify store execute` to add products, collections, pages, and more.',
+      text: ['Use ', {command: 'shopify store execute'}, ' to add products, collections, pages, and more.'],
+    },
+    {
+      json: 'Use `shopify theme pull` and `shopify theme push` to edit your store design.',
+      text: [
+        'Use ',
+        {command: 'shopify theme pull'},
+        ' and ',
+        {command: 'shopify theme push'},
+        ' to edit your store design.',
+      ],
+    },
+  ]
+}
+
+function renderTextResult(result: CreatePreviewStoreResult): void {
+  renderSuccess({
+    // Design copy intentionally omits trailing punctuation.
+    // eslint-disable-next-line @shopify/cli/banner-headline-format
+    headline: 'Store created',
+    customSections: [
+      {
+        body: {
+          tabularData: [
+            ['Name', result.store.name],
+            ['Domain', result.store.subdomain],
+          ],
+          firstColumnSubdued: true,
+        },
+      },
+      {
+        body: result.message,
+      },
+      {
+        title: 'Next steps',
+        body: {
+          list: {
+            items: previewStoreNextSteps(result).map((step) => step.text),
+          },
+        },
+      },
+    ],
+  })
+}

--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -1,11 +1,13 @@
 import StoreAuth from './cli/commands/store/auth.js'
 import StoreCreateDev from './cli/commands/store/create/dev.js'
+import StoreCreatePreview from './cli/commands/store/create/preview.js'
 import StoreExecute from './cli/commands/store/execute.js'
 import StoreInfo from './cli/commands/store/info.js'
 
 const COMMANDS = {
   'store:auth': StoreAuth,
   'store:create:dev': StoreCreateDev,
+  'store:create:preview': StoreCreatePreview,
   'store:execute': StoreExecute,
   'store:info': StoreInfo,
 }


### PR DESCRIPTION
### WHY are these changes introduced?

This productionizes `shopify store create preview` on top of the shipped preview-store backend endpoint so an agent can create a preview store and immediately use the returned Admin API token through existing store command auth plumbing.

The command targets the production endpoint contract from shop/world:

- unauthenticated `POST /services/preview-stores`
- request body with optional top-level `name`
- optional country sent as `variables.storeCreatePayload.country`
- CLI attribution headers for rollout/rate-limit/tracking
- response body with `shop` details, `placeholder_account_uuid`, `admin_api_token`, and `access_url`

### WHAT is this pull request doing?

- Adds `shopify store create preview` with flags:
    - `--name`
    - `--country` with two-letter code validation
    - `--json`
    - existing global `--no-color` / `--verbose`
- Calls `https://<app-management-fqdn>/services/preview-stores` without Basic auth or Identity auth.
- Sends:
    - `X-Shopify-CLI-Instance` from a stable locally persisted install id
    - `X-Shopify-CLI-Version`
    - `User-Agent`
    - JSON accept/content headers
    - `variables.storeCreatePayload.country` when `--country` is provided
- Parses the production response shape:
    - `shop.id`
    - `shop.name`
    - `shop.domain`
    - `placeholder_account_uuid` when present
    - `admin_api_token`
    - `access_url`
- Persists the returned Admin API token into the existing local store-auth session cache, tagged as `kind: 'preview'`, so the store is immediately usable by `shopify store execute --store <domain>` without `shopify store auth`.
- Persists preview-store metadata, including the returned access URL, in the store-auth session cache.
- Prints the backend-returned access URL in text output and includes it in JSON output.
- Redacts both `admin_api_token` and tokenized `access_url` from malformed-response diagnostics.
- Adds generated command README, OCLIF manifest, shopify.dev command interface docs, and a changeset.

### Notes / open questions

- Preview-store token expiry is intentionally not managed in this PR.
- The CLI handles both the requested `422 preview_store_create_failed` path and the currently observed backend `500 preview_store_create_failed` path defensively.
- Store-auth persistence is performed before best-effort store FQDN metadata recording so a metadata failure does not orphan a successfully created preview store without local credentials.

### How to test your changes?

Ideally, the endpoint will be ready in prod to test this (protected behind a flag) and we can test as follows:

- Enable [flag](https://experiments.shopify.io/flags/31810) for your CLI instance UUID
- Run from this branch `pnpm shopify store create preview --country US`
- A new preview store should be created
- The returned access URL should open the preview store
- `pnpm shopify store execute --store <returned-domain>` should use the cached preview-store Admin API token

Local validation run:

- `pnpm --filter @shopify/store exec vitest run src/cli/commands/store/create/preview.test.ts src/cli/services/store/create/preview/client.test.ts src/cli/services/store/create/preview/index.test.ts src/cli/services/store/create/preview/result.test.ts src/cli/services/store/auth/session-store.test.ts`
- `pnpm nx run store:lint --skip-nx-cache --output-style=stream`
- `pnpm --filter @shopify/store run type-check`
- `/usr/bin/git diff --check`

### Post-release steps

None.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows) — local persistence uses existing `LocalStorage`; command logic is platform-neutral.
- [x] I've considered possible [documentation](https://shopify.dev) changes — command README, OCLIF manifest, generated docs interface, and generated docs data are updated.
- [x] I've considered analytics changes to measure impact — request sends CLI instance/version/user-agent headers read by the backend tracking path; store FQDN metadata is recorded after persistence.
- [x] The change is user-facing — minor changeset added for `@shopify/cli` and `@shopify/store`.
