### PR TITLE
Improve JSON schema error messages

### DIFF
--- a/.changeset/mighty-hotels-tickle.md
+++ b/.changeset/mighty-hotels-tickle.md
@@ -1,5 +1,6 @@
 ---
 '@shopify/cli-kit': patch
+'@shopify/app': patch
 ---
 
-Improve JSON Schema validation error messages for arrays.
+Improve JSON Schema validation error messages for arrays and add a TOML table hint for object/array mismatches.

--- a/.changeset/mighty-hotels-tickle.md
+++ b/.changeset/mighty-hotels-tickle.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': patch
+---
+
+Improve JSON Schema validation error messages for arrays.

--- a/packages/app/src/cli/models/app/loader.ts
+++ b/packages/app/src/cli/models/app/loader.ts
@@ -73,11 +73,21 @@ export interface ConfigurationError {
   code?: string
 }
 
+function tomlObjectArrayHint(error: ConfigurationError): string | undefined {
+  if (!error.file.endsWith('.toml')) return undefined
+  if (error.message !== 'Expected object, received array') return undefined
+
+  return 'Use a single TOML table instead of an array of tables. [table] defines one table; [[table]] defines an array of tables.'
+}
+
 export function formatConfigurationError(error: ConfigurationError): string {
+  const hint = tomlObjectArrayHint(error)
+  const message = hint ? `${error.message}. ${hint}` : error.message
+
   if (error.path?.length) {
-    return `[${error.path.join('.')}]: ${error.message}`
+    return `[${error.path.join('.')}]: ${message}`
   }
-  return error.message
+  return message
 }
 
 type ConfigurationResult<T> = {data: T; errors?: never} | {data?: never; errors: ConfigurationError[]}

--- a/packages/app/src/cli/models/app/loader.ts
+++ b/packages/app/src/cli/models/app/loader.ts
@@ -77,7 +77,7 @@ function tomlObjectArrayHint(error: ConfigurationError): string | undefined {
   if (!error.file.endsWith('.toml')) return undefined
   if (error.message !== 'Expected object, received array') return undefined
 
-  return 'Use a single TOML table instead of an array of tables. [table] defines one table; [[table]] defines an array of tables.'
+  return 'Use a TOML table instead of an array. [table] defines a single table; [[table]] defines an array of tables.'
 }
 
 export function formatConfigurationError(error: ConfigurationError): string {

--- a/packages/app/src/cli/services/validate.test.ts
+++ b/packages/app/src/cli/services/validate.test.ts
@@ -6,6 +6,7 @@ import {describe, expect, test, vi} from 'vitest'
 import {outputResult} from '@shopify/cli-kit/node/output'
 import {renderError, renderSuccess} from '@shopify/cli-kit/node/ui'
 import {AbortSilentError} from '@shopify/cli-kit/node/error'
+import {jsonSchemaValidate} from '@shopify/cli-kit/node/json-schema'
 
 vi.mock('../metadata.js', () => ({default: {addPublicMetadata: vi.fn()}}))
 vi.mock('@shopify/cli-kit/node/output', async (importOriginal) => {
@@ -46,7 +47,45 @@ describe('formatConfigurationError', () => {
         message: 'Expected object, received array',
       }),
     ).toBe(
-      '[events.1.metrics]: Expected object, received array. Use a single TOML table instead of an array of tables. [table] defines one table; [[table]] defines an array of tables.',
+      '[events.1.metrics]: Expected object, received array. Use a TOML table instead of an array. [table] defines a single table; [[table]] defines an array of tables.',
+    )
+  })
+
+  test('adds a TOML table hint to JSON Schema object array type mismatches', () => {
+    const schemaParsed = jsonSchemaValidate(
+      {events: [{metrics: []}]},
+      {
+        type: 'object',
+        properties: {
+          events: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                metrics: {type: 'object'},
+              },
+            },
+          },
+        },
+      },
+      'strip',
+    )
+
+    expect(schemaParsed.state).toBe('error')
+    expect(schemaParsed.errors).toEqual([
+      {
+        path: ['events', '0', 'metrics'],
+        message: 'Expected object, received array',
+      },
+    ])
+
+    expect(
+      formatConfigurationError({
+        file: 'shopify.app.toml',
+        ...schemaParsed.errors![0],
+      }),
+    ).toBe(
+      '[events.0.metrics]: Expected object, received array. Use a TOML table instead of an array. [table] defines a single table; [[table]] defines an array of tables.',
     )
   })
 
@@ -58,6 +97,16 @@ describe('formatConfigurationError', () => {
         message: 'Expected object, received array',
       }),
     ).toBe('[events.1.metrics]: Expected object, received array')
+  })
+
+  test('does not add a TOML table hint for other type mismatches', () => {
+    expect(
+      formatConfigurationError({
+        file: 'shopify.app.toml',
+        path: ['events', '1', 'metrics'],
+        message: 'Expected object, received string',
+      }),
+    ).toBe('[events.1.metrics]: Expected object, received string')
   })
 })
 

--- a/packages/app/src/cli/services/validate.test.ts
+++ b/packages/app/src/cli/services/validate.test.ts
@@ -37,6 +37,28 @@ describe('formatConfigurationError', () => {
       '[access.admin]: Required',
     )
   })
+
+  test('adds a TOML table hint for object array type mismatches', () => {
+    expect(
+      formatConfigurationError({
+        file: 'shopify.app.toml',
+        path: ['events', '1', 'metrics'],
+        message: 'Expected object, received array',
+      }),
+    ).toBe(
+      '[events.1.metrics]: Expected object, received array. Use a single TOML table instead of an array of tables. [table] defines one table; [[table]] defines an array of tables.',
+    )
+  })
+
+  test('does not add a TOML table hint for non-TOML files', () => {
+    expect(
+      formatConfigurationError({
+        file: 'config.json',
+        path: ['events', '1', 'metrics'],
+        message: 'Expected object, received array',
+      }),
+    ).toBe('[events.1.metrics]: Expected object, received array')
+  })
 })
 
 describe('validateApp', () => {

--- a/packages/app/src/cli/services/validate.test.ts
+++ b/packages/app/src/cli/services/validate.test.ts
@@ -79,10 +79,14 @@ describe('formatConfigurationError', () => {
       },
     ])
 
+    const schemaError = schemaParsed.errors?.[0]
+    expect(schemaError).toBeDefined()
+    expect(schemaError?.message).toBe('Expected object, received array')
     expect(
       formatConfigurationError({
         file: 'shopify.app.toml',
-        ...schemaParsed.errors![0],
+        path: schemaError!.path,
+        message: schemaError!.message!,
       }),
     ).toBe(
       '[events.0.metrics]: Expected object, received array. Use a TOML table instead of an array. [table] defines a single table; [[table]] defines an array of tables.',

--- a/packages/cli-kit/src/public/node/json-schema.test.ts
+++ b/packages/cli-kit/src/public/node/json-schema.test.ts
@@ -263,6 +263,63 @@ describe('jsonSchemaValidate', () => {
     expect(schemaParsed.errors, `Converting ${JSON.stringify(schemaParsed.rawErrors)}`).toEqual(zodErrors)
   })
 
+  test('reports arrays distinctly when an object is expected', () => {
+    const subject = {
+      events: [
+        {},
+        {
+          metrics: [],
+        },
+      ],
+    }
+    const contract = {
+      type: 'object',
+      properties: {
+        events: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              metrics: {type: 'object'},
+            },
+          },
+        },
+      },
+    }
+
+    const schemaParsed = jsonSchemaValidate(subject, contract, 'strip')
+
+    expect(schemaParsed.state).toBe('error')
+    expect(schemaParsed.errors).toEqual([
+      {
+        path: ['events', '1', 'metrics'],
+        message: 'Expected object, received array',
+      },
+    ])
+  })
+
+  test('reports null distinctly when an object is expected', () => {
+    const subject = {
+      foo: null,
+    }
+    const contract = {
+      type: 'object',
+      properties: {
+        foo: {type: 'object'},
+      },
+    }
+
+    const schemaParsed = jsonSchemaValidate(subject, contract, 'strip')
+
+    expect(schemaParsed.state).toBe('error')
+    expect(schemaParsed.errors).toEqual([
+      {
+        path: ['foo'],
+        message: 'Expected object, received null',
+      },
+    ])
+  })
+
   test('ignores custom x-taplo directive', () => {
     const subject = {
       foo: 'bar',

--- a/packages/cli-kit/src/public/node/json-schema.test.ts
+++ b/packages/cli-kit/src/public/node/json-schema.test.ts
@@ -320,6 +320,30 @@ describe('jsonSchemaValidate', () => {
     ])
   })
 
+  test('reports top-level arrays distinctly when an object is expected', () => {
+    const schemaParsed = jsonSchemaValidate([], {type: 'object'}, 'strip')
+
+    expect(schemaParsed.state).toBe('error')
+    expect(schemaParsed.errors).toEqual([
+      {
+        path: [],
+        message: 'Expected object, received array',
+      },
+    ])
+  })
+
+  test('reports top-level null distinctly when an object is expected', () => {
+    const schemaParsed = jsonSchemaValidate(null as unknown as object, {type: 'object'}, 'strip')
+
+    expect(schemaParsed.state).toBe('error')
+    expect(schemaParsed.errors).toEqual([
+      {
+        path: [],
+        message: 'Expected object, received null',
+      },
+    ])
+  })
+
   test('ignores custom x-taplo directive', () => {
     const subject = {
       foo: 'bar',

--- a/packages/cli-kit/src/public/node/json-schema.ts
+++ b/packages/cli-kit/src/public/node/json-schema.ts
@@ -112,6 +112,12 @@ export function jsonSchemaValidate(
  * @param schema - The JSON schema to validated against.
  * @returns The errors in a zod-like format.
  */
+function getJsonSchemaValueType(value: unknown): string {
+  if (Array.isArray(value)) return 'array'
+  if (value === null) return 'null'
+  return typeof value
+}
+
 function convertJsonSchemaErrors(rawErrors: AjvError[], subject: object, schema: SchemaObject) {
   // This reduces the number of errors by simplifying errors coming from different branches of a union
   const errors = simplifyUnionErrors(rawErrors, subject, schema)
@@ -129,7 +135,7 @@ function convertJsonSchemaErrors(rawErrors: AjvError[], subject: object, schema:
         ? error.params.type.join(', ')
         : (error.params.type as string)
       const actualType = getPathValue(subject, path.join('.'))
-      return {path, message: `Expected ${expectedType}, received ${typeof actualType}`}
+      return {path, message: `Expected ${expectedType}, received ${getJsonSchemaValueType(actualType)}`}
     }
 
     if (error.keyword === 'anyOf' || error.keyword === 'oneOf') {

--- a/packages/cli-kit/src/public/node/json-schema.ts
+++ b/packages/cli-kit/src/public/node/json-schema.ts
@@ -116,6 +116,10 @@ function getJsonSchemaValueType(value: unknown): string {
   return typeof value
 }
 
+function getJsonSchemaErrorValue(subject: object, path: string[]): unknown {
+  return path.length === 0 ? subject : getPathValue(subject, path)
+}
+
 /**
  * Converts errors from Ajv into a zod-like format.
  *
@@ -140,7 +144,7 @@ function convertJsonSchemaErrors(rawErrors: AjvError[], subject: object, schema:
       const expectedType = Array.isArray(error.params.type)
         ? error.params.type.join(', ')
         : (error.params.type as string)
-      const actualType = getPathValue(subject, path.join('.'))
+      const actualType = getJsonSchemaErrorValue(subject, path)
       return {path, message: `Expected ${expectedType}, received ${getJsonSchemaValueType(actualType)}`}
     }
 
@@ -150,7 +154,7 @@ function convertJsonSchemaErrors(rawErrors: AjvError[], subject: object, schema:
 
     if (error.params.allowedValues) {
       const allowedValues = error.params.allowedValues as string[]
-      const actualValue = getPathValue(subject, path.join('.'))
+      const actualValue = getJsonSchemaErrorValue(subject, path)
       return {
         path,
         message: `Invalid enum value. Expected ${allowedValues
@@ -162,7 +166,7 @@ function convertJsonSchemaErrors(rawErrors: AjvError[], subject: object, schema:
     if (error.params.comparison) {
       const comparison = error.params.comparison as string
       const limit = error.params.limit
-      const actualValue = getPathValue(subject, path.join('.'))
+      const actualValue = getJsonSchemaErrorValue(subject, path)
 
       let comparisonText = comparison
       switch (comparison) {

--- a/packages/cli-kit/src/public/node/json-schema.ts
+++ b/packages/cli-kit/src/public/node/json-schema.ts
@@ -105,12 +105,10 @@ export function jsonSchemaValidate(
 }
 
 /**
- * Converts errors from Ajv into a zod-like format.
+ * Get a more precise type name for JSON Schema error messages.
  *
- * @param rawErrors - JSON Schema errors taken directly from Ajv.
- * @param subject - The object being validated.
- * @param schema - The JSON schema to validated against.
- * @returns The errors in a zod-like format.
+ * @param value - The value to get the type of.
+ * @returns A string representing the type (e.g., 'array', 'null', 'object').
  */
 function getJsonSchemaValueType(value: unknown): string {
   if (Array.isArray(value)) return 'array'
@@ -118,6 +116,14 @@ function getJsonSchemaValueType(value: unknown): string {
   return typeof value
 }
 
+/**
+ * Converts errors from Ajv into a zod-like format.
+ *
+ * @param rawErrors - JSON Schema errors taken directly from Ajv.
+ * @param subject - The object being validated.
+ * @param schema - The JSON schema to validated against.
+ * @returns The errors in a zod-like format.
+ */
 function convertJsonSchemaErrors(rawErrors: AjvError[], subject: object, schema: SchemaObject) {
   // This reduces the number of errors by simplifying errors coming from different branches of a union
   const errors = simplifyUnionErrors(rawErrors, subject, schema)

--- a/packages/cli-kit/src/public/node/json-schema.ts
+++ b/packages/cli-kit/src/public/node/json-schema.ts
@@ -253,7 +253,7 @@ function simplifyUnionErrors(rawErrors: AjvError[], subject: object, schema: Sch
     const dottedSchemaPath = unionError.schemaPath.replace('#/', '').replace(/\//g, '.')
     const unionSchemas = getPathValue<SchemaObject[]>(schema, dottedSchemaPath)
     // and the slice of the subject that caused the issue
-    const subjectValue = getPathValue(subject, unionError.instancePath.split('/').slice(1).join('.'))
+    const subjectValue = getJsonSchemaErrorValue(subject, unionError.instancePath.split('/').slice(1))
 
     if (unionSchemas !== undefined && subjectValue !== undefined) {
       // we know that none of the union schemas are correct, but for each of them we can measure how wrong they are
@@ -268,7 +268,7 @@ function simplifyUnionErrors(rawErrors: AjvError[], subject: object, schema: Sch
             const candidatesObjectProperties = Object.keys(candidateSchemaFromUnion.properties)
             score = candidatesObjectProperties.reduce((acc, propertyName) => {
               const subSchema = candidateSchemaFromUnion.properties[propertyName] as SchemaObject
-              const subjectValueSlice = getPathValue(subjectValue, propertyName)
+              const subjectValueSlice = getJsonSchemaErrorValue(subjectValue as object, [propertyName])
 
               const subValidator = createAjvValidator('fail', subSchema)
               if (subValidator(subjectValueSlice)) {


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it's a work in progress
-->

### WHY are these changes introduced?

Fixes #[22951](https://github.com/shop/issues-develop/issues/22951#issue-4626249810)

TOML app module validation could report confusing JSON Schema errors such as `Expected object, received object` when a TOML array of tables was used where an object was expected.

<!-- link to issue if one exists -->

<!--
  Context about the problem that's being addressed.
-->

### WHAT is this pull request doing?

- Updates JSON Schema validation error formatting to report arrays as `array`instead of relying on JavaScript `typeof` output.
- Adds a TOML-specific hint for app configuration errors when an object was expected but an array was received.
- Adds regression tests for array/null received-type formatting and the TOML validation hint.

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?

- `pnpm --filter @shopify/cli-kit vitest src/public/node/json-schema.test.ts`
- `pnpm --filter @shopify/app vitest src/cli/services/validate.test.ts`
- Can run Shopify CLI locally with a local app module and verify validation. I followed [this document ](https://docs.google.com/document/d/1_fs9oHyxt4xqKnLk3WpMVIAU2gSaPUBHIVsFzcUMSlk/edit?tab=t.0)to set up a local test app and used this command in your cli repo: `SHOPIFY_CLI_NEVER_USE_PARTNERS_API=1 SHOPIFY_SERVICE_ENV=local pnpm shopify app dev --path [path to test app]`

<!--
  Please, provide steps for the reviewer to test your changes locally.
  You can post a comment with `/snapit` to generate a snapshot of the changes to be tested.
-->

### Post-release steps

None.

  
The change is user-facing. I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`