### PR TITLE
Replace placeholder README TODO

### DIFF
--- a/packages/ui-extensions-server-kit/README.md
+++ b/packages/ui-extensions-server-kit/README.md
@@ -28,8 +28,7 @@ import {ExtensionServerProvider, useExtensionServerContext} from '@shopify/ui-ex
 function LocalExtensionsComponent() {
   const {state: {extensions}} = useExtensionServerContext();
 
-  // TODO: Something with the extensions
-  return null;
+  return <div>{extensions.length} local extensions running</div>;
 }
 
 function App() {


### PR DESCRIPTION
### WHY are these changes introduced?

The UI extensions server kit README includes placeholder TODO text in a sample component.

### WHAT is this pull request doing?

Replaces the placeholder TODO comment with a concrete example render using the `extensions` value returned by `useExtensionServerContext`.

### How to test your changes?

- `git diff --check`
- `pnpm nx run ui-extensions-server-kit:lint`

### Post-release steps

None.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible documentation changes
- [x] I've considered analytics changes to measure impact
- [x] This change is documentation-only and not user-facing product behavior, so no changeset is needed
