### PR TITLE
[Refactor] Use uniq helper in unionArrayStrategy

### DIFF
--- a/packages/cli-kit/src/private/common/array.ts
+++ b/packages/cli-kit/src/private/common/array.ts
@@ -1,3 +1,5 @@
+import {uniq} from '../../public/common/array.js'
+
 export function unionArrayStrategy(destinationArray: unknown[], sourceArray: unknown[]): unknown[] {
-  return Array.from(new Set([...destinationArray, ...sourceArray]))
+  return uniq([...destinationArray, ...sourceArray])
 }


### PR DESCRIPTION
### WHY are these changes introduced?

This refactor improves code consistency and readability by utilizing an existing utility function instead of manual deduplication logic.

### WHAT is this pull request doing?

Replaces `Array.from(new Set([...destinationArray, ...sourceArray]))` with `uniq([...destinationArray, ...sourceArray])` in `packages/cli-kit/src/private/common/array.ts`.

### How to test your changes?

CI

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [6608183129656299532](https://jules.google.com/task/6608183129656299532) started by @gonzaloriestra*