### PR TITLE
[Performance] Memoize isWsl

### DIFF
--- a/packages/cli-kit/src/public/node/system.test.ts
+++ b/packages/cli-kit/src/public/node/system.test.ts
@@ -1,6 +1,6 @@
 import * as system from './system.js'
 import {execa} from 'execa'
-import {describe, expect, test, vi} from 'vitest'
+import {describe, expect, test, vi, beforeEach} from 'vitest'
 import which from 'which'
 import {Readable} from 'stream'
 
@@ -350,6 +350,38 @@ describe('isStdinPiped', () => {
 
     // Then
     expect(got).toBe(false)
+  })
+})
+
+describe('isWsl', () => {
+  beforeEach(() => {
+    system._resetIsWsl()
+  })
+
+  test('returns the value from is-wsl', async () => {
+    // Given
+    vi.doMock('is-wsl', () => ({
+      default: true,
+    }))
+
+    // When
+    const got = await system.isWsl()
+
+    // Then
+    expect(got).toBe(true)
+  })
+
+  test('memoizes the result', async () => {
+    // Given
+    const isWslModule = await import('is-wsl')
+    const spy = vi.spyOn(isWslModule, 'default', 'get').mockReturnValue(true)
+
+    // When
+    await system.isWsl()
+    await system.isWsl()
+
+    // Then
+    expect(spy).toHaveBeenCalledTimes(1)
   })
 })
 

--- a/packages/cli-kit/src/public/node/system.ts
+++ b/packages/cli-kit/src/public/node/system.ts
@@ -355,13 +355,28 @@ export function isCI(): boolean {
 }
 
 /**
+ * Memoized promise for the WSL check.
+ */
+let memoizedIsWsl: Promise<boolean> | undefined
+
+/**
  * Check if the current environment is a WSL environment.
  *
  * @returns True if the current environment is a WSL environment.
  */
-export async function isWsl(): Promise<boolean> {
-  const wsl = await import('is-wsl')
-  return wsl.default
+export function isWsl(): Promise<boolean> {
+  memoizedIsWsl ??= (async () => {
+    const wsl = await import('is-wsl')
+    return wsl.default
+  })()
+  return memoizedIsWsl
+}
+
+/**
+ * Resets the memoized WSL check.
+ */
+export function _resetIsWsl(): void {
+  memoizedIsWsl = undefined
 }
 
 /**


### PR DESCRIPTION
### WHY are these changes introduced?

The `isWsl` function in `packages/cli-kit/src/public/node/system.ts` performs a dynamic import of the `is-wsl` package every time it's called. While Node.js caches module imports, memoizing the result at the application level avoids the overhead of repeated module resolution lookups and promise creation.

### WHAT is this pull request doing?

This PR memoizes the `isWsl` function by caching the promise of the dynamic import in a module-level variable. It also adds and exports an internal `_resetIsWsl` function to ensure test isolation. Unit tests have been updated and expanded to verify the memoization behavior.

### How to test your changes?

CI

### Post-release steps

N/A

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [15665184249994513171](https://jules.google.com/task/15665184249994513171) started by @gonzaloriestra*