### PR TITLE
Ignore current Knip dependency false positives

### DIFF
--- a/package.json
+++ b/package.json
@@ -221,7 +221,8 @@
         ],
         "ignoreDependencies": [
           "@graphql-typed-document-node/core",
-          "@shopify/plugin-cloudflare"
+          "@shopify/plugin-cloudflare",
+          "http-proxy-node16"
         ],
         "vite": {
           "config": [
@@ -369,13 +370,20 @@
           "**/scripts/*.ts!",
           "**/src/testing/index.ts"
         ],
-        "project": "**/*.{ts,tsx}!"
+        "project": "**/*.{ts,tsx}!",
+        "ignoreDependencies": [
+          "react-dom"
+        ]
       },
       "packages/ui-extensions-test-utils": {
         "entry": [
           "**/src/index.ts"
         ],
-        "project": "**/*.{ts,tsx}"
+        "project": "**/*.{ts,tsx}",
+        "ignoreDependencies": [
+          "@types/react-dom",
+          "react-dom"
+        ]
       }
     }
   }


### PR DESCRIPTION
### WHY are these changes introduced?

`pnpm knip --reporter compact` currently reports dependency false positives for packages that are intentionally present:

- `http-proxy-node16` is lazy-imported by the app reverse proxy to avoid blocking ESM module loading.
- `react-dom` / `@types/react-dom` are present for React testing-library and test environment compatibility in UI extensions packages.

### WHAT is this pull request doing?

Adds targeted Knip `ignoreDependencies` entries for those current false positives in the affected workspaces so the unused-code check can stay focused on actionable findings.

### How to test your changes?

- `pnpm knip --reporter compact`

### Post-release steps

None.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible documentation changes
- [x] I've considered analytics changes to measure impact
- [x] This change is not user-facing, so no changeset is needed
