### PR TITLE
Skip config link org picker in E2E

### DIFF
--- a/packages/app/src/cli/commands/app/config/link.ts
+++ b/packages/app/src/cli/commands/app/config/link.ts
@@ -2,6 +2,7 @@ import {appFlags} from '../../../flags.js'
 import {linkedAppContext} from '../../../services/app-context.js'
 import link, {LinkOptions} from '../../../services/app/config/link.js'
 import AppLinkedCommand, {AppLinkedCommandOutput} from '../../../utilities/app-linked-command.js'
+import {Flags} from '@oclif/core'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
 
 export default class ConfigLink extends AppLinkedCommand {
@@ -17,6 +18,11 @@ export default class ConfigLink extends AppLinkedCommand {
   static flags = {
     ...globalFlags,
     ...appFlags,
+    'organization-id': Flags.string({
+      hidden: true,
+      env: 'SHOPIFY_FLAG_ORGANIZATION_ID',
+      exclusive: ['client-id'],
+    }),
   }
 
   public async run(): Promise<AppLinkedCommandOutput> {
@@ -25,6 +31,7 @@ export default class ConfigLink extends AppLinkedCommand {
     const options: LinkOptions = {
       directory: flags.path,
       apiKey: flags['client-id'],
+      organizationId: flags['organization-id'],
       configName: flags.config,
     }
 

--- a/packages/app/src/cli/services/app/config/link.ts
+++ b/packages/app/src/cli/services/app/config/link.ts
@@ -122,7 +122,11 @@ async function selectOrCreateRemoteAppToLinkTo(options: LinkOptions): Promise<{
     }
   }
 
-  const remoteApp = await fetchOrCreateOrganizationApp({...creationOptions, directory: appDirectory})
+  const remoteApp = await fetchOrCreateOrganizationApp({
+    ...creationOptions,
+    directory: appDirectory,
+    organizationId: options.organizationId,
+  })
 
   const developerPlatformClient = remoteApp.developerPlatformClient
 

--- a/packages/app/src/cli/services/context.ts
+++ b/packages/app/src/cli/services/context.ts
@@ -1,5 +1,5 @@
 import {selectOrCreateApp} from './dev/select-app.js'
-import {fetchOrganizations} from './dev/fetch.js'
+import {fetchOrganizations, fetchOrgFromId} from './dev/fetch.js'
 import {ensureDeploymentIdsPresence} from './context/identifiers.js'
 import {createExtension} from './dev/create-extension.js'
 import {CachedAppInfo} from './local-storage.js'
@@ -298,8 +298,12 @@ function includeConfigOnDeployPrompt(configPath: string): Promise<boolean> {
   })
 }
 
-export async function fetchOrCreateOrganizationApp(options: CreateAppOptions): Promise<OrganizationApp> {
-  const org = await selectOrg()
+export async function fetchOrCreateOrganizationApp(
+  options: CreateAppOptions & {organizationId?: string},
+): Promise<OrganizationApp> {
+  const org = options.organizationId
+    ? await fetchOrgFromId(options.organizationId, selectDeveloperPlatformClient())
+    : await selectOrg()
   const developerPlatformClient = selectDeveloperPlatformClient({organization: org})
   const {organization, apps, hasMorePages} = await developerPlatformClient.orgAndApps(org.id)
   const remoteApp = await selectOrCreateApp(apps, hasMorePages, organization, developerPlatformClient, options)

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -469,6 +469,17 @@
           "name": "no-color",
           "type": "boolean"
         },
+        "organization-id": {
+          "env": "SHOPIFY_FLAG_ORGANIZATION_ID",
+          "exclusive": [
+            "client-id"
+          ],
+          "hasDynamicHelp": false,
+          "hidden": true,
+          "multiple": false,
+          "name": "organization-id",
+          "type": "option"
+        },
         "path": {
           "description": "The path to your app directory.",
           "env": "SHOPIFY_FLAG_PATH",

--- a/packages/e2e/setup/app.ts
+++ b/packages/e2e/setup/app.ts
@@ -230,7 +230,7 @@ export async function versionsList(
 /**
  * Run `app config link` to create a brand-new app on Shopify interactively.
  * Answers the prompts:
- *   "Which organization is this work for?" → filter by orgId → Enter
+ *   --organization-id flag skips the organization picker
  *   "Create this project as a new app on Shopify?" → Yes (default)
  *   "App name" → appName
  *   "Configuration file name" → skipped via `--config` flag
@@ -257,7 +257,7 @@ export async function configLink(
     configName?: string
   },
 ): Promise<ExecResult> {
-  const args = ['app', 'config', 'link']
+  const args = ['app', 'config', 'link', '--organization-id', ctx.orgId]
   // Pass configName as --config flag. link.ts → loadConfigurationFileName skips
   // the "Configuration file name" prompt when options.configName is set, which
   // also side-steps a painful interactive quirk: that prompt uses
@@ -279,42 +279,18 @@ export async function configLink(
   const settle = (ms = 50) => new Promise<void>((resolve) => setTimeout(resolve, ms))
 
   try {
-    // The first prompt is either the multi-org selector or — when the account
-    // has only one org, or none of the orgs have existing apps — we jump
-    // straight to `createAsNewAppPrompt`. Race all three; the loser
-    // waitForOutput calls are cancelled via AbortSignal so their timers and
-    // outputWaiter entries are freed immediately when the winner resolves.
+    // With --organization-id, the first prompt is either "Create this project"
+    // when the org has existing apps, or "App name" when it does not. Race both;
+    // the loser waitForOutput call is cancelled via AbortSignal so its timer and
+    // outputWaiter entry are freed immediately when the winner resolves.
     const firstPrompt = await raceWaiters((signal) => [
-      proc.waitForOutput('Which organization', {timeoutMs: CLI_TIMEOUT.medium, signal}).then(() => 'org' as const),
       proc
         .waitForOutput('Create this project as a new app', {timeoutMs: CLI_TIMEOUT.medium, signal})
         .then(() => 'create' as const),
       proc.waitForOutput('App name', {timeoutMs: CLI_TIMEOUT.medium, signal}).then(() => 'appName' as const),
     ])
 
-    if (firstPrompt === 'org') {
-      // Type the orgId to filter the autocomplete prompt to exactly one match.
-      // selectOrganizationPrompt's label includes `(${org.id})` when duplicate
-      // org names exist (which is true for the e2e test account), so substring
-      // matching on the numeric ID is unique. Avoids relying on MRU ordering.
-      await settle()
-      proc.ptyProcess.write(ctx.orgId)
-      await settle()
-      proc.sendKey('\r')
-      // After org selection the CLI fetches apps for the chosen org. If
-      // the org has existing apps → "Create this project" prompt. If it has
-      // zero apps → selectOrCreateApp skips straight to appNamePrompt.
-      const next = await raceWaiters((signal) => [
-        proc
-          .waitForOutput('Create this project as a new app', {timeoutMs: CLI_TIMEOUT.medium, signal})
-          .then(() => 'create' as const),
-        proc.waitForOutput('App name', {timeoutMs: CLI_TIMEOUT.medium, signal}).then(() => 'appName' as const),
-      ])
-      if (next === 'create') {
-        await settle()
-        proc.sendKey('\r')
-      }
-    } else if (firstPrompt === 'create') {
+    if (firstPrompt === 'create') {
       await settle()
       proc.sendKey('\r')
     }


### PR DESCRIPTION
## What

Adds a hidden `--organization-id` flag to `shopify app config link` and uses it from the E2E `configLink` helper.

## Why

The current E2E helper drives the organization autocomplete by typing `E2E_ORG_ID`. In CI the prompt can get stuck at the organization picker with `No results found`, so the app deploy E2E test never reaches the `Create this project as a new app` prompt and times out.

Passing the organization ID directly makes this setup path deterministic and avoids relying on autocomplete filtering/selection in CI.

## Testing

- `pnpm vitest run packages/app/src/cli/commands/app/config/link.test.ts packages/app/src/cli/services/app/config/link.test.ts`
- `pnpm --filter @shopify/app lint`
- `pnpm --filter e2e lint`
- `pnpm refresh-manifests` attempted, but local build is blocked by existing `cli-kit:build` GraphiQL dependency errors. I manually updated `packages/cli/oclif.manifest.json` for the hidden flag.
