### PR TITLE
[Tests] Remove filesystem mocks in app init command tests

### DIFF
--- a/packages/app/src/cli/commands/app/init.test.ts
+++ b/packages/app/src/cli/commands/app/init.test.ts
@@ -14,7 +14,7 @@ import {
 } from '../../models/app/app.test-data.js'
 import {describe, expect, test, vi} from 'vitest'
 import {mockAndCaptureOutput} from '@shopify/cli-kit/node/testing/output'
-import {generateRandomNameForSubdirectory} from '@shopify/cli-kit/node/fs'
+import {inTemporaryDirectory} from '@shopify/cli-kit/node/fs'
 import {inferPackageManager} from '@shopify/cli-kit/node/node-package-manager'
 
 vi.mock('../../prompts/init/init.js')
@@ -30,241 +30,278 @@ vi.mock('../../services/dev/fetch.js', async (importOriginal) => {
 })
 vi.mock('../../prompts/dev.js')
 vi.mock('../../services/init/validate.js')
-vi.mock('@shopify/cli-kit/node/fs')
 vi.mock('@shopify/cli-kit/node/node-package-manager')
 
 describe('Init command', () => {
   test('runs init command with default flags', async () => {
-    // Given
-    const mockOrganization = testOrganization()
-    const mockDeveloperPlatformClient = testDeveloperPlatformClient()
-    const mockApp = testAppLinked()
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      const mockOrganization = testOrganization()
+      const mockDeveloperPlatformClient = testDeveloperPlatformClient()
+      const mockApp = testAppLinked()
 
-    mockAndCaptureOutput()
-    vi.mocked(validateTemplateValue).mockReturnValue(undefined)
-    vi.mocked(validateFlavorValue).mockReturnValue(undefined)
-    vi.mocked(inferPackageManager).mockReturnValue('npm')
-    vi.mocked(generateRandomNameForSubdirectory).mockResolvedValue('test-app')
-    vi.mocked(selectDeveloperPlatformClient).mockReturnValue(mockDeveloperPlatformClient)
-    vi.mocked(selectOrg).mockResolvedValue(mockOrganization)
-
-    // Mock the orgAndApps method on the developer platform client
-    vi.mocked(mockDeveloperPlatformClient.orgAndApps).mockResolvedValue({
-      organization: mockOrganization,
-      apps: [],
-      hasMorePages: false,
-    })
-
-    vi.mocked(initPrompt).mockResolvedValue({
-      template: 'https://github.com/Shopify/shopify-app-template-remix',
-      templateType: 'remix',
-      globalCLIResult: {install: false, alreadyInstalled: false},
-    })
-    vi.mocked(createAsNewAppPrompt).mockResolvedValue(true)
-    vi.mocked(appNamePrompt).mockResolvedValue('test-app')
-    vi.mocked(initService).mockResolvedValue({app: mockApp})
-
-    // When
-    await Init.run([])
-
-    // Then
-    expect(initService).toHaveBeenCalledWith(
-      expect.objectContaining({
-        name: 'test-app',
-        packageManager: 'npm',
-      }),
-    )
-  })
-
-  test('runs init command without prompts when organization-id, name, and template flags are provided', async () => {
-    // Given
-    const mockOrganization = testOrganization()
-    const mockDeveloperPlatformClient = testDeveloperPlatformClient()
-    const mockApp = testAppLinked()
-
-    mockAndCaptureOutput()
-    vi.mocked(validateTemplateValue).mockReturnValue(undefined)
-    vi.mocked(validateFlavorValue).mockReturnValue(undefined)
-    vi.mocked(inferPackageManager).mockReturnValue('npm')
-    vi.mocked(selectDeveloperPlatformClient).mockReturnValue(mockDeveloperPlatformClient)
-
-    // Mock fetchOrgFromId to return the organization
-    vi.mocked(fetchOrgFromId).mockResolvedValue(mockOrganization)
-
-    // Mock the orgAndApps method on the developer platform client
-    vi.mocked(mockDeveloperPlatformClient.orgAndApps).mockResolvedValue({
-      organization: mockOrganization,
-      apps: [],
-      hasMorePages: false,
-    })
-
-    vi.mocked(initPrompt).mockResolvedValue({
-      template: 'https://github.com/Shopify/shopify-app-template-remix',
-      templateType: 'remix',
-      globalCLIResult: {install: false, alreadyInstalled: false},
-    })
-    vi.mocked(initService).mockResolvedValue({app: mockApp})
-
-    // When
-    await Init.run(['--organization-id', mockOrganization.id, '--name', 'my-app', '--template', 'remix'])
-
-    // Then
-    // Verify that prompt functions were NOT called
-    // Any other interactive prompts would also cause the test to fail with an AbortError
-    expect(selectOrg).not.toHaveBeenCalled()
-    expect(createAsNewAppPrompt).not.toHaveBeenCalled()
-    expect(appNamePrompt).not.toHaveBeenCalled()
-
-    // Verify the command completed successfully
-    expect(initService).toHaveBeenCalledWith(
-      expect.objectContaining({
-        name: 'my-app',
-        packageManager: 'npm',
-        template: 'https://github.com/Shopify/shopify-app-template-remix',
-      }),
-    )
-  })
-
-  test('fails with clear error message when invalid organization-id is provided', async () => {
-    // Given
-    const mockDeveloperPlatformClient = testDeveloperPlatformClient()
-
-    // Suppress stderr output for this error test
-    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
-
-    try {
-      const outputMock = mockAndCaptureOutput()
+      mockAndCaptureOutput()
       vi.mocked(validateTemplateValue).mockReturnValue(undefined)
       vi.mocked(validateFlavorValue).mockReturnValue(undefined)
       vi.mocked(inferPackageManager).mockReturnValue('npm')
       vi.mocked(selectDeveloperPlatformClient).mockReturnValue(mockDeveloperPlatformClient)
+      vi.mocked(selectOrg).mockResolvedValue(mockOrganization)
 
-      // Mock fetchOrgFromId to throw NoOrgError for invalid organization
-      vi.mocked(fetchOrgFromId).mockRejectedValue(
-        new NoOrgError({type: 'UserAccount', email: 'test@example.com'}, 'invalid-org-id'),
-      )
+      // Mock the orgAndApps method on the developer platform client
+      vi.mocked(mockDeveloperPlatformClient.orgAndApps).mockResolvedValue({
+        organization: mockOrganization,
+        apps: [],
+        hasMorePages: false,
+      })
 
       vi.mocked(initPrompt).mockResolvedValue({
         template: 'https://github.com/Shopify/shopify-app-template-remix',
         templateType: 'remix',
         globalCLIResult: {install: false, alreadyInstalled: false},
       })
+      vi.mocked(createAsNewAppPrompt).mockResolvedValue(true)
+      vi.mocked(appNamePrompt).mockResolvedValue('test-app')
+      vi.mocked(initService).mockResolvedValue({app: mockApp})
 
-      // When/Then
-      // The command throws an AbortError which is caught by oclif's error handler
-      // This causes process.exit(1) which vitest intercepts
-      await expect(
-        Init.run(['--organization-id', 'invalid-org-id', '--name', 'my-app', '--template', 'remix']),
-      ).rejects.toThrow('process.exit unexpectedly called with "1"')
+      // When
+      await Init.run(['--path', tmpDir])
 
-      // Verify the error message was displayed
-      expect(outputMock.error()).toContain('No Organization found')
+      // Then
+      expect(initService).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'test-app',
+          packageManager: 'npm',
+        }),
+      )
+    })
+  })
 
-      // Verify initService was never called since validation failed
-      expect(initService).not.toHaveBeenCalled()
-    } finally {
-      // Always restore console.error, even if the test fails
-      consoleErrorSpy.mockRestore()
-    }
+  test('runs init command without prompts when organization-id, name, and template flags are provided', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      const mockOrganization = testOrganization()
+      const mockDeveloperPlatformClient = testDeveloperPlatformClient()
+      const mockApp = testAppLinked()
+
+      mockAndCaptureOutput()
+      vi.mocked(validateTemplateValue).mockReturnValue(undefined)
+      vi.mocked(validateFlavorValue).mockReturnValue(undefined)
+      vi.mocked(inferPackageManager).mockReturnValue('npm')
+      vi.mocked(selectDeveloperPlatformClient).mockReturnValue(mockDeveloperPlatformClient)
+
+      // Mock fetchOrgFromId to return the organization
+      vi.mocked(fetchOrgFromId).mockResolvedValue(mockOrganization)
+
+      // Mock the orgAndApps method on the developer platform client
+      vi.mocked(mockDeveloperPlatformClient.orgAndApps).mockResolvedValue({
+        organization: mockOrganization,
+        apps: [],
+        hasMorePages: false,
+      })
+
+      vi.mocked(initPrompt).mockResolvedValue({
+        template: 'https://github.com/Shopify/shopify-app-template-remix',
+        templateType: 'remix',
+        globalCLIResult: {install: false, alreadyInstalled: false},
+      })
+      vi.mocked(initService).mockResolvedValue({app: mockApp})
+
+      // When
+      await Init.run([
+        '--organization-id',
+        mockOrganization.id,
+        '--name',
+        'my-app',
+        '--template',
+        'remix',
+        '--path',
+        tmpDir,
+      ])
+
+      // Then
+      // Verify that prompt functions were NOT called
+      // Any other interactive prompts would also cause the test to fail with an AbortError
+      expect(selectOrg).not.toHaveBeenCalled()
+      expect(createAsNewAppPrompt).not.toHaveBeenCalled()
+      expect(appNamePrompt).not.toHaveBeenCalled()
+
+      // Verify the command completed successfully
+      expect(initService).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'my-app',
+          packageManager: 'npm',
+          template: 'https://github.com/Shopify/shopify-app-template-remix',
+        }),
+      )
+    })
+  })
+
+  test('fails with clear error message when invalid organization-id is provided', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      const mockDeveloperPlatformClient = testDeveloperPlatformClient()
+
+      // Suppress stderr output for this error test
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      try {
+        const outputMock = mockAndCaptureOutput()
+        vi.mocked(validateTemplateValue).mockReturnValue(undefined)
+        vi.mocked(validateFlavorValue).mockReturnValue(undefined)
+        vi.mocked(inferPackageManager).mockReturnValue('npm')
+        vi.mocked(selectDeveloperPlatformClient).mockReturnValue(mockDeveloperPlatformClient)
+
+        // Mock fetchOrgFromId to throw NoOrgError for invalid organization
+        vi.mocked(fetchOrgFromId).mockRejectedValue(
+          new NoOrgError({type: 'UserAccount', email: 'test@example.com'}, 'invalid-org-id'),
+        )
+
+        vi.mocked(initPrompt).mockResolvedValue({
+          template: 'https://github.com/Shopify/shopify-app-template-remix',
+          templateType: 'remix',
+          globalCLIResult: {install: false, alreadyInstalled: false},
+        })
+
+        // When/Then
+        // The command throws an AbortError which is caught by oclif's error handler
+        // This causes process.exit(1) which vitest intercepts
+        await expect(
+          Init.run([
+            '--organization-id',
+            'invalid-org-id',
+            '--name',
+            'my-app',
+            '--template',
+            'remix',
+            '--path',
+            tmpDir,
+          ]),
+        ).rejects.toThrow('process.exit unexpectedly called with "1"')
+
+        // Verify the error message was displayed
+        expect(outputMock.error()).toContain('No Organization found')
+
+        // Verify initService was never called since validation failed
+        expect(initService).not.toHaveBeenCalled()
+      } finally {
+        // Always restore console.error, even if the test fails
+        consoleErrorSpy.mockRestore()
+      }
+    })
   })
 
   test('skips app selection prompts when organization has existing apps but --name flag is provided', async () => {
-    // Given
-    const mockOrganization = testOrganization()
-    const mockDeveloperPlatformClient = testDeveloperPlatformClient()
-    const mockApp = testAppLinked()
-    const existingApp = testOrganizationApp()
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      const mockOrganization = testOrganization()
+      const mockDeveloperPlatformClient = testDeveloperPlatformClient()
+      const mockApp = testAppLinked()
+      const existingApp = testOrganizationApp()
 
-    mockAndCaptureOutput()
-    vi.mocked(validateTemplateValue).mockReturnValue(undefined)
-    vi.mocked(validateFlavorValue).mockReturnValue(undefined)
-    vi.mocked(inferPackageManager).mockReturnValue('npm')
-    vi.mocked(selectDeveloperPlatformClient).mockReturnValue(mockDeveloperPlatformClient)
+      mockAndCaptureOutput()
+      vi.mocked(validateTemplateValue).mockReturnValue(undefined)
+      vi.mocked(validateFlavorValue).mockReturnValue(undefined)
+      vi.mocked(inferPackageManager).mockReturnValue('npm')
+      vi.mocked(selectDeveloperPlatformClient).mockReturnValue(mockDeveloperPlatformClient)
 
-    // Mock fetchOrgFromId to return the organization
-    vi.mocked(fetchOrgFromId).mockResolvedValue(mockOrganization)
+      // Mock fetchOrgFromId to return the organization
+      vi.mocked(fetchOrgFromId).mockResolvedValue(mockOrganization)
 
-    // Mock the orgAndApps method to return existing apps
-    vi.mocked(mockDeveloperPlatformClient.orgAndApps).mockResolvedValue({
-      organization: mockOrganization,
-      apps: [existingApp],
-      hasMorePages: false,
-    })
+      // Mock the orgAndApps method to return existing apps
+      vi.mocked(mockDeveloperPlatformClient.orgAndApps).mockResolvedValue({
+        organization: mockOrganization,
+        apps: [existingApp],
+        hasMorePages: false,
+      })
 
-    vi.mocked(initPrompt).mockResolvedValue({
-      template: 'https://github.com/Shopify/shopify-app-template-remix',
-      templateType: 'remix',
-      globalCLIResult: {install: false, alreadyInstalled: false},
-    })
-    vi.mocked(initService).mockResolvedValue({app: mockApp})
-
-    // When
-    await Init.run(['--organization-id', mockOrganization.id, '--name', 'my-new-app', '--template', 'remix'])
-
-    // Then
-    // Verify that app selection prompts were NOT called even though org has existing apps
-    expect(selectOrg).not.toHaveBeenCalled()
-    expect(createAsNewAppPrompt).not.toHaveBeenCalled()
-    expect(selectAppPrompt).not.toHaveBeenCalled()
-    expect(appNamePrompt).not.toHaveBeenCalled()
-
-    // Verify the command completed successfully with the provided name
-    expect(initService).toHaveBeenCalledWith(
-      expect.objectContaining({
-        name: 'my-new-app',
-        packageManager: 'npm',
+      vi.mocked(initPrompt).mockResolvedValue({
         template: 'https://github.com/Shopify/shopify-app-template-remix',
-      }),
-    )
+        templateType: 'remix',
+        globalCLIResult: {install: false, alreadyInstalled: false},
+      })
+      vi.mocked(initService).mockResolvedValue({app: mockApp})
+
+      // When
+      await Init.run([
+        '--organization-id',
+        mockOrganization.id,
+        '--name',
+        'my-new-app',
+        '--template',
+        'remix',
+        '--path',
+        tmpDir,
+      ])
+
+      // Then
+      // Verify that app selection prompts were NOT called even though org has existing apps
+      expect(selectOrg).not.toHaveBeenCalled()
+      expect(createAsNewAppPrompt).not.toHaveBeenCalled()
+      expect(selectAppPrompt).not.toHaveBeenCalled()
+      expect(appNamePrompt).not.toHaveBeenCalled()
+
+      // Verify the command completed successfully with the provided name
+      expect(initService).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'my-new-app',
+          packageManager: 'npm',
+          template: 'https://github.com/Shopify/shopify-app-template-remix',
+        }),
+      )
+    })
   })
 
   test('fails with clear error message when --name flag is empty', async () => {
-    // Given
-    // Suppress stderr output for this error test
-    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      // Suppress stderr output for this error test
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
 
-    try {
-      const outputMock = mockAndCaptureOutput()
-      vi.mocked(validateTemplateValue).mockReturnValue(undefined)
-      vi.mocked(validateFlavorValue).mockReturnValue(undefined)
+      try {
+        const outputMock = mockAndCaptureOutput()
+        vi.mocked(validateTemplateValue).mockReturnValue(undefined)
+        vi.mocked(validateFlavorValue).mockReturnValue(undefined)
 
-      // When/Then
-      await expect(Init.run(['--name', '', '--template', 'remix'])).rejects.toThrow(
-        'process.exit unexpectedly called with "1"',
-      )
+        // When/Then
+        await expect(Init.run(['--name', '', '--template', 'remix', '--path', tmpDir])).rejects.toThrow(
+          'process.exit unexpectedly called with "1"',
+        )
 
-      // Verify the error message was displayed
-      expect(outputMock.error()).toContain("The --name flag can't be empty")
+        // Verify the error message was displayed
+        expect(outputMock.error()).toContain("The --name flag can't be empty")
 
-      // Verify initService was never called since validation failed
-      expect(initService).not.toHaveBeenCalled()
-    } finally {
-      consoleErrorSpy.mockRestore()
-    }
+        // Verify initService was never called since validation failed
+        expect(initService).not.toHaveBeenCalled()
+      } finally {
+        consoleErrorSpy.mockRestore()
+      }
+    })
   })
 
   test('fails with clear error message when --name flag is whitespace only', async () => {
-    // Given
-    // Suppress stderr output for this error test
-    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      // Suppress stderr output for this error test
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
 
-    try {
-      const outputMock = mockAndCaptureOutput()
-      vi.mocked(validateTemplateValue).mockReturnValue(undefined)
-      vi.mocked(validateFlavorValue).mockReturnValue(undefined)
+      try {
+        const outputMock = mockAndCaptureOutput()
+        vi.mocked(validateTemplateValue).mockReturnValue(undefined)
+        vi.mocked(validateFlavorValue).mockReturnValue(undefined)
 
-      // When/Then
-      await expect(Init.run(['--name', '   ', '--template', 'remix'])).rejects.toThrow(
-        'process.exit unexpectedly called with "1"',
-      )
+        // When/Then
+        await expect(Init.run(['--name', '   ', '--template', 'remix', '--path', tmpDir])).rejects.toThrow(
+          'process.exit unexpectedly called with "1"',
+        )
 
-      // Verify the error message was displayed
-      expect(outputMock.error()).toContain("The --name flag can't be empty")
+        // Verify the error message was displayed
+        expect(outputMock.error()).toContain("The --name flag can't be empty")
 
-      // Verify initService was never called since validation failed
-      expect(initService).not.toHaveBeenCalled()
-    } finally {
-      consoleErrorSpy.mockRestore()
-    }
+        // Verify initService was never called since validation failed
+        expect(initService).not.toHaveBeenCalled()
+      } finally {
+        consoleErrorSpy.mockRestore()
+      }
+    })
   })
 })


### PR DESCRIPTION
### WHY are these changes introduced?

Filesystem mocking can lead to tests that don't accurately reflect real-world behavior and are brittle to changes in the underlying implementation of filesystem utilities.

### WHAT is this pull request doing?

Refactors `packages/app/src/cli/commands/app/init.test.ts` to use real temporary directories via `inTemporaryDirectory` instead of mocking `@shopify/cli-kit/node/fs`.

### How to test your changes?

CI

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [9629675890244724247](https://jules.google.com/task/9629675890244724247) started by @gonzaloriestra*