### PR TITLE
[Performance] Memoize isWsl result

### DIFF
--- a/packages/cli-kit/src/public/node/system.test.ts
+++ b/packages/cli-kit/src/public/node/system.test.ts
@@ -353,6 +353,32 @@ describe('isStdinPiped', () => {
   })
 })
 
+describe('isWsl', () => {
+  test('memoizes the result', async () => {
+    // When
+    const result1 = system.isWsl()
+    const result2 = system.isWsl()
+
+    // Then
+    expect(result1).toBe(result2)
+    await expect(result1).resolves.toBeTypeOf('boolean')
+  })
+
+  test('clears the cache when reset', async () => {
+    // Given
+    const result1 = system.isWsl()
+    system._resetIsWsl()
+
+    // When
+    const result2 = system.isWsl()
+
+    // Then
+    expect(result1).not.toBe(result2)
+    await expect(result1).resolves.toBeTypeOf('boolean')
+    await expect(result2).resolves.toBeTypeOf('boolean')
+  })
+})
+
 describe('readStdinString', () => {
   test('returns undefined when stdin is not piped', async () => {
     // Given

--- a/packages/cli-kit/src/public/node/system.ts
+++ b/packages/cli-kit/src/public/node/system.ts
@@ -355,13 +355,25 @@ export function isCI(): boolean {
 }
 
 /**
+ * Memoized value for the WSL check.
+ */
+let memoizedIsWsl: Promise<boolean> | undefined
+
+/**
  * Check if the current environment is a WSL environment.
  *
  * @returns True if the current environment is a WSL environment.
  */
-export async function isWsl(): Promise<boolean> {
-  const wsl = await import('is-wsl')
-  return wsl.default
+export function isWsl(): Promise<boolean> {
+  return (memoizedIsWsl ??= import('is-wsl').then((module) => module.default))
+}
+
+/**
+ * Resets the memoized value for the WSL check.
+ * This is used for testing purposes.
+ */
+export function _resetIsWsl() {
+  memoizedIsWsl = undefined
 }
 
 /**


### PR DESCRIPTION
### WHY are these changes introduced?

The `isWsl` function in `packages/cli-kit/src/public/node/system.ts` performs a dynamic import of the `is-wsl` package every time it is called. Since the environment (WSL or not) does not change during the execution of the process, this result can be safely memoized to avoid redundant imports and computations.

### WHAT is this pull request doing?

This PR memoizes the promise returned by the dynamic `is-wsl` import in the `isWsl` function.
- Introduced a module-level `memoizedIsWsl` variable.
- Updated `isWsl` to use the nullish coalescing assignment operator (`??=`) to cache and return the promise.
- Exported an internal `_resetIsWsl` function to allow clearing the cache during unit tests, ensuring test isolation.
- Added unit tests in `packages/cli-kit/src/public/node/system.test.ts` to verify memoization and reset behavior.

### How to test your changes?

CI

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [1458224654387623489](https://jules.google.com/task/1458224654387623489) started by @gonzaloriestra*