### PR TITLE
[Performance] Memoize isWsl result

### DIFF
--- a/packages/cli-kit/src/public/node/system.test.ts
+++ b/packages/cli-kit/src/public/node/system.test.ts
@@ -393,3 +393,18 @@ describe('readStdinString', () => {
     await expect(got).rejects.toThrow('Stdin input exceeded the maximum allowed size.')
   })
 })
+
+describe('isWsl', () => {
+  test('memoizes the result', async () => {
+    // Given
+    system._resetIsWsl()
+
+    // When
+    const firstCall = system.isWsl()
+    const secondCall = system.isWsl()
+
+    // Then
+    expect(firstCall).toBe(secondCall)
+    await expect(firstCall).resolves.toBeTypeOf('boolean')
+  })
+})

--- a/packages/cli-kit/src/public/node/system.ts
+++ b/packages/cli-kit/src/public/node/system.ts
@@ -355,13 +355,25 @@ export function isCI(): boolean {
 }
 
 /**
+ * Memoized value for the WSL check.
+ */
+let memoizedIsWsl: Promise<boolean> | undefined
+
+/**
  * Check if the current environment is a WSL environment.
  *
  * @returns True if the current environment is a WSL environment.
  */
-export async function isWsl(): Promise<boolean> {
-  const wsl = await import('is-wsl')
-  return wsl.default
+export function isWsl(): Promise<boolean> {
+  return (memoizedIsWsl ??= import('is-wsl').then((wsl) => wsl.default))
+}
+
+/**
+ * Resets the memoized value for the WSL check.
+ * This is only used for testing purposes.
+ */
+export function _resetIsWsl() {
+  memoizedIsWsl = undefined
 }
 
 /**


### PR DESCRIPTION
### WHY are these changes introduced?

The `isWsl` function performs a dynamic import of `is-wsl`. Repeatedly calling this function introduces unnecessary overhead, especially in high-frequency code paths like analytics gathering. Memoizing the result improves performance by ensuring the dynamic import and check only happen once per process.

### WHAT is this pull request doing?

- Introduced a module-level variable `memoizedIsWsl` to store the result promise.
- Updated `isWsl` to return the memoized promise.
- Added `_resetIsWsl` for test isolation.
- Added a unit test to verify memoization.

### How to test your changes?

CI

### Post-release steps

N/A

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [353186469740054345](https://jules.google.com/task/353186469740054345) started by @gonzaloriestra*