### PR TITLE
[Security] Mask credentials and case-insensitive query params in sanitizeURL

### DIFF
--- a/packages/cli-kit/src/private/node/api/urls.test.ts
+++ b/packages/cli-kit/src/private/node/api/urls.test.ts
@@ -79,4 +79,26 @@ describe('sanitizeURL', () => {
       'https://example.com/?access_token=****&refresh_token=****&device_code=****&subject_token=****&other=keep',
     )
   })
+
+  test('sanitizes URL credentials', () => {
+    // Given
+    const url = 'https://user:pass@example.com'
+
+    // When
+    const sanitizedUrl = sanitizeURL(url)
+
+    // Then
+    expect(sanitizedUrl).toBe('https://****:****@example.com/')
+  })
+
+  test('sanitizes case-insensitive query parameters', () => {
+    // Given
+    const url = 'https://example.com?TOKEN=secret&Access_Token=hidden'
+
+    // When
+    const sanitizedUrl = sanitizeURL(url)
+
+    // Then
+    expect(sanitizedUrl).toBe('https://example.com/?TOKEN=****&Access_Token=****')
+  })
 })

--- a/packages/cli-kit/src/private/node/api/urls.ts
+++ b/packages/cli-kit/src/private/node/api/urls.ts
@@ -21,10 +21,19 @@ const SENSITIVE_QUERY_PARAMS = [
  */
 export function sanitizeURL(url: string): string {
   const parsedUrl = new URL(url)
-  for (const param of SENSITIVE_QUERY_PARAMS) {
-    if (parsedUrl.searchParams.has(param)) {
-      parsedUrl.searchParams.set(param, '****')
+
+  if (parsedUrl.username) {
+    parsedUrl.username = '****'
+  }
+  if (parsedUrl.password) {
+    parsedUrl.password = '****'
+  }
+
+  for (const [key] of parsedUrl.searchParams) {
+    if (SENSITIVE_QUERY_PARAMS.includes(key.toLowerCase())) {
+      parsedUrl.searchParams.set(key, '****')
     }
   }
+
   return parsedUrl.toString()
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Addresses sensitive data exposure in logs by improving URL sanitization.

### WHAT is this pull request doing?

Hardens the `sanitizeURL` function to redact URL credentials (username/password) and ensure case-insensitive matching for sensitive query parameters.

### How to test your changes?

CI

### Post-release steps

None.

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [17903126390004484203](https://jules.google.com/task/17903126390004484203) started by @gonzaloriestra*