### PR TITLE
[Security] Mitigate command injection in Cloudflare plugin

### DIFF
--- a/packages/plugin-cloudflare/src/install-cloudflared.test.ts
+++ b/packages/plugin-cloudflare/src/install-cloudflared.test.ts
@@ -42,7 +42,7 @@ describe('install-cloudflare', () => {
       const binPath = joinPath(tmpDir, 'cloudflared')
       const env = {SHOPIFY_CLI_CLOUDFLARED_PATH: binPath}
       mockFetch()
-      vi.mocked(childProcess.execSync).mockImplementation((_command, options) => {
+      vi.mocked(childProcess.execFileSync).mockImplementation((_command, _args, options) => {
         // Simulate tar extracting the file
         const cwd = options?.cwd as string
         writeFileSync(joinPath(cwd, 'cloudflared'), 'extracted binary')
@@ -69,7 +69,7 @@ describe('install-cloudflare', () => {
       const binPath = joinPath(tmpDir, 'cloudflared')
       const env = {SHOPIFY_CLI_CLOUDFLARED_PATH: binPath}
       mockFetch()
-      vi.mocked(childProcess.execSync).mockImplementation((_command, options) => {
+      vi.mocked(childProcess.execFileSync).mockImplementation((_command, _args, options) => {
         const cwd = options?.cwd as string
         writeFileSync(joinPath(cwd, 'cloudflared'), 'extracted binary')
         return Buffer.from('')

--- a/packages/plugin-cloudflare/src/install-cloudflared.ts
+++ b/packages/plugin-cloudflare/src/install-cloudflared.ts
@@ -14,7 +14,7 @@ import {fileURLToPath} from 'url'
 import util from 'util'
 import {pipeline} from 'stream'
 // eslint-disable-next-line no-restricted-imports
-import {execSync, execFileSync} from 'child_process'
+import {execFileSync} from 'child_process'
 
 export const CURRENT_CLOUDFLARE_VERSION = '2024.8.2'
 const CLOUDFLARE_REPO = `https://github.com/cloudflare/cloudflared/releases/download/${CURRENT_CLOUDFLARE_VERSION}/`
@@ -132,7 +132,8 @@ async function installWindows(file: string, binTarget: string) {
 async function installMacos(file: string, binTarget: string) {
   await downloadFile(file, `${binTarget}.tgz`)
   const filename = basename(`${binTarget}.tgz`)
-  execSync(`tar -xzf ${filename}`, {cwd: dirname(binTarget)})
+  // Use execFileSync to avoid shell interpretation and mitigate command injection
+  execFileSync('tar', ['-xzf', filename], {cwd: dirname(binTarget)})
   unlinkFileSync(`${binTarget}.tgz`)
   await renameFile(`${dirname(binTarget)}/cloudflared`, binTarget)
 }


### PR DESCRIPTION
Replaces execSync with execFileSync in the Cloudflare plugin's installation logic to prevent command injection vulnerabilities. Updates corresponding unit tests.

---
*PR created automatically by Jules for task [16197642149888329908](https://jules.google.com/task/16197642149888329908) started by @gonzaloriestra*