### PR TITLE
Fix flaky tests

### DIFF
--- a/configurations/vite.config.ts
+++ b/configurations/vite.config.ts
@@ -1,5 +1,5 @@
 import * as path from 'pathe'
-import {defineConfig} from 'vitest/config'
+import {configDefaults, defineConfig} from 'vitest/config'
 import type {AliasOptions} from 'vite'
 
 const TIMEOUTS = {
@@ -41,6 +41,7 @@ export default function config(packagePath: string, {poolStrategy}: ConfigOption
       clearMocks: true,
       mockReset: true, // Note: In Vitest 3.0, mockReset restores the original implementation
       setupFiles: [path.join(__dirname, './vitest/setup.js')],
+      exclude: [...configDefaults.exclude, '**/dist/**'],
       reporters: process.env.CI ? ['basic'] : ['verbose', 'hanging-process'],
       pool: poolStrategy,
       coverage: {

--- a/packages/cli-kit/src/public/node/http.ts
+++ b/packages/cli-kit/src/public/node/http.ts
@@ -10,6 +10,7 @@ import {DEFAULT_MAX_TIME_MS} from '../../private/node/sleep-with-backoff.js'
 
 import FormData from 'form-data'
 import nodeFetch, {RequestInfo, RequestInit, Response} from 'node-fetch'
+import {pipeline} from 'stream/promises'
 
 export {FetchError, Request, Response} from 'node-fetch'
 
@@ -224,42 +225,33 @@ export function downloadFile(url: string, to: string): Promise<string> {
   const sanitizedUrl = sanitizeURL(url)
   outputDebug(`Downloading ${sanitizedUrl} to ${to}`)
 
-  return runWithTimer('cmd_all_timing_network_ms')(() => {
-    return new Promise<string>((resolve, reject) => {
-      if (!fileExistsSync(dirname(to))) {
-        mkdirSync(dirname(to))
-      }
+  return runWithTimer('cmd_all_timing_network_ms')(async () => {
+    if (!fileExistsSync(dirname(to))) {
+      mkdirSync(dirname(to))
+    }
 
-      const file = createFileWriteStream(to)
-
-      // if we can't remove the file for some reason (seen on windows), that's ok -- it's in a temporary directory
-      const tryToRemoveFile = () => {
-        try {
+    // if we can't remove the file for some reason (seen on windows), that's ok -- it's in a temporary directory
+    const tryToRemoveFile = () => {
+      try {
+        if (fileExistsSync(to)) {
           unlinkFileSync(to)
-          // eslint-disable-next-line no-catch-all/no-catch-all
-        } catch (err: unknown) {
-          outputDebug(outputContent`Failed to remove file ${outputToken.path(to)}: ${outputToken.raw(String(err))}`)
         }
+        // eslint-disable-next-line no-catch-all/no-catch-all
+      } catch (err: unknown) {
+        outputDebug(outputContent`Failed to remove file ${outputToken.path(to)}: ${outputToken.raw(String(err))}`)
       }
+    }
 
-      file.on('finish', () => {
-        file.close()
-        resolve(to)
-      })
-
-      file.on('error', (err) => {
-        tryToRemoveFile()
-        reject(err)
-      })
-
-      nodeFetch(url, {redirect: 'follow'})
-        .then((res) => {
-          res.body?.pipe(file)
-        })
-        .catch((err) => {
-          tryToRemoveFile()
-          reject(err instanceof Error ? err : new Error(String(err)))
-        })
-    })
+    try {
+      const res = await nodeFetch(url, {redirect: 'follow'})
+      if (!res.body) {
+        throw new Error(`No response body received when downloading ${sanitizedUrl}`)
+      }
+      await pipeline(res.body, createFileWriteStream(to))
+      return to
+    } catch (err) {
+      tryToRemoveFile()
+      throw err instanceof Error ? err : new Error(String(err))
+    }
   })
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes flaky unit tests from CI jobs:
- https://github.com/Shopify/cli/actions/runs/27264801962/job/80519156807
- https://github.com/Shopify/cli/actions/runs/27265610190/job/80521802847?pr=7776

### WHAT is this pull request doing?

- Excludes `dist` from Vitest test discovery.
- Makes failed downloads clean up after the stream settles. Previously, `downloadFile` opened the destination write stream before `nodeFetch` completed. If the fetch rejected, cleanup could try to unlink the file while that stream was still open. On macOS/Node 26, that could leave an empty destination file behind, which is the behavior the failing test caught.

### How to test your changes?

CI

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible documentation changes
- [x] I've considered analytics changes to measure impact
- [x] Not user-facing; no changeset needed
