### PR TITLE
Fix analytics metadata for app/theme

### DIFF
--- a/packages/cli/bin/bundle.js
+++ b/packages/cli/bin/bundle.js
@@ -47,9 +47,9 @@ const hookEntryPoints = glob.sync('./src/hooks/*.ts', {
 })
 
 // Build esbuild entry points for app/theme commands so they get bundled into
-// the CLI's own dist/ with all imports resolved. This is needed because
-// @shopify/app and @shopify/theme are devDependencies (private packages) and
-// won't exist as real node_modules in the published snapshot.
+// the CLI's own dist/ with all imports resolved. These entrypoints use the
+// app/theme dist outputs so package imports and per-command imports share the
+// same module graph.
 const manifest = JSON.parse(readFileSync(joinPath(process.cwd(), 'oclif.manifest.json'), 'utf8'))
 const commandEntryPointOverrides = {
   'app:logs:sources': 'cli/commands/app/app-logs/sources',
@@ -58,13 +58,13 @@ const commandEntryPointOverrides = {
   'doctor-release': 'cli/commands/doctor-release/doctor-release',
   'doctor-release:theme': 'cli/commands/doctor-release/theme/index',
 }
-const externalPackageDirs = {'@shopify/app': '../app/', '@shopify/theme': '../theme/'}
+const externalPackageDirs = {'@shopify/app': '../app/dist/', '@shopify/theme': '../theme/dist/'}
 
 const externalCommandEntryPoints = Object.entries(manifest.commands)
   .filter(([, cmd]) => externalPackageDirs[cmd.customPluginName])
   .map(([id, cmd]) => {
     const out = commandEntryPointOverrides[id] ?? `cli/commands/${id.replace(/:/g, '/')}`
-    const inPath = externalPackageDirs[cmd.customPluginName] + `src/${out}.ts`
+    const inPath = externalPackageDirs[cmd.customPluginName] + `${out}.js`
     return {in: inPath, out}
   })
 

--- a/packages/e2e/setup/env.ts
+++ b/packages/e2e/setup/env.ts
@@ -150,6 +150,7 @@ export const envFixture = base.extend<{testSection: void}, {env: E2EEnv}>({
         ...xdgEnv,
         SHOPIFY_CLI_CLOUDFLARED_PATH: cloudflaredPath,
         SHOPIFY_RUN_AS_USER: '0',
+        SHOPIFY_CLI_NO_ANALYTICS: '1',
         NODE_OPTIONS: '',
         CI: '1',
         SHOPIFY_CLI_1P_DEV: undefined,

--- a/packages/e2e/setup/global-auth.ts
+++ b/packages/e2e/setup/global-auth.ts
@@ -52,6 +52,7 @@ export default async function globalSetup() {
     ...process.env,
     ...xdgEnv,
     SHOPIFY_RUN_AS_USER: '0',
+    SHOPIFY_CLI_NO_ANALYTICS: '1',
     NODE_OPTIONS: '',
     CI: '1',
     SHOPIFY_CLI_1P_DEV: undefined,

--- a/packages/e2e/tests/app-deploy.spec.ts
+++ b/packages/e2e/tests/app-deploy.spec.ts
@@ -2,6 +2,7 @@ import {appTestFixture as test, createApp, deployApp, versionsList, configLink} 
 import {teardownAll} from '../setup/teardown.js'
 import {TEST_TIMEOUT} from '../setup/constants.js'
 import {requireEnv} from '../setup/env.js'
+import {stripAnsi} from '../helpers/strip-ansi.js'
 import {expect} from '@playwright/test'
 import * as fs from 'fs'
 // eslint-disable-next-line no-restricted-imports
@@ -28,6 +29,13 @@ import * as path from 'path'
 interface VersionLine {
   versionTag?: string | null
   status: string
+}
+
+function assertDeployAnalytics(opts: {output: string; appName: string; step: string}) {
+  const output = stripAnsi(opts.output)
+  expect(output, `${opts.step} - expected deploy analytics command`).toContain('"command": "app deploy"')
+  expect(output, `${opts.step} - expected deploy analytics success`).toContain('"success": true')
+  expect(output, `${opts.step} - expected deploy analytics app name`).toContain(`"app_name": "${opts.appName}"`)
 }
 
 /**
@@ -85,9 +93,26 @@ test.describe('App deploy', () => {
 
       // Step 2: Deploy with a tagged version
       const versionTag = `E2E-v1-${Date.now()}`
-      const deployResult = await deployApp({cli, appDir, version: versionTag, message: 'E2E A primary deployment'})
+      const deployResult = await cli.exec(
+        [
+          'app',
+          'deploy',
+          '--version',
+          versionTag,
+          '--message',
+          'E2E A primary deployment',
+          '--allow-updates',
+          '--path',
+          appDir,
+        ],
+        {
+          env: {SHOPIFY_FLAG_VERBOSE: '1'},
+          timeout: TEST_TIMEOUT.long,
+        },
+      )
       const deployOutput = deployResult.stdout + deployResult.stderr
       expect(deployResult.exitCode, `Step 2 - deploy failed:\n${deployOutput}`).toBe(0)
+      assertDeployAnalytics({output: deployOutput, appName, step: 'Step 2'})
 
       // Step 3: Verify the primary tag is active and no other version is stuck active.
       const listResult = await versionsList({cli, appDir})


### PR DESCRIPTION
### WHY are these changes introduced?

Related thread: https://shopify.slack.com/archives/C05E3BDFDRB/p1780923031432789

In https://github.com/Shopify/cli/pull/7010 we changed the way to load files, and the analytics metadata we add for app or theme commands is not being included.

The bundled CLI was loading app/theme code through two different module graphs: command entrypoints were bundled from source files, while package imports and hooks resolved through built `dist` files. That meant in-memory metadata could be recorded in one module instance and read from another, so app command analytics could miss app-specific fields.

### WHAT is this pull request doing?

- Bundles app/theme command entrypoints from `../app/dist` and `../theme/dist` instead of source files, so command imports and package imports share the same module graph.
- Disables analytics in E2E subprocess environments to prevent tests from sending real analytics events.
- Adds coverage to the existing app deploy E2E by checking verbose analytics output includes the deploy command, success state, and app name.

### How to test your changes?

`shopify app deploy --verbose`

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [x] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`
