### PR TITLE
Omit admin URL for preview stores in store info

### DIFF
--- a/packages/store/src/cli/services/store/info/index.test.ts
+++ b/packages/store/src/cli/services/store/info/index.test.ts
@@ -185,10 +185,11 @@ describe('getStoreInfo', () => {
       id: 'gid://shopify/Shop/123',
       displayName: 'Lavender Candles',
       subdomain: SHOP,
-      adminUrl: 'https://admin.shopify.com/store/shop',
       accessUrl: 'https://app.shopify.com/auth/preview-store?token=fresh-access-token',
       saveUrl: 'https://admin.shopify.com/store-transfer/accept/claim-token',
     })
+    // The admin URL doesn't resolve for an unclaimed preview store, so it's deliberately omitted.
+    expect(result.adminUrl).toBeUndefined()
   })
 
   test('prefers BP when store auth exists and BP can resolve the store', async () => {

--- a/packages/store/src/cli/services/store/info/index.ts
+++ b/packages/store/src/cli/services/store/info/index.ts
@@ -242,10 +242,10 @@ function buildPreviewStoreResult(args: {
   previewStoreUrls: PreviewStoreUrls
 }): StoreInfoResult {
   const {store, previewSession, previewStoreUrls} = args
+  // The admin URL is intentionally omitted: it doesn't resolve for an unclaimed preview store yet.
   const fields: Partial<StoreInfoResult> = {
     id: buildShopGid(previewSession.preview.shopId),
     displayName: previewSession.preview.name,
-    adminUrl: buildAdminUrl(extractMyshopifyHandle(store)),
     accessUrl: previewStoreUrls.accessUrl,
     saveUrl: previewStoreUrls.saveUrl,
   }


### PR DESCRIPTION
### What

`shopify store info` no longer surfaces an **admin URL** for preview stores.

### Why

The admin URL doesn't resolve for an unclaimed preview store, so showing it is misleading. Preview stores already get their info from the locally stored session plus the claim/access URLs (they short-circuit before `StoreInfoAdminShopQuery`), so `partnerDevelopment` was never queried for them and needs no change here.

### Changes

- `index.ts` — drop `adminUrl` from `buildPreviewStoreResult`.
- `index.test.ts` — update the preview-store assertion and explicitly assert `adminUrl` is omitted.

No changeset: preview stores aren't a public feature yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)