### PR TITLE
[Security] Redact SHOPIFY_API_SECRET from console output

### DIFF
--- a/knip_output.txt
+++ b/knip_output.txt
@@ -1,0 +1,3 @@
+
+> @0.0.0 knip /app
+> knip --workspace \@shopify/app

--- a/packages/app/src/cli/services/app/env/pull.test.ts
+++ b/packages/app/src/cli/services/app/env/pull.test.ts
@@ -40,7 +40,7 @@ describe('env pull', () => {
       "Created ${filePath}:
 
       SHOPIFY_API_KEY=api-key
-      SHOPIFY_API_SECRET=api-secret
+      SHOPIFY_API_SECRET=******
       SCOPES=my-scope
       "
       `)
@@ -66,15 +66,15 @@ describe('env pull', () => {
       "Updated ${filePath} to be:
 
       SHOPIFY_API_KEY=api-key
-      SHOPIFY_API_SECRET=api-secret
+      SHOPIFY_API_SECRET=******
       SCOPES=my-scope
 
       Here's what changed:
 
       - SHOPIFY_API_KEY=ABC
-      - SHOPIFY_API_SECRET=XYZ
+      - SHOPIFY_API_SECRET=******
       + SHOPIFY_API_KEY=api-key
-      + SHOPIFY_API_SECRET=api-secret
+      + SHOPIFY_API_SECRET=******
       SCOPES=my-scope
         "
       `)

--- a/packages/app/src/cli/services/app/env/pull.ts
+++ b/packages/app/src/cli/services/app/env/pull.ts
@@ -34,13 +34,20 @@ export async function pullEnv({app, remoteApp, organization, envFile}: PullEnvOp
       await writeFile(envFile, updatedEnvFileContent)
 
       const diff = diffLines(envFileContent ?? '', updatedEnvFileContent)
+      const redactedDiff = diff.map((change) => ({
+        ...change,
+        value: change.value.replace(/^(SHOPIFY_API_SECRET=)(.*)$/gm, '$1******'),
+      }))
+
+      const redactedEnvFileContent = updatedEnvFileContent.replace(/^(SHOPIFY_API_SECRET=)(.*)$/gm, '$1******')
+
       return outputContent`Updated ${outputToken.path(envFile)} to be:
 
-${updatedEnvFileContent}
+${redactedEnvFileContent}
 
 Here's what changed:
 
-${outputToken.linesDiff(diff)}
+${outputToken.linesDiff(redactedDiff)}
   `
     }
   } else {
@@ -48,9 +55,11 @@ ${outputToken.linesDiff(diff)}
 
     await writeFile(envFile, newEnvFileContent)
 
+    const redactedEnvFileContent = newEnvFileContent.replace(/^(SHOPIFY_API_SECRET=)(.*)$/gm, '$1******')
+
     return outputContent`Created ${outputToken.path(envFile)}:
 
-${newEnvFileContent}
+${redactedEnvFileContent}
 `
   }
 }

--- a/packages/app/src/cli/services/app/env/show.test.ts
+++ b/packages/app/src/cli/services/app/env/show.test.ts
@@ -38,7 +38,7 @@ describe('env show', () => {
     expect(unstyled(stringifyMessage(result))).toMatchInlineSnapshot(`
     "
         SHOPIFY_API_KEY=api-key
-        SHOPIFY_API_SECRET=api-secret
+        SHOPIFY_API_SECRET=******
         SCOPES=my-scope
       "
     `)

--- a/packages/app/src/cli/services/app/env/show.ts
+++ b/packages/app/src/cli/services/app/env/show.ts
@@ -21,16 +21,17 @@ export async function outputEnv(
 ): Promise<OutputMessage> {
   await logMetadataForLoadedContext(remoteApp, organization.source)
 
+  const redactedApiSecret = remoteApp.apiSecretKeys[0]?.secret ? '******' : ''
   if (format === 'json') {
     return outputContent`${outputToken.json({
       SHOPIFY_API_KEY: remoteApp.apiKey,
-      SHOPIFY_API_SECRET: remoteApp.apiSecretKeys[0]?.secret,
+      SHOPIFY_API_SECRET: redactedApiSecret,
       SCOPES: getAppScopes(app.configuration),
     })}`
   } else {
     return outputContent`
     ${outputToken.green('SHOPIFY_API_KEY')}=${remoteApp.apiKey}
-    ${outputToken.green('SHOPIFY_API_SECRET')}=${remoteApp.apiSecretKeys[0]?.secret ?? ''}
+    ${outputToken.green('SHOPIFY_API_SECRET')}=${redactedApiSecret}
     ${outputToken.green('SCOPES')}=${getAppScopes(app.configuration)}
   `
   }

--- a/packages/app/src/cli/services/info.test.ts
+++ b/packages/app/src/cli/services/info.test.ts
@@ -97,7 +97,7 @@ describe('info', () => {
       expect(unstyled(stringifyMessage(result))).toMatchInlineSnapshot(`
       "
           SHOPIFY_API_KEY=api-key
-          SHOPIFY_API_SECRET=api-secret
+          SHOPIFY_API_SECRET=******
           SCOPES=my-scope
         "
       `)
@@ -121,7 +121,7 @@ describe('info', () => {
       expect(unstyled(stringifyMessage(result))).toMatchInlineSnapshot(`
         "{
           "SHOPIFY_API_KEY": "api-key",
-          "SHOPIFY_API_SECRET": "api-secret",
+          "SHOPIFY_API_SECRET": "******",
           "SCOPES": "my-scope"
         }"
       `)


### PR DESCRIPTION
### WHY are these changes introduced?

Hardens the CLI by redacting the `SHOPIFY_API_SECRET` from console output when running `app env show` and `app env pull`. This reduces the risk of accidental exposure of the API secret in terminal logs, screen sharing, or CI/CD logs.

### WHAT is this pull request doing?

- Redacts `SHOPIFY_API_SECRET` in `packages/app/src/cli/services/app/env/show.ts` for both text and JSON formats.
- Redacts `SHOPIFY_API_SECRET` in `packages/app/src/cli/services/app/env/pull.ts` when displaying the updated `.env` file content and the diff of changes.
- Ensures the actual secret is still written to the `.env` file on disk.
- Updates unit tests to verify the redaction.

### How to test your changes?

`shopify app env show`
`shopify app env pull`

### Post-release steps

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (\`patch\` for bug fixes · \`minor\` for new features · \`major\` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with \`pnpm changeset add\`

---
*PR created automatically by Jules for task [10066652050855391840](https://jules.google.com/task/10066652050855391840) started by @gonzaloriestra*