### PR TITLE
[Security] Harden URL sanitization

### DIFF
--- a/packages/cli-kit/src/private/node/api/urls.test.ts
+++ b/packages/cli-kit/src/private/node/api/urls.test.ts
@@ -79,4 +79,26 @@ describe('sanitizeURL', () => {
       'https://example.com/?access_token=****&refresh_token=****&device_code=****&subject_token=****&other=keep',
     )
   })
+
+  test('sanitizes URL credentials', () => {
+    // Given
+    const url = 'https://user:pass@example.com'
+
+    // When
+    const sanitizedUrl = sanitizeURL(url)
+
+    // Then
+    expect(sanitizedUrl).toBe('https://****:****@example.com/')
+  })
+
+  test('sanitizes query parameters case-insensitively', () => {
+    // Given
+    const url = 'https://example.com?ACCESS_TOKEN=abc&Token=def'
+
+    // When
+    const sanitizedUrl = sanitizeURL(url)
+
+    // Then
+    expect(sanitizedUrl).toBe('https://example.com/?ACCESS_TOKEN=****&Token=****')
+  })
 })

--- a/packages/cli-kit/src/private/node/api/urls.ts
+++ b/packages/cli-kit/src/private/node/api/urls.ts
@@ -15,15 +15,23 @@ const SENSITIVE_QUERY_PARAMS = [
 ]
 
 /**
- * Removes the sensitive data from the url and outputs them as a string.
- * @param url - HTTP headers.
- * @returns A sanitized version of the url as a string.
+ * Removes sensitive data (credentials, tokens) from the URL before it is logged
+ * or displayed to the user to prevent accidental leakage of secrets.
+ *
+ * @param url - The URL to sanitize.
+ * @returns A sanitized version of the URL.
  */
 export function sanitizeURL(url: string): string {
   const parsedUrl = new URL(url)
-  for (const param of SENSITIVE_QUERY_PARAMS) {
-    if (parsedUrl.searchParams.has(param)) {
-      parsedUrl.searchParams.set(param, '****')
+
+  if (parsedUrl.username) parsedUrl.username = '****'
+  if (parsedUrl.password) parsedUrl.password = '****'
+
+  const sensitiveParams = SENSITIVE_QUERY_PARAMS.map((param) => param.toLowerCase())
+
+  for (const [key] of parsedUrl.searchParams.entries()) {
+    if (sensitiveParams.includes(key.toLowerCase())) {
+      parsedUrl.searchParams.set(key, '****')
     }
   }
   return parsedUrl.toString()


### PR DESCRIPTION
### WHY are these changes introduced?

To prevent accidental leakage of sensitive information (URL credentials and tokens) in logs or user-facing output.

### WHAT is this pull request doing?

This PR hardens the `sanitizeURL` utility to:
- Mask URL credentials (username and password).
- Perform case-insensitive matching for sensitive query parameters.

### How to test your changes?

CI

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [13770331723120389215](https://jules.google.com/task/13770331723120389215) started by @gonzaloriestra*