### PR TITLE
Only treat .myshopify.io as a normalized store FQDN suffix

### DIFF
--- a/.changeset/normalize-store-fqdn-suffix.md
+++ b/.changeset/normalize-store-fqdn-suffix.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': patch
+---
+
+Only treat `.myshopify.io` (not any `shopify.io` suffix) as an already-normalized store FQDN

--- a/packages/cli-kit/src/public/node/context/fqdn.test.ts
+++ b/packages/cli-kit/src/public/node/context/fqdn.test.ts
@@ -217,4 +217,37 @@ describe('normalizeStore', () => {
     // Then
     expect(got).toEqual('example.myshopify.com')
   })
+
+  test('preserves local dev store names ending in .myshopify.io', async () => {
+    // Given
+    vi.mocked(serviceEnvironment).mockReturnValue(Environment.Local)
+
+    // When
+    const got = normalizeStoreFqdn('example.myshopify.io')
+
+    // Then
+    expect(got).toEqual('example.myshopify.io')
+  })
+
+  test('does not treat other domains ending in shopify.io as already normalized', async () => {
+    // Given
+    vi.mocked(serviceEnvironment).mockReturnValue(Environment.Production)
+
+    // When
+    const got = normalizeStoreFqdn('exampleshopify.io')
+
+    // Then
+    expect(got).toEqual('exampleshopify.io.myshopify.com')
+  })
+
+  test('does not treat nested domains ending in shopify.io as already normalized', async () => {
+    // Given
+    vi.mocked(serviceEnvironment).mockReturnValue(Environment.Production)
+
+    // When
+    const got = normalizeStoreFqdn('example.exampleshopify.io')
+
+    // Then
+    expect(got).toEqual('example.exampleshopify.io.myshopify.com')
+  })
 })

--- a/packages/cli-kit/src/public/node/context/fqdn.ts
+++ b/packages/cli-kit/src/public/node/context/fqdn.ts
@@ -139,7 +139,7 @@ export function normalizeStoreFqdn(store: string): string {
     }
   }
   const containDomain = (storeFqdn: string) =>
-    storeFqdn.endsWith('.myshopify.com') || storeFqdn.endsWith('shopify.io') || storeFqdn.endsWith('.shop.dev')
+    storeFqdn.endsWith('.myshopify.com') || storeFqdn.endsWith('.myshopify.io') || storeFqdn.endsWith('.shop.dev')
   return containDomain(storeFqdn) ? storeFqdn : addDomain(storeFqdn)
 }
 


### PR DESCRIPTION
The `shopify.io` suffix check matched any domain ending in `shopify.io` (e.g. `notshopify.io`); tighten it to `.myshopify.io`.

`*.myshopify.io` is the hostname the legacy local dev server assigns to stores (see [`dev-server-2016.ts`](https://github.com/Shopify/cli/blob/0991f169bc613b2378ecb2e5c51af4b28268fa28/packages/cli-kit/src/public/node/vendor/dev_server/dev-server-2016.ts#L25)), which is why it's treated as already-normalized.