### PR TITLE
Pin oclif to 4.8.3

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -60,7 +60,7 @@
   "dependencies": {
     "@graphql-typed-document-node/core": "3.2.0",
     "@luckycatfactory/esbuild-graphql-loader": "3.8.1",
-    "@oclif/core": "4.11.4",
+    "@oclif/core": "4.8.3",
     "@shopify/cli-kit": "4.1.0",
     "@shopify/plugin-cloudflare": "4.1.0",
     "@shopify/organizations": "4.1.0",

--- a/packages/cli-kit/package.json
+++ b/packages/cli-kit/package.json
@@ -106,7 +106,7 @@
     "@bugsnag/js": "8.9.0",
     "@graphql-typed-document-node/core": "3.2.0",
     "@iarna/toml": "2.2.5",
-    "@oclif/core": "4.11.4",
+    "@oclif/core": "4.8.3",
     "@shopify/polaris": "12.27.0",
     "@shopify/polaris-icons": "8.11.1",
     "@shopify/toml-patch": "0.3.0",

--- a/packages/cli-kit/src/public/node/cli-launcher.test.ts
+++ b/packages/cli-kit/src/public/node/cli-launcher.test.ts
@@ -1,5 +1,7 @@
 import {launchCLI} from './cli-launcher.js'
-import {describe, expect, test} from 'vitest'
+import {ShopifyConfig} from './custom-oclif-loader.js'
+import {run} from '@oclif/core'
+import {describe, expect, test, vi} from 'vitest'
 
 describe('launchCLI', () => {
   test('launches the CLI successfully with help flag', async () => {
@@ -10,5 +12,24 @@ describe('launchCLI', () => {
 
   test('fails if args are invalid', async () => {
     await expect(launchCLI({moduleURL: import.meta.url, argv: ['this', 'is', 'invalid']})).rejects.toThrow()
+  })
+
+  test('preserves the loaded Shopify config so commands can be loaded lazily', async () => {
+    const command = {id: 'lazy-test'} as any
+    const config = new ShopifyConfig({root: import.meta.url})
+    const lazyCommandLoader = vi.fn().mockResolvedValue({
+      run: vi.fn().mockResolvedValue('ok'),
+    })
+
+    config.setLazyCommandLoader(lazyCommandLoader)
+    config.findCommand = vi.fn().mockReturnValue(command)
+    config.runHook = vi.fn().mockResolvedValue({successes: [], failures: []})
+    config.pjson = {oclif: {}} as any
+    config.userAgent = '@shopify/cli-kit/test'
+
+    await expect(run(['lazy-test'], config)).resolves.toBe('ok')
+
+    expect(lazyCommandLoader).toHaveBeenCalledWith('lazy-test')
+    expect(config.findCommand).toHaveBeenCalledWith('lazy-test')
   })
 })

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -57,7 +57,7 @@
     "global-agent": "3.0.0"
   },
   "devDependencies": {
-    "@oclif/core": "4.11.4",
+    "@oclif/core": "4.8.3",
     "@oclif/plugin-commands": "4.1.57",
     "@oclif/plugin-plugins": "5.4.47",
     "@shopify/app": "4.1.0",

--- a/packages/plugin-cloudflare/package.json
+++ b/packages/plugin-cloudflare/package.json
@@ -45,7 +45,7 @@
     ]
   },
   "dependencies": {
-    "@oclif/core": "4.11.4",
+    "@oclif/core": "4.8.3",
     "@shopify/cli-kit": "4.1.0"
   },
   "devDependencies": {

--- a/packages/plugin-did-you-mean/package.json
+++ b/packages/plugin-did-you-mean/package.json
@@ -40,7 +40,7 @@
     ]
   },
   "dependencies": {
-    "@oclif/core": "4.11.4",
+    "@oclif/core": "4.8.3",
     "@shopify/cli-kit": "4.1.0",
     "n-gram": "2.0.2"
   },

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@graphql-typed-document-node/core": "3.2.0",
-    "@oclif/core": "4.11.4",
+    "@oclif/core": "4.8.3",
     "@shopify/cli-kit": "4.1.0",
     "@shopify/organizations": "4.1.0"
   },

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -40,7 +40,7 @@
     ]
   },
   "dependencies": {
-    "@oclif/core": "4.11.4",
+    "@oclif/core": "4.8.3",
     "@shopify/cli-kit": "4.1.0",
     "@shopify/theme-check-node": "3.26.1",
     "@shopify/theme-language-server-node": "2.21.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -171,8 +171,8 @@ importers:
         specifier: 3.8.1
         version: 3.8.1(esbuild@0.28.0)(graphql-tag@2.12.6(graphql@16.14.2))(graphql@16.14.2)
       '@oclif/core':
-        specifier: 4.11.4
-        version: 4.11.4
+        specifier: 4.8.3
+        version: 4.8.3
       '@shopify/cli-kit':
         specifier: 4.1.0
         version: link:../cli-kit
@@ -263,8 +263,8 @@ importers:
         version: 3.0.0
     devDependencies:
       '@oclif/core':
-        specifier: 4.11.4
-        version: 4.11.4
+        specifier: 4.8.3
+        version: 4.8.3
       '@oclif/plugin-commands':
         specifier: 4.1.57
         version: 4.1.57
@@ -317,8 +317,8 @@ importers:
         specifier: 2.2.5
         version: 2.2.5
       '@oclif/core':
-        specifier: 4.11.4
-        version: 4.11.4
+        specifier: 4.8.3
+        version: 4.8.3
       '@opentelemetry/api':
         specifier: 1.9.1
         version: 1.9.1
@@ -639,8 +639,8 @@ importers:
   packages/plugin-cloudflare:
     dependencies:
       '@oclif/core':
-        specifier: 4.11.4
-        version: 4.11.4
+        specifier: 4.8.3
+        version: 4.8.3
       '@shopify/cli-kit':
         specifier: 4.1.0
         version: link:../cli-kit
@@ -652,8 +652,8 @@ importers:
   packages/plugin-did-you-mean:
     dependencies:
       '@oclif/core':
-        specifier: 4.11.4
-        version: 4.11.4
+        specifier: 4.8.3
+        version: 4.8.3
       '@shopify/cli-kit':
         specifier: 4.1.0
         version: link:../cli-kit
@@ -671,8 +671,8 @@ importers:
         specifier: 3.2.0
         version: 3.2.0(graphql@16.14.2)
       '@oclif/core':
-        specifier: 4.11.4
-        version: 4.11.4
+        specifier: 4.8.3
+        version: 4.8.3
       '@shopify/cli-kit':
         specifier: 4.1.0
         version: link:../cli-kit
@@ -687,8 +687,8 @@ importers:
   packages/theme:
     dependencies:
       '@oclif/core':
-        specifier: 4.11.4
-        version: 4.11.4
+        specifier: 4.8.3
+        version: 4.8.3
       '@shopify/cli-kit':
         specifier: 4.1.0
         version: link:../cli-kit
@@ -3051,6 +3051,10 @@ packages:
 
   '@oclif/core@4.11.4':
     resolution: {integrity: sha512-URwiQ5ALx/sJ2iH4vzXEd+H4K6NAI7LRs6Jag3hrgKEpGmaE6alfRC8qjO4GIgb6A3ACaJumqP9twi/M9ywdHQ==, tarball: https://registry.npmjs.org/@oclif/core/-/core-4.11.4.tgz}
+    engines: {node: '>=18.0.0'}
+
+  '@oclif/core@4.8.3':
+    resolution: {integrity: sha512-f7Rc1JBZO0wNMyDmNzP5IFOv5eM97S9pO4JUFdu2OLyk73YeBI9wog1Yyf666NOQvyptkbG1xh8inzMDQLNTyQ==, tarball: https://registry.npmjs.org/@oclif/core/-/core-4.8.3.tgz}
     engines: {node: '>=18.0.0'}
 
   '@oclif/core@4.9.0':
@@ -8124,11 +8128,6 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  semver@7.8.1:
-    resolution: {integrity: sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==, tarball: https://registry.npmjs.org/semver/-/semver-7.8.1.tgz}
-    engines: {node: '>=10'}
-    hasBin: true
-
   semver@7.8.4:
     resolution: {integrity: sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==, tarball: https://registry.npmjs.org/semver/-/semver-7.8.4.tgz}
     engines: {node: '>=10'}
@@ -12229,7 +12228,28 @@ snapshots:
       is-wsl: 2.2.0
       lilconfig: 3.1.3
       minimatch: 10.2.5
-      semver: 7.8.1
+      semver: 7.8.4
+      string-width: 4.2.3
+      supports-color: 8.1.1
+      tinyglobby: 0.2.16
+      widest-line: 3.1.0
+      wordwrap: 1.0.0
+      wrap-ansi: 7.0.0
+
+  '@oclif/core@4.8.3':
+    dependencies:
+      ansi-escapes: 4.3.2
+      ansis: 3.17.0
+      clean-stack: 3.0.1
+      cli-spinners: 2.9.2
+      debug: 4.4.3(supports-color@8.1.1)
+      ejs: 3.1.10
+      get-package-type: 0.1.0
+      indent-string: 4.0.0
+      is-wsl: 2.2.0
+      lilconfig: 3.1.3
+      minimatch: 10.2.5
+      semver: 7.8.4
       string-width: 4.2.3
       supports-color: 8.1.1
       tinyglobby: 0.2.16
@@ -12260,7 +12280,7 @@ snapshots:
 
   '@oclif/plugin-commands@4.1.57':
     dependencies:
-      '@oclif/core': 4.11.4
+      '@oclif/core': 4.8.3
       '@oclif/table': 0.5.9
       lodash: 4.18.1
       object-treeify: 4.0.1
@@ -12271,7 +12291,7 @@ snapshots:
 
   '@oclif/plugin-help@6.2.45':
     dependencies:
-      '@oclif/core': 4.11.4
+      '@oclif/core': 4.8.3
 
   '@oclif/plugin-not-found@3.2.81(@types/node@18.19.130)':
     dependencies:
@@ -12284,7 +12304,7 @@ snapshots:
 
   '@oclif/plugin-plugins@5.4.47':
     dependencies:
-      '@oclif/core': 4.11.4
+      '@oclif/core': 4.8.3
       ansis: 3.17.0
       debug: 4.4.0
       npm: 10.9.4
@@ -12300,7 +12320,7 @@ snapshots:
 
   '@oclif/plugin-warn-if-update-available@3.1.61':
     dependencies:
-      '@oclif/core': 4.11.4
+      '@oclif/core': 4.8.3
       ansis: 3.17.0
       debug: 4.4.3(supports-color@8.1.1)
       http-call: 5.3.0
@@ -18086,8 +18106,6 @@ snapshots:
   semver@7.6.3: {}
 
   semver@7.7.4: {}
-
-  semver@7.8.1: {}
 
   semver@7.8.4: {}
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes the lazy command loader regression introduced by the `@oclif/core` upgrade.

Starting in `@oclif/core@4.8.4`, `Config.load(config)` always rebuilds a plain `Config` instance when passed an already-loaded config. That discards our `ShopifyConfig` subclass and bypasses `lazyCommandLoader`.

### WHAT is this pull request doing?

Pins direct workspace usage of `@oclif/core` to `4.8.3`, the latest version that preserves the loaded config instance when the oclif base matches.

Also added a test to ensure lazy loading works.

### How to test your changes?

CI

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`
