### PR TITLE
[Refactor] Use uniq helper in scopes.ts

### DIFF
--- a/packages/cli-kit/src/private/node/session/scopes.ts
+++ b/packages/cli-kit/src/private/node/session/scopes.ts
@@ -1,5 +1,6 @@
 import {allAPIs, API} from '../api.js'
 import {BugError} from '../../../public/node/error.js'
+import {uniq} from '../../../public/common/array.js'
 
 /**
  * Generate a flat array with all the default scopes for all the APIs plus
@@ -10,7 +11,7 @@ import {BugError} from '../../../public/node/error.js'
 export function allDefaultScopes(extraScopes: string[] = []): string[] {
   let scopes = allAPIs.map((api) => defaultApiScopes(api)).flat()
   scopes = ['openid', ...scopes, ...extraScopes].map(scopeTransform)
-  return Array.from(new Set(scopes))
+  return uniq(scopes)
 }
 
 /**
@@ -22,7 +23,7 @@ export function allDefaultScopes(extraScopes: string[] = []): string[] {
  */
 export function apiScopes(api: API, extraScopes: string[] = []): string[] {
   const scopes = [...defaultApiScopes(api), ...extraScopes.map(scopeTransform)].map(scopeTransform)
-  return Array.from(new Set(scopes))
+  return uniq(scopes)
 }
 
 /**


### PR DESCRIPTION
### WHY are these changes introduced?

To improve code readability and maintainability by using a shared utility function for array deduplication instead of manual `Set` construction.

### WHAT is this pull request doing?

Replaces manual `Array.from(new Set(scopes))` with the `uniq(scopes)` helper in `packages/cli-kit/src/private/node/session/scopes.ts`.

### How to test your changes?

CI

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`


---
*PR created automatically by Jules for task [4497289829820548214](https://jules.google.com/task/4497289829820548214) started by @gonzaloriestra*