### PR TITLE
[Refactor] Use uniq helper in scopes

### DIFF
--- a/packages/cli-kit/src/private/node/session/scopes.ts
+++ b/packages/cli-kit/src/private/node/session/scopes.ts
@@ -1,5 +1,6 @@
 import {allAPIs, API} from '../api.js'
 import {BugError} from '../../../public/node/error.js'
+import {uniq} from '../../../public/common/array.js'
 
 /**
  * Generate a flat array with all the default scopes for all the APIs plus
@@ -10,7 +11,7 @@ import {BugError} from '../../../public/node/error.js'
 export function allDefaultScopes(extraScopes: string[] = []): string[] {
   let scopes = allAPIs.map((api) => defaultApiScopes(api)).flat()
   scopes = ['openid', ...scopes, ...extraScopes].map(scopeTransform)
-  return Array.from(new Set(scopes))
+  return uniq(scopes)
 }
 
 /**
@@ -22,7 +23,7 @@ export function allDefaultScopes(extraScopes: string[] = []): string[] {
  */
 export function apiScopes(api: API, extraScopes: string[] = []): string[] {
   const scopes = [...defaultApiScopes(api), ...extraScopes.map(scopeTransform)].map(scopeTransform)
-  return Array.from(new Set(scopes))
+  return uniq(scopes)
 }
 
 /**


### PR DESCRIPTION
### What's in this PR?

Refactored `packages/cli-kit/src/private/node/session/scopes.ts` to use the `uniq` helper from `@shopify/cli-kit/common/array` instead of manual `Set` deduplication.

### How to test your changes?

CI


---
*PR created automatically by Jules for task [4960416436050537126](https://jules.google.com/task/4960416436050537126) started by @gonzaloriestra*