### PR TITLE
[Refactor] Use uniq helper in repo-health.test.ts

### DIFF
--- a/packages/cli/src/cli/repo-health.test.ts
+++ b/packages/cli/src/cli/repo-health.test.ts
@@ -1,4 +1,5 @@
 /* eslint-disable no-restricted-imports, no-await-in-loop */
+import {uniq} from '@shopify/cli-kit/common/array'
 import {describe, test, expect} from 'vitest'
 import glob from 'fast-glob'
 import * as fs from 'fs/promises'
@@ -91,7 +92,7 @@ describe('Node dependency version sync', () => {
         }
       }
 
-      const uniqueVersions = [...new Set(depVersions.map((ver) => ver.version))]
+      const uniqueVersions = uniq(depVersions.map((ver) => ver.version))
       if (uniqueVersions.length > 1) {
         different.push({dep, versions: depVersions})
       }


### PR DESCRIPTION
### WHY are these changes introduced?

Follow the project's standardized practices by using the `uniq` utility function from `@shopify/cli-kit` instead of manual `Set` deduplication.

### WHAT is this pull request doing?

Replaced `[...new Set(array)]` with `uniq(array)` in `packages/cli/src/cli/repo-health.test.ts`.

### How to test your changes?

CI

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [18250549657295788053](https://jules.google.com/task/18250549657295788053) started by @gonzaloriestra*