### PR TITLE
[Performance] Memoize isWsl check

### DIFF
--- a/packages/cli-kit/src/public/node/system.test.ts
+++ b/packages/cli-kit/src/public/node/system.test.ts
@@ -393,3 +393,32 @@ describe('readStdinString', () => {
     await expect(got).rejects.toThrow('Stdin input exceeded the maximum allowed size.')
   })
 })
+
+describe('isWsl', () => {
+  test('memoizes the promise', async () => {
+    // Given
+    system._resetIsWsl()
+
+    // When
+    const promise1 = system.isWsl()
+    const promise2 = system.isWsl()
+
+    // Then
+    expect(promise1).toBe(promise2)
+    await promise1
+  })
+
+  test('resets the memoized promise', async () => {
+    // Given
+    system._resetIsWsl()
+    const promise1 = system.isWsl()
+
+    // When
+    system._resetIsWsl()
+    const promise2 = system.isWsl()
+
+    // Then
+    expect(promise1).not.toBe(promise2)
+    await Promise.all([promise1, promise2])
+  })
+})

--- a/packages/cli-kit/src/public/node/system.ts
+++ b/packages/cli-kit/src/public/node/system.ts
@@ -355,13 +355,27 @@ export function isCI(): boolean {
 }
 
 /**
+ * Memoized promise for the WSL check.
+ */
+let memoizedIsWsl: Promise<boolean> | undefined
+
+/**
  * Check if the current environment is a WSL environment.
  *
  * @returns True if the current environment is a WSL environment.
  */
-export async function isWsl(): Promise<boolean> {
-  const wsl = await import('is-wsl')
-  return wsl.default
+export function isWsl(): Promise<boolean> {
+  return (memoizedIsWsl ??= (async () => {
+    const wsl = await import('is-wsl')
+    return wsl.default
+  })())
+}
+
+/**
+ * Resets the memoized WSL check.
+ */
+export function _resetIsWsl(): void {
+  memoizedIsWsl = undefined
 }
 
 /**


### PR DESCRIPTION
### WHY are these changes introduced?

The `isWsl` check involves a dynamic import and internal logic that is constant for the duration of a CLI process. Repeatedly calling it adds unnecessary overhead in high-frequency paths.

### WHAT is this pull request doing?

Memoizes the `isWsl` promise in `packages/cli-kit/src/public/node/system.ts` so subsequent calls return the same cached promise. Added unit tests to verify memoization and a reset function for testing isolation.

### How to test your changes?

CI

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [3450321297428259022](https://jules.google.com/task/3450321297428259022) started by @gonzaloriestra*