### PR TITLE
[Performance] Memoize isWsl function

### DIFF
--- a/packages/cli-kit/src/public/node/system.test.ts
+++ b/packages/cli-kit/src/public/node/system.test.ts
@@ -353,6 +353,18 @@ describe('isStdinPiped', () => {
   })
 })
 
+describe('isWsl', () => {
+  test('memoizes the result', async () => {
+    // When
+    const result1 = system.isWsl()
+    const result2 = system.isWsl()
+
+    // Then
+    expect(result1).toBe(result2)
+    await expect(result1).resolves.toBeTypeOf('boolean')
+  })
+})
+
 describe('readStdinString', () => {
   test('returns undefined when stdin is not piped', async () => {
     // Given

--- a/packages/cli-kit/src/public/node/system.ts
+++ b/packages/cli-kit/src/public/node/system.ts
@@ -355,13 +355,28 @@ export function isCI(): boolean {
 }
 
 /**
+ * Memoized value for the WSL check.
+ */
+let memoizedIsWsl: Promise<boolean> | undefined
+
+/**
  * Check if the current environment is a WSL environment.
  *
  * @returns True if the current environment is a WSL environment.
  */
-export async function isWsl(): Promise<boolean> {
-  const wsl = await import('is-wsl')
-  return wsl.default
+export function isWsl(): Promise<boolean> {
+  return (memoizedIsWsl ??= (async () => {
+    const wsl = await import('is-wsl')
+    return wsl.default
+  })())
+}
+
+/**
+ * Resets the memoized value for the WSL check.
+ * This is used for testing purposes.
+ */
+export function _resetIsWsl(): void {
+  memoizedIsWsl = undefined
 }
 
 /**


### PR DESCRIPTION
### WHY are these changes introduced?

The `isWsl` function in `@shopify/cli-kit` is used to determine if the CLI is running under Windows Subsystem for Linux. This check involves a dynamic import of the `is-wsl` package and subsequent computation. As this value does not change during the lifecycle of the CLI and is called in high-frequency paths like analytics, it is a good candidate for memoization.

### WHAT is this pull request doing?

- Memoizes the result of `isWsl()` in `packages/cli-kit/src/public/node/system.ts` using a module-level promise.
- Exports an internal `_resetIsWsl()` function to facilitate cache resetting in tests.
- Adds a unit test in `packages/cli-kit/src/public/node/system.test.ts` to verify memoization behavior.

Expected performance impact: Reduces overhead of repeated `is-wsl` checks, avoiding redundant dynamic imports and system calls.

### How to test your changes?

CI

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [13364146102369441427](https://jules.google.com/task/13364146102369441427) started by @gonzaloriestra*