### PR TITLE
Use vi.waitFor in app event watcher test

### DIFF
--- a/packages/app/src/cli/services/dev/app-events/app-event-watcher.test.ts
+++ b/packages/app/src/cli/services/dev/app-events/app-event-watcher.test.ts
@@ -383,23 +383,17 @@ describe('app-event-watcher', () => {
 
           await flushPromises()
 
-          // Wait until emitSpy has been called at least once
-          // We need this because there are I/O operations that make the test finish before the event is emitted
-          await new Promise<void>((resolve, reject) => {
-            const initialTime = Date.now()
-            const checkEmitSpy = () => {
+          // Wait until emitSpy has been called at least once.
+          // We need this because there are I/O operations that make the test finish before the event is emitted.
+          await vi.waitFor(
+            () => {
               const allCalled = emitSpy.mock.calls.some((call) => call[0] === 'all')
               const readyCalled = emitSpy.mock.calls.some((call) => call[0] === 'ready')
-              if (allCalled && readyCalled) {
-                resolve()
-              } else if (Date.now() - initialTime < 3000) {
-                setTimeout(checkEmitSpy, 100)
-              } else {
-                reject(new Error('Timeout waiting for emitSpy to be called'))
-              }
-            }
-            checkEmitSpy()
-          })
+              expect(allCalled).toBe(true)
+              expect(readyCalled).toBe(true)
+            },
+            {timeout: 3000, interval: 100},
+          )
 
           expect(emitSpy).toHaveBeenCalledWith('all', {
             app: expect.objectContaining({realExtensions: finalExtensions}),


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes N/A

`app-event-watcher.test.ts` had a hand-rolled polling loop using `setTimeout` to wait for async watcher emissions. Using Vitest's built-in wait helper makes the test easier to read and avoids maintaining custom timer logic.

### WHAT is this pull request doing?

Replaces the custom `new Promise` / `setTimeout` polling loop with `vi.waitFor` while preserving the same timeout and polling interval semantics. The assertions still wait for both `all` and `ready` events before continuing.

### How to test your changes?

Validated locally from `~/worktrees/cli-use-vi-waitfor-app-event-watcher`:

```sh
pnpm install --frozen-lockfile
pnpm --filter @shopify/app vitest src/cli/services/dev/app-events/app-event-watcher.test.ts --run
pnpm --filter @shopify/app lint
NX_SKIP_NX_CACHE=true pnpm --filter @shopify/app type-check
git diff --check
```

### Post-release steps

None.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [x] This change is not user-facing, so no changeset is required
