### PR TITLE
[Performance] Memoize isShopify

### DIFF
--- a/packages/cli-kit/src/public/node/context/local.test.ts
+++ b/packages/cli-kit/src/public/node/context/local.test.ts
@@ -10,11 +10,12 @@ import {
   macAddress,
   getThemeKitAccessDomain,
   opentelemetryDomain,
+  _resetIsShopify,
 } from './local.js'
 import {fileExists} from '../fs.js'
 import {exec} from '../system.js'
 
-import {afterEach, expect, describe, vi, test} from 'vitest'
+import {afterEach, beforeEach, expect, describe, vi, test} from 'vitest'
 
 vi.mock('../fs.js')
 vi.mock('../system.js')
@@ -97,6 +98,10 @@ describe('isDevelopment', () => {
 })
 
 describe('isShopify', () => {
+  beforeEach(() => {
+    _resetIsShopify()
+  })
+
   test('returns false when the SHOPIFY_RUN_AS_USER env. variable is truthy', async () => {
     // Given
     const env = {SHOPIFY_RUN_AS_USER: '1'}
@@ -119,6 +124,18 @@ describe('isShopify', () => {
 
     // When
     await expect(isShopify()).resolves.toBe(true)
+  })
+
+  test('memoizes the result', async () => {
+    // Given
+    vi.mocked(fileExists).mockResolvedValue(true)
+
+    // When
+    await isShopify()
+    await isShopify()
+
+    // Then
+    expect(fileExists).toHaveBeenCalledTimes(1)
   })
 })
 

--- a/packages/cli-kit/src/public/node/context/local.ts
+++ b/packages/cli-kit/src/public/node/context/local.ts
@@ -45,6 +45,11 @@ let memoizedIsVerbose: boolean | undefined
 let memoizedIsUnitTest: boolean | undefined
 
 /**
+ * Memoized value for the shopify check.
+ */
+let memoizedIsShopify: Promise<boolean> | undefined
+
+/**
  * Returns true if the CLI is running in debug mode.
  *
  * @param env - The environment variables from the environment of the current process.
@@ -77,6 +82,14 @@ export function isVerbose(env = process.env): boolean {
  * @returns True if the CLI is used in a Shopify environment.
  */
 export async function isShopify(env = process.env): Promise<boolean> {
+  if (env === process.env) {
+    // Memoize the result to avoid repeated disk checks for the 'dev' executable.
+    return (memoizedIsShopify ??= checkIsShopify(env))
+  }
+  return checkIsShopify(env)
+}
+
+async function checkIsShopify(env: NodeJS.ProcessEnv): Promise<boolean> {
   if (Object.prototype.hasOwnProperty.call(env, environmentVariables.runAsUser)) {
     return !isTruthy(env[environmentVariables.runAsUser])
   }
@@ -323,6 +336,13 @@ export function opentelemetryDomain(env = process.env): string {
   const domain = env[environmentVariables.otelURL]
 
   return isSet(domain) ? domain : 'https://otlp-http-production-cli.shopifysvc.com'
+}
+
+/**
+ * Resets the memoized value for the shopify check.
+ */
+export function _resetIsShopify(): void {
+  memoizedIsShopify = undefined
 }
 
 export type CIMetadata = Metadata


### PR DESCRIPTION
### WHY are these changes introduced?

The `isShopify` function performs a disk check to see if the `dev` executable is present. This function is called multiple times during the CLI lifecycle, including for every analytics event. Memoizing the result avoids redundant disk I/O, which can measurably reduce the execution time of commands, especially when multiple analytics events are triggered.

### WHAT is this pull request doing?

- Memoizes the result of `isShopify` when called with the default `process.env`.
- Uses a module-level promise to ensure that concurrent calls await the same operation.
- Exposes an internal `_resetIsShopify` function to maintain test isolation.
- Adds a unit test to verify that the file system check is only performed once.

### How to test your changes?

CI

### Post-release steps

N/A

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [8086827328400609332](https://jules.google.com/task/8086827328400609332) started by @gonzaloriestra*