### PR TITLE
Add preview store claim URL to store info

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -2196,7 +2196,7 @@ DESCRIPTION
   Surface metadata about a Shopify store.
 
   Returns available metadata about a store you have access to, such as its id, display name, subdomain, organization,
-  store owner, type, plan, feature preview, and admin URL.
+  store owner, type, plan, feature preview, admin URL, and save URL for preview stores.
 
   Some details may be omitted when they are not available for the store.
 

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -6012,8 +6012,8 @@
       "args": {
       },
       "customPluginName": "@shopify/store",
-      "description": "Returns available metadata about a store you have access to, such as its id, display name, subdomain, organization, store owner, type, plan, feature preview, and admin URL.\n\nSome details may be omitted when they are not available for the store.\n\nUse `--json` for machine-readable output.",
-      "descriptionWithMarkdown": "Returns available metadata about a store you have access to, such as its id, display name, subdomain, organization, store owner, type, plan, feature preview, and admin URL.\n\nSome details may be omitted when they are not available for the store.\n\nUse `--json` for machine-readable output.",
+      "description": "Returns available metadata about a store you have access to, such as its id, display name, subdomain, organization, store owner, type, plan, feature preview, admin URL, and save URL for preview stores.\n\nSome details may be omitted when they are not available for the store.\n\nUse `--json` for machine-readable output.",
+      "descriptionWithMarkdown": "Returns available metadata about a store you have access to, such as its id, display name, subdomain, organization, store owner, type, plan, feature preview, admin URL, and save URL for preview stores.\n\nSome details may be omitted when they are not available for the store.\n\nUse `--json` for machine-readable output.",
       "examples": [
         "<%= config.bin %> <%= command.id %> --store shop.myshopify.com",
         "<%= config.bin %> <%= command.id %> --store shop.myshopify.com --json"

--- a/packages/store/src/cli/commands/store/info.ts
+++ b/packages/store/src/cli/commands/store/info.ts
@@ -7,7 +7,7 @@ import {globalFlags, jsonFlag} from '@shopify/cli-kit/node/cli'
 export default class StoreInfo extends StoreCommand {
   static summary = 'Surface metadata about a Shopify store.'
 
-  static descriptionWithMarkdown = `Returns available metadata about a store you have access to, such as its id, display name, subdomain, organization, store owner, type, plan, feature preview, and admin URL.
+  static descriptionWithMarkdown = `Returns available metadata about a store you have access to, such as its id, display name, subdomain, organization, store owner, type, plan, feature preview, admin URL, and save URL for preview stores.
 
 Some details may be omitted when they are not available for the store.
 

--- a/packages/store/src/cli/services/store/info/index.test.ts
+++ b/packages/store/src/cli/services/store/info/index.test.ts
@@ -5,6 +5,7 @@ import {STORE_AUTH_APP_CLIENT_ID} from '../auth/config.js'
 import {loadStoredStoreSession} from '../auth/session-lifecycle.js'
 import {clearStoredStoreAppSession, getCurrentStoredStoreAppSession} from '../auth/session-store.js'
 import {recordStoreFqdnMetadata} from '../attribution.js'
+import {claimPreviewStore} from '../create/preview/client.js'
 import {AbortError, BugError} from '@shopify/cli-kit/node/error'
 import {adminUrl} from '@shopify/cli-kit/node/api/admin'
 import {graphqlRequest} from '@shopify/cli-kit/node/api/graphql'
@@ -24,6 +25,7 @@ vi.mock('./organization-shop.js')
 vi.mock('../auth/session-lifecycle.js')
 vi.mock('../auth/session-store.js')
 vi.mock('../attribution.js')
+vi.mock('../create/preview/client.js')
 vi.mock('@shopify/cli-kit/node/api/graphql')
 vi.mock('@shopify/cli-kit/node/session')
 vi.mock('@shopify/cli-kit/node/api/admin', async () => {
@@ -126,6 +128,7 @@ describe('getStoreInfo', () => {
     expect(fetchOrganizationShop).toHaveBeenCalledWith({store: SHOP, organizationId: '149572536', noPrompt: false})
     expect(loadStoredStoreSession).not.toHaveBeenCalled()
     expect(graphqlRequest).not.toHaveBeenCalled()
+    expect(claimPreviewStore).not.toHaveBeenCalled()
     expect(result).toEqual({
       id: 'gid://shopify/Shop/72193245184',
       displayName: 'My Shop (Org)',
@@ -160,6 +163,45 @@ describe('getStoreInfo', () => {
       plan: 'grow',
       featurePreview: 'extended_variants',
       adminUrl: 'https://admin.shopify.com/store/shop',
+    })
+    expect(claimPreviewStore).not.toHaveBeenCalled()
+  })
+
+  test('returns a save URL for locally stored preview stores', async () => {
+    vi.mocked(getCurrentStoredStoreAppSession).mockReturnValueOnce({
+      store: SHOP,
+      clientId: STORE_AUTH_APP_CLIENT_ID,
+      userId: 'preview:placeholder-uuid',
+      accessToken: 'shpat_preview_token',
+      scopes: [],
+      acquiredAt: '2026-06-08T12:00:00.000Z',
+      kind: 'preview',
+      preview: {
+        placeholderAccountUuid: 'placeholder-uuid',
+        shopId: '123',
+        name: 'Lavender Candles',
+        createdAt: '2026-06-08T12:00:00.000Z',
+        accessUrl: 'https://app.shopify.com/auth/preview-store?token=access-token',
+      },
+    })
+    vi.mocked(claimPreviewStore).mockResolvedValueOnce({
+      claimUrl: 'https://admin.shopify.com/store-transfer/accept/claim-token',
+    })
+
+    const result = await getStoreInfo({store: SHOP})
+
+    expect(fetchDestinationsContext).not.toHaveBeenCalled()
+    expect(fetchOrganizationShop).not.toHaveBeenCalled()
+    expect(claimPreviewStore).toHaveBeenCalledWith({
+      shopId: '123',
+      adminApiToken: 'shpat_preview_token',
+    })
+    expect(result).toEqual({
+      id: 'gid://shopify/Shop/123',
+      displayName: 'Lavender Candles',
+      subdomain: SHOP,
+      adminUrl: 'https://admin.shopify.com/store/shop',
+      saveUrl: 'https://admin.shopify.com/store-transfer/accept/claim-token',
     })
   })
 

--- a/packages/store/src/cli/services/store/info/index.ts
+++ b/packages/store/src/cli/services/store/info/index.ts
@@ -5,6 +5,7 @@ import {classifyAdminApiError, throwIfStoredStoreAuthIsInvalid} from '../admin-e
 import {recordStoreFqdnMetadata} from '../attribution.js'
 import {loadStoredStoreSession} from '../auth/session-lifecycle.js'
 import {getCurrentStoredStoreAppSession} from '../auth/session-store.js'
+import {claimPreviewStore} from '../create/preview/client.js'
 import {AbortError} from '@shopify/cli-kit/node/error'
 import {adminUrl} from '@shopify/cli-kit/node/api/admin'
 import {graphqlRequest} from '@shopify/cli-kit/node/api/graphql'
@@ -59,7 +60,17 @@ export async function getStoreInfo(options: GetStoreInfoOptions): Promise<StoreI
     )
   }
 
-  const hasStoredStoreAuth = Boolean(getCurrentStoredStoreAppSession(store))
+  const storedSession = getCurrentStoredStoreAppSession(store)
+
+  if (isPreviewStoreSession(storedSession)) {
+    return buildPreviewStoreResult({
+      store,
+      previewSession: storedSession,
+      saveUrl: await fetchPreviewStoreSaveUrl(storedSession),
+    })
+  }
+
+  const hasStoredStoreAuth = Boolean(storedSession)
 
   try {
     return await getBusinessPlatformStoreInfo(store, {noPrompt: hasStoredStoreAuth})
@@ -117,6 +128,23 @@ async function fetchAdminShopInfo(
 
     throw error
   }
+}
+
+type PreviewStoreSession = StoredStoreAppSession & {
+  kind: 'preview'
+  preview: NonNullable<StoredStoreAppSession['preview']>
+}
+
+function isPreviewStoreSession(session: StoredStoreAppSession | undefined): session is PreviewStoreSession {
+  return session?.kind === 'preview' && session.preview !== undefined
+}
+
+async function fetchPreviewStoreSaveUrl(previewSession: PreviewStoreSession): Promise<string> {
+  const claim = await claimPreviewStore({
+    shopId: previewSession.preview.shopId,
+    adminApiToken: previewSession.accessToken,
+  })
+  return claim.claimUrl
 }
 
 async function safeFetchOrganizationShop(
@@ -193,6 +221,22 @@ function buildBusinessPlatformResult(args: BuildBusinessPlatformResultArgs): Sto
     plan: mapPlanToPublicHandle(orgShop?.planName),
     featurePreview: orgShop?.developerPreviewHandle,
     adminUrl: buildAdminUrl(extractMyshopifyHandle(store)),
+  }
+
+  return {...compact(fields), subdomain: store} as StoreInfoResult
+}
+
+function buildPreviewStoreResult(args: {
+  store: string
+  previewSession: PreviewStoreSession
+  saveUrl: string
+}): StoreInfoResult {
+  const {store, previewSession, saveUrl} = args
+  const fields: Partial<StoreInfoResult> = {
+    id: buildShopGid(previewSession.preview.shopId),
+    displayName: previewSession.preview.name,
+    adminUrl: buildAdminUrl(extractMyshopifyHandle(store)),
+    saveUrl,
   }
 
   return {...compact(fields), subdomain: store} as StoreInfoResult

--- a/packages/store/src/cli/services/store/info/result.test.ts
+++ b/packages/store/src/cli/services/store/info/result.test.ts
@@ -35,6 +35,7 @@ describe('renderStoreInfoResult', () => {
         plan: 'grow',
         featurePreview: 'extended_variants',
         adminUrl: 'https://admin.shopify.com/store/acme-widgets',
+        saveUrl: 'https://admin.shopify.com/store-transfer/accept/claim-token',
       }),
       'json',
     )
@@ -52,6 +53,7 @@ describe('renderStoreInfoResult', () => {
       plan: 'grow',
       featurePreview: 'extended_variants',
       adminUrl: 'https://admin.shopify.com/store/acme-widgets',
+      saveUrl: 'https://admin.shopify.com/store-transfer/accept/claim-token',
     })
     expect(renderInfo).not.toHaveBeenCalled()
   })
@@ -73,6 +75,7 @@ describe('renderStoreInfoResult', () => {
         plan: 'grow',
         featurePreview: 'extended_variants',
         adminUrl: 'https://admin.shopify.com/store/acme-widgets',
+        saveUrl: 'https://admin.shopify.com/store-transfer/accept/claim-token',
       }),
       'text',
     )
@@ -86,6 +89,7 @@ describe('renderStoreInfoResult', () => {
     expect(items).toContain('Plan: Grow')
     expect(items).toContain('Feature Preview: extended_variants')
     expect(items).toContain('Admin URL: https://admin.shopify.com/store/acme-widgets')
+    expect(items).toContain('Save URL: https://admin.shopify.com/store-transfer/accept/claim-token')
   })
 
   test('formats the store owner as "name (email)" when both are present', () => {
@@ -110,5 +114,6 @@ describe('renderStoreInfoResult', () => {
     expect(items.some((item) => item.startsWith('Store owner'))).toBe(false)
     expect(items.some((item) => item.startsWith('Type'))).toBe(false)
     expect(items.some((item) => item.startsWith('Plan'))).toBe(false)
+    expect(items.some((item) => item.startsWith('Save URL'))).toBe(false)
   })
 })

--- a/packages/store/src/cli/services/store/info/result.ts
+++ b/packages/store/src/cli/services/store/info/result.ts
@@ -26,6 +26,7 @@ function storeDetailItems(result: StoreInfoResult): string[] {
   push(items, 'Plan', result.plan ? capitalizeWords(result.plan) : undefined)
   push(items, 'Feature Preview', result.featurePreview)
   push(items, 'Admin URL', result.adminUrl)
+  push(items, 'Save URL', result.saveUrl)
   return items
 }
 

--- a/packages/store/src/cli/services/store/info/types.ts
+++ b/packages/store/src/cli/services/store/info/types.ts
@@ -26,6 +26,7 @@ export interface StoreInfoResult {
   plan?: string
   featurePreview?: string
   adminUrl?: string
+  saveUrl?: string
 }
 
 /**


### PR DESCRIPTION
## What
- Fetch a fresh preview-store claim URL for locally stored preview store sessions in `store info`
- Include the claim URL in text and JSON `store info` output
- Update generated CLI help surfaces and add a changeset

## Testing
- `pnpm --filter @shopify/store vitest run src/cli/services/store/info/index.test.ts src/cli/services/store/info/result.test.ts src/cli/commands/store/info.test.ts`
- `pnpm --filter @shopify/store type-check`
- `pnpm --filter @shopify/store lint`
- `pnpm nx run cli:refresh-manifests`
