### PR TITLE
Support store-auth backed store info

### DIFF
--- a/.changeset/spicy-otters-cheer.md
+++ b/.changeset/spicy-otters-cheer.md
@@ -1,0 +1,5 @@
+---
+'@shopify/store': patch
+---
+
+`store info` now supports store-auth sessions, falling back to the Admin API when a stored store auth token is available and the Business Platform lookup can't be used.

--- a/packages/cli-kit/src/public/node/session.test.ts
+++ b/packages/cli-kit/src/public/node/session.test.ts
@@ -216,6 +216,17 @@ describe('ensureAuthenticatedBusinessPlatform', () => {
     expect(got).toEqual('business_platform')
   })
 
+  test('passes additional auth options through to the shared authenticator', async () => {
+    // Given
+    vi.mocked(ensureAuthenticated).mockResolvedValueOnce({businessPlatform: 'business_platform', userId: '1234-5678'})
+
+    // When
+    await ensureAuthenticatedBusinessPlatform([], {noPrompt: true})
+
+    // Then
+    expect(ensureAuthenticated).toHaveBeenCalledWith({businessPlatformApi: {scopes: []}}, process.env, {noPrompt: true})
+  })
+
   test('throws error if there is no business_platform token', async () => {
     // Given
     vi.mocked(ensureAuthenticated).mockResolvedValueOnce({partners: 'partners_token', userId: '1234-5678'})

--- a/packages/cli-kit/src/public/node/session.ts
+++ b/packages/cli-kit/src/public/node/session.ts
@@ -270,13 +270,17 @@ ${outputToken.json(scopes)}
  * Ensure that we have a valid session to access the Business Platform API.
  *
  * @param scopes - Optional array of extra scopes to authenticate with.
+ * @param options - Optional extra options to use.
  * @returns The access token for the Business Platform API.
  */
-export async function ensureAuthenticatedBusinessPlatform(scopes: BusinessPlatformScope[] = []): Promise<string> {
+export async function ensureAuthenticatedBusinessPlatform(
+  scopes: BusinessPlatformScope[] = [],
+  options: EnsureAuthenticatedAdditionalOptions = {},
+): Promise<string> {
   outputDebug(outputContent`Ensuring that the user is authenticated with the Business Platform API with the following scopes:
 ${outputToken.json(scopes)}
 `)
-  const tokens = await ensureAuthenticated({businessPlatformApi: {scopes}}, process.env)
+  const tokens = await ensureAuthenticated({businessPlatformApi: {scopes}}, process.env, options)
   if (!tokens.businessPlatform) {
     throw new BugError('No business-platform token found after ensuring authenticated')
   }

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -2195,8 +2195,10 @@ FLAGS
 DESCRIPTION
   Surface metadata about a Shopify store.
 
-  Returns metadata about a store you have access to: id, display name, subdomain, organization, store owner, type, plan,
-  feature preview, and admin URL.
+  Returns available metadata about a store you have access to, such as its id, display name, subdomain, organization,
+  store owner, type, plan, feature preview, and admin URL.
+
+  Some details may be omitted when they are not available for the store.
 
   Use `--json` for machine-readable output.
 

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -5943,8 +5943,8 @@
       "args": {
       },
       "customPluginName": "@shopify/store",
-      "description": "Returns metadata about a store you have access to: id, display name, subdomain, organization, store owner, type, plan, feature preview, and admin URL.\n\nUse `--json` for machine-readable output.",
-      "descriptionWithMarkdown": "Returns metadata about a store you have access to: id, display name, subdomain, organization, store owner, type, plan, feature preview, and admin URL.\n\nUse `--json` for machine-readable output.",
+      "description": "Returns available metadata about a store you have access to, such as its id, display name, subdomain, organization, store owner, type, plan, feature preview, and admin URL.\n\nSome details may be omitted when they are not available for the store.\n\nUse `--json` for machine-readable output.",
+      "descriptionWithMarkdown": "Returns available metadata about a store you have access to, such as its id, display name, subdomain, organization, store owner, type, plan, feature preview, and admin URL.\n\nSome details may be omitted when they are not available for the store.\n\nUse `--json` for machine-readable output.",
       "examples": [
         "<%= config.bin %> <%= command.id %> --store shop.myshopify.com",
         "<%= config.bin %> <%= command.id %> --store shop.myshopify.com --json"

--- a/packages/store/src/cli/commands/store/info.ts
+++ b/packages/store/src/cli/commands/store/info.ts
@@ -7,7 +7,9 @@ import {globalFlags, jsonFlag} from '@shopify/cli-kit/node/cli'
 export default class StoreInfo extends StoreCommand {
   static summary = 'Surface metadata about a Shopify store.'
 
-  static descriptionWithMarkdown = `Returns metadata about a store you have access to: id, display name, subdomain, organization, store owner, type, plan, feature preview, and admin URL.
+  static descriptionWithMarkdown = `Returns available metadata about a store you have access to, such as its id, display name, subdomain, organization, store owner, type, plan, feature preview, and admin URL.
+
+Some details may be omitted when they are not available for the store.
 
 Use \`--json\` for machine-readable output.`
 

--- a/packages/store/src/cli/services/store/admin-errors.ts
+++ b/packages/store/src/cli/services/store/admin-errors.ts
@@ -1,0 +1,68 @@
+import {throwReauthenticateStoreAuthError} from './auth/recovery.js'
+import {clearStoredStoreAppSession} from './auth/session-store.js'
+import {AbortError} from '@shopify/cli-kit/node/error'
+import type {StoredStoreAppSession} from './auth/session-store.js'
+
+interface GraphQLClientErrorLike {
+  response: {status?: number; errors?: unknown}
+}
+
+export function isGraphQLClientErrorLike(error: unknown): error is GraphQLClientErrorLike {
+  if (!error || typeof error !== 'object' || !('response' in error)) return false
+  const response = (error as {response?: unknown}).response
+  return Boolean(response) && typeof response === 'object'
+}
+
+function graphQLClientErrorStatus(error: unknown): number | undefined {
+  if (!isGraphQLClientErrorLike(error)) return undefined
+  const status = error.response.status
+  return typeof status === 'number' ? status : undefined
+}
+
+// Lower-cased substrings that Node's fetch/undici implementations use to signal an
+// aborted request. cli-kit's lower-level transport (`isTransientNetworkError` in
+// packages/cli-kit/src/private/node/api.ts) already recognizes 'the operation was
+// aborted'; we cover that shape and add 'the user aborted a request' (the literal
+// node-fetch surfaces) so a fetch that bubbles past cli-kit's retry layer is still
+// classified correctly. Exported so tests reference the same source of truth as
+// production.
+export const ABORTED_FETCH_MESSAGE_FRAGMENTS = ['the user aborted a request', 'the operation was aborted'] as const
+
+function isUserAbortedFetchError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false
+  if (error.name === 'AbortError') return true
+  const message = error.message.toLowerCase()
+  return ABORTED_FETCH_MESSAGE_FRAGMENTS.some((fragment) => message.includes(fragment))
+}
+
+export function classifyAdminApiError(error: unknown, storeFqdn: string): AbortError | undefined {
+  // 402 Payment Required: the shop is frozen / on hold / otherwise unavailable. Store-state
+  // issue, not a CLI bug.
+  if (graphQLClientErrorStatus(error) === 402) {
+    // eslint-disable-next-line @shopify/cli/no-error-factory-functions
+    return new AbortError(
+      `The store ${storeFqdn} is currently unavailable.`,
+      'Check the store in the Shopify admin and try again once it is reactivated.',
+    )
+  }
+
+  // User-aborted fetches (Ctrl-C, CLI-side fetch timeouts) are user-driven, not CLI bugs.
+  if (isUserAbortedFetchError(error)) {
+    // eslint-disable-next-line @shopify/cli/no-error-factory-functions
+    return new AbortError(`Request to ${storeFqdn} was aborted before it completed.`)
+  }
+
+  return undefined
+}
+
+export function throwIfStoredStoreAuthIsInvalid(error: unknown, session: StoredStoreAppSession): void {
+  const status = graphQLClientErrorStatus(error)
+  if (status !== 401 && status !== 404) return
+
+  clearStoredStoreAppSession(session.store, session.userId)
+  throwReauthenticateStoreAuthError(
+    `Stored app authentication for ${session.store} is no longer valid.`,
+    session.store,
+    session.scopes.join(','),
+  )
+}

--- a/packages/store/src/cli/services/store/execute/admin-transport.ts
+++ b/packages/store/src/cli/services/store/execute/admin-transport.ts
@@ -1,4 +1,10 @@
 import {throwReauthenticateStoreAuthError} from '../auth/recovery.js'
+import {
+  classifyAdminApiError,
+  isGraphQLClientErrorLike,
+  throwIfStoredStoreAuthIsInvalid,
+  ABORTED_FETCH_MESSAGE_FRAGMENTS,
+} from '../admin-errors.js'
 import {clearStoredStoreAppSession} from '../auth/session-store.js'
 import {adminUrl} from '@shopify/cli-kit/node/api/admin'
 import {graphqlRequest} from '@shopify/cli-kit/node/api/graphql'
@@ -9,6 +15,8 @@ import type {AdminSession} from '@shopify/cli-kit/node/session'
 import type {PreparedStoreExecuteRequest} from './request.js'
 import type {AdminStoreGraphQLContext} from './admin-context.js'
 import type {StoredStoreAppSession} from '../auth/session-store.js'
+
+export {ABORTED_FETCH_MESSAGE_FRAGMENTS}
 
 interface ApiVersion {
   handle: string
@@ -47,15 +55,7 @@ export async function fetchPublicApiVersions(input: {
     })
     return response.publicApiVersions
   } catch (error) {
-    const status = graphQLClientErrorStatus(error)
-    if (status === 401 || status === 404) {
-      clearStoredStoreAppSession(input.session.store, input.session.userId)
-      throwReauthenticateStoreAuthError(
-        `Stored app authentication for ${input.session.store} is no longer valid.`,
-        input.session.store,
-        input.session.scopes.join(','),
-      )
-    }
+    throwIfStoredStoreAuthIsInvalid(error, input.session)
 
     const classified = classifyAdminApiError(error, input.adminSession.storeFqdn)
     if (classified) throw classified
@@ -105,69 +105,4 @@ export async function runAdminStoreGraphQLOperation(input: {
 
     throw error
   }
-}
-
-// ---------- error classification ----------
-//
-// Both Admin GraphQL calls above see the same raw error shapes from `graphqlRequest`:
-//
-//   - graphql-request `ClientError` (matched structurally on `{response: {status}}` so
-//     `@shopify/store` doesn't need to depend on `graphql-request` at runtime),
-//   - fetch-aborted `Error`s (semantic `name === 'AbortError'`, with a message-string
-//     fallback for older transports).
-//
-// `classifyAdminApiError` covers the shapes both phases agree are user-facing rather
-// than CLI bugs. Phase-specific recovery (clearing stored auth on 401/404 etc.) stays
-// at the call site.
-
-interface GraphQLClientErrorLike {
-  response: {status?: number; errors?: unknown}
-}
-
-function isGraphQLClientErrorLike(error: unknown): error is GraphQLClientErrorLike {
-  if (!error || typeof error !== 'object' || !('response' in error)) return false
-  const response = (error as {response?: unknown}).response
-  return Boolean(response) && typeof response === 'object'
-}
-
-function graphQLClientErrorStatus(error: unknown): number | undefined {
-  if (!isGraphQLClientErrorLike(error)) return undefined
-  const status = error.response.status
-  return typeof status === 'number' ? status : undefined
-}
-
-// Lower-cased substrings that Node's fetch/undici implementations use to signal an
-// aborted request. cli-kit's lower-level transport (`isTransientNetworkError` in
-// packages/cli-kit/src/private/node/api.ts) already recognizes 'the operation was
-// aborted'; we cover that shape and add 'the user aborted a request' (the literal
-// node-fetch surfaces) so a fetch that bubbles past cli-kit's retry layer is still
-// classified correctly. Exported so tests reference the same source of truth as
-// production.
-export const ABORTED_FETCH_MESSAGE_FRAGMENTS = ['the user aborted a request', 'the operation was aborted'] as const
-
-function isUserAbortedFetchError(error: unknown): boolean {
-  if (!(error instanceof Error)) return false
-  if (error.name === 'AbortError') return true
-  const message = error.message.toLowerCase()
-  return ABORTED_FETCH_MESSAGE_FRAGMENTS.some((fragment) => message.includes(fragment))
-}
-
-function classifyAdminApiError(error: unknown, storeFqdn: string): AbortError | undefined {
-  // 402 Payment Required: the shop is frozen / on hold / otherwise unavailable. Store-state
-  // issue, not a CLI bug.
-  if (graphQLClientErrorStatus(error) === 402) {
-    // eslint-disable-next-line @shopify/cli/no-error-factory-functions
-    return new AbortError(
-      `The store ${storeFqdn} is currently unavailable.`,
-      'Check the store in the Shopify admin and try again once it is reactivated.',
-    )
-  }
-
-  // User-aborted fetches (Ctrl-C, CLI-side fetch timeouts) are user-driven, not CLI bugs.
-  if (isUserAbortedFetchError(error)) {
-    // eslint-disable-next-line @shopify/cli/no-error-factory-functions
-    return new AbortError(`Request to ${storeFqdn} was aborted before it completed.`)
-  }
-
-  return undefined
 }

--- a/packages/store/src/cli/services/store/info/destinations.test.ts
+++ b/packages/store/src/cli/services/store/info/destinations.test.ts
@@ -146,4 +146,17 @@ describe('fetchDestinationsContext', () => {
     expect(ensureAuthenticatedBusinessPlatform).not.toHaveBeenCalled()
     expect(vi.mocked(businessPlatformRequestDoc).mock.calls[0]?.[0].token).toBe('preset')
   })
+
+  test('passes noPrompt through when authenticating', async () => {
+    vi.mocked(businessPlatformRequestDoc).mockResolvedValueOnce({
+      currentUserAccount: {destinations: {nodes: [destinationNode()]}},
+    } as never)
+    vi.mocked(businessPlatformRequestDoc).mockResolvedValueOnce({
+      currentUserAccount: {organizationForDestination: {id: 'gid', name: 'O'}},
+    } as never)
+
+    await fetchDestinationsContext({store: SHOP, noPrompt: true})
+
+    expect(ensureAuthenticatedBusinessPlatform).toHaveBeenCalledWith([], {noPrompt: true})
+  })
 })

--- a/packages/store/src/cli/services/store/info/destinations.ts
+++ b/packages/store/src/cli/services/store/info/destinations.ts
@@ -23,14 +23,17 @@ type DestinationNodeFromQuery = NonNullable<
 interface FetchDestinationsContextOptions {
   store: string
   token?: string
+  noPrompt?: boolean
 }
 
+export class StoreInfoBusinessPlatformStoreNotFoundError extends AbortError {}
+
 export async function fetchDestinationsContext(options: FetchDestinationsContextOptions): Promise<DestinationsContext> {
-  const token = options.token ?? (await ensureAuthenticatedBusinessPlatform())
+  const token = options.token ?? (await ensureAuthenticatedBusinessPlatform([], {noPrompt: options.noPrompt}))
   const unauthorizedHandler = {
     type: 'token_refresh' as const,
     handler: async () => {
-      const newToken = await ensureAuthenticatedBusinessPlatform()
+      const newToken = await ensureAuthenticatedBusinessPlatform([], {noPrompt: options.noPrompt})
       return {token: newToken}
     },
   }
@@ -56,7 +59,7 @@ export async function fetchDestinationsContext(options: FetchDestinationsContext
   const matchedNode = nodes.find((node) => matchesStore(node, targetHost))
 
   if (!matchedNode) {
-    throw new AbortError(
+    throw new StoreInfoBusinessPlatformStoreNotFoundError(
       `Couldn't find a store with domain ${options.store} for the current account.`,
       'Verify the domain (must be the canonical `myshopify.com` FQDN) and that you are signed in to an account with access to the store. Inactive shops are not searchable.',
     )

--- a/packages/store/src/cli/services/store/info/index.test.ts
+++ b/packages/store/src/cli/services/store/info/index.test.ts
@@ -1,15 +1,51 @@
 import {getStoreInfo} from './index.js'
-import {fetchDestinationsContext} from './destinations.js'
+import {StoreInfoBusinessPlatformStoreNotFoundError, fetchDestinationsContext} from './destinations.js'
 import {fetchOrganizationShop} from './organization-shop.js'
-import {AbortError} from '@shopify/cli-kit/node/error'
-import {describe, test, expect, vi} from 'vitest'
+import {STORE_AUTH_APP_CLIENT_ID} from '../auth/config.js'
+import {loadStoredStoreSession} from '../auth/session-lifecycle.js'
+import {clearStoredStoreAppSession, getCurrentStoredStoreAppSession} from '../auth/session-store.js'
+import {recordStoreFqdnMetadata} from '../attribution.js'
+import {AbortError, BugError} from '@shopify/cli-kit/node/error'
+import {adminUrl} from '@shopify/cli-kit/node/api/admin'
+import {graphqlRequest} from '@shopify/cli-kit/node/api/graphql'
+import {setLastSeenUserId} from '@shopify/cli-kit/node/session'
+import {beforeEach, describe, test, expect, vi} from 'vitest'
 import type {OrganizationShopFields} from './types.js'
 import type {Store} from '../../../api/graphql/business-platform-organizations/generated/types.js'
 
-vi.mock('./destinations.js')
+vi.mock('./destinations.js', async () => {
+  const actual = await vi.importActual<typeof import('./destinations.js')>('./destinations.js')
+  return {
+    ...actual,
+    fetchDestinationsContext: vi.fn(),
+  }
+})
 vi.mock('./organization-shop.js')
+vi.mock('../auth/session-lifecycle.js')
+vi.mock('../auth/session-store.js')
+vi.mock('../attribution.js')
+vi.mock('@shopify/cli-kit/node/api/graphql')
+vi.mock('@shopify/cli-kit/node/session')
+vi.mock('@shopify/cli-kit/node/api/admin', async () => {
+  const actual = await vi.importActual<typeof import('@shopify/cli-kit/node/api/admin')>(
+    '@shopify/cli-kit/node/api/admin',
+  )
+  return {
+    ...actual,
+    adminUrl: vi.fn(),
+  }
+})
 
 const SHOP = 'shop.myshopify.com'
+const STORED_SESSION = {
+  store: SHOP,
+  clientId: STORE_AUTH_APP_CLIENT_ID,
+  userId: '42',
+  accessToken: 'token',
+  refreshToken: 'refresh-token',
+  scopes: ['read_products'],
+  acquiredAt: '2026-04-02T00:00:00.000Z',
+}
 
 function orgShop(overrides: Partial<OrganizationShopFields> = {}): OrganizationShopFields {
   return {
@@ -25,21 +61,71 @@ function orgShop(overrides: Partial<OrganizationShopFields> = {}): OrganizationS
   }
 }
 
+function adminShop(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'gid://shopify/Shop/72193245184',
+    name: 'My Shop',
+    myshopifyDomain: SHOP,
+    email: 'jane@acme.com',
+    shopOwnerName: 'Jane Doe',
+    plan: {
+      publicDisplayName: 'Grow',
+      partnerDevelopment: false,
+    },
+    ...overrides,
+  }
+}
+
+// Structural fake of graphql-request's `ClientError`; production matches on shape.
+function makeClientErrorLike(status: number, message = 'GraphQL Error'): Error {
+  const error = new Error(message) as Error & {response: {status: number; errors: {message: string}[]}}
+  error.response = {status, errors: [{message}]}
+  return error
+}
+
+function mockStoredStoreAuth(): void {
+  vi.mocked(getCurrentStoredStoreAppSession).mockReturnValue(STORED_SESSION)
+}
+
+function mockBusinessPlatformUnavailable(
+  error: Error = new StoreInfoBusinessPlatformStoreNotFoundError(
+    `Couldn't find a store with domain ${SHOP} for the current account.`,
+  ),
+): void {
+  vi.mocked(fetchDestinationsContext).mockRejectedValue(error)
+}
+
+function mockStoreAuthFallback(): void {
+  mockStoredStoreAuth()
+  mockBusinessPlatformUnavailable()
+}
+
 describe('getStoreInfo', () => {
+  beforeEach(() => {
+    vi.mocked(getCurrentStoredStoreAppSession).mockReturnValue(undefined)
+    vi.mocked(fetchDestinationsContext).mockResolvedValue({owningOrg: {name: 'Acme Holdings', id: '149572536'}})
+    vi.mocked(fetchOrganizationShop).mockResolvedValue(orgShop())
+    vi.mocked(loadStoredStoreSession).mockResolvedValue(STORED_SESSION)
+    vi.mocked(adminUrl).mockReturnValue(`https://${SHOP}/admin/api/unstable/graphql.json`)
+    vi.mocked(graphqlRequest).mockResolvedValue({shop: adminShop()})
+  })
+
   test('throws AbortError when no store is provided', async () => {
     const err = await getStoreInfo({}).catch((error: unknown) => error)
     expect(err).toBeInstanceOf(AbortError)
     expect((err as AbortError).message).toContain('No store')
+    expect(fetchDestinationsContext).not.toHaveBeenCalled()
+    expect(loadStoredStoreSession).not.toHaveBeenCalled()
   })
 
-  test('composes fields from destinations + org-shop', async () => {
-    vi.mocked(fetchDestinationsContext).mockResolvedValueOnce({
-      owningOrg: {name: 'Acme Holdings', id: '149572536'},
-    })
-    vi.mocked(fetchOrganizationShop).mockResolvedValueOnce(orgShop())
-
+  test('uses BP destinations and org-shop when there is no stored store auth session', async () => {
     const result = await getStoreInfo({store: SHOP})
 
+    expect(getCurrentStoredStoreAppSession).toHaveBeenCalledWith(SHOP)
+    expect(fetchDestinationsContext).toHaveBeenCalledWith({store: SHOP, noPrompt: false})
+    expect(fetchOrganizationShop).toHaveBeenCalledWith({store: SHOP, organizationId: '149572536', noPrompt: false})
+    expect(loadStoredStoreSession).not.toHaveBeenCalled()
+    expect(graphqlRequest).not.toHaveBeenCalled()
     expect(result).toEqual({
       id: 'gid://shopify/Shop/72193245184',
       displayName: 'My Shop (Org)',
@@ -54,31 +140,146 @@ describe('getStoreInfo', () => {
     })
   })
 
-  test('derives the admin URL from the myshopify subdomain', async () => {
-    vi.mocked(fetchDestinationsContext).mockResolvedValueOnce({owningOrg: {name: 'Acme', id: '42'}})
-    vi.mocked(fetchOrganizationShop).mockResolvedValueOnce(orgShop())
+  test('prefers BP when store auth exists and BP can resolve the store', async () => {
+    mockStoredStoreAuth()
 
-    const result = await getStoreInfo({store: 'acme-widgets.myshopify.com'})
+    const result = await getStoreInfo({store: SHOP})
 
+    expect(fetchDestinationsContext).toHaveBeenCalledWith({store: SHOP, noPrompt: true})
+    expect(fetchOrganizationShop).toHaveBeenCalledWith({store: SHOP, organizationId: '149572536', noPrompt: true})
+    expect(loadStoredStoreSession).not.toHaveBeenCalled()
+    expect(graphqlRequest).not.toHaveBeenCalled()
+    expect(result).toEqual({
+      id: 'gid://shopify/Shop/72193245184',
+      displayName: 'My Shop (Org)',
+      subdomain: SHOP,
+      organizationId: '149572536',
+      organizationName: 'Acme Holdings',
+      storeOwner: {name: 'Jane Doe', email: 'jane@acme.com'},
+      type: 'production',
+      plan: 'grow',
+      featurePreview: 'extended_variants',
+      adminUrl: 'https://admin.shopify.com/store/shop',
+    })
+  })
+
+  test('falls back to stored store auth when BP cannot resolve a store-auth store', async () => {
+    mockStoreAuthFallback()
+
+    const result = await getStoreInfo({store: SHOP})
+
+    expect(fetchDestinationsContext).toHaveBeenCalledWith({store: SHOP, noPrompt: true})
+    expect(fetchOrganizationShop).not.toHaveBeenCalled()
+    expect(loadStoredStoreSession).toHaveBeenCalledWith(SHOP)
+    expect(recordStoreFqdnMetadata).toHaveBeenCalledWith(SHOP, true)
+    expect(setLastSeenUserId).toHaveBeenCalledWith('42')
+    expect(adminUrl).toHaveBeenCalledWith(SHOP, 'unstable')
+    expect(graphqlRequest).toHaveBeenCalledWith({
+      query: expect.stringContaining('query StoreInfoAdminShop'),
+      api: 'Admin',
+      url: `https://${SHOP}/admin/api/unstable/graphql.json`,
+      token: 'token',
+      responseOptions: {handleErrors: false},
+    })
+    expect(result).toEqual({
+      id: 'gid://shopify/Shop/72193245184',
+      displayName: 'My Shop',
+      subdomain: SHOP,
+      storeOwner: {name: 'Jane Doe', email: 'jane@acme.com'},
+      plan: 'Grow',
+      adminUrl: 'https://admin.shopify.com/store/shop',
+    })
+  })
+
+  test('falls back to stored store auth when BP auth would need to prompt', async () => {
+    const noPromptError = new AbortError(`The currently available CLI credentials are invalid.
+
+The CLI is currently unable to prompt for reauthentication.`)
+    mockStoreAuthFallback()
+    mockBusinessPlatformUnavailable(noPromptError)
+
+    const result = await getStoreInfo({store: SHOP})
+
+    expect(fetchDestinationsContext).toHaveBeenCalledWith({store: SHOP, noPrompt: true})
+    expect(loadStoredStoreSession).toHaveBeenCalledWith(SHOP)
+    expect(result.displayName).toBe('My Shop')
+  })
+
+  test('throws the BP error when BP cannot resolve a store and no store auth exists', async () => {
+    mockBusinessPlatformUnavailable()
+
+    await expect(getStoreInfo({store: SHOP})).rejects.toMatchObject({
+      message: `Couldn't find a store with domain ${SHOP} for the current account.`,
+    })
+    expect(loadStoredStoreSession).not.toHaveBeenCalled()
+  })
+
+  test('rethrows unexpected BP errors instead of falling back to stored store auth', async () => {
+    mockStoredStoreAuth()
+    vi.mocked(fetchDestinationsContext).mockRejectedValue(new Error('upstream exploded'))
+
+    await expect(getStoreInfo({store: SHOP})).rejects.toThrow('upstream exploded')
+    expect(loadStoredStoreSession).not.toHaveBeenCalled()
+  })
+
+  test('uses the refreshed session store returned by the stored-auth loader', async () => {
+    mockStoreAuthFallback()
+    vi.mocked(loadStoredStoreSession).mockResolvedValue({
+      ...STORED_SESSION,
+      store: 'permanent-shop.myshopify.com',
+      accessToken: 'fresh-token',
+    })
+    vi.mocked(graphqlRequest).mockResolvedValue({
+      shop: adminShop({myshopifyDomain: 'permanent-shop.myshopify.com'}),
+    })
+
+    const result = await getStoreInfo({store: SHOP})
+
+    expect(recordStoreFqdnMetadata).toHaveBeenCalledWith('permanent-shop.myshopify.com', true)
+    expect(adminUrl).toHaveBeenCalledWith('permanent-shop.myshopify.com', 'unstable')
+    expect(graphqlRequest).toHaveBeenCalledWith(expect.objectContaining({token: 'fresh-token'}))
+    expect(result.subdomain).toBe('permanent-shop.myshopify.com')
+    expect(result.adminUrl).toBe('https://admin.shopify.com/store/permanent-shop')
+  })
+
+  test('derives the admin URL from the Admin myshopify domain for store-auth stores', async () => {
+    mockStoreAuthFallback()
+    vi.mocked(graphqlRequest).mockResolvedValue({
+      shop: adminShop({myshopifyDomain: 'acme-widgets.myshopify.com'}),
+    })
+
+    const result = await getStoreInfo({store: SHOP})
+
+    expect(result.subdomain).toBe('acme-widgets.myshopify.com')
     expect(result.adminUrl).toBe('https://admin.shopify.com/store/acme-widgets')
   })
 
-  test('maps the raw plan name to a public handle', async () => {
-    vi.mocked(fetchDestinationsContext).mockResolvedValueOnce({owningOrg: {name: 'Acme', id: '42'}})
-    vi.mocked(fetchOrganizationShop).mockResolvedValueOnce(orgShop({planName: 'shopify_plus'}))
+  test('falls back to the stored session store when Admin omits myshopifyDomain', async () => {
+    mockStoreAuthFallback()
+    vi.mocked(graphqlRequest).mockResolvedValue({
+      shop: adminShop({myshopifyDomain: undefined}),
+    })
+
+    const result = await getStoreInfo({store: SHOP})
+
+    expect(result.subdomain).toBe(SHOP)
+    expect(result.adminUrl).toBe('https://admin.shopify.com/store/shop')
+  })
+
+  test('maps the BP raw plan name to a public handle', async () => {
+    vi.mocked(fetchOrganizationShop).mockResolvedValue(orgShop({planName: 'shopify_plus'}))
 
     const result = await getStoreInfo({store: SHOP})
 
     expect(result.plan).toBe('plus')
   })
 
-  test('omits the plan when the raw plan name is unrecognized', async () => {
-    vi.mocked(fetchDestinationsContext).mockResolvedValueOnce({owningOrg: {name: 'Acme', id: '42'}})
-    vi.mocked(fetchOrganizationShop).mockResolvedValueOnce(orgShop({planName: 'development_legacy'}))
+  test('uses the Admin public plan display name for store-auth stores', async () => {
+    mockStoreAuthFallback()
 
     const result = await getStoreInfo({store: SHOP})
 
-    expect(result.plan).toBeUndefined()
+    expect(result.plan).toBe('Grow')
   })
 
   test.each<[Store, string]>([
@@ -88,35 +289,55 @@ describe('getStoreInfo', () => {
     ['PRODUCTION', 'production'],
     ['CLIENT_TRANSFER', 'client_transfer'],
     ['COLLABORATOR', 'collaborator'],
-  ])('maps the %s store type to the `%s` handle', async (storeType, expected) => {
-    vi.mocked(fetchDestinationsContext).mockResolvedValueOnce({owningOrg: {name: 'Acme', id: '42'}})
-    vi.mocked(fetchOrganizationShop).mockResolvedValueOnce(orgShop({storeType}))
+  ])('maps the BP %s store type to the `%s` handle', async (storeType, expected) => {
+    vi.mocked(fetchOrganizationShop).mockResolvedValue(orgShop({storeType}))
 
     const result = await getStoreInfo({store: SHOP})
 
     expect(result.type).toBe(expected)
   })
 
-  test('omits the type for an unrecognized store type', async () => {
-    vi.mocked(fetchDestinationsContext).mockResolvedValueOnce({owningOrg: {name: 'Acme', id: '42'}})
-    vi.mocked(fetchOrganizationShop).mockResolvedValueOnce(orgShop({storeType: 'MANAGED_MARKETS' as Store}))
+  test('marks type as dev when the Admin plan identifies a partner development store', async () => {
+    mockStoreAuthFallback()
+    vi.mocked(graphqlRequest).mockResolvedValue({
+      shop: adminShop({plan: {publicDisplayName: 'Development', partnerDevelopment: true}}),
+    })
+
+    const result = await getStoreInfo({store: SHOP})
+
+    expect(result.type).toBe('dev')
+    expect(result.plan).toBe('Development')
+  })
+
+  test('omits type when the Admin plan does not identify a development store', async () => {
+    mockStoreAuthFallback()
 
     const result = await getStoreInfo({store: SHOP})
 
     expect(result.type).toBeUndefined()
   })
 
-  test('omits storeOwner when neither name nor email is present', async () => {
-    vi.mocked(fetchDestinationsContext).mockResolvedValueOnce({owningOrg: {name: 'Acme', id: '42'}})
-    vi.mocked(fetchOrganizationShop).mockResolvedValueOnce(orgShop({ownerName: undefined, ownerEmail: undefined}))
+  test('omits storeOwner when neither Admin name nor email is present', async () => {
+    mockStoreAuthFallback()
+    vi.mocked(graphqlRequest).mockResolvedValue({
+      shop: adminShop({shopOwnerName: undefined, email: undefined}),
+    })
 
     const result = await getStoreInfo({store: SHOP})
 
     expect(result.storeOwner).toBeUndefined()
   })
 
-  test('omits org-sourced fields when the owning org is unknown', async () => {
-    vi.mocked(fetchDestinationsContext).mockResolvedValueOnce({})
+  test('omits storeOwner when neither BP name nor email is present', async () => {
+    vi.mocked(fetchOrganizationShop).mockResolvedValue(orgShop({ownerName: undefined, ownerEmail: undefined}))
+
+    const result = await getStoreInfo({store: SHOP})
+
+    expect(result.storeOwner).toBeUndefined()
+  })
+
+  test('omits org-sourced fields when the owning org is unknown in the BP path', async () => {
+    vi.mocked(fetchDestinationsContext).mockResolvedValue({})
 
     const result = await getStoreInfo({store: SHOP})
 
@@ -127,17 +348,68 @@ describe('getStoreInfo', () => {
     })
   })
 
-  test('omits org-sourced fields without throwing when the org-shop lookup fails', async () => {
-    vi.mocked(fetchDestinationsContext).mockResolvedValueOnce({owningOrg: {name: 'Acme', id: '42'}})
-    vi.mocked(fetchOrganizationShop).mockRejectedValueOnce(new Error('5xx'))
+  test('omits org-sourced fields without throwing when the BP org-shop lookup fails', async () => {
+    vi.mocked(fetchOrganizationShop).mockRejectedValue(new Error('5xx'))
 
     const result = await getStoreInfo({store: SHOP})
 
     expect(result).toEqual({
       subdomain: SHOP,
-      organizationId: '42',
-      organizationName: 'Acme',
+      organizationId: '149572536',
+      organizationName: 'Acme Holdings',
       adminUrl: 'https://admin.shopify.com/store/shop',
     })
+  })
+
+  test('throws when Shopify does not return Admin shop info', async () => {
+    mockStoreAuthFallback()
+    vi.mocked(graphqlRequest).mockResolvedValue({shop: undefined})
+
+    await expect(getStoreInfo({store: SHOP})).rejects.toThrow(`Shopify did not return store information for ${SHOP}.`)
+  })
+
+  test('clears stored auth and throws a re-auth error on Admin 401', async () => {
+    mockStoreAuthFallback()
+    vi.mocked(graphqlRequest).mockRejectedValue(makeClientErrorLike(401, 'Unauthorized'))
+
+    await expect(getStoreInfo({store: SHOP})).rejects.toMatchObject({
+      message: `Stored app authentication for ${SHOP} is no longer valid.`,
+      tryMessage: 'To re-authenticate, run:',
+      nextSteps: [[{command: `shopify store auth --store ${SHOP} --scopes read_products`}]],
+    })
+    expect(clearStoredStoreAppSession).toHaveBeenCalledWith(SHOP, '42')
+  })
+
+  test('also treats Admin 404 as a stored-auth-no-longer-valid signal', async () => {
+    mockStoreAuthFallback()
+    vi.mocked(graphqlRequest).mockRejectedValue(makeClientErrorLike(404, 'Not Found'))
+
+    await expect(getStoreInfo({store: SHOP})).rejects.toMatchObject({
+      message: `Stored app authentication for ${SHOP} is no longer valid.`,
+    })
+    expect(clearStoredStoreAppSession).toHaveBeenCalledWith(SHOP, '42')
+  })
+
+  test('maps unavailable Admin stores to a user-facing AbortError', async () => {
+    mockStoreAuthFallback()
+    vi.mocked(graphqlRequest).mockRejectedValue(makeClientErrorLike(402, 'Unavailable Shop'))
+
+    let captured: AbortError | undefined
+    await getStoreInfo({store: SHOP}).catch((error) => {
+      captured = error as AbortError
+    })
+
+    expect(captured).toBeInstanceOf(AbortError)
+    expect(captured).not.toBeInstanceOf(BugError)
+    expect(captured?.message).toBe(`The store ${SHOP} is currently unavailable.`)
+    expect(clearStoredStoreAppSession).not.toHaveBeenCalled()
+  })
+
+  test('rethrows unrelated Admin API errors', async () => {
+    mockStoreAuthFallback()
+    vi.mocked(graphqlRequest).mockRejectedValue(new Error('upstream exploded'))
+
+    await expect(getStoreInfo({store: SHOP})).rejects.toThrow('upstream exploded')
+    expect(clearStoredStoreAppSession).not.toHaveBeenCalled()
   })
 })

--- a/packages/store/src/cli/services/store/info/index.ts
+++ b/packages/store/src/cli/services/store/info/index.ts
@@ -1,16 +1,54 @@
-import {fetchDestinationsContext} from './destinations.js'
+import {StoreInfoBusinessPlatformStoreNotFoundError, fetchDestinationsContext} from './destinations.js'
 import {fetchOrganizationShop} from './organization-shop.js'
 import {mapPlanToPublicHandle} from './plan.js'
+import {classifyAdminApiError, throwIfStoredStoreAuthIsInvalid} from '../admin-errors.js'
+import {recordStoreFqdnMetadata} from '../attribution.js'
+import {loadStoredStoreSession} from '../auth/session-lifecycle.js'
+import {getCurrentStoredStoreAppSession} from '../auth/session-store.js'
 import {AbortError} from '@shopify/cli-kit/node/error'
+import {adminUrl} from '@shopify/cli-kit/node/api/admin'
+import {graphqlRequest} from '@shopify/cli-kit/node/api/graphql'
 import {compact} from '@shopify/cli-kit/common/object'
 import {extractMyshopifyHandle} from '@shopify/cli-kit/common/url'
+import {setLastSeenUserId} from '@shopify/cli-kit/node/session'
 import {outputDebug} from '@shopify/cli-kit/node/output'
 import type {Store} from '../../../api/graphql/business-platform-organizations/generated/types.js'
 import type {DestinationsContext, OrganizationShopFields, StoreInfoResult, StoreInfoStoreOwner} from './types.js'
+import type {StoredStoreAppSession} from '../auth/session-store.js'
 
 interface GetStoreInfoOptions {
   store?: string
 }
+
+interface AdminStoreInfoResponse {
+  shop?: {
+    id?: string
+    name?: string
+    myshopifyDomain?: string
+    email?: string
+    shopOwnerName?: string
+    plan?: {
+      publicDisplayName?: string
+      partnerDevelopment?: boolean
+    }
+  }
+}
+
+const StoreInfoAdminShopQuery = `#graphql
+  query StoreInfoAdminShop {
+    shop {
+      id
+      name
+      myshopifyDomain
+      email
+      shopOwnerName
+      plan {
+        publicDisplayName
+        partnerDevelopment
+      }
+    }
+  }
+`
 
 export async function getStoreInfo(options: GetStoreInfoOptions): Promise<StoreInfoResult> {
   const store = options.store
@@ -21,15 +59,70 @@ export async function getStoreInfo(options: GetStoreInfoOptions): Promise<StoreI
     )
   }
 
-  const destinationsCtx = await fetchDestinationsContext({store})
-  const orgShop = await safeFetchOrganizationShop(destinationsCtx, store)
+  const hasStoredStoreAuth = Boolean(getCurrentStoredStoreAppSession(store))
 
-  return buildResult({store, destinationsCtx, orgShop})
+  try {
+    return await getBusinessPlatformStoreInfo(store, {noPrompt: hasStoredStoreAuth})
+  } catch (error) {
+    if (!hasStoredStoreAuth || !isBusinessPlatformFallbackError(error)) {
+      throw error
+    }
+
+    outputDebug(`BP store info lookup failed; falling back to stored store auth: ${errorMessage(error)}`)
+    return getAdminStoreInfo(store)
+  }
+}
+
+async function getAdminStoreInfo(store: string): Promise<StoreInfoResult> {
+  const session = await loadStoredStoreSession(store)
+  await recordStoreFqdnMetadata(session.store, true)
+  setLastSeenUserId(session.userId)
+  const shop = await fetchAdminShopInfo(session)
+
+  return buildAdminResult({store: session.store, shop})
+}
+
+async function getBusinessPlatformStoreInfo(
+  store: string,
+  options: {noPrompt?: boolean} = {},
+): Promise<StoreInfoResult> {
+  const destinationsCtx = await fetchDestinationsContext({store, noPrompt: options.noPrompt})
+  const orgShop = await safeFetchOrganizationShop(destinationsCtx, store, {noPrompt: options.noPrompt})
+
+  return buildBusinessPlatformResult({store, destinationsCtx, orgShop})
+}
+
+async function fetchAdminShopInfo(
+  session: StoredStoreAppSession,
+): Promise<NonNullable<AdminStoreInfoResponse['shop']>> {
+  try {
+    const response = await graphqlRequest<AdminStoreInfoResponse>({
+      query: StoreInfoAdminShopQuery,
+      api: 'Admin',
+      url: adminUrl(session.store, 'unstable'),
+      token: session.accessToken,
+      responseOptions: {handleErrors: false},
+    })
+
+    if (!response.shop) {
+      throw new AbortError(`Shopify did not return store information for ${session.store}.`)
+    }
+
+    return response.shop
+  } catch (error) {
+    throwIfStoredStoreAuthIsInvalid(error, session)
+
+    const classified = classifyAdminApiError(error, session.store)
+    if (classified) throw classified
+
+    throw error
+  }
 }
 
 async function safeFetchOrganizationShop(
   ctx: DestinationsContext,
   store: string,
+  options: {noPrompt?: boolean} = {},
 ): Promise<OrganizationShopFields | undefined> {
   if (!ctx.owningOrg?.id) {
     // Without an org id we can't address the BP Organizations API, so the shop-level fields
@@ -39,7 +132,7 @@ async function safeFetchOrganizationShop(
     return undefined
   }
   try {
-    return await fetchOrganizationShop({store, organizationId: ctx.owningOrg.id})
+    return await fetchOrganizationShop({store, organizationId: ctx.owningOrg.id, noPrompt: options.noPrompt})
     // eslint-disable-next-line no-catch-all/no-catch-all
   } catch (error) {
     outputDebug(`BP Organizations shop lookup failed: ${error instanceof Error ? error.message : String(error)}`)
@@ -47,13 +140,47 @@ async function safeFetchOrganizationShop(
   }
 }
 
-interface BuildResultArgs {
+function isBusinessPlatformFallbackError(error: unknown): boolean {
+  return error instanceof StoreInfoBusinessPlatformStoreNotFoundError || isNoPromptAuthenticationError(error)
+}
+
+function isNoPromptAuthenticationError(error: unknown): boolean {
+  return error instanceof AbortError && error.message.includes('unable to prompt for reauthentication')
+}
+
+function errorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message
+  return String(error)
+}
+
+interface BuildAdminResultArgs {
+  store: string
+  shop: NonNullable<AdminStoreInfoResponse['shop']>
+}
+
+function buildAdminResult(args: BuildAdminResultArgs): StoreInfoResult {
+  const {store, shop} = args
+  const subdomain = shop.myshopifyDomain ?? store
+
+  const fields: Partial<StoreInfoResult> = {
+    id: shop.id,
+    displayName: shop.name,
+    storeOwner: buildAdminStoreOwner(shop),
+    type: shop.plan?.partnerDevelopment ? 'dev' : undefined,
+    plan: shop.plan?.publicDisplayName,
+    adminUrl: buildAdminUrl(extractMyshopifyHandle(subdomain)),
+  }
+
+  return {...compact(fields), subdomain} as StoreInfoResult
+}
+
+interface BuildBusinessPlatformResultArgs {
   store: string
   destinationsCtx: DestinationsContext
   orgShop: OrganizationShopFields | undefined
 }
 
-function buildResult(args: BuildResultArgs): StoreInfoResult {
+function buildBusinessPlatformResult(args: BuildBusinessPlatformResultArgs): StoreInfoResult {
   const {store, destinationsCtx, orgShop} = args
 
   const fields: Partial<StoreInfoResult> = {
@@ -61,7 +188,7 @@ function buildResult(args: BuildResultArgs): StoreInfoResult {
     displayName: orgShop?.name,
     organizationId: destinationsCtx.owningOrg?.id,
     organizationName: destinationsCtx.owningOrg?.name,
-    storeOwner: buildStoreOwner(orgShop),
+    storeOwner: buildBusinessPlatformStoreOwner(orgShop),
     type: mapStoreType(orgShop?.storeType),
     plan: mapPlanToPublicHandle(orgShop?.planName),
     featurePreview: orgShop?.developerPreviewHandle,
@@ -77,7 +204,12 @@ function buildShopGid(shopifyShopId: string | undefined): string | undefined {
   return `gid://shopify/Shop/${shopifyShopId}`
 }
 
-function buildStoreOwner(orgShop: OrganizationShopFields | undefined): StoreInfoStoreOwner | undefined {
+function buildAdminStoreOwner(shop: NonNullable<AdminStoreInfoResponse['shop']>): StoreInfoStoreOwner | undefined {
+  const owner = compact({name: shop.shopOwnerName, email: shop.email}) as StoreInfoStoreOwner
+  return Object.keys(owner).length > 0 ? owner : undefined
+}
+
+function buildBusinessPlatformStoreOwner(orgShop: OrganizationShopFields | undefined): StoreInfoStoreOwner | undefined {
   if (!orgShop) return undefined
   const owner = compact({name: orgShop.ownerName, email: orgShop.ownerEmail}) as StoreInfoStoreOwner
   return Object.keys(owner).length > 0 ? owner : undefined

--- a/packages/store/src/cli/services/store/info/organization-shop.test.ts
+++ b/packages/store/src/cli/services/store/info/organization-shop.test.ts
@@ -74,6 +74,16 @@ describe('fetchOrganizationShop', () => {
     expect(ensureAuthenticatedBusinessPlatform).not.toHaveBeenCalled()
   })
 
+  test('passes noPrompt through when authenticating', async () => {
+    vi.mocked(businessPlatformOrganizationsRequestDoc).mockResolvedValueOnce({
+      organization: {id: 'gid', name: 'Acme', accessibleShops: {edges: [{node: shopNode()}]}},
+    } as never)
+
+    await fetchOrganizationShop({store: SHOP, organizationId: ORG_ID, noPrompt: true})
+
+    expect(ensureAuthenticatedBusinessPlatform).toHaveBeenCalledWith([], {noPrompt: true})
+  })
+
   test('throws when organization is missing', async () => {
     vi.mocked(businessPlatformOrganizationsRequestDoc).mockResolvedValueOnce({organization: null} as never)
     await expect(fetchOrganizationShop({store: SHOP, organizationId: ORG_ID})).rejects.toBeInstanceOf(BugError)

--- a/packages/store/src/cli/services/store/info/organization-shop.ts
+++ b/packages/store/src/cli/services/store/info/organization-shop.ts
@@ -13,14 +13,15 @@ interface FetchOrganizationShopOptions {
   store: string
   organizationId: string
   token?: string
+  noPrompt?: boolean
 }
 
 export async function fetchOrganizationShop(options: FetchOrganizationShopOptions): Promise<OrganizationShopFields> {
-  const token = options.token ?? (await ensureAuthenticatedBusinessPlatform())
+  const token = options.token ?? (await ensureAuthenticatedBusinessPlatform([], {noPrompt: options.noPrompt}))
   const unauthorizedHandler = {
     type: 'token_refresh' as const,
     handler: async () => {
-      const newToken = await ensureAuthenticatedBusinessPlatform()
+      const newToken = await ensureAuthenticatedBusinessPlatform([], {noPrompt: options.noPrompt})
       return {token: newToken}
     },
   }

--- a/packages/store/src/cli/services/store/info/types.ts
+++ b/packages/store/src/cli/services/store/info/types.ts
@@ -22,8 +22,7 @@ export interface StoreInfoResult {
   organizationName?: string
   storeOwner?: StoreInfoStoreOwner
   type?: string
-  // Public plan handle (basic | grow | advanced | plus), mapped from the raw BP plan name.
-  // Unrecognized plans are omitted. See `plan.ts`.
+  // Admin API public display name for store-auth stores, or public plan handle for BP-backed stores.
   plan?: string
   featurePreview?: string
   adminUrl?: string


### PR DESCRIPTION
## What changed
- Preserve the existing enriched `store info` path as the preferred source of store metadata.
- When a stored store-auth session exists, attempt the enriched lookup without prompting for login.
- Fall back to the stored store-auth/Admin API path only when the enriched lookup cannot proceed without prompting, or when the store is not found there.
- Share Admin API stored-auth error handling with `store execute`.
- Update command help and generated CLI docs to describe the bottom-line behavior without exposing internal auth details.

## Store-auth fallback field coverage
The fallback path can return:
- ID
- Display name
- Subdomain
- Store owner name/email
- Plan public display name
- Admin URL
- `Type: Dev` when the Admin plan reports a partner development store

The fallback path does not include fields that currently only come from the enriched organization-backed lookup:
- Organization name / organization ID
- Feature preview handle
- Full store type mapping such as production, collaborator, client transfer, or development superset

When those fields are unavailable, `store info` omits them from text and JSON output instead of blocking the command. Stores that are available through the enriched lookup still get the fuller output, even if store auth also exists.

## Testing
- `pnpm vitest packages/store/src/cli/services/store/info/index.test.ts packages/store/src/cli/services/store/info/destinations.test.ts packages/store/src/cli/services/store/info/organization-shop.test.ts packages/store/src/cli/services/store/info/plan.test.ts packages/store/src/cli/services/store/info/result.test.ts packages/store/src/cli/commands/store/info.test.ts packages/store/src/cli/services/store/execute/admin-transport.test.ts packages/cli-kit/src/public/node/session.test.ts`
- `pnpm nx run store:type-check`