### PR TITLE
[Security] Replace execSync with execFileSync in cloudflared installation

### DIFF
--- a/packages/plugin-cloudflare/src/install-cloudflared.test.ts
+++ b/packages/plugin-cloudflare/src/install-cloudflared.test.ts
@@ -42,7 +42,7 @@ describe('install-cloudflare', () => {
       const binPath = joinPath(tmpDir, 'cloudflared')
       const env = {SHOPIFY_CLI_CLOUDFLARED_PATH: binPath}
       mockFetch()
-      vi.mocked(childProcess.execSync).mockImplementation((_command, options) => {
+      vi.mocked(childProcess.execFileSync).mockImplementation((_command, _args, options) => {
         // Simulate tar extracting the file
         const cwd = options?.cwd as string
         writeFileSync(joinPath(cwd, 'cloudflared'), 'extracted binary')
@@ -69,7 +69,7 @@ describe('install-cloudflare', () => {
       const binPath = joinPath(tmpDir, 'cloudflared')
       const env = {SHOPIFY_CLI_CLOUDFLARED_PATH: binPath}
       mockFetch()
-      vi.mocked(childProcess.execSync).mockImplementation((_command, options) => {
+      vi.mocked(childProcess.execFileSync).mockImplementation((_command, _args, options) => {
         const cwd = options?.cwd as string
         writeFileSync(joinPath(cwd, 'cloudflared'), 'extracted binary')
         return Buffer.from('')

--- a/packages/plugin-cloudflare/src/install-cloudflared.ts
+++ b/packages/plugin-cloudflare/src/install-cloudflared.ts
@@ -14,7 +14,7 @@ import {fileURLToPath} from 'url'
 import util from 'util'
 import {pipeline} from 'stream'
 // eslint-disable-next-line no-restricted-imports
-import {execSync, execFileSync} from 'child_process'
+import {execFileSync} from 'child_process'
 
 export const CURRENT_CLOUDFLARE_VERSION = '2024.8.2'
 const CLOUDFLARE_REPO = `https://github.com/cloudflare/cloudflared/releases/download/${CURRENT_CLOUDFLARE_VERSION}/`
@@ -132,7 +132,7 @@ async function installWindows(file: string, binTarget: string) {
 async function installMacos(file: string, binTarget: string) {
   await downloadFile(file, `${binTarget}.tgz`)
   const filename = basename(`${binTarget}.tgz`)
-  execSync(`tar -xzf ${filename}`, {cwd: dirname(binTarget)})
+  execFileSync('tar', ['-xzf', filename], {cwd: dirname(binTarget)})
   unlinkFileSync(`${binTarget}.tgz`)
   await renameFile(`${dirname(binTarget)}/cloudflared`, binTarget)
 }


### PR DESCRIPTION
### WHY are these changes introduced?

This pull request addresses a potential command injection vulnerability in the `plugin-cloudflare` package.

### WHAT is this pull request doing?

It replaces the use of `execSync` with `execFileSync` when extracting the `cloudflared` binary on macOS. By avoiding the shell, we eliminate the risk of shell metacharacters in the filename being interpreted as commands.

### How to test your changes?

CI

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`


---
*PR created automatically by Jules for task [18102053969332206110](https://jules.google.com/task/18102053969332206110) started by @gonzaloriestra*