### PR TITLE
[Performance] Memoize isWsl check

### DIFF
--- a/packages/cli-kit/src/public/node/system.test.ts
+++ b/packages/cli-kit/src/public/node/system.test.ts
@@ -1,6 +1,6 @@
 import * as system from './system.js'
 import {execa} from 'execa'
-import {describe, expect, test, vi} from 'vitest'
+import {describe, expect, test, vi, beforeEach} from 'vitest'
 import which from 'which'
 import {Readable} from 'stream'
 
@@ -350,6 +350,65 @@ describe('isStdinPiped', () => {
 
     // Then
     expect(got).toBe(false)
+  })
+})
+
+describe('isWsl', () => {
+  beforeEach(() => {
+    system._resetIsWsl()
+  })
+
+  test('returns true when is-wsl returns true', async () => {
+    // Given
+    vi.doMock('is-wsl', () => ({default: true}))
+
+    // When
+    const got = await system.isWsl()
+
+    // Then
+    expect(got).toBe(true)
+  })
+
+  test('returns false when is-wsl returns false', async () => {
+    // Given
+    vi.doMock('is-wsl', () => ({default: false}))
+
+    // When
+    const got = await system.isWsl()
+
+    // Then
+    expect(got).toBe(false)
+  })
+
+  test('memoizes the result', async () => {
+    // Given
+    vi.doMock('is-wsl', () => ({default: true}))
+
+    // When
+    const result1 = system.isWsl()
+    const result2 = system.isWsl()
+
+    // Then
+    await expect(result1).resolves.toBe(true)
+    await expect(result2).resolves.toBe(true)
+    expect(result1).toBe(result2)
+  })
+
+  test('resets the memoized value', async () => {
+    // Given
+    vi.doMock('is-wsl', () => ({default: true}))
+    const result1 = system.isWsl()
+    await result1
+
+    // When
+    system._resetIsWsl()
+    vi.doMock('is-wsl', () => ({default: false}))
+    const result2 = system.isWsl()
+
+    // Then
+    await expect(result1).resolves.toBe(true)
+    await expect(result2).resolves.toBe(false)
+    expect(result1).not.toBe(result2)
   })
 })
 

--- a/packages/cli-kit/src/public/node/system.ts
+++ b/packages/cli-kit/src/public/node/system.ts
@@ -355,13 +355,24 @@ export function isCI(): boolean {
 }
 
 /**
+ * Memoized value for the WSL check.
+ */
+let memoizedIsWsl: Promise<boolean> | undefined
+
+/**
  * Check if the current environment is a WSL environment.
  *
  * @returns True if the current environment is a WSL environment.
  */
-export async function isWsl(): Promise<boolean> {
-  const wsl = await import('is-wsl')
-  return wsl.default
+export function isWsl(): Promise<boolean> {
+  return (memoizedIsWsl ??= import('is-wsl').then((wsl) => wsl.default))
+}
+
+/**
+ * Resets the memoized value for the WSL check.
+ */
+export function _resetIsWsl(): void {
+  memoizedIsWsl = undefined
 }
 
 /**


### PR DESCRIPTION
Memoizes the results of the isWsl check in `@shopify/cli-kit` to avoid redundant dynamic imports and environment checks. This improvement reduces the overhead of calling `isWsl` repeatedly across the codebase.

### Expected Performance Impact
Reduced overhead of `isWsl` calls by caching the result of the dynamic import after the first call. This avoids redundant filesystem and OS checks on subsequent calls.

### How to test your changes?
CI

---
*PR created automatically by Jules for task [11590658677194908089](https://jules.google.com/task/11590658677194908089) started by @gonzaloriestra*