### PR TITLE
Support numeric store IDs and Shop GIDs for the shared --store flag

### DIFF
--- a/.changeset/store-flag-id-gid.md
+++ b/.changeset/store-flag-id-gid.md
@@ -1,0 +1,5 @@
+---
+'@shopify/store': minor
+---
+
+`shopify store` commands now accept a numeric store ID or a Shop GID (`gid://shopify/Shop/<id>`) for `--store`, in addition to the myshopify.com domain. IDs and GIDs are resolved to the store's domain via the Business Platform. The `--store` value now also trims surrounding whitespace.

--- a/docs-shopify.dev/commands/interfaces/store-auth.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/store-auth.interface.ts
@@ -23,7 +23,7 @@ export interface storeauth {
   '--scopes <value>': string
 
   /**
-   * The myshopify.com domain of the store.
+   * The store to operate on: its myshopify.com domain, numeric store ID, or Shop GID (gid://shopify/Shop/<id>).
    * @environment SHOPIFY_FLAG_STORE
    */
   '-s, --store <value>': string

--- a/docs-shopify.dev/commands/interfaces/store-execute.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/store-execute.interface.ts
@@ -41,7 +41,7 @@ export interface storeexecute {
   '--query-file <value>'?: string
 
   /**
-   * The myshopify.com domain of the store.
+   * The store to operate on: its myshopify.com domain, numeric store ID, or Shop GID (gid://shopify/Shop/<id>).
    * @environment SHOPIFY_FLAG_STORE
    */
   '-s, --store <value>': string

--- a/docs-shopify.dev/commands/interfaces/store-info.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/store-info.interface.ts
@@ -17,7 +17,7 @@ export interface storeinfo {
   '--no-color'?: ''
 
   /**
-   * The myshopify.com domain of the store.
+   * The store to operate on: its myshopify.com domain, numeric store ID, or Shop GID (gid://shopify/Shop/<id>).
    * @environment SHOPIFY_FLAG_STORE
    */
   '-s, --store <value>': string

--- a/docs-shopify.dev/generated/generated_docs_data_v2.json
+++ b/docs-shopify.dev/generated/generated_docs_data_v2.json
@@ -4177,11 +4177,11 @@
           "syntaxKind": "PropertySignature",
           "name": "-s, --store <value>",
           "value": "string",
-          "description": "The myshopify.com domain of the store.",
+          "description": "The store to operate on: its myshopify.com domain, numeric store ID, or Shop GID (gid://shopify/Shop/<id>).",
           "environmentValue": "SHOPIFY_FLAG_STORE"
         }
       ],
-      "value": "export interface storeauth {\n  /**\n   * Output the result as JSON. Automatically disables color output.\n   * @environment SHOPIFY_FLAG_JSON\n   */\n  '-j, --json'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Comma-separated Admin API scopes to request for the app.\n   * @environment SHOPIFY_FLAG_SCOPES\n   */\n  '--scopes <value>': string\n\n  /**\n   * The myshopify.com domain of the store.\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>': string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+      "value": "export interface storeauth {\n  /**\n   * Output the result as JSON. Automatically disables color output.\n   * @environment SHOPIFY_FLAG_JSON\n   */\n  '-j, --json'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Comma-separated Admin API scopes to request for the app.\n   * @environment SHOPIFY_FLAG_SCOPES\n   */\n  '--scopes <value>': string\n\n  /**\n   * The store to operate on: its myshopify.com domain, numeric store ID, or Shop GID (gid://shopify/Shop/<id>).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>': string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
     }
   },
   "storeexecute": {
@@ -4277,7 +4277,7 @@
           "syntaxKind": "PropertySignature",
           "name": "-s, --store <value>",
           "value": "string",
-          "description": "The myshopify.com domain of the store.",
+          "description": "The store to operate on: its myshopify.com domain, numeric store ID, or Shop GID (gid://shopify/Shop/<id>).",
           "environmentValue": "SHOPIFY_FLAG_STORE"
         },
         {
@@ -4290,7 +4290,7 @@
           "environmentValue": "SHOPIFY_FLAG_VARIABLES"
         }
       ],
-      "value": "export interface storeexecute {\n  /**\n   * Allow GraphQL mutations to run against the target store.\n   * @environment SHOPIFY_FLAG_ALLOW_MUTATIONS\n   */\n  '--allow-mutations'?: ''\n\n  /**\n   * Output the result as JSON. Automatically disables color output.\n   * @environment SHOPIFY_FLAG_JSON\n   */\n  '-j, --json'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The file name where results should be written, instead of STDOUT.\n   * @environment SHOPIFY_FLAG_OUTPUT_FILE\n   */\n  '--output-file <value>'?: string\n\n  /**\n   * The GraphQL query or mutation, as a string.\n   * @environment SHOPIFY_FLAG_QUERY\n   */\n  '-q, --query <value>'?: string\n\n  /**\n   * Path to a file containing the GraphQL query or mutation. Can't be used with --query.\n   * @environment SHOPIFY_FLAG_QUERY_FILE\n   */\n  '--query-file <value>'?: string\n\n  /**\n   * The myshopify.com domain of the store.\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>': string\n\n  /**\n   * Path to a file containing GraphQL variables in JSON format. Can't be used with --variables.\n   * @environment SHOPIFY_FLAG_VARIABLE_FILE\n   */\n  '--variable-file <value>'?: string\n\n  /**\n   * The values for any GraphQL variables in your query or mutation, in JSON format.\n   * @environment SHOPIFY_FLAG_VARIABLES\n   */\n  '-v, --variables <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n\n  /**\n   * The API version to use for the query or mutation. Defaults to the latest stable version.\n   * @environment SHOPIFY_FLAG_VERSION\n   */\n  '--version <value>'?: string\n}"
+      "value": "export interface storeexecute {\n  /**\n   * Allow GraphQL mutations to run against the target store.\n   * @environment SHOPIFY_FLAG_ALLOW_MUTATIONS\n   */\n  '--allow-mutations'?: ''\n\n  /**\n   * Output the result as JSON. Automatically disables color output.\n   * @environment SHOPIFY_FLAG_JSON\n   */\n  '-j, --json'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The file name where results should be written, instead of STDOUT.\n   * @environment SHOPIFY_FLAG_OUTPUT_FILE\n   */\n  '--output-file <value>'?: string\n\n  /**\n   * The GraphQL query or mutation, as a string.\n   * @environment SHOPIFY_FLAG_QUERY\n   */\n  '-q, --query <value>'?: string\n\n  /**\n   * Path to a file containing the GraphQL query or mutation. Can't be used with --query.\n   * @environment SHOPIFY_FLAG_QUERY_FILE\n   */\n  '--query-file <value>'?: string\n\n  /**\n   * The store to operate on: its myshopify.com domain, numeric store ID, or Shop GID (gid://shopify/Shop/<id>).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>': string\n\n  /**\n   * Path to a file containing GraphQL variables in JSON format. Can't be used with --variables.\n   * @environment SHOPIFY_FLAG_VARIABLE_FILE\n   */\n  '--variable-file <value>'?: string\n\n  /**\n   * The values for any GraphQL variables in your query or mutation, in JSON format.\n   * @environment SHOPIFY_FLAG_VARIABLES\n   */\n  '-v, --variables <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n\n  /**\n   * The API version to use for the query or mutation. Defaults to the latest stable version.\n   * @environment SHOPIFY_FLAG_VERSION\n   */\n  '--version <value>'?: string\n}"
     }
   },
   "storeinfo": {
@@ -4332,11 +4332,11 @@
           "syntaxKind": "PropertySignature",
           "name": "-s, --store <value>",
           "value": "string",
-          "description": "The myshopify.com domain of the store.",
+          "description": "The store to operate on: its myshopify.com domain, numeric store ID, or Shop GID (gid://shopify/Shop/<id>).",
           "environmentValue": "SHOPIFY_FLAG_STORE"
         }
       ],
-      "value": "export interface storeinfo {\n  /**\n   * Output the result as JSON. Automatically disables color output.\n   * @environment SHOPIFY_FLAG_JSON\n   */\n  '-j, --json'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The myshopify.com domain of the store.\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>': string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+      "value": "export interface storeinfo {\n  /**\n   * Output the result as JSON. Automatically disables color output.\n   * @environment SHOPIFY_FLAG_JSON\n   */\n  '-j, --json'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The store to operate on: its myshopify.com domain, numeric store ID, or Shop GID (gid://shopify/Shop/<id>).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>': string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
     }
   },
   "themecheck": {

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -2112,7 +2112,8 @@ USAGE
 
 FLAGS
   -j, --json            [env: SHOPIFY_FLAG_JSON] Output the result as JSON. Automatically disables color output.
-  -s, --store=<value>   (required) [env: SHOPIFY_FLAG_STORE] The myshopify.com domain of the store.
+  -s, --store=<value>   (required) [env: SHOPIFY_FLAG_STORE] The store to operate on: its myshopify.com domain, numeric
+                        store ID, or Shop GID (gid://shopify/Shop/<id>).
       --no-color        [env: SHOPIFY_FLAG_NO_COLOR] Disable color output.
       --scopes=<value>  (required) [env: SHOPIFY_FLAG_SCOPES] Comma-separated Admin API scopes to request for the app.
       --verbose         [env: SHOPIFY_FLAG_VERBOSE] Increase the verbosity of the output.
@@ -2143,7 +2144,8 @@ USAGE
 FLAGS
   -j, --json                   [env: SHOPIFY_FLAG_JSON] Output the result as JSON. Automatically disables color output.
   -q, --query=<value>          [env: SHOPIFY_FLAG_QUERY] The GraphQL query or mutation, as a string.
-  -s, --store=<value>          (required) [env: SHOPIFY_FLAG_STORE] The myshopify.com domain of the store.
+  -s, --store=<value>          (required) [env: SHOPIFY_FLAG_STORE] The store to operate on: its myshopify.com domain,
+                               numeric store ID, or Shop GID (gid://shopify/Shop/<id>).
   -v, --variables=<value>      [env: SHOPIFY_FLAG_VARIABLES] The values for any GraphQL variables in your query or
                                mutation, in JSON format.
       --allow-mutations        [env: SHOPIFY_FLAG_ALLOW_MUTATIONS] Allow GraphQL mutations to run against the target
@@ -2188,7 +2190,8 @@ USAGE
 
 FLAGS
   -j, --json           [env: SHOPIFY_FLAG_JSON] Output the result as JSON. Automatically disables color output.
-  -s, --store=<value>  (required) [env: SHOPIFY_FLAG_STORE] The myshopify.com domain of the store.
+  -s, --store=<value>  (required) [env: SHOPIFY_FLAG_STORE] The store to operate on: its myshopify.com domain, numeric
+                       store ID, or Shop GID (gid://shopify/Shop/<id>).
       --no-color       [env: SHOPIFY_FLAG_NO_COLOR] Disable color output.
       --verbose        [env: SHOPIFY_FLAG_VERBOSE] Increase the verbosity of the output.
 

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -5710,7 +5710,7 @@
         },
         "store": {
           "char": "s",
-          "description": "The myshopify.com domain of the store.",
+          "description": "The store to operate on: its myshopify.com domain, numeric store ID, or Shop GID (gid://shopify/Shop/<id>).",
           "env": "SHOPIFY_FLAG_STORE",
           "hasDynamicHelp": false,
           "multiple": false,
@@ -5804,7 +5804,7 @@
         },
         "store": {
           "char": "s",
-          "description": "The myshopify.com domain of the store.",
+          "description": "The store to operate on: its myshopify.com domain, numeric store ID, or Shop GID (gid://shopify/Shop/<id>).",
           "env": "SHOPIFY_FLAG_STORE",
           "hasDynamicHelp": false,
           "multiple": false,
@@ -5894,7 +5894,7 @@
         },
         "store": {
           "char": "s",
-          "description": "The myshopify.com domain of the store.",
+          "description": "The store to operate on: its myshopify.com domain, numeric store ID, or Shop GID (gid://shopify/Shop/<id>).",
           "env": "SHOPIFY_FLAG_STORE",
           "hasDynamicHelp": false,
           "multiple": false,

--- a/packages/store/src/cli/api/graphql/business-platform-destinations/generated/resolve-store-by-id.ts
+++ b/packages/store/src/cli/api/graphql/business-platform-destinations/generated/resolve-store-by-id.ts
@@ -1,0 +1,64 @@
+/* eslint-disable @typescript-eslint/consistent-type-definitions */
+import * as Types from './types.js'
+
+import {TypedDocumentNode as DocumentNode} from '@graphql-typed-document-node/core'
+
+export type ResolveStoreByIdQueryVariables = Types.Exact<{
+  id: Types.Scalars['DestinationPublicID']['input']
+}>
+
+export type ResolveStoreByIdQuery = {
+  currentUserAccount?: {destination?: {webUrl: string; primaryDomain?: string | null} | null} | null
+}
+
+export const ResolveStoreById = {
+  kind: 'Document',
+  definitions: [
+    {
+      kind: 'OperationDefinition',
+      operation: 'query',
+      name: {kind: 'Name', value: 'ResolveStoreById'},
+      variableDefinitions: [
+        {
+          kind: 'VariableDefinition',
+          variable: {kind: 'Variable', name: {kind: 'Name', value: 'id'}},
+          type: {kind: 'NonNullType', type: {kind: 'NamedType', name: {kind: 'Name', value: 'DestinationPublicID'}}},
+        },
+      ],
+      selectionSet: {
+        kind: 'SelectionSet',
+        selections: [
+          {
+            kind: 'Field',
+            name: {kind: 'Name', value: 'currentUserAccount'},
+            selectionSet: {
+              kind: 'SelectionSet',
+              selections: [
+                {
+                  kind: 'Field',
+                  name: {kind: 'Name', value: 'destination'},
+                  arguments: [
+                    {
+                      kind: 'Argument',
+                      name: {kind: 'Name', value: 'id'},
+                      value: {kind: 'Variable', name: {kind: 'Name', value: 'id'}},
+                    },
+                  ],
+                  selectionSet: {
+                    kind: 'SelectionSet',
+                    selections: [
+                      {kind: 'Field', name: {kind: 'Name', value: 'webUrl'}},
+                      {kind: 'Field', name: {kind: 'Name', value: 'primaryDomain'}},
+                      {kind: 'Field', name: {kind: 'Name', value: '__typename'}},
+                    ],
+                  },
+                },
+                {kind: 'Field', name: {kind: 'Name', value: '__typename'}},
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<ResolveStoreByIdQuery, ResolveStoreByIdQueryVariables>

--- a/packages/store/src/cli/api/graphql/business-platform-destinations/queries/resolve-store-by-id.graphql
+++ b/packages/store/src/cli/api/graphql/business-platform-destinations/queries/resolve-store-by-id.graphql
@@ -1,0 +1,8 @@
+query ResolveStoreById($id: DestinationPublicID!) {
+  currentUserAccount {
+    destination(id: $id) {
+      webUrl
+      primaryDomain
+    }
+  }
+}

--- a/packages/store/src/cli/flags.ts
+++ b/packages/store/src/cli/flags.ts
@@ -1,12 +1,11 @@
-import {normalizeStoreFqdn} from '@shopify/cli-kit/node/context/fqdn'
 import {Flags} from '@oclif/core'
 
 export const storeFlags = {
   store: Flags.string({
     char: 's',
-    description: 'The myshopify.com domain of the store.',
+    description:
+      'The store to operate on: its myshopify.com domain, numeric store ID, or Shop GID (gid://shopify/Shop/<id>).',
     env: 'SHOPIFY_FLAG_STORE',
-    parse: async (input) => normalizeStoreFqdn(input),
     required: true,
   }),
 }

--- a/packages/store/src/cli/utilities/store-command.ts
+++ b/packages/store/src/cli/utilities/store-command.ts
@@ -1,8 +1,30 @@
-import Command from '@shopify/cli-kit/node/base-command'
+import {resolveStore} from './store-resolution.js'
+import Command, {ArgOutput, FlagOutput} from '@shopify/cli-kit/node/base-command'
+import {Input, ParserOutput} from '@oclif/core/parser'
 
 /**
  * Base class that includes shared behavior for all store commands.
  */
 export default abstract class StoreCommand extends Command {
   public abstract run(): Promise<void>
+
+  // Resolve `--store` AFTER oclif has parsed and validated every other flag. Doing the
+  // auth+network resolution here (rather than in the flag's `parse`) means unknown/required/
+  // exclusive flag errors are reported before we ever reach out to the Business Platform, so
+  // users don't get surprising auth prompts ahead of a plain flag-validation error.
+  protected async parse<
+    TFlags extends FlagOutput & {path?: string; verbose?: boolean},
+    TGlobalFlags extends FlagOutput,
+    TArgs extends ArgOutput,
+  >(
+    options?: Input<TFlags, TGlobalFlags, TArgs>,
+    argv?: string[],
+  ): Promise<ParserOutput<TFlags, TGlobalFlags, TArgs> & {argv: string[]}> {
+    const result = await super.parse<TFlags, TGlobalFlags, TArgs>(options, argv)
+    const flags = result?.flags as {store?: unknown} | undefined
+    if (flags && typeof flags.store === 'string') {
+      flags.store = await resolveStore(flags.store)
+    }
+    return result
+  }
 }

--- a/packages/store/src/cli/utilities/store-resolution.test.ts
+++ b/packages/store/src/cli/utilities/store-resolution.test.ts
@@ -1,0 +1,220 @@
+import {resolveStore} from './store-resolution.js'
+import {businessPlatformRequestDoc} from '@shopify/cli-kit/node/api/business-platform'
+import {ensureAuthenticatedBusinessPlatform} from '@shopify/cli-kit/node/session'
+import {AbortError} from '@shopify/cli-kit/node/error'
+import {encodeGid} from '@shopify/cli-kit/common/gid'
+import {describe, test, expect, vi, beforeEach} from 'vitest'
+
+vi.mock('@shopify/cli-kit/node/api/business-platform')
+vi.mock('@shopify/cli-kit/node/session')
+
+const SHOP = 'shop.myshopify.com'
+
+// BP's DestinationPublicID input scalar expects a base64-encoded `gid://organization/ShopifyShop/<id>`.
+// Compute the expected value dynamically rather than hardcoding the base64 string.
+const ENCODED_123 = encodeGid('gid://organization/ShopifyShop/123')
+
+function destinationResponse(fields: {webUrl?: string | null; primaryDomain?: string | null}) {
+  return {currentUserAccount: {destination: {webUrl: fields.webUrl, primaryDomain: fields.primaryDomain}}}
+}
+
+describe('resolveStore', () => {
+  beforeEach(() => {
+    vi.mocked(ensureAuthenticatedBusinessPlatform).mockResolvedValue('bp-token')
+  })
+
+  describe('domain inputs (no network)', () => {
+    test.each([
+      ['shop.myshopify.com', 'shop.myshopify.com'],
+      ['shop', 'shop.myshopify.com'],
+      ['https://shop.myshopify.com/admin', 'shop.myshopify.com'],
+      // normalizeStoreFqdn does not lowercase the subdomain; resolveStore must preserve
+      // that exact behavior for domain inputs.
+      ['SHOP', 'SHOP.myshopify.com'],
+    ])('%s resolves to %s without any BP calls', async (input, expected) => {
+      const result = await resolveStore(input)
+
+      expect(result).toBe(expected)
+      expect(businessPlatformRequestDoc).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('numeric store ID', () => {
+    test('resolves via a single destinations lookup keyed by the encoded shop id', async () => {
+      vi.mocked(businessPlatformRequestDoc).mockResolvedValueOnce(
+        destinationResponse({webUrl: `https://${SHOP}`, primaryDomain: `https://${SHOP}`}) as never,
+      )
+
+      const result = await resolveStore('123')
+
+      expect(result).toBe(SHOP)
+      expect(businessPlatformRequestDoc).toHaveBeenCalledTimes(1)
+      expect(vi.mocked(businessPlatformRequestDoc).mock.calls[0]?.[0]).toMatchObject({
+        variables: {id: ENCODED_123},
+      })
+    })
+
+    test('prefers webUrl over a custom primaryDomain', async () => {
+      vi.mocked(businessPlatformRequestDoc).mockResolvedValueOnce(
+        destinationResponse({webUrl: `https://${SHOP}`, primaryDomain: 'https://www.custom-domain.com'}) as never,
+      )
+
+      const result = await resolveStore('123')
+
+      expect(result).toBe(SHOP)
+    })
+
+    test('falls back to primaryDomain when webUrl yields no host', async () => {
+      vi.mocked(businessPlatformRequestDoc).mockResolvedValueOnce(
+        destinationResponse({webUrl: null, primaryDomain: `https://${SHOP}`}) as never,
+      )
+
+      const result = await resolveStore('123')
+
+      expect(result).toBe(SHOP)
+    })
+
+    test('strips scheme and trailing slash from the returned domain', async () => {
+      vi.mocked(businessPlatformRequestDoc).mockResolvedValueOnce(
+        destinationResponse({webUrl: `https://${SHOP}/`, primaryDomain: null}) as never,
+      )
+
+      const result = await resolveStore('123')
+
+      expect(result).toBe(SHOP)
+    })
+
+    test('returns a bare-host webUrl (no scheme) as-is', async () => {
+      vi.mocked(businessPlatformRequestDoc).mockResolvedValueOnce(
+        destinationResponse({webUrl: SHOP, primaryDomain: null}) as never,
+      )
+
+      const result = await resolveStore('123')
+
+      expect(result).toBe(SHOP)
+    })
+
+    test('throws AbortError mentioning the id when the destination is null', async () => {
+      vi.mocked(businessPlatformRequestDoc).mockResolvedValueOnce({currentUserAccount: {destination: null}} as never)
+
+      const err = await resolveStore('999').catch((error: unknown) => error)
+
+      expect(err).toBeInstanceOf(AbortError)
+      expect((err as AbortError).message).toContain('999')
+      expect((err as AbortError).message).toContain("Couldn't find")
+    })
+
+    test('throws AbortError mentioning the id when currentUserAccount is null', async () => {
+      vi.mocked(businessPlatformRequestDoc).mockResolvedValueOnce({currentUserAccount: null} as never)
+
+      const err = await resolveStore('999').catch((error: unknown) => error)
+
+      expect(err).toBeInstanceOf(AbortError)
+      expect((err as AbortError).message).toContain('999')
+      expect((err as AbortError).message).toContain("Couldn't find")
+    })
+
+    test('throws a distinct AbortError when the store is found but has no domain', async () => {
+      vi.mocked(businessPlatformRequestDoc).mockResolvedValueOnce(
+        destinationResponse({webUrl: null, primaryDomain: null}) as never,
+      )
+
+      const err = await resolveStore('123').catch((error: unknown) => error)
+
+      expect(err).toBeInstanceOf(AbortError)
+      expect((err as AbortError).message).toContain("couldn't determine its domain")
+    })
+
+    test('surfaces an auth failure as an AbortError mentioning the id', async () => {
+      vi.mocked(ensureAuthenticatedBusinessPlatform).mockRejectedValueOnce(new Error('boom'))
+
+      const err = await resolveStore('123').catch((error: unknown) => error)
+
+      expect(err).toBeInstanceOf(AbortError)
+      expect((err as AbortError).message).toContain('123')
+      expect((err as AbortError).message).toContain("Couldn't reach the Business Platform")
+    })
+
+    test('surfaces a request failure as an AbortError mentioning the id', async () => {
+      vi.mocked(businessPlatformRequestDoc).mockRejectedValueOnce(new Error('network error'))
+
+      const err = await resolveStore('123').catch((error: unknown) => error)
+
+      expect(err).toBeInstanceOf(AbortError)
+      expect((err as AbortError).message).toContain('123')
+      expect((err as AbortError).message).toContain("Couldn't reach the Business Platform")
+    })
+
+    test('trims surrounding whitespace before resolving a numeric id', async () => {
+      vi.mocked(businessPlatformRequestDoc).mockResolvedValueOnce(
+        destinationResponse({webUrl: `https://${SHOP}`, primaryDomain: null}) as never,
+      )
+
+      const result = await resolveStore('  123  ')
+
+      expect(result).toBe(SHOP)
+      expect(vi.mocked(businessPlatformRequestDoc).mock.calls[0]?.[0]).toMatchObject({
+        variables: {id: ENCODED_123},
+      })
+    })
+  })
+
+  describe('GID inputs', () => {
+    test('gid://shopify/Shop/<id> resolves the same as the numeric id', async () => {
+      vi.mocked(businessPlatformRequestDoc).mockResolvedValueOnce(
+        destinationResponse({webUrl: `https://${SHOP}`, primaryDomain: null}) as never,
+      )
+
+      const result = await resolveStore('gid://shopify/Shop/123')
+
+      expect(result).toBe(SHOP)
+      expect(vi.mocked(businessPlatformRequestDoc).mock.calls[0]?.[0]).toMatchObject({
+        variables: {id: ENCODED_123},
+      })
+    })
+
+    test('lowercase gid://shopify/shop/<id> is accepted', async () => {
+      vi.mocked(businessPlatformRequestDoc).mockResolvedValueOnce(
+        destinationResponse({webUrl: `https://${SHOP}`, primaryDomain: null}) as never,
+      )
+
+      const result = await resolveStore('gid://shopify/shop/123')
+
+      expect(result).toBe(SHOP)
+    })
+
+    test('non-Shop GID throws AbortError without any BP calls', async () => {
+      const err = await resolveStore('gid://shopify/Product/1').catch((error: unknown) => error)
+
+      expect(err).toBeInstanceOf(AbortError)
+      expect(businessPlatformRequestDoc).not.toHaveBeenCalled()
+    })
+
+    test('malformed GID throws AbortError without any BP calls', async () => {
+      const err = await resolveStore('gid://shopify/Shop/').catch((error: unknown) => error)
+
+      expect(err).toBeInstanceOf(AbortError)
+      expect(businessPlatformRequestDoc).not.toHaveBeenCalled()
+    })
+
+    test('GID with extra path segments throws AbortError without any BP calls', async () => {
+      const err = await resolveStore('gid://shopify/Shop/123/456').catch((error: unknown) => error)
+
+      expect(err).toBeInstanceOf(AbortError)
+      expect(businessPlatformRequestDoc).not.toHaveBeenCalled()
+    })
+
+    test('trims surrounding whitespace before resolving a GID', async () => {
+      vi.mocked(businessPlatformRequestDoc).mockResolvedValueOnce(
+        destinationResponse({webUrl: `https://${SHOP}`, primaryDomain: null}) as never,
+      )
+
+      const result = await resolveStore('  gid://shopify/Shop/123  ')
+
+      expect(result).toBe(SHOP)
+      expect(vi.mocked(businessPlatformRequestDoc).mock.calls[0]?.[0]).toMatchObject({
+        variables: {id: ENCODED_123},
+      })
+    })
+  })
+})

--- a/packages/store/src/cli/utilities/store-resolution.ts
+++ b/packages/store/src/cli/utilities/store-resolution.ts
@@ -1,0 +1,125 @@
+import {ResolveStoreById} from '../api/graphql/business-platform-destinations/generated/resolve-store-by-id.js'
+import {AbortError} from '@shopify/cli-kit/node/error'
+import {businessPlatformRequestDoc} from '@shopify/cli-kit/node/api/business-platform'
+import {ensureAuthenticatedBusinessPlatform} from '@shopify/cli-kit/node/session'
+import {normalizeStoreFqdn} from '@shopify/cli-kit/node/context/fqdn'
+import {encodeGid} from '@shopify/cli-kit/common/gid'
+import {extractHost} from '@shopify/cli-kit/common/url'
+import type {
+  ResolveStoreByIdQuery,
+  ResolveStoreByIdQueryVariables,
+} from '../api/graphql/business-platform-destinations/generated/resolve-store-by-id.js'
+
+// Matches a plain GraphQL global id of the shape `gid://shopify/<Type>/<numericId>`.
+// The `gid://` prefix is matched case-insensitively for friendliness; the captured
+// type segment is compared explicitly below. We do NOT reuse `numericIdFromGid` for
+// validation because it only extracts the trailing number and would happily accept a
+// non-Shop GID (for example `gid://shopify/Product/1`).
+const SHOP_GID_REGEX = /^gid:\/\/shopify\/([^/]+)\/(\d+)$/i
+
+/**
+ * Resolves a user-supplied `--store` value to a normalized myshopify.com FQDN.
+ *
+ * Accepted inputs:
+ * - A Shop GID (`gid://shopify/Shop/<id>`) — resolved to the store's domain via the
+ *   Business Platform.
+ * - A bare numeric store ID (`<id>`) — resolved the same way. A purely numeric value is
+ *   always treated as a store ID, never as an all-numeric subdomain; users with an
+ *   all-numeric subdomain must pass the full `<sub>.myshopify.com`.
+ * - Anything else — treated as a domain and normalized locally with no network calls,
+ *   preserving the previous behavior of the flag exactly.
+ *
+ * @param input - The raw value passed to `--store`.
+ * @returns A normalized myshopify.com FQDN.
+ */
+export async function resolveStore(input: string): Promise<string> {
+  const trimmed = input.trim()
+
+  if (/^gid:\/\//i.test(trimmed)) {
+    const match = SHOP_GID_REGEX.exec(trimmed)
+    if (!match || match[1]?.toLowerCase() !== 'shop') {
+      throw new AbortError(
+        `${trimmed} isn't a valid store identifier.`,
+        'Pass a Shop GID (gid://shopify/Shop/<id>), a numeric store ID, or a myshopify.com domain.',
+      )
+    }
+    return resolveShopIdToFqdn(match[2]!)
+  }
+
+  if (/^\d+$/.test(trimmed)) {
+    return resolveShopIdToFqdn(trimmed)
+  }
+
+  // Existing domain path: pure string normalization, no network.
+  return normalizeStoreFqdn(trimmed)
+}
+
+/**
+ * Resolves a numeric shop id to its myshopify.com FQDN via the Business Platform.
+ *
+ * The org-agnostic destinations API (`currentUserAccount`) exposes a single direct
+ * `destination(id:)` lookup, so resolution is one request — no org enumeration. A shop
+ * destination's `publicId` is the shop's numeric id, encoded as a `DestinationPublicID`.
+ *
+ * @param shopId - The bare numeric shop id.
+ * @returns The store's normalized myshopify.com host.
+ */
+async function resolveShopIdToFqdn(shopId: string): Promise<string> {
+  // The token_refresh handler transparently swaps in a fresh token if one expires
+  // mid-resolution.
+  const unauthorizedHandler = {
+    type: 'token_refresh' as const,
+    handler: async () => {
+      const newToken = await ensureAuthenticatedBusinessPlatform()
+      return {token: newToken}
+    },
+  }
+
+  // BP's DestinationPublicID *input* scalar expects a base64-encoded
+  // `gid://organization/ShopifyShop/<id>`, not the bare numeric id. Mirrors the encoding
+  // used by app-management-client.ts `encodedGidFromShopId`.
+  const id = encodeGid(`gid://organization/ShopifyShop/${shopId}`)
+
+  // Authenticate once and make the single direct lookup. If we can't reach the Business
+  // Platform at all (auth failure, network error), present a friendly AbortError rather than
+  // a raw stack trace. Existing AbortErrors pass through unchanged so we don't double-wrap.
+  let response: ResolveStoreByIdQuery
+  try {
+    const token = await ensureAuthenticatedBusinessPlatform()
+    response = await businessPlatformRequestDoc<ResolveStoreByIdQuery, ResolveStoreByIdQueryVariables>({
+      query: ResolveStoreById,
+      token,
+      variables: {id},
+      unauthorizedHandler,
+    })
+  } catch (error) {
+    if (error instanceof AbortError) throw error
+    throw new AbortError(
+      `Couldn't reach the Business Platform to resolve store ID ${shopId}.`,
+      'Pass the myshopify.com domain instead.',
+    )
+  }
+
+  const dest = response.currentUserAccount?.destination
+  if (!dest) {
+    throw new AbortError(
+      `Couldn't find a store with ID ${shopId} in your organizations.`,
+      "Verify the ID, pass the myshopify.com domain instead, or make sure you're signed in to an account with access to the store.",
+    )
+  }
+
+  // Read the host from `webUrl` FIRST: it is the canonical `*.myshopify.com` URL. Only fall
+  // back to `primaryDomain`, which MAY be a merchant custom domain — preferring it would
+  // resolve a custom-domain store to e.g. `www.example.com` and break downstream handling.
+  // Note: `extractHost` lowercases the host, whereas the domain-input path uses
+  // `normalizeStoreFqdn`, which preserves case. This asymmetry is intentional and harmless
+  // for canonical BP-resolved myshopify.com domains, which are already lowercase.
+  const domain = extractHost(dest.webUrl) ?? (dest.primaryDomain ? extractHost(dest.primaryDomain) : undefined)
+  if (!domain) {
+    throw new AbortError(
+      `Found the store with ID ${shopId} but couldn't determine its domain.`,
+      'Pass the myshopify.com domain directly.',
+    )
+  }
+  return domain
+}


### PR DESCRIPTION
## Summary

The shared `--store` flag (defined in the `store` package) previously accepted **only** myshopify.com domains. Per the [project brief](https://docs.google.com/document/d/1mVZBvOBcoFzqdYWrDyfF6MloQhhaNNE1lgVOtWsMgxI/edit?tab=t.7kido7i4t7du#heading=h.oli0001xgl1v), it should also accept numeric store IDs and Shop GIDs. This PR adds centralized resolution so **all** `store` commands accept all three input forms with no per-command changes:

- a **myshopify.com domain** — e.g. `shop.myshopify.com`, `shop`, or an admin URL (unchanged behavior, zero network calls)
- a **numeric store ID** — e.g. `123`
- a **Shop GID** — e.g. `gid://shopify/Shop/123`

## How it works

Resolution lives in a new `resolveStore()` utility, invoked from a `StoreCommand.parse` post-parse hook:

- **GID** (`/^gid:\/\//`) → validated against `gid://shopify/Shop/<id>`; non-Shop GIDs are rejected.
- **bare numeric** (`/^\d+$/`) → treated as a store ID.
- **anything else** → treated as a domain and normalized locally via the existing `normalizeStoreFqdn` (no network).

IDs and GIDs resolve to the store's domain through **a single, org-agnostic Business Platform "destinations" call**:

```graphql
currentUserAccount { destination(id: $id) { webUrl primaryDomain } }
```

This works because a shop destination's `publicId` *is* the shop's `shopify_shop_id` (backend `destination/shop.rb`: `public_id: shop.shopify_shop_id`). The numeric id / Shop GID is encoded into the `DestinationPublicID` input — `base64("gid://organization/ShopifyShop/<id>")` — and the canonical `*.myshopify.com` host is read from the destination's `webUrl`.

## Is this easier or harder than what we do now?

**Slightly harder** than the domain path — that path is pure string normalization with zero network calls, whereas an ID/GID needs Business Platform auth and one GraphQL request plus new codegen. But it's only marginally so: it's a *single* request (see the design note below), and the domain path is preserved exactly and stays network-free, so the added cost is paid only when an ID or GID is actually passed.

## How do we distinguish the formats?

- **GIDs are unambiguous** — they begin with `gid://` and contain slashes, which a domain never does. (As the brief notes, we don't need to worry about GID-style domains.)
- A **bare run of digits** is treated as a store ID (see D1).
- **Everything else** is a domain.

## Decisions made (flagged for your review)

The task said to make informed decisions on points of ambiguity and document them here rather than ask upfront:

- **D1 — A bare all-numeric input is a store ID, never a subdomain.** Domains *can* be all-numeric (e.g. `123.myshopify.com`), but a bare `123` resolves as a store ID. A user with an all-numeric subdomain must pass the full `123.myshopify.com`. Rationale: store IDs are the headline new capability and the common case; the workaround for the rare all-numeric subdomain is trivial and the flag help text spells out the accepted forms.
- **D2 — Resolution runs in `StoreCommand.parse`, not in the flag's `parse` callback.** A flag-level `parse` fires *before* oclif validates the other flags, so a user with an unrelated flag typo would get an auth prompt *ahead of* the plain validation error. Moving resolution to a post-parse hook (mirroring `BaseCommand.parse`) means all flag validation happens first, and it keeps the logic centralized — no command has to opt in.
- **D3 — Domains stay zero-network; only IDs/GIDs contact the Business Platform.** Preserves existing latency and offline behavior for the overwhelmingly common domain case.
- **D4 — Single org-agnostic `destination(id:)` lookup (no org enumeration).** ⭐ *Updated after review.* An earlier revision enumerated the user's organizations and probed each with `accessibleShop(id:)` (org-scoped API) — an N+1 loop. After confirming against the BP backend that `currentUserAccount.destination(id:)` is org-agnostic and that a shop's `publicId == shopify_shop_id`, this is now a **single request** — no enumeration, no per-org loop.
- **D5 — Resolve the domain from `webUrl`, falling back to `primaryDomain`.** A destination's `webUrl` (= `shop.uri`) is the canonical `*.myshopify.com` URL; its `primaryDomain` (= `shop.primary_domain || shop.uri`) **may be a merchant custom domain**. Reading `webUrl` first avoids resolving a custom-domain store to e.g. `www.example.com`. *(This replaces the previous D5, the "first:100 org cap", which no longer exists now that there's no enumeration.)*
- **D6 — Non-Shop GIDs are rejected** (e.g. `gid://shopify/Product/1`) with a friendly error, rather than extracting the trailing number and guessing intent.
- **D7 — `DestinationPublicID` / `ShopifyShopID` input encoding.** These BP *input* scalars expect a **base64-encoded GID** (`gid://organization/ShopifyShop/<id>`), even though shop ids **serialize in responses as the bare numeric**. We encode via `encodeGid`, mirroring `app-management-client.ts`'s `encodedGidFromShopId`. (An in-repo comment describing the *output* format initially misled the research here; caught in cross-provider review.)
- **D8 — Local auth-cache fast-path deferred.** The `store auth` session cache is keyed by domain and stores no shop ID today, so it can't map ID→domain. There's separate in-flight work to allow iterating all cached stores; once that lands, we'll add the store ID to the cache and short-circuit resolution for already-authed stores. Punted for now — with resolution down to one cheap call, the payoff is small.

## ⚠️ Verification gap — please QA before GA

The resolver is unit-tested against a **mocked** Business Platform (21 tests covering the domain / numeric / GID paths, the input encoding, the `webUrl`-over-`primaryDomain` priority, not-found, no-domain, auth/network failure, and whitespace trimming). It has **not** been exercised against the live Business Platform. The `DestinationPublicID` input encoding (D7) and the `destination(id:)` response shape should be confirmed against a real store before this ships.

## Testing

- `store` package: type-check ✅ · lint ✅ · unit tests ✅ (21/21 in `store-resolution.test.ts`)
- The oclif manifest, `packages/cli/README.md`, and the shopify.dev reference docs were regenerated for the flag-description change; the flag descriptions match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
