### PR TITLE
Add plan, feature-preview, and with-demo-data flags to `store create dev`

### DIFF
--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -5942,6 +5942,14 @@
       "descriptionWithMarkdown": "Creates a new app development store in your organization.",
       "enableJsonFlag": false,
       "flags": {
+        "feature-preview": {
+          "description": "The handle of a feature preview to enable on the new development store.",
+          "env": "SHOPIFY_FLAG_STORE_FEATURE_PREVIEW",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "feature-preview",
+          "type": "option"
+        },
         "json": {
           "allowNo": false,
           "char": "j",
@@ -5976,12 +5984,34 @@
           "name": "organization-id",
           "type": "option"
         },
+        "plan": {
+          "description": "The Shopify plan to use for the new development store.",
+          "env": "SHOPIFY_FLAG_STORE_PLAN",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "plan",
+          "options": [
+            "basic",
+            "grow",
+            "advanced",
+            "plus"
+          ],
+          "required": true,
+          "type": "option"
+        },
         "verbose": {
           "allowNo": false,
           "description": "Increase the verbosity of the output.",
           "env": "SHOPIFY_FLAG_VERBOSE",
           "hidden": false,
           "name": "verbose",
+          "type": "boolean"
+        },
+        "with-demo-data": {
+          "allowNo": false,
+          "description": "Populate the new development store with demo data.",
+          "env": "SHOPIFY_FLAG_STORE_WITH_DEMO_DATA",
+          "name": "with-demo-data",
           "type": "boolean"
         }
       },

--- a/packages/store/src/cli/api/graphql/business-platform-organizations/generated/create_app_development_store.ts
+++ b/packages/store/src/cli/api/graphql/business-platform-organizations/generated/create_app_development_store.ts
@@ -7,6 +7,7 @@ export type CreateAppDevelopmentStoreMutationVariables = Types.Exact<{
   shopName: Types.Scalars['String']['input']
   priceLookupKey: Types.Scalars['String']['input']
   prepopulateTestData?: Types.InputMaybe<Types.Scalars['Boolean']['input']>
+  developerPreviewHandle?: Types.InputMaybe<Types.Scalars['String']['input']>
 }>
 
 export type CreateAppDevelopmentStoreMutation = {
@@ -40,6 +41,11 @@ export const CreateAppDevelopmentStore = {
           variable: {kind: 'Variable', name: {kind: 'Name', value: 'prepopulateTestData'}},
           type: {kind: 'NamedType', name: {kind: 'Name', value: 'Boolean'}},
         },
+        {
+          kind: 'VariableDefinition',
+          variable: {kind: 'Variable', name: {kind: 'Name', value: 'developerPreviewHandle'}},
+          type: {kind: 'NamedType', name: {kind: 'Name', value: 'String'}},
+        },
       ],
       selectionSet: {
         kind: 'SelectionSet',
@@ -62,6 +68,11 @@ export const CreateAppDevelopmentStore = {
                 kind: 'Argument',
                 name: {kind: 'Name', value: 'prepopulateTestData'},
                 value: {kind: 'Variable', name: {kind: 'Name', value: 'prepopulateTestData'}},
+              },
+              {
+                kind: 'Argument',
+                name: {kind: 'Name', value: 'developerPreviewHandle'},
+                value: {kind: 'Variable', name: {kind: 'Name', value: 'developerPreviewHandle'}},
               },
             ],
             selectionSet: {

--- a/packages/store/src/cli/api/graphql/business-platform-organizations/mutations/create_app_development_store.graphql
+++ b/packages/store/src/cli/api/graphql/business-platform-organizations/mutations/create_app_development_store.graphql
@@ -1,8 +1,9 @@
-mutation CreateAppDevelopmentStore($shopName: String!, $priceLookupKey: String!, $prepopulateTestData: Boolean) {
+mutation CreateAppDevelopmentStore($shopName: String!, $priceLookupKey: String!, $prepopulateTestData: Boolean, $developerPreviewHandle: String) {
   createAppDevelopmentStore(
     shopName: $shopName
     priceLookupKey: $priceLookupKey
     prepopulateTestData: $prepopulateTestData
+    developerPreviewHandle: $developerPreviewHandle
   ) {
     shopAdminUrl
     shopDomain

--- a/packages/store/src/cli/commands/store/create/dev.test.ts
+++ b/packages/store/src/cli/commands/store/create/dev.test.ts
@@ -16,38 +16,81 @@ vi.mock('@shopify/cli-kit/node/output', async (importOriginal) => {
 
 describe('store create dev command', () => {
   test('passes parsed flags through to the service', async () => {
-    await StoreCreateDev.run(['--name', 'my-test-store'])
+    await StoreCreateDev.run(['--name', 'my-test-store', '--plan', 'plus'])
 
     expect(createDevStore).toHaveBeenCalledWith({
       name: 'my-test-store',
       organizationId: undefined,
+      plan: 'plus',
+      featurePreview: undefined,
+      withDemoData: false,
       json: false,
     })
   })
 
   test('passes organization-id flag through to the service', async () => {
-    await StoreCreateDev.run(['--name', 'my-test-store', '--organization-id', '12345'])
+    await StoreCreateDev.run(['--name', 'my-test-store', '--organization-id', '12345', '--plan', 'plus'])
 
     expect(createDevStore).toHaveBeenCalledWith({
       name: 'my-test-store',
       organizationId: 12345,
+      plan: 'plus',
+      featurePreview: undefined,
+      withDemoData: false,
       json: false,
     })
   })
 
   test('passes json flag through to the service', async () => {
-    await StoreCreateDev.run(['--name', 'my-test-store', '--json'])
+    await StoreCreateDev.run(['--name', 'my-test-store', '--json', '--plan', 'plus'])
 
     expect(createDevStore).toHaveBeenCalledWith({
       name: 'my-test-store',
       organizationId: undefined,
+      plan: 'plus',
+      featurePreview: undefined,
+      withDemoData: false,
       json: true,
     })
+  })
+
+  test('passes plan, feature-preview, and with-demo-data flags through to the service', async () => {
+    await StoreCreateDev.run([
+      '--name',
+      'my-test-store',
+      '--plan',
+      'basic',
+      '--feature-preview',
+      'extended_variants',
+      '--with-demo-data',
+    ])
+
+    expect(createDevStore).toHaveBeenCalledWith({
+      name: 'my-test-store',
+      organizationId: undefined,
+      plan: 'basic',
+      featurePreview: 'extended_variants',
+      withDemoData: true,
+      json: false,
+    })
+  })
+
+  test('rejects an invalid plan value without calling the service', async () => {
+    await expect(StoreCreateDev.run(['--name', 'my-test-store', '--plan', 'enterprise'])).rejects.toThrow()
+    expect(createDevStore).not.toHaveBeenCalled()
+  })
+
+  test('requires the plan flag', async () => {
+    await expect(StoreCreateDev.run(['--name', 'my-test-store'])).rejects.toThrow()
+    expect(createDevStore).not.toHaveBeenCalled()
   })
 
   test('defines the expected flags', () => {
     expect(StoreCreateDev.flags.name).toBeDefined()
     expect(StoreCreateDev.flags['organization-id']).toBeDefined()
+    expect(StoreCreateDev.flags.plan).toBeDefined()
+    expect(StoreCreateDev.flags['feature-preview']).toBeDefined()
+    expect(StoreCreateDev.flags['with-demo-data']).toBeDefined()
     expect(StoreCreateDev.flags.json).toBeDefined()
   })
 
@@ -57,7 +100,9 @@ describe('store create dev command', () => {
       throw new Error('process.exit')
     }) as never)
 
-    await expect(StoreCreateDev.run(['--name', 'my-test-store', '--json'])).rejects.toThrow('process.exit')
+    await expect(StoreCreateDev.run(['--name', 'my-test-store', '--plan', 'plus', '--json'])).rejects.toThrow(
+      'process.exit',
+    )
 
     const call = vi.mocked(outputResult).mock.calls[0]![0] as string
     const parsed = JSON.parse(call)
@@ -75,14 +120,14 @@ describe('store create dev command', () => {
   test('does not output JSON for non-AbortError even when --json is active', async () => {
     vi.mocked(createDevStore).mockRejectedValueOnce(new Error('unexpected'))
 
-    await expect(StoreCreateDev.run(['--name', 'my-test-store', '--json'])).rejects.toThrow()
+    await expect(StoreCreateDev.run(['--name', 'my-test-store', '--plan', 'plus', '--json'])).rejects.toThrow()
     expect(vi.mocked(outputResult)).not.toHaveBeenCalled()
   })
 
   test('does not output JSON for AbortError when --json is not active', async () => {
     vi.mocked(createDevStore).mockRejectedValueOnce(new AbortError('Something went wrong'))
 
-    await expect(StoreCreateDev.run(['--name', 'my-test-store'])).rejects.toThrow()
+    await expect(StoreCreateDev.run(['--name', 'my-test-store', '--plan', 'plus'])).rejects.toThrow()
     expect(vi.mocked(outputResult)).not.toHaveBeenCalled()
   })
 })

--- a/packages/store/src/cli/commands/store/create/dev.ts
+++ b/packages/store/src/cli/commands/store/create/dev.ts
@@ -1,4 +1,5 @@
 import {createDevStore} from '../../../services/store/create/dev.js'
+import {devStorePlanHandles, DevStorePlan} from '../../../services/store/constants.js'
 import {storeFlags} from '../../../flags.js'
 import Command from '@shopify/cli-kit/node/base-command'
 import {globalFlags, jsonFlag} from '@shopify/cli-kit/node/cli'
@@ -24,6 +25,21 @@ export default class StoreCreateDev extends Command {
       env: 'SHOPIFY_FLAG_STORE_NAME',
     }),
     'organization-id': storeFlags['organization-id'],
+    plan: Flags.string({
+      description: 'The Shopify plan to use for the new development store.',
+      options: devStorePlanHandles,
+      required: true,
+      env: 'SHOPIFY_FLAG_STORE_PLAN',
+    }),
+    'feature-preview': Flags.string({
+      description: 'The handle of a feature preview to enable on the new development store.',
+      env: 'SHOPIFY_FLAG_STORE_FEATURE_PREVIEW',
+    }),
+    'with-demo-data': Flags.boolean({
+      description: 'Populate the new development store with demo data.',
+      default: false,
+      env: 'SHOPIFY_FLAG_STORE_WITH_DEMO_DATA',
+    }),
   }
 
   async run(): Promise<void> {
@@ -32,6 +48,9 @@ export default class StoreCreateDev extends Command {
       await createDevStore({
         name: flags.name,
         organizationId: flags['organization-id'],
+        plan: flags.plan as DevStorePlan,
+        featurePreview: flags['feature-preview'],
+        withDemoData: flags['with-demo-data'],
         json: flags.json,
       })
     } catch (error) {

--- a/packages/store/src/cli/services/store/constants.ts
+++ b/packages/store/src/cli/services/store/constants.ts
@@ -1,0 +1,44 @@
+/**
+ * Plan data shared by `store create dev` and `store info`.
+ *
+ * The two commands need the plan taxonomy in opposite directions, so each direction is its
+ * own explicit map below. They're co-located here so the overlap is easy to keep in sync,
+ * but deliberately written out in full rather than derived from one another — the explicit
+ * form is far easier to read and reason about than any clever de-duplication.
+ */
+
+/**
+ * `store create dev`: each user-facing `--plan` handle → the price lookup key the Business
+ * Platform `createAppDevelopmentStore` mutation expects. The backend argument is a plain
+ * string with no reusable enum, so this is the canonical source. The handles mirror the
+ * labels shown in the Dev Dashboard store-creation form.
+ */
+export const DEV_STORE_PLANS = {
+  basic: 'BASIC_APP_DEVELOPMENT',
+  grow: 'PROFESSIONAL_APP_DEVELOPMENT',
+  advanced: 'UNLIMITED_APP_DEVELOPMENT',
+  plus: 'SHOPIFY_PLUS_APP_DEVELOPMENT',
+} as const
+
+/** A public, user-facing plan handle accepted by `--plan`. */
+export type DevStorePlan = keyof typeof DEV_STORE_PLANS
+
+/** The accepted `--plan` values, in display order (the keys of {@link DEV_STORE_PLANS}). */
+export const devStorePlanHandles = Object.keys(DEV_STORE_PLANS) as DevStorePlan[]
+
+/**
+ * `store info`: a raw BP plan name (`Shop.planName`) → the public plan handle it reports.
+ * The raw names are Shopify-internal and intentionally differ from the marketing names
+ * (e.g. `professional` is Grow, `unlimited` is Advanced). The public handle is also accepted
+ * as a key, because the exact form BP returns isn't pinned down by the schema. Anything not
+ * listed here is treated as unrecognized and omitted from the output.
+ */
+export const PLAN_HANDLES_BY_NAME: {[planName: string]: string} = {
+  basic: 'basic',
+  professional: 'grow',
+  grow: 'grow',
+  unlimited: 'advanced',
+  advanced: 'advanced',
+  shopify_plus: 'plus',
+  plus: 'plus',
+}

--- a/packages/store/src/cli/services/store/create/dev.test.ts
+++ b/packages/store/src/cli/services/store/create/dev.test.ts
@@ -64,7 +64,7 @@ describe('createDevStore', () => {
         organization: {id: '123', storeCreation: {status: 'COMPLETE'}},
       })
 
-    await createDevStore({name: 'test-store', json: false})
+    await createDevStore({name: 'test-store', plan: 'plus', json: false})
 
     expect(selectOrg).toHaveBeenCalledWith(undefined)
     expect(ensureAuthenticatedBusinessPlatform).toHaveBeenCalled()
@@ -77,6 +77,7 @@ describe('createDevStore', () => {
           shopName: 'test-store',
           priceLookupKey: 'SHOPIFY_PLUS_APP_DEVELOPMENT',
           prepopulateTestData: false,
+          developerPreviewHandle: undefined,
         },
       }),
     )
@@ -87,6 +88,79 @@ describe('createDevStore', () => {
     )
   })
 
+  test.each([
+    ['basic', 'BASIC_APP_DEVELOPMENT'],
+    ['grow', 'PROFESSIONAL_APP_DEVELOPMENT'],
+    ['advanced', 'UNLIMITED_APP_DEVELOPMENT'],
+    ['plus', 'SHOPIFY_PLUS_APP_DEVELOPMENT'],
+  ] as const)('maps the %s plan to the %s price lookup key', async (plan, priceLookupKey) => {
+    vi.mocked(businessPlatformOrganizationsRequestDoc)
+      .mockResolvedValueOnce(defaultMutationResult)
+      .mockResolvedValueOnce({
+        organization: {id: '123', storeCreation: {status: 'COMPLETE'}},
+      })
+
+    await createDevStore({name: 'test-store', plan, json: false})
+
+    expect(businessPlatformOrganizationsRequestDoc).toHaveBeenCalledWith(
+      expect.objectContaining({
+        variables: expect.objectContaining({priceLookupKey}),
+      }),
+    )
+  })
+
+  test('passes the feature preview as developerPreviewHandle', async () => {
+    vi.mocked(businessPlatformOrganizationsRequestDoc)
+      .mockResolvedValueOnce(defaultMutationResult)
+      .mockResolvedValueOnce({
+        organization: {id: '123', storeCreation: {status: 'COMPLETE'}},
+      })
+
+    await createDevStore({name: 'test-store', plan: 'plus', featurePreview: 'extended_variants', json: false})
+
+    expect(businessPlatformOrganizationsRequestDoc).toHaveBeenCalledWith(
+      expect.objectContaining({
+        variables: expect.objectContaining({developerPreviewHandle: 'extended_variants'}),
+      }),
+    )
+  })
+
+  test('passes prepopulateTestData when --with-demo-data is set', async () => {
+    vi.mocked(businessPlatformOrganizationsRequestDoc)
+      .mockResolvedValueOnce(defaultMutationResult)
+      .mockResolvedValueOnce({
+        organization: {id: '123', storeCreation: {status: 'COMPLETE'}},
+      })
+
+    await createDevStore({name: 'test-store', plan: 'plus', withDemoData: true, json: false})
+
+    expect(businessPlatformOrganizationsRequestDoc).toHaveBeenCalledWith(
+      expect.objectContaining({
+        variables: expect.objectContaining({prepopulateTestData: true}),
+      }),
+    )
+  })
+
+  test('includes plan, feature preview, and demo data in JSON output', async () => {
+    vi.mocked(businessPlatformOrganizationsRequestDoc)
+      .mockResolvedValueOnce(defaultMutationResult)
+      .mockResolvedValueOnce({
+        organization: {id: '123', storeCreation: {status: 'COMPLETE'}},
+      })
+
+    await createDevStore({
+      name: 'test-store',
+      plan: 'basic',
+      featurePreview: 'extended_variants',
+      withDemoData: true,
+      json: true,
+    })
+
+    expect(outputResult).toHaveBeenCalledWith(expect.stringContaining('"plan": "basic"'))
+    expect(outputResult).toHaveBeenCalledWith(expect.stringContaining('"featurePreview": "extended_variants"'))
+    expect(outputResult).toHaveBeenCalledWith(expect.stringContaining('"demoData": true'))
+  })
+
   test('outputs JSON when --json flag is set', async () => {
     vi.mocked(businessPlatformOrganizationsRequestDoc)
       .mockResolvedValueOnce(defaultMutationResult)
@@ -94,7 +168,7 @@ describe('createDevStore', () => {
         organization: {id: '123', storeCreation: {status: 'COMPLETE'}},
       })
 
-    await createDevStore({name: 'test-store', json: true})
+    await createDevStore({name: 'test-store', plan: 'plus', json: true})
 
     expect(outputResult).toHaveBeenCalledWith(expect.stringContaining('"domain": "test-store.myshopify.com"'))
     expect(renderSuccess).not.toHaveBeenCalled()
@@ -105,7 +179,9 @@ describe('createDevStore', () => {
       createAppDevelopmentStore: null,
     })
 
-    await expect(createDevStore({name: 'test-store', json: false})).rejects.toThrow('unexpected empty response')
+    await expect(createDevStore({name: 'test-store', plan: 'plus', json: false})).rejects.toThrow(
+      'unexpected empty response',
+    )
   })
 
   test('throws AbortError when mutation returns userErrors', async () => {
@@ -117,7 +193,7 @@ describe('createDevStore', () => {
       },
     })
 
-    await expect(createDevStore({name: 'test-store', json: false})).rejects.toThrow('Name is taken')
+    await expect(createDevStore({name: 'test-store', plan: 'plus', json: false})).rejects.toThrow('Name is taken')
   })
 
   test('throws AbortError when mutation returns no shopDomain', async () => {
@@ -129,7 +205,9 @@ describe('createDevStore', () => {
       },
     })
 
-    await expect(createDevStore({name: 'test-store', json: false})).rejects.toThrow('no shop domain was returned')
+    await expect(createDevStore({name: 'test-store', plan: 'plus', json: false})).rejects.toThrow(
+      'no shop domain was returned',
+    )
   })
 
   test('throws AbortError when polling returns FAILED status', async () => {
@@ -139,7 +217,7 @@ describe('createDevStore', () => {
         organization: {id: '123', storeCreation: {status: 'FAILED'}},
       })
 
-    await expect(createDevStore({name: 'test-store', json: false})).rejects.toThrow(
+    await expect(createDevStore({name: 'test-store', plan: 'plus', json: false})).rejects.toThrow(
       'Store creation failed with status: FAILED',
     )
   })
@@ -151,7 +229,7 @@ describe('createDevStore', () => {
         organization: {id: '123', storeCreation: {status: 'TIMED_OUT'}},
       })
 
-    await expect(createDevStore({name: 'test-store', json: false})).rejects.toThrow(
+    await expect(createDevStore({name: 'test-store', plan: 'plus', json: false})).rejects.toThrow(
       'Store creation failed with status: TIMED_OUT',
     )
   })
@@ -163,7 +241,7 @@ describe('createDevStore', () => {
         organization: {id: '123', storeCreation: {status: 'USER_ERROR'}},
       })
 
-    await expect(createDevStore({name: 'test-store', json: false})).rejects.toThrow(
+    await expect(createDevStore({name: 'test-store', plan: 'plus', json: false})).rejects.toThrow(
       'Store creation failed with status: USER_ERROR',
     )
   })
@@ -179,7 +257,7 @@ describe('createDevStore', () => {
 
     vi.mocked(businessPlatformOrganizationsRequestDoc).mockResolvedValueOnce(defaultMutationResult)
 
-    await expect(createDevStore({name: 'test-store', json: false})).rejects.toThrow(
+    await expect(createDevStore({name: 'test-store', plan: 'plus', json: false})).rejects.toThrow(
       'Store creation timed out after 5 minutes',
     )
   })
@@ -191,7 +269,7 @@ describe('createDevStore', () => {
         organization: {id: '123', storeCreation: {status: 'COMPLETE'}},
       })
 
-    await createDevStore({name: 'test-store', organizationId: 456, json: false})
+    await createDevStore({name: 'test-store', plan: 'plus', organizationId: 456, json: false})
 
     expect(selectOrg).toHaveBeenCalledWith('456')
   })
@@ -206,7 +284,7 @@ describe('createDevStore', () => {
         organization: {id: '123', storeCreation: {status: 'COMPLETE'}},
       })
 
-    await createDevStore({name: 'test-store', json: false})
+    await createDevStore({name: 'test-store', plan: 'plus', json: false})
 
     expect(sleep).toHaveBeenCalledWith(2)
   })
@@ -218,7 +296,7 @@ describe('createDevStore', () => {
         organization: {id: '123', storeCreation: {status: 'COMPLETE'}},
       })
 
-    await createDevStore({name: 'test-store', json: false})
+    await createDevStore({name: 'test-store', plan: 'plus', json: false})
 
     expect(renderSingleTask).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/packages/store/src/cli/services/store/create/dev.ts
+++ b/packages/store/src/cli/services/store/create/dev.ts
@@ -1,4 +1,5 @@
 import {businessPlatformTokenRefreshHandler} from '../business-platform.js'
+import {DEV_STORE_PLANS, DevStorePlan} from '../constants.js'
 import {CreateAppDevelopmentStore} from '../../../api/graphql/business-platform-organizations/generated/create_app_development_store.js'
 import {
   PollStoreCreation,
@@ -17,7 +18,10 @@ const POLL_TIMEOUT_MS = 5 * 60 * 1000
 
 interface CreateDevStoreOptions {
   name: string
+  plan: DevStorePlan
   organizationId?: number
+  featurePreview?: string
+  withDemoData?: boolean
   json: boolean
 }
 
@@ -57,8 +61,9 @@ export async function createDevStore(options: CreateDevStoreOptions): Promise<vo
     organizationId: org.id,
     variables: {
       shopName: options.name,
-      priceLookupKey: 'SHOPIFY_PLUS_APP_DEVELOPMENT',
-      prepopulateTestData: false,
+      priceLookupKey: DEV_STORE_PLANS[options.plan],
+      prepopulateTestData: options.withDemoData ?? false,
+      developerPreviewHandle: options.featurePreview,
     },
     unauthorizedHandler,
   })
@@ -125,6 +130,9 @@ export async function createDevStore(options: CreateDevStoreOptions): Promise<vo
             name: options.name,
             domain: shopDomain,
             adminUrl: shopAdminUrl,
+            plan: options.plan,
+            ...(options.featurePreview ? {featurePreview: options.featurePreview} : {}),
+            demoData: options.withDemoData ?? false,
           },
           organization: {
             id: org.id,
@@ -138,7 +146,13 @@ export async function createDevStore(options: CreateDevStoreOptions): Promise<vo
   } else {
     renderSuccess({
       headline: `Development store "${options.name}" created successfully.`,
-      body: [`Domain: ${shopDomain}`, `Admin: ${shopAdminUrl ?? 'N/A'}`],
+      body: [
+        `Domain: ${shopDomain}`,
+        `Admin: ${shopAdminUrl ?? 'N/A'}`,
+        `Plan: ${options.plan}`,
+        ...(options.featurePreview ? [`Feature preview: ${options.featurePreview}`] : []),
+        `Demo data: ${options.withDemoData ? 'enabled' : 'disabled'}`,
+      ],
     })
   }
 }

--- a/packages/store/src/cli/services/store/info/plan.ts
+++ b/packages/store/src/cli/services/store/info/plan.ts
@@ -1,24 +1,10 @@
-/**
- * Maps a raw BP plan name (`Shop.planName`) to the public plan handle surfaced by `store info`.
- *
- * The raw names BP returns are Shopify-internal and intentionally differ from the marketing
- * names (e.g. `professional` is Grow, `unlimited` is Advanced). The mapping is assumed stable
- * and 1:1, so it's hardcoded here rather than fetched. Both the internal name and the public
- * handle are accepted as keys because the exact form BP returns isn't pinned down by the schema.
- *
- * Anything not in this table is treated as unrecognized and omitted from the output.
- */
-const PLAN_HANDLES: {[planName: string]: string} = {
-  basic: 'basic',
-  professional: 'grow',
-  grow: 'grow',
-  unlimited: 'advanced',
-  advanced: 'advanced',
-  shopify_plus: 'plus',
-  plus: 'plus',
-}
+import {PLAN_HANDLES_BY_NAME} from '../constants.js'
 
+/**
+ * Maps a raw BP plan name (`Shop.planName`) to its public handle, or undefined when the plan
+ * isn't recognized. Matching is case-insensitive; see {@link PLAN_HANDLES_BY_NAME}.
+ */
 export function mapPlanToPublicHandle(planName: string | undefined): string | undefined {
   if (!planName) return undefined
-  return PLAN_HANDLES[planName.toLowerCase()]
+  return PLAN_HANDLES_BY_NAME[planName.toLowerCase()]
 }


### PR DESCRIPTION
### WHY are these changes introduced?

The hidden `shopify store create dev` command should accept the additional flags described in the [Store management with AI Kit project brief](https://docs.google.com/document/d/1mVZBvOBcoFzqdYWrDyfF6MloQhhaNNE1lgVOtWsMgxI/edit?tab=t.7kido7i4t7du#heading=h.ig3ol33lpgy). This PR implements the three that the Business Platform `createAppDevelopmentStore` mutation already supports.

### WHAT is this pull request doing?

Wires three new flags through to the `createAppDevelopmentStore` mutation:

| Flag | Backend variable | Notes |
|------|-----------------|-------|
| `--plan` (required) | `priceLookupKey` | Maps user-facing handles → backend price lookup keys (see below). |
| `--feature-preview` | `developerPreviewHandle` | Pass-through string (added to the mutation document); no canonical list since previews change over time. |
| `--with-demo-data` | `prepopulateTestData` | Previously hardcoded to `false`. |

**Plan mapping** (canonical, lives in the new shared `services/store/constants.ts` — the backend argument is a plain string with no reusable enum; handles mirror the Dev Dashboard store-creation form):

| `--plan` (handle) | `priceLookupKey` |
|----------|------------------|
| `basic` | `BASIC_APP_DEVELOPMENT` |
| `grow` | `PROFESSIONAL_APP_DEVELOPMENT` |
| `advanced` | `UNLIMITED_APP_DEVELOPMENT` |
| `plus` | `SHOPIFY_PLUS_APP_DEVELOPMENT` |

`store info` already mapped raw `Shop.planName` values (`professional`, `unlimited`, `shopify_plus`, …) to these public handles using its own copy of the taxonomy. Rather than leave that scattered, both mappings now sit side by side in `constants.ts` as two explicit per-direction maps — kept deliberately literal (not derived from one another) for readability. All plan data lives in one file while each command keeps its own lookup. This is why `services/store/info/plan.ts` appears in the diff; **no behavior change to `store info`.**

The plan, feature preview, and demo-data status are also surfaced in the success output and JSON result.

#### Deferred (need backend work in `shop/world`)

`--country` and `--subdomain` are intentionally **not** included — they require new backend support and are tracked in shop/issues-develop#22968:
- `--country`: Core already accepts `country`, but the BP mutation derives it from the org address rather than exposing an argument.
- `--subdomain`: no subdomain input exists at any layer.

The command remains `hidden`, so these flags aren't user-visible yet (no changeset).

### How to test your changes?

- `pnpm nx run store:type-check`
- `pnpm nx run store:lint`
- Store package tests: `cd packages/store && vitest run` — 201 passing, including new coverage for the plan→priceLookupKey mapping, feature preview, demo data, and `--plan` validation (required + rejects invalid values).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
