### PR TITLE
[Refactor] Use uniq helper in session scopes

### DIFF
--- a/packages/cli-kit/src/private/node/session/scopes.ts
+++ b/packages/cli-kit/src/private/node/session/scopes.ts
@@ -1,4 +1,5 @@
 import {allAPIs, API} from '../api.js'
+import {uniq} from '../../../public/common/array.js'
 import {BugError} from '../../../public/node/error.js'
 
 /**
@@ -10,7 +11,7 @@ import {BugError} from '../../../public/node/error.js'
 export function allDefaultScopes(extraScopes: string[] = []): string[] {
   let scopes = allAPIs.map((api) => defaultApiScopes(api)).flat()
   scopes = ['openid', ...scopes, ...extraScopes].map(scopeTransform)
-  return Array.from(new Set(scopes))
+  return uniq(scopes)
 }
 
 /**
@@ -22,7 +23,7 @@ export function allDefaultScopes(extraScopes: string[] = []): string[] {
  */
 export function apiScopes(api: API, extraScopes: string[] = []): string[] {
   const scopes = [...defaultApiScopes(api), ...extraScopes.map(scopeTransform)].map(scopeTransform)
-  return Array.from(new Set(scopes))
+  return uniq(scopes)
 }
 
 /**


### PR DESCRIPTION
### What is being refactored?
This PR refactors `packages/cli-kit/src/private/node/session/scopes.ts` to use the `uniq` helper from `@shopify/cli-kit/common/array` instead of manual `Set` deduplication.

### Why is this necessary?
Using the `uniq` utility function throughout the codebase improves consistency and makes the intent of array deduplication clearer compared to the manual `Array.from(new Set(array))` pattern.

### How to test your changes?
CI

---
*PR created automatically by Jules for task [9575244148370966177](https://jules.google.com/task/9575244148370966177) started by @gonzaloriestra*