### PR TITLE
[Refactor] Use uniq and flatMap in app-management-client.ts

### DIFF
--- a/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
@@ -160,6 +160,7 @@ import {
 } from '@shopify/cli-kit/node/api/business-platform'
 import {CLI_KIT_VERSION} from '@shopify/cli-kit/common/version'
 import {encodeGid, numericIdFromEncodedGid, numericIdFromGid} from '@shopify/cli-kit/common/gid'
+import {uniq} from '@shopify/cli-kit/common/array'
 import {versionSatisfies} from '@shopify/cli-kit/node/node-package-manager'
 import {outputDebug} from '@shopify/cli-kit/node/output'
 import {developerDashboardFqdn, normalizeStoreFqdn} from '@shopify/cli-kit/node/context/fqdn'
@@ -1343,8 +1344,8 @@ export async function allowedTemplates(
   version: string = CLI_KIT_VERSION,
 ): Promise<GatedExtensionTemplate[]> {
   // Extract both types of flags from templates
-  const allBetaFlags = Array.from(new Set(templates.map((ext) => ext.organizationBetaFlags ?? []).flat()))
-  const allExpFlags = Array.from(new Set(templates.map((ext) => ext.organizationExpFlags ?? []).flat()))
+  const allBetaFlags = uniq(templates.flatMap((ext) => ext.organizationBetaFlags ?? []))
+  const allExpFlags = uniq(templates.flatMap((ext) => ext.organizationExpFlags ?? []))
 
   // Fetch both flag types in parallel
   const [enabledBetaFlags, enabledExpFlags] = await Promise.all([


### PR DESCRIPTION
### WHY are these changes introduced?

This refactor improves code readability and maintainability by using project-standard utility functions for array deduplication and flattening.

### WHAT is this pull request doing?

Refactors the `allowedTemplates` function in `packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts` to:
- Use the `uniq` helper from `@shopify/cli-kit/common/array` instead of manual `Array.from(new Set(...))` construction.
- Use `flatMap` instead of `map(...).flat()`.

### How to test your changes?

CI

### Post-release steps

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [8031308280060896414](https://jules.google.com/task/8031308280060896414) started by @gonzaloriestra*