### PR TITLE
Delete app deploy E2E apps by direct URL

### DIFF
--- a/packages/e2e/setup/teardown.ts
+++ b/packages/e2e/setup/teardown.ts
@@ -11,6 +11,8 @@ const log = createLogger('browser')
 interface TeardownCtx {
   browserPage: Page
   appName: string
+  /** Direct Dev Dashboard app URL. Prefer this when available to avoid slow org-wide pagination. */
+  appUrl?: string
   orgId?: string
   workerIndex?: number
   /** If set, uninstalls app from store + deletes store before deleting the app */
@@ -124,7 +126,7 @@ export async function teardownAll(ctx: TeardownCtx): Promise<void> {
   let stillHasInstalls = false
   for (let attempt = 1; attempt <= 3; attempt++) {
     try {
-      const appUrl = await findAppOnDevDashboard(page, ctx.appName, ctx.orgId)
+      const appUrl = ctx.appUrl ?? (await findAppOnDevDashboard(page, ctx.appName, ctx.orgId))
       if (!appUrl) {
         // null could mean "app not in the list" OR "pagination ended on a stuck error page"
         // — findAppOnDevDashboard's refresh-on-error doesn't cover every iteration.

--- a/packages/e2e/tests/app-deploy.spec.ts
+++ b/packages/e2e/tests/app-deploy.spec.ts
@@ -38,6 +38,11 @@ function assertDeployAnalytics(opts: {output: string; appName: string; step: str
   expect(output, `${opts.step} - expected deploy analytics app name`).toContain(`"app_name": "${opts.appName}"`)
 }
 
+function devDashboardAppUrlFromOutput(output: string): string | undefined {
+  const match = stripAnsi(output).match(/https:\/\/dev\.shopify\.com\/dashboard\/\d+\/apps\/\d+/)
+  return match?.[0]
+}
+
 /**
  * Asserts a `versions list --json` result shows:
  *   - `expectedTag` is present and `active`
@@ -77,6 +82,9 @@ test.describe('App deploy', () => {
     const appName = `E2E-deploy1-${Date.now()}`
     const secondaryAppName = `E2E-deploy2-${Date.now()}`
 
+    let primaryAppUrl: string | undefined
+    let secondaryAppUrl: string | undefined
+
     try {
       // Step 1: Create primary app (React Router template)
       const initResult = await createApp({
@@ -112,6 +120,7 @@ test.describe('App deploy', () => {
       )
       const deployOutput = deployResult.stdout + deployResult.stderr
       expect(deployResult.exitCode, `Step 2 - deploy failed:\n${deployOutput}`).toBe(0)
+      primaryAppUrl = devDashboardAppUrlFromOutput(deployOutput)
       assertDeployAnalytics({output: deployOutput, appName, step: 'Step 2'})
 
       // Step 3: Verify the primary tag is active and no other version is stuck active.
@@ -151,6 +160,7 @@ test.describe('App deploy', () => {
       })
       const secondaryDeployOutput = secondaryDeployResult.stdout + secondaryDeployResult.stderr
       expect(secondaryDeployResult.exitCode, `Step 5 - secondary deploy failed:\n${secondaryDeployOutput}`).toBe(0)
+      secondaryAppUrl = devDashboardAppUrlFromOutput(secondaryDeployOutput)
 
       // Step 6: Verify the secondary deploy hit the secondary app (not a silent
       // fallback to primary). Checks the secondary tag is active, no other
@@ -170,12 +180,14 @@ test.describe('App deploy', () => {
         await teardownAll({
           browserPage,
           appName,
+          appUrl: primaryAppUrl,
           orgId: env.orgId,
           workerIndex: env.workerIndex,
         })
         await teardownAll({
           browserPage,
           appName: secondaryAppName,
+          appUrl: secondaryAppUrl,
           orgId: env.orgId,
           workerIndex: env.workerIndex,
         })


### PR DESCRIPTION
## What

Deletes app-deploy E2E apps by direct Dev Dashboard app URL when deploy output provides one.

- Extracts the app URL from primary and secondary deploy output.
- Passes the URL into `teardownAll`.
- Lets `teardownAll` skip org-wide dashboard pagination when an exact app URL is available.

## Why

A failed run showed the `app-deploy.spec.ts` flow itself passing, then timing out in cleanup:

- primary app cleanup searched/deleted successfully
- secondary app cleanup searched `env.orgId`
- the secondary deploy output linked the app under a different dashboard org
- dashboard pagination kept scanning the wrong org until the test timeout closed the Playwright page

Using the deploy output URL makes cleanup target the actual app that was deployed, instead of assuming the secondary app lives under `env.orgId`.

This is stacked on #7803, which caps teardown time and avoids browser-closed retry noise. This PR addresses the root cause for the app-deploy secondary cleanup path.

## Testing

- `pnpm --filter e2e lint`
- `pnpm --filter e2e type-check`
