### PR TITLE
Handle spread flags in command flags lint rule

### DIFF
--- a/packages/eslint-plugin-cli/rules/command-flags-with-env.js
+++ b/packages/eslint-plugin-cli/rules/command-flags-with-env.js
@@ -10,22 +10,22 @@ module.exports = {
   create(context) {
     return {
       PropertyDefinition(node) {
-        if (node.key.name === 'flags') {
-          node.value.properties.forEach((flag) => {
-            const arguments = flag.value?.arguments ?? []
-            const argument = arguments[0]
-            if (!argument) {
-              return
-            }
-            const properties = argument.properties.map((property) => property.key.name)
-            if (!properties.includes('env')) {
-              context.report(
-                argument,
-                'Flags must specify the environment variable that represents the flag through the env property',
-              )
-            }
-          })
-        }
+        if (node.key.name !== 'flags') return
+
+        const flags = node.value?.properties ?? []
+        flags.forEach((flag) => {
+          const argument = flag.value?.arguments?.[0]
+          if (!argument?.properties) {
+            return
+          }
+          const properties = argument.properties.map((property) => property.key.name)
+          if (!properties.includes('env')) {
+            context.report(
+              argument,
+              'Flags must specify the environment variable that represents the flag through the env property',
+            )
+          }
+        })
       },
     }
   },


### PR DESCRIPTION
### WHY are these changes introduced?

The custom `@shopify/cli/command-flags-with-env` ESLint rule can crash while linting command classes that include spread flag definitions or shared flag objects.

Recent CI failures showed:

- `TypeError: Cannot read properties of undefined (reading 'map')`
- `Rule: "@shopify/cli/command-flags-with-env"`

### WHAT is this pull request doing?

Updates the rule to skip flag entries that do not have inline option object properties, such as spread elements or shared flag references, instead of assuming every entry is a direct `Flags.*({...})` call.

### How to test your changes?

- `node <inline ESLint smoke test>` — verified a fixture with `...globalFlags`, an inline env-backed flag, and a shared flag reference lints without fatal errors and reports `[]`.
- `pnpm eslint packages/eslint-plugin-cli/rules/command-flags-with-env.js`
- `pnpm nx run store:lint` — attempted, but it currently fails on unrelated existing lint issues in `packages/store/src/cli/services/store/auth/callback.test.ts` and `packages/store/src/cli/services/store/auth/token-client.ts`.

### Post-release steps

None.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible documentation changes
- [x] I've considered analytics changes to measure impact
- [x] This change is not user-facing, so no changeset is needed
