### PR TITLE
[Performance] Memoize isShopify

### DIFF
--- a/packages/cli-kit/src/public/node/context/local.test.ts
+++ b/packages/cli-kit/src/public/node/context/local.test.ts
@@ -3,6 +3,7 @@ import {
   hasGit,
   isDevelopment,
   isShopify,
+  _resetIsShopifyCache,
   isTerminalInteractive,
   isUnitTest,
   analyticsDisabled,
@@ -97,6 +98,10 @@ describe('isDevelopment', () => {
 })
 
 describe('isShopify', () => {
+  afterEach(() => {
+    _resetIsShopifyCache()
+  })
+
   test('returns false when the SHOPIFY_RUN_AS_USER env. variable is truthy', async () => {
     // Given
     const env = {SHOPIFY_RUN_AS_USER: '1'}
@@ -119,6 +124,18 @@ describe('isShopify', () => {
 
     // When
     await expect(isShopify()).resolves.toBe(true)
+  })
+
+  test('memoizes the result', async () => {
+    // Given
+    vi.mocked(fileExists).mockResolvedValue(true)
+
+    // When
+    await isShopify()
+    await isShopify()
+
+    // Then
+    expect(fileExists).toHaveBeenCalledTimes(1)
   })
 })
 

--- a/packages/cli-kit/src/public/node/context/local.ts
+++ b/packages/cli-kit/src/public/node/context/local.ts
@@ -45,6 +45,11 @@ let memoizedIsVerbose: boolean | undefined
 let memoizedIsUnitTest: boolean | undefined
 
 /**
+ * Memoized value for the shopify check.
+ */
+let memoizedIsShopify: Promise<boolean> | undefined
+
+/**
  * Returns true if the CLI is running in debug mode.
  *
  * @param env - The environment variables from the environment of the current process.
@@ -77,11 +82,22 @@ export function isVerbose(env = process.env): boolean {
  * @returns True if the CLI is used in a Shopify environment.
  */
 export async function isShopify(env = process.env): Promise<boolean> {
-  if (Object.prototype.hasOwnProperty.call(env, environmentVariables.runAsUser)) {
-    return !isTruthy(env[environmentVariables.runAsUser])
+  if (env === process.env && memoizedIsShopify !== undefined) {
+    return memoizedIsShopify
   }
-  const devInstalled = await lazyFileExists(pathConstants.executables.dev)
-  return devInstalled
+
+  const resultPromise = (async () => {
+    if (Object.prototype.hasOwnProperty.call(env, environmentVariables.runAsUser)) {
+      return !isTruthy(env[environmentVariables.runAsUser])
+    } else {
+      return lazyFileExists(pathConstants.executables.dev)
+    }
+  })()
+
+  if (env === process.env) {
+    memoizedIsShopify = resultPromise
+  }
+  return resultPromise
 }
 
 /**
@@ -323,6 +339,14 @@ export function opentelemetryDomain(env = process.env): string {
   const domain = env[environmentVariables.otelURL]
 
   return isSet(domain) ? domain : 'https://otlp-http-production-cli.shopifysvc.com'
+}
+
+/**
+ * This function is only used during UnitTesting.
+ * It resets the memoized value of the shopify check.
+ */
+export function _resetIsShopifyCache(): void {
+  memoizedIsShopify = undefined
 }
 
 export type CIMetadata = Metadata


### PR DESCRIPTION
### WHY are these changes introduced?

`isShopify` is called frequently (e.g., during analytics reporting) and performs a filesystem check to see if the `dev` executable exists. This I/O operation can be costly when repeated across the CLI lifecycle.

### WHAT is this pull request doing?

Memoizes the result of the `isShopify` check when using the default `process.env`. It caches the promise of the operation to ensure concurrent calls await the same operation and avoid race conditions. An internal `_resetIsShopifyCache` function is exported and used in tests to ensure isolation.

### How to test your changes?

CI

### Post-release steps

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [16016265137240540030](https://jules.google.com/task/16016265137240540030) started by @gonzaloriestra*