### PR TITLE
Fetch and display claim URL after creating a preview storesave

### DIFF
--- a/.changeset/preview-store-claim-url.md
+++ b/.changeset/preview-store-claim-url.md
@@ -1,0 +1,5 @@
+---
+'@shopify/store': minor
+---
+
+Fetch and display the claim URL after creating a preview store.

--- a/packages/store/src/cli/commands/store/create/preview.test.ts
+++ b/packages/store/src/cli/commands/store/create/preview.test.ts
@@ -26,6 +26,8 @@ describe('store create preview command', () => {
         subdomain: 'x.myshopify.com',
         country: 'US',
         storefrontUrl: 'https://x.myshopify.com',
+        saveUrl: 'https://admin.shopify.com/store-transfer/accept/claim-token',
+
       },
     }
     vi.mocked(createPreviewStoreCommand).mockResolvedValueOnce(result)

--- a/packages/store/src/cli/commands/store/create/preview.test.ts
+++ b/packages/store/src/cli/commands/store/create/preview.test.ts
@@ -27,7 +27,6 @@ describe('store create preview command', () => {
         country: 'US',
         storefrontUrl: 'https://x.myshopify.com',
         saveUrl: 'https://admin.shopify.com/store-transfer/accept/claim-token',
-
       },
     }
     vi.mocked(createPreviewStoreCommand).mockResolvedValueOnce(result)

--- a/packages/store/src/cli/services/store/create/preview/client.test.ts
+++ b/packages/store/src/cli/services/store/create/preview/client.test.ts
@@ -1,8 +1,10 @@
 import {
   CLI_INSTANCE_HEADER,
   CLI_VERSION_HEADER,
+  claimPreviewStore,
   createPreviewStore,
   getOrCreateCliInstanceId,
+  previewStoreClaimHeaders,
   previewStoreCreateHeaders,
 } from './client.js'
 import {shopifyFetch} from '@shopify/cli-kit/node/http'
@@ -56,6 +58,18 @@ describe('preview store client', () => {
       'User-Agent': `Shopify CLI; v=${CLI_KIT_VERSION}`,
       [CLI_INSTANCE_HEADER]: 'instance-1',
       [CLI_VERSION_HEADER]: CLI_KIT_VERSION,
+    })
+  })
+
+  test('builds claim request headers with the Admin API token', () => {
+    expect(previewStoreClaimHeaders('instance-1', 'shpat_token')).toEqual({
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+      'User-Agent': `Shopify CLI; v=${CLI_KIT_VERSION}`,
+      [CLI_INSTANCE_HEADER]: 'instance-1',
+      [CLI_VERSION_HEADER]: CLI_KIT_VERSION,
+      authorization: 'shpat_token',
+      'X-Shopify-Access-Token': 'shpat_token',
     })
   })
 
@@ -124,7 +138,42 @@ describe('preview store client', () => {
     await expect(createPreviewStore({}, {storage: inMemoryStorage('instance-1')})).rejects.toThrow(message)
   })
 
-  test('rejects malformed success responses without leaking the admin API token or access URL', async () => {
+  test('POSTs to /services/preview-stores/:shop_id/claim with the Admin API token', async () => {
+    vi.mocked(shopifyFetch).mockResolvedValueOnce(
+      response(201, {claim_url: 'https://admin.shopify.com/store-transfer/accept/claim-token'}),
+    )
+
+    const got = await claimPreviewStore(
+      {shopId: '123', adminApiToken: 'shpat_token'},
+      {storage: inMemoryStorage('instance-1')},
+    )
+
+    expect(shopifyFetch).toHaveBeenCalledWith('https://app.shopify.com/services/preview-stores/123/claim', {
+      method: 'POST',
+      headers: expect.objectContaining({
+        [CLI_INSTANCE_HEADER]: 'instance-1',
+        authorization: 'shpat_token',
+        'X-Shopify-Access-Token': 'shpat_token',
+      }),
+      body: JSON.stringify({}),
+    })
+    expect(got).toEqual({claimUrl: 'https://admin.shopify.com/store-transfer/accept/claim-token'})
+  })
+
+  test('sends optional email when requesting a preview store claim URL', async () => {
+    vi.mocked(shopifyFetch).mockResolvedValueOnce(
+      response(201, {claim_url: 'https://admin.shopify.com/store-transfer/accept/claim-token'}),
+    )
+
+    await claimPreviewStore(
+      {shopId: '123', adminApiToken: 'shpat_token', email: 'merchant@example.com'},
+      {storage: inMemoryStorage('instance-1')},
+    )
+
+    expect(vi.mocked(shopifyFetch).mock.calls[0]![1]!.body).toBe(JSON.stringify({email: 'merchant@example.com'}))
+  })
+
+  test('rejects malformed create responses without leaking the admin API token or access URL', async () => {
     vi.mocked(shopifyFetch).mockResolvedValueOnce(
       response(201, {
         shop: {id: 123},
@@ -176,5 +225,16 @@ describe('preview store client', () => {
     })
     expect(error.tryMessage).not.toContain('access-token')
     expect(error.tryMessage).not.toContain('shpat_token')
+  })
+
+  test('rejects malformed claim responses without leaking the claim URL', async () => {
+    vi.mocked(shopifyFetch).mockResolvedValueOnce(response(201, {claim_url: 123}))
+
+    await expect(
+      claimPreviewStore({shopId: '123', adminApiToken: 'shpat_token'}, {storage: inMemoryStorage('instance-1')}),
+    ).rejects.toMatchObject({
+      message: 'Preview store claim URL response is missing required fields.',
+      tryMessage: expect.stringContaining('"claim_url":"[REDACTED]"'),
+    })
   })
 })

--- a/packages/store/src/cli/services/store/create/preview/client.ts
+++ b/packages/store/src/cli/services/store/create/preview/client.ts
@@ -62,7 +62,7 @@ interface PreviewStoreClaimRequest {
   email?: string
 }
 
-export interface PreviewStoreClaimResponse {
+interface PreviewStoreClaimResponse {
   claimUrl: string
 }
 
@@ -251,7 +251,8 @@ function previewStoreClaimError(status: number, rawText: string): {message: stri
 
   return {
     message: `Preview store claim URL request failed with HTTP ${status}.`,
-    tryMessage: parsed.message ?? (redactedRawText.length > 0 ? redactedRawText.slice(0, 1000) : 'No response body returned.'),
+    tryMessage:
+      parsed.message ?? (redactedRawText.length > 0 ? redactedRawText.slice(0, 1000) : 'No response body returned.'),
   }
 }
 

--- a/packages/store/src/cli/services/store/create/preview/client.ts
+++ b/packages/store/src/cli/services/store/create/preview/client.ts
@@ -158,7 +158,7 @@ export async function claimPreviewStore(
   options: PreviewStoreRequestOptions = {},
 ): Promise<PreviewStoreClaimResponse> {
   const fqdn = await appManagementFqdn()
-  const url = `https://${fqdn}/services/preview-stores/${request.shopId}/claim`
+  const url = `https://${fqdn}/services/preview-stores/${encodeURIComponent(request.shopId)}/claim`
   const body = JSON.stringify({...(request.email ? {email: request.email} : {})})
 
   const response = await shopifyFetch(url, {

--- a/packages/store/src/cli/services/store/create/preview/client.ts
+++ b/packages/store/src/cli/services/store/create/preview/client.ts
@@ -12,6 +12,10 @@ interface PreviewStoreClientStorageSchema {
   cliInstanceId?: string
 }
 
+interface PreviewStoreRequestOptions {
+  storage?: LocalStorage<PreviewStoreClientStorageSchema>
+}
+
 let _clientStorage: LocalStorage<PreviewStoreClientStorageSchema> | undefined
 
 function clientStorage() {
@@ -19,9 +23,7 @@ function clientStorage() {
   return _clientStorage
 }
 
-export interface PreviewStoreClientOptions {
-  storage?: LocalStorage<PreviewStoreClientStorageSchema>
-}
+export interface PreviewStoreClientOptions extends PreviewStoreRequestOptions {}
 
 interface PreviewStoreCreateRequest {
   name?: string
@@ -54,6 +56,20 @@ interface RawPreviewStoreCreateResponse {
   access_url?: unknown
 }
 
+interface PreviewStoreClaimRequest {
+  shopId: string
+  adminApiToken: string
+  email?: string
+}
+
+export interface PreviewStoreClaimResponse {
+  claimUrl: string
+}
+
+interface RawPreviewStoreClaimResponse {
+  claim_url?: unknown
+}
+
 interface RawPreviewStoreErrorResponse {
   error_code?: string
   message?: string
@@ -70,13 +86,25 @@ export function getOrCreateCliInstanceId(
   return next
 }
 
-export function previewStoreCreateHeaders(cliInstanceId: string): Record<string, string> {
+function previewStoreBaseHeaders(cliInstanceId: string): Record<string, string> {
   return {
     Accept: 'application/json',
     'Content-Type': 'application/json',
     'User-Agent': `Shopify CLI; v=${CLI_KIT_VERSION}`,
     [CLI_INSTANCE_HEADER]: cliInstanceId,
     [CLI_VERSION_HEADER]: CLI_KIT_VERSION,
+  }
+}
+
+export function previewStoreCreateHeaders(cliInstanceId: string): Record<string, string> {
+  return previewStoreBaseHeaders(cliInstanceId)
+}
+
+export function previewStoreClaimHeaders(cliInstanceId: string, adminApiToken: string): Record<string, string> {
+  return {
+    ...previewStoreBaseHeaders(cliInstanceId),
+    authorization: adminApiToken,
+    'X-Shopify-Access-Token': adminApiToken,
   }
 }
 
@@ -122,7 +150,41 @@ export async function createPreviewStore(
     )
   }
 
-  return narrowResponse(parsed)
+  return narrowCreateResponse(parsed)
+}
+
+export async function claimPreviewStore(
+  request: PreviewStoreClaimRequest,
+  options: PreviewStoreRequestOptions = {},
+): Promise<PreviewStoreClaimResponse> {
+  const fqdn = await appManagementFqdn()
+  const url = `https://${fqdn}/services/preview-stores/${request.shopId}/claim`
+  const body = JSON.stringify({...(request.email ? {email: request.email} : {})})
+
+  const response = await shopifyFetch(url, {
+    method: 'POST',
+    headers: previewStoreClaimHeaders(getOrCreateCliInstanceId(options.storage), request.adminApiToken),
+    body,
+  })
+
+  const rawText = await response.text()
+  if (!response.ok) {
+    const error = previewStoreClaimError(response.status, rawText)
+    throw new AbortError(error.message, error.tryMessage)
+  }
+
+  let parsed: RawPreviewStoreClaimResponse
+  try {
+    parsed = JSON.parse(rawText) as RawPreviewStoreClaimResponse
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error'
+    throw new AbortError(
+      'Preview store claim URL request returned a non-JSON response.',
+      `Parse error: ${message}. Body (truncated): ${redactPreviewStoreRawText(rawText).slice(0, 500)}`,
+    )
+  }
+
+  return narrowClaimResponse(parsed)
 }
 
 function previewStoreError(status: number, rawText: string): {message: string; tryMessage?: string} {
@@ -183,7 +245,17 @@ function parseErrorBody(rawText: string): RawPreviewStoreErrorResponse {
   }
 }
 
-function narrowResponse(parsed: RawPreviewStoreCreateResponse): PreviewStoreCreateResponse {
+function previewStoreClaimError(status: number, rawText: string): {message: string; tryMessage?: string} {
+  const parsed = parseErrorBody(rawText)
+  const redactedRawText = redactPreviewStoreRawText(rawText)
+
+  return {
+    message: `Preview store claim URL request failed with HTTP ${status}.`,
+    tryMessage: parsed.message ?? (redactedRawText.length > 0 ? redactedRawText.slice(0, 1000) : 'No response body returned.'),
+  }
+}
+
+function narrowCreateResponse(parsed: RawPreviewStoreCreateResponse): PreviewStoreCreateResponse {
   const shop = parsed.shop
   const id = typeof shop?.id === 'string' || typeof shop?.id === 'number' ? String(shop.id) : undefined
   const name = typeof shop?.name === 'string' ? shop.name : undefined
@@ -208,6 +280,19 @@ function narrowResponse(parsed: RawPreviewStoreCreateResponse): PreviewStoreCrea
   }
 }
 
+function narrowClaimResponse(parsed: RawPreviewStoreClaimResponse): PreviewStoreClaimResponse {
+  const claimUrl = typeof parsed.claim_url === 'string' ? parsed.claim_url : undefined
+
+  if (!claimUrl) {
+    throw new AbortError(
+      'Preview store claim URL response is missing required fields.',
+      `Got: ${JSON.stringify(redactPreviewStoreClaimResponse(parsed)).slice(0, 500)}`,
+    )
+  }
+
+  return {claimUrl}
+}
+
 function redactPreviewStoreResponse(parsed: RawPreviewStoreCreateResponse): RawPreviewStoreCreateResponse {
   return {
     ...parsed,
@@ -216,9 +301,16 @@ function redactPreviewStoreResponse(parsed: RawPreviewStoreCreateResponse): RawP
   }
 }
 
+function redactPreviewStoreClaimResponse(parsed: RawPreviewStoreClaimResponse): RawPreviewStoreClaimResponse {
+  return {
+    ...parsed,
+    ...(parsed.claim_url ? {claim_url: '[REDACTED]'} : {}),
+  }
+}
+
 function redactPreviewStoreRawText(rawText: string): string {
   return rawText
     .replace(/(["']?(?:admin_api_token|adminApiToken)["']?\s*:\s*["'])[^"']+/gi, '$1[REDACTED]')
-    .replace(/(["']?(?:access_url|accessUrl)["']?\s*:\s*["'])[^"']+/gi, '$1[REDACTED]')
+    .replace(/(["']?(?:access_url|accessUrl|claim_url|claimUrl)["']?\s*:\s*["'])[^"']+/gi, '$1[REDACTED]')
     .replace(/([?&](?:token|access_token)=)[^&\s"'<>]+/gi, '$1[REDACTED]')
 }

--- a/packages/store/src/cli/services/store/create/preview/index.test.ts
+++ b/packages/store/src/cli/services/store/create/preview/index.test.ts
@@ -7,6 +7,9 @@ describe('preview store create service', () => {
     const setStoredStoreAppSession = vi.fn()
     const recordStoreFqdnMetadata = vi.fn()
     const setLastSeenUserId = vi.fn()
+    const claimPreviewStore = vi.fn(async () => ({
+      claimUrl: 'https://admin.shopify.com/store-transfer/accept/claim-token',
+    }))
 
     const result = await createPreviewStoreCommand(
       {name: 'Lavender Candles', country: 'US'},
@@ -17,6 +20,7 @@ describe('preview store create service', () => {
           adminApiToken: 'shpat_token',
           accessUrl: 'https://app.shopify.com/auth/preview-store?token=access-token',
         })),
+        claimPreviewStore,
         setStoredStoreAppSession,
         recordStoreFqdnMetadata,
         setLastSeenUserId,
@@ -54,8 +58,10 @@ describe('preview store create service', () => {
         subdomain: 'x12y45z.myshopify.com',
         country: 'US',
         storefrontUrl: 'https://app.shopify.com/auth/preview-store?token=access-token',
+        saveUrl: 'https://admin.shopify.com/store-transfer/accept/claim-token',
       },
     })
+    expect(claimPreviewStore).toHaveBeenCalledWith({shopId: '123', adminApiToken: 'shpat_token'}, undefined)
   })
 
   test('uses the shop id as the preview user id when no placeholder account uuid is returned', async () => {
@@ -70,6 +76,9 @@ describe('preview store create service', () => {
           adminApiToken: 'shpat_token',
           accessUrl: 'https://app.shopify.com/auth/preview-store?token=access-token',
         })),
+        claimPreviewStore: vi.fn(async () => ({
+          claimUrl: 'https://admin.shopify.com/store-transfer/accept/claim-token',
+        })),
         setStoredStoreAppSession,
         recordStoreFqdnMetadata: vi.fn(),
         setLastSeenUserId,
@@ -81,6 +90,33 @@ describe('preview store create service', () => {
       expect.objectContaining({userId: `${PREVIEW_USER_ID_PREFIX}123`}),
     )
     expect(setLastSeenUserId).toHaveBeenCalledWith(`${PREVIEW_USER_ID_PREFIX}123`)
+  })
+
+  test('passes client options to both create and claim requests', async () => {
+    const client = {} as any
+    const createPreviewStore = vi.fn(async () => ({
+      shop: {id: '123', name: 'Lavender Candles', domain: 'x12y45z.myshopify.com'},
+      adminApiToken: 'shpat_token',
+      accessUrl: 'https://app.shopify.com/auth/preview-store?token=access-token',
+    }))
+    const claimPreviewStore = vi.fn(async () => ({
+      claimUrl: 'https://admin.shopify.com/store-transfer/accept/claim-token',
+    }))
+
+    await createPreviewStoreCommand(
+      {client},
+      {
+        createPreviewStore,
+        claimPreviewStore,
+        setStoredStoreAppSession: vi.fn(),
+        recordStoreFqdnMetadata: vi.fn(),
+        setLastSeenUserId: vi.fn(),
+        now: () => new Date('2026-06-08T12:00:00.000Z'),
+      },
+    )
+
+    expect(createPreviewStore).toHaveBeenCalledWith({name: undefined, country: undefined}, client)
+    expect(claimPreviewStore).toHaveBeenCalledWith({shopId: '123', adminApiToken: 'shpat_token'}, client)
   })
 
   test('persists a store session and returns success when recording store metadata fails', async () => {
@@ -97,6 +133,9 @@ describe('preview store create service', () => {
           shop: {id: '123', name: 'Lavender Candles', domain: 'x12y45z.myshopify.com'},
           adminApiToken: 'shpat_token',
           accessUrl: 'https://app.shopify.com/auth/preview-store?token=access-token',
+        })),
+        claimPreviewStore: vi.fn(async () => ({
+          claimUrl: 'https://admin.shopify.com/store-transfer/accept/claim-token',
         })),
         setStoredStoreAppSession,
         recordStoreFqdnMetadata,
@@ -124,6 +163,9 @@ describe('preview store create service', () => {
           createPreviewStore: vi.fn(async () => {
             throw new Error('Preview store creation failed.')
           }),
+          claimPreviewStore: vi.fn(async () => ({
+            claimUrl: 'https://admin.shopify.com/store-transfer/accept/claim-token',
+          })),
           setStoredStoreAppSession,
           recordStoreFqdnMetadata,
           setLastSeenUserId,

--- a/packages/store/src/cli/services/store/create/preview/index.ts
+++ b/packages/store/src/cli/services/store/create/preview/index.ts
@@ -1,4 +1,4 @@
-import {PreviewStoreClientOptions, PreviewStoreCreateResponse, createPreviewStore} from './client.js'
+import {PreviewStoreClientOptions, PreviewStoreCreateResponse, claimPreviewStore, createPreviewStore} from './client.js'
 import {STORE_AUTH_APP_CLIENT_ID} from '../../auth/config.js'
 import {setStoredStoreAppSession} from '../../auth/session-store.js'
 import {recordStoreFqdnMetadata} from '../../attribution.js'
@@ -14,6 +14,7 @@ interface CreatePreviewStoreInput {
 
 interface CreatePreviewStoreDependencies {
   createPreviewStore: typeof createPreviewStore
+  claimPreviewStore: typeof claimPreviewStore
   setStoredStoreAppSession: typeof setStoredStoreAppSession
   recordStoreFqdnMetadata: typeof recordStoreFqdnMetadata
   setLastSeenUserId: typeof setLastSeenUserId
@@ -29,11 +30,13 @@ export interface CreatePreviewStoreResult {
     subdomain: string
     country?: string
     storefrontUrl: string
+    saveUrl: string
   }
 }
 
 const defaultDependencies: CreatePreviewStoreDependencies = {
   createPreviewStore,
+  claimPreviewStore,
   setStoredStoreAppSession,
   recordStoreFqdnMetadata,
   setLastSeenUserId,
@@ -53,7 +56,7 @@ export async function createPreviewStoreCommand(
     input.client,
   )
 
-  return persistPreviewStoreSession(response, input.country, resolvedDependencies)
+  return persistPreviewStoreSession(response, input.country, resolvedDependencies, input.client)
 }
 
 function previewUserId(response: PreviewStoreCreateResponse): string {
@@ -64,6 +67,7 @@ async function persistPreviewStoreSession(
   response: PreviewStoreCreateResponse,
   country: string | undefined,
   dependencies: CreatePreviewStoreDependencies,
+  client: PreviewStoreClientOptions | undefined,
 ): Promise<CreatePreviewStoreResult> {
   const acquiredAt = dependencies.now().toISOString()
   const userId = previewUserId(response)
@@ -93,6 +97,11 @@ async function persistPreviewStoreSession(
     // Store metadata is best-effort; credentials and access URL are already persisted.
   }
 
+  const claim = await dependencies.claimPreviewStore(
+    {shopId: response.shop.id, adminApiToken: response.adminApiToken},
+    client,
+  )
+
   return {
     status: 'success',
     message:
@@ -103,6 +112,7 @@ async function persistPreviewStoreSession(
       subdomain: response.shop.domain,
       ...(country ? {country} : {}),
       storefrontUrl: response.accessUrl,
+      saveUrl: claim.claimUrl,
     },
   }
 }

--- a/packages/store/src/cli/services/store/create/preview/result.test.ts
+++ b/packages/store/src/cli/services/store/create/preview/result.test.ts
@@ -22,11 +22,12 @@ const result = {
     subdomain: 'x12y45z.myshopify.com',
     country: 'US',
     storefrontUrl: 'https://x12y45z.myshopify.com/?foo=bar',
+    saveUrl: 'https://admin.shopify.com/store-transfer/accept/claim-token',
   },
 }
 
 describe('preview store create result presenter', () => {
-  test('writes JSON output with the storefront URL and no save URL', () => {
+  test('writes JSON output with the storefront and save URLs', () => {
     writeCreatePreviewStoreResult(result, 'json')
 
     expect(outputResult).toHaveBeenCalledWith(
@@ -41,9 +42,11 @@ describe('preview store create result presenter', () => {
             subdomain: 'x12y45z.myshopify.com',
             country: 'US',
             storefrontUrl: 'https://x12y45z.myshopify.com/?foo=bar',
+            saveUrl: 'https://admin.shopify.com/store-transfer/accept/claim-token',
           },
           next_steps: [
             'Open your store (https://x12y45z.myshopify.com/?foo=bar) to preview the storefront.',
+            'Create an account (https://admin.shopify.com/store-transfer/accept/claim-token) for free to save progress.',
             'Use `shopify store execute` to add products, collections, pages, and more.',
             'Use `shopify theme pull` and `shopify theme push` to edit your store design.',
           ],
@@ -87,6 +90,16 @@ describe('preview store create result presenter', () => {
                       },
                     },
                     ' to preview the storefront.',
+                  ],
+                  [
+                    'Create ',
+                    {
+                      link: {
+                        label: 'an account',
+                        url: 'https://admin.shopify.com/store-transfer/accept/claim-token',
+                      },
+                    },
+                    ' for free to save progress.',
                   ],
                   ['Use ', {command: 'shopify store execute'}, ' to add products, collections, pages, and more.'],
                   [

--- a/packages/store/src/cli/services/store/create/preview/result.ts
+++ b/packages/store/src/cli/services/store/create/preview/result.ts
@@ -36,6 +36,10 @@ function previewStoreNextSteps(result: CreatePreviewStoreResult): PreviewStoreNe
       text: ['Open ', {link: {label: 'your store', url: result.store.storefrontUrl}}, ' to preview the storefront.'],
     },
     {
+      json: `Create an account (${result.store.saveUrl}) for free to save progress.`,
+      text: ['Create ', {link: {label: 'an account', url: result.store.saveUrl}}, ' for free to save progress.'],
+    },
+    {
       json: 'Use `shopify store execute` to add products, collections, pages, and more.',
       text: ['Use ', {command: 'shopify store execute'}, ' to add products, collections, pages, and more.'],
     },


### PR DESCRIPTION
### WHY are these changes introduced?

Preview store creation now returns an access URL for immediately opening the store, but saving/claiming the preview store is a separate backend step. This PR extends `shopify store create preview` to request the claim URL after a successful create so the command output includes both access and claim links.

Backend endpoint contract:

```http
POST /services/preview-stores/:shop_id/claim
```

Headers:

- Requires the preview store Admin API token returned by create.

Request:

```json
{
  "email": "optional recipient email"
}
```

Response:

```json
{
  "claim_url": "https://admin.shopify.com/store-transfer/accept/:claim_token"
}
```

### WHAT is this pull request doing?

- Adds a preview-store claim client for `POST /services/preview-stores/:shop_id/claim`.
- Sends the returned Admin API token in the claim request headers.
- Calls the claim endpoint after preview store creation and local auth persistence.
- Includes the returned `claim_url` in `store create preview` JSON output.
- Displays the claim URL in text output and next steps.
- Redacts tokenized claim URLs from malformed-response diagnostics.

### How to test your changes?

- `pnpm --filter @shopify/store exec vitest run src/cli/commands/store/create/preview.test.ts src/cli/services/store/create/preview/client.test.ts src/cli/services/store/create/preview/index.test.ts src/cli/services/store/create/preview/result.test.ts`
- `pnpm nx run store:lint --skip-nx-cache --output-style=stream`
- `pnpm --filter @shopify/store run type-check`
- `/usr/bin/git diff --check`

### Post-release steps

None.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible documentation changes
- [x] I've considered analytics changes to measure impact
- [x] The change is user-facing — changeset added for `@shopify/store`
