### PR TITLE
Remove fixed wait from dev hot reload E2E

### DIFF
--- a/packages/e2e/tests/dev-hot-reload.spec.ts
+++ b/packages/e2e/tests/dev-hot-reload.spec.ts
@@ -173,9 +173,6 @@ test.describe('Dev hot reload', () => {
         writeFlowTriggerExtension(appDir, 'doomed-ext')
         await proc.waitForOutput('Extension created', CLI_TIMEOUT.medium)
 
-        // Wait for the dev session to settle before deleting
-        await new Promise((resolve) => setTimeout(resolve, 5000))
-
         fs.rmSync(path.join(appDir, 'extensions', 'doomed-ext'), {recursive: true, force: true})
 
         await proc.waitForOutput('Extension deleted', CLI_TIMEOUT.medium)


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes N/A

The dev hot reload delete E2E test used a fixed 5 second sleep after detecting extension creation. That made the test slower and still relied on timing rather than the observable state the test already waits for.

### WHAT is this pull request doing?

Removes the fixed settle wait from `tests/dev-hot-reload.spec.ts` before deleting the generated extension. The test now proceeds once the CLI has emitted `Extension created`, then deletes the extension and waits for the existing `Extension deleted` signal.

### How to test your changes?

Validated locally from `~/worktrees/cli-remove-dev-hot-reload-fixed-wait`:

```sh
pnpm install --frozen-lockfile
pnpm --filter @shopify/e2e lint
NX_SKIP_NX_CACHE=true pnpm --filter @shopify/e2e type-check
git diff --check
```

I did not run the full E2E spec locally because it requires E2E environment credentials.

### Post-release steps

None.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [x] This change is not user-facing, so no changeset is required
