### PR TITLE
Allow kafka:// URIs in webhook subscription TOML validation

### DIFF
--- a/packages/app/src/cli/models/app/loader.test.ts
+++ b/packages/app/src/cli/models/app/loader.test.ts
@@ -2815,7 +2815,7 @@ describe('WebhooksSchema', () => {
     const errorObj = {
       code: zod.ZodIssueCode.custom,
       message:
-        "URI format isn't correct. Valid formats include: relative path starting with a slash, HTTPS URL, pubsub://{project-id}:{topic-id} or Eventbridge ARN",
+        "URI format isn't correct. Valid formats include: relative path starting with a slash, HTTPS URL, pubsub://{project-id}:{topic-id}, kafka://{topic-id} or Eventbridge ARN",
       path: ['webhooks', 'subscriptions', 0, 'uri'],
     }
 
@@ -2835,7 +2835,7 @@ describe('WebhooksSchema', () => {
     expect(result.parsedConfiguration.webhooks).toMatchObject(webhookConfig)
   })
 
-  test('throws an error if uri is not a valid https URL, pubsub URI, or Eventbridge ARN', async () => {
+  test('throws an error if uri is not a valid https URL, pubsub URI, kafka URI, or Eventbridge ARN', async () => {
     const webhookConfig: WebhooksConfig = {
       api_version: '2021-07',
       subscriptions: [{uri: 'my::URI-thing::Shopify::123', topics: ['products/create']}],
@@ -2843,7 +2843,7 @@ describe('WebhooksSchema', () => {
     const errorObj = {
       code: zod.ZodIssueCode.custom,
       message:
-        "URI format isn't correct. Valid formats include: relative path starting with a slash, HTTPS URL, pubsub://{project-id}:{topic-id} or Eventbridge ARN",
+        "URI format isn't correct. Valid formats include: relative path starting with a slash, HTTPS URL, pubsub://{project-id}:{topic-id}, kafka://{topic-id} or Eventbridge ARN",
       path: ['webhooks', 'subscriptions', 0, 'uri'],
     }
 
@@ -2889,6 +2889,33 @@ describe('WebhooksSchema', () => {
     expect(result.parsedConfiguration.webhooks).toMatchObject(webhookConfig)
   })
 
+  test('accepts a kafka uri', async () => {
+    const webhookConfig: WebhooksConfig = {
+      api_version: '2021-07',
+      subscriptions: [{uri: 'kafka://my_topic.name-1', topics: ['products/create']}],
+    }
+
+    const result = await setupParsing({}, webhookConfig)
+    expect(result.threw).toBe(false)
+    expect(result.parsedConfiguration.webhooks).toMatchObject(webhookConfig)
+  })
+
+  test('throws an error if kafka topic contains invalid characters', async () => {
+    const webhookConfig: WebhooksConfig = {
+      api_version: '2021-07',
+      subscriptions: [{uri: 'kafka://invalid topic!', topics: ['products/create']}],
+    }
+    const errorObj = {
+      code: zod.ZodIssueCode.custom,
+      message:
+        "URI format isn't correct. Valid formats include: relative path starting with a slash, HTTPS URL, pubsub://{project-id}:{topic-id}, kafka://{topic-id} or Eventbridge ARN",
+      path: ['webhooks', 'subscriptions', 0, 'uri'],
+    }
+
+    const result = await setupParsing(errorObj, webhookConfig)
+    expect(result.threw).toBe(true)
+  })
+
   test('accepts combination of uris', async () => {
     const webhookConfig: WebhooksConfig = {
       api_version: '2021-07',
@@ -2903,6 +2930,10 @@ describe('WebhooksSchema', () => {
         },
         {
           uri: 'pubsub://my-project-123:my-topic',
+          topics: ['products/create', 'products/update'],
+        },
+        {
+          uri: 'kafka://my-topic',
           topics: ['products/create', 'products/update'],
         },
       ],
@@ -2925,6 +2956,14 @@ describe('WebhooksSchema', () => {
         },
         {
           uri: 'https://example.com',
+          topics: ['products/update'],
+        },
+        {
+          uri: 'kafka://my-topic',
+          topics: ['products/create'],
+        },
+        {
+          uri: 'kafka://my-topic',
           topics: ['products/update'],
         },
         {
@@ -2997,7 +3036,7 @@ describe('WebhooksSchema', () => {
     expect(result.parsedConfiguration.webhooks).toMatchObject(webhookConfig)
   })
 
-  test('throws an error if uri is not an https uri', async () => {
+  test('throws an error for http:// uri in subscription (rejects insecure scheme)', async () => {
     const webhookConfig: WebhooksConfig = {
       api_version: '2021-07',
       subscriptions: [
@@ -3010,7 +3049,7 @@ describe('WebhooksSchema', () => {
     const errorObj = {
       code: zod.ZodIssueCode.custom,
       message:
-        "URI format isn't correct. Valid formats include: relative path starting with a slash, HTTPS URL, pubsub://{project-id}:{topic-id} or Eventbridge ARN",
+        "URI format isn't correct. Valid formats include: relative path starting with a slash, HTTPS URL, pubsub://{project-id}:{topic-id}, kafka://{topic-id} or Eventbridge ARN",
       path: ['webhooks', 'subscriptions', 0, 'uri'],
     }
 

--- a/packages/app/src/cli/models/extensions/specifications/validation/common.ts
+++ b/packages/app/src/cli/models/extensions/specifications/validation/common.ts
@@ -6,6 +6,8 @@ const pubSubRegex = /^pubsub:\/\/(?<gcp_project_id>[^:]+):(?<gcp_topic>.+)$/
 // example Eventbridge ARN - arn:aws:events:{region}::event-source/aws.partner/shopify.com/{app_id}/{path}
 const arnRegex =
   /^arn:aws:events:(?<aws_region>[a-z]{2}-[a-z]+-[0-9]+)::event-source\/aws\.partner\/shopify\.com(\.test)?\/(?<api_client_id>\d+)\/(?<event_source_name>.+)$/
+// example Kafka URI - kafka://{topic}. Restricted to internal apps; the platform enforces authorization.
+const kafkaRegex = /^kafka:\/\/(?<kafka_topic>[a-zA-Z0-9_.-]+)$/
 
 export function removeTrailingSlash(arg: string): string
 export function removeTrailingSlash(arg: unknown): unknown {
@@ -16,10 +18,10 @@ export const WebhookSubscriptionUriValidation = zod.string({invalid_type_error: 
   (uri) => {
     if (uri.startsWith('/')) return true
 
-    return httpsRegex.test(uri) || pubSubRegex.test(uri) || arnRegex.test(uri)
+    return httpsRegex.test(uri) || pubSubRegex.test(uri) || arnRegex.test(uri) || kafkaRegex.test(uri)
   },
   {
     message:
-      "URI format isn't correct. Valid formats include: relative path starting with a slash, HTTPS URL, pubsub://{project-id}:{topic-id} or Eventbridge ARN",
+      "URI format isn't correct. Valid formats include: relative path starting with a slash, HTTPS URL, pubsub://{project-id}:{topic-id}, kafka://{topic-id} or Eventbridge ARN",
   },
 )


### PR DESCRIPTION
### WHY are these changes introduced?

- Part of [shop/issues-event-foundations#252](https://github.com/shop/issues-event-foundations/issues/252).

The webhook subscription URI validator (`WebhookSubscriptionUriValidation` in `common.ts`) only accepted relative paths, HTTPS URLs, `pubsub://` URIs, and Eventbridge ARNs. `kafka://` URIs were rejected at TOML validation time, which blocked the internal Shopify apps that currently rely on Kafka delivery (Email, Shop, Flow, etc.) from adopting declarative webhooks.

### What is this change?

- Add a `kafka://{topic}` regex to `common.ts`. The topic character set (`[a-zA-Z0-9_.-]+`) mirrors the server-side validator so the CLI rejects exactly what the platform rejects on shape.
- Include `kafkaRegex.test(uri)` in the `.refine()` predicate and update the error message to mention `kafka://{topic-id}`.
- Add tests covering: accepting a well-formed `kafka://my_topic.name-1` URI; rejecting `kafka://invalid topic!`; and including kafka in the combined-URI subscriptions test (whose expansion sorts alphabetically by URI: arn → https → kafka → pubsub).
- Update the 3 places in `loader.test.ts` that assert the previous error string to include `kafka://{topic-id}`.

### Authorization is enforced server-side, not in the CLI

The CLI validates URI shape only. Internal-app-only enforcement happens at the platform: `webhook_uri_validator.rb#validate_kafka_topic` checks `record.api_client.internal_graphql_access?` and returns `"uses delivery method 'kafka' and is not supported"` for non-internal clients. This mirrors how `pubsub://` and Eventbridge ARNs are validated today — the CLI doesn't reproduce server authorization rules, it only filters obviously malformed input.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows) — pure TS regex, no platform-specific code.
- [x] I've considered possible documentation changes — added a changeset; no user-facing docs reference the old error string.
