### PR TITLE
Fix Nx build output paths

### DIFF
--- a/packages/app/project.json
+++ b/packages/app/project.json
@@ -15,7 +15,7 @@
     },
     "build": {
       "executor": "nx:run-commands",
-      "outputs": ["{workspaceRoot}/dist"],
+      "outputs": ["{projectRoot}/dist"],
       "inputs": ["{projectRoot}/src/**/*", "{projectRoot}/package.json"],
       "options": {
         "command": "pnpm tsc -b ./tsconfig.build.json",
@@ -50,7 +50,7 @@
     "graphql-codegen:formatting": {
       "executor": "nx:run-commands",
       "dependsOn": ["graphql-codegen:postfix"],
-      "inputs": [{ "dependentTasksOutputFiles": "**/*.ts" }],
+      "inputs": [{"dependentTasksOutputFiles": "**/*.ts"}],
       "outputs": [
         "{projectRoot}/src/cli/api/graphql/partners/generated/**/*.ts",
         "{projectRoot}/src/cli/api/graphql/business-platform-destinations/generated/**/*.ts",
@@ -82,31 +82,31 @@
       "inputs": ["{workspaceRoot}/graphql.config.ts", "{projectRoot}/src/cli/api/graphql/partners/**/*.graphql"],
       "outputs": ["{projectRoot}/src/cli/api/graphql/partners/generated/**/*.ts"],
       "options": {
-        "commands": [
-          "pnpm exec graphql-codegen --project=partners"
-        ],
+        "commands": ["pnpm exec graphql-codegen --project=partners"],
         "cwd": "{workspaceRoot}"
       }
     },
     "graphql-codegen:generate:business-platform-destinations": {
       "executor": "nx:run-commands",
-      "inputs": ["{workspaceRoot}/graphql.config.ts", "{projectRoot}/src/cli/api/graphql/business-platform-destinations/**/*.graphql"],
+      "inputs": [
+        "{workspaceRoot}/graphql.config.ts",
+        "{projectRoot}/src/cli/api/graphql/business-platform-destinations/**/*.graphql"
+      ],
       "outputs": ["{projectRoot}/src/cli/api/graphql/business-platform-destinations/generated/**/*.ts"],
       "options": {
-        "commands": [
-          "pnpm exec graphql-codegen --project=businessPlatformDestinations"
-        ],
+        "commands": ["pnpm exec graphql-codegen --project=businessPlatformDestinations"],
         "cwd": "{workspaceRoot}"
       }
     },
     "graphql-codegen:generate:business-platform-organizations": {
       "executor": "nx:run-commands",
-      "inputs": ["{workspaceRoot}/graphql.config.ts", "{projectRoot}/src/cli/api/graphql/business-platform-organizations/**/*.graphql"],
+      "inputs": [
+        "{workspaceRoot}/graphql.config.ts",
+        "{projectRoot}/src/cli/api/graphql/business-platform-organizations/**/*.graphql"
+      ],
       "outputs": ["{projectRoot}/src/cli/api/graphql/business-platform-organizations/generated/**/*.ts"],
       "options": {
-        "commands": [
-          "pnpm exec graphql-codegen --project=businessPlatformOrganizations"
-        ],
+        "commands": ["pnpm exec graphql-codegen --project=businessPlatformOrganizations"],
         "cwd": "{workspaceRoot}"
       }
     },
@@ -115,9 +115,7 @@
       "inputs": ["{workspaceRoot}/graphql.config.ts", "{projectRoot}/src/cli/api/graphql/app-dev/**/*.graphql"],
       "outputs": ["{projectRoot}/src/cli/api/graphql/app-dev/generated/**/*.ts"],
       "options": {
-        "commands": [
-          "pnpm exec graphql-codegen --project=appDev"
-        ],
+        "commands": ["pnpm exec graphql-codegen --project=appDev"],
         "cwd": "{workspaceRoot}"
       }
     },
@@ -126,9 +124,7 @@
       "inputs": ["{workspaceRoot}/graphql.config.ts", "{projectRoot}/src/cli/api/graphql/webhooks/**/*.graphql"],
       "outputs": ["{projectRoot}/src/cli/api/graphql/webhooks/generated/**/*.ts"],
       "options": {
-        "commands": [
-          "pnpm exec graphql-codegen --project=webhooks"
-        ],
+        "commands": ["pnpm exec graphql-codegen --project=webhooks"],
         "cwd": "{workspaceRoot}"
       }
     },
@@ -137,9 +133,7 @@
       "inputs": ["{workspaceRoot}/graphql.config.ts", "{projectRoot}/src/cli/api/graphql/app-management/**/*.graphql"],
       "outputs": ["{projectRoot}/src/cli/api/graphql/app-management/generated/**/*.ts"],
       "options": {
-        "commands": [
-          "pnpm exec graphql-codegen --project=appManagement"
-        ],
+        "commands": ["pnpm exec graphql-codegen --project=appManagement"],
         "cwd": "{workspaceRoot}"
       }
     },
@@ -148,9 +142,7 @@
       "inputs": ["{workspaceRoot}/graphql.config.ts", "{projectRoot}/src/cli/api/graphql/functions/**/*.graphql"],
       "outputs": ["{projectRoot}/src/cli/api/graphql/functions/generated/**/*.ts"],
       "options": {
-        "commands": [
-          "pnpm exec graphql-codegen --project=functions"
-        ],
+        "commands": ["pnpm exec graphql-codegen --project=functions"],
         "cwd": "{workspaceRoot}"
       }
     },
@@ -159,9 +151,7 @@
       "inputs": ["{workspaceRoot}/graphql.config.ts", "{projectRoot}/src/cli/api/graphql/bulk-operations/**/*.graphql"],
       "outputs": ["{projectRoot}/src/cli/api/graphql/bulk-operations/generated/**/*.ts"],
       "options": {
-        "commands": [
-          "pnpm exec graphql-codegen --project=bulkOperations"
-        ],
+        "commands": ["pnpm exec graphql-codegen --project=bulkOperations"],
         "cwd": "{workspaceRoot}"
       }
     },
@@ -170,9 +160,7 @@
       "inputs": ["{workspaceRoot}/graphql.config.ts", "{projectRoot}/src/cli/api/graphql/admin/**/*.graphql"],
       "outputs": ["{projectRoot}/src/cli/api/graphql/admin/generated/**/*.ts"],
       "options": {
-        "commands": [
-          "pnpm exec graphql-codegen --project=adminAsApp"
-        ],
+        "commands": ["pnpm exec graphql-codegen --project=adminAsApp"],
         "cwd": "{workspaceRoot}"
       }
     },
@@ -189,7 +177,7 @@
         "graphql-codegen:generate:bulk-operations",
         "graphql-codegen:generate:admin-as-app"
       ],
-      "inputs": [{ "dependentTasksOutputFiles": "**/*.ts" }],
+      "inputs": [{"dependentTasksOutputFiles": "**/*.ts"}],
       "outputs": [
         "{projectRoot}/src/cli/api/graphql/partners/generated/**/*.ts",
         "{projectRoot}/src/cli/api/graphql/business-platform-destinations/generated/**/*.ts",

--- a/packages/cli-kit/project.json
+++ b/packages/cli-kit/project.json
@@ -3,9 +3,7 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "packages/cli-kit/src",
   "projectType": "library",
-  "tags": [
-    "scope:foundation"
-  ],
+  "tags": ["scope:foundation"],
   "targets": {
     "clean": {
       "executor": "nx:run-commands",
@@ -16,15 +14,9 @@
     },
     "build": {
       "executor": "nx:run-commands",
-      "outputs": [
-        "{workspaceRoot}/dist"
-      ],
-      "inputs": [
-        "{projectRoot}/src/**/*"
-      ],
-      "dependsOn": [
-        "generate-version"
-      ],
+      "outputs": ["{projectRoot}/dist"],
+      "inputs": ["{projectRoot}/src/**/*"],
+      "dependsOn": ["generate-version"],
       "options": {
         "command": "pnpm tsc -b ./tsconfig.build.json",
         "cwd": "packages/cli-kit"
@@ -32,21 +24,15 @@
     },
     "generate-version": {
       "executor": "nx:run-commands",
-      "outputs": [
-        "{projectRoot}/src/public/common/version.ts"
-      ],
-      "inputs": [
-        "{projectRoot}/package.json"
-      ],
+      "outputs": ["{projectRoot}/src/public/common/version.ts"],
+      "inputs": ["{projectRoot}/package.json"],
       "options": {
         "command": "node bin/update-cli-kit-version.js"
       }
     },
     "build-api-docs": {
       "executor": "nx:run-commands",
-      "outputs": [
-        "{workspaceRoot}/docs"
-      ],
+      "outputs": ["{workspaceRoot}/docs"],
       "options": {
         "command": "node ./scripts/build-api-docs.js",
         "cwd": "packages/cli-kit"
@@ -54,9 +40,7 @@
     },
     "open-api-docs": {
       "executor": "nx:run-commands",
-      "dependsOn": [
-        "build-api-docs"
-      ],
+      "dependsOn": ["build-api-docs"],
       "options": {
         "command": "open ../../docs/api/cli-kit/index.html",
         "cwd": "packages/cli-kit"
@@ -92,59 +76,40 @@
     },
     "graphql-codegen": {
       "executor": "nx:noop",
-      "dependsOn": [
-        "graphql-codegen:formatting"
-      ]
+      "dependsOn": ["graphql-codegen:formatting"]
     },
     "graphql-codegen:formatting": {
       "executor": "nx:run-commands",
-      "dependsOn": [
-        "graphql-codegen:postfix"
-      ],
+      "dependsOn": ["graphql-codegen:postfix"],
       "inputs": [
         {
           "dependentTasksOutputFiles": "**/*.ts"
         }
       ],
-      "outputs": [
-        "{projectRoot}/src/cli/api/graphql/admin/generated/**/*.ts"
-      ],
+      "outputs": ["{projectRoot}/src/cli/api/graphql/admin/generated/**/*.ts"],
       "options": {
-        "commands": [
-          "pnpm eslint 'src/cli/api/graphql/admin/generated/**/*.{ts,tsx}' --fix"
-        ],
+        "commands": ["pnpm eslint 'src/cli/api/graphql/admin/generated/**/*.{ts,tsx}' --fix"],
         "cwd": "packages/cli-kit"
       }
     },
     "graphql-codegen:generate:admin": {
       "executor": "nx:run-commands",
-      "inputs": [
-        "{workspaceRoot}/graphql.config.ts",
-        "{projectRoot}/src/cli/api/graphql/admin/**/*.graphql"
-      ],
-      "outputs": [
-        "{projectRoot}/src/cli/api/graphql/admin/generated/**/*.ts"
-      ],
+      "inputs": ["{workspaceRoot}/graphql.config.ts", "{projectRoot}/src/cli/api/graphql/admin/**/*.graphql"],
+      "outputs": ["{projectRoot}/src/cli/api/graphql/admin/generated/**/*.ts"],
       "options": {
-        "commands": [
-          "pnpm exec graphql-codegen --project=admin"
-        ],
+        "commands": ["pnpm exec graphql-codegen --project=admin"],
         "cwd": "{workspaceRoot}"
       }
     },
     "graphql-codegen:postfix": {
       "executor": "nx:run-commands",
-      "dependsOn": [
-        "graphql-codegen:generate:admin"
-      ],
+      "dependsOn": ["graphql-codegen:generate:admin"],
       "inputs": [
         {
           "dependentTasksOutputFiles": "**/*.ts"
         }
       ],
-      "outputs": [
-        "{projectRoot}/src/cli/api/graphql/admin/generated/**/*.ts"
-      ],
+      "outputs": ["{projectRoot}/src/cli/api/graphql/admin/generated/**/*.ts"],
       "options": {
         "commands": [
           "find ./packages/cli-kit/src/cli/api/graphql/admin/generated/ -type f -name '*.ts' -exec sh -c 'sed -i \"\" \"s|import \\* as Types from '\\''./types'\\'';|import \\* as Types from '\\''./types.js'\\'';|g; s|export const \\([A-Za-z0-9_]*\\)Document =|export const \\1 =|g\" \"$0\"' {} \\;"

--- a/packages/cli/project.json
+++ b/packages/cli/project.json
@@ -15,7 +15,7 @@
     },
     "build": {
       "executor": "nx:run-commands",
-      "outputs": ["{workspaceRoot}/dist"],
+      "outputs": ["{projectRoot}/dist"],
       "inputs": ["{projectRoot}/src/**/*"],
       "options": {
         "command": "pnpm tsc -b ./tsconfig.build.json",
@@ -24,12 +24,7 @@
     },
     "bundle": {
       "executor": "nx:run-commands",
-      "dependsOn": [
-        "build",
-        "cli-kit:generate-version",
-        "app:build",
-        "theme:build"
-      ],
+      "dependsOn": ["build", "cli-kit:generate-version", "app:build", "theme:build"],
       "options": {
         "command": "node bin/bundle",
         "cwd": "packages/cli"

--- a/packages/create-app/project.json
+++ b/packages/create-app/project.json
@@ -14,7 +14,7 @@
     },
     "build": {
       "executor": "nx:run-commands",
-      "outputs": ["{workspaceRoot}/dist"],
+      "outputs": ["{projectRoot}/dist"],
       "inputs": ["{projectRoot}/src/**/*"],
       "options": {
         "command": "pnpm tsc -b ./tsconfig.build.json",

--- a/packages/organizations/project.json
+++ b/packages/organizations/project.json
@@ -14,7 +14,7 @@
     },
     "build": {
       "executor": "nx:run-commands",
-      "outputs": ["{workspaceRoot}/dist"],
+      "outputs": ["{projectRoot}/dist"],
       "inputs": ["{projectRoot}/src/**/*", "{projectRoot}/package.json"],
       "options": {
         "command": "pnpm tsc -b ./tsconfig.build.json",
@@ -68,7 +68,10 @@
     },
     "graphql-codegen:generate:organizations-destinations": {
       "executor": "nx:run-commands",
-      "inputs": ["{workspaceRoot}/graphql.config.ts", "{projectRoot}/src/cli/api/graphql/business-platform-destinations/**/*.graphql"],
+      "inputs": [
+        "{workspaceRoot}/graphql.config.ts",
+        "{projectRoot}/src/cli/api/graphql/business-platform-destinations/**/*.graphql"
+      ],
       "outputs": ["{projectRoot}/src/cli/api/graphql/business-platform-destinations/generated/**/*.ts"],
       "options": {
         "commands": ["pnpm exec graphql-codegen --project=organizationsDestinations"],

--- a/packages/plugin-cloudflare/project.json
+++ b/packages/plugin-cloudflare/project.json
@@ -14,7 +14,7 @@
     },
     "build": {
       "executor": "nx:run-commands",
-      "outputs": ["{workspaceRoot}/dist"],
+      "outputs": ["{projectRoot}/dist"],
       "inputs": ["{projectRoot}/src/**/*", "{projectRoot}/package.json"],
       "options": {
         "command": "pnpm tsc -b ./tsconfig.build.json",

--- a/packages/plugin-did-you-mean/project.json
+++ b/packages/plugin-did-you-mean/project.json
@@ -14,7 +14,7 @@
     },
     "build": {
       "executor": "nx:run-commands",
-      "outputs": ["{workspaceRoot}/dist"],
+      "outputs": ["{projectRoot}/dist"],
       "inputs": ["{projectRoot}/src/**/*", "{projectRoot}/package.json"],
       "options": {
         "command": "pnpm tsc -b ./tsconfig.build.json",

--- a/packages/store/project.json
+++ b/packages/store/project.json
@@ -14,7 +14,7 @@
     },
     "build": {
       "executor": "nx:run-commands",
-      "outputs": ["{workspaceRoot}/dist"],
+      "outputs": ["{projectRoot}/dist"],
       "inputs": ["{projectRoot}/src/**/*", "{projectRoot}/package.json"],
       "options": {
         "command": "pnpm tsc -b ./tsconfig.build.json",

--- a/packages/theme/project.json
+++ b/packages/theme/project.json
@@ -14,7 +14,7 @@
     },
     "build": {
       "executor": "nx:run-commands",
-      "outputs": ["{workspaceRoot}/dist"],
+      "outputs": ["{projectRoot}/dist"],
       "inputs": ["{projectRoot}/src/**/*", "{projectRoot}/package.json"],
       "options": {
         "command": "pnpm tsc -b ./tsconfig.build.json",
@@ -23,7 +23,7 @@
     },
     "dev": {
       "executor": "nx:run-commands",
-      "outputs": ["{workspaceRoot}/dist"],
+      "outputs": ["{projectRoot}/dist"],
       "inputs": ["{projectRoot}/src/**/*", "{projectRoot}/package.json"],
       "options": {
         "command": "pnpm tsc -b ./tsconfig.build.json --watch",

--- a/packages/ui-extensions-server-kit/project.json
+++ b/packages/ui-extensions-server-kit/project.json
@@ -15,7 +15,7 @@
     },
     "build:code": {
       "executor": "nx:run-commands",
-      "outputs": ["{workspaceRoot}/dist"],
+      "outputs": ["{projectRoot}/dist"],
       "options": {
         "command": "pnpm vite build --config vite.config.mts",
         "cwd": "packages/ui-extensions-server-kit"
@@ -24,7 +24,7 @@
     "build:types": {
       "executor": "nx:run-commands",
       "dependsOn": ["^build"],
-      "outputs": ["{workspaceRoot}/dist"],
+      "outputs": ["{projectRoot}/dist"],
       "options": {
         "command": "pnpm tsc --emitDeclarationOnly",
         "cwd": "packages/ui-extensions-server-kit"
@@ -33,7 +33,7 @@
     "build": {
       "executor": "nx:run-commands",
       "dependsOn": ["build:code", "build:types"],
-      "outputs": ["{workspaceRoot}/dist"],
+      "outputs": ["{projectRoot}/dist"],
       "inputs": ["{projectRoot}/src/**/*", "{projectRoot}/testing.*", "{projectRoot}/index.*"],
       "options": {
         "command": "cd .",

--- a/packages/ui-extensions-test-utils/project.json
+++ b/packages/ui-extensions-test-utils/project.json
@@ -14,7 +14,7 @@
     },
     "build": {
       "executor": "nx:run-commands",
-      "outputs": ["{workspaceRoot}/dist"],
+      "outputs": ["{projectRoot}/dist"],
       "inputs": ["{projectRoot}/src/**/*"],
       "options": {
         "command": "pnpm tsc",


### PR DESCRIPTION
## Summary
- Point Nx build outputs at each package's local `dist` directory instead of the workspace root.
- This makes Nx cache restore the files each build target actually produces.

## Validation
- `package.json`/`project.json` JSON parse
- `prettier --check` on changed project configs
- `git diff --check`