### PR TITLE
Fix Snapit action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Force snapshot changeset
         run: "mv .changeset/force-snapshot-build.md.ignore .changeset/force-snapshot-build.md"
       - name: Create snapshot version
-        uses: Shopify/snapit@0fec17dd6a0ae66f2672738dc8086f394218436c # registry-and-package-manager
+        uses: Shopify/snapit@2a7ca29133cfeb2c8703654d54bc6dbc565caa69 # registry-and-package-manager
         with:
           comment_is_global: 'true'
           comment_packages: '@shopify/cli'


### PR DESCRIPTION
## Why

Changesets was updated and it doesn't accept anymore some flags we are using from the snapit workflow: `changeset publish --no-git-tags --snapshot --tag snapshot`.

Example: https://github.com/Shopify/cli/actions/runs/27546316888/job/81420516158

## What

Updates the Release workflow Snapit action pin to the [most recent commit](https://github.com/Shopify/snapit/pull/41/changes/2a7ca29133cfeb2c8703654d54bc6dbc565caa69).

That commit removes the deprecated publish flags and uses `changeset publish --no-git-tag --tag snapshot`.