### PR TITLE
[Security] Harden cloudflared installation against command injection

### DIFF
--- a/packages/plugin-cloudflare/src/install-cloudflared.test.ts
+++ b/packages/plugin-cloudflare/src/install-cloudflared.test.ts
@@ -92,32 +92,35 @@ describe('install-cloudflare', () => {
     })
   })
 
-  test('installMacos is no longer vulnerable to command injection via binTarget', async () => {
-    await inTemporaryDirectory(async (tmpDir) => {
-      // Given
-      // A malicious path that attempts to escape the tar command and execute 'touch exploit'
-      const binPath = joinPath(tmpDir, '"; touch exploit; #')
-      const env = {SHOPIFY_CLI_CLOUDFLARED_PATH: binPath}
-      mockFetch()
-      vi.mocked(childProcess.execFileSync).mockImplementation((command, args, options) => {
-        if (command === 'tar') {
-          const cwd = options?.cwd as string
-          writeFileSync(joinPath(cwd, 'cloudflared'), 'extracted binary')
-        }
-        return Buffer.from('')
+  test.skipIf(process.platform === 'win32')(
+    'installMacos is no longer vulnerable to command injection via binTarget',
+    async () => {
+      await inTemporaryDirectory(async (tmpDir) => {
+        // Given
+        // A malicious path that attempts to escape the tar command and execute 'touch exploit'
+        const binPath = joinPath(tmpDir, '"; touch exploit; #')
+        const env = {SHOPIFY_CLI_CLOUDFLARED_PATH: binPath}
+        mockFetch()
+        vi.mocked(childProcess.execFileSync).mockImplementation((command, args, options) => {
+          if (command === 'tar') {
+            const cwd = options?.cwd as string
+            writeFileSync(joinPath(cwd, 'cloudflared'), 'extracted binary')
+          }
+          return Buffer.from('')
+        })
+
+        // When
+        await install(env, 'darwin', 'x64')
+
+        // Then
+        expect(childProcess.execFileSync).toHaveBeenCalledWith(
+          'tar',
+          expect.arrayContaining(['-xzf', expect.stringContaining('; touch exploit; #')]),
+          expect.anything(),
+        )
       })
-
-      // When
-      await install(env, 'darwin', 'x64')
-
-      // Then
-      expect(childProcess.execFileSync).toHaveBeenCalledWith(
-        'tar',
-        expect.arrayContaining(['-xzf', expect.stringContaining('; touch exploit; #')]),
-        expect.anything(),
-      )
-    })
-  })
+    },
+  )
 
   test('downloads the correct binary for linux', async () => {
     await inTemporaryDirectory(async (tmpDir) => {

--- a/packages/plugin-cloudflare/src/install-cloudflared.test.ts
+++ b/packages/plugin-cloudflare/src/install-cloudflared.test.ts
@@ -42,10 +42,12 @@ describe('install-cloudflare', () => {
       const binPath = joinPath(tmpDir, 'cloudflared')
       const env = {SHOPIFY_CLI_CLOUDFLARED_PATH: binPath}
       mockFetch()
-      vi.mocked(childProcess.execSync).mockImplementation((_command, options) => {
-        // Simulate tar extracting the file
-        const cwd = options?.cwd as string
-        writeFileSync(joinPath(cwd, 'cloudflared'), 'extracted binary')
+      vi.mocked(childProcess.execFileSync).mockImplementation((command, args, options) => {
+        if (command === 'tar') {
+          // Simulate tar extracting the file
+          const cwd = options?.cwd as string
+          writeFileSync(joinPath(cwd, 'cloudflared'), 'extracted binary')
+        }
         return Buffer.from('')
       })
 
@@ -69,9 +71,11 @@ describe('install-cloudflare', () => {
       const binPath = joinPath(tmpDir, 'cloudflared')
       const env = {SHOPIFY_CLI_CLOUDFLARED_PATH: binPath}
       mockFetch()
-      vi.mocked(childProcess.execSync).mockImplementation((_command, options) => {
-        const cwd = options?.cwd as string
-        writeFileSync(joinPath(cwd, 'cloudflared'), 'extracted binary')
+      vi.mocked(childProcess.execFileSync).mockImplementation((command, args, options) => {
+        if (command === 'tar') {
+          const cwd = options?.cwd as string
+          writeFileSync(joinPath(cwd, 'cloudflared'), 'extracted binary')
+        }
         return Buffer.from('')
       })
 
@@ -85,6 +89,33 @@ describe('install-cloudflare', () => {
         'slow-request',
       )
       await expect(fileExists(binPath)).resolves.toBe(true)
+    })
+  })
+
+  test('installMacos is no longer vulnerable to command injection via binTarget', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      // A malicious path that attempts to escape the tar command and execute 'touch exploit'
+      const binPath = joinPath(tmpDir, '"; touch exploit; #')
+      const env = {SHOPIFY_CLI_CLOUDFLARED_PATH: binPath}
+      mockFetch()
+      vi.mocked(childProcess.execFileSync).mockImplementation((command, args, options) => {
+        if (command === 'tar') {
+          const cwd = options?.cwd as string
+          writeFileSync(joinPath(cwd, 'cloudflared'), 'extracted binary')
+        }
+        return Buffer.from('')
+      })
+
+      // When
+      await install(env, 'darwin', 'x64')
+
+      // Then
+      expect(childProcess.execFileSync).toHaveBeenCalledWith(
+        'tar',
+        expect.arrayContaining(['-xzf', expect.stringContaining('; touch exploit; #')]),
+        expect.anything(),
+      )
     })
   })
 

--- a/packages/plugin-cloudflare/src/install-cloudflared.ts
+++ b/packages/plugin-cloudflare/src/install-cloudflared.ts
@@ -14,7 +14,7 @@ import {fileURLToPath} from 'url'
 import util from 'util'
 import {pipeline} from 'stream'
 // eslint-disable-next-line no-restricted-imports
-import {execSync, execFileSync} from 'child_process'
+import {execFileSync} from 'child_process'
 
 export const CURRENT_CLOUDFLARE_VERSION = '2024.8.2'
 const CLOUDFLARE_REPO = `https://github.com/cloudflare/cloudflared/releases/download/${CURRENT_CLOUDFLARE_VERSION}/`
@@ -132,7 +132,7 @@ async function installWindows(file: string, binTarget: string) {
 async function installMacos(file: string, binTarget: string) {
   await downloadFile(file, `${binTarget}.tgz`)
   const filename = basename(`${binTarget}.tgz`)
-  execSync(`tar -xzf ${filename}`, {cwd: dirname(binTarget)})
+  execFileSync('tar', ['-xzf', filename], {cwd: dirname(binTarget)})
   unlinkFileSync(`${binTarget}.tgz`)
   await renameFile(`${dirname(binTarget)}/cloudflared`, binTarget)
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Hardens the codebase against a potential command injection vulnerability in the cloudflared installation script.

### WHAT is this pull request doing?

Replaces `execSync` with `execFileSync` in the macOS installation path for cloudflared. This ensures that the binary path and filename are treated as literal arguments rather than being interpreted by a shell, preventing command injection if a malicious path is provided.

### How to test your changes?

CI

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [5314096495162801865](https://jules.google.com/task/5314096495162801865) started by @gonzaloriestra*