### PR TITLE
Add non-mutating auth alias support

### DIFF
--- a/.changeset/theme-account-alias.md
+++ b/.changeset/theme-account-alias.md
@@ -1,0 +1,6 @@
+---
+'@shopify/cli-kit': patch
+'@shopify/theme': patch
+---
+
+Allow theme commands to authenticate with a Shopify account alias without changing the current global CLI session.

--- a/docs-shopify.dev/commands/interfaces/app-build.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/app-build.interface.ts
@@ -5,6 +5,12 @@
  */
 export interface appbuild {
   /**
+   * Alias of the Shopify account to use for authentication.
+   * @environment SHOPIFY_FLAG_AUTH_ALIAS
+   */
+  '--auth-alias <value>'?: string
+
+  /**
    * The Client ID of your app.
    * @environment SHOPIFY_FLAG_CLIENT_ID
    */

--- a/docs-shopify.dev/commands/interfaces/app-bulk-cancel.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/app-bulk-cancel.interface.ts
@@ -5,6 +5,12 @@
  */
 export interface appbulkcancel {
   /**
+   * Alias of the Shopify account to use for authentication.
+   * @environment SHOPIFY_FLAG_AUTH_ALIAS
+   */
+  '--auth-alias <value>'?: string
+
+  /**
    * The Client ID of your app.
    * @environment SHOPIFY_FLAG_CLIENT_ID
    */

--- a/docs-shopify.dev/commands/interfaces/app-bulk-execute.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/app-bulk-execute.interface.ts
@@ -5,6 +5,12 @@
  */
 export interface appbulkexecute {
   /**
+   * Alias of the Shopify account to use for authentication.
+   * @environment SHOPIFY_FLAG_AUTH_ALIAS
+   */
+  '--auth-alias <value>'?: string
+
+  /**
    * The Client ID of your app.
    * @environment SHOPIFY_FLAG_CLIENT_ID
    */

--- a/docs-shopify.dev/commands/interfaces/app-bulk-status.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/app-bulk-status.interface.ts
@@ -5,6 +5,12 @@
  */
 export interface appbulkstatus {
   /**
+   * Alias of the Shopify account to use for authentication.
+   * @environment SHOPIFY_FLAG_AUTH_ALIAS
+   */
+  '--auth-alias <value>'?: string
+
+  /**
    * The Client ID of your app.
    * @environment SHOPIFY_FLAG_CLIENT_ID
    */

--- a/docs-shopify.dev/commands/interfaces/app-config-link.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/app-config-link.interface.ts
@@ -5,6 +5,12 @@
  */
 export interface appconfiglink {
   /**
+   * Alias of the Shopify account to use for authentication.
+   * @environment SHOPIFY_FLAG_AUTH_ALIAS
+   */
+  '--auth-alias <value>'?: string
+
+  /**
    * The Client ID of your app.
    * @environment SHOPIFY_FLAG_CLIENT_ID
    */

--- a/docs-shopify.dev/commands/interfaces/app-config-pull.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/app-config-pull.interface.ts
@@ -5,6 +5,12 @@
  */
 export interface appconfigpull {
   /**
+   * Alias of the Shopify account to use for authentication.
+   * @environment SHOPIFY_FLAG_AUTH_ALIAS
+   */
+  '--auth-alias <value>'?: string
+
+  /**
    * The Client ID of your app.
    * @environment SHOPIFY_FLAG_CLIENT_ID
    */

--- a/docs-shopify.dev/commands/interfaces/app-config-use.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/app-config-use.interface.ts
@@ -5,6 +5,12 @@
  */
 export interface appconfiguse {
   /**
+   * Alias of the Shopify account to use for authentication.
+   * @environment SHOPIFY_FLAG_AUTH_ALIAS
+   */
+  '--auth-alias <value>'?: string
+
+  /**
    * The Client ID of your app.
    * @environment SHOPIFY_FLAG_CLIENT_ID
    */

--- a/docs-shopify.dev/commands/interfaces/app-config-validate.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/app-config-validate.interface.ts
@@ -5,6 +5,12 @@
  */
 export interface appconfigvalidate {
   /**
+   * Alias of the Shopify account to use for authentication.
+   * @environment SHOPIFY_FLAG_AUTH_ALIAS
+   */
+  '--auth-alias <value>'?: string
+
+  /**
    * The Client ID of your app.
    * @environment SHOPIFY_FLAG_CLIENT_ID
    */

--- a/docs-shopify.dev/commands/interfaces/app-deploy.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/app-deploy.interface.ts
@@ -17,6 +17,12 @@ export interface appdeploy {
   '--allow-updates'?: ''
 
   /**
+   * Alias of the Shopify account to use for authentication.
+   * @environment SHOPIFY_FLAG_AUTH_ALIAS
+   */
+  '--auth-alias <value>'?: string
+
+  /**
    * The Client ID of your app.
    * @environment SHOPIFY_FLAG_CLIENT_ID
    */

--- a/docs-shopify.dev/commands/interfaces/app-dev-clean.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/app-dev-clean.interface.ts
@@ -5,6 +5,12 @@
  */
 export interface appdevclean {
   /**
+   * Alias of the Shopify account to use for authentication.
+   * @environment SHOPIFY_FLAG_AUTH_ALIAS
+   */
+  '--auth-alias <value>'?: string
+
+  /**
    * The Client ID of your app.
    * @environment SHOPIFY_FLAG_CLIENT_ID
    */

--- a/docs-shopify.dev/commands/interfaces/app-dev.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/app-dev.interface.ts
@@ -5,6 +5,12 @@
  */
 export interface appdev {
   /**
+   * Alias of the Shopify account to use for authentication.
+   * @environment SHOPIFY_FLAG_AUTH_ALIAS
+   */
+  '--auth-alias <value>'?: string
+
+  /**
    * Resource URL for checkout UI extension. Format: "/cart/{productVariantID}:{productQuantity}"
    * @environment SHOPIFY_FLAG_CHECKOUT_CART_URL
    */

--- a/docs-shopify.dev/commands/interfaces/app-env-pull.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/app-env-pull.interface.ts
@@ -5,6 +5,12 @@
  */
 export interface appenvpull {
   /**
+   * Alias of the Shopify account to use for authentication.
+   * @environment SHOPIFY_FLAG_AUTH_ALIAS
+   */
+  '--auth-alias <value>'?: string
+
+  /**
    * The Client ID of your app.
    * @environment SHOPIFY_FLAG_CLIENT_ID
    */

--- a/docs-shopify.dev/commands/interfaces/app-env-show.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/app-env-show.interface.ts
@@ -5,6 +5,12 @@
  */
 export interface appenvshow {
   /**
+   * Alias of the Shopify account to use for authentication.
+   * @environment SHOPIFY_FLAG_AUTH_ALIAS
+   */
+  '--auth-alias <value>'?: string
+
+  /**
    * The Client ID of your app.
    * @environment SHOPIFY_FLAG_CLIENT_ID
    */

--- a/docs-shopify.dev/commands/interfaces/app-execute.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/app-execute.interface.ts
@@ -5,6 +5,12 @@
  */
 export interface appexecute {
   /**
+   * Alias of the Shopify account to use for authentication.
+   * @environment SHOPIFY_FLAG_AUTH_ALIAS
+   */
+  '--auth-alias <value>'?: string
+
+  /**
    * The Client ID of your app.
    * @environment SHOPIFY_FLAG_CLIENT_ID
    */

--- a/docs-shopify.dev/commands/interfaces/app-function-build.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/app-function-build.interface.ts
@@ -5,6 +5,12 @@
  */
 export interface appfunctionbuild {
   /**
+   * Alias of the Shopify account to use for authentication.
+   * @environment SHOPIFY_FLAG_AUTH_ALIAS
+   */
+  '--auth-alias <value>'?: string
+
+  /**
    * The Client ID of your app.
    * @environment SHOPIFY_FLAG_CLIENT_ID
    */

--- a/docs-shopify.dev/commands/interfaces/app-function-info.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/app-function-info.interface.ts
@@ -5,6 +5,12 @@
  */
 export interface appfunctioninfo {
   /**
+   * Alias of the Shopify account to use for authentication.
+   * @environment SHOPIFY_FLAG_AUTH_ALIAS
+   */
+  '--auth-alias <value>'?: string
+
+  /**
    * The Client ID of your app.
    * @environment SHOPIFY_FLAG_CLIENT_ID
    */

--- a/docs-shopify.dev/commands/interfaces/app-function-replay.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/app-function-replay.interface.ts
@@ -5,6 +5,12 @@
  */
 export interface appfunctionreplay {
   /**
+   * Alias of the Shopify account to use for authentication.
+   * @environment SHOPIFY_FLAG_AUTH_ALIAS
+   */
+  '--auth-alias <value>'?: string
+
+  /**
    * The Client ID of your app.
    * @environment SHOPIFY_FLAG_CLIENT_ID
    */

--- a/docs-shopify.dev/commands/interfaces/app-function-run.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/app-function-run.interface.ts
@@ -5,6 +5,12 @@
  */
 export interface appfunctionrun {
   /**
+   * Alias of the Shopify account to use for authentication.
+   * @environment SHOPIFY_FLAG_AUTH_ALIAS
+   */
+  '--auth-alias <value>'?: string
+
+  /**
    * The Client ID of your app.
    * @environment SHOPIFY_FLAG_CLIENT_ID
    */

--- a/docs-shopify.dev/commands/interfaces/app-function-schema.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/app-function-schema.interface.ts
@@ -5,6 +5,12 @@
  */
 export interface appfunctionschema {
   /**
+   * Alias of the Shopify account to use for authentication.
+   * @environment SHOPIFY_FLAG_AUTH_ALIAS
+   */
+  '--auth-alias <value>'?: string
+
+  /**
    * The Client ID of your app.
    * @environment SHOPIFY_FLAG_CLIENT_ID
    */

--- a/docs-shopify.dev/commands/interfaces/app-function-typegen.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/app-function-typegen.interface.ts
@@ -5,6 +5,12 @@
  */
 export interface appfunctiontypegen {
   /**
+   * Alias of the Shopify account to use for authentication.
+   * @environment SHOPIFY_FLAG_AUTH_ALIAS
+   */
+  '--auth-alias <value>'?: string
+
+  /**
    * The Client ID of your app.
    * @environment SHOPIFY_FLAG_CLIENT_ID
    */

--- a/docs-shopify.dev/commands/interfaces/app-generate-extension.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/app-generate-extension.interface.ts
@@ -5,6 +5,12 @@
  */
 export interface appgenerateextension {
   /**
+   * Alias of the Shopify account to use for authentication.
+   * @environment SHOPIFY_FLAG_AUTH_ALIAS
+   */
+  '--auth-alias <value>'?: string
+
+  /**
    * The Client ID of your app.
    * @environment SHOPIFY_FLAG_CLIENT_ID
    */

--- a/docs-shopify.dev/commands/interfaces/app-import-custom-data-definitions.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/app-import-custom-data-definitions.interface.ts
@@ -5,6 +5,12 @@
  */
 export interface appimportcustomdatadefinitions {
   /**
+   * Alias of the Shopify account to use for authentication.
+   * @environment SHOPIFY_FLAG_AUTH_ALIAS
+   */
+  '--auth-alias <value>'?: string
+
+  /**
    * The Client ID of your app.
    * @environment SHOPIFY_FLAG_CLIENT_ID
    */

--- a/docs-shopify.dev/commands/interfaces/app-import-extensions.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/app-import-extensions.interface.ts
@@ -5,6 +5,12 @@
  */
 export interface appimportextensions {
   /**
+   * Alias of the Shopify account to use for authentication.
+   * @environment SHOPIFY_FLAG_AUTH_ALIAS
+   */
+  '--auth-alias <value>'?: string
+
+  /**
    * The Client ID of your app.
    * @environment SHOPIFY_FLAG_CLIENT_ID
    */

--- a/docs-shopify.dev/commands/interfaces/app-info.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/app-info.interface.ts
@@ -5,6 +5,12 @@
  */
 export interface appinfo {
   /**
+   * Alias of the Shopify account to use for authentication.
+   * @environment SHOPIFY_FLAG_AUTH_ALIAS
+   */
+  '--auth-alias <value>'?: string
+
+  /**
    * The Client ID of your app.
    * @environment SHOPIFY_FLAG_CLIENT_ID
    */

--- a/docs-shopify.dev/commands/interfaces/app-init.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/app-init.interface.ts
@@ -5,6 +5,12 @@
  */
 export interface appinit {
   /**
+   * Alias of the Shopify account to use for authentication.
+   * @environment SHOPIFY_FLAG_AUTH_ALIAS
+   */
+  '--auth-alias <value>'?: string
+
+  /**
    * The Client ID of your app. Use this to automatically link your new project to an existing app. Using this flag avoids the app selection prompt.
    * @environment SHOPIFY_FLAG_CLIENT_ID
    */

--- a/docs-shopify.dev/commands/interfaces/app-logs-sources.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/app-logs-sources.interface.ts
@@ -5,6 +5,12 @@
  */
 export interface applogssources {
   /**
+   * Alias of the Shopify account to use for authentication.
+   * @environment SHOPIFY_FLAG_AUTH_ALIAS
+   */
+  '--auth-alias <value>'?: string
+
+  /**
    * The Client ID of your app.
    * @environment SHOPIFY_FLAG_CLIENT_ID
    */

--- a/docs-shopify.dev/commands/interfaces/app-logs.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/app-logs.interface.ts
@@ -5,6 +5,12 @@
  */
 export interface applogs {
   /**
+   * Alias of the Shopify account to use for authentication.
+   * @environment SHOPIFY_FLAG_AUTH_ALIAS
+   */
+  '--auth-alias <value>'?: string
+
+  /**
    * The Client ID of your app.
    * @environment SHOPIFY_FLAG_CLIENT_ID
    */

--- a/docs-shopify.dev/commands/interfaces/app-release.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/app-release.interface.ts
@@ -17,6 +17,12 @@ export interface apprelease {
   '--allow-updates'?: ''
 
   /**
+   * Alias of the Shopify account to use for authentication.
+   * @environment SHOPIFY_FLAG_AUTH_ALIAS
+   */
+  '--auth-alias <value>'?: string
+
+  /**
    * The Client ID of your app.
    * @environment SHOPIFY_FLAG_CLIENT_ID
    */

--- a/docs-shopify.dev/commands/interfaces/app-versions-list.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/app-versions-list.interface.ts
@@ -5,6 +5,12 @@
  */
 export interface appversionslist {
   /**
+   * Alias of the Shopify account to use for authentication.
+   * @environment SHOPIFY_FLAG_AUTH_ALIAS
+   */
+  '--auth-alias <value>'?: string
+
+  /**
    * The Client ID of your app.
    * @environment SHOPIFY_FLAG_CLIENT_ID
    */

--- a/docs-shopify.dev/commands/interfaces/app-webhook-trigger.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/app-webhook-trigger.interface.ts
@@ -22,6 +22,12 @@ export interface appwebhooktrigger {
   '--api-version <value>'?: string
 
   /**
+   * Alias of the Shopify account to use for authentication.
+   * @environment SHOPIFY_FLAG_AUTH_ALIAS
+   */
+  '--auth-alias <value>'?: string
+
+  /**
    * The Client ID of your app.
    * @environment SHOPIFY_FLAG_CLIENT_ID
    */

--- a/docs-shopify.dev/commands/interfaces/hydrogen-deploy.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/hydrogen-deploy.interface.ts
@@ -5,6 +5,12 @@
  */
 export interface hydrogendeploy {
   /**
+   * Directory containing the client assets to deploy, relative to the project root. Defaults to the detected Vite client output directory, then falls back to `dist/client`.
+   * @environment SHOPIFY_HYDROGEN_FLAG_ASSETS_DIR
+   */
+  '--assets-dir <value>'?: string
+
+  /**
    * Generate an authentication bypass token, which can be used to perform end-to-end tests against the deployment.
    * @environment AUTH_BYPASS_TOKEN
    */
@@ -17,7 +23,7 @@ export interface hydrogendeploy {
   '--auth-bypass-token-duration <value>'?: string
 
   /**
-   * Specify a build command to run before deploying. If not specified, `shopify hydrogen build` will be used.
+   * Specify a build command to run before deploying. If not specified, the Hydrogen build pipeline will be used. When custom output directories are configured, defaults to `node --run build`.
    *
    */
   '--build-command <value>'?: string
@@ -47,7 +53,7 @@ export interface hydrogendeploy {
   '--env-file <value>'?: string
 
   /**
-   * Forces a deployment to proceed if there are uncommited changes in its Git repository.
+   * Forces a deployment to proceed if there are uncommitted changes in its Git repository.
    * @environment SHOPIFY_HYDROGEN_FLAG_FORCE
    */
   '-f, --force'?: ''
@@ -71,7 +77,7 @@ export interface hydrogendeploy {
   '--lockfile-check'?: ''
 
   /**
-   * Description of the changes in the deployment. Defaults to the commit message of the latest commit if there are no uncommited changes.
+   * Description of the changes in the deployment. Defaults to the commit message of the latest commit if there are no uncommitted changes.
    * @environment SHOPIFY_HYDROGEN_FLAG_METADATA_DESCRIPTION
    */
   '--metadata-description <value>'?: string
@@ -111,4 +117,10 @@ export interface hydrogendeploy {
    * @environment SHOPIFY_HYDROGEN_DEPLOYMENT_TOKEN
    */
   '-t, --token <value>'?: string
+
+  /**
+   * Directory containing the Oxygen worker entry point (`index.js` or `index.mjs`), relative to the project root. Defaults to the detected Vite server output directory, then falls back to `dist/server`.
+   * @environment SHOPIFY_HYDROGEN_FLAG_WORKER_DIR
+   */
+  '--worker-dir <value>'?: string
 }

--- a/docs-shopify.dev/commands/interfaces/hydrogen-deploy.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/hydrogen-deploy.interface.ts
@@ -5,12 +5,6 @@
  */
 export interface hydrogendeploy {
   /**
-   * Directory containing the client assets to deploy, relative to the project root. Defaults to the detected Vite client output directory, then falls back to `dist/client`.
-   * @environment SHOPIFY_HYDROGEN_FLAG_ASSETS_DIR
-   */
-  '--assets-dir <value>'?: string
-
-  /**
    * Generate an authentication bypass token, which can be used to perform end-to-end tests against the deployment.
    * @environment AUTH_BYPASS_TOKEN
    */
@@ -23,7 +17,7 @@ export interface hydrogendeploy {
   '--auth-bypass-token-duration <value>'?: string
 
   /**
-   * Specify a build command to run before deploying. If not specified, the Hydrogen build pipeline will be used. When custom output directories are configured, defaults to `node --run build`.
+   * Specify a build command to run before deploying. If not specified, `shopify hydrogen build` will be used.
    *
    */
   '--build-command <value>'?: string
@@ -53,7 +47,7 @@ export interface hydrogendeploy {
   '--env-file <value>'?: string
 
   /**
-   * Forces a deployment to proceed if there are uncommitted changes in its Git repository.
+   * Forces a deployment to proceed if there are uncommited changes in its Git repository.
    * @environment SHOPIFY_HYDROGEN_FLAG_FORCE
    */
   '-f, --force'?: ''
@@ -77,7 +71,7 @@ export interface hydrogendeploy {
   '--lockfile-check'?: ''
 
   /**
-   * Description of the changes in the deployment. Defaults to the commit message of the latest commit if there are no uncommitted changes.
+   * Description of the changes in the deployment. Defaults to the commit message of the latest commit if there are no uncommited changes.
    * @environment SHOPIFY_HYDROGEN_FLAG_METADATA_DESCRIPTION
    */
   '--metadata-description <value>'?: string
@@ -117,10 +111,4 @@ export interface hydrogendeploy {
    * @environment SHOPIFY_HYDROGEN_DEPLOYMENT_TOKEN
    */
   '-t, --token <value>'?: string
-
-  /**
-   * Directory containing the Oxygen worker entry point (`index.js` or `index.mjs`), relative to the project root. Defaults to the detected Vite server output directory, then falls back to `dist/server`.
-   * @environment SHOPIFY_HYDROGEN_FLAG_WORKER_DIR
-   */
-  '--worker-dir <value>'?: string
 }

--- a/docs-shopify.dev/commands/interfaces/hydrogen-generate-route.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/hydrogen-generate-route.interface.ts
@@ -5,7 +5,7 @@
  */
 export interface hydrogengenerateroute {
   /**
-   * Remix adapter used in the route. The default is `@shopify/remix-oxygen`.
+   * React Router adapter used in the route. The default is `react-router`.
    * @environment SHOPIFY_HYDROGEN_FLAG_ADAPTER
    */
   '--adapter <value>'?: string

--- a/docs-shopify.dev/commands/interfaces/hydrogen-generate-route.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/hydrogen-generate-route.interface.ts
@@ -5,7 +5,7 @@
  */
 export interface hydrogengenerateroute {
   /**
-   * React Router adapter used in the route. The default is `react-router`.
+   * Remix adapter used in the route. The default is `@shopify/remix-oxygen`.
    * @environment SHOPIFY_HYDROGEN_FLAG_ADAPTER
    */
   '--adapter <value>'?: string

--- a/docs-shopify.dev/commands/interfaces/hydrogen-generate-routes.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/hydrogen-generate-routes.interface.ts
@@ -5,7 +5,7 @@
  */
 export interface hydrogengenerateroutes {
   /**
-   * Remix adapter used in the route. The default is `@shopify/remix-oxygen`.
+   * React Router adapter used in the route. The default is `react-router`.
    * @environment SHOPIFY_HYDROGEN_FLAG_ADAPTER
    */
   '--adapter <value>'?: string

--- a/docs-shopify.dev/commands/interfaces/hydrogen-generate-routes.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/hydrogen-generate-routes.interface.ts
@@ -5,7 +5,7 @@
  */
 export interface hydrogengenerateroutes {
   /**
-   * React Router adapter used in the route. The default is `react-router`.
+   * Remix adapter used in the route. The default is `@shopify/remix-oxygen`.
    * @environment SHOPIFY_HYDROGEN_FLAG_ADAPTER
    */
   '--adapter <value>'?: string

--- a/docs-shopify.dev/commands/interfaces/theme-console.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/theme-console.interface.ts
@@ -5,6 +5,12 @@
  */
 export interface themeconsole {
   /**
+   * Alias of the Shopify account to use for authentication.
+   * @environment SHOPIFY_FLAG_AUTH_ALIAS
+   */
+  '--alias <value>'?: string
+
+  /**
    * The environment to apply to the current command.
    * @environment SHOPIFY_FLAG_ENVIRONMENT
    */

--- a/docs-shopify.dev/commands/interfaces/theme-console.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/theme-console.interface.ts
@@ -8,7 +8,7 @@ export interface themeconsole {
    * Alias of the Shopify account to use for authentication.
    * @environment SHOPIFY_FLAG_AUTH_ALIAS
    */
-  '--alias <value>'?: string
+  '--auth-alias <value>'?: string
 
   /**
    * The environment to apply to the current command.

--- a/docs-shopify.dev/commands/interfaces/theme-delete.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/theme-delete.interface.ts
@@ -8,7 +8,7 @@ export interface themedelete {
    * Alias of the Shopify account to use for authentication.
    * @environment SHOPIFY_FLAG_AUTH_ALIAS
    */
-  '--alias <value>'?: string
+  '--auth-alias <value>'?: string
 
   /**
    * Delete your development theme.

--- a/docs-shopify.dev/commands/interfaces/theme-delete.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/theme-delete.interface.ts
@@ -5,6 +5,12 @@
  */
 export interface themedelete {
   /**
+   * Alias of the Shopify account to use for authentication.
+   * @environment SHOPIFY_FLAG_AUTH_ALIAS
+   */
+  '--alias <value>'?: string
+
+  /**
    * Delete your development theme.
    * @environment SHOPIFY_FLAG_DEVELOPMENT
    */

--- a/docs-shopify.dev/commands/interfaces/theme-dev.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/theme-dev.interface.ts
@@ -5,16 +5,16 @@
  */
 export interface themedev {
   /**
-   * Alias of the Shopify account to use for authentication.
-   * @environment SHOPIFY_FLAG_AUTH_ALIAS
-   */
-  '--alias <value>'?: string
-
-  /**
    * Allow development on a live theme.
    * @environment SHOPIFY_FLAG_ALLOW_LIVE
    */
   '-a, --allow-live'?: ''
+
+  /**
+   * Alias of the Shopify account to use for authentication.
+   * @environment SHOPIFY_FLAG_AUTH_ALIAS
+   */
+  '--auth-alias <value>'?: string
 
   /**
    * The environment to apply to the current command.

--- a/docs-shopify.dev/commands/interfaces/theme-dev.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/theme-dev.interface.ts
@@ -5,6 +5,12 @@
  */
 export interface themedev {
   /**
+   * Alias of the Shopify account to use for authentication.
+   * @environment SHOPIFY_FLAG_AUTH_ALIAS
+   */
+  '--alias <value>'?: string
+
+  /**
    * Allow development on a live theme.
    * @environment SHOPIFY_FLAG_ALLOW_LIVE
    */

--- a/docs-shopify.dev/commands/interfaces/theme-duplicate.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/theme-duplicate.interface.ts
@@ -5,6 +5,12 @@
  */
 export interface themeduplicate {
   /**
+   * Alias of the Shopify account to use for authentication.
+   * @environment SHOPIFY_FLAG_AUTH_ALIAS
+   */
+  '--alias <value>'?: string
+
+  /**
    * The environment to apply to the current command.
    * @environment SHOPIFY_FLAG_ENVIRONMENT
    */

--- a/docs-shopify.dev/commands/interfaces/theme-duplicate.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/theme-duplicate.interface.ts
@@ -8,7 +8,7 @@ export interface themeduplicate {
    * Alias of the Shopify account to use for authentication.
    * @environment SHOPIFY_FLAG_AUTH_ALIAS
    */
-  '--alias <value>'?: string
+  '--auth-alias <value>'?: string
 
   /**
    * The environment to apply to the current command.

--- a/docs-shopify.dev/commands/interfaces/theme-info.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/theme-info.interface.ts
@@ -5,6 +5,12 @@
  */
 export interface themeinfo {
   /**
+   * Alias of the Shopify account to use for authentication.
+   * @environment SHOPIFY_FLAG_AUTH_ALIAS
+   */
+  '--alias <value>'?: string
+
+  /**
    * Retrieve info from your development theme.
    * @environment SHOPIFY_FLAG_DEVELOPMENT
    */

--- a/docs-shopify.dev/commands/interfaces/theme-info.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/theme-info.interface.ts
@@ -8,7 +8,7 @@ export interface themeinfo {
    * Alias of the Shopify account to use for authentication.
    * @environment SHOPIFY_FLAG_AUTH_ALIAS
    */
-  '--alias <value>'?: string
+  '--auth-alias <value>'?: string
 
   /**
    * Retrieve info from your development theme.

--- a/docs-shopify.dev/commands/interfaces/theme-list.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/theme-list.interface.ts
@@ -5,6 +5,12 @@
  */
 export interface themelist {
   /**
+   * Alias of the Shopify account to use for authentication.
+   * @environment SHOPIFY_FLAG_AUTH_ALIAS
+   */
+  '--alias <value>'?: string
+
+  /**
    * The environment to apply to the current command.
    * @environment SHOPIFY_FLAG_ENVIRONMENT
    */

--- a/docs-shopify.dev/commands/interfaces/theme-list.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/theme-list.interface.ts
@@ -8,7 +8,7 @@ export interface themelist {
    * Alias of the Shopify account to use for authentication.
    * @environment SHOPIFY_FLAG_AUTH_ALIAS
    */
-  '--alias <value>'?: string
+  '--auth-alias <value>'?: string
 
   /**
    * The environment to apply to the current command.

--- a/docs-shopify.dev/commands/interfaces/theme-metafields-pull.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/theme-metafields-pull.interface.ts
@@ -8,7 +8,7 @@ export interface thememetafieldspull {
    * Alias of the Shopify account to use for authentication.
    * @environment SHOPIFY_FLAG_AUTH_ALIAS
    */
-  '--alias <value>'?: string
+  '--auth-alias <value>'?: string
 
   /**
    * The environment to apply to the current command.

--- a/docs-shopify.dev/commands/interfaces/theme-metafields-pull.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/theme-metafields-pull.interface.ts
@@ -5,6 +5,12 @@
  */
 export interface thememetafieldspull {
   /**
+   * Alias of the Shopify account to use for authentication.
+   * @environment SHOPIFY_FLAG_AUTH_ALIAS
+   */
+  '--alias <value>'?: string
+
+  /**
    * The environment to apply to the current command.
    * @environment SHOPIFY_FLAG_ENVIRONMENT
    */

--- a/docs-shopify.dev/commands/interfaces/theme-open.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/theme-open.interface.ts
@@ -8,7 +8,7 @@ export interface themeopen {
    * Alias of the Shopify account to use for authentication.
    * @environment SHOPIFY_FLAG_AUTH_ALIAS
    */
-  '--alias <value>'?: string
+  '--auth-alias <value>'?: string
 
   /**
    * Open your development theme.

--- a/docs-shopify.dev/commands/interfaces/theme-open.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/theme-open.interface.ts
@@ -5,6 +5,12 @@
  */
 export interface themeopen {
   /**
+   * Alias of the Shopify account to use for authentication.
+   * @environment SHOPIFY_FLAG_AUTH_ALIAS
+   */
+  '--alias <value>'?: string
+
+  /**
    * Open your development theme.
    * @environment SHOPIFY_FLAG_DEVELOPMENT
    */

--- a/docs-shopify.dev/commands/interfaces/theme-preview.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/theme-preview.interface.ts
@@ -8,7 +8,7 @@ export interface themepreview {
    * Alias of the Shopify account to use for authentication.
    * @environment SHOPIFY_FLAG_AUTH_ALIAS
    */
-  '--alias <value>'?: string
+  '--auth-alias <value>'?: string
 
   /**
    * The environment to apply to the current command.

--- a/docs-shopify.dev/commands/interfaces/theme-preview.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/theme-preview.interface.ts
@@ -5,6 +5,12 @@
  */
 export interface themepreview {
   /**
+   * Alias of the Shopify account to use for authentication.
+   * @environment SHOPIFY_FLAG_AUTH_ALIAS
+   */
+  '--alias <value>'?: string
+
+  /**
    * The environment to apply to the current command.
    * @environment SHOPIFY_FLAG_ENVIRONMENT
    */

--- a/docs-shopify.dev/commands/interfaces/theme-profile.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/theme-profile.interface.ts
@@ -8,7 +8,7 @@ export interface themeprofile {
    * Alias of the Shopify account to use for authentication.
    * @environment SHOPIFY_FLAG_AUTH_ALIAS
    */
-  '--alias <value>'?: string
+  '--auth-alias <value>'?: string
 
   /**
    * The environment to apply to the current command.

--- a/docs-shopify.dev/commands/interfaces/theme-profile.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/theme-profile.interface.ts
@@ -5,6 +5,12 @@
  */
 export interface themeprofile {
   /**
+   * Alias of the Shopify account to use for authentication.
+   * @environment SHOPIFY_FLAG_AUTH_ALIAS
+   */
+  '--alias <value>'?: string
+
+  /**
    * The environment to apply to the current command.
    * @environment SHOPIFY_FLAG_ENVIRONMENT
    */

--- a/docs-shopify.dev/commands/interfaces/theme-publish.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/theme-publish.interface.ts
@@ -5,6 +5,12 @@
  */
 export interface themepublish {
   /**
+   * Alias of the Shopify account to use for authentication.
+   * @environment SHOPIFY_FLAG_AUTH_ALIAS
+   */
+  '--alias <value>'?: string
+
+  /**
    * The environment to apply to the current command.
    * @environment SHOPIFY_FLAG_ENVIRONMENT
    */

--- a/docs-shopify.dev/commands/interfaces/theme-publish.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/theme-publish.interface.ts
@@ -8,7 +8,7 @@ export interface themepublish {
    * Alias of the Shopify account to use for authentication.
    * @environment SHOPIFY_FLAG_AUTH_ALIAS
    */
-  '--alias <value>'?: string
+  '--auth-alias <value>'?: string
 
   /**
    * The environment to apply to the current command.

--- a/docs-shopify.dev/commands/interfaces/theme-pull.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/theme-pull.interface.ts
@@ -5,6 +5,12 @@
  */
 export interface themepull {
   /**
+   * Alias of the Shopify account to use for authentication.
+   * @environment SHOPIFY_FLAG_AUTH_ALIAS
+   */
+  '--alias <value>'?: string
+
+  /**
    * Pull theme files from your remote development theme.
    * @environment SHOPIFY_FLAG_DEVELOPMENT
    */

--- a/docs-shopify.dev/commands/interfaces/theme-pull.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/theme-pull.interface.ts
@@ -8,7 +8,7 @@ export interface themepull {
    * Alias of the Shopify account to use for authentication.
    * @environment SHOPIFY_FLAG_AUTH_ALIAS
    */
-  '--alias <value>'?: string
+  '--auth-alias <value>'?: string
 
   /**
    * Pull theme files from your remote development theme.

--- a/docs-shopify.dev/commands/interfaces/theme-push.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/theme-push.interface.ts
@@ -5,6 +5,12 @@
  */
 export interface themepush {
   /**
+   * Alias of the Shopify account to use for authentication.
+   * @environment SHOPIFY_FLAG_AUTH_ALIAS
+   */
+  '--alias <value>'?: string
+
+  /**
    * Allow push to a live theme.
    * @environment SHOPIFY_FLAG_ALLOW_LIVE
    */

--- a/docs-shopify.dev/commands/interfaces/theme-push.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/theme-push.interface.ts
@@ -5,16 +5,16 @@
  */
 export interface themepush {
   /**
-   * Alias of the Shopify account to use for authentication.
-   * @environment SHOPIFY_FLAG_AUTH_ALIAS
-   */
-  '--alias <value>'?: string
-
-  /**
    * Allow push to a live theme.
    * @environment SHOPIFY_FLAG_ALLOW_LIVE
    */
   '-a, --allow-live'?: ''
+
+  /**
+   * Alias of the Shopify account to use for authentication.
+   * @environment SHOPIFY_FLAG_AUTH_ALIAS
+   */
+  '--auth-alias <value>'?: string
 
   /**
    * Push theme files from your remote development theme.

--- a/docs-shopify.dev/commands/interfaces/theme-rename.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/theme-rename.interface.ts
@@ -5,6 +5,12 @@
  */
 export interface themerename {
   /**
+   * Alias of the Shopify account to use for authentication.
+   * @environment SHOPIFY_FLAG_AUTH_ALIAS
+   */
+  '--alias <value>'?: string
+
+  /**
    * Rename your development theme.
    * @environment SHOPIFY_FLAG_DEVELOPMENT
    */

--- a/docs-shopify.dev/commands/interfaces/theme-rename.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/theme-rename.interface.ts
@@ -8,7 +8,7 @@ export interface themerename {
    * Alias of the Shopify account to use for authentication.
    * @environment SHOPIFY_FLAG_AUTH_ALIAS
    */
-  '--alias <value>'?: string
+  '--auth-alias <value>'?: string
 
   /**
    * Rename your development theme.

--- a/docs-shopify.dev/commands/interfaces/theme-share.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/theme-share.interface.ts
@@ -8,7 +8,7 @@ export interface themeshare {
    * Alias of the Shopify account to use for authentication.
    * @environment SHOPIFY_FLAG_AUTH_ALIAS
    */
-  '--alias <value>'?: string
+  '--auth-alias <value>'?: string
 
   /**
    * The environment to apply to the current command.

--- a/docs-shopify.dev/commands/interfaces/theme-share.interface.ts
+++ b/docs-shopify.dev/commands/interfaces/theme-share.interface.ts
@@ -5,6 +5,12 @@
  */
 export interface themeshare {
   /**
+   * Alias of the Shopify account to use for authentication.
+   * @environment SHOPIFY_FLAG_AUTH_ALIAS
+   */
+  '--alias <value>'?: string
+
+  /**
    * The environment to apply to the current command.
    * @environment SHOPIFY_FLAG_ENVIRONMENT
    */

--- a/docs-shopify.dev/generated/generated_docs_data_v2.json
+++ b/docs-shopify.dev/generated/generated_docs_data_v2.json
@@ -4806,6 +4806,15 @@
         {
           "filePath": "docs-shopify.dev/commands/interfaces/theme-console.interface.ts",
           "syntaxKind": "PropertySignature",
+          "name": "--alias <value>",
+          "value": "string",
+          "description": "Alias of the Shopify account to use for authentication.",
+          "isOptional": true,
+          "environmentValue": "SHOPIFY_FLAG_AUTH_ALIAS"
+        },
+        {
+          "filePath": "docs-shopify.dev/commands/interfaces/theme-console.interface.ts",
+          "syntaxKind": "PropertySignature",
           "name": "--no-color",
           "value": "''",
           "description": "Disable color output.",
@@ -4876,7 +4885,7 @@
           "environmentValue": "SHOPIFY_FLAG_STORE"
         }
       ],
-      "value": "export interface themeconsole {\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Password generated from the Theme Access app or an Admin API token.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * The path where you want to run the command. Defaults to the current working directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * The password for storefronts with password protection.\n   * @environment SHOPIFY_FLAG_STORE_PASSWORD\n   */\n  '--store-password <value>'?: string\n\n  /**\n   * The url to be used as context\n   * @environment SHOPIFY_FLAG_URL\n   */\n  '--url <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+      "value": "export interface themeconsole {\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--alias <value>'?: string\n\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Password generated from the Theme Access app or an Admin API token.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * The path where you want to run the command. Defaults to the current working directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * The password for storefronts with password protection.\n   * @environment SHOPIFY_FLAG_STORE_PASSWORD\n   */\n  '--store-password <value>'?: string\n\n  /**\n   * The url to be used as context\n   * @environment SHOPIFY_FLAG_URL\n   */\n  '--url <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
     }
   },
   "themedelete": {
@@ -4886,6 +4895,15 @@
       "description": "The following flags are available for the `theme delete` command:",
       "isPublicDocs": true,
       "members": [
+        {
+          "filePath": "docs-shopify.dev/commands/interfaces/theme-delete.interface.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "--alias <value>",
+          "value": "string",
+          "description": "Alias of the Shopify account to use for authentication.",
+          "isOptional": true,
+          "environmentValue": "SHOPIFY_FLAG_AUTH_ALIAS"
+        },
         {
           "filePath": "docs-shopify.dev/commands/interfaces/theme-delete.interface.ts",
           "syntaxKind": "PropertySignature",
@@ -4977,7 +4995,7 @@
           "environmentValue": "SHOPIFY_FLAG_THEME_ID"
         }
       ],
-      "value": "export interface themedelete {\n  /**\n   * Delete your development theme.\n   * @environment SHOPIFY_FLAG_DEVELOPMENT\n   */\n  '-d, --development'?: ''\n\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Skip confirmation.\n   * @environment SHOPIFY_FLAG_FORCE\n   */\n  '-f, --force'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Password generated from the Theme Access app or an Admin API token.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * The path where you want to run the command. Defaults to the current working directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Include others development themes in theme list.\n   * @environment SHOPIFY_FLAG_SHOW_ALL\n   */\n  '-a, --show-all'?: ''\n\n  /**\n   * Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Theme ID or name of the remote theme.\n   * @environment SHOPIFY_FLAG_THEME_ID\n   */\n  '-t, --theme <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+      "value": "export interface themedelete {\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--alias <value>'?: string\n\n  /**\n   * Delete your development theme.\n   * @environment SHOPIFY_FLAG_DEVELOPMENT\n   */\n  '-d, --development'?: ''\n\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Skip confirmation.\n   * @environment SHOPIFY_FLAG_FORCE\n   */\n  '-f, --force'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Password generated from the Theme Access app or an Admin API token.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * The path where you want to run the command. Defaults to the current working directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Include others development themes in theme list.\n   * @environment SHOPIFY_FLAG_SHOW_ALL\n   */\n  '-a, --show-all'?: ''\n\n  /**\n   * Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Theme ID or name of the remote theme.\n   * @environment SHOPIFY_FLAG_THEME_ID\n   */\n  '-t, --theme <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
     }
   },
   "themedev": {
@@ -4987,6 +5005,15 @@
       "description": "The following flags are available for the `theme dev` command:",
       "isPublicDocs": true,
       "members": [
+        {
+          "filePath": "docs-shopify.dev/commands/interfaces/theme-dev.interface.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "--alias <value>",
+          "value": "string",
+          "description": "Alias of the Shopify account to use for authentication.",
+          "isOptional": true,
+          "environmentValue": "SHOPIFY_FLAG_AUTH_ALIAS"
+        },
         {
           "filePath": "docs-shopify.dev/commands/interfaces/theme-dev.interface.ts",
           "syntaxKind": "PropertySignature",
@@ -5177,7 +5204,7 @@
           "environmentValue": "SHOPIFY_FLAG_IGNORE"
         }
       ],
-      "value": "export interface themedev {\n  /**\n   * Allow development on a live theme.\n   * @environment SHOPIFY_FLAG_ALLOW_LIVE\n   */\n  '-a, --allow-live'?: ''\n\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Controls the visibility of the error overlay when an theme asset upload fails:\n- silent Prevents the error overlay from appearing.\n- default Displays the error overlay.\n      \n   * @environment SHOPIFY_FLAG_ERROR_OVERLAY\n   */\n  '--error-overlay <value>'?: string\n\n  /**\n   * Set which network interface the web server listens on. The default value is 127.0.0.1.\n   * @environment SHOPIFY_FLAG_HOST\n   */\n  '--host <value>'?: string\n\n  /**\n   * Skip hot reloading any files that match the specified pattern.\n   * @environment SHOPIFY_FLAG_IGNORE\n   */\n  '-x, --ignore <value>'?: string\n\n  /**\n   * The listing preset to use for multi-preset themes. Applies preset files from listings/[preset-name] directory.\n   * @environment SHOPIFY_FLAG_LISTING\n   */\n  '--listing <value>'?: string\n\n  /**\n   * The live reload mode switches the server behavior when a file is modified:\n- hot-reload Hot reloads local changes to CSS and sections (default)\n- full-page  Always refreshes the entire page\n- off        Deactivate live reload\n   * @environment SHOPIFY_FLAG_LIVE_RELOAD\n   */\n  '--live-reload <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Prevents files from being deleted in the remote theme when a file has been deleted locally. This applies to files that are deleted while the command is running, and files that have been deleted locally before the command is run.\n   * @environment SHOPIFY_FLAG_NODELETE\n   */\n  '-n, --nodelete'?: ''\n\n  /**\n   * The file path or URL. The file path is to a file that you want updated on idle. The URL path is where you want a webhook posted to report on file changes.\n   * @environment SHOPIFY_FLAG_NOTIFY\n   */\n  '--notify <value>'?: string\n\n  /**\n   * Hot reload only files that match the specified pattern.\n   * @environment SHOPIFY_FLAG_ONLY\n   */\n  '-o, --only <value>'?: string\n\n  /**\n   * Automatically launch the theme preview in your default web browser.\n   * @environment SHOPIFY_FLAG_OPEN\n   */\n  '--open'?: ''\n\n  /**\n   * Password generated from the Theme Access app or an Admin API token.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * The path where you want to run the command. Defaults to the current working directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Local port to serve theme preview from. Must be between 1 and 65535.\n   * @environment SHOPIFY_FLAG_PORT\n   */\n  '--port <value>'?: string\n\n  /**\n   * Inject the standard events inspector into storefront HTML.\n   * @environment SHOPIFY_FLAG_STANDARD_EVENTS_INSPECTOR\n   */\n  '--standard-events-inspector'?: ''\n\n  /**\n   * Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * The password for storefronts with password protection.\n   * @environment SHOPIFY_FLAG_STORE_PASSWORD\n   */\n  '--store-password <value>'?: string\n\n  /**\n   * Theme ID or name of the remote theme.\n   * @environment SHOPIFY_FLAG_THEME_ID\n   */\n  '-t, --theme <value>'?: string\n\n  /**\n   * Synchronize Theme Editor updates in the local theme files.\n   * @environment SHOPIFY_FLAG_THEME_EDITOR_SYNC\n   */\n  '--theme-editor-sync'?: ''\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+      "value": "export interface themedev {\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--alias <value>'?: string\n\n  /**\n   * Allow development on a live theme.\n   * @environment SHOPIFY_FLAG_ALLOW_LIVE\n   */\n  '-a, --allow-live'?: ''\n\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Controls the visibility of the error overlay when an theme asset upload fails:\n- silent Prevents the error overlay from appearing.\n- default Displays the error overlay.\n      \n   * @environment SHOPIFY_FLAG_ERROR_OVERLAY\n   */\n  '--error-overlay <value>'?: string\n\n  /**\n   * Set which network interface the web server listens on. The default value is 127.0.0.1.\n   * @environment SHOPIFY_FLAG_HOST\n   */\n  '--host <value>'?: string\n\n  /**\n   * Skip hot reloading any files that match the specified pattern.\n   * @environment SHOPIFY_FLAG_IGNORE\n   */\n  '-x, --ignore <value>'?: string\n\n  /**\n   * The listing preset to use for multi-preset themes. Applies preset files from listings/[preset-name] directory.\n   * @environment SHOPIFY_FLAG_LISTING\n   */\n  '--listing <value>'?: string\n\n  /**\n   * The live reload mode switches the server behavior when a file is modified:\n- hot-reload Hot reloads local changes to CSS and sections (default)\n- full-page  Always refreshes the entire page\n- off        Deactivate live reload\n   * @environment SHOPIFY_FLAG_LIVE_RELOAD\n   */\n  '--live-reload <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Prevents files from being deleted in the remote theme when a file has been deleted locally. This applies to files that are deleted while the command is running, and files that have been deleted locally before the command is run.\n   * @environment SHOPIFY_FLAG_NODELETE\n   */\n  '-n, --nodelete'?: ''\n\n  /**\n   * The file path or URL. The file path is to a file that you want updated on idle. The URL path is where you want a webhook posted to report on file changes.\n   * @environment SHOPIFY_FLAG_NOTIFY\n   */\n  '--notify <value>'?: string\n\n  /**\n   * Hot reload only files that match the specified pattern.\n   * @environment SHOPIFY_FLAG_ONLY\n   */\n  '-o, --only <value>'?: string\n\n  /**\n   * Automatically launch the theme preview in your default web browser.\n   * @environment SHOPIFY_FLAG_OPEN\n   */\n  '--open'?: ''\n\n  /**\n   * Password generated from the Theme Access app or an Admin API token.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * The path where you want to run the command. Defaults to the current working directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Local port to serve theme preview from. Must be between 1 and 65535.\n   * @environment SHOPIFY_FLAG_PORT\n   */\n  '--port <value>'?: string\n\n  /**\n   * Inject the standard events inspector into storefront HTML.\n   * @environment SHOPIFY_FLAG_STANDARD_EVENTS_INSPECTOR\n   */\n  '--standard-events-inspector'?: ''\n\n  /**\n   * Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * The password for storefronts with password protection.\n   * @environment SHOPIFY_FLAG_STORE_PASSWORD\n   */\n  '--store-password <value>'?: string\n\n  /**\n   * Theme ID or name of the remote theme.\n   * @environment SHOPIFY_FLAG_THEME_ID\n   */\n  '-t, --theme <value>'?: string\n\n  /**\n   * Synchronize Theme Editor updates in the local theme files.\n   * @environment SHOPIFY_FLAG_THEME_EDITOR_SYNC\n   */\n  '--theme-editor-sync'?: ''\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
     }
   },
   "themeduplicate": {
@@ -5187,6 +5214,15 @@
       "description": "The following flags are available for the `theme duplicate` command:",
       "isPublicDocs": true,
       "members": [
+        {
+          "filePath": "docs-shopify.dev/commands/interfaces/theme-duplicate.interface.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "--alias <value>",
+          "value": "string",
+          "description": "Alias of the Shopify account to use for authentication.",
+          "isOptional": true,
+          "environmentValue": "SHOPIFY_FLAG_AUTH_ALIAS"
+        },
         {
           "filePath": "docs-shopify.dev/commands/interfaces/theme-duplicate.interface.ts",
           "syntaxKind": "PropertySignature",
@@ -5269,7 +5305,7 @@
           "environmentValue": "SHOPIFY_FLAG_THEME_ID"
         }
       ],
-      "value": "export interface themeduplicate {\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Force the duplicate operation to run without prompts or confirmations.\n   * @environment SHOPIFY_FLAG_FORCE\n   */\n  '-f, --force'?: ''\n\n  /**\n   * Output the result as JSON. Automatically disables color output.\n   * @environment SHOPIFY_FLAG_JSON\n   */\n  '-j, --json'?: ''\n\n  /**\n   * Name of the newly duplicated theme.\n   * @environment SHOPIFY_FLAG_NAME\n   */\n  '-n, --name <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Password generated from the Theme Access app or an Admin API token.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Theme ID or name of the remote theme.\n   * @environment SHOPIFY_FLAG_THEME_ID\n   */\n  '-t, --theme <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+      "value": "export interface themeduplicate {\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--alias <value>'?: string\n\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Force the duplicate operation to run without prompts or confirmations.\n   * @environment SHOPIFY_FLAG_FORCE\n   */\n  '-f, --force'?: ''\n\n  /**\n   * Output the result as JSON. Automatically disables color output.\n   * @environment SHOPIFY_FLAG_JSON\n   */\n  '-j, --json'?: ''\n\n  /**\n   * Name of the newly duplicated theme.\n   * @environment SHOPIFY_FLAG_NAME\n   */\n  '-n, --name <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Password generated from the Theme Access app or an Admin API token.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Theme ID or name of the remote theme.\n   * @environment SHOPIFY_FLAG_THEME_ID\n   */\n  '-t, --theme <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
     }
   },
   "themeinfo": {
@@ -5279,6 +5315,15 @@
       "description": "The following flags are available for the `theme info` command:",
       "isPublicDocs": true,
       "members": [
+        {
+          "filePath": "docs-shopify.dev/commands/interfaces/theme-info.interface.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "--alias <value>",
+          "value": "string",
+          "description": "Alias of the Shopify account to use for authentication.",
+          "isOptional": true,
+          "environmentValue": "SHOPIFY_FLAG_AUTH_ALIAS"
+        },
         {
           "filePath": "docs-shopify.dev/commands/interfaces/theme-info.interface.ts",
           "syntaxKind": "PropertySignature",
@@ -5361,7 +5406,7 @@
           "environmentValue": "SHOPIFY_FLAG_THEME_ID"
         }
       ],
-      "value": "export interface themeinfo {\n  /**\n   * Retrieve info from your development theme.\n   * @environment SHOPIFY_FLAG_DEVELOPMENT\n   */\n  '-d, --development'?: ''\n\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Output the result as JSON. Automatically disables color output.\n   * @environment SHOPIFY_FLAG_JSON\n   */\n  '-j, --json'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Password generated from the Theme Access app or an Admin API token.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * The path where you want to run the command. Defaults to the current working directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Theme ID or name of the remote theme.\n   * @environment SHOPIFY_FLAG_THEME_ID\n   */\n  '-t, --theme <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+      "value": "export interface themeinfo {\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--alias <value>'?: string\n\n  /**\n   * Retrieve info from your development theme.\n   * @environment SHOPIFY_FLAG_DEVELOPMENT\n   */\n  '-d, --development'?: ''\n\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Output the result as JSON. Automatically disables color output.\n   * @environment SHOPIFY_FLAG_JSON\n   */\n  '-j, --json'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Password generated from the Theme Access app or an Admin API token.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * The path where you want to run the command. Defaults to the current working directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Theme ID or name of the remote theme.\n   * @environment SHOPIFY_FLAG_THEME_ID\n   */\n  '-t, --theme <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
     }
   },
   "themeinit": {
@@ -5459,6 +5504,15 @@
         {
           "filePath": "docs-shopify.dev/commands/interfaces/theme-list.interface.ts",
           "syntaxKind": "PropertySignature",
+          "name": "--alias <value>",
+          "value": "string",
+          "description": "Alias of the Shopify account to use for authentication.",
+          "isOptional": true,
+          "environmentValue": "SHOPIFY_FLAG_AUTH_ALIAS"
+        },
+        {
+          "filePath": "docs-shopify.dev/commands/interfaces/theme-list.interface.ts",
+          "syntaxKind": "PropertySignature",
           "name": "--id <value>",
           "value": "string",
           "description": "Only list theme with the given ID.",
@@ -5547,7 +5601,7 @@
           "environmentValue": "SHOPIFY_FLAG_STORE"
         }
       ],
-      "value": "export interface themelist {\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Only list theme with the given ID.\n   * @environment SHOPIFY_FLAG_ID\n   */\n  '--id <value>'?: string\n\n  /**\n   * Output the result as JSON. Automatically disables color output.\n   * @environment SHOPIFY_FLAG_JSON\n   */\n  '-j, --json'?: ''\n\n  /**\n   * Only list themes that contain the given name.\n   * @environment SHOPIFY_FLAG_NAME\n   */\n  '--name <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Password generated from the Theme Access app or an Admin API token.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * The path where you want to run the command. Defaults to the current working directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Only list themes with the given role.\n   * @environment SHOPIFY_FLAG_ROLE\n   */\n  '--role <value>'?: string\n\n  /**\n   * Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+      "value": "export interface themelist {\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--alias <value>'?: string\n\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Only list theme with the given ID.\n   * @environment SHOPIFY_FLAG_ID\n   */\n  '--id <value>'?: string\n\n  /**\n   * Output the result as JSON. Automatically disables color output.\n   * @environment SHOPIFY_FLAG_JSON\n   */\n  '-j, --json'?: ''\n\n  /**\n   * Only list themes that contain the given name.\n   * @environment SHOPIFY_FLAG_NAME\n   */\n  '--name <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Password generated from the Theme Access app or an Admin API token.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * The path where you want to run the command. Defaults to the current working directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Only list themes with the given role.\n   * @environment SHOPIFY_FLAG_ROLE\n   */\n  '--role <value>'?: string\n\n  /**\n   * Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
     }
   },
   "thememetafieldspull": {
@@ -5557,6 +5611,15 @@
       "description": "The following flags are available for the `theme metafields pull` command:",
       "isPublicDocs": true,
       "members": [
+        {
+          "filePath": "docs-shopify.dev/commands/interfaces/theme-metafields-pull.interface.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "--alias <value>",
+          "value": "string",
+          "description": "Alias of the Shopify account to use for authentication.",
+          "isOptional": true,
+          "environmentValue": "SHOPIFY_FLAG_AUTH_ALIAS"
+        },
         {
           "filePath": "docs-shopify.dev/commands/interfaces/theme-metafields-pull.interface.ts",
           "syntaxKind": "PropertySignature",
@@ -5612,7 +5675,7 @@
           "environmentValue": "SHOPIFY_FLAG_STORE"
         }
       ],
-      "value": "export interface thememetafieldspull {\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Password generated from the Theme Access app or an Admin API token.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * The path where you want to run the command. Defaults to the current working directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+      "value": "export interface thememetafieldspull {\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--alias <value>'?: string\n\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Password generated from the Theme Access app or an Admin API token.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * The path where you want to run the command. Defaults to the current working directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
     }
   },
   "themeopen": {
@@ -5622,6 +5685,15 @@
       "description": "The following flags are available for the `theme open` command:",
       "isPublicDocs": true,
       "members": [
+        {
+          "filePath": "docs-shopify.dev/commands/interfaces/theme-open.interface.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "--alias <value>",
+          "value": "string",
+          "description": "Alias of the Shopify account to use for authentication.",
+          "isOptional": true,
+          "environmentValue": "SHOPIFY_FLAG_AUTH_ALIAS"
+        },
         {
           "filePath": "docs-shopify.dev/commands/interfaces/theme-open.interface.ts",
           "syntaxKind": "PropertySignature",
@@ -5713,7 +5785,7 @@
           "environmentValue": "SHOPIFY_FLAG_THEME_ID"
         }
       ],
-      "value": "export interface themeopen {\n  /**\n   * Open your development theme.\n   * @environment SHOPIFY_FLAG_DEVELOPMENT\n   */\n  '-d, --development'?: ''\n\n  /**\n   * Open the theme editor for the specified theme in the browser.\n   * @environment SHOPIFY_FLAG_EDITOR\n   */\n  '-E, --editor'?: ''\n\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Open your live (published) theme.\n   * @environment SHOPIFY_FLAG_LIVE\n   */\n  '-l, --live'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Password generated from the Theme Access app or an Admin API token.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * The path where you want to run the command. Defaults to the current working directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Theme ID or name of the remote theme.\n   * @environment SHOPIFY_FLAG_THEME_ID\n   */\n  '-t, --theme <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+      "value": "export interface themeopen {\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--alias <value>'?: string\n\n  /**\n   * Open your development theme.\n   * @environment SHOPIFY_FLAG_DEVELOPMENT\n   */\n  '-d, --development'?: ''\n\n  /**\n   * Open the theme editor for the specified theme in the browser.\n   * @environment SHOPIFY_FLAG_EDITOR\n   */\n  '-E, --editor'?: ''\n\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Open your live (published) theme.\n   * @environment SHOPIFY_FLAG_LIVE\n   */\n  '-l, --live'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Password generated from the Theme Access app or an Admin API token.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * The path where you want to run the command. Defaults to the current working directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Theme ID or name of the remote theme.\n   * @environment SHOPIFY_FLAG_THEME_ID\n   */\n  '-t, --theme <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
     }
   },
   "themepackage": {
@@ -5761,6 +5833,15 @@
       "description": "The following flags are available for the `theme preview` command:",
       "isPublicDocs": true,
       "members": [
+        {
+          "filePath": "docs-shopify.dev/commands/interfaces/theme-preview.interface.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "--alias <value>",
+          "value": "string",
+          "description": "Alias of the Shopify account to use for authentication.",
+          "isOptional": true,
+          "environmentValue": "SHOPIFY_FLAG_AUTH_ALIAS"
+        },
         {
           "filePath": "docs-shopify.dev/commands/interfaces/theme-preview.interface.ts",
           "syntaxKind": "PropertySignature",
@@ -5859,7 +5940,7 @@
           "environmentValue": "SHOPIFY_FLAG_THEME_ID"
         }
       ],
-      "value": "export interface themepreview {\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Output the preview URL and identifier as JSON.\n   * @environment SHOPIFY_FLAG_JSON\n   */\n  '--json'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Automatically launch the theme preview in your default web browser.\n   * @environment SHOPIFY_FLAG_OPEN\n   */\n  '--open'?: ''\n\n  /**\n   * Path to a JSON overrides file.\n   * @environment SHOPIFY_FLAG_OVERRIDES\n   */\n  '--overrides <value>': string\n\n  /**\n   * Password generated from the Theme Access app or an Admin API token.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * The path where you want to run the command. Defaults to the current working directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * An existing preview identifier to update instead of creating a new preview.\n   * @environment SHOPIFY_FLAG_PREVIEW_ID\n   */\n  '--preview-id <value>'?: string\n\n  /**\n   * Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Theme ID or name of the remote theme.\n   * @environment SHOPIFY_FLAG_THEME_ID\n   */\n  '-t, --theme <value>': string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+      "value": "export interface themepreview {\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--alias <value>'?: string\n\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Output the preview URL and identifier as JSON.\n   * @environment SHOPIFY_FLAG_JSON\n   */\n  '--json'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Automatically launch the theme preview in your default web browser.\n   * @environment SHOPIFY_FLAG_OPEN\n   */\n  '--open'?: ''\n\n  /**\n   * Path to a JSON overrides file.\n   * @environment SHOPIFY_FLAG_OVERRIDES\n   */\n  '--overrides <value>': string\n\n  /**\n   * Password generated from the Theme Access app or an Admin API token.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * The path where you want to run the command. Defaults to the current working directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * An existing preview identifier to update instead of creating a new preview.\n   * @environment SHOPIFY_FLAG_PREVIEW_ID\n   */\n  '--preview-id <value>'?: string\n\n  /**\n   * Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Theme ID or name of the remote theme.\n   * @environment SHOPIFY_FLAG_THEME_ID\n   */\n  '-t, --theme <value>': string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
     }
   },
   "themeprofile": {
@@ -5869,6 +5950,15 @@
       "description": "The following flags are available for the `theme profile` command:",
       "isPublicDocs": true,
       "members": [
+        {
+          "filePath": "docs-shopify.dev/commands/interfaces/theme-profile.interface.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "--alias <value>",
+          "value": "string",
+          "description": "Alias of the Shopify account to use for authentication.",
+          "isOptional": true,
+          "environmentValue": "SHOPIFY_FLAG_AUTH_ALIAS"
+        },
         {
           "filePath": "docs-shopify.dev/commands/interfaces/theme-profile.interface.ts",
           "syntaxKind": "PropertySignature",
@@ -5960,7 +6050,7 @@
           "environmentValue": "SHOPIFY_FLAG_THEME_ID"
         }
       ],
-      "value": "export interface themeprofile {\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Output the result as JSON. Automatically disables color output.\n   * @environment SHOPIFY_FLAG_JSON\n   */\n  '-j, --json'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Password generated from the Theme Access app or an Admin API token.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * The path where you want to run the command. Defaults to the current working directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * The password for storefronts with password protection.\n   * @environment SHOPIFY_FLAG_STORE_PASSWORD\n   */\n  '--store-password <value>'?: string\n\n  /**\n   * Theme ID or name of the remote theme.\n   * @environment SHOPIFY_FLAG_THEME_ID\n   */\n  '-t, --theme <value>'?: string\n\n  /**\n   * The url to be used as context\n   * @environment SHOPIFY_FLAG_URL\n   */\n  '--url <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+      "value": "export interface themeprofile {\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--alias <value>'?: string\n\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Output the result as JSON. Automatically disables color output.\n   * @environment SHOPIFY_FLAG_JSON\n   */\n  '-j, --json'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Password generated from the Theme Access app or an Admin API token.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * The path where you want to run the command. Defaults to the current working directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * The password for storefronts with password protection.\n   * @environment SHOPIFY_FLAG_STORE_PASSWORD\n   */\n  '--store-password <value>'?: string\n\n  /**\n   * Theme ID or name of the remote theme.\n   * @environment SHOPIFY_FLAG_THEME_ID\n   */\n  '-t, --theme <value>'?: string\n\n  /**\n   * The url to be used as context\n   * @environment SHOPIFY_FLAG_URL\n   */\n  '--url <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
     }
   },
   "themepublish": {
@@ -5970,6 +6060,15 @@
       "description": "The following flags are available for the `theme publish` command:",
       "isPublicDocs": true,
       "members": [
+        {
+          "filePath": "docs-shopify.dev/commands/interfaces/theme-publish.interface.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "--alias <value>",
+          "value": "string",
+          "description": "Alias of the Shopify account to use for authentication.",
+          "isOptional": true,
+          "environmentValue": "SHOPIFY_FLAG_AUTH_ALIAS"
+        },
         {
           "filePath": "docs-shopify.dev/commands/interfaces/theme-publish.interface.ts",
           "syntaxKind": "PropertySignature",
@@ -6043,7 +6142,7 @@
           "environmentValue": "SHOPIFY_FLAG_THEME_ID"
         }
       ],
-      "value": "export interface themepublish {\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Skip confirmation.\n   * @environment SHOPIFY_FLAG_FORCE\n   */\n  '-f, --force'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Password generated from the Theme Access app or an Admin API token.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * The path where you want to run the command. Defaults to the current working directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Theme ID or name of the remote theme.\n   * @environment SHOPIFY_FLAG_THEME_ID\n   */\n  '-t, --theme <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+      "value": "export interface themepublish {\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--alias <value>'?: string\n\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Skip confirmation.\n   * @environment SHOPIFY_FLAG_FORCE\n   */\n  '-f, --force'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Password generated from the Theme Access app or an Admin API token.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * The path where you want to run the command. Defaults to the current working directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Theme ID or name of the remote theme.\n   * @environment SHOPIFY_FLAG_THEME_ID\n   */\n  '-t, --theme <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
     }
   },
   "themepull": {
@@ -6053,6 +6152,15 @@
       "description": "The following flags are available for the `theme pull` command:",
       "isPublicDocs": true,
       "members": [
+        {
+          "filePath": "docs-shopify.dev/commands/interfaces/theme-pull.interface.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "--alias <value>",
+          "value": "string",
+          "description": "Alias of the Shopify account to use for authentication.",
+          "isOptional": true,
+          "environmentValue": "SHOPIFY_FLAG_AUTH_ALIAS"
+        },
         {
           "filePath": "docs-shopify.dev/commands/interfaces/theme-pull.interface.ts",
           "syntaxKind": "PropertySignature",
@@ -6162,7 +6270,7 @@
           "environmentValue": "SHOPIFY_FLAG_IGNORE"
         }
       ],
-      "value": "export interface themepull {\n  /**\n   * Pull theme files from your remote development theme.\n   * @environment SHOPIFY_FLAG_DEVELOPMENT\n   */\n  '-d, --development'?: ''\n\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Skip downloading the specified files (Multiple flags allowed). Wrap the value in double quotes if you're using wildcards.\n   * @environment SHOPIFY_FLAG_IGNORE\n   */\n  '-x, --ignore <value>'?: string\n\n  /**\n   * Pull theme files from your remote live theme.\n   * @environment SHOPIFY_FLAG_LIVE\n   */\n  '-l, --live'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Prevent deleting local files that don't exist remotely.\n   * @environment SHOPIFY_FLAG_NODELETE\n   */\n  '-n, --nodelete'?: ''\n\n  /**\n   * Download only the specified files (Multiple flags allowed). Wrap the value in double quotes if you're using wildcards.\n   * @environment SHOPIFY_FLAG_ONLY\n   */\n  '-o, --only <value>'?: string\n\n  /**\n   * Password generated from the Theme Access app or an Admin API token.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * The path where you want to run the command. Defaults to the current working directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Theme ID or name of the remote theme.\n   * @environment SHOPIFY_FLAG_THEME_ID\n   */\n  '-t, --theme <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+      "value": "export interface themepull {\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--alias <value>'?: string\n\n  /**\n   * Pull theme files from your remote development theme.\n   * @environment SHOPIFY_FLAG_DEVELOPMENT\n   */\n  '-d, --development'?: ''\n\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Skip downloading the specified files (Multiple flags allowed). Wrap the value in double quotes if you're using wildcards.\n   * @environment SHOPIFY_FLAG_IGNORE\n   */\n  '-x, --ignore <value>'?: string\n\n  /**\n   * Pull theme files from your remote live theme.\n   * @environment SHOPIFY_FLAG_LIVE\n   */\n  '-l, --live'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Prevent deleting local files that don't exist remotely.\n   * @environment SHOPIFY_FLAG_NODELETE\n   */\n  '-n, --nodelete'?: ''\n\n  /**\n   * Download only the specified files (Multiple flags allowed). Wrap the value in double quotes if you're using wildcards.\n   * @environment SHOPIFY_FLAG_ONLY\n   */\n  '-o, --only <value>'?: string\n\n  /**\n   * Password generated from the Theme Access app or an Admin API token.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * The path where you want to run the command. Defaults to the current working directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Theme ID or name of the remote theme.\n   * @environment SHOPIFY_FLAG_THEME_ID\n   */\n  '-t, --theme <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
     }
   },
   "themepush": {
@@ -6172,6 +6280,15 @@
       "description": "The following flags are available for the `theme push` command:",
       "isPublicDocs": true,
       "members": [
+        {
+          "filePath": "docs-shopify.dev/commands/interfaces/theme-push.interface.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "--alias <value>",
+          "value": "string",
+          "description": "Alias of the Shopify account to use for authentication.",
+          "isOptional": true,
+          "environmentValue": "SHOPIFY_FLAG_AUTH_ALIAS"
+        },
         {
           "filePath": "docs-shopify.dev/commands/interfaces/theme-push.interface.ts",
           "syntaxKind": "PropertySignature",
@@ -6344,7 +6461,7 @@
           "environmentValue": "SHOPIFY_FLAG_IGNORE"
         }
       ],
-      "value": "export interface themepush {\n  /**\n   * Allow push to a live theme.\n   * @environment SHOPIFY_FLAG_ALLOW_LIVE\n   */\n  '-a, --allow-live'?: ''\n\n  /**\n   * Push theme files from your remote development theme.\n   * @environment SHOPIFY_FLAG_DEVELOPMENT\n   */\n  '-d, --development'?: ''\n\n  /**\n   * Unique identifier for a development theme context (e.g., PR number, branch name). Reuses an existing development theme with this context name, or creates one if none exists.\n   * @environment SHOPIFY_FLAG_DEVELOPMENT_CONTEXT\n   */\n  '-c, --development-context <value>'?: string\n\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Skip uploading the specified files (Multiple flags allowed). Wrap the value in double quotes if you're using wildcards.\n   * @environment SHOPIFY_FLAG_IGNORE\n   */\n  '-x, --ignore <value>'?: string\n\n  /**\n   * Output the result as JSON. Automatically disables color output.\n   * @environment SHOPIFY_FLAG_JSON\n   */\n  '-j, --json'?: ''\n\n  /**\n   * The listing preset to use for multi-preset themes. Applies preset files from listings/[preset-name] directory.\n   * @environment SHOPIFY_FLAG_LISTING\n   */\n  '--listing <value>'?: string\n\n  /**\n   * Push theme files from your remote live theme.\n   * @environment SHOPIFY_FLAG_LIVE\n   */\n  '-l, --live'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Prevent deleting remote files that don't exist locally.\n   * @environment SHOPIFY_FLAG_NODELETE\n   */\n  '-n, --nodelete'?: ''\n\n  /**\n   * Upload only the specified files (Multiple flags allowed). Wrap the value in double quotes if you're using wildcards.\n   * @environment SHOPIFY_FLAG_ONLY\n   */\n  '-o, --only <value>'?: string\n\n  /**\n   * Password generated from the Theme Access app or an Admin API token.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * The path where you want to run the command. Defaults to the current working directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Publish as the live theme after uploading.\n   * @environment SHOPIFY_FLAG_PUBLISH\n   */\n  '-p, --publish'?: ''\n\n  /**\n   * Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Require theme check to pass without errors before pushing. Warnings are allowed.\n   * @environment SHOPIFY_FLAG_STRICT_PUSH\n   */\n  '--strict'?: ''\n\n  /**\n   * Theme ID or name of the remote theme.\n   * @environment SHOPIFY_FLAG_THEME_ID\n   */\n  '-t, --theme <value>'?: string\n\n  /**\n   * Create a new unpublished theme and push to it.\n   * @environment SHOPIFY_FLAG_UNPUBLISHED\n   */\n  '-u, --unpublished'?: ''\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+      "value": "export interface themepush {\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--alias <value>'?: string\n\n  /**\n   * Allow push to a live theme.\n   * @environment SHOPIFY_FLAG_ALLOW_LIVE\n   */\n  '-a, --allow-live'?: ''\n\n  /**\n   * Push theme files from your remote development theme.\n   * @environment SHOPIFY_FLAG_DEVELOPMENT\n   */\n  '-d, --development'?: ''\n\n  /**\n   * Unique identifier for a development theme context (e.g., PR number, branch name). Reuses an existing development theme with this context name, or creates one if none exists.\n   * @environment SHOPIFY_FLAG_DEVELOPMENT_CONTEXT\n   */\n  '-c, --development-context <value>'?: string\n\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Skip uploading the specified files (Multiple flags allowed). Wrap the value in double quotes if you're using wildcards.\n   * @environment SHOPIFY_FLAG_IGNORE\n   */\n  '-x, --ignore <value>'?: string\n\n  /**\n   * Output the result as JSON. Automatically disables color output.\n   * @environment SHOPIFY_FLAG_JSON\n   */\n  '-j, --json'?: ''\n\n  /**\n   * The listing preset to use for multi-preset themes. Applies preset files from listings/[preset-name] directory.\n   * @environment SHOPIFY_FLAG_LISTING\n   */\n  '--listing <value>'?: string\n\n  /**\n   * Push theme files from your remote live theme.\n   * @environment SHOPIFY_FLAG_LIVE\n   */\n  '-l, --live'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Prevent deleting remote files that don't exist locally.\n   * @environment SHOPIFY_FLAG_NODELETE\n   */\n  '-n, --nodelete'?: ''\n\n  /**\n   * Upload only the specified files (Multiple flags allowed). Wrap the value in double quotes if you're using wildcards.\n   * @environment SHOPIFY_FLAG_ONLY\n   */\n  '-o, --only <value>'?: string\n\n  /**\n   * Password generated from the Theme Access app or an Admin API token.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * The path where you want to run the command. Defaults to the current working directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Publish as the live theme after uploading.\n   * @environment SHOPIFY_FLAG_PUBLISH\n   */\n  '-p, --publish'?: ''\n\n  /**\n   * Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Require theme check to pass without errors before pushing. Warnings are allowed.\n   * @environment SHOPIFY_FLAG_STRICT_PUSH\n   */\n  '--strict'?: ''\n\n  /**\n   * Theme ID or name of the remote theme.\n   * @environment SHOPIFY_FLAG_THEME_ID\n   */\n  '-t, --theme <value>'?: string\n\n  /**\n   * Create a new unpublished theme and push to it.\n   * @environment SHOPIFY_FLAG_UNPUBLISHED\n   */\n  '-u, --unpublished'?: ''\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
     }
   },
   "themerename": {
@@ -6354,6 +6471,15 @@
       "description": "The following flags are available for the `theme rename` command:",
       "isPublicDocs": true,
       "members": [
+        {
+          "filePath": "docs-shopify.dev/commands/interfaces/theme-rename.interface.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "--alias <value>",
+          "value": "string",
+          "description": "Alias of the Shopify account to use for authentication.",
+          "isOptional": true,
+          "environmentValue": "SHOPIFY_FLAG_AUTH_ALIAS"
+        },
         {
           "filePath": "docs-shopify.dev/commands/interfaces/theme-rename.interface.ts",
           "syntaxKind": "PropertySignature",
@@ -6445,7 +6571,7 @@
           "environmentValue": "SHOPIFY_FLAG_THEME_ID"
         }
       ],
-      "value": "export interface themerename {\n  /**\n   * Rename your development theme.\n   * @environment SHOPIFY_FLAG_DEVELOPMENT\n   */\n  '-d, --development'?: ''\n\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Rename your remote live theme.\n   * @environment SHOPIFY_FLAG_LIVE\n   */\n  '-l, --live'?: ''\n\n  /**\n   * The new name for the theme.\n   * @environment SHOPIFY_FLAG_NEW_NAME\n   */\n  '-n, --name <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Password generated from the Theme Access app or an Admin API token.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * The path where you want to run the command. Defaults to the current working directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Theme ID or name of the remote theme.\n   * @environment SHOPIFY_FLAG_THEME_ID\n   */\n  '-t, --theme <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+      "value": "export interface themerename {\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--alias <value>'?: string\n\n  /**\n   * Rename your development theme.\n   * @environment SHOPIFY_FLAG_DEVELOPMENT\n   */\n  '-d, --development'?: ''\n\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Rename your remote live theme.\n   * @environment SHOPIFY_FLAG_LIVE\n   */\n  '-l, --live'?: ''\n\n  /**\n   * The new name for the theme.\n   * @environment SHOPIFY_FLAG_NEW_NAME\n   */\n  '-n, --name <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Password generated from the Theme Access app or an Admin API token.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * The path where you want to run the command. Defaults to the current working directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Theme ID or name of the remote theme.\n   * @environment SHOPIFY_FLAG_THEME_ID\n   */\n  '-t, --theme <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
     }
   },
   "themeshare": {
@@ -6455,6 +6581,15 @@
       "description": "The following flags are available for the `theme share` command:",
       "isPublicDocs": true,
       "members": [
+        {
+          "filePath": "docs-shopify.dev/commands/interfaces/theme-share.interface.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "--alias <value>",
+          "value": "string",
+          "description": "Alias of the Shopify account to use for authentication.",
+          "isOptional": true,
+          "environmentValue": "SHOPIFY_FLAG_AUTH_ALIAS"
+        },
         {
           "filePath": "docs-shopify.dev/commands/interfaces/theme-share.interface.ts",
           "syntaxKind": "PropertySignature",
@@ -6519,7 +6654,7 @@
           "environmentValue": "SHOPIFY_FLAG_STORE"
         }
       ],
-      "value": "export interface themeshare {\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * The listing preset to use for multi-preset themes. Applies preset files from listings/[preset-name] directory.\n   * @environment SHOPIFY_FLAG_LISTING\n   */\n  '--listing <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Password generated from the Theme Access app or an Admin API token.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * The path where you want to run the command. Defaults to the current working directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+      "value": "export interface themeshare {\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--alias <value>'?: string\n\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * The listing preset to use for multi-preset themes. Applies preset files from listings/[preset-name] directory.\n   * @environment SHOPIFY_FLAG_LISTING\n   */\n  '--listing <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Password generated from the Theme Access app or an Admin API token.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * The path where you want to run the command. Defaults to the current working directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
     }
   },
   "upgrade": {

--- a/docs-shopify.dev/generated/generated_docs_data_v2.json
+++ b/docs-shopify.dev/generated/generated_docs_data_v2.json
@@ -3385,6 +3385,15 @@
         {
           "filePath": "docs-shopify.dev/commands/interfaces/hydrogen-deploy.interface.ts",
           "syntaxKind": "PropertySignature",
+          "name": "--assets-dir <value>",
+          "value": "string",
+          "description": "Directory containing the client assets to deploy, relative to the project root. Defaults to the detected Vite client output directory, then falls back to `dist/client`.",
+          "isOptional": true,
+          "environmentValue": "SHOPIFY_HYDROGEN_FLAG_ASSETS_DIR"
+        },
+        {
+          "filePath": "docs-shopify.dev/commands/interfaces/hydrogen-deploy.interface.ts",
+          "syntaxKind": "PropertySignature",
           "name": "--auth-bypass-token",
           "value": "''",
           "description": "Generate an authentication bypass token, which can be used to perform end-to-end tests against the deployment.",
@@ -3405,7 +3414,7 @@
           "syntaxKind": "PropertySignature",
           "name": "--build-command <value>",
           "value": "string",
-          "description": "Specify a build command to run before deploying. If not specified, `shopify hydrogen build` will be used.",
+          "description": "Specify a build command to run before deploying. If not specified, the Hydrogen build pipeline will be used. When custom output directories are configured, defaults to `node --run build`.",
           "isOptional": true
         },
         {
@@ -3473,7 +3482,7 @@
           "syntaxKind": "PropertySignature",
           "name": "--metadata-description <value>",
           "value": "string",
-          "description": "Description of the changes in the deployment. Defaults to the commit message of the latest commit if there are no uncommited changes.",
+          "description": "Description of the changes in the deployment. Defaults to the commit message of the latest commit if there are no uncommitted changes.",
           "isOptional": true,
           "environmentValue": "SHOPIFY_HYDROGEN_FLAG_METADATA_DESCRIPTION"
         },
@@ -3514,9 +3523,18 @@
         {
           "filePath": "docs-shopify.dev/commands/interfaces/hydrogen-deploy.interface.ts",
           "syntaxKind": "PropertySignature",
+          "name": "--worker-dir <value>",
+          "value": "string",
+          "description": "Directory containing the Oxygen worker entry point (`index.js` or `index.mjs`), relative to the project root. Defaults to the detected Vite server output directory, then falls back to `dist/server`.",
+          "isOptional": true,
+          "environmentValue": "SHOPIFY_HYDROGEN_FLAG_WORKER_DIR"
+        },
+        {
+          "filePath": "docs-shopify.dev/commands/interfaces/hydrogen-deploy.interface.ts",
+          "syntaxKind": "PropertySignature",
           "name": "-f, --force",
           "value": "''",
-          "description": "Forces a deployment to proceed if there are uncommited changes in its Git repository.",
+          "description": "Forces a deployment to proceed if there are uncommitted changes in its Git repository.",
           "isOptional": true,
           "environmentValue": "SHOPIFY_HYDROGEN_FLAG_FORCE"
         },
@@ -3539,7 +3557,7 @@
           "environmentValue": "SHOPIFY_HYDROGEN_DEPLOYMENT_TOKEN"
         }
       ],
-      "value": "export interface hydrogendeploy {\n  /**\n   * Generate an authentication bypass token, which can be used to perform end-to-end tests against the deployment.\n   * @environment AUTH_BYPASS_TOKEN\n   */\n  '--auth-bypass-token'?: ''\n\n  /**\n   * Specify the duration (in hours) up to 12 hours for the authentication bypass token. Defaults to `2`\n   * @environment AUTH_BYPASS_TOKEN_DURATION\n   */\n  '--auth-bypass-token-duration <value>'?: string\n\n  /**\n   * Specify a build command to run before deploying. If not specified, `shopify hydrogen build` will be used.\n   *\n   */\n  '--build-command <value>'?: string\n\n  /**\n   * Entry file for the worker. Defaults to `./server`.\n   * @environment SHOPIFY_HYDROGEN_FLAG_ENTRY\n   */\n  '--entry <value>'?: string\n\n  /**\n   * Specifies the environment to perform the operation using its handle. Fetch the handle using the `env list` command.\n   *\n   */\n  '--env <value>'?: string\n\n  /**\n   * Specifies the environment to perform the operation using its Git branch name.\n   * @environment SHOPIFY_HYDROGEN_ENVIRONMENT_BRANCH\n   */\n  '--env-branch <value>'?: string\n\n  /**\n   * Path to an environment file to override existing environment variables for the deployment.\n   *\n   */\n  '--env-file <value>'?: string\n\n  /**\n   * Forces a deployment to proceed if there are uncommited changes in its Git repository.\n   * @environment SHOPIFY_HYDROGEN_FLAG_FORCE\n   */\n  '-f, --force'?: ''\n\n  /**\n   * Client sourcemapping is avoided by default because it makes backend code visible in the browser. Use this flag to force enabling it.\n   * @environment SHOPIFY_HYDROGEN_FLAG_FORCE_CLIENT_SOURCEMAP\n   */\n  '--force-client-sourcemap'?: ''\n\n  /**\n   * Create a JSON file containing the deployment details in CI environments. Defaults to true, use `--no-json-output` to disable.\n   *\n   */\n  '--json-output'?: ''\n\n  /**\n   * Checks that there is exactly one valid lockfile in the project. Defaults to `true`. Deactivate with `--no-lockfile-check`.\n   * @environment SHOPIFY_HYDROGEN_FLAG_LOCKFILE_CHECK\n   */\n  '--lockfile-check'?: ''\n\n  /**\n   * Description of the changes in the deployment. Defaults to the commit message of the latest commit if there are no uncommited changes.\n   * @environment SHOPIFY_HYDROGEN_FLAG_METADATA_DESCRIPTION\n   */\n  '--metadata-description <value>'?: string\n\n  /**\n   * User that initiated the deployment. Will be saved and displayed in the Shopify admin\n   * @environment SHOPIFY_HYDROGEN_FLAG_METADATA_USER\n   */\n  '--metadata-user <value>'?: string\n\n  /**\n   * Skip the routability verification step after deployment.\n   *\n   */\n  '--no-verify'?: ''\n\n  /**\n   * The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.\n   * @environment SHOPIFY_HYDROGEN_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Deploys to the Preview environment.\n   *\n   */\n  '--preview'?: ''\n\n  /**\n   * Shop URL. It can be the shop prefix (janes-apparel) or the full myshopify.com URL (janes-apparel.myshopify.com, https://janes-apparel.myshopify.com).\n   * @environment SHOPIFY_SHOP\n   */\n  '-s, --shop <value>'?: string\n\n  /**\n   * Oxygen deployment token. Defaults to the linked storefront's token if available.\n   * @environment SHOPIFY_HYDROGEN_DEPLOYMENT_TOKEN\n   */\n  '-t, --token <value>'?: string\n}"
+      "value": "export interface hydrogendeploy {\n  /**\n   * Directory containing the client assets to deploy, relative to the project root. Defaults to the detected Vite client output directory, then falls back to `dist/client`.\n   * @environment SHOPIFY_HYDROGEN_FLAG_ASSETS_DIR\n   */\n  '--assets-dir <value>'?: string\n\n  /**\n   * Generate an authentication bypass token, which can be used to perform end-to-end tests against the deployment.\n   * @environment AUTH_BYPASS_TOKEN\n   */\n  '--auth-bypass-token'?: ''\n\n  /**\n   * Specify the duration (in hours) up to 12 hours for the authentication bypass token. Defaults to `2`\n   * @environment AUTH_BYPASS_TOKEN_DURATION\n   */\n  '--auth-bypass-token-duration <value>'?: string\n\n  /**\n   * Specify a build command to run before deploying. If not specified, the Hydrogen build pipeline will be used. When custom output directories are configured, defaults to `node --run build`.\n   *\n   */\n  '--build-command <value>'?: string\n\n  /**\n   * Entry file for the worker. Defaults to `./server`.\n   * @environment SHOPIFY_HYDROGEN_FLAG_ENTRY\n   */\n  '--entry <value>'?: string\n\n  /**\n   * Specifies the environment to perform the operation using its handle. Fetch the handle using the `env list` command.\n   *\n   */\n  '--env <value>'?: string\n\n  /**\n   * Specifies the environment to perform the operation using its Git branch name.\n   * @environment SHOPIFY_HYDROGEN_ENVIRONMENT_BRANCH\n   */\n  '--env-branch <value>'?: string\n\n  /**\n   * Path to an environment file to override existing environment variables for the deployment.\n   *\n   */\n  '--env-file <value>'?: string\n\n  /**\n   * Forces a deployment to proceed if there are uncommitted changes in its Git repository.\n   * @environment SHOPIFY_HYDROGEN_FLAG_FORCE\n   */\n  '-f, --force'?: ''\n\n  /**\n   * Client sourcemapping is avoided by default because it makes backend code visible in the browser. Use this flag to force enabling it.\n   * @environment SHOPIFY_HYDROGEN_FLAG_FORCE_CLIENT_SOURCEMAP\n   */\n  '--force-client-sourcemap'?: ''\n\n  /**\n   * Create a JSON file containing the deployment details in CI environments. Defaults to true, use `--no-json-output` to disable.\n   *\n   */\n  '--json-output'?: ''\n\n  /**\n   * Checks that there is exactly one valid lockfile in the project. Defaults to `true`. Deactivate with `--no-lockfile-check`.\n   * @environment SHOPIFY_HYDROGEN_FLAG_LOCKFILE_CHECK\n   */\n  '--lockfile-check'?: ''\n\n  /**\n   * Description of the changes in the deployment. Defaults to the commit message of the latest commit if there are no uncommitted changes.\n   * @environment SHOPIFY_HYDROGEN_FLAG_METADATA_DESCRIPTION\n   */\n  '--metadata-description <value>'?: string\n\n  /**\n   * User that initiated the deployment. Will be saved and displayed in the Shopify admin\n   * @environment SHOPIFY_HYDROGEN_FLAG_METADATA_USER\n   */\n  '--metadata-user <value>'?: string\n\n  /**\n   * Skip the routability verification step after deployment.\n   *\n   */\n  '--no-verify'?: ''\n\n  /**\n   * The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.\n   * @environment SHOPIFY_HYDROGEN_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Deploys to the Preview environment.\n   *\n   */\n  '--preview'?: ''\n\n  /**\n   * Shop URL. It can be the shop prefix (janes-apparel) or the full myshopify.com URL (janes-apparel.myshopify.com, https://janes-apparel.myshopify.com).\n   * @environment SHOPIFY_SHOP\n   */\n  '-s, --shop <value>'?: string\n\n  /**\n   * Oxygen deployment token. Defaults to the linked storefront's token if available.\n   * @environment SHOPIFY_HYDROGEN_DEPLOYMENT_TOKEN\n   */\n  '-t, --token <value>'?: string\n\n  /**\n   * Directory containing the Oxygen worker entry point (`index.js` or `index.mjs`), relative to the project root. Defaults to the detected Vite server output directory, then falls back to `dist/server`.\n   * @environment SHOPIFY_HYDROGEN_FLAG_WORKER_DIR\n   */\n  '--worker-dir <value>'?: string\n}"
     }
   },
   "hydrogendev": {
@@ -3813,7 +3831,7 @@
           "syntaxKind": "PropertySignature",
           "name": "--adapter <value>",
           "value": "string",
-          "description": "Remix adapter used in the route. The default is `@shopify/remix-oxygen`.",
+          "description": "React Router adapter used in the route. The default is `react-router`.",
           "isOptional": true,
           "environmentValue": "SHOPIFY_HYDROGEN_FLAG_ADAPTER"
         },
@@ -3854,7 +3872,7 @@
           "environmentValue": "SHOPIFY_HYDROGEN_FLAG_FORCE"
         }
       ],
-      "value": "export interface hydrogengenerateroute {\n  /**\n   * Remix adapter used in the route. The default is `@shopify/remix-oxygen`.\n   * @environment SHOPIFY_HYDROGEN_FLAG_ADAPTER\n   */\n  '--adapter <value>'?: string\n\n  /**\n   * Overwrites the destination directory and files if they already exist.\n   * @environment SHOPIFY_HYDROGEN_FLAG_FORCE\n   */\n  '-f, --force'?: ''\n\n  /**\n   * The param name in Remix routes for the i18n locale, if any. Example: `locale` becomes ($locale).\n   * @environment SHOPIFY_HYDROGEN_FLAG_ADAPTER\n   */\n  '--locale-param <value>'?: string\n\n  /**\n   * The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.\n   * @environment SHOPIFY_HYDROGEN_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Generate TypeScript files\n   * @environment SHOPIFY_HYDROGEN_FLAG_TYPESCRIPT\n   */\n  '--typescript'?: ''\n}"
+      "value": "export interface hydrogengenerateroute {\n  /**\n   * React Router adapter used in the route. The default is `react-router`.\n   * @environment SHOPIFY_HYDROGEN_FLAG_ADAPTER\n   */\n  '--adapter <value>'?: string\n\n  /**\n   * Overwrites the destination directory and files if they already exist.\n   * @environment SHOPIFY_HYDROGEN_FLAG_FORCE\n   */\n  '-f, --force'?: ''\n\n  /**\n   * The param name in Remix routes for the i18n locale, if any. Example: `locale` becomes ($locale).\n   * @environment SHOPIFY_HYDROGEN_FLAG_ADAPTER\n   */\n  '--locale-param <value>'?: string\n\n  /**\n   * The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.\n   * @environment SHOPIFY_HYDROGEN_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Generate TypeScript files\n   * @environment SHOPIFY_HYDROGEN_FLAG_TYPESCRIPT\n   */\n  '--typescript'?: ''\n}"
     }
   },
   "hydrogengenerateroutes": {
@@ -3869,7 +3887,7 @@
           "syntaxKind": "PropertySignature",
           "name": "--adapter <value>",
           "value": "string",
-          "description": "Remix adapter used in the route. The default is `@shopify/remix-oxygen`.",
+          "description": "React Router adapter used in the route. The default is `react-router`.",
           "isOptional": true,
           "environmentValue": "SHOPIFY_HYDROGEN_FLAG_ADAPTER"
         },
@@ -3910,7 +3928,7 @@
           "environmentValue": "SHOPIFY_HYDROGEN_FLAG_FORCE"
         }
       ],
-      "value": "export interface hydrogengenerateroutes {\n  /**\n   * Remix adapter used in the route. The default is `@shopify/remix-oxygen`.\n   * @environment SHOPIFY_HYDROGEN_FLAG_ADAPTER\n   */\n  '--adapter <value>'?: string\n\n  /**\n   * Overwrites the destination directory and files if they already exist.\n   * @environment SHOPIFY_HYDROGEN_FLAG_FORCE\n   */\n  '-f, --force'?: ''\n\n  /**\n   * The param name in Remix routes for the i18n locale, if any. Example: `locale` becomes ($locale).\n   * @environment SHOPIFY_HYDROGEN_FLAG_ADAPTER\n   */\n  '--locale-param <value>'?: string\n\n  /**\n   * The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.\n   * @environment SHOPIFY_HYDROGEN_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Generate TypeScript files\n   * @environment SHOPIFY_HYDROGEN_FLAG_TYPESCRIPT\n   */\n  '--typescript'?: ''\n}"
+      "value": "export interface hydrogengenerateroutes {\n  /**\n   * React Router adapter used in the route. The default is `react-router`.\n   * @environment SHOPIFY_HYDROGEN_FLAG_ADAPTER\n   */\n  '--adapter <value>'?: string\n\n  /**\n   * Overwrites the destination directory and files if they already exist.\n   * @environment SHOPIFY_HYDROGEN_FLAG_FORCE\n   */\n  '-f, --force'?: ''\n\n  /**\n   * The param name in Remix routes for the i18n locale, if any. Example: `locale` becomes ($locale).\n   * @environment SHOPIFY_HYDROGEN_FLAG_ADAPTER\n   */\n  '--locale-param <value>'?: string\n\n  /**\n   * The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.\n   * @environment SHOPIFY_HYDROGEN_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Generate TypeScript files\n   * @environment SHOPIFY_HYDROGEN_FLAG_TYPESCRIPT\n   */\n  '--typescript'?: ''\n}"
     }
   },
   "hydrogeninit": {

--- a/docs-shopify.dev/generated/generated_docs_data_v2.json
+++ b/docs-shopify.dev/generated/generated_docs_data_v2.json
@@ -9,6 +9,15 @@
         {
           "filePath": "docs-shopify.dev/commands/interfaces/app-build.interface.ts",
           "syntaxKind": "PropertySignature",
+          "name": "--auth-alias <value>",
+          "value": "string",
+          "description": "Alias of the Shopify account to use for authentication.",
+          "isOptional": true,
+          "environmentValue": "SHOPIFY_FLAG_AUTH_ALIAS"
+        },
+        {
+          "filePath": "docs-shopify.dev/commands/interfaces/app-build.interface.ts",
+          "syntaxKind": "PropertySignature",
           "name": "--client-id <value>",
           "value": "string",
           "description": "The Client ID of your app.",
@@ -70,7 +79,7 @@
           "environmentValue": "SHOPIFY_FLAG_APP_CONFIG"
         }
       ],
-      "value": "export interface appbuild {\n  /**\n   * The Client ID of your app.\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your app directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Reset all your settings.\n   * @environment SHOPIFY_FLAG_RESET\n   */\n  '--reset'?: ''\n\n  /**\n   * Skips the installation of dependencies. Deprecated, use workspaces instead.\n   * @environment SHOPIFY_FLAG_SKIP_DEPENDENCIES_INSTALLATION\n   */\n  '--skip-dependencies-installation'?: ''\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+      "value": "export interface appbuild {\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--auth-alias <value>'?: string\n\n  /**\n   * The Client ID of your app.\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your app directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Reset all your settings.\n   * @environment SHOPIFY_FLAG_RESET\n   */\n  '--reset'?: ''\n\n  /**\n   * Skips the installation of dependencies. Deprecated, use workspaces instead.\n   * @environment SHOPIFY_FLAG_SKIP_DEPENDENCIES_INSTALLATION\n   */\n  '--skip-dependencies-installation'?: ''\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
     }
   },
   "appbulkcancel": {
@@ -80,6 +89,15 @@
       "description": "The following flags are available for the `app bulk cancel` command:",
       "isPublicDocs": true,
       "members": [
+        {
+          "filePath": "docs-shopify.dev/commands/interfaces/app-bulk-cancel.interface.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "--auth-alias <value>",
+          "value": "string",
+          "description": "Alias of the Shopify account to use for authentication.",
+          "isOptional": true,
+          "environmentValue": "SHOPIFY_FLAG_AUTH_ALIAS"
+        },
         {
           "filePath": "docs-shopify.dev/commands/interfaces/app-bulk-cancel.interface.ts",
           "syntaxKind": "PropertySignature",
@@ -152,7 +170,7 @@
           "environmentValue": "SHOPIFY_FLAG_STORE"
         }
       ],
-      "value": "export interface appbulkcancel {\n  /**\n   * The Client ID of your app.\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * The bulk operation ID to cancel (numeric ID or full GID).\n   * @environment SHOPIFY_FLAG_ID\n   */\n  '--id <value>': string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your app directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Reset all your settings.\n   * @environment SHOPIFY_FLAG_RESET\n   */\n  '--reset'?: ''\n\n  /**\n   * The store domain. Must be an existing dev store.\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+      "value": "export interface appbulkcancel {\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--auth-alias <value>'?: string\n\n  /**\n   * The Client ID of your app.\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * The bulk operation ID to cancel (numeric ID or full GID).\n   * @environment SHOPIFY_FLAG_ID\n   */\n  '--id <value>': string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your app directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Reset all your settings.\n   * @environment SHOPIFY_FLAG_RESET\n   */\n  '--reset'?: ''\n\n  /**\n   * The store domain. Must be an existing dev store.\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
     }
   },
   "appbulkexecute": {
@@ -162,6 +180,15 @@
       "description": "The following flags are available for the `app bulk execute` command:",
       "isPublicDocs": true,
       "members": [
+        {
+          "filePath": "docs-shopify.dev/commands/interfaces/app-bulk-execute.interface.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "--auth-alias <value>",
+          "value": "string",
+          "description": "Alias of the Shopify account to use for authentication.",
+          "isOptional": true,
+          "environmentValue": "SHOPIFY_FLAG_AUTH_ALIAS"
+        },
         {
           "filePath": "docs-shopify.dev/commands/interfaces/app-bulk-execute.interface.ts",
           "syntaxKind": "PropertySignature",
@@ -289,7 +316,7 @@
           "environmentValue": "SHOPIFY_FLAG_VARIABLES"
         }
       ],
-      "value": "export interface appbulkexecute {\n  /**\n   * The Client ID of your app.\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The file path where results should be written if --watch is specified. If not specified, results will be written to STDOUT.\n   * @environment SHOPIFY_FLAG_OUTPUT_FILE\n   */\n  '--output-file <value>'?: string\n\n  /**\n   * The path to your app directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * The GraphQL query or mutation to run as a bulk operation.\n   * @environment SHOPIFY_FLAG_QUERY\n   */\n  '-q, --query <value>'?: string\n\n  /**\n   * Path to a file containing the GraphQL query or mutation. Can't be used with --query.\n   * @environment SHOPIFY_FLAG_QUERY_FILE\n   */\n  '--query-file <value>'?: string\n\n  /**\n   * Reset all your settings.\n   * @environment SHOPIFY_FLAG_RESET\n   */\n  '--reset'?: ''\n\n  /**\n   * The store domain. Must be an existing dev store.\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Path to a file containing GraphQL variables in JSONL format (one JSON object per line). Can't be used with --variables.\n   * @environment SHOPIFY_FLAG_VARIABLE_FILE\n   */\n  '--variable-file <value>'?: string\n\n  /**\n   * The values for any GraphQL variables in your mutation, in JSON format. Can be specified multiple times.\n   * @environment SHOPIFY_FLAG_VARIABLES\n   */\n  '-v, --variables <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n\n  /**\n   * The API version to use for the bulk operation. If not specified, uses the latest stable version.\n   * @environment SHOPIFY_FLAG_VERSION\n   */\n  '--version <value>'?: string\n\n  /**\n   * Wait for bulk operation results before exiting. Defaults to false.\n   * @environment SHOPIFY_FLAG_WATCH\n   */\n  '--watch'?: ''\n}"
+      "value": "export interface appbulkexecute {\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--auth-alias <value>'?: string\n\n  /**\n   * The Client ID of your app.\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The file path where results should be written if --watch is specified. If not specified, results will be written to STDOUT.\n   * @environment SHOPIFY_FLAG_OUTPUT_FILE\n   */\n  '--output-file <value>'?: string\n\n  /**\n   * The path to your app directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * The GraphQL query or mutation to run as a bulk operation.\n   * @environment SHOPIFY_FLAG_QUERY\n   */\n  '-q, --query <value>'?: string\n\n  /**\n   * Path to a file containing the GraphQL query or mutation. Can't be used with --query.\n   * @environment SHOPIFY_FLAG_QUERY_FILE\n   */\n  '--query-file <value>'?: string\n\n  /**\n   * Reset all your settings.\n   * @environment SHOPIFY_FLAG_RESET\n   */\n  '--reset'?: ''\n\n  /**\n   * The store domain. Must be an existing dev store.\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Path to a file containing GraphQL variables in JSONL format (one JSON object per line). Can't be used with --variables.\n   * @environment SHOPIFY_FLAG_VARIABLE_FILE\n   */\n  '--variable-file <value>'?: string\n\n  /**\n   * The values for any GraphQL variables in your mutation, in JSON format. Can be specified multiple times.\n   * @environment SHOPIFY_FLAG_VARIABLES\n   */\n  '-v, --variables <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n\n  /**\n   * The API version to use for the bulk operation. If not specified, uses the latest stable version.\n   * @environment SHOPIFY_FLAG_VERSION\n   */\n  '--version <value>'?: string\n\n  /**\n   * Wait for bulk operation results before exiting. Defaults to false.\n   * @environment SHOPIFY_FLAG_WATCH\n   */\n  '--watch'?: ''\n}"
     }
   },
   "appbulkstatus": {
@@ -299,6 +326,15 @@
       "description": "The following flags are available for the `app bulk status` command:",
       "isPublicDocs": true,
       "members": [
+        {
+          "filePath": "docs-shopify.dev/commands/interfaces/app-bulk-status.interface.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "--auth-alias <value>",
+          "value": "string",
+          "description": "Alias of the Shopify account to use for authentication.",
+          "isOptional": true,
+          "environmentValue": "SHOPIFY_FLAG_AUTH_ALIAS"
+        },
         {
           "filePath": "docs-shopify.dev/commands/interfaces/app-bulk-status.interface.ts",
           "syntaxKind": "PropertySignature",
@@ -372,7 +408,7 @@
           "environmentValue": "SHOPIFY_FLAG_STORE"
         }
       ],
-      "value": "export interface appbulkstatus {\n  /**\n   * The Client ID of your app.\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * The bulk operation ID (numeric ID or full GID). If not provided, lists all bulk operations belonging to this app on this store in the last 7 days.\n   * @environment SHOPIFY_FLAG_ID\n   */\n  '--id <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your app directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Reset all your settings.\n   * @environment SHOPIFY_FLAG_RESET\n   */\n  '--reset'?: ''\n\n  /**\n   * The store domain. Must be an existing dev store.\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+      "value": "export interface appbulkstatus {\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--auth-alias <value>'?: string\n\n  /**\n   * The Client ID of your app.\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * The bulk operation ID (numeric ID or full GID). If not provided, lists all bulk operations belonging to this app on this store in the last 7 days.\n   * @environment SHOPIFY_FLAG_ID\n   */\n  '--id <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your app directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Reset all your settings.\n   * @environment SHOPIFY_FLAG_RESET\n   */\n  '--reset'?: ''\n\n  /**\n   * The store domain. Must be an existing dev store.\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
     }
   },
   "appconfiglink": {
@@ -385,6 +421,15 @@
         {
           "filePath": "docs-shopify.dev/commands/interfaces/app-config-link.interface.ts",
           "syntaxKind": "PropertySignature",
+          "name": "--auth-alias <value>",
+          "value": "string",
+          "description": "Alias of the Shopify account to use for authentication.",
+          "isOptional": true,
+          "environmentValue": "SHOPIFY_FLAG_AUTH_ALIAS"
+        },
+        {
+          "filePath": "docs-shopify.dev/commands/interfaces/app-config-link.interface.ts",
+          "syntaxKind": "PropertySignature",
           "name": "--client-id <value>",
           "value": "string",
           "description": "The Client ID of your app.",
@@ -437,7 +482,7 @@
           "environmentValue": "SHOPIFY_FLAG_APP_CONFIG"
         }
       ],
-      "value": "export interface appconfiglink {\n  /**\n   * The Client ID of your app.\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your app directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Reset all your settings.\n   * @environment SHOPIFY_FLAG_RESET\n   */\n  '--reset'?: ''\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+      "value": "export interface appconfiglink {\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--auth-alias <value>'?: string\n\n  /**\n   * The Client ID of your app.\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your app directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Reset all your settings.\n   * @environment SHOPIFY_FLAG_RESET\n   */\n  '--reset'?: ''\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
     }
   },
   "appconfigpull": {
@@ -450,6 +495,15 @@
         {
           "filePath": "docs-shopify.dev/commands/interfaces/app-config-pull.interface.ts",
           "syntaxKind": "PropertySignature",
+          "name": "--auth-alias <value>",
+          "value": "string",
+          "description": "Alias of the Shopify account to use for authentication.",
+          "isOptional": true,
+          "environmentValue": "SHOPIFY_FLAG_AUTH_ALIAS"
+        },
+        {
+          "filePath": "docs-shopify.dev/commands/interfaces/app-config-pull.interface.ts",
+          "syntaxKind": "PropertySignature",
           "name": "--client-id <value>",
           "value": "string",
           "description": "The Client ID of your app.",
@@ -502,7 +556,7 @@
           "environmentValue": "SHOPIFY_FLAG_APP_CONFIG"
         }
       ],
-      "value": "export interface appconfigpull {\n  /**\n   * The Client ID of your app.\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your app directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Reset all your settings.\n   * @environment SHOPIFY_FLAG_RESET\n   */\n  '--reset'?: ''\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+      "value": "export interface appconfigpull {\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--auth-alias <value>'?: string\n\n  /**\n   * The Client ID of your app.\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your app directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Reset all your settings.\n   * @environment SHOPIFY_FLAG_RESET\n   */\n  '--reset'?: ''\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
     }
   },
   "appconfiguse": {
@@ -512,6 +566,15 @@
       "description": "The following flags are available for the `app config use` command:",
       "isPublicDocs": true,
       "members": [
+        {
+          "filePath": "docs-shopify.dev/commands/interfaces/app-config-use.interface.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "--auth-alias <value>",
+          "value": "string",
+          "description": "Alias of the Shopify account to use for authentication.",
+          "isOptional": true,
+          "environmentValue": "SHOPIFY_FLAG_AUTH_ALIAS"
+        },
         {
           "filePath": "docs-shopify.dev/commands/interfaces/app-config-use.interface.ts",
           "syntaxKind": "PropertySignature",
@@ -558,7 +621,7 @@
           "environmentValue": "SHOPIFY_FLAG_VERBOSE"
         }
       ],
-      "value": "export interface appconfiguse {\n  /**\n   * The Client ID of your app.\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your app directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Reset all your settings.\n   * @environment SHOPIFY_FLAG_RESET\n   */\n  '--reset'?: ''\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+      "value": "export interface appconfiguse {\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--auth-alias <value>'?: string\n\n  /**\n   * The Client ID of your app.\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your app directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Reset all your settings.\n   * @environment SHOPIFY_FLAG_RESET\n   */\n  '--reset'?: ''\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
     }
   },
   "appconfigvalidate": {
@@ -568,6 +631,15 @@
       "description": "The following flags are available for the `app config validate` command:",
       "isPublicDocs": true,
       "members": [
+        {
+          "filePath": "docs-shopify.dev/commands/interfaces/app-config-validate.interface.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "--auth-alias <value>",
+          "value": "string",
+          "description": "Alias of the Shopify account to use for authentication.",
+          "isOptional": true,
+          "environmentValue": "SHOPIFY_FLAG_AUTH_ALIAS"
+        },
         {
           "filePath": "docs-shopify.dev/commands/interfaces/app-config-validate.interface.ts",
           "syntaxKind": "PropertySignature",
@@ -632,7 +704,7 @@
           "environmentValue": "SHOPIFY_FLAG_JSON"
         }
       ],
-      "value": "export interface appconfigvalidate {\n  /**\n   * The Client ID of your app.\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Output the result as JSON. Automatically disables color output.\n   * @environment SHOPIFY_FLAG_JSON\n   */\n  '-j, --json'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your app directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Reset all your settings.\n   * @environment SHOPIFY_FLAG_RESET\n   */\n  '--reset'?: ''\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+      "value": "export interface appconfigvalidate {\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--auth-alias <value>'?: string\n\n  /**\n   * The Client ID of your app.\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Output the result as JSON. Automatically disables color output.\n   * @environment SHOPIFY_FLAG_JSON\n   */\n  '-j, --json'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your app directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Reset all your settings.\n   * @environment SHOPIFY_FLAG_RESET\n   */\n  '--reset'?: ''\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
     }
   },
   "appdeploy": {
@@ -659,6 +731,15 @@
           "description": "Allows adding and updating extensions and configuration without requiring user confirmation. Recommended option for CI/CD environments.",
           "isOptional": true,
           "environmentValue": "SHOPIFY_FLAG_ALLOW_UPDATES"
+        },
+        {
+          "filePath": "docs-shopify.dev/commands/interfaces/app-deploy.interface.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "--auth-alias <value>",
+          "value": "string",
+          "description": "Alias of the Shopify account to use for authentication.",
+          "isOptional": true,
+          "environmentValue": "SHOPIFY_FLAG_AUTH_ALIAS"
         },
         {
           "filePath": "docs-shopify.dev/commands/interfaces/app-deploy.interface.ts",
@@ -760,7 +841,7 @@
           "environmentValue": "SHOPIFY_FLAG_APP_CONFIG"
         }
       ],
-      "value": "export interface appdeploy {\n  /**\n   * Allows removing extensions and configuration without requiring user confirmation. For CI/CD environments, the recommended flag is --allow-updates.\n   * @environment SHOPIFY_FLAG_ALLOW_DELETES\n   */\n  '--allow-deletes'?: ''\n\n  /**\n   * Allows adding and updating extensions and configuration without requiring user confirmation. Recommended option for CI/CD environments.\n   * @environment SHOPIFY_FLAG_ALLOW_UPDATES\n   */\n  '--allow-updates'?: ''\n\n  /**\n   * The Client ID of your app.\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Optional message that will be associated with this version. This is for internal use only and won't be available externally.\n   * @environment SHOPIFY_FLAG_MESSAGE\n   */\n  '--message <value>'?: string\n\n  /**\n   * Use with caution: Skips building any elements of the app that require building. You should ensure your app has been prepared in advance, such as by running `shopify app build` or by caching build artifacts.\n   * @environment SHOPIFY_FLAG_NO_BUILD\n   */\n  '--no-build'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Creates a version but doesn't release it - it's not made available to merchants. With this flag, a user confirmation is not required.\n   * @environment SHOPIFY_FLAG_NO_RELEASE\n   */\n  '--no-release'?: ''\n\n  /**\n   * The path to your app directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Reset all your settings.\n   * @environment SHOPIFY_FLAG_RESET\n   */\n  '--reset'?: ''\n\n  /**\n   * URL associated with the new app version.\n   * @environment SHOPIFY_FLAG_SOURCE_CONTROL_URL\n   */\n  '--source-control-url <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n\n  /**\n   * Optional version tag that will be associated with this app version. If not provided, an auto-generated identifier will be generated for this app version.\n   * @environment SHOPIFY_FLAG_VERSION\n   */\n  '--version <value>'?: string\n}"
+      "value": "export interface appdeploy {\n  /**\n   * Allows removing extensions and configuration without requiring user confirmation. For CI/CD environments, the recommended flag is --allow-updates.\n   * @environment SHOPIFY_FLAG_ALLOW_DELETES\n   */\n  '--allow-deletes'?: ''\n\n  /**\n   * Allows adding and updating extensions and configuration without requiring user confirmation. Recommended option for CI/CD environments.\n   * @environment SHOPIFY_FLAG_ALLOW_UPDATES\n   */\n  '--allow-updates'?: ''\n\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--auth-alias <value>'?: string\n\n  /**\n   * The Client ID of your app.\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Optional message that will be associated with this version. This is for internal use only and won't be available externally.\n   * @environment SHOPIFY_FLAG_MESSAGE\n   */\n  '--message <value>'?: string\n\n  /**\n   * Use with caution: Skips building any elements of the app that require building. You should ensure your app has been prepared in advance, such as by running `shopify app build` or by caching build artifacts.\n   * @environment SHOPIFY_FLAG_NO_BUILD\n   */\n  '--no-build'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Creates a version but doesn't release it - it's not made available to merchants. With this flag, a user confirmation is not required.\n   * @environment SHOPIFY_FLAG_NO_RELEASE\n   */\n  '--no-release'?: ''\n\n  /**\n   * The path to your app directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Reset all your settings.\n   * @environment SHOPIFY_FLAG_RESET\n   */\n  '--reset'?: ''\n\n  /**\n   * URL associated with the new app version.\n   * @environment SHOPIFY_FLAG_SOURCE_CONTROL_URL\n   */\n  '--source-control-url <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n\n  /**\n   * Optional version tag that will be associated with this app version. If not provided, an auto-generated identifier will be generated for this app version.\n   * @environment SHOPIFY_FLAG_VERSION\n   */\n  '--version <value>'?: string\n}"
     }
   },
   "appdevclean": {
@@ -770,6 +851,15 @@
       "description": "The following flags are available for the `app dev clean` command:",
       "isPublicDocs": true,
       "members": [
+        {
+          "filePath": "docs-shopify.dev/commands/interfaces/app-dev-clean.interface.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "--auth-alias <value>",
+          "value": "string",
+          "description": "Alias of the Shopify account to use for authentication.",
+          "isOptional": true,
+          "environmentValue": "SHOPIFY_FLAG_AUTH_ALIAS"
+        },
         {
           "filePath": "docs-shopify.dev/commands/interfaces/app-dev-clean.interface.ts",
           "syntaxKind": "PropertySignature",
@@ -834,7 +924,7 @@
           "environmentValue": "SHOPIFY_FLAG_STORE"
         }
       ],
-      "value": "export interface appdevclean {\n  /**\n   * The Client ID of your app.\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your app directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Reset all your settings.\n   * @environment SHOPIFY_FLAG_RESET\n   */\n  '--reset'?: ''\n\n  /**\n   * Store URL. Must be an existing development store.\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+      "value": "export interface appdevclean {\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--auth-alias <value>'?: string\n\n  /**\n   * The Client ID of your app.\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your app directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Reset all your settings.\n   * @environment SHOPIFY_FLAG_RESET\n   */\n  '--reset'?: ''\n\n  /**\n   * Store URL. Must be an existing development store.\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
     }
   },
   "appdev": {
@@ -844,6 +934,15 @@
       "description": "The following flags are available for the `app dev` command:",
       "isPublicDocs": true,
       "members": [
+        {
+          "filePath": "docs-shopify.dev/commands/interfaces/app-dev.interface.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "--auth-alias <value>",
+          "value": "string",
+          "description": "Alias of the Shopify account to use for authentication.",
+          "isOptional": true,
+          "environmentValue": "SHOPIFY_FLAG_AUTH_ALIAS"
+        },
         {
           "filePath": "docs-shopify.dev/commands/interfaces/app-dev.interface.ts",
           "syntaxKind": "PropertySignature",
@@ -998,7 +1097,7 @@
           "environmentValue": "SHOPIFY_FLAG_THEME"
         }
       ],
-      "value": "export interface appdev {\n  /**\n   * Resource URL for checkout UI extension. Format: \"/cart/{productVariantID}:{productQuantity}\"\n   * @environment SHOPIFY_FLAG_CHECKOUT_CART_URL\n   */\n  '--checkout-cart-url <value>'?: string\n\n  /**\n   * The Client ID of your app.\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Port to use for localhost. Must be between 1 and 65535.\n   * @environment SHOPIFY_FLAG_LOCALHOST_PORT\n   */\n  '--localhost-port <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Uses the app URL from the toml file instead an autogenerated URL for dev.\n   * @environment SHOPIFY_FLAG_NO_UPDATE\n   */\n  '--no-update'?: ''\n\n  /**\n   * The file path or URL. The file path is to a file that you want updated on idle. The URL path is where you want a webhook posted to report on file changes.\n   * @environment SHOPIFY_FLAG_NOTIFY\n   */\n  '--notify <value>'?: string\n\n  /**\n   * The path to your app directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Reset all your settings.\n   * @environment SHOPIFY_FLAG_RESET\n   */\n  '--reset'?: ''\n\n  /**\n   * Skips the installation of dependencies. Deprecated, use workspaces instead.\n   * @environment SHOPIFY_FLAG_SKIP_DEPENDENCIES_INSTALLATION\n   */\n  '--skip-dependencies-installation'?: ''\n\n  /**\n   * Store URL. Must be an existing development or Shopify Plus sandbox store.\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Resource URL for subscription UI extension. Format: \"/products/{productId}\"\n   * @environment SHOPIFY_FLAG_SUBSCRIPTION_PRODUCT_URL\n   */\n  '--subscription-product-url <value>'?: string\n\n  /**\n   * Theme ID or name of the theme app extension host theme.\n   * @environment SHOPIFY_FLAG_THEME\n   */\n  '-t, --theme <value>'?: string\n\n  /**\n   * Local port of the theme app extension development server. Must be between 1 and 65535.\n   * @environment SHOPIFY_FLAG_THEME_APP_EXTENSION_PORT\n   */\n  '--theme-app-extension-port <value>'?: string\n\n  /**\n   * Use a custom tunnel, it must be running before executing dev. Format: \"https://my-tunnel-url:port\".\n   * @environment SHOPIFY_FLAG_TUNNEL_URL\n   */\n  '--tunnel-url <value>'?: string\n\n  /**\n   * Service entry point will listen to localhost. A tunnel won't be used. Will work for testing many app features, but not those that directly invoke your app (E.g: Webhooks)\n   * @environment SHOPIFY_FLAG_USE_LOCALHOST\n   */\n  '--use-localhost'?: ''\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+      "value": "export interface appdev {\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--auth-alias <value>'?: string\n\n  /**\n   * Resource URL for checkout UI extension. Format: \"/cart/{productVariantID}:{productQuantity}\"\n   * @environment SHOPIFY_FLAG_CHECKOUT_CART_URL\n   */\n  '--checkout-cart-url <value>'?: string\n\n  /**\n   * The Client ID of your app.\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Port to use for localhost. Must be between 1 and 65535.\n   * @environment SHOPIFY_FLAG_LOCALHOST_PORT\n   */\n  '--localhost-port <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Uses the app URL from the toml file instead an autogenerated URL for dev.\n   * @environment SHOPIFY_FLAG_NO_UPDATE\n   */\n  '--no-update'?: ''\n\n  /**\n   * The file path or URL. The file path is to a file that you want updated on idle. The URL path is where you want a webhook posted to report on file changes.\n   * @environment SHOPIFY_FLAG_NOTIFY\n   */\n  '--notify <value>'?: string\n\n  /**\n   * The path to your app directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Reset all your settings.\n   * @environment SHOPIFY_FLAG_RESET\n   */\n  '--reset'?: ''\n\n  /**\n   * Skips the installation of dependencies. Deprecated, use workspaces instead.\n   * @environment SHOPIFY_FLAG_SKIP_DEPENDENCIES_INSTALLATION\n   */\n  '--skip-dependencies-installation'?: ''\n\n  /**\n   * Store URL. Must be an existing development or Shopify Plus sandbox store.\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Resource URL for subscription UI extension. Format: \"/products/{productId}\"\n   * @environment SHOPIFY_FLAG_SUBSCRIPTION_PRODUCT_URL\n   */\n  '--subscription-product-url <value>'?: string\n\n  /**\n   * Theme ID or name of the theme app extension host theme.\n   * @environment SHOPIFY_FLAG_THEME\n   */\n  '-t, --theme <value>'?: string\n\n  /**\n   * Local port of the theme app extension development server. Must be between 1 and 65535.\n   * @environment SHOPIFY_FLAG_THEME_APP_EXTENSION_PORT\n   */\n  '--theme-app-extension-port <value>'?: string\n\n  /**\n   * Use a custom tunnel, it must be running before executing dev. Format: \"https://my-tunnel-url:port\".\n   * @environment SHOPIFY_FLAG_TUNNEL_URL\n   */\n  '--tunnel-url <value>'?: string\n\n  /**\n   * Service entry point will listen to localhost. A tunnel won't be used. Will work for testing many app features, but not those that directly invoke your app (E.g: Webhooks)\n   * @environment SHOPIFY_FLAG_USE_LOCALHOST\n   */\n  '--use-localhost'?: ''\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
     }
   },
   "appenvpull": {
@@ -1008,6 +1107,15 @@
       "description": "The following flags are available for the `app env pull` command:",
       "isPublicDocs": true,
       "members": [
+        {
+          "filePath": "docs-shopify.dev/commands/interfaces/app-env-pull.interface.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "--auth-alias <value>",
+          "value": "string",
+          "description": "Alias of the Shopify account to use for authentication.",
+          "isOptional": true,
+          "environmentValue": "SHOPIFY_FLAG_AUTH_ALIAS"
+        },
         {
           "filePath": "docs-shopify.dev/commands/interfaces/app-env-pull.interface.ts",
           "syntaxKind": "PropertySignature",
@@ -1072,7 +1180,7 @@
           "environmentValue": "SHOPIFY_FLAG_APP_CONFIG"
         }
       ],
-      "value": "export interface appenvpull {\n  /**\n   * The Client ID of your app.\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Specify an environment file to update if the update flag is set\n   * @environment SHOPIFY_FLAG_ENV_FILE\n   */\n  '--env-file <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your app directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Reset all your settings.\n   * @environment SHOPIFY_FLAG_RESET\n   */\n  '--reset'?: ''\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+      "value": "export interface appenvpull {\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--auth-alias <value>'?: string\n\n  /**\n   * The Client ID of your app.\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Specify an environment file to update if the update flag is set\n   * @environment SHOPIFY_FLAG_ENV_FILE\n   */\n  '--env-file <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your app directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Reset all your settings.\n   * @environment SHOPIFY_FLAG_RESET\n   */\n  '--reset'?: ''\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
     }
   },
   "appenvshow": {
@@ -1082,6 +1190,15 @@
       "description": "The following flags are available for the `app env show` command:",
       "isPublicDocs": true,
       "members": [
+        {
+          "filePath": "docs-shopify.dev/commands/interfaces/app-env-show.interface.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "--auth-alias <value>",
+          "value": "string",
+          "description": "Alias of the Shopify account to use for authentication.",
+          "isOptional": true,
+          "environmentValue": "SHOPIFY_FLAG_AUTH_ALIAS"
+        },
         {
           "filePath": "docs-shopify.dev/commands/interfaces/app-env-show.interface.ts",
           "syntaxKind": "PropertySignature",
@@ -1137,7 +1254,7 @@
           "environmentValue": "SHOPIFY_FLAG_APP_CONFIG"
         }
       ],
-      "value": "export interface appenvshow {\n  /**\n   * The Client ID of your app.\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your app directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Reset all your settings.\n   * @environment SHOPIFY_FLAG_RESET\n   */\n  '--reset'?: ''\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+      "value": "export interface appenvshow {\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--auth-alias <value>'?: string\n\n  /**\n   * The Client ID of your app.\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your app directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Reset all your settings.\n   * @environment SHOPIFY_FLAG_RESET\n   */\n  '--reset'?: ''\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
     }
   },
   "appexecute": {
@@ -1147,6 +1264,15 @@
       "description": "The following flags are available for the `app execute` command:",
       "isPublicDocs": true,
       "members": [
+        {
+          "filePath": "docs-shopify.dev/commands/interfaces/app-execute.interface.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "--auth-alias <value>",
+          "value": "string",
+          "description": "Alias of the Shopify account to use for authentication.",
+          "isOptional": true,
+          "environmentValue": "SHOPIFY_FLAG_AUTH_ALIAS"
+        },
         {
           "filePath": "docs-shopify.dev/commands/interfaces/app-execute.interface.ts",
           "syntaxKind": "PropertySignature",
@@ -1265,7 +1391,7 @@
           "environmentValue": "SHOPIFY_FLAG_VARIABLES"
         }
       ],
-      "value": "export interface appexecute {\n  /**\n   * The Client ID of your app.\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The file name where results should be written, instead of STDOUT.\n   * @environment SHOPIFY_FLAG_OUTPUT_FILE\n   */\n  '--output-file <value>'?: string\n\n  /**\n   * The path to your app directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * The GraphQL query or mutation, as a string.\n   * @environment SHOPIFY_FLAG_QUERY\n   */\n  '-q, --query <value>'?: string\n\n  /**\n   * Path to a file containing the GraphQL query or mutation. Can't be used with --query.\n   * @environment SHOPIFY_FLAG_QUERY_FILE\n   */\n  '--query-file <value>'?: string\n\n  /**\n   * Reset all your settings.\n   * @environment SHOPIFY_FLAG_RESET\n   */\n  '--reset'?: ''\n\n  /**\n   * The myshopify.com domain of the store to execute against. The app must be installed on the store. If not specified, you will be prompted to select a store.\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Path to a file containing GraphQL variables in JSON format. Can't be used with --variables.\n   * @environment SHOPIFY_FLAG_VARIABLE_FILE\n   */\n  '--variable-file <value>'?: string\n\n  /**\n   * The values for any GraphQL variables in your query or mutation, in JSON format.\n   * @environment SHOPIFY_FLAG_VARIABLES\n   */\n  '-v, --variables <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n\n  /**\n   * The API version to use for the query or mutation. Defaults to the latest stable version.\n   * @environment SHOPIFY_FLAG_VERSION\n   */\n  '--version <value>'?: string\n}"
+      "value": "export interface appexecute {\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--auth-alias <value>'?: string\n\n  /**\n   * The Client ID of your app.\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The file name where results should be written, instead of STDOUT.\n   * @environment SHOPIFY_FLAG_OUTPUT_FILE\n   */\n  '--output-file <value>'?: string\n\n  /**\n   * The path to your app directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * The GraphQL query or mutation, as a string.\n   * @environment SHOPIFY_FLAG_QUERY\n   */\n  '-q, --query <value>'?: string\n\n  /**\n   * Path to a file containing the GraphQL query or mutation. Can't be used with --query.\n   * @environment SHOPIFY_FLAG_QUERY_FILE\n   */\n  '--query-file <value>'?: string\n\n  /**\n   * Reset all your settings.\n   * @environment SHOPIFY_FLAG_RESET\n   */\n  '--reset'?: ''\n\n  /**\n   * The myshopify.com domain of the store to execute against. The app must be installed on the store. If not specified, you will be prompted to select a store.\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Path to a file containing GraphQL variables in JSON format. Can't be used with --variables.\n   * @environment SHOPIFY_FLAG_VARIABLE_FILE\n   */\n  '--variable-file <value>'?: string\n\n  /**\n   * The values for any GraphQL variables in your query or mutation, in JSON format.\n   * @environment SHOPIFY_FLAG_VARIABLES\n   */\n  '-v, --variables <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n\n  /**\n   * The API version to use for the query or mutation. Defaults to the latest stable version.\n   * @environment SHOPIFY_FLAG_VERSION\n   */\n  '--version <value>'?: string\n}"
     }
   },
   "appfunctionbuild": {
@@ -1275,6 +1401,15 @@
       "description": "The following flags are available for the `app function build` command:",
       "isPublicDocs": true,
       "members": [
+        {
+          "filePath": "docs-shopify.dev/commands/interfaces/app-function-build.interface.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "--auth-alias <value>",
+          "value": "string",
+          "description": "Alias of the Shopify account to use for authentication.",
+          "isOptional": true,
+          "environmentValue": "SHOPIFY_FLAG_AUTH_ALIAS"
+        },
         {
           "filePath": "docs-shopify.dev/commands/interfaces/app-function-build.interface.ts",
           "syntaxKind": "PropertySignature",
@@ -1330,7 +1465,7 @@
           "environmentValue": "SHOPIFY_FLAG_APP_CONFIG"
         }
       ],
-      "value": "export interface appfunctionbuild {\n  /**\n   * The Client ID of your app.\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your function directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Reset all your settings.\n   * @environment SHOPIFY_FLAG_RESET\n   */\n  '--reset'?: ''\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+      "value": "export interface appfunctionbuild {\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--auth-alias <value>'?: string\n\n  /**\n   * The Client ID of your app.\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your function directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Reset all your settings.\n   * @environment SHOPIFY_FLAG_RESET\n   */\n  '--reset'?: ''\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
     }
   },
   "appfunctioninfo": {
@@ -1340,6 +1475,15 @@
       "description": "The following flags are available for the `app function info` command:",
       "isPublicDocs": true,
       "members": [
+        {
+          "filePath": "docs-shopify.dev/commands/interfaces/app-function-info.interface.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "--auth-alias <value>",
+          "value": "string",
+          "description": "Alias of the Shopify account to use for authentication.",
+          "isOptional": true,
+          "environmentValue": "SHOPIFY_FLAG_AUTH_ALIAS"
+        },
         {
           "filePath": "docs-shopify.dev/commands/interfaces/app-function-info.interface.ts",
           "syntaxKind": "PropertySignature",
@@ -1404,7 +1548,7 @@
           "environmentValue": "SHOPIFY_FLAG_JSON"
         }
       ],
-      "value": "export interface appfunctioninfo {\n  /**\n   * The Client ID of your app.\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Output the result as JSON. Automatically disables color output.\n   * @environment SHOPIFY_FLAG_JSON\n   */\n  '-j, --json'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your function directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Reset all your settings.\n   * @environment SHOPIFY_FLAG_RESET\n   */\n  '--reset'?: ''\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+      "value": "export interface appfunctioninfo {\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--auth-alias <value>'?: string\n\n  /**\n   * The Client ID of your app.\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Output the result as JSON. Automatically disables color output.\n   * @environment SHOPIFY_FLAG_JSON\n   */\n  '-j, --json'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your function directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Reset all your settings.\n   * @environment SHOPIFY_FLAG_RESET\n   */\n  '--reset'?: ''\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
     }
   },
   "appfunctionreplay": {
@@ -1414,6 +1558,15 @@
       "description": "The following flags are available for the `app function replay` command:",
       "isPublicDocs": true,
       "members": [
+        {
+          "filePath": "docs-shopify.dev/commands/interfaces/app-function-replay.interface.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "--auth-alias <value>",
+          "value": "string",
+          "description": "Alias of the Shopify account to use for authentication.",
+          "isOptional": true,
+          "environmentValue": "SHOPIFY_FLAG_AUTH_ALIAS"
+        },
         {
           "filePath": "docs-shopify.dev/commands/interfaces/app-function-replay.interface.ts",
           "syntaxKind": "PropertySignature",
@@ -1496,7 +1649,7 @@
           "environmentValue": "SHOPIFY_FLAG_WATCH"
         }
       ],
-      "value": "export interface appfunctionreplay {\n  /**\n   * The Client ID of your app.\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Output the result as JSON. Automatically disables color output.\n   * @environment SHOPIFY_FLAG_JSON\n   */\n  '-j, --json'?: ''\n\n  /**\n   * Specifies a log identifier to replay instead of selecting from a list. The identifier is provided in the output of `shopify app dev` and is the suffix of the log file name.\n   * @environment SHOPIFY_FLAG_LOG\n   */\n  '-l, --log <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your function directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Reset all your settings.\n   * @environment SHOPIFY_FLAG_RESET\n   */\n  '--reset'?: ''\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n\n  /**\n   * Re-run the function when the source code changes.\n   * @environment SHOPIFY_FLAG_WATCH\n   */\n  '-w, --watch'?: ''\n}"
+      "value": "export interface appfunctionreplay {\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--auth-alias <value>'?: string\n\n  /**\n   * The Client ID of your app.\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Output the result as JSON. Automatically disables color output.\n   * @environment SHOPIFY_FLAG_JSON\n   */\n  '-j, --json'?: ''\n\n  /**\n   * Specifies a log identifier to replay instead of selecting from a list. The identifier is provided in the output of `shopify app dev` and is the suffix of the log file name.\n   * @environment SHOPIFY_FLAG_LOG\n   */\n  '-l, --log <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your function directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Reset all your settings.\n   * @environment SHOPIFY_FLAG_RESET\n   */\n  '--reset'?: ''\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n\n  /**\n   * Re-run the function when the source code changes.\n   * @environment SHOPIFY_FLAG_WATCH\n   */\n  '-w, --watch'?: ''\n}"
     }
   },
   "appfunctionrun": {
@@ -1506,6 +1659,15 @@
       "description": "The following flags are available for the `app function run` command:",
       "isPublicDocs": true,
       "members": [
+        {
+          "filePath": "docs-shopify.dev/commands/interfaces/app-function-run.interface.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "--auth-alias <value>",
+          "value": "string",
+          "description": "Alias of the Shopify account to use for authentication.",
+          "isOptional": true,
+          "environmentValue": "SHOPIFY_FLAG_AUTH_ALIAS"
+        },
         {
           "filePath": "docs-shopify.dev/commands/interfaces/app-function-run.interface.ts",
           "syntaxKind": "PropertySignature",
@@ -1588,7 +1750,7 @@
           "environmentValue": "SHOPIFY_FLAG_JSON"
         }
       ],
-      "value": "export interface appfunctionrun {\n  /**\n   * The Client ID of your app.\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Name of the WebAssembly export to invoke.\n   * @environment SHOPIFY_FLAG_EXPORT\n   */\n  '-e, --export <value>'?: string\n\n  /**\n   * The input JSON to pass to the function. If omitted, standard input is used.\n   * @environment SHOPIFY_FLAG_INPUT\n   */\n  '-i, --input <value>'?: string\n\n  /**\n   * Output the result as JSON. Automatically disables color output.\n   * @environment SHOPIFY_FLAG_JSON\n   */\n  '-j, --json'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your function directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Reset all your settings.\n   * @environment SHOPIFY_FLAG_RESET\n   */\n  '--reset'?: ''\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+      "value": "export interface appfunctionrun {\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--auth-alias <value>'?: string\n\n  /**\n   * The Client ID of your app.\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Name of the WebAssembly export to invoke.\n   * @environment SHOPIFY_FLAG_EXPORT\n   */\n  '-e, --export <value>'?: string\n\n  /**\n   * The input JSON to pass to the function. If omitted, standard input is used.\n   * @environment SHOPIFY_FLAG_INPUT\n   */\n  '-i, --input <value>'?: string\n\n  /**\n   * Output the result as JSON. Automatically disables color output.\n   * @environment SHOPIFY_FLAG_JSON\n   */\n  '-j, --json'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your function directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Reset all your settings.\n   * @environment SHOPIFY_FLAG_RESET\n   */\n  '--reset'?: ''\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
     }
   },
   "appfunctionschema": {
@@ -1598,6 +1760,15 @@
       "description": "The following flags are available for the `app function schema` command:",
       "isPublicDocs": true,
       "members": [
+        {
+          "filePath": "docs-shopify.dev/commands/interfaces/app-function-schema.interface.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "--auth-alias <value>",
+          "value": "string",
+          "description": "Alias of the Shopify account to use for authentication.",
+          "isOptional": true,
+          "environmentValue": "SHOPIFY_FLAG_AUTH_ALIAS"
+        },
         {
           "filePath": "docs-shopify.dev/commands/interfaces/app-function-schema.interface.ts",
           "syntaxKind": "PropertySignature",
@@ -1662,7 +1833,7 @@
           "environmentValue": "SHOPIFY_FLAG_APP_CONFIG"
         }
       ],
-      "value": "export interface appfunctionschema {\n  /**\n   * The Client ID of your app.\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your function directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Reset all your settings.\n   * @environment SHOPIFY_FLAG_RESET\n   */\n  '--reset'?: ''\n\n  /**\n   * Output the schema to stdout instead of writing to a file.\n   * @environment SHOPIFY_FLAG_STDOUT\n   */\n  '--stdout'?: ''\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+      "value": "export interface appfunctionschema {\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--auth-alias <value>'?: string\n\n  /**\n   * The Client ID of your app.\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your function directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Reset all your settings.\n   * @environment SHOPIFY_FLAG_RESET\n   */\n  '--reset'?: ''\n\n  /**\n   * Output the schema to stdout instead of writing to a file.\n   * @environment SHOPIFY_FLAG_STDOUT\n   */\n  '--stdout'?: ''\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
     }
   },
   "appfunctiontypegen": {
@@ -1672,6 +1843,15 @@
       "description": "The following flags are available for the `app function typegen` command:",
       "isPublicDocs": true,
       "members": [
+        {
+          "filePath": "docs-shopify.dev/commands/interfaces/app-function-typegen.interface.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "--auth-alias <value>",
+          "value": "string",
+          "description": "Alias of the Shopify account to use for authentication.",
+          "isOptional": true,
+          "environmentValue": "SHOPIFY_FLAG_AUTH_ALIAS"
+        },
         {
           "filePath": "docs-shopify.dev/commands/interfaces/app-function-typegen.interface.ts",
           "syntaxKind": "PropertySignature",
@@ -1727,7 +1907,7 @@
           "environmentValue": "SHOPIFY_FLAG_APP_CONFIG"
         }
       ],
-      "value": "export interface appfunctiontypegen {\n  /**\n   * The Client ID of your app.\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your function directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Reset all your settings.\n   * @environment SHOPIFY_FLAG_RESET\n   */\n  '--reset'?: ''\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+      "value": "export interface appfunctiontypegen {\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--auth-alias <value>'?: string\n\n  /**\n   * The Client ID of your app.\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your function directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Reset all your settings.\n   * @environment SHOPIFY_FLAG_RESET\n   */\n  '--reset'?: ''\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
     }
   },
   "appgenerateextension": {
@@ -1737,6 +1917,15 @@
       "description": "The following flags are available for the `app generate extension` command:",
       "isPublicDocs": true,
       "members": [
+        {
+          "filePath": "docs-shopify.dev/commands/interfaces/app-generate-extension.interface.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "--auth-alias <value>",
+          "value": "string",
+          "description": "Alias of the Shopify account to use for authentication.",
+          "isOptional": true,
+          "environmentValue": "SHOPIFY_FLAG_AUTH_ALIAS"
+        },
         {
           "filePath": "docs-shopify.dev/commands/interfaces/app-generate-extension.interface.ts",
           "syntaxKind": "PropertySignature",
@@ -1819,7 +2008,7 @@
           "environmentValue": "SHOPIFY_FLAG_EXTENSION_TEMPLATE"
         }
       ],
-      "value": "export interface appgenerateextension {\n  /**\n   * The Client ID of your app.\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Choose a starting template for your extension, where applicable\n   * @environment SHOPIFY_FLAG_FLAVOR\n   */\n  '--flavor <value>'?: string\n\n  /**\n   * name of your Extension\n   * @environment SHOPIFY_FLAG_NAME\n   */\n  '-n, --name <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your app directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Reset all your settings.\n   * @environment SHOPIFY_FLAG_RESET\n   */\n  '--reset'?: ''\n\n  /**\n   * Extension template\n   * @environment SHOPIFY_FLAG_EXTENSION_TEMPLATE\n   */\n  '-t, --template <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+      "value": "export interface appgenerateextension {\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--auth-alias <value>'?: string\n\n  /**\n   * The Client ID of your app.\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Choose a starting template for your extension, where applicable\n   * @environment SHOPIFY_FLAG_FLAVOR\n   */\n  '--flavor <value>'?: string\n\n  /**\n   * name of your Extension\n   * @environment SHOPIFY_FLAG_NAME\n   */\n  '-n, --name <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your app directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Reset all your settings.\n   * @environment SHOPIFY_FLAG_RESET\n   */\n  '--reset'?: ''\n\n  /**\n   * Extension template\n   * @environment SHOPIFY_FLAG_EXTENSION_TEMPLATE\n   */\n  '-t, --template <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
     }
   },
   "appimportcustomdatadefinitions": {
@@ -1829,6 +2018,15 @@
       "description": "The following flags are available for the `app import-custom-data-definitions` command:",
       "isPublicDocs": true,
       "members": [
+        {
+          "filePath": "docs-shopify.dev/commands/interfaces/app-import-custom-data-definitions.interface.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "--auth-alias <value>",
+          "value": "string",
+          "description": "Alias of the Shopify account to use for authentication.",
+          "isOptional": true,
+          "environmentValue": "SHOPIFY_FLAG_AUTH_ALIAS"
+        },
         {
           "filePath": "docs-shopify.dev/commands/interfaces/app-import-custom-data-definitions.interface.ts",
           "syntaxKind": "PropertySignature",
@@ -1902,7 +2100,7 @@
           "environmentValue": "SHOPIFY_FLAG_STORE"
         }
       ],
-      "value": "export interface appimportcustomdatadefinitions {\n  /**\n   * The Client ID of your app.\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Include existing declared definitions in the output.\n   * @environment SHOPIFY_FLAG_INCLUDE_EXISTING\n   */\n  '--include-existing'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your app directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Reset all your settings.\n   * @environment SHOPIFY_FLAG_RESET\n   */\n  '--reset'?: ''\n\n  /**\n   * Store URL. Must be an existing development or Shopify Plus sandbox store.\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+      "value": "export interface appimportcustomdatadefinitions {\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--auth-alias <value>'?: string\n\n  /**\n   * The Client ID of your app.\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Include existing declared definitions in the output.\n   * @environment SHOPIFY_FLAG_INCLUDE_EXISTING\n   */\n  '--include-existing'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your app directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Reset all your settings.\n   * @environment SHOPIFY_FLAG_RESET\n   */\n  '--reset'?: ''\n\n  /**\n   * Store URL. Must be an existing development or Shopify Plus sandbox store.\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
     }
   },
   "appimportextensions": {
@@ -1912,6 +2110,15 @@
       "description": "The following flags are available for the `app import-extensions` command:",
       "isPublicDocs": true,
       "members": [
+        {
+          "filePath": "docs-shopify.dev/commands/interfaces/app-import-extensions.interface.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "--auth-alias <value>",
+          "value": "string",
+          "description": "Alias of the Shopify account to use for authentication.",
+          "isOptional": true,
+          "environmentValue": "SHOPIFY_FLAG_AUTH_ALIAS"
+        },
         {
           "filePath": "docs-shopify.dev/commands/interfaces/app-import-extensions.interface.ts",
           "syntaxKind": "PropertySignature",
@@ -1967,7 +2174,7 @@
           "environmentValue": "SHOPIFY_FLAG_APP_CONFIG"
         }
       ],
-      "value": "export interface appimportextensions {\n  /**\n   * The Client ID of your app.\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your app directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Reset all your settings.\n   * @environment SHOPIFY_FLAG_RESET\n   */\n  '--reset'?: ''\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+      "value": "export interface appimportextensions {\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--auth-alias <value>'?: string\n\n  /**\n   * The Client ID of your app.\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your app directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Reset all your settings.\n   * @environment SHOPIFY_FLAG_RESET\n   */\n  '--reset'?: ''\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
     }
   },
   "appinfo": {
@@ -1977,6 +2184,15 @@
       "description": "The following flags are available for the `app info` command:",
       "isPublicDocs": true,
       "members": [
+        {
+          "filePath": "docs-shopify.dev/commands/interfaces/app-info.interface.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "--auth-alias <value>",
+          "value": "string",
+          "description": "Alias of the Shopify account to use for authentication.",
+          "isOptional": true,
+          "environmentValue": "SHOPIFY_FLAG_AUTH_ALIAS"
+        },
         {
           "filePath": "docs-shopify.dev/commands/interfaces/app-info.interface.ts",
           "syntaxKind": "PropertySignature",
@@ -2050,7 +2266,7 @@
           "environmentValue": "SHOPIFY_FLAG_JSON"
         }
       ],
-      "value": "export interface appinfo {\n  /**\n   * The Client ID of your app.\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Output the result as JSON. Automatically disables color output.\n   * @environment SHOPIFY_FLAG_JSON\n   */\n  '-j, --json'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your app directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Reset all your settings.\n   * @environment SHOPIFY_FLAG_RESET\n   */\n  '--reset'?: ''\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n\n  /**\n   * Outputs environment variables necessary for running and deploying web/.\n   * @environment SHOPIFY_FLAG_OUTPUT_WEB_ENV\n   */\n  '--web-env'?: ''\n}"
+      "value": "export interface appinfo {\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--auth-alias <value>'?: string\n\n  /**\n   * The Client ID of your app.\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Output the result as JSON. Automatically disables color output.\n   * @environment SHOPIFY_FLAG_JSON\n   */\n  '-j, --json'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your app directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Reset all your settings.\n   * @environment SHOPIFY_FLAG_RESET\n   */\n  '--reset'?: ''\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n\n  /**\n   * Outputs environment variables necessary for running and deploying web/.\n   * @environment SHOPIFY_FLAG_OUTPUT_WEB_ENV\n   */\n  '--web-env'?: ''\n}"
     }
   },
   "appinit": {
@@ -2060,6 +2276,15 @@
       "description": "The following flags are available for the `app init` command:",
       "isPublicDocs": true,
       "members": [
+        {
+          "filePath": "docs-shopify.dev/commands/interfaces/app-init.interface.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "--auth-alias <value>",
+          "value": "string",
+          "description": "Alias of the Shopify account to use for authentication.",
+          "isOptional": true,
+          "environmentValue": "SHOPIFY_FLAG_AUTH_ALIAS"
+        },
         {
           "filePath": "docs-shopify.dev/commands/interfaces/app-init.interface.ts",
           "syntaxKind": "PropertySignature",
@@ -2142,7 +2367,7 @@
           "environmentValue": "SHOPIFY_FLAG_PATH"
         }
       ],
-      "value": "export interface appinit {\n  /**\n   * The Client ID of your app. Use this to automatically link your new project to an existing app. Using this flag avoids the app selection prompt.\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * Which flavor of the given template to use.\n   * @environment SHOPIFY_FLAG_TEMPLATE_FLAVOR\n   */\n  '--flavor <value>'?: string\n\n  /**\n   * The name for the new app. When provided, skips the app selection prompt and creates a new app with this name.\n   * @environment SHOPIFY_FLAG_NAME\n   */\n  '-n, --name <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The organization ID. Your organization ID can be found in your Dev Dashboard URL: https://dev.shopify.com/dashboard/<organization-id>\n   * @environment SHOPIFY_FLAG_ORGANIZATION_ID\n   */\n  '--organization-id <value>'?: string\n\n  /**\n   * \n   * @environment SHOPIFY_FLAG_PACKAGE_MANAGER\n   */\n  '-d, --package-manager <value>'?: string\n\n  /**\n   * \n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '-p, --path <value>'?: string\n\n  /**\n   * The app template. Accepts one of the following:\n       - <reactRouter|none>\n       - Any GitHub repo with optional branch and subpath, e.g., https://github.com/Shopify/<repository>/[subpath]#[branch]\n   * @environment SHOPIFY_FLAG_TEMPLATE\n   */\n  '--template <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+      "value": "export interface appinit {\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--auth-alias <value>'?: string\n\n  /**\n   * The Client ID of your app. Use this to automatically link your new project to an existing app. Using this flag avoids the app selection prompt.\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * Which flavor of the given template to use.\n   * @environment SHOPIFY_FLAG_TEMPLATE_FLAVOR\n   */\n  '--flavor <value>'?: string\n\n  /**\n   * The name for the new app. When provided, skips the app selection prompt and creates a new app with this name.\n   * @environment SHOPIFY_FLAG_NAME\n   */\n  '-n, --name <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The organization ID. Your organization ID can be found in your Dev Dashboard URL: https://dev.shopify.com/dashboard/<organization-id>\n   * @environment SHOPIFY_FLAG_ORGANIZATION_ID\n   */\n  '--organization-id <value>'?: string\n\n  /**\n   * \n   * @environment SHOPIFY_FLAG_PACKAGE_MANAGER\n   */\n  '-d, --package-manager <value>'?: string\n\n  /**\n   * \n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '-p, --path <value>'?: string\n\n  /**\n   * The app template. Accepts one of the following:\n       - <reactRouter|none>\n       - Any GitHub repo with optional branch and subpath, e.g., https://github.com/Shopify/<repository>/[subpath]#[branch]\n   * @environment SHOPIFY_FLAG_TEMPLATE\n   */\n  '--template <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
     }
   },
   "applogssources": {
@@ -2152,6 +2377,15 @@
       "description": "The following flags are available for the `app logs sources` command:",
       "isPublicDocs": true,
       "members": [
+        {
+          "filePath": "docs-shopify.dev/commands/interfaces/app-logs-sources.interface.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "--auth-alias <value>",
+          "value": "string",
+          "description": "Alias of the Shopify account to use for authentication.",
+          "isOptional": true,
+          "environmentValue": "SHOPIFY_FLAG_AUTH_ALIAS"
+        },
         {
           "filePath": "docs-shopify.dev/commands/interfaces/app-logs-sources.interface.ts",
           "syntaxKind": "PropertySignature",
@@ -2207,7 +2441,7 @@
           "environmentValue": "SHOPIFY_FLAG_APP_CONFIG"
         }
       ],
-      "value": "export interface applogssources {\n  /**\n   * The Client ID of your app.\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your app directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Reset all your settings.\n   * @environment SHOPIFY_FLAG_RESET\n   */\n  '--reset'?: ''\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+      "value": "export interface applogssources {\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--auth-alias <value>'?: string\n\n  /**\n   * The Client ID of your app.\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your app directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Reset all your settings.\n   * @environment SHOPIFY_FLAG_RESET\n   */\n  '--reset'?: ''\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
     }
   },
   "applogs": {
@@ -2217,6 +2451,15 @@
       "description": "The following flags are available for the `app logs` command:",
       "isPublicDocs": true,
       "members": [
+        {
+          "filePath": "docs-shopify.dev/commands/interfaces/app-logs.interface.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "--auth-alias <value>",
+          "value": "string",
+          "description": "Alias of the Shopify account to use for authentication.",
+          "isOptional": true,
+          "environmentValue": "SHOPIFY_FLAG_AUTH_ALIAS"
+        },
         {
           "filePath": "docs-shopify.dev/commands/interfaces/app-logs.interface.ts",
           "syntaxKind": "PropertySignature",
@@ -2308,7 +2551,7 @@
           "environmentValue": "SHOPIFY_FLAG_STORE"
         }
       ],
-      "value": "export interface applogs {\n  /**\n   * The Client ID of your app.\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Output the result as JSON. Automatically disables color output.\n   * @environment SHOPIFY_FLAG_JSON\n   */\n  '-j, --json'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your app directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Reset all your settings.\n   * @environment SHOPIFY_FLAG_RESET\n   */\n  '--reset'?: ''\n\n  /**\n   * Filters output to the specified log source.\n   * @environment SHOPIFY_FLAG_SOURCE\n   */\n  '--source <value>'?: string\n\n  /**\n   * Filters output to the specified status (success or failure).\n   * @environment SHOPIFY_FLAG_STATUS\n   */\n  '--status <value>'?: string\n\n  /**\n   * Store URL. Must be an existing development or Shopify Plus sandbox store.\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+      "value": "export interface applogs {\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--auth-alias <value>'?: string\n\n  /**\n   * The Client ID of your app.\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Output the result as JSON. Automatically disables color output.\n   * @environment SHOPIFY_FLAG_JSON\n   */\n  '-j, --json'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your app directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Reset all your settings.\n   * @environment SHOPIFY_FLAG_RESET\n   */\n  '--reset'?: ''\n\n  /**\n   * Filters output to the specified log source.\n   * @environment SHOPIFY_FLAG_SOURCE\n   */\n  '--source <value>'?: string\n\n  /**\n   * Filters output to the specified status (success or failure).\n   * @environment SHOPIFY_FLAG_STATUS\n   */\n  '--status <value>'?: string\n\n  /**\n   * Store URL. Must be an existing development or Shopify Plus sandbox store.\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
     }
   },
   "apprelease": {
@@ -2335,6 +2578,15 @@
           "description": "Allows adding and updating extensions and configuration without requiring user confirmation. Recommended option for CI/CD environments.",
           "isOptional": true,
           "environmentValue": "SHOPIFY_FLAG_ALLOW_UPDATES"
+        },
+        {
+          "filePath": "docs-shopify.dev/commands/interfaces/app-release.interface.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "--auth-alias <value>",
+          "value": "string",
+          "description": "Alias of the Shopify account to use for authentication.",
+          "isOptional": true,
+          "environmentValue": "SHOPIFY_FLAG_AUTH_ALIAS"
         },
         {
           "filePath": "docs-shopify.dev/commands/interfaces/app-release.interface.ts",
@@ -2399,7 +2651,7 @@
           "environmentValue": "SHOPIFY_FLAG_APP_CONFIG"
         }
       ],
-      "value": "export interface apprelease {\n  /**\n   * Allows removing extensions and configuration without requiring user confirmation. For CI/CD environments, the recommended flag is --allow-updates.\n   * @environment SHOPIFY_FLAG_ALLOW_DELETES\n   */\n  '--allow-deletes'?: ''\n\n  /**\n   * Allows adding and updating extensions and configuration without requiring user confirmation. Recommended option for CI/CD environments.\n   * @environment SHOPIFY_FLAG_ALLOW_UPDATES\n   */\n  '--allow-updates'?: ''\n\n  /**\n   * The Client ID of your app.\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your app directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Reset all your settings.\n   * @environment SHOPIFY_FLAG_RESET\n   */\n  '--reset'?: ''\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n\n  /**\n   * The name of the app version to release.\n   * @environment SHOPIFY_FLAG_VERSION\n   */\n  '--version <value>': string\n}"
+      "value": "export interface apprelease {\n  /**\n   * Allows removing extensions and configuration without requiring user confirmation. For CI/CD environments, the recommended flag is --allow-updates.\n   * @environment SHOPIFY_FLAG_ALLOW_DELETES\n   */\n  '--allow-deletes'?: ''\n\n  /**\n   * Allows adding and updating extensions and configuration without requiring user confirmation. Recommended option for CI/CD environments.\n   * @environment SHOPIFY_FLAG_ALLOW_UPDATES\n   */\n  '--allow-updates'?: ''\n\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--auth-alias <value>'?: string\n\n  /**\n   * The Client ID of your app.\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your app directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Reset all your settings.\n   * @environment SHOPIFY_FLAG_RESET\n   */\n  '--reset'?: ''\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n\n  /**\n   * The name of the app version to release.\n   * @environment SHOPIFY_FLAG_VERSION\n   */\n  '--version <value>': string\n}"
     }
   },
   "appversionslist": {
@@ -2409,6 +2661,15 @@
       "description": "The following flags are available for the `app versions list` command:",
       "isPublicDocs": true,
       "members": [
+        {
+          "filePath": "docs-shopify.dev/commands/interfaces/app-versions-list.interface.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "--auth-alias <value>",
+          "value": "string",
+          "description": "Alias of the Shopify account to use for authentication.",
+          "isOptional": true,
+          "environmentValue": "SHOPIFY_FLAG_AUTH_ALIAS"
+        },
         {
           "filePath": "docs-shopify.dev/commands/interfaces/app-versions-list.interface.ts",
           "syntaxKind": "PropertySignature",
@@ -2473,7 +2734,7 @@
           "environmentValue": "SHOPIFY_FLAG_JSON"
         }
       ],
-      "value": "export interface appversionslist {\n  /**\n   * The Client ID of your app.\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Output the result as JSON. Automatically disables color output.\n   * @environment SHOPIFY_FLAG_JSON\n   */\n  '-j, --json'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your app directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Reset all your settings.\n   * @environment SHOPIFY_FLAG_RESET\n   */\n  '--reset'?: ''\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+      "value": "export interface appversionslist {\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--auth-alias <value>'?: string\n\n  /**\n   * The Client ID of your app.\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Output the result as JSON. Automatically disables color output.\n   * @environment SHOPIFY_FLAG_JSON\n   */\n  '-j, --json'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your app directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Reset all your settings.\n   * @environment SHOPIFY_FLAG_RESET\n   */\n  '--reset'?: ''\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
     }
   },
   "appwebhooktrigger": {
@@ -2500,6 +2761,15 @@
           "description": "The API Version of the webhook topic.",
           "isOptional": true,
           "environmentValue": "SHOPIFY_FLAG_API_VERSION"
+        },
+        {
+          "filePath": "docs-shopify.dev/commands/interfaces/app-webhook-trigger.interface.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "--auth-alias <value>",
+          "value": "string",
+          "description": "Alias of the Shopify account to use for authentication.",
+          "isOptional": true,
+          "environmentValue": "SHOPIFY_FLAG_AUTH_ALIAS"
         },
         {
           "filePath": "docs-shopify.dev/commands/interfaces/app-webhook-trigger.interface.ts",
@@ -2574,7 +2844,7 @@
           "environmentValue": "SHOPIFY_FLAG_APP_CONFIG"
         }
       ],
-      "value": "export interface appwebhooktrigger {\n  /**\n   * The URL where the webhook payload should be sent.\n                    You will need a different address type for each delivery-method:\n                          · For remote HTTP testing, use a URL that starts with https://\n      · For local HTTP testing, use http://localhost:{port}/{url-path}\n                          · For Google Pub/Sub, use pubsub://{project-id}:{topic-id}\n                          · For Amazon EventBridge, use an Amazon Resource Name (ARN) starting with arn:aws:events:\n   * @environment SHOPIFY_FLAG_ADDRESS\n   */\n  '--address <value>'?: string\n\n  /**\n   * The API Version of the webhook topic.\n   * @environment SHOPIFY_FLAG_API_VERSION\n   */\n  '--api-version <value>'?: string\n\n  /**\n   * The Client ID of your app.\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * Your app's client secret. This secret allows us to return the X-Shopify-Hmac-SHA256 header that lets you validate the origin of the response that you receive.\n   * @environment SHOPIFY_FLAG_CLIENT_SECRET\n   */\n  '--client-secret <value>'?: string\n\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Method chosen to deliver the topic payload. If not passed, it's inferred from the address.\n   * @environment SHOPIFY_FLAG_DELIVERY_METHOD\n   */\n  '--delivery-method <value>'?: string\n\n  /**\n   * This help. When you run the trigger command the CLI will prompt you for any information that isn't passed using flags.\n   * @environment SHOPIFY_FLAG_HELP\n   */\n  '--help'?: ''\n\n  /**\n   * The path to your app directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Reset all your settings.\n   * @environment SHOPIFY_FLAG_RESET\n   */\n  '--reset'?: ''\n\n  /**\n   * The requested webhook topic.\n   * @environment SHOPIFY_FLAG_TOPIC\n   */\n  '--topic <value>'?: string\n}"
+      "value": "export interface appwebhooktrigger {\n  /**\n   * The URL where the webhook payload should be sent.\n                    You will need a different address type for each delivery-method:\n                          · For remote HTTP testing, use a URL that starts with https://\n      · For local HTTP testing, use http://localhost:{port}/{url-path}\n                          · For Google Pub/Sub, use pubsub://{project-id}:{topic-id}\n                          · For Amazon EventBridge, use an Amazon Resource Name (ARN) starting with arn:aws:events:\n   * @environment SHOPIFY_FLAG_ADDRESS\n   */\n  '--address <value>'?: string\n\n  /**\n   * The API Version of the webhook topic.\n   * @environment SHOPIFY_FLAG_API_VERSION\n   */\n  '--api-version <value>'?: string\n\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--auth-alias <value>'?: string\n\n  /**\n   * The Client ID of your app.\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * Your app's client secret. This secret allows us to return the X-Shopify-Hmac-SHA256 header that lets you validate the origin of the response that you receive.\n   * @environment SHOPIFY_FLAG_CLIENT_SECRET\n   */\n  '--client-secret <value>'?: string\n\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Method chosen to deliver the topic payload. If not passed, it's inferred from the address.\n   * @environment SHOPIFY_FLAG_DELIVERY_METHOD\n   */\n  '--delivery-method <value>'?: string\n\n  /**\n   * This help. When you run the trigger command the CLI will prompt you for any information that isn't passed using flags.\n   * @environment SHOPIFY_FLAG_HELP\n   */\n  '--help'?: ''\n\n  /**\n   * The path to your app directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Reset all your settings.\n   * @environment SHOPIFY_FLAG_RESET\n   */\n  '--reset'?: ''\n\n  /**\n   * The requested webhook topic.\n   * @environment SHOPIFY_FLAG_TOPIC\n   */\n  '--topic <value>'?: string\n}"
     }
   },
   "authlogin": {
@@ -3115,15 +3385,6 @@
         {
           "filePath": "docs-shopify.dev/commands/interfaces/hydrogen-deploy.interface.ts",
           "syntaxKind": "PropertySignature",
-          "name": "--assets-dir <value>",
-          "value": "string",
-          "description": "Directory containing the client assets to deploy, relative to the project root. Defaults to the detected Vite client output directory, then falls back to `dist/client`.",
-          "isOptional": true,
-          "environmentValue": "SHOPIFY_HYDROGEN_FLAG_ASSETS_DIR"
-        },
-        {
-          "filePath": "docs-shopify.dev/commands/interfaces/hydrogen-deploy.interface.ts",
-          "syntaxKind": "PropertySignature",
           "name": "--auth-bypass-token",
           "value": "''",
           "description": "Generate an authentication bypass token, which can be used to perform end-to-end tests against the deployment.",
@@ -3144,7 +3405,7 @@
           "syntaxKind": "PropertySignature",
           "name": "--build-command <value>",
           "value": "string",
-          "description": "Specify a build command to run before deploying. If not specified, the Hydrogen build pipeline will be used. When custom output directories are configured, defaults to `node --run build`.",
+          "description": "Specify a build command to run before deploying. If not specified, `shopify hydrogen build` will be used.",
           "isOptional": true
         },
         {
@@ -3212,7 +3473,7 @@
           "syntaxKind": "PropertySignature",
           "name": "--metadata-description <value>",
           "value": "string",
-          "description": "Description of the changes in the deployment. Defaults to the commit message of the latest commit if there are no uncommitted changes.",
+          "description": "Description of the changes in the deployment. Defaults to the commit message of the latest commit if there are no uncommited changes.",
           "isOptional": true,
           "environmentValue": "SHOPIFY_HYDROGEN_FLAG_METADATA_DESCRIPTION"
         },
@@ -3253,18 +3514,9 @@
         {
           "filePath": "docs-shopify.dev/commands/interfaces/hydrogen-deploy.interface.ts",
           "syntaxKind": "PropertySignature",
-          "name": "--worker-dir <value>",
-          "value": "string",
-          "description": "Directory containing the Oxygen worker entry point (`index.js` or `index.mjs`), relative to the project root. Defaults to the detected Vite server output directory, then falls back to `dist/server`.",
-          "isOptional": true,
-          "environmentValue": "SHOPIFY_HYDROGEN_FLAG_WORKER_DIR"
-        },
-        {
-          "filePath": "docs-shopify.dev/commands/interfaces/hydrogen-deploy.interface.ts",
-          "syntaxKind": "PropertySignature",
           "name": "-f, --force",
           "value": "''",
-          "description": "Forces a deployment to proceed if there are uncommitted changes in its Git repository.",
+          "description": "Forces a deployment to proceed if there are uncommited changes in its Git repository.",
           "isOptional": true,
           "environmentValue": "SHOPIFY_HYDROGEN_FLAG_FORCE"
         },
@@ -3287,7 +3539,7 @@
           "environmentValue": "SHOPIFY_HYDROGEN_DEPLOYMENT_TOKEN"
         }
       ],
-      "value": "export interface hydrogendeploy {\n  /**\n   * Directory containing the client assets to deploy, relative to the project root. Defaults to the detected Vite client output directory, then falls back to `dist/client`.\n   * @environment SHOPIFY_HYDROGEN_FLAG_ASSETS_DIR\n   */\n  '--assets-dir <value>'?: string\n\n  /**\n   * Generate an authentication bypass token, which can be used to perform end-to-end tests against the deployment.\n   * @environment AUTH_BYPASS_TOKEN\n   */\n  '--auth-bypass-token'?: ''\n\n  /**\n   * Specify the duration (in hours) up to 12 hours for the authentication bypass token. Defaults to `2`\n   * @environment AUTH_BYPASS_TOKEN_DURATION\n   */\n  '--auth-bypass-token-duration <value>'?: string\n\n  /**\n   * Specify a build command to run before deploying. If not specified, the Hydrogen build pipeline will be used. When custom output directories are configured, defaults to `node --run build`.\n   *\n   */\n  '--build-command <value>'?: string\n\n  /**\n   * Entry file for the worker. Defaults to `./server`.\n   * @environment SHOPIFY_HYDROGEN_FLAG_ENTRY\n   */\n  '--entry <value>'?: string\n\n  /**\n   * Specifies the environment to perform the operation using its handle. Fetch the handle using the `env list` command.\n   *\n   */\n  '--env <value>'?: string\n\n  /**\n   * Specifies the environment to perform the operation using its Git branch name.\n   * @environment SHOPIFY_HYDROGEN_ENVIRONMENT_BRANCH\n   */\n  '--env-branch <value>'?: string\n\n  /**\n   * Path to an environment file to override existing environment variables for the deployment.\n   *\n   */\n  '--env-file <value>'?: string\n\n  /**\n   * Forces a deployment to proceed if there are uncommitted changes in its Git repository.\n   * @environment SHOPIFY_HYDROGEN_FLAG_FORCE\n   */\n  '-f, --force'?: ''\n\n  /**\n   * Client sourcemapping is avoided by default because it makes backend code visible in the browser. Use this flag to force enabling it.\n   * @environment SHOPIFY_HYDROGEN_FLAG_FORCE_CLIENT_SOURCEMAP\n   */\n  '--force-client-sourcemap'?: ''\n\n  /**\n   * Create a JSON file containing the deployment details in CI environments. Defaults to true, use `--no-json-output` to disable.\n   *\n   */\n  '--json-output'?: ''\n\n  /**\n   * Checks that there is exactly one valid lockfile in the project. Defaults to `true`. Deactivate with `--no-lockfile-check`.\n   * @environment SHOPIFY_HYDROGEN_FLAG_LOCKFILE_CHECK\n   */\n  '--lockfile-check'?: ''\n\n  /**\n   * Description of the changes in the deployment. Defaults to the commit message of the latest commit if there are no uncommitted changes.\n   * @environment SHOPIFY_HYDROGEN_FLAG_METADATA_DESCRIPTION\n   */\n  '--metadata-description <value>'?: string\n\n  /**\n   * User that initiated the deployment. Will be saved and displayed in the Shopify admin\n   * @environment SHOPIFY_HYDROGEN_FLAG_METADATA_USER\n   */\n  '--metadata-user <value>'?: string\n\n  /**\n   * Skip the routability verification step after deployment.\n   *\n   */\n  '--no-verify'?: ''\n\n  /**\n   * The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.\n   * @environment SHOPIFY_HYDROGEN_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Deploys to the Preview environment.\n   *\n   */\n  '--preview'?: ''\n\n  /**\n   * Shop URL. It can be the shop prefix (janes-apparel) or the full myshopify.com URL (janes-apparel.myshopify.com, https://janes-apparel.myshopify.com).\n   * @environment SHOPIFY_SHOP\n   */\n  '-s, --shop <value>'?: string\n\n  /**\n   * Oxygen deployment token. Defaults to the linked storefront's token if available.\n   * @environment SHOPIFY_HYDROGEN_DEPLOYMENT_TOKEN\n   */\n  '-t, --token <value>'?: string\n\n  /**\n   * Directory containing the Oxygen worker entry point (`index.js` or `index.mjs`), relative to the project root. Defaults to the detected Vite server output directory, then falls back to `dist/server`.\n   * @environment SHOPIFY_HYDROGEN_FLAG_WORKER_DIR\n   */\n  '--worker-dir <value>'?: string\n}"
+      "value": "export interface hydrogendeploy {\n  /**\n   * Generate an authentication bypass token, which can be used to perform end-to-end tests against the deployment.\n   * @environment AUTH_BYPASS_TOKEN\n   */\n  '--auth-bypass-token'?: ''\n\n  /**\n   * Specify the duration (in hours) up to 12 hours for the authentication bypass token. Defaults to `2`\n   * @environment AUTH_BYPASS_TOKEN_DURATION\n   */\n  '--auth-bypass-token-duration <value>'?: string\n\n  /**\n   * Specify a build command to run before deploying. If not specified, `shopify hydrogen build` will be used.\n   *\n   */\n  '--build-command <value>'?: string\n\n  /**\n   * Entry file for the worker. Defaults to `./server`.\n   * @environment SHOPIFY_HYDROGEN_FLAG_ENTRY\n   */\n  '--entry <value>'?: string\n\n  /**\n   * Specifies the environment to perform the operation using its handle. Fetch the handle using the `env list` command.\n   *\n   */\n  '--env <value>'?: string\n\n  /**\n   * Specifies the environment to perform the operation using its Git branch name.\n   * @environment SHOPIFY_HYDROGEN_ENVIRONMENT_BRANCH\n   */\n  '--env-branch <value>'?: string\n\n  /**\n   * Path to an environment file to override existing environment variables for the deployment.\n   *\n   */\n  '--env-file <value>'?: string\n\n  /**\n   * Forces a deployment to proceed if there are uncommited changes in its Git repository.\n   * @environment SHOPIFY_HYDROGEN_FLAG_FORCE\n   */\n  '-f, --force'?: ''\n\n  /**\n   * Client sourcemapping is avoided by default because it makes backend code visible in the browser. Use this flag to force enabling it.\n   * @environment SHOPIFY_HYDROGEN_FLAG_FORCE_CLIENT_SOURCEMAP\n   */\n  '--force-client-sourcemap'?: ''\n\n  /**\n   * Create a JSON file containing the deployment details in CI environments. Defaults to true, use `--no-json-output` to disable.\n   *\n   */\n  '--json-output'?: ''\n\n  /**\n   * Checks that there is exactly one valid lockfile in the project. Defaults to `true`. Deactivate with `--no-lockfile-check`.\n   * @environment SHOPIFY_HYDROGEN_FLAG_LOCKFILE_CHECK\n   */\n  '--lockfile-check'?: ''\n\n  /**\n   * Description of the changes in the deployment. Defaults to the commit message of the latest commit if there are no uncommited changes.\n   * @environment SHOPIFY_HYDROGEN_FLAG_METADATA_DESCRIPTION\n   */\n  '--metadata-description <value>'?: string\n\n  /**\n   * User that initiated the deployment. Will be saved and displayed in the Shopify admin\n   * @environment SHOPIFY_HYDROGEN_FLAG_METADATA_USER\n   */\n  '--metadata-user <value>'?: string\n\n  /**\n   * Skip the routability verification step after deployment.\n   *\n   */\n  '--no-verify'?: ''\n\n  /**\n   * The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.\n   * @environment SHOPIFY_HYDROGEN_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Deploys to the Preview environment.\n   *\n   */\n  '--preview'?: ''\n\n  /**\n   * Shop URL. It can be the shop prefix (janes-apparel) or the full myshopify.com URL (janes-apparel.myshopify.com, https://janes-apparel.myshopify.com).\n   * @environment SHOPIFY_SHOP\n   */\n  '-s, --shop <value>'?: string\n\n  /**\n   * Oxygen deployment token. Defaults to the linked storefront's token if available.\n   * @environment SHOPIFY_HYDROGEN_DEPLOYMENT_TOKEN\n   */\n  '-t, --token <value>'?: string\n}"
     }
   },
   "hydrogendev": {
@@ -3561,7 +3813,7 @@
           "syntaxKind": "PropertySignature",
           "name": "--adapter <value>",
           "value": "string",
-          "description": "React Router adapter used in the route. The default is `react-router`.",
+          "description": "Remix adapter used in the route. The default is `@shopify/remix-oxygen`.",
           "isOptional": true,
           "environmentValue": "SHOPIFY_HYDROGEN_FLAG_ADAPTER"
         },
@@ -3602,7 +3854,7 @@
           "environmentValue": "SHOPIFY_HYDROGEN_FLAG_FORCE"
         }
       ],
-      "value": "export interface hydrogengenerateroute {\n  /**\n   * React Router adapter used in the route. The default is `react-router`.\n   * @environment SHOPIFY_HYDROGEN_FLAG_ADAPTER\n   */\n  '--adapter <value>'?: string\n\n  /**\n   * Overwrites the destination directory and files if they already exist.\n   * @environment SHOPIFY_HYDROGEN_FLAG_FORCE\n   */\n  '-f, --force'?: ''\n\n  /**\n   * The param name in Remix routes for the i18n locale, if any. Example: `locale` becomes ($locale).\n   * @environment SHOPIFY_HYDROGEN_FLAG_ADAPTER\n   */\n  '--locale-param <value>'?: string\n\n  /**\n   * The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.\n   * @environment SHOPIFY_HYDROGEN_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Generate TypeScript files\n   * @environment SHOPIFY_HYDROGEN_FLAG_TYPESCRIPT\n   */\n  '--typescript'?: ''\n}"
+      "value": "export interface hydrogengenerateroute {\n  /**\n   * Remix adapter used in the route. The default is `@shopify/remix-oxygen`.\n   * @environment SHOPIFY_HYDROGEN_FLAG_ADAPTER\n   */\n  '--adapter <value>'?: string\n\n  /**\n   * Overwrites the destination directory and files if they already exist.\n   * @environment SHOPIFY_HYDROGEN_FLAG_FORCE\n   */\n  '-f, --force'?: ''\n\n  /**\n   * The param name in Remix routes for the i18n locale, if any. Example: `locale` becomes ($locale).\n   * @environment SHOPIFY_HYDROGEN_FLAG_ADAPTER\n   */\n  '--locale-param <value>'?: string\n\n  /**\n   * The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.\n   * @environment SHOPIFY_HYDROGEN_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Generate TypeScript files\n   * @environment SHOPIFY_HYDROGEN_FLAG_TYPESCRIPT\n   */\n  '--typescript'?: ''\n}"
     }
   },
   "hydrogengenerateroutes": {
@@ -3617,7 +3869,7 @@
           "syntaxKind": "PropertySignature",
           "name": "--adapter <value>",
           "value": "string",
-          "description": "React Router adapter used in the route. The default is `react-router`.",
+          "description": "Remix adapter used in the route. The default is `@shopify/remix-oxygen`.",
           "isOptional": true,
           "environmentValue": "SHOPIFY_HYDROGEN_FLAG_ADAPTER"
         },
@@ -3658,7 +3910,7 @@
           "environmentValue": "SHOPIFY_HYDROGEN_FLAG_FORCE"
         }
       ],
-      "value": "export interface hydrogengenerateroutes {\n  /**\n   * React Router adapter used in the route. The default is `react-router`.\n   * @environment SHOPIFY_HYDROGEN_FLAG_ADAPTER\n   */\n  '--adapter <value>'?: string\n\n  /**\n   * Overwrites the destination directory and files if they already exist.\n   * @environment SHOPIFY_HYDROGEN_FLAG_FORCE\n   */\n  '-f, --force'?: ''\n\n  /**\n   * The param name in Remix routes for the i18n locale, if any. Example: `locale` becomes ($locale).\n   * @environment SHOPIFY_HYDROGEN_FLAG_ADAPTER\n   */\n  '--locale-param <value>'?: string\n\n  /**\n   * The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.\n   * @environment SHOPIFY_HYDROGEN_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Generate TypeScript files\n   * @environment SHOPIFY_HYDROGEN_FLAG_TYPESCRIPT\n   */\n  '--typescript'?: ''\n}"
+      "value": "export interface hydrogengenerateroutes {\n  /**\n   * Remix adapter used in the route. The default is `@shopify/remix-oxygen`.\n   * @environment SHOPIFY_HYDROGEN_FLAG_ADAPTER\n   */\n  '--adapter <value>'?: string\n\n  /**\n   * Overwrites the destination directory and files if they already exist.\n   * @environment SHOPIFY_HYDROGEN_FLAG_FORCE\n   */\n  '-f, --force'?: ''\n\n  /**\n   * The param name in Remix routes for the i18n locale, if any. Example: `locale` becomes ($locale).\n   * @environment SHOPIFY_HYDROGEN_FLAG_ADAPTER\n   */\n  '--locale-param <value>'?: string\n\n  /**\n   * The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.\n   * @environment SHOPIFY_HYDROGEN_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Generate TypeScript files\n   * @environment SHOPIFY_HYDROGEN_FLAG_TYPESCRIPT\n   */\n  '--typescript'?: ''\n}"
     }
   },
   "hydrogeninit": {
@@ -4806,7 +5058,7 @@
         {
           "filePath": "docs-shopify.dev/commands/interfaces/theme-console.interface.ts",
           "syntaxKind": "PropertySignature",
-          "name": "--alias <value>",
+          "name": "--auth-alias <value>",
           "value": "string",
           "description": "Alias of the Shopify account to use for authentication.",
           "isOptional": true,
@@ -4885,7 +5137,7 @@
           "environmentValue": "SHOPIFY_FLAG_STORE"
         }
       ],
-      "value": "export interface themeconsole {\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--alias <value>'?: string\n\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Password generated from the Theme Access app or an Admin API token.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * The path where you want to run the command. Defaults to the current working directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * The password for storefronts with password protection.\n   * @environment SHOPIFY_FLAG_STORE_PASSWORD\n   */\n  '--store-password <value>'?: string\n\n  /**\n   * The url to be used as context\n   * @environment SHOPIFY_FLAG_URL\n   */\n  '--url <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+      "value": "export interface themeconsole {\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--auth-alias <value>'?: string\n\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Password generated from the Theme Access app or an Admin API token.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * The path where you want to run the command. Defaults to the current working directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * The password for storefronts with password protection.\n   * @environment SHOPIFY_FLAG_STORE_PASSWORD\n   */\n  '--store-password <value>'?: string\n\n  /**\n   * The url to be used as context\n   * @environment SHOPIFY_FLAG_URL\n   */\n  '--url <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
     }
   },
   "themedelete": {
@@ -4898,7 +5150,7 @@
         {
           "filePath": "docs-shopify.dev/commands/interfaces/theme-delete.interface.ts",
           "syntaxKind": "PropertySignature",
-          "name": "--alias <value>",
+          "name": "--auth-alias <value>",
           "value": "string",
           "description": "Alias of the Shopify account to use for authentication.",
           "isOptional": true,
@@ -4995,7 +5247,7 @@
           "environmentValue": "SHOPIFY_FLAG_THEME_ID"
         }
       ],
-      "value": "export interface themedelete {\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--alias <value>'?: string\n\n  /**\n   * Delete your development theme.\n   * @environment SHOPIFY_FLAG_DEVELOPMENT\n   */\n  '-d, --development'?: ''\n\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Skip confirmation.\n   * @environment SHOPIFY_FLAG_FORCE\n   */\n  '-f, --force'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Password generated from the Theme Access app or an Admin API token.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * The path where you want to run the command. Defaults to the current working directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Include others development themes in theme list.\n   * @environment SHOPIFY_FLAG_SHOW_ALL\n   */\n  '-a, --show-all'?: ''\n\n  /**\n   * Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Theme ID or name of the remote theme.\n   * @environment SHOPIFY_FLAG_THEME_ID\n   */\n  '-t, --theme <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+      "value": "export interface themedelete {\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--auth-alias <value>'?: string\n\n  /**\n   * Delete your development theme.\n   * @environment SHOPIFY_FLAG_DEVELOPMENT\n   */\n  '-d, --development'?: ''\n\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Skip confirmation.\n   * @environment SHOPIFY_FLAG_FORCE\n   */\n  '-f, --force'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Password generated from the Theme Access app or an Admin API token.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * The path where you want to run the command. Defaults to the current working directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Include others development themes in theme list.\n   * @environment SHOPIFY_FLAG_SHOW_ALL\n   */\n  '-a, --show-all'?: ''\n\n  /**\n   * Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Theme ID or name of the remote theme.\n   * @environment SHOPIFY_FLAG_THEME_ID\n   */\n  '-t, --theme <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
     }
   },
   "themedev": {
@@ -5008,7 +5260,7 @@
         {
           "filePath": "docs-shopify.dev/commands/interfaces/theme-dev.interface.ts",
           "syntaxKind": "PropertySignature",
-          "name": "--alias <value>",
+          "name": "--auth-alias <value>",
           "value": "string",
           "description": "Alias of the Shopify account to use for authentication.",
           "isOptional": true,
@@ -5204,7 +5456,7 @@
           "environmentValue": "SHOPIFY_FLAG_IGNORE"
         }
       ],
-      "value": "export interface themedev {\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--alias <value>'?: string\n\n  /**\n   * Allow development on a live theme.\n   * @environment SHOPIFY_FLAG_ALLOW_LIVE\n   */\n  '-a, --allow-live'?: ''\n\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Controls the visibility of the error overlay when an theme asset upload fails:\n- silent Prevents the error overlay from appearing.\n- default Displays the error overlay.\n      \n   * @environment SHOPIFY_FLAG_ERROR_OVERLAY\n   */\n  '--error-overlay <value>'?: string\n\n  /**\n   * Set which network interface the web server listens on. The default value is 127.0.0.1.\n   * @environment SHOPIFY_FLAG_HOST\n   */\n  '--host <value>'?: string\n\n  /**\n   * Skip hot reloading any files that match the specified pattern.\n   * @environment SHOPIFY_FLAG_IGNORE\n   */\n  '-x, --ignore <value>'?: string\n\n  /**\n   * The listing preset to use for multi-preset themes. Applies preset files from listings/[preset-name] directory.\n   * @environment SHOPIFY_FLAG_LISTING\n   */\n  '--listing <value>'?: string\n\n  /**\n   * The live reload mode switches the server behavior when a file is modified:\n- hot-reload Hot reloads local changes to CSS and sections (default)\n- full-page  Always refreshes the entire page\n- off        Deactivate live reload\n   * @environment SHOPIFY_FLAG_LIVE_RELOAD\n   */\n  '--live-reload <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Prevents files from being deleted in the remote theme when a file has been deleted locally. This applies to files that are deleted while the command is running, and files that have been deleted locally before the command is run.\n   * @environment SHOPIFY_FLAG_NODELETE\n   */\n  '-n, --nodelete'?: ''\n\n  /**\n   * The file path or URL. The file path is to a file that you want updated on idle. The URL path is where you want a webhook posted to report on file changes.\n   * @environment SHOPIFY_FLAG_NOTIFY\n   */\n  '--notify <value>'?: string\n\n  /**\n   * Hot reload only files that match the specified pattern.\n   * @environment SHOPIFY_FLAG_ONLY\n   */\n  '-o, --only <value>'?: string\n\n  /**\n   * Automatically launch the theme preview in your default web browser.\n   * @environment SHOPIFY_FLAG_OPEN\n   */\n  '--open'?: ''\n\n  /**\n   * Password generated from the Theme Access app or an Admin API token.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * The path where you want to run the command. Defaults to the current working directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Local port to serve theme preview from. Must be between 1 and 65535.\n   * @environment SHOPIFY_FLAG_PORT\n   */\n  '--port <value>'?: string\n\n  /**\n   * Inject the standard events inspector into storefront HTML.\n   * @environment SHOPIFY_FLAG_STANDARD_EVENTS_INSPECTOR\n   */\n  '--standard-events-inspector'?: ''\n\n  /**\n   * Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * The password for storefronts with password protection.\n   * @environment SHOPIFY_FLAG_STORE_PASSWORD\n   */\n  '--store-password <value>'?: string\n\n  /**\n   * Theme ID or name of the remote theme.\n   * @environment SHOPIFY_FLAG_THEME_ID\n   */\n  '-t, --theme <value>'?: string\n\n  /**\n   * Synchronize Theme Editor updates in the local theme files.\n   * @environment SHOPIFY_FLAG_THEME_EDITOR_SYNC\n   */\n  '--theme-editor-sync'?: ''\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+      "value": "export interface themedev {\n  /**\n   * Allow development on a live theme.\n   * @environment SHOPIFY_FLAG_ALLOW_LIVE\n   */\n  '-a, --allow-live'?: ''\n\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--auth-alias <value>'?: string\n\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Controls the visibility of the error overlay when an theme asset upload fails:\n- silent Prevents the error overlay from appearing.\n- default Displays the error overlay.\n      \n   * @environment SHOPIFY_FLAG_ERROR_OVERLAY\n   */\n  '--error-overlay <value>'?: string\n\n  /**\n   * Set which network interface the web server listens on. The default value is 127.0.0.1.\n   * @environment SHOPIFY_FLAG_HOST\n   */\n  '--host <value>'?: string\n\n  /**\n   * Skip hot reloading any files that match the specified pattern.\n   * @environment SHOPIFY_FLAG_IGNORE\n   */\n  '-x, --ignore <value>'?: string\n\n  /**\n   * The listing preset to use for multi-preset themes. Applies preset files from listings/[preset-name] directory.\n   * @environment SHOPIFY_FLAG_LISTING\n   */\n  '--listing <value>'?: string\n\n  /**\n   * The live reload mode switches the server behavior when a file is modified:\n- hot-reload Hot reloads local changes to CSS and sections (default)\n- full-page  Always refreshes the entire page\n- off        Deactivate live reload\n   * @environment SHOPIFY_FLAG_LIVE_RELOAD\n   */\n  '--live-reload <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Prevents files from being deleted in the remote theme when a file has been deleted locally. This applies to files that are deleted while the command is running, and files that have been deleted locally before the command is run.\n   * @environment SHOPIFY_FLAG_NODELETE\n   */\n  '-n, --nodelete'?: ''\n\n  /**\n   * The file path or URL. The file path is to a file that you want updated on idle. The URL path is where you want a webhook posted to report on file changes.\n   * @environment SHOPIFY_FLAG_NOTIFY\n   */\n  '--notify <value>'?: string\n\n  /**\n   * Hot reload only files that match the specified pattern.\n   * @environment SHOPIFY_FLAG_ONLY\n   */\n  '-o, --only <value>'?: string\n\n  /**\n   * Automatically launch the theme preview in your default web browser.\n   * @environment SHOPIFY_FLAG_OPEN\n   */\n  '--open'?: ''\n\n  /**\n   * Password generated from the Theme Access app or an Admin API token.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * The path where you want to run the command. Defaults to the current working directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Local port to serve theme preview from. Must be between 1 and 65535.\n   * @environment SHOPIFY_FLAG_PORT\n   */\n  '--port <value>'?: string\n\n  /**\n   * Inject the standard events inspector into storefront HTML.\n   * @environment SHOPIFY_FLAG_STANDARD_EVENTS_INSPECTOR\n   */\n  '--standard-events-inspector'?: ''\n\n  /**\n   * Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * The password for storefronts with password protection.\n   * @environment SHOPIFY_FLAG_STORE_PASSWORD\n   */\n  '--store-password <value>'?: string\n\n  /**\n   * Theme ID or name of the remote theme.\n   * @environment SHOPIFY_FLAG_THEME_ID\n   */\n  '-t, --theme <value>'?: string\n\n  /**\n   * Synchronize Theme Editor updates in the local theme files.\n   * @environment SHOPIFY_FLAG_THEME_EDITOR_SYNC\n   */\n  '--theme-editor-sync'?: ''\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
     }
   },
   "themeduplicate": {
@@ -5217,7 +5469,7 @@
         {
           "filePath": "docs-shopify.dev/commands/interfaces/theme-duplicate.interface.ts",
           "syntaxKind": "PropertySignature",
-          "name": "--alias <value>",
+          "name": "--auth-alias <value>",
           "value": "string",
           "description": "Alias of the Shopify account to use for authentication.",
           "isOptional": true,
@@ -5305,7 +5557,7 @@
           "environmentValue": "SHOPIFY_FLAG_THEME_ID"
         }
       ],
-      "value": "export interface themeduplicate {\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--alias <value>'?: string\n\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Force the duplicate operation to run without prompts or confirmations.\n   * @environment SHOPIFY_FLAG_FORCE\n   */\n  '-f, --force'?: ''\n\n  /**\n   * Output the result as JSON. Automatically disables color output.\n   * @environment SHOPIFY_FLAG_JSON\n   */\n  '-j, --json'?: ''\n\n  /**\n   * Name of the newly duplicated theme.\n   * @environment SHOPIFY_FLAG_NAME\n   */\n  '-n, --name <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Password generated from the Theme Access app or an Admin API token.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Theme ID or name of the remote theme.\n   * @environment SHOPIFY_FLAG_THEME_ID\n   */\n  '-t, --theme <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+      "value": "export interface themeduplicate {\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--auth-alias <value>'?: string\n\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Force the duplicate operation to run without prompts or confirmations.\n   * @environment SHOPIFY_FLAG_FORCE\n   */\n  '-f, --force'?: ''\n\n  /**\n   * Output the result as JSON. Automatically disables color output.\n   * @environment SHOPIFY_FLAG_JSON\n   */\n  '-j, --json'?: ''\n\n  /**\n   * Name of the newly duplicated theme.\n   * @environment SHOPIFY_FLAG_NAME\n   */\n  '-n, --name <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Password generated from the Theme Access app or an Admin API token.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Theme ID or name of the remote theme.\n   * @environment SHOPIFY_FLAG_THEME_ID\n   */\n  '-t, --theme <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
     }
   },
   "themeinfo": {
@@ -5318,7 +5570,7 @@
         {
           "filePath": "docs-shopify.dev/commands/interfaces/theme-info.interface.ts",
           "syntaxKind": "PropertySignature",
-          "name": "--alias <value>",
+          "name": "--auth-alias <value>",
           "value": "string",
           "description": "Alias of the Shopify account to use for authentication.",
           "isOptional": true,
@@ -5406,7 +5658,7 @@
           "environmentValue": "SHOPIFY_FLAG_THEME_ID"
         }
       ],
-      "value": "export interface themeinfo {\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--alias <value>'?: string\n\n  /**\n   * Retrieve info from your development theme.\n   * @environment SHOPIFY_FLAG_DEVELOPMENT\n   */\n  '-d, --development'?: ''\n\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Output the result as JSON. Automatically disables color output.\n   * @environment SHOPIFY_FLAG_JSON\n   */\n  '-j, --json'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Password generated from the Theme Access app or an Admin API token.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * The path where you want to run the command. Defaults to the current working directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Theme ID or name of the remote theme.\n   * @environment SHOPIFY_FLAG_THEME_ID\n   */\n  '-t, --theme <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+      "value": "export interface themeinfo {\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--auth-alias <value>'?: string\n\n  /**\n   * Retrieve info from your development theme.\n   * @environment SHOPIFY_FLAG_DEVELOPMENT\n   */\n  '-d, --development'?: ''\n\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Output the result as JSON. Automatically disables color output.\n   * @environment SHOPIFY_FLAG_JSON\n   */\n  '-j, --json'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Password generated from the Theme Access app or an Admin API token.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * The path where you want to run the command. Defaults to the current working directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Theme ID or name of the remote theme.\n   * @environment SHOPIFY_FLAG_THEME_ID\n   */\n  '-t, --theme <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
     }
   },
   "themeinit": {
@@ -5504,7 +5756,7 @@
         {
           "filePath": "docs-shopify.dev/commands/interfaces/theme-list.interface.ts",
           "syntaxKind": "PropertySignature",
-          "name": "--alias <value>",
+          "name": "--auth-alias <value>",
           "value": "string",
           "description": "Alias of the Shopify account to use for authentication.",
           "isOptional": true,
@@ -5601,7 +5853,7 @@
           "environmentValue": "SHOPIFY_FLAG_STORE"
         }
       ],
-      "value": "export interface themelist {\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--alias <value>'?: string\n\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Only list theme with the given ID.\n   * @environment SHOPIFY_FLAG_ID\n   */\n  '--id <value>'?: string\n\n  /**\n   * Output the result as JSON. Automatically disables color output.\n   * @environment SHOPIFY_FLAG_JSON\n   */\n  '-j, --json'?: ''\n\n  /**\n   * Only list themes that contain the given name.\n   * @environment SHOPIFY_FLAG_NAME\n   */\n  '--name <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Password generated from the Theme Access app or an Admin API token.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * The path where you want to run the command. Defaults to the current working directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Only list themes with the given role.\n   * @environment SHOPIFY_FLAG_ROLE\n   */\n  '--role <value>'?: string\n\n  /**\n   * Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+      "value": "export interface themelist {\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--auth-alias <value>'?: string\n\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Only list theme with the given ID.\n   * @environment SHOPIFY_FLAG_ID\n   */\n  '--id <value>'?: string\n\n  /**\n   * Output the result as JSON. Automatically disables color output.\n   * @environment SHOPIFY_FLAG_JSON\n   */\n  '-j, --json'?: ''\n\n  /**\n   * Only list themes that contain the given name.\n   * @environment SHOPIFY_FLAG_NAME\n   */\n  '--name <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Password generated from the Theme Access app or an Admin API token.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * The path where you want to run the command. Defaults to the current working directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Only list themes with the given role.\n   * @environment SHOPIFY_FLAG_ROLE\n   */\n  '--role <value>'?: string\n\n  /**\n   * Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
     }
   },
   "thememetafieldspull": {
@@ -5614,7 +5866,7 @@
         {
           "filePath": "docs-shopify.dev/commands/interfaces/theme-metafields-pull.interface.ts",
           "syntaxKind": "PropertySignature",
-          "name": "--alias <value>",
+          "name": "--auth-alias <value>",
           "value": "string",
           "description": "Alias of the Shopify account to use for authentication.",
           "isOptional": true,
@@ -5675,7 +5927,7 @@
           "environmentValue": "SHOPIFY_FLAG_STORE"
         }
       ],
-      "value": "export interface thememetafieldspull {\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--alias <value>'?: string\n\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Password generated from the Theme Access app or an Admin API token.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * The path where you want to run the command. Defaults to the current working directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+      "value": "export interface thememetafieldspull {\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--auth-alias <value>'?: string\n\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Password generated from the Theme Access app or an Admin API token.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * The path where you want to run the command. Defaults to the current working directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
     }
   },
   "themeopen": {
@@ -5688,7 +5940,7 @@
         {
           "filePath": "docs-shopify.dev/commands/interfaces/theme-open.interface.ts",
           "syntaxKind": "PropertySignature",
-          "name": "--alias <value>",
+          "name": "--auth-alias <value>",
           "value": "string",
           "description": "Alias of the Shopify account to use for authentication.",
           "isOptional": true,
@@ -5785,7 +6037,7 @@
           "environmentValue": "SHOPIFY_FLAG_THEME_ID"
         }
       ],
-      "value": "export interface themeopen {\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--alias <value>'?: string\n\n  /**\n   * Open your development theme.\n   * @environment SHOPIFY_FLAG_DEVELOPMENT\n   */\n  '-d, --development'?: ''\n\n  /**\n   * Open the theme editor for the specified theme in the browser.\n   * @environment SHOPIFY_FLAG_EDITOR\n   */\n  '-E, --editor'?: ''\n\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Open your live (published) theme.\n   * @environment SHOPIFY_FLAG_LIVE\n   */\n  '-l, --live'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Password generated from the Theme Access app or an Admin API token.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * The path where you want to run the command. Defaults to the current working directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Theme ID or name of the remote theme.\n   * @environment SHOPIFY_FLAG_THEME_ID\n   */\n  '-t, --theme <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+      "value": "export interface themeopen {\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--auth-alias <value>'?: string\n\n  /**\n   * Open your development theme.\n   * @environment SHOPIFY_FLAG_DEVELOPMENT\n   */\n  '-d, --development'?: ''\n\n  /**\n   * Open the theme editor for the specified theme in the browser.\n   * @environment SHOPIFY_FLAG_EDITOR\n   */\n  '-E, --editor'?: ''\n\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Open your live (published) theme.\n   * @environment SHOPIFY_FLAG_LIVE\n   */\n  '-l, --live'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Password generated from the Theme Access app or an Admin API token.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * The path where you want to run the command. Defaults to the current working directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Theme ID or name of the remote theme.\n   * @environment SHOPIFY_FLAG_THEME_ID\n   */\n  '-t, --theme <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
     }
   },
   "themepackage": {
@@ -5836,7 +6088,7 @@
         {
           "filePath": "docs-shopify.dev/commands/interfaces/theme-preview.interface.ts",
           "syntaxKind": "PropertySignature",
-          "name": "--alias <value>",
+          "name": "--auth-alias <value>",
           "value": "string",
           "description": "Alias of the Shopify account to use for authentication.",
           "isOptional": true,
@@ -5940,7 +6192,7 @@
           "environmentValue": "SHOPIFY_FLAG_THEME_ID"
         }
       ],
-      "value": "export interface themepreview {\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--alias <value>'?: string\n\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Output the preview URL and identifier as JSON.\n   * @environment SHOPIFY_FLAG_JSON\n   */\n  '--json'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Automatically launch the theme preview in your default web browser.\n   * @environment SHOPIFY_FLAG_OPEN\n   */\n  '--open'?: ''\n\n  /**\n   * Path to a JSON overrides file.\n   * @environment SHOPIFY_FLAG_OVERRIDES\n   */\n  '--overrides <value>': string\n\n  /**\n   * Password generated from the Theme Access app or an Admin API token.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * The path where you want to run the command. Defaults to the current working directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * An existing preview identifier to update instead of creating a new preview.\n   * @environment SHOPIFY_FLAG_PREVIEW_ID\n   */\n  '--preview-id <value>'?: string\n\n  /**\n   * Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Theme ID or name of the remote theme.\n   * @environment SHOPIFY_FLAG_THEME_ID\n   */\n  '-t, --theme <value>': string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+      "value": "export interface themepreview {\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--auth-alias <value>'?: string\n\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Output the preview URL and identifier as JSON.\n   * @environment SHOPIFY_FLAG_JSON\n   */\n  '--json'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Automatically launch the theme preview in your default web browser.\n   * @environment SHOPIFY_FLAG_OPEN\n   */\n  '--open'?: ''\n\n  /**\n   * Path to a JSON overrides file.\n   * @environment SHOPIFY_FLAG_OVERRIDES\n   */\n  '--overrides <value>': string\n\n  /**\n   * Password generated from the Theme Access app or an Admin API token.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * The path where you want to run the command. Defaults to the current working directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * An existing preview identifier to update instead of creating a new preview.\n   * @environment SHOPIFY_FLAG_PREVIEW_ID\n   */\n  '--preview-id <value>'?: string\n\n  /**\n   * Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Theme ID or name of the remote theme.\n   * @environment SHOPIFY_FLAG_THEME_ID\n   */\n  '-t, --theme <value>': string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
     }
   },
   "themeprofile": {
@@ -5953,7 +6205,7 @@
         {
           "filePath": "docs-shopify.dev/commands/interfaces/theme-profile.interface.ts",
           "syntaxKind": "PropertySignature",
-          "name": "--alias <value>",
+          "name": "--auth-alias <value>",
           "value": "string",
           "description": "Alias of the Shopify account to use for authentication.",
           "isOptional": true,
@@ -6050,7 +6302,7 @@
           "environmentValue": "SHOPIFY_FLAG_THEME_ID"
         }
       ],
-      "value": "export interface themeprofile {\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--alias <value>'?: string\n\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Output the result as JSON. Automatically disables color output.\n   * @environment SHOPIFY_FLAG_JSON\n   */\n  '-j, --json'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Password generated from the Theme Access app or an Admin API token.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * The path where you want to run the command. Defaults to the current working directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * The password for storefronts with password protection.\n   * @environment SHOPIFY_FLAG_STORE_PASSWORD\n   */\n  '--store-password <value>'?: string\n\n  /**\n   * Theme ID or name of the remote theme.\n   * @environment SHOPIFY_FLAG_THEME_ID\n   */\n  '-t, --theme <value>'?: string\n\n  /**\n   * The url to be used as context\n   * @environment SHOPIFY_FLAG_URL\n   */\n  '--url <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+      "value": "export interface themeprofile {\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--auth-alias <value>'?: string\n\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Output the result as JSON. Automatically disables color output.\n   * @environment SHOPIFY_FLAG_JSON\n   */\n  '-j, --json'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Password generated from the Theme Access app or an Admin API token.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * The path where you want to run the command. Defaults to the current working directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * The password for storefronts with password protection.\n   * @environment SHOPIFY_FLAG_STORE_PASSWORD\n   */\n  '--store-password <value>'?: string\n\n  /**\n   * Theme ID or name of the remote theme.\n   * @environment SHOPIFY_FLAG_THEME_ID\n   */\n  '-t, --theme <value>'?: string\n\n  /**\n   * The url to be used as context\n   * @environment SHOPIFY_FLAG_URL\n   */\n  '--url <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
     }
   },
   "themepublish": {
@@ -6063,7 +6315,7 @@
         {
           "filePath": "docs-shopify.dev/commands/interfaces/theme-publish.interface.ts",
           "syntaxKind": "PropertySignature",
-          "name": "--alias <value>",
+          "name": "--auth-alias <value>",
           "value": "string",
           "description": "Alias of the Shopify account to use for authentication.",
           "isOptional": true,
@@ -6142,7 +6394,7 @@
           "environmentValue": "SHOPIFY_FLAG_THEME_ID"
         }
       ],
-      "value": "export interface themepublish {\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--alias <value>'?: string\n\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Skip confirmation.\n   * @environment SHOPIFY_FLAG_FORCE\n   */\n  '-f, --force'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Password generated from the Theme Access app or an Admin API token.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * The path where you want to run the command. Defaults to the current working directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Theme ID or name of the remote theme.\n   * @environment SHOPIFY_FLAG_THEME_ID\n   */\n  '-t, --theme <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+      "value": "export interface themepublish {\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--auth-alias <value>'?: string\n\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Skip confirmation.\n   * @environment SHOPIFY_FLAG_FORCE\n   */\n  '-f, --force'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Password generated from the Theme Access app or an Admin API token.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * The path where you want to run the command. Defaults to the current working directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Theme ID or name of the remote theme.\n   * @environment SHOPIFY_FLAG_THEME_ID\n   */\n  '-t, --theme <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
     }
   },
   "themepull": {
@@ -6155,7 +6407,7 @@
         {
           "filePath": "docs-shopify.dev/commands/interfaces/theme-pull.interface.ts",
           "syntaxKind": "PropertySignature",
-          "name": "--alias <value>",
+          "name": "--auth-alias <value>",
           "value": "string",
           "description": "Alias of the Shopify account to use for authentication.",
           "isOptional": true,
@@ -6270,7 +6522,7 @@
           "environmentValue": "SHOPIFY_FLAG_IGNORE"
         }
       ],
-      "value": "export interface themepull {\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--alias <value>'?: string\n\n  /**\n   * Pull theme files from your remote development theme.\n   * @environment SHOPIFY_FLAG_DEVELOPMENT\n   */\n  '-d, --development'?: ''\n\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Skip downloading the specified files (Multiple flags allowed). Wrap the value in double quotes if you're using wildcards.\n   * @environment SHOPIFY_FLAG_IGNORE\n   */\n  '-x, --ignore <value>'?: string\n\n  /**\n   * Pull theme files from your remote live theme.\n   * @environment SHOPIFY_FLAG_LIVE\n   */\n  '-l, --live'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Prevent deleting local files that don't exist remotely.\n   * @environment SHOPIFY_FLAG_NODELETE\n   */\n  '-n, --nodelete'?: ''\n\n  /**\n   * Download only the specified files (Multiple flags allowed). Wrap the value in double quotes if you're using wildcards.\n   * @environment SHOPIFY_FLAG_ONLY\n   */\n  '-o, --only <value>'?: string\n\n  /**\n   * Password generated from the Theme Access app or an Admin API token.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * The path where you want to run the command. Defaults to the current working directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Theme ID or name of the remote theme.\n   * @environment SHOPIFY_FLAG_THEME_ID\n   */\n  '-t, --theme <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+      "value": "export interface themepull {\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--auth-alias <value>'?: string\n\n  /**\n   * Pull theme files from your remote development theme.\n   * @environment SHOPIFY_FLAG_DEVELOPMENT\n   */\n  '-d, --development'?: ''\n\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Skip downloading the specified files (Multiple flags allowed). Wrap the value in double quotes if you're using wildcards.\n   * @environment SHOPIFY_FLAG_IGNORE\n   */\n  '-x, --ignore <value>'?: string\n\n  /**\n   * Pull theme files from your remote live theme.\n   * @environment SHOPIFY_FLAG_LIVE\n   */\n  '-l, --live'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Prevent deleting local files that don't exist remotely.\n   * @environment SHOPIFY_FLAG_NODELETE\n   */\n  '-n, --nodelete'?: ''\n\n  /**\n   * Download only the specified files (Multiple flags allowed). Wrap the value in double quotes if you're using wildcards.\n   * @environment SHOPIFY_FLAG_ONLY\n   */\n  '-o, --only <value>'?: string\n\n  /**\n   * Password generated from the Theme Access app or an Admin API token.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * The path where you want to run the command. Defaults to the current working directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Theme ID or name of the remote theme.\n   * @environment SHOPIFY_FLAG_THEME_ID\n   */\n  '-t, --theme <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
     }
   },
   "themepush": {
@@ -6283,7 +6535,7 @@
         {
           "filePath": "docs-shopify.dev/commands/interfaces/theme-push.interface.ts",
           "syntaxKind": "PropertySignature",
-          "name": "--alias <value>",
+          "name": "--auth-alias <value>",
           "value": "string",
           "description": "Alias of the Shopify account to use for authentication.",
           "isOptional": true,
@@ -6461,7 +6713,7 @@
           "environmentValue": "SHOPIFY_FLAG_IGNORE"
         }
       ],
-      "value": "export interface themepush {\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--alias <value>'?: string\n\n  /**\n   * Allow push to a live theme.\n   * @environment SHOPIFY_FLAG_ALLOW_LIVE\n   */\n  '-a, --allow-live'?: ''\n\n  /**\n   * Push theme files from your remote development theme.\n   * @environment SHOPIFY_FLAG_DEVELOPMENT\n   */\n  '-d, --development'?: ''\n\n  /**\n   * Unique identifier for a development theme context (e.g., PR number, branch name). Reuses an existing development theme with this context name, or creates one if none exists.\n   * @environment SHOPIFY_FLAG_DEVELOPMENT_CONTEXT\n   */\n  '-c, --development-context <value>'?: string\n\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Skip uploading the specified files (Multiple flags allowed). Wrap the value in double quotes if you're using wildcards.\n   * @environment SHOPIFY_FLAG_IGNORE\n   */\n  '-x, --ignore <value>'?: string\n\n  /**\n   * Output the result as JSON. Automatically disables color output.\n   * @environment SHOPIFY_FLAG_JSON\n   */\n  '-j, --json'?: ''\n\n  /**\n   * The listing preset to use for multi-preset themes. Applies preset files from listings/[preset-name] directory.\n   * @environment SHOPIFY_FLAG_LISTING\n   */\n  '--listing <value>'?: string\n\n  /**\n   * Push theme files from your remote live theme.\n   * @environment SHOPIFY_FLAG_LIVE\n   */\n  '-l, --live'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Prevent deleting remote files that don't exist locally.\n   * @environment SHOPIFY_FLAG_NODELETE\n   */\n  '-n, --nodelete'?: ''\n\n  /**\n   * Upload only the specified files (Multiple flags allowed). Wrap the value in double quotes if you're using wildcards.\n   * @environment SHOPIFY_FLAG_ONLY\n   */\n  '-o, --only <value>'?: string\n\n  /**\n   * Password generated from the Theme Access app or an Admin API token.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * The path where you want to run the command. Defaults to the current working directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Publish as the live theme after uploading.\n   * @environment SHOPIFY_FLAG_PUBLISH\n   */\n  '-p, --publish'?: ''\n\n  /**\n   * Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Require theme check to pass without errors before pushing. Warnings are allowed.\n   * @environment SHOPIFY_FLAG_STRICT_PUSH\n   */\n  '--strict'?: ''\n\n  /**\n   * Theme ID or name of the remote theme.\n   * @environment SHOPIFY_FLAG_THEME_ID\n   */\n  '-t, --theme <value>'?: string\n\n  /**\n   * Create a new unpublished theme and push to it.\n   * @environment SHOPIFY_FLAG_UNPUBLISHED\n   */\n  '-u, --unpublished'?: ''\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+      "value": "export interface themepush {\n  /**\n   * Allow push to a live theme.\n   * @environment SHOPIFY_FLAG_ALLOW_LIVE\n   */\n  '-a, --allow-live'?: ''\n\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--auth-alias <value>'?: string\n\n  /**\n   * Push theme files from your remote development theme.\n   * @environment SHOPIFY_FLAG_DEVELOPMENT\n   */\n  '-d, --development'?: ''\n\n  /**\n   * Unique identifier for a development theme context (e.g., PR number, branch name). Reuses an existing development theme with this context name, or creates one if none exists.\n   * @environment SHOPIFY_FLAG_DEVELOPMENT_CONTEXT\n   */\n  '-c, --development-context <value>'?: string\n\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Skip uploading the specified files (Multiple flags allowed). Wrap the value in double quotes if you're using wildcards.\n   * @environment SHOPIFY_FLAG_IGNORE\n   */\n  '-x, --ignore <value>'?: string\n\n  /**\n   * Output the result as JSON. Automatically disables color output.\n   * @environment SHOPIFY_FLAG_JSON\n   */\n  '-j, --json'?: ''\n\n  /**\n   * The listing preset to use for multi-preset themes. Applies preset files from listings/[preset-name] directory.\n   * @environment SHOPIFY_FLAG_LISTING\n   */\n  '--listing <value>'?: string\n\n  /**\n   * Push theme files from your remote live theme.\n   * @environment SHOPIFY_FLAG_LIVE\n   */\n  '-l, --live'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Prevent deleting remote files that don't exist locally.\n   * @environment SHOPIFY_FLAG_NODELETE\n   */\n  '-n, --nodelete'?: ''\n\n  /**\n   * Upload only the specified files (Multiple flags allowed). Wrap the value in double quotes if you're using wildcards.\n   * @environment SHOPIFY_FLAG_ONLY\n   */\n  '-o, --only <value>'?: string\n\n  /**\n   * Password generated from the Theme Access app or an Admin API token.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * The path where you want to run the command. Defaults to the current working directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Publish as the live theme after uploading.\n   * @environment SHOPIFY_FLAG_PUBLISH\n   */\n  '-p, --publish'?: ''\n\n  /**\n   * Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Require theme check to pass without errors before pushing. Warnings are allowed.\n   * @environment SHOPIFY_FLAG_STRICT_PUSH\n   */\n  '--strict'?: ''\n\n  /**\n   * Theme ID or name of the remote theme.\n   * @environment SHOPIFY_FLAG_THEME_ID\n   */\n  '-t, --theme <value>'?: string\n\n  /**\n   * Create a new unpublished theme and push to it.\n   * @environment SHOPIFY_FLAG_UNPUBLISHED\n   */\n  '-u, --unpublished'?: ''\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
     }
   },
   "themerename": {
@@ -6474,7 +6726,7 @@
         {
           "filePath": "docs-shopify.dev/commands/interfaces/theme-rename.interface.ts",
           "syntaxKind": "PropertySignature",
-          "name": "--alias <value>",
+          "name": "--auth-alias <value>",
           "value": "string",
           "description": "Alias of the Shopify account to use for authentication.",
           "isOptional": true,
@@ -6571,7 +6823,7 @@
           "environmentValue": "SHOPIFY_FLAG_THEME_ID"
         }
       ],
-      "value": "export interface themerename {\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--alias <value>'?: string\n\n  /**\n   * Rename your development theme.\n   * @environment SHOPIFY_FLAG_DEVELOPMENT\n   */\n  '-d, --development'?: ''\n\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Rename your remote live theme.\n   * @environment SHOPIFY_FLAG_LIVE\n   */\n  '-l, --live'?: ''\n\n  /**\n   * The new name for the theme.\n   * @environment SHOPIFY_FLAG_NEW_NAME\n   */\n  '-n, --name <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Password generated from the Theme Access app or an Admin API token.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * The path where you want to run the command. Defaults to the current working directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Theme ID or name of the remote theme.\n   * @environment SHOPIFY_FLAG_THEME_ID\n   */\n  '-t, --theme <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+      "value": "export interface themerename {\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--auth-alias <value>'?: string\n\n  /**\n   * Rename your development theme.\n   * @environment SHOPIFY_FLAG_DEVELOPMENT\n   */\n  '-d, --development'?: ''\n\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Rename your remote live theme.\n   * @environment SHOPIFY_FLAG_LIVE\n   */\n  '-l, --live'?: ''\n\n  /**\n   * The new name for the theme.\n   * @environment SHOPIFY_FLAG_NEW_NAME\n   */\n  '-n, --name <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Password generated from the Theme Access app or an Admin API token.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * The path where you want to run the command. Defaults to the current working directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Theme ID or name of the remote theme.\n   * @environment SHOPIFY_FLAG_THEME_ID\n   */\n  '-t, --theme <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
     }
   },
   "themeshare": {
@@ -6584,7 +6836,7 @@
         {
           "filePath": "docs-shopify.dev/commands/interfaces/theme-share.interface.ts",
           "syntaxKind": "PropertySignature",
-          "name": "--alias <value>",
+          "name": "--auth-alias <value>",
           "value": "string",
           "description": "Alias of the Shopify account to use for authentication.",
           "isOptional": true,
@@ -6654,7 +6906,7 @@
           "environmentValue": "SHOPIFY_FLAG_STORE"
         }
       ],
-      "value": "export interface themeshare {\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--alias <value>'?: string\n\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * The listing preset to use for multi-preset themes. Applies preset files from listings/[preset-name] directory.\n   * @environment SHOPIFY_FLAG_LISTING\n   */\n  '--listing <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Password generated from the Theme Access app or an Admin API token.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * The path where you want to run the command. Defaults to the current working directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+      "value": "export interface themeshare {\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--auth-alias <value>'?: string\n\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * The listing preset to use for multi-preset themes. Applies preset files from listings/[preset-name] directory.\n   * @environment SHOPIFY_FLAG_LISTING\n   */\n  '--listing <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Password generated from the Theme Access app or an Admin API token.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * The path where you want to run the command. Defaults to the current working directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
     }
   },
   "upgrade": {

--- a/packages/app/src/cli/commands/app/app-logs/sources.ts
+++ b/packages/app/src/cli/commands/app/app-logs/sources.ts
@@ -24,6 +24,7 @@ export default class Sources extends AppLinkedCommand {
       clientId: flags['client-id'],
       forceRelink: flags.reset,
       userProvidedConfigName: flags.config,
+      authAlias: flags['auth-alias'],
     })
 
     if (app.errors.isEmpty()) {

--- a/packages/app/src/cli/commands/app/config/link.ts
+++ b/packages/app/src/cli/commands/app/config/link.ts
@@ -2,6 +2,7 @@ import {appFlags} from '../../../flags.js'
 import {linkedAppContext} from '../../../services/app-context.js'
 import link, {LinkOptions} from '../../../services/app/config/link.js'
 import AppLinkedCommand, {AppLinkedCommandOutput} from '../../../utilities/app-linked-command.js'
+import {sessionIdFromAuthAlias} from '../../../utilities/auth-alias.js'
 import {Flags} from '@oclif/core'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
 
@@ -27,12 +28,14 @@ export default class ConfigLink extends AppLinkedCommand {
 
   public async run(): Promise<AppLinkedCommandOutput> {
     const {flags} = await this.parse(ConfigLink)
+    const authSessionId = await sessionIdFromAuthAlias(flags['auth-alias'])
 
     const options: LinkOptions = {
       directory: flags.path,
       apiKey: flags['client-id'],
       organizationId: flags['organization-id'],
       configName: flags.config,
+      ...(authSessionId ? {authSessionId} : {}),
     }
 
     const result = await link(options)
@@ -42,6 +45,7 @@ export default class ConfigLink extends AppLinkedCommand {
       clientId: undefined,
       forceRelink: false,
       userProvidedConfigName: result.configFileName,
+      authAlias: flags['auth-alias'],
     })
 
     return {app}

--- a/packages/app/src/cli/commands/app/config/pull.ts
+++ b/packages/app/src/cli/commands/app/config/pull.ts
@@ -28,6 +28,7 @@ This command reuses the existing linked app and organization and skips all inter
       clientId: flags['client-id'],
       forceRelink: flags.reset,
       userProvidedConfigName: flags.config,
+      authAlias: flags['auth-alias'],
     })
 
     const {configuration, configPath} = await pull({

--- a/packages/app/src/cli/commands/app/config/validate.ts
+++ b/packages/app/src/cli/commands/app/config/validate.ts
@@ -91,6 +91,7 @@ export default class Validate extends AppLinkedCommand {
         clientId: flags['client-id'],
         forceRelink: flags.reset,
         userProvidedConfigName: flags.config,
+        authAlias: flags['auth-alias'],
         unsafeTolerateErrors: true,
       })
       app = context.app

--- a/packages/app/src/cli/commands/app/demo/watcher.ts
+++ b/packages/app/src/cli/commands/app/demo/watcher.ts
@@ -24,6 +24,7 @@ export default class DemoWatcher extends AppLinkedCommand {
       clientId: flags['client-id'],
       forceRelink: flags.reset,
       userProvidedConfigName: flags.config,
+      authAlias: flags['auth-alias'],
     })
 
     const watcher = new AppEventWatcher(app)

--- a/packages/app/src/cli/commands/app/deploy.ts
+++ b/packages/app/src/cli/commands/app/deploy.ts
@@ -102,6 +102,7 @@ export default class Deploy extends AppLinkedCommand {
       clientId,
       forceRelink: flags.reset,
       userProvidedConfigName: flags.config,
+      authAlias: flags['auth-alias'],
     })
 
     const allowUpdates = force || flags['allow-updates']

--- a/packages/app/src/cli/commands/app/dev.ts
+++ b/packages/app/src/cli/commands/app/dev.ts
@@ -116,6 +116,7 @@ export default class Dev extends AppLinkedCommand {
       clientId: flags['client-id'],
       forceRelink: flags.reset,
       userProvidedConfigName: flags.config,
+      authAlias: flags['auth-alias'],
     })
     const store = await storeContext({
       appContextResult,

--- a/packages/app/src/cli/commands/app/dev/clean.ts
+++ b/packages/app/src/cli/commands/app/dev/clean.ts
@@ -37,6 +37,7 @@ export default class DevClean extends AppLinkedCommand {
       clientId: flags['client-id'],
       forceRelink: flags.reset,
       userProvidedConfigName: flags.config,
+      authAlias: flags['auth-alias'],
     })
 
     const store = await storeContext({

--- a/packages/app/src/cli/commands/app/env/pull.ts
+++ b/packages/app/src/cli/commands/app/env/pull.ts
@@ -35,6 +35,7 @@ export default class EnvPull extends AppLinkedCommand {
       clientId: flags['client-id'],
       forceRelink: flags.reset,
       userProvidedConfigName: flags.config,
+      authAlias: flags['auth-alias'],
     })
     const envFile = resolvePath(app.directory, flags['env-file'] ?? getDotEnvFileName(app.configPath))
     outputResult(await pullEnv({app, remoteApp, organization, envFile}))

--- a/packages/app/src/cli/commands/app/env/show.ts
+++ b/packages/app/src/cli/commands/app/env/show.ts
@@ -24,6 +24,7 @@ export default class EnvShow extends AppLinkedCommand {
       clientId: flags['client-id'],
       forceRelink: flags.reset,
       userProvidedConfigName: flags.config,
+      authAlias: flags['auth-alias'],
     })
     outputResult(await showEnv(app, remoteApp, organization))
     return {app}

--- a/packages/app/src/cli/commands/app/function/info.ts
+++ b/packages/app/src/cli/commands/app/function/info.ts
@@ -48,6 +48,7 @@ export default class FunctionInfo extends AppUnlinkedCommand {
       flags['client-id'],
       flags.reset,
       flags.config,
+      flags['auth-alias'],
     )
 
     const result = functionInfo(ourFunction, {

--- a/packages/app/src/cli/commands/app/function/replay.ts
+++ b/packages/app/src/cli/commands/app/function/replay.ts
@@ -42,6 +42,7 @@ export default class FunctionReplay extends AppLinkedCommand {
       clientId: flags['client-id'],
       forceRelink: flags.reset,
       userProvidedConfigName: flags.config,
+      authAlias: flags['auth-alias'],
     })
 
     const ourFunction = await chooseFunction(app, flags.path)

--- a/packages/app/src/cli/commands/app/function/run.ts
+++ b/packages/app/src/cli/commands/app/function/run.ts
@@ -83,6 +83,7 @@ export default class FunctionRun extends AppUnlinkedCommand {
       flags['client-id'],
       flags.reset,
       flags.config,
+      flags['auth-alias'],
     )
 
     await runFunction({

--- a/packages/app/src/cli/commands/app/function/schema.ts
+++ b/packages/app/src/cli/commands/app/function/schema.ts
@@ -35,6 +35,7 @@ export default class FetchSchema extends AppLinkedCommand {
       clientId: flags['client-id'],
       forceRelink: flags.reset,
       userProvidedConfigName: flags.config,
+      authAlias: flags['auth-alias'],
     })
 
     const ourFunction = await chooseFunction(app, flags.path)

--- a/packages/app/src/cli/commands/app/generate/extension.ts
+++ b/packages/app/src/cli/commands/app/generate/extension.ts
@@ -63,6 +63,7 @@ export default class AppGenerateExtension extends AppLinkedCommand {
       clientId: flags['client-id'],
       forceRelink: flags.reset,
       userProvidedConfigName: flags.config,
+      authAlias: flags['auth-alias'],
     })
 
     await generate({

--- a/packages/app/src/cli/commands/app/import-custom-data-definitions.ts
+++ b/packages/app/src/cli/commands/app/import-custom-data-definitions.ts
@@ -46,6 +46,7 @@ export default class ImportCustomDataDefinitions extends AppLinkedCommand {
           clientId: flags['client-id'],
           forceRelink: flags.reset,
           userProvidedConfigName: flags.config,
+          authAlias: flags['auth-alias'],
         })
         const store = await storeContext({
           appContextResult,

--- a/packages/app/src/cli/commands/app/import-extensions.ts
+++ b/packages/app/src/cli/commands/app/import-extensions.ts
@@ -29,6 +29,7 @@ export default class ImportExtensions extends AppLinkedCommand {
       clientId: flags['client-id'],
       forceRelink: flags.reset,
       userProvidedConfigName: flags.config,
+      authAlias: flags['auth-alias'],
     })
 
     const extensions = await getExtensions({

--- a/packages/app/src/cli/commands/app/info.ts
+++ b/packages/app/src/cli/commands/app/info.ts
@@ -39,6 +39,7 @@ export default class AppInfo extends AppLinkedCommand {
       clientId: flags['client-id'],
       forceRelink: flags.reset,
       userProvidedConfigName: flags.config,
+      authAlias: flags['auth-alias'],
       unsafeTolerateErrors: true,
     })
     const results = await info(app, remoteApp, organization, project, {

--- a/packages/app/src/cli/commands/app/init.test.ts
+++ b/packages/app/src/cli/commands/app/init.test.ts
@@ -2,6 +2,7 @@ import Init from './init.js'
 import initPrompt from '../../prompts/init/init.js'
 import initService from '../../services/init/init.js'
 import {selectDeveloperPlatformClient} from '../../utilities/developer-platform-client.js'
+import {sessionIdFromAuthAlias} from '../../utilities/auth-alias.js'
 import {selectOrg} from '../../services/context.js'
 import {fetchOrgFromId, NoOrgError} from '../../services/dev/fetch.js'
 import {appNamePrompt, createAsNewAppPrompt, selectAppPrompt} from '../../prompts/dev.js'
@@ -12,7 +13,7 @@ import {
   testOrganization,
   testOrganizationApp,
 } from '../../models/app/app.test-data.js'
-import {describe, expect, test, vi} from 'vitest'
+import {beforeEach, describe, expect, test, vi} from 'vitest'
 import {mockAndCaptureOutput} from '@shopify/cli-kit/node/testing/output'
 import {generateRandomNameForSubdirectory} from '@shopify/cli-kit/node/fs'
 import {inferPackageManager} from '@shopify/cli-kit/node/node-package-manager'
@@ -20,6 +21,7 @@ import {inferPackageManager} from '@shopify/cli-kit/node/node-package-manager'
 vi.mock('../../prompts/init/init.js')
 vi.mock('../../services/init/init.js')
 vi.mock('../../utilities/developer-platform-client.js')
+vi.mock('../../utilities/auth-alias.js')
 vi.mock('../../services/context.js')
 vi.mock('../../services/dev/fetch.js', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../../services/dev/fetch.js')>()
@@ -34,6 +36,10 @@ vi.mock('@shopify/cli-kit/node/fs')
 vi.mock('@shopify/cli-kit/node/node-package-manager')
 
 describe('Init command', () => {
+  beforeEach(() => {
+    vi.mocked(sessionIdFromAuthAlias).mockResolvedValue(undefined)
+  })
+
   test('runs init command with default flags', async () => {
     // Given
     const mockOrganization = testOrganization()
@@ -72,6 +78,52 @@ describe('Init command', () => {
       expect.objectContaining({
         name: 'test-app',
         packageManager: 'npm',
+      }),
+    )
+  })
+
+  test('uses auth alias when selecting organization and initializing service', async () => {
+    // Given
+    const mockOrganization = testOrganization()
+    const mockDeveloperPlatformClient = testDeveloperPlatformClient()
+    const mockApp = testAppLinked()
+
+    mockAndCaptureOutput()
+    vi.mocked(sessionIdFromAuthAlias).mockResolvedValue('session-id-for-work')
+    vi.mocked(validateTemplateValue).mockReturnValue(undefined)
+    vi.mocked(validateFlavorValue).mockReturnValue(undefined)
+    vi.mocked(inferPackageManager).mockReturnValue('npm')
+    vi.mocked(generateRandomNameForSubdirectory).mockResolvedValue('test-app')
+    vi.mocked(selectDeveloperPlatformClient).mockReturnValue(mockDeveloperPlatformClient)
+    vi.mocked(selectOrg).mockResolvedValue(mockOrganization)
+    vi.mocked(mockDeveloperPlatformClient.orgAndApps).mockResolvedValue({
+      organization: mockOrganization,
+      apps: [],
+      hasMorePages: false,
+    })
+    vi.mocked(initPrompt).mockResolvedValue({
+      template: 'https://github.com/Shopify/shopify-app-template-remix',
+      templateType: 'remix',
+      globalCLIResult: {install: false, alreadyInstalled: false},
+    })
+    vi.mocked(createAsNewAppPrompt).mockResolvedValue(true)
+    vi.mocked(appNamePrompt).mockResolvedValue('test-app')
+    vi.mocked(initService).mockResolvedValue({app: mockApp})
+
+    // When
+    await Init.run(['--auth-alias', 'work'])
+
+    // Then
+    expect(sessionIdFromAuthAlias).toHaveBeenCalledWith('work')
+    expect(selectDeveloperPlatformClient).toHaveBeenCalledWith({authSessionId: 'session-id-for-work'})
+    expect(selectOrg).toHaveBeenCalledWith('session-id-for-work')
+    expect(selectDeveloperPlatformClient).toHaveBeenCalledWith({
+      organization: mockOrganization,
+      authSessionId: 'session-id-for-work',
+    })
+    expect(initService).toHaveBeenCalledWith(
+      expect.objectContaining({
+        authAlias: 'work',
       }),
     )
   })

--- a/packages/app/src/cli/commands/app/init.ts
+++ b/packages/app/src/cli/commands/app/init.ts
@@ -3,12 +3,14 @@ import initService from '../../services/init/init.js'
 import {DeveloperPlatformClient, selectDeveloperPlatformClient} from '../../utilities/developer-platform-client.js'
 import {appFromIdentifiers, selectOrg} from '../../services/context.js'
 import {fetchOrgFromId} from '../../services/dev/fetch.js'
+import {appFlags} from '../../flags.js'
 import AppLinkedCommand, {AppLinkedCommandOutput} from '../../utilities/app-linked-command.js'
 import {validateFlavorValue, validateTemplateValue} from '../../services/init/validate.js'
 import {MinimalOrganizationApp, Organization, OrganizationApp} from '../../models/organization.js'
 import {appNamePrompt, createAsNewAppPrompt, selectAppPrompt} from '../../prompts/dev.js'
 import {searchForAppsByNameFactory} from '../../services/dev/prompt-helpers.js'
 import {isValidName} from '../../models/app/validation/common.js'
+import {sessionIdFromAuthAlias} from '../../utilities/auth-alias.js'
 import {Flags} from '@oclif/core'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
 import {resolvePath, cwd} from '@shopify/cli-kit/node/path'
@@ -74,6 +76,7 @@ export default class Init extends AppLinkedCommand {
       env: 'SHOPIFY_FLAG_ORGANIZATION_ID',
       exclusive: ['client-id'],
     }),
+    'auth-alias': appFlags['auth-alias'],
   }
 
   async run(): Promise<AppLinkedCommandOutput> {
@@ -89,9 +92,10 @@ export default class Init extends AppLinkedCommand {
 
     const inferredPackageManager = inferPackageManager(flags['package-manager'])
     const name = flags.name ?? (await getAppName(flags.path))
+    const authSessionId = await sessionIdFromAuthAlias(flags['auth-alias'])
 
     // Force user authentication before prompting.
-    let developerPlatformClient = selectDeveloperPlatformClient()
+    let developerPlatformClient = selectDeveloperPlatformClient(authSessionId ? {authSessionId} : undefined)
     await developerPlatformClient.session()
 
     const promptAnswers = await initPrompt({
@@ -103,7 +107,10 @@ export default class Init extends AppLinkedCommand {
     let appName: string
     if (flags['client-id']) {
       // If a client-id is provided we don't need to prompt the user and can link directly to that app.
-      const selectedApp = await appFromIdentifiers({apiKey: flags['client-id']})
+      const selectedApp = await appFromIdentifiers({
+        apiKey: flags['client-id'],
+        ...(authSessionId ? {authSessionId} : {}),
+      })
       appName = selectedApp.title
       developerPlatformClient = selectedApp.developerPlatformClient ?? developerPlatformClient
       selectAppResult = {result: 'existing', app: selectedApp}
@@ -113,9 +120,12 @@ export default class Init extends AppLinkedCommand {
         // If an organization-id is provided, fetch the organization directly
         org = await fetchOrgFromId(flags['organization-id'], developerPlatformClient)
       } else {
-        org = await selectOrg()
+        org = await selectOrg(authSessionId)
       }
-      developerPlatformClient = selectDeveloperPlatformClient({organization: org})
+      developerPlatformClient = selectDeveloperPlatformClient({
+        organization: org,
+        ...(authSessionId ? {authSessionId} : {}),
+      })
       const {organization, apps, hasMorePages} = await developerPlatformClient.orgAndApps(org.id)
       selectAppResult = await selectAppOrNewAppName(
         flags.name !== undefined,
@@ -146,6 +156,7 @@ export default class Init extends AppLinkedCommand {
       directory: flags.path,
       useGlobalCLI: promptAnswers.globalCLIResult.alreadyInstalled || promptAnswers.globalCLIResult.install,
       developerPlatformClient,
+      authAlias: flags['auth-alias'],
       postCloneActions: {
         removeLockfilesFromGitignore: promptAnswers.templateType !== 'custom',
       },

--- a/packages/app/src/cli/commands/app/logs.ts
+++ b/packages/app/src/cli/commands/app/logs.ts
@@ -55,6 +55,7 @@ export default class Logs extends AppLinkedCommand {
       clientId: flags['client-id'],
       forceRelink: flags.reset,
       userProvidedConfigName: flags.config,
+      authAlias: flags['auth-alias'],
     })
 
     const primaryStore = await storeContext({

--- a/packages/app/src/cli/commands/app/release.ts
+++ b/packages/app/src/cli/commands/app/release.ts
@@ -64,6 +64,7 @@ export default class Release extends AppLinkedCommand {
       clientId,
       forceRelink: flags.reset,
       userProvidedConfigName: flags.config,
+      authAlias: flags['auth-alias'],
     })
 
     await release({

--- a/packages/app/src/cli/commands/app/versions/list.ts
+++ b/packages/app/src/cli/commands/app/versions/list.ts
@@ -25,6 +25,7 @@ export default class VersionsList extends AppLinkedCommand {
       clientId: flags['client-id'],
       forceRelink: flags.reset,
       userProvidedConfigName: flags.config,
+      authAlias: flags['auth-alias'],
     })
 
     await versionList({

--- a/packages/app/src/cli/commands/app/webhook/trigger.ts
+++ b/packages/app/src/cli/commands/app/webhook/trigger.ts
@@ -81,6 +81,7 @@ export default class WebhookTrigger extends AppLinkedCommand {
       clientId: flags['client-id'],
       forceRelink: flags.reset,
       userProvidedConfigName: flags.config,
+      authAlias: flags['auth-alias'],
     })
 
     const usedFlags: WebhookTriggerInput = {

--- a/packages/app/src/cli/flags.ts
+++ b/packages/app/src/cli/flags.ts
@@ -26,6 +26,10 @@ export const appFlags = {
     env: 'SHOPIFY_FLAG_CLIENT_ID',
     exclusive: ['config'],
   }),
+  'auth-alias': Flags.string({
+    description: 'Alias of the Shopify account to use for authentication.',
+    env: 'SHOPIFY_FLAG_AUTH_ALIAS',
+  }),
   reset: Flags.boolean({
     hidden: false,
     description: 'Reset all your settings.',

--- a/packages/app/src/cli/services/app-context.test.ts
+++ b/packages/app/src/cli/services/app-context.test.ts
@@ -6,6 +6,7 @@ import {appFromIdentifiers} from './context.js'
 
 import * as localStorage from './local-storage.js'
 import {fetchOrgFromId} from './dev/fetch.js'
+import {sessionIdFromAuthAlias} from '../utilities/auth-alias.js'
 import {testOrganizationApp, testDeveloperPlatformClient, testOrganization} from '../models/app/app.test-data.js'
 import metadata from '../metadata.js'
 import * as loader from '../models/app/loader.js'
@@ -22,6 +23,7 @@ vi.mock('./context.js')
 vi.mock('./dev/fetch.js')
 vi.mock('./app/add-uid-to-extension-toml.js')
 vi.mock('../models/extensions/load-specifications.js')
+vi.mock('../utilities/auth-alias.js')
 
 async function writeAppConfig(tmp: string, content: string, configName?: string) {
   const appConfigPath = joinPath(tmp, configName ?? 'shopify.app.toml')
@@ -43,6 +45,7 @@ beforeEach(() => {
   vi.mocked(fetchSpecifications).mockResolvedValue([])
   vi.mocked(appFromIdentifiers).mockResolvedValue(mockRemoteApp)
   vi.mocked(fetchOrgFromId).mockResolvedValue(mockOrganization)
+  vi.mocked(sessionIdFromAuthAlias).mockResolvedValue(undefined)
 })
 
 describe('linkedAppContext', () => {
@@ -145,6 +148,34 @@ client_id="test-api-key"`
     })
   })
 
+  test('passes account alias session to remote app lookup', async () => {
+    await inTemporaryDirectory(async (tmp) => {
+      // Given
+      vi.mocked(sessionIdFromAuthAlias).mockResolvedValue('session-id-for-work')
+      const content = `
+name = "test-app"
+client_id="test-api-key"`
+      await writeAppConfig(tmp, content)
+
+      // When
+      const result = await linkedAppContext({
+        directory: tmp,
+        forceRelink: false,
+        userProvidedConfigName: undefined,
+        clientId: undefined,
+        authAlias: 'work',
+      })
+
+      // Then
+      expect(sessionIdFromAuthAlias).toHaveBeenCalledWith('work')
+      expect(appFromIdentifiers).toHaveBeenCalledWith({
+        apiKey: 'test-api-key',
+        authSessionId: 'session-id-for-work',
+      })
+      expect(result.authSessionId).toBe('session-id-for-work')
+    })
+  })
+
   test('resets app when there is a valid toml but reset option is true', async () => {
     await inTemporaryDirectory(async (tmp) => {
       // Given
@@ -173,6 +204,44 @@ client_id="test-api-key"`
 
       // Then
       expect(link).toHaveBeenCalledWith({directory: tmp, apiKey: undefined, configName: undefined})
+    })
+  })
+
+  test('passes account alias session when relinking', async () => {
+    await inTemporaryDirectory(async (tmp) => {
+      // Given
+      vi.mocked(sessionIdFromAuthAlias).mockResolvedValue('session-id-for-work')
+      const content = `
+name = "test-app"
+client_id="test-api-key"`
+      await writeAppConfig(tmp, content)
+
+      vi.mocked(link).mockResolvedValue({
+        remoteApp: mockRemoteApp,
+        configFileName: 'shopify.app.toml',
+        configuration: {
+          client_id: 'test-api-key',
+          name: 'test-app',
+          path: normalizePath(joinPath(tmp, 'shopify.app.toml')),
+        } as any,
+      })
+
+      // When
+      await linkedAppContext({
+        directory: tmp,
+        forceRelink: true,
+        userProvidedConfigName: undefined,
+        clientId: 'test-client-id',
+        authAlias: 'work',
+      })
+
+      // Then
+      expect(link).toHaveBeenCalledWith({
+        directory: tmp,
+        apiKey: 'test-client-id',
+        configName: undefined,
+        authSessionId: 'session-id-for-work',
+      })
     })
   })
 

--- a/packages/app/src/cli/services/app-context.ts
+++ b/packages/app/src/cli/services/app-context.ts
@@ -5,6 +5,7 @@ import link from './app/config/link.js'
 import {fetchOrgFromId} from './dev/fetch.js'
 import {addUidToTomlsIfNecessary} from './app/add-uid-to-extension-toml.js'
 import {loadLocalExtensionsSpecifications} from '../models/extensions/load-specifications.js'
+import {sessionIdFromAuthAlias} from '../utilities/auth-alias.js'
 import {Organization, OrganizationApp, OrganizationSource} from '../models/organization.js'
 import {DeveloperPlatformClient} from '../utilities/developer-platform-client.js'
 import {
@@ -36,6 +37,7 @@ export interface LoadedAppContextOutput {
   specifications: RemoteAwareExtensionSpecification[]
   project: Project
   activeConfig: ActiveConfig
+  authSessionId?: string
 }
 
 /**
@@ -54,6 +56,7 @@ interface LoadedAppContextOptions {
   clientId: string | undefined
   userProvidedConfigName: string | undefined
   unsafeTolerateErrors?: boolean
+  authAlias?: string
 }
 
 /**
@@ -83,15 +86,18 @@ export async function linkedAppContext({
   forceRelink,
   userProvidedConfigName,
   unsafeTolerateErrors = false,
+  authAlias,
 }: LoadedAppContextOptions): Promise<LoadedAppContextOutput> {
   let project: Project
   let activeConfig: ActiveConfig
   let remoteApp: OrganizationApp | undefined
+  const authSessionId = await sessionIdFromAuthAlias(authAlias)
+  const authOptions = authSessionId ? {authSessionId} : {}
 
   if (forceRelink) {
     // Skip getAppConfigurationContext() when force-relinking — it may prompt the
     // user to select a TOML file that will be immediately discarded by link().
-    const result = await link({directory, apiKey: clientId})
+    const result = await link({directory, apiKey: clientId, configName: undefined, ...authOptions})
     remoteApp = result.remoteApp
     const reloaded = await getAppConfigurationContext(directory, result.configFileName)
     project = reloaded.project
@@ -106,7 +112,12 @@ export async function linkedAppContext({
     }
 
     if (!activeConfig.isLinked) {
-      const result = await link({directory, apiKey: clientId, configName: basename(activeConfig.file.path)})
+      const result = await link({
+        directory,
+        apiKey: clientId,
+        configName: basename(activeConfig.file.path),
+        ...authOptions,
+      })
       remoteApp = result.remoteApp
       const reloaded = await getAppConfigurationContext(directory, result.configFileName)
       project = reloaded.project
@@ -122,7 +133,7 @@ export async function linkedAppContext({
   const effectiveClientId = clientId ?? configClientId
 
   // Fetch the remote app, using a different clientID if provided via flag.
-  remoteApp ??= await appFromIdentifiers({apiKey: effectiveClientId})
+  remoteApp ??= await appFromIdentifiers({apiKey: effectiveClientId, ...authOptions})
   const developerPlatformClient = remoteApp.developerPlatformClient
 
   const organization = await fetchOrgFromId(remoteApp.organizationId, developerPlatformClient)
@@ -158,7 +169,16 @@ export async function linkedAppContext({
     await addUidToTomlsIfNecessary(localApp.allExtensions, developerPlatformClient)
   }
 
-  return {project, activeConfig, app: localApp, remoteApp, developerPlatformClient, specifications, organization}
+  const output = {
+    project,
+    activeConfig,
+    app: localApp,
+    remoteApp,
+    developerPlatformClient,
+    specifications,
+    organization,
+  }
+  return authSessionId ? {...output, authSessionId} : output
 }
 
 async function logMetadata(app: {apiKey: string}, organization: Organization, resetUsed: boolean) {

--- a/packages/app/src/cli/services/app/config/link.ts
+++ b/packages/app/src/cli/services/app/config/link.ts
@@ -38,6 +38,7 @@ export interface LinkOptions {
   configName?: string
   developerPlatformClient?: DeveloperPlatformClient
   isNewApp?: boolean
+  authSessionId?: string
 }
 
 interface LinkOutput {
@@ -108,7 +109,10 @@ async function selectOrCreateRemoteAppToLinkTo(options: LinkOptions): Promise<{
 
   if (options.apiKey) {
     // Remote API Key provided by the caller, so use that app specifically
-    const remoteApp = await appFromIdentifiers({apiKey: options.apiKey})
+    const remoteApp = await appFromIdentifiers({
+      apiKey: options.apiKey,
+      ...(options.authSessionId ? {authSessionId: options.authSessionId} : {}),
+    })
     if (!remoteApp) {
       const errorMessage = InvalidApiKeyErrorMessage(options.apiKey)
       throw new AbortError(errorMessage.message, errorMessage.tryMessage)
@@ -126,6 +130,7 @@ async function selectOrCreateRemoteAppToLinkTo(options: LinkOptions): Promise<{
     ...creationOptions,
     directory: appDirectory,
     organizationId: options.organizationId,
+    ...(options.authSessionId ? {authSessionId: options.authSessionId} : {}),
   })
 
   const developerPlatformClient = remoteApp.developerPlatformClient

--- a/packages/app/src/cli/services/context.ts
+++ b/packages/app/src/cli/services/context.ts
@@ -67,10 +67,11 @@ const appNotFoundHelpMessage = (accountIdentifier: string, isOrg = false) => [
 
 interface AppFromIdOptions {
   apiKey: string
+  authSessionId?: string
 }
 
 export const appFromIdentifiers = async (options: AppFromIdOptions): Promise<OrganizationApp> => {
-  const allClients = allDeveloperPlatformClients()
+  const allClients = allDeveloperPlatformClients(options.authSessionId ? {sessionId: options.authSessionId} : undefined)
 
   let app: OrganizationApp | undefined
   for (const client of allClients) {
@@ -299,12 +300,18 @@ function includeConfigOnDeployPrompt(configPath: string): Promise<boolean> {
 }
 
 export async function fetchOrCreateOrganizationApp(
-  options: CreateAppOptions & {organizationId?: string},
+  options: CreateAppOptions & {organizationId?: string; authSessionId?: string},
 ): Promise<OrganizationApp> {
   const org = options.organizationId
-    ? await fetchOrgFromId(options.organizationId, selectDeveloperPlatformClient())
-    : await selectOrg()
-  const developerPlatformClient = selectDeveloperPlatformClient({organization: org})
+    ? await fetchOrgFromId(
+        options.organizationId,
+        selectDeveloperPlatformClient(options.authSessionId ? {authSessionId: options.authSessionId} : undefined),
+      )
+    : await selectOrg(options.authSessionId)
+  const developerPlatformClient = selectDeveloperPlatformClient({
+    organization: org,
+    ...(options.authSessionId ? {authSessionId: options.authSessionId} : {}),
+  })
   const {organization, apps, hasMorePages} = await developerPlatformClient.orgAndApps(org.id)
   const remoteApp = await selectOrCreateApp(apps, hasMorePages, organization, developerPlatformClient, options)
 
@@ -318,8 +325,8 @@ export async function fetchOrCreateOrganizationApp(
  * @param developerPlatformClient - The client to access the platform API
  * @returns The selected organization ID
  */
-export async function selectOrg(): Promise<Organization> {
-  const orgs = await fetchOrganizations()
+export async function selectOrg(authSessionId?: string): Promise<Organization> {
+  const orgs = await fetchOrganizations(authSessionId)
   if (orgs.length === 0) {
     throw new AbortError('No organizations found.', 'Make sure you have access to a Shopify organization.')
   }

--- a/packages/app/src/cli/services/dev.ts
+++ b/packages/app/src/cli/services/dev.ts
@@ -71,6 +71,7 @@ export interface DevOptions {
   notify?: string
   graphiqlPort?: number
   graphiqlKey?: string
+  authSessionId?: string
 }
 
 export async function dev(commandOptions: DevOptions) {

--- a/packages/app/src/cli/services/dev/extension/utilities.ts
+++ b/packages/app/src/cli/services/dev/extension/utilities.ts
@@ -7,11 +7,16 @@ import {fetchProductVariant} from '../../../utilities/extensions/fetch-product-v
  * @param extensions - The UI Extensions to dev
  * @param store - The store FQDN
  */
-export async function buildCartURLIfNeeded(extensions: ExtensionInstance[], store: string, checkoutCartUrl?: string) {
+export async function buildCartURLIfNeeded(
+  extensions: ExtensionInstance[],
+  store: string,
+  checkoutCartUrl?: string,
+  authSessionId?: string,
+) {
   const hasUIExtension = extensions.filter((extension) => extension.shouldFetchCartUrl()).length > 0
   if (!hasUIExtension) return undefined
   if (checkoutCartUrl) return checkoutCartUrl
-  const variantId = await fetchProductVariant(store)
+  const variantId = await fetchProductVariant(store, authSessionId)
   return `/cart/${variantId}:1`
 }
 

--- a/packages/app/src/cli/services/dev/fetch.ts
+++ b/packages/app/src/cli/services/dev/fetch.ts
@@ -76,9 +76,9 @@ export class NoOrgError extends AbortError {
  * If the user doesn't belong to any org, throw an error
  * @returns List of organizations
  */
-export async function fetchOrganizations(): Promise<Organization[]> {
+export async function fetchOrganizations(authSessionId?: string): Promise<Organization[]> {
   const organizations: Organization[] = []
-  for (const client of allDeveloperPlatformClients()) {
+  for (const client of allDeveloperPlatformClients(authSessionId ? {sessionId: authSessionId} : undefined)) {
     // We don't want to run this in parallel because there could be port conflicts
     // eslint-disable-next-line no-await-in-loop
     const clientOrganizations = await client.organizations()
@@ -86,7 +86,7 @@ export async function fetchOrganizations(): Promise<Organization[]> {
   }
 
   if (organizations.length === 0) {
-    const developerPlatformClient = selectDeveloperPlatformClient()
+    const developerPlatformClient = selectDeveloperPlatformClient(authSessionId ? {authSessionId} : undefined)
     const session = await developerPlatformClient.session()
     const accountInfo = await fetchCurrentAccountInformation(developerPlatformClient, session.userId)
     throw new NoOrgError(accountInfo)

--- a/packages/app/src/cli/services/dev/processes/previewable-extension.ts
+++ b/packages/app/src/cli/services/dev/processes/previewable-extension.ts
@@ -24,6 +24,7 @@ interface PreviewableExtensionOptions {
   grantedScopes: string[]
   allExtensions: ExtensionInstance[]
   appWatcher: AppEventWatcher
+  authSessionId?: string
 }
 
 export interface PreviewableExtensionProcess extends BaseProcess<PreviewableExtensionOptions> {
@@ -75,6 +76,7 @@ export async function setupPreviewableExtensionsProcess({
   allExtensions,
   storeFqdn,
   checkoutCartUrl,
+  authSessionId,
   ...options
 }: Omit<PreviewableExtensionOptions, 'pathPrefix' | 'allExtensions' | 'port' | 'cartUrl'> & {
   allExtensions: ExtensionInstance[]
@@ -82,7 +84,7 @@ export async function setupPreviewableExtensionsProcess({
 }): Promise<PreviewableExtensionProcess | undefined> {
   const previewableExtensions = allExtensions.filter((ext) => ext.isPreviewable)
 
-  const cartUrl = await buildCartURLIfNeeded(previewableExtensions, storeFqdn, checkoutCartUrl)
+  const cartUrl = await buildCartURLIfNeeded(previewableExtensions, storeFqdn, checkoutCartUrl, authSessionId)
 
   return {
     prefix: 'extensions',
@@ -94,6 +96,7 @@ export async function setupPreviewableExtensionsProcess({
       storeFqdn,
       allExtensions,
       cartUrl,
+      ...(authSessionId ? {authSessionId} : {}),
       ...options,
     },
   }

--- a/packages/app/src/cli/services/dev/processes/setup-dev-processes.ts
+++ b/packages/app/src/cli/services/dev/processes/setup-dev-processes.ts
@@ -170,6 +170,7 @@ export async function setupDevProcesses({
       appId: remoteApp.id,
       appDirectory: reloadedApp.directory,
       appWatcher,
+      ...(commandOptions.authSessionId ? {authSessionId: commandOptions.authSessionId} : {}),
     }),
     developerPlatformClient.supportsDevSessions
       ? await setupDevSessionProcess({
@@ -199,6 +200,7 @@ export async function setupDevProcesses({
       storeFqdn,
       theme: commandOptions.theme,
       themeExtensionPort: commandOptions.themeExtensionPort,
+      ...(commandOptions.authSessionId ? {authSessionId: commandOptions.authSessionId} : {}),
     }),
     setupSendUninstallWebhookProcess({
       webs: reloadedApp.webs,

--- a/packages/app/src/cli/services/dev/processes/theme-app-extension.test.ts
+++ b/packages/app/src/cli/services/dev/processes/theme-app-extension.test.ts
@@ -127,6 +127,28 @@ describe('setupPreviewThemeAppExtensionsProcess', () => {
     })
   })
 
+  test('passes auth session ID to admin authentication when provided', async () => {
+    // Given
+    const mockTheme = {id: 123} as Theme
+    vi.mocked(fetchTheme).mockResolvedValue(mockTheme)
+
+    const storeFqdn = 'test.myshopify.com'
+    const remoteApp = testOrganizationApp()
+    const localApp = testApp({allExtensions: [await testThemeExtensions()]})
+
+    // When
+    await setupPreviewThemeAppExtensionsProcess({
+      localApp,
+      remoteApp,
+      storeFqdn,
+      theme: '123',
+      authSessionId: 'session-id-for-work',
+    })
+
+    // Then
+    expect(ensureAuthenticatedAdmin).toHaveBeenCalledWith(storeFqdn, [], {sessionId: 'session-id-for-work'})
+  })
+
   test('Returns PreviewThemeAppExtensionsOptions if theme extensions are present - Management API app', async () => {
     // Given
     const mockTheme = {id: 123} as Theme

--- a/packages/app/src/cli/services/dev/processes/theme-app-extension.ts
+++ b/packages/app/src/cli/services/dev/processes/theme-app-extension.ts
@@ -26,6 +26,7 @@ interface HostThemeSetupOptions {
   storeFqdn: string
   theme?: string
   themeExtensionPort?: number
+  authSessionId?: string
 }
 
 export interface PreviewThemeAppExtensionsProcess extends BaseProcess<ThemeAppExtensionServerOptions> {
@@ -46,10 +47,10 @@ export async function setupPreviewThemeAppExtensionsProcess(
   const themeExtensionDirectory = themeExtension.directory
   const themeExtensionPort = options.themeExtensionPort ?? 9293
 
-  const [adminSession, appUrl] = await Promise.all([
-    ensureAuthenticatedAdmin(options.storeFqdn),
-    buildAppUrl(remoteApp),
-  ])
+  const adminSessionPromise = options.authSessionId
+    ? ensureAuthenticatedAdmin(options.storeFqdn, [], {sessionId: options.authSessionId})
+    : ensureAuthenticatedAdmin(options.storeFqdn)
+  const [adminSession, appUrl] = await Promise.all([adminSessionPromise, buildAppUrl(remoteApp)])
 
   const storeFqdn = adminSession.storeFqdn
   const storefrontPassword = (await isStorefrontPasswordProtected(adminSession))

--- a/packages/app/src/cli/services/function/common.test.ts
+++ b/packages/app/src/cli/services/function/common.test.ts
@@ -65,7 +65,7 @@ describe('getOrGenerateSchemaPath', () => {
 
       // When
       // Pass extension, app.directory, clientId, forceRelink, userProvidedConfigName
-      const result = await getOrGenerateSchemaPath(extension, app.directory, '123', false, undefined)
+      const result = await getOrGenerateSchemaPath(extension, app.directory, '123', false, undefined, undefined)
 
       // Then
       expect(result).toBe(expectedPath)
@@ -87,7 +87,7 @@ describe('getOrGenerateSchemaPath', () => {
 
       // When
       // Pass extension, app.directory, clientId, forceRelink, userProvidedConfigName
-      const result = await getOrGenerateSchemaPath(extension, app.directory, '123', false, undefined)
+      const result = await getOrGenerateSchemaPath(extension, app.directory, '123', false, undefined, undefined)
 
       // Then
       expect(result).toBe(expectedPath)

--- a/packages/app/src/cli/services/function/common.ts
+++ b/packages/app/src/cli/services/function/common.ts
@@ -47,6 +47,7 @@ export async function getOrGenerateSchemaPath(
   clientId: string | undefined,
   forceRelink: boolean,
   userProvidedConfigName: string | undefined,
+  authAlias: string | undefined,
 ): Promise<string | undefined> {
   const path = joinPath(extension.directory, 'schema.graphql')
   if (await fileExists(path)) {
@@ -58,6 +59,7 @@ export async function getOrGenerateSchemaPath(
     clientId,
     forceRelink,
     userProvidedConfigName,
+    authAlias,
   })
 
   await generateSchemaService({

--- a/packages/app/src/cli/services/init/init.ts
+++ b/packages/app/src/cli/services/init/init.ts
@@ -45,6 +45,7 @@ interface InitOptions {
   local: boolean
   useGlobalCLI: boolean
   developerPlatformClient: DeveloperPlatformClient
+  authAlias?: string
   postCloneActions: {
     removeLockfilesFromGitignore: boolean
   }
@@ -247,6 +248,7 @@ async function init(options: InitOptions) {
     clientId: undefined,
     forceRelink: false,
     userProvidedConfigName: undefined,
+    authAlias: options.authAlias,
   })
 
   renderSuccess({

--- a/packages/app/src/cli/utilities/auth-alias.test.ts
+++ b/packages/app/src/cli/utilities/auth-alias.test.ts
@@ -1,0 +1,31 @@
+import {sessionIdFromAuthAlias} from './auth-alias.js'
+import {findSessionIdByAlias} from '@shopify/cli-kit/node/session'
+import {describe, expect, test, vi, beforeEach} from 'vitest'
+
+vi.mock('@shopify/cli-kit/node/session')
+
+describe('sessionIdFromAuthAlias', () => {
+  beforeEach(() => {
+    vi.mocked(findSessionIdByAlias).mockResolvedValue(undefined)
+  })
+
+  test('returns undefined when no alias is provided', async () => {
+    const got = await sessionIdFromAuthAlias(undefined)
+
+    expect(got).toBeUndefined()
+    expect(findSessionIdByAlias).not.toHaveBeenCalled()
+  })
+
+  test('returns the session ID for the alias', async () => {
+    vi.mocked(findSessionIdByAlias).mockResolvedValue('session-id-for-work')
+
+    const got = await sessionIdFromAuthAlias('work')
+
+    expect(got).toBe('session-id-for-work')
+    expect(findSessionIdByAlias).toHaveBeenCalledWith('work')
+  })
+
+  test('throws with login guidance when alias is missing', async () => {
+    await expect(sessionIdFromAuthAlias('missing')).rejects.toThrow('No authenticated account found for alias')
+  })
+})

--- a/packages/app/src/cli/utilities/auth-alias.ts
+++ b/packages/app/src/cli/utilities/auth-alias.ts
@@ -1,0 +1,17 @@
+import {findSessionIdByAlias} from '@shopify/cli-kit/node/session'
+import {AbortError} from '@shopify/cli-kit/node/error'
+import {outputContent, outputToken} from '@shopify/cli-kit/node/output'
+
+export async function sessionIdFromAuthAlias(authAlias?: string): Promise<string | undefined> {
+  if (!authAlias) return undefined
+
+  const sessionId = await findSessionIdByAlias(authAlias)
+  if (!sessionId) {
+    throw new AbortError(
+      outputContent`No authenticated account found for alias ${outputToken.yellow(authAlias)}.`,
+      outputContent`Run ${outputToken.genericShellCommand(`shopify auth login --alias ${authAlias}`)} first.`,
+    )
+  }
+
+  return sessionId
+}

--- a/packages/app/src/cli/utilities/developer-platform-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client.ts
@@ -77,6 +77,11 @@ export type Paginateable<T> = T & {
 
 interface SelectDeveloperPlatformClientOptions {
   organization?: Organization
+  authSessionId?: string
+}
+
+export interface DeveloperPlatformClientAuthOptions {
+  sessionId?: string
 }
 
 export interface AppVersionIdentifiers {
@@ -84,13 +89,17 @@ export interface AppVersionIdentifiers {
   versionId: string
 }
 
-export function allDeveloperPlatformClients(): DeveloperPlatformClient[] {
+export function allDeveloperPlatformClients(
+  authOptions?: DeveloperPlatformClientAuthOptions,
+): DeveloperPlatformClient[] {
   const clients: DeveloperPlatformClient[] = []
 
-  clients.push(AppManagementClient.getInstance())
+  clients.push(
+    authOptions ? AppManagementClient.getInstance(undefined, authOptions) : AppManagementClient.getInstance(),
+  )
 
   if (!blockPartnersAccess()) {
-    clients.push(PartnersClient.getInstance())
+    clients.push(authOptions ? PartnersClient.getInstance(undefined, authOptions) : PartnersClient.getInstance())
   }
 
   return clients
@@ -98,20 +107,29 @@ export function allDeveloperPlatformClients(): DeveloperPlatformClient[] {
 
 export function selectDeveloperPlatformClient({
   organization,
+  authSessionId,
 }: SelectDeveloperPlatformClientOptions = {}): DeveloperPlatformClient {
-  if (organization) return selectDeveloperPlatformClientByOrg(organization)
-  return defaultDeveloperPlatformClient()
+  const authOptions = authSessionId ? {sessionId: authSessionId} : undefined
+  if (organization) return selectDeveloperPlatformClientByOrg(organization, authOptions)
+  return defaultDeveloperPlatformClient(authOptions)
 }
 
-function selectDeveloperPlatformClientByOrg(organization: Organization): DeveloperPlatformClient {
-  if (organization.source === OrganizationSource.BusinessPlatform) return AppManagementClient.getInstance()
-  return PartnersClient.getInstance()
+function selectDeveloperPlatformClientByOrg(
+  organization: Organization,
+  authOptions?: DeveloperPlatformClientAuthOptions,
+): DeveloperPlatformClient {
+  if (organization.source === OrganizationSource.BusinessPlatform) {
+    return authOptions ? AppManagementClient.getInstance(undefined, authOptions) : AppManagementClient.getInstance()
+  }
+  return authOptions ? PartnersClient.getInstance(undefined, authOptions) : PartnersClient.getInstance()
 }
 
-function defaultDeveloperPlatformClient(): DeveloperPlatformClient {
-  if (firstPartyDev() && !blockPartnersAccess()) return PartnersClient.getInstance()
+function defaultDeveloperPlatformClient(authOptions?: DeveloperPlatformClientAuthOptions): DeveloperPlatformClient {
+  if (firstPartyDev() && !blockPartnersAccess()) {
+    return authOptions ? PartnersClient.getInstance(undefined, authOptions) : PartnersClient.getInstance()
+  }
 
-  return AppManagementClient.getInstance()
+  return authOptions ? AppManagementClient.getInstance(undefined, authOptions) : AppManagementClient.getInstance()
 }
 
 export interface CreateAppOptions {

--- a/packages/app/src/cli/utilities/developer-platform-client/app-management-client.test.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/app-management-client.test.ts
@@ -2145,6 +2145,15 @@ describe('singleton pattern', () => {
     expect(instance1).toBe(instance2)
   })
 
+  test('getInstance returns fresh instances for explicit sessions', () => {
+    // Given/When
+    const instance1 = AppManagementClient.getInstance(undefined, {sessionId: 'session-id-for-work'})
+    const instance2 = AppManagementClient.getInstance(undefined, {sessionId: 'session-id-for-work'})
+
+    // Then
+    expect(instance1).not.toBe(instance2)
+  })
+
   test('resetInstance allows creating a new instance', () => {
     // Given
     const instance1 = AppManagementClient.getInstance()

--- a/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
@@ -12,6 +12,7 @@ import {environmentVariableNames} from '../../constants.js'
 import {RemoteSpecification} from '../../api/graphql/extension_specifications.js'
 import {
   DeveloperPlatformClient,
+  DeveloperPlatformClientAuthOptions,
   TemplateSpecificationsOptions,
   Paginateable,
   AppVersion,
@@ -190,7 +191,8 @@ export interface GatedExtensionTemplate extends ExtensionTemplate {
 export class AppManagementClient implements DeveloperPlatformClient {
   private static instance: AppManagementClient | undefined
 
-  static getInstance(session?: Session): AppManagementClient {
+  static getInstance(session?: Session, authOptions: DeveloperPlatformClientAuthOptions = {}): AppManagementClient {
+    if (authOptions.sessionId) return new AppManagementClient(session, authOptions)
     AppManagementClient.instance ??= new AppManagementClient(session)
     return AppManagementClient.instance
   }
@@ -208,9 +210,11 @@ export class AppManagementClient implements DeveloperPlatformClient {
   public readonly bundleFormat = 'br'
   public readonly supportsDashboardManagedExtensions = false
   private _session: Session | undefined
+  private readonly authOptions: DeveloperPlatformClientAuthOptions
 
-  private constructor(session?: Session) {
+  private constructor(session?: Session, authOptions: DeveloperPlatformClientAuthOptions = {}) {
     this._session = session
+    this.authOptions = authOptions
   }
 
   async subscribeToAppLogs(
@@ -278,7 +282,7 @@ export class AppManagementClient implements DeveloperPlatformClient {
         throw new Error('AppManagementClient.session() should not be invoked dynamically in a unit test')
       }
 
-      const tokenResult = await ensureAuthenticatedAppManagementAndBusinessPlatform()
+      const tokenResult = await ensureAuthenticatedAppManagementAndBusinessPlatform(this.authOptions)
       const {appManagementToken, businessPlatformToken, userId} = tokenResult
 
       // This one can't use the shared businessPlatformRequest because the token is not globally available yet.
@@ -343,7 +347,11 @@ export class AppManagementClient implements DeveloperPlatformClient {
   }
 
   async unsafeRefreshToken(): Promise<string> {
-    const result = await ensureAuthenticatedAppManagementAndBusinessPlatform({noPrompt: true, forceRefresh: true})
+    const result = await ensureAuthenticatedAppManagementAndBusinessPlatform({
+      ...this.authOptions,
+      noPrompt: true,
+      forceRefresh: true,
+    })
     const session = await this.session()
     session.token = result.appManagementToken
     session.businessPlatformToken = result.businessPlatformToken

--- a/packages/app/src/cli/utilities/developer-platform-client/partners-client.test.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/partners-client.test.ts
@@ -225,6 +225,15 @@ describe('singleton pattern', () => {
     expect(instance1).toBe(instance2)
   })
 
+  test('getInstance returns fresh instances for explicit sessions', () => {
+    // Given/When
+    const instance1 = PartnersClient.getInstance(undefined, {sessionId: 'session-id-for-work'})
+    const instance2 = PartnersClient.getInstance(undefined, {sessionId: 'session-id-for-work'})
+
+    // Then
+    expect(instance1).not.toBe(instance2)
+  })
+
   test('resetInstance allows creating a new instance', () => {
     // Given
     const instance1 = PartnersClient.getInstance()

--- a/packages/app/src/cli/utilities/developer-platform-client/partners-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/partners-client.ts
@@ -13,6 +13,7 @@ import {
   CreateAppOptions,
   AppLogsResponse,
   createUnauthorizedHandler,
+  DeveloperPlatformClientAuthOptions,
 } from '../developer-platform-client.js'
 import {fetchCurrentAccountInformation} from '../../services/context/partner-account-info.js'
 import {
@@ -202,7 +203,8 @@ interface OrgAndAppsResponse {
 export class PartnersClient implements DeveloperPlatformClient {
   private static instance: PartnersClient | undefined
 
-  static getInstance(session?: Session): PartnersClient {
+  static getInstance(session?: Session, authOptions: DeveloperPlatformClientAuthOptions = {}): PartnersClient {
+    if (authOptions.sessionId) return new PartnersClient(session, authOptions)
     PartnersClient.instance ??= new PartnersClient(session)
     return PartnersClient.instance
   }
@@ -220,9 +222,11 @@ export class PartnersClient implements DeveloperPlatformClient {
   public readonly bundleFormat = 'zip'
   public readonly supportsDashboardManagedExtensions = true
   private _session: Session | undefined
+  private readonly authOptions: DeveloperPlatformClientAuthOptions
 
-  private constructor(session?: Session) {
+  private constructor(session?: Session, authOptions: DeveloperPlatformClientAuthOptions = {}) {
     this._session = session
+    this.authOptions = authOptions
   }
 
   async session(): Promise<Session> {
@@ -230,7 +234,7 @@ export class PartnersClient implements DeveloperPlatformClient {
       if (isUnitTest()) {
         throw new Error('PartnersClient.session() should not be invoked dynamically in a unit test')
       }
-      const {token, userId} = await ensureAuthenticatedPartners()
+      const {token, userId} = await ensureAuthenticatedPartners([], process.env, this.authOptions)
       this._session = {
         token,
         businessPlatformToken: '',
@@ -271,7 +275,11 @@ export class PartnersClient implements DeveloperPlatformClient {
   }
 
   async unsafeRefreshToken(): Promise<string> {
-    const {token} = await ensureAuthenticatedPartners([], process.env, {noPrompt: true, forceRefresh: true})
+    const {token} = await ensureAuthenticatedPartners([], process.env, {
+      ...this.authOptions,
+      noPrompt: true,
+      forceRefresh: true,
+    })
     const session = await this.session()
     if (token) {
       session.token = token

--- a/packages/app/src/cli/utilities/execute-command-helpers.test.ts
+++ b/packages/app/src/cli/utilities/execute-command-helpers.test.ts
@@ -83,6 +83,18 @@ describe('prepareAppStoreContext', () => {
       userProvidedConfigName: undefined,
     })
   })
+
+  test('passes auth alias to linkedAppContext when provided', async () => {
+    await prepareAppStoreContext({...mockFlags, 'auth-alias': 'work'})
+
+    expect(linkedAppContext).toHaveBeenCalledWith({
+      directory: mockFlags.path,
+      clientId: mockFlags['client-id'],
+      forceRelink: mockFlags.reset,
+      userProvidedConfigName: mockFlags.config,
+      authAlias: 'work',
+    })
+  })
 })
 
 describe('prepareExecuteContext', () => {

--- a/packages/app/src/cli/utilities/execute-command-helpers.ts
+++ b/packages/app/src/cli/utilities/execute-command-helpers.ts
@@ -6,6 +6,7 @@ import {resolveBulkOperationQuery} from '@shopify/cli-kit/node/api/bulk-operatio
 interface AppStoreContextFlags {
   path: string
   'client-id'?: string
+  'auth-alias'?: string
   reset: boolean
   config?: string
   store?: string
@@ -38,6 +39,7 @@ export async function prepareAppStoreContext(flags: AppStoreContextFlags): Promi
     clientId: flags['client-id'],
     forceRelink: flags.reset,
     userProvidedConfigName: flags.config,
+    ...(flags['auth-alias'] ? {authAlias: flags['auth-alias']} : {}),
   })
 
   const store = await storeContext({

--- a/packages/app/src/cli/utilities/extensions/fetch-product-variant.test.ts
+++ b/packages/app/src/cli/utilities/extensions/fetch-product-variant.test.ts
@@ -1,0 +1,45 @@
+import {fetchProductVariant} from './fetch-product-variant.js'
+import {adminRequest} from '@shopify/cli-kit/node/api/admin'
+import {ensureAuthenticatedAdmin} from '@shopify/cli-kit/node/session'
+import {beforeEach, describe, expect, test, vi} from 'vitest'
+
+vi.mock('@shopify/cli-kit/node/api/admin')
+vi.mock('@shopify/cli-kit/node/session')
+
+describe('fetchProductVariant', () => {
+  beforeEach(() => {
+    vi.mocked(ensureAuthenticatedAdmin).mockResolvedValue({
+      token: 'admin-token',
+      storeFqdn: 'test.myshopify.com',
+    })
+    vi.mocked(adminRequest).mockResolvedValue({
+      products: {
+        edges: [
+          {
+            node: {
+              variants: {
+                edges: [{node: {id: 'gid://shopify/ProductVariant/123'}}],
+              },
+            },
+          },
+        ],
+      },
+    } as any)
+  })
+
+  test('authenticates with the default session when no auth session ID is provided', async () => {
+    const got = await fetchProductVariant('test.myshopify.com')
+
+    expect(got).toBe('123')
+    expect(ensureAuthenticatedAdmin).toHaveBeenCalledWith('test.myshopify.com')
+  })
+
+  test('authenticates with the provided auth session ID', async () => {
+    const got = await fetchProductVariant('test.myshopify.com', 'session-id-for-work')
+
+    expect(got).toBe('123')
+    expect(ensureAuthenticatedAdmin).toHaveBeenCalledWith('test.myshopify.com', [], {
+      sessionId: 'session-id-for-work',
+    })
+  })
+})

--- a/packages/app/src/cli/utilities/extensions/fetch-product-variant.ts
+++ b/packages/app/src/cli/utilities/extensions/fetch-product-variant.ts
@@ -10,8 +10,10 @@ import {outputContent, outputToken} from '@shopify/cli-kit/node/output'
  * @param store - Store FQDN
  * @returns variantID if exists
  */
-export async function fetchProductVariant(store: string) {
-  const adminSession = await ensureAuthenticatedAdmin(store)
+export async function fetchProductVariant(store: string, authSessionId?: string) {
+  const adminSession = authSessionId
+    ? await ensureAuthenticatedAdmin(store, [], {sessionId: authSessionId})
+    : await ensureAuthenticatedAdmin(store)
   const result: FindProductVariantSchema = await adminRequest(FindProductVariantQuery, adminSession)
   const products = result.products.edges
   if (products.length === 0) {

--- a/packages/cli-kit/src/private/node/session.test.ts
+++ b/packages/cli-kit/src/private/node/session.test.ts
@@ -19,7 +19,7 @@ import {ApplicationToken, IdentityToken, Sessions} from './session/schema.js'
 import {validateSession} from './session/validate.js'
 import {applicationId} from './session/identity.js'
 import {pollForDeviceAuthorization, requestDeviceAuthorization} from './session/device-authorization.js'
-import {getCurrentSessionId} from './conf-store.js'
+import {getCurrentSessionId, setCurrentSessionId} from './conf-store.js'
 import * as fqdnModule from '../../public/node/context/fqdn.js'
 import {themeToken} from '../../public/node/context/local.js'
 import {partnersRequest} from '../../public/node/api/partners.js'
@@ -313,6 +313,33 @@ describe('when existing session is valid', () => {
     expect(fetchSessions).toHaveBeenCalledOnce()
   })
 
+  test('uses an explicitly selected session without reading the current session ID', async () => {
+    // Given
+    const selectedUserId = 'selected-user-id'
+    const sessions: Sessions = {
+      [fqdn]: {
+        [userId]: {
+          identity: validIdentityToken,
+          applications: {},
+        },
+        [selectedUserId]: {
+          identity: {...validIdentityToken, userId: selectedUserId},
+          applications: appTokens,
+        },
+      },
+    }
+    vi.mocked(validateSession).mockResolvedValueOnce('ok')
+    vi.mocked(fetchSessions).mockResolvedValue(sessions)
+
+    // When
+    const got = await ensureAuthenticated(defaultApplications, process.env, {sessionId: selectedUserId})
+
+    // Then
+    expect(getCurrentSessionId).not.toHaveBeenCalled()
+    expect(validateSession).toHaveBeenCalledWith(expect.any(Array), expect.any(Object), sessions[fqdn]![selectedUserId])
+    expect(got).toEqual({...validTokens, userId: selectedUserId})
+  })
+
   test('overwrites partners token if provided with a custom CLI token', async () => {
     // Given
     vi.mocked(validateSession).mockResolvedValueOnce('ok')
@@ -349,6 +376,31 @@ describe('when existing session is valid', () => {
     await expect(getLastSeenUserIdAfterAuth()).resolves.toBe('1234-5678')
     await expect(getLastSeenAuthMethod()).resolves.toEqual('device_auth')
     expect(fetchSessions).toHaveBeenCalledOnce()
+  })
+
+  test('refreshes an explicitly selected session without changing the current session ID', async () => {
+    // Given
+    const selectedUserId = 'selected-user-id'
+    const sessions: Sessions = {
+      [fqdn]: {
+        [selectedUserId]: {
+          identity: {...validIdentityToken, userId: selectedUserId},
+          applications: appTokens,
+        },
+      },
+    }
+    vi.mocked(validateSession).mockResolvedValueOnce('needs_refresh')
+    vi.mocked(fetchSessions).mockResolvedValue(sessions)
+    vi.mocked(refreshAccessToken).mockResolvedValueOnce({...validIdentityToken, userId: selectedUserId})
+
+    // When
+    const got = await ensureAuthenticated(defaultApplications, process.env, {sessionId: selectedUserId})
+
+    // Then
+    expect(refreshAccessToken).toHaveBeenCalled()
+    expect(storeSessions).toHaveBeenCalledWith(sessions)
+    expect(setCurrentSessionId).not.toHaveBeenCalled()
+    expect(got).toEqual({...validTokens, userId: selectedUserId})
   })
 })
 

--- a/packages/cli-kit/src/private/node/session.ts
+++ b/packages/cli-kit/src/private/node/session.ts
@@ -183,6 +183,7 @@ export interface EnsureAuthenticatedAdditionalOptions {
   noPrompt?: boolean
   forceRefresh?: boolean
   forceNewSession?: boolean
+  sessionId?: string
 }
 
 /**
@@ -196,7 +197,12 @@ export interface EnsureAuthenticatedAdditionalOptions {
 export async function ensureAuthenticated(
   applications: OAuthApplications,
   _env?: NodeJS.ProcessEnv,
-  {forceRefresh = false, noPrompt = false, forceNewSession = false}: EnsureAuthenticatedAdditionalOptions = {},
+  {
+    forceRefresh = false,
+    noPrompt = false,
+    forceNewSession = false,
+    sessionId,
+  }: EnsureAuthenticatedAdditionalOptions = {},
 ): Promise<OAuthSession> {
   const fqdn = await identityFqdn()
 
@@ -210,8 +216,8 @@ export async function ensureAuthenticated(
 
   const sessions = (await sessionStore.fetch()) ?? {}
 
-  let currentSessionId = getCurrentSessionId()
-  if (!currentSessionId) {
+  let currentSessionId = forceNewSession ? undefined : (sessionId ?? getCurrentSessionId())
+  if (!currentSessionId && !sessionId) {
     const userIds = Object.keys(sessions[fqdn] ?? {})
     if (userIds.length > 0) currentSessionId = userIds[0]
   }
@@ -260,7 +266,7 @@ ${outputToken.json(applications)}
   // Save the new session info if it has changed
   if (!isEmpty(newSession)) {
     await sessionStore.store(updatedSessions)
-    setCurrentSessionId(newSessionId)
+    if (!sessionId) setCurrentSessionId(newSessionId)
   }
 
   const tokens = await tokensFor(applications, completeSession)

--- a/packages/cli-kit/src/public/node/session.test.ts
+++ b/packages/cli-kit/src/public/node/session.test.ts
@@ -6,6 +6,7 @@ import {
   ensureAuthenticatedPartners,
   ensureAuthenticatedStorefront,
   ensureAuthenticatedThemes,
+  findSessionIdByAlias,
   setLastSeenUserId,
 } from './session.js'
 
@@ -13,6 +14,7 @@ import {nonRandomUUID} from './crypto.js'
 import {getAppAutomationToken} from './environment.js'
 import {shopifyFetch} from './http.js'
 import {ensureAuthenticated, setLastSeenAuthMethod, setLastSeenUserIdAfterAuth} from '../../private/node/session.js'
+import * as sessionStore from '../../private/node/session/store.js'
 import {ApplicationToken} from '../../private/node/session/schema.js'
 import {
   exchangeCustomPartnerToken,
@@ -32,6 +34,7 @@ const partnersToken: ApplicationToken = {
 
 vi.mock('../../private/node/session.js')
 vi.mock('../../private/node/session/exchange.js')
+vi.mock('../../private/node/session/store.js')
 vi.mock('./environment.js')
 vi.mock('./http.js')
 
@@ -40,6 +43,20 @@ describe('store command analytics session helpers', () => {
     setLastSeenUserId('store-user-id')
 
     expect(setLastSeenUserIdAfterAuth).toHaveBeenCalledWith('store-user-id')
+  })
+})
+
+describe('findSessionIdByAlias', () => {
+  test('returns the matching session ID without selecting it', async () => {
+    // Given
+    vi.mocked(sessionStore.findSessionByAlias).mockResolvedValueOnce('user-id')
+
+    // When
+    const got = await findSessionIdByAlias('work')
+
+    // Then
+    expect(got).toEqual('user-id')
+    expect(sessionStore.findSessionByAlias).toHaveBeenCalledWith('work')
   })
 })
 
@@ -171,6 +188,23 @@ describe('ensureAuthenticatedTheme', () => {
     expect(got).toEqual({token: 'admin_token', storeFqdn: 'mystore.myshopify.com'})
     expect(setLastSeenAuthMethod).not.toBeCalled()
     expect(setLastSeenUserIdAfterAuth).not.toBeCalled()
+  })
+
+  test('passes additional auth options through to the shared authenticator', async () => {
+    // Given
+    vi.mocked(ensureAuthenticated).mockResolvedValueOnce({
+      admin: {token: 'admin_token', storeFqdn: 'mystore.myshopify.com'},
+      userId: '1234-5678',
+    })
+
+    // When
+    const got = await ensureAuthenticatedThemes('mystore', undefined, [], {sessionId: 'user-id'})
+
+    // Then
+    expect(got).toEqual({token: 'admin_token', storeFqdn: 'mystore.myshopify.com', sessionId: '1234-5678'})
+    expect(ensureAuthenticated).toHaveBeenCalledWith({adminApi: {scopes: [], storeFqdn: 'mystore'}}, process.env, {
+      sessionId: 'user-id',
+    })
   })
 
   test('throws error if there is no token when no password is provided', async () => {

--- a/packages/cli-kit/src/public/node/session.ts
+++ b/packages/cli-kit/src/public/node/session.ts
@@ -28,6 +28,7 @@ import {isThemeAccessSession} from '../../private/node/api/rest.js'
 export interface AdminSession {
   token: string
   storeFqdn: string
+  sessionId?: string
 }
 
 /**
@@ -49,6 +50,16 @@ export type AccountInfo = UserAccountInfo | ServiceAccountInfo | UnknownAccountI
  */
 export function setLastSeenUserId(userId: string): void {
   setLastSeenUserIdAfterAuth(userId)
+}
+
+/**
+ * Finds a stored Shopify account session by alias without changing the current session.
+ *
+ * @param alias - The account alias to find.
+ * @returns The matching session ID, or undefined if no session matches.
+ */
+export async function findSessionIdByAlias(alias: string): Promise<string | undefined> {
+  return sessionStore.findSessionByAlias(alias)
 }
 
 interface UserAccountInfo {
@@ -233,7 +244,10 @@ ${outputToken.json(scopes)}
   if (!tokens.admin) {
     throw new BugError('No admin token found after ensuring authenticated')
   }
-  return tokens.admin
+  return {
+    ...tokens.admin,
+    ...(options.sessionId ? {sessionId: tokens.userId} : {}),
+  }
 }
 
 /**

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1456,25 +1456,29 @@ Builds and deploys a Hydrogen storefront to Oxygen.
 
 ```
 USAGE
-  $ shopify hydrogen deploy [--auth-bypass-token-duration <value> --auth-bypass-token] [--build-command <value>]
-    [--entry <value>] [--env <value> | --env-branch <value>] [--env-file <value>] [-f] [--force-client-sourcemap]
-    [--json-output] [--lockfile-check] [--metadata-description <value>] [--metadata-user <value>] [--no-verify] [--path
-    <value>] [--preview] [-s <value>] [-t <value>]
+  $ shopify hydrogen deploy [--assets-dir <value>] [--auth-bypass-token-duration <value> --auth-bypass-token]
+    [--build-command <value>] [--entry <value>] [--env <value> | --env-branch <value>] [--env-file <value>] [-f]
+    [--force-client-sourcemap] [--json-output] [--lockfile-check] [--metadata-description <value>] [--metadata-user
+    <value>] [--no-verify] [--path <value>] [--preview] [-s <value>] [-t <value>] [--worker-dir <value>]
 
 FLAGS
   -f, --force                               [env: SHOPIFY_HYDROGEN_FLAG_FORCE] Forces a deployment to proceed if there
-                                            are uncommited changes in its Git repository.
+                                            are uncommitted changes in its Git repository.
   -s, --shop=<value>                        [env: SHOPIFY_SHOP] Shop URL. It can be the shop prefix (janes-apparel) or
                                             the full myshopify.com URL (janes-apparel.myshopify.com,
                                             https://janes-apparel.myshopify.com).
   -t, --token=<value>                       [env: SHOPIFY_HYDROGEN_DEPLOYMENT_TOKEN] Oxygen deployment token. Defaults
                                             to the linked storefront's token if available.
+      --assets-dir=<value>                  [env: SHOPIFY_HYDROGEN_FLAG_ASSETS_DIR] Directory containing the client
+                                            assets to deploy, relative to the project root. Defaults to the detected
+                                            Vite client output directory, then falls back to `dist/client`.
       --auth-bypass-token                   [env: AUTH_BYPASS_TOKEN] Generate an authentication bypass token, which can
                                             be used to perform end-to-end tests against the deployment.
       --auth-bypass-token-duration=<value>  [env: AUTH_BYPASS_TOKEN_DURATION] Specify the duration (in hours) up to 12
                                             hours for the authentication bypass token. Defaults to `2`
-      --build-command=<value>               Specify a build command to run before deploying. If not specified, `shopify
-                                            hydrogen build` will be used.
+      --build-command=<value>               Specify a build command to run before deploying. If not specified, the
+                                            Hydrogen build pipeline will be used. When custom output directories are
+                                            configured, defaults to `node --run build`.
       --entry=<value>                       [env: SHOPIFY_HYDROGEN_FLAG_ENTRY] Entry file for the worker. Defaults to
                                             `./server`.
       --env=<value>                         Specifies the environment to perform the operation using its handle. Fetch
@@ -1493,13 +1497,17 @@ FLAGS
                                             `--no-lockfile-check`.
       --metadata-description=<value>        [env: SHOPIFY_HYDROGEN_FLAG_METADATA_DESCRIPTION] Description of the changes
                                             in the deployment. Defaults to the commit message of the latest commit if
-                                            there are no uncommited changes.
+                                            there are no uncommitted changes.
       --metadata-user=<value>               [env: SHOPIFY_HYDROGEN_FLAG_METADATA_USER] User that initiated the
                                             deployment. Will be saved and displayed in the Shopify admin
       --no-verify                           Skip the routability verification step after deployment.
       --path=<value>                        [env: SHOPIFY_HYDROGEN_FLAG_PATH] The path to the directory of the Hydrogen
                                             storefront. Defaults to the current directory where the command is run.
       --preview                             Deploys to the Preview environment.
+      --worker-dir=<value>                  [env: SHOPIFY_HYDROGEN_FLAG_WORKER_DIR] Directory containing the Oxygen
+                                            worker entry point (`index.js` or `index.mjs`), relative to the project
+                                            root. Defaults to the detected Vite server output directory, then falls back
+                                            to `dist/server`.
 
 DESCRIPTION
   Builds and deploys a Hydrogen storefront to Oxygen.
@@ -1620,15 +1628,14 @@ USAGE
     [--typescript]
 
 ARGUMENTS
-  ROUTENAME  (home|page|cart|products|collections|policies|blogs|account|search|robots|sitemap|tokenlessApi|all) The
-             route to generate. One of
-             home,page,cart,products,collections,policies,blogs,account,search,robots,sitemap,tokenlessApi,all.
+  ROUTENAME  (home|page|cart|products|collections|policies|blogs|account|search|robots|sitemap|all) The route to
+             generate. One of home,page,cart,products,collections,policies,blogs,account,search,robots,sitemap,all.
 
 FLAGS
   -f, --force                 [env: SHOPIFY_HYDROGEN_FLAG_FORCE] Overwrites the destination directory and files if they
                               already exist.
-      --adapter=<value>       [env: SHOPIFY_HYDROGEN_FLAG_ADAPTER] Remix adapter used in the route. The default is
-                              `@shopify/remix-oxygen`.
+      --adapter=<value>       [env: SHOPIFY_HYDROGEN_FLAG_ADAPTER] React Router adapter used in the route. The default
+                              is `react-router`.
       --locale-param=<value>  [env: SHOPIFY_HYDROGEN_FLAG_ADAPTER] The param name in Remix routes for the i18n locale,
                               if any. Example: `locale` becomes ($locale).
       --path=<value>          [env: SHOPIFY_HYDROGEN_FLAG_PATH] The path to the directory of the Hydrogen storefront.
@@ -1650,8 +1657,8 @@ USAGE
 FLAGS
   -f, --force                 [env: SHOPIFY_HYDROGEN_FLAG_FORCE] Overwrites the destination directory and files if they
                               already exist.
-      --adapter=<value>       [env: SHOPIFY_HYDROGEN_FLAG_ADAPTER] Remix adapter used in the route. The default is
-                              `@shopify/remix-oxygen`.
+      --adapter=<value>       [env: SHOPIFY_HYDROGEN_FLAG_ADAPTER] React Router adapter used in the route. The default
+                              is `react-router`.
       --locale-param=<value>  [env: SHOPIFY_HYDROGEN_FLAG_ADAPTER] The param name in Remix routes for the i18n locale,
                               if any. Example: `locale` becomes ($locale).
       --path=<value>          [env: SHOPIFY_HYDROGEN_FLAG_PATH] The path to the directory of the Hydrogen storefront.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -2447,6 +2447,7 @@ FLAGS
   -e, --environment=<value>...  [env: SHOPIFY_FLAG_ENVIRONMENT] The environment to apply to the current command.
   -s, --store=<value>           [env: SHOPIFY_FLAG_STORE] Store URL. It can be the store prefix (example) or the full
                                 myshopify.com URL (example.myshopify.com, https://example.myshopify.com).
+      --alias=<value>           [env: SHOPIFY_FLAG_AUTH_ALIAS] Alias of the Shopify account to use for authentication.
       --no-color                [env: SHOPIFY_FLAG_NO_COLOR] Disable color output.
       --password=<value>        [env: SHOPIFY_CLI_THEME_TOKEN] Password generated from the Theme Access app or an Admin
                                 API token.
@@ -2472,8 +2473,8 @@ Delete remote themes from the connected store. This command can't be undone.
 
 ```
 USAGE
-  $ shopify theme delete [-d] [-e <value>...] [-f] [--no-color] [--password <value>] [--path <value>] [-a] [-s
-    <value>] [-t <value>...] [--verbose]
+  $ shopify theme delete [--alias <value>] [-d] [-e <value>...] [-f] [--no-color] [--password <value>] [--path
+    <value>] [-a] [-s <value>] [-t <value>...] [--verbose]
 
 FLAGS
   -a, --show-all                [env: SHOPIFY_FLAG_SHOW_ALL] Include others development themes in theme list.
@@ -2483,6 +2484,7 @@ FLAGS
   -s, --store=<value>           [env: SHOPIFY_FLAG_STORE] Store URL. It can be the store prefix (example) or the full
                                 myshopify.com URL (example.myshopify.com, https://example.myshopify.com).
   -t, --theme=<value>...        [env: SHOPIFY_FLAG_THEME_ID] Theme ID or name of the remote theme.
+      --alias=<value>           [env: SHOPIFY_FLAG_AUTH_ALIAS] Alias of the Shopify account to use for authentication.
       --no-color                [env: SHOPIFY_FLAG_NO_COLOR] Disable color output.
       --password=<value>        [env: SHOPIFY_CLI_THEME_TOKEN] Password generated from the Theme Access app or an Admin
                                 API token.
@@ -2508,10 +2510,10 @@ Uploads the current theme as a development theme to the connected store, then pr
 
 ```
 USAGE
-  $ shopify theme dev [-a] [-e <value>...] [--error-overlay silent|default] [--host <value>] [-x <value>...]
-    [--listing <value>] [--live-reload hot-reload|full-page|off] [--no-color] [-n] [--notify <value>] [-o <value>...]
-    [--open] [--password <value>] [--path <value>] [--port <value>] [--standard-events-inspector] [-s <value>]
-    [--store-password <value>] [-t <value>] [--theme-editor-sync] [--verbose]
+  $ shopify theme dev [--alias <value>] [-a] [-e <value>...] [--error-overlay silent|default] [--host <value>]
+    [-x <value>...] [--listing <value>] [--live-reload hot-reload|full-page|off] [--no-color] [-n] [--notify <value>]
+    [-o <value>...] [--open] [--password <value>] [--path <value>] [--port <value>] [--standard-events-inspector] [-s
+    <value>] [--store-password <value>] [-t <value>] [--theme-editor-sync] [--verbose]
 
 FLAGS
   -a, --allow-live
@@ -2537,6 +2539,9 @@ FLAGS
 
   -x, --ignore=<value>...
       [env: SHOPIFY_FLAG_IGNORE] Skip hot reloading any files that match the specified pattern.
+
+  --alias=<value>
+      [env: SHOPIFY_FLAG_AUTH_ALIAS] Alias of the Shopify account to use for authentication.
 
   --error-overlay=<option>
       [default: default, env: SHOPIFY_FLAG_ERROR_OVERLAY] Controls the visibility of the error overlay when an theme asset
@@ -2645,6 +2650,7 @@ FLAGS
   -s, --store=<value>           [env: SHOPIFY_FLAG_STORE] Store URL. It can be the store prefix (example) or the full
                                 myshopify.com URL (example.myshopify.com, https://example.myshopify.com).
   -t, --theme=<value>           [env: SHOPIFY_FLAG_THEME_ID] Theme ID or name of the remote theme.
+      --alias=<value>           [env: SHOPIFY_FLAG_AUTH_ALIAS] Alias of the Shopify account to use for authentication.
       --no-color                [env: SHOPIFY_FLAG_NO_COLOR] Disable color output.
       --password=<value>        [env: SHOPIFY_CLI_THEME_TOKEN] Password generated from the Theme Access app or an Admin
                                 API token.
@@ -2694,8 +2700,8 @@ Displays information about your theme environment, including your current store.
 
 ```
 USAGE
-  $ shopify theme info [-d] [-e <value>...] [-j] [--no-color] [--password <value>] [--path <value>] [-s <value>]
-    [-t <value>] [--verbose]
+  $ shopify theme info [--alias <value>] [-d] [-e <value>...] [-j] [--no-color] [--password <value>] [--path
+    <value>] [-s <value>] [-t <value>] [--verbose]
 
 FLAGS
   -d, --development             [env: SHOPIFY_FLAG_DEVELOPMENT] Retrieve info from your development theme.
@@ -2704,6 +2710,7 @@ FLAGS
   -s, --store=<value>           [env: SHOPIFY_FLAG_STORE] Store URL. It can be the store prefix (example) or the full
                                 myshopify.com URL (example.myshopify.com, https://example.myshopify.com).
   -t, --theme=<value>           [env: SHOPIFY_FLAG_THEME_ID] Theme ID or name of the remote theme.
+      --alias=<value>           [env: SHOPIFY_FLAG_AUTH_ALIAS] Alias of the Shopify account to use for authentication.
       --no-color                [env: SHOPIFY_FLAG_NO_COLOR] Disable color output.
       --password=<value>        [env: SHOPIFY_CLI_THEME_TOKEN] Password generated from the Theme Access app or an Admin
                                 API token.
@@ -2774,14 +2781,15 @@ Lists the themes in your store, along with their IDs and statuses.
 
 ```
 USAGE
-  $ shopify theme list [-e <value>...] [--id <value>] [-j] [--name <value>] [--no-color] [--password <value>]
-    [--path <value>] [--role live|unpublished|development] [-s <value>] [--verbose]
+  $ shopify theme list [--alias <value>] [-e <value>...] [--id <value>] [-j] [--name <value>] [--no-color]
+    [--password <value>] [--path <value>] [--role live|unpublished|development] [-s <value>] [--verbose]
 
 FLAGS
   -e, --environment=<value>...  [env: SHOPIFY_FLAG_ENVIRONMENT] The environment to apply to the current command.
   -j, --json                    [env: SHOPIFY_FLAG_JSON] Output the result as JSON. Automatically disables color output.
   -s, --store=<value>           [env: SHOPIFY_FLAG_STORE] Store URL. It can be the store prefix (example) or the full
                                 myshopify.com URL (example.myshopify.com, https://example.myshopify.com).
+      --alias=<value>           [env: SHOPIFY_FLAG_AUTH_ALIAS] Alias of the Shopify account to use for authentication.
       --id=<value>              [env: SHOPIFY_FLAG_ID] Only list theme with the given ID.
       --name=<value>            [env: SHOPIFY_FLAG_NAME] Only list themes that contain the given name.
       --no-color                [env: SHOPIFY_FLAG_NO_COLOR] Disable color output.
@@ -2803,13 +2811,14 @@ Download metafields definitions from your shop into a local file.
 
 ```
 USAGE
-  $ shopify theme metafields pull [-e <value>...] [--no-color] [--password <value>] [--path <value>] [-s <value>]
-    [--verbose]
+  $ shopify theme metafields pull [--alias <value>] [-e <value>...] [--no-color] [--password <value>] [--path <value>] [-s
+    <value>] [--verbose]
 
 FLAGS
   -e, --environment=<value>...  [env: SHOPIFY_FLAG_ENVIRONMENT] The environment to apply to the current command.
   -s, --store=<value>           [env: SHOPIFY_FLAG_STORE] Store URL. It can be the store prefix (example) or the full
                                 myshopify.com URL (example.myshopify.com, https://example.myshopify.com).
+      --alias=<value>           [env: SHOPIFY_FLAG_AUTH_ALIAS] Alias of the Shopify account to use for authentication.
       --no-color                [env: SHOPIFY_FLAG_NO_COLOR] Disable color output.
       --password=<value>        [env: SHOPIFY_CLI_THEME_TOKEN] Password generated from the Theme Access app or an Admin
                                 API token.
@@ -2831,8 +2840,8 @@ Opens the preview of your remote theme.
 
 ```
 USAGE
-  $ shopify theme open [-d] [-E] [-e <value>...] [-l] [--no-color] [--password <value>] [--path <value>] [-s
-    <value>] [-t <value>] [--verbose]
+  $ shopify theme open [--alias <value>] [-d] [-E] [-e <value>...] [-l] [--no-color] [--password <value>]
+    [--path <value>] [-s <value>] [-t <value>] [--verbose]
 
 FLAGS
   -E, --editor                  [env: SHOPIFY_FLAG_EDITOR] Open the theme editor for the specified theme in the browser.
@@ -2842,6 +2851,7 @@ FLAGS
   -s, --store=<value>           [env: SHOPIFY_FLAG_STORE] Store URL. It can be the store prefix (example) or the full
                                 myshopify.com URL (example.myshopify.com, https://example.myshopify.com).
   -t, --theme=<value>           [env: SHOPIFY_FLAG_THEME_ID] Theme ID or name of the remote theme.
+      --alias=<value>           [env: SHOPIFY_FLAG_AUTH_ALIAS] Alias of the Shopify account to use for authentication.
       --no-color                [env: SHOPIFY_FLAG_NO_COLOR] Disable color output.
       --password=<value>        [env: SHOPIFY_CLI_THEME_TOKEN] Password generated from the Theme Access app or an Admin
                                 API token.
@@ -2899,14 +2909,15 @@ Applies JSON overrides to a theme and returns a preview URL.
 
 ```
 USAGE
-  $ shopify theme preview --overrides <value> -t <value> [-e <value>...] [--json] [--no-color] [--open] [--password
-    <value>] [--path <value>] [--preview-id <value>] [-s <value>] [--verbose]
+  $ shopify theme preview --overrides <value> -t <value> [--alias <value>] [-e <value>...] [--json] [--no-color]
+    [--open] [--password <value>] [--path <value>] [--preview-id <value>] [-s <value>] [--verbose]
 
 FLAGS
   -e, --environment=<value>...  [env: SHOPIFY_FLAG_ENVIRONMENT] The environment to apply to the current command.
   -s, --store=<value>           [env: SHOPIFY_FLAG_STORE] Store URL. It can be the store prefix (example) or the full
                                 myshopify.com URL (example.myshopify.com, https://example.myshopify.com).
   -t, --theme=<value>           (required) [env: SHOPIFY_FLAG_THEME_ID] Theme ID or name of the remote theme.
+      --alias=<value>           [env: SHOPIFY_FLAG_AUTH_ALIAS] Alias of the Shopify account to use for authentication.
       --json                    [env: SHOPIFY_FLAG_JSON] Output the preview URL and identifier as JSON.
       --no-color                [env: SHOPIFY_FLAG_NO_COLOR] Disable color output.
       --open                    [env: SHOPIFY_FLAG_OPEN] Automatically launch the theme preview in your default web
@@ -2944,6 +2955,7 @@ FLAGS
   -s, --store=<value>           [env: SHOPIFY_FLAG_STORE] Store URL. It can be the store prefix (example) or the full
                                 myshopify.com URL (example.myshopify.com, https://example.myshopify.com).
   -t, --theme=<value>           [env: SHOPIFY_FLAG_THEME_ID] Theme ID or name of the remote theme.
+      --alias=<value>           [env: SHOPIFY_FLAG_AUTH_ALIAS] Alias of the Shopify account to use for authentication.
       --no-color                [env: SHOPIFY_FLAG_NO_COLOR] Disable color output.
       --password=<value>        [env: SHOPIFY_CLI_THEME_TOKEN] Password generated from the Theme Access app or an Admin
                                 API token.
@@ -2969,8 +2981,8 @@ Set a remote theme as the live theme.
 
 ```
 USAGE
-  $ shopify theme publish [-e <value>...] [-f] [--no-color] [--password <value>] [--path <value>] [-s <value>] [-t
-    <value>] [--verbose]
+  $ shopify theme publish [--alias <value>] [-e <value>...] [-f] [--no-color] [--password <value>] [--path <value>]
+    [-s <value>] [-t <value>] [--verbose]
 
 FLAGS
   -e, --environment=<value>...  [env: SHOPIFY_FLAG_ENVIRONMENT] The environment to apply to the current command.
@@ -2978,6 +2990,7 @@ FLAGS
   -s, --store=<value>           [env: SHOPIFY_FLAG_STORE] Store URL. It can be the store prefix (example) or the full
                                 myshopify.com URL (example.myshopify.com, https://example.myshopify.com).
   -t, --theme=<value>           [env: SHOPIFY_FLAG_THEME_ID] Theme ID or name of the remote theme.
+      --alias=<value>           [env: SHOPIFY_FLAG_AUTH_ALIAS] Alias of the Shopify account to use for authentication.
       --no-color                [env: SHOPIFY_FLAG_NO_COLOR] Disable color output.
       --password=<value>        [env: SHOPIFY_CLI_THEME_TOKEN] Password generated from the Theme Access app or an Admin
                                 API token.
@@ -3006,8 +3019,8 @@ Download your remote theme files locally.
 
 ```
 USAGE
-  $ shopify theme pull [-d] [-e <value>...] [-x <value>...] [-l] [--no-color] [-n] [-o <value>...] [--password
-    <value>] [--path <value>] [-s <value>] [-t <value>] [--verbose]
+  $ shopify theme pull [--alias <value>] [-d] [-e <value>...] [-x <value>...] [-l] [--no-color] [-n] [-o
+    <value>...] [--password <value>] [--path <value>] [-s <value>] [-t <value>] [--verbose]
 
 FLAGS
   -d, --development             [env: SHOPIFY_FLAG_DEVELOPMENT] Pull theme files from your remote development theme.
@@ -3021,6 +3034,7 @@ FLAGS
   -t, --theme=<value>           [env: SHOPIFY_FLAG_THEME_ID] Theme ID or name of the remote theme.
   -x, --ignore=<value>...       [env: SHOPIFY_FLAG_IGNORE] Skip downloading the specified files (Multiple flags
                                 allowed). Wrap the value in double quotes if you're using wildcards.
+      --alias=<value>           [env: SHOPIFY_FLAG_AUTH_ALIAS] Alias of the Shopify account to use for authentication.
       --no-color                [env: SHOPIFY_FLAG_NO_COLOR] Disable color output.
       --password=<value>        [env: SHOPIFY_CLI_THEME_TOKEN] Password generated from the Theme Access app or an Admin
                                 API token.
@@ -3067,6 +3081,8 @@ FLAGS
   -u, --unpublished                  [env: SHOPIFY_FLAG_UNPUBLISHED] Create a new unpublished theme and push to it.
   -x, --ignore=<value>...            [env: SHOPIFY_FLAG_IGNORE] Skip uploading the specified files (Multiple flags
                                      allowed). Wrap the value in double quotes if you're using wildcards.
+      --alias=<value>                [env: SHOPIFY_FLAG_AUTH_ALIAS] Alias of the Shopify account to use for
+                                     authentication.
       --listing=<value>              [env: SHOPIFY_FLAG_LISTING] The listing preset to use for multi-preset themes.
                                      Applies preset files from listings/[preset-name] directory.
       --no-color                     [env: SHOPIFY_FLAG_NO_COLOR] Disable color output.
@@ -3121,8 +3137,8 @@ Renames an existing theme.
 
 ```
 USAGE
-  $ shopify theme rename [-d] [-e <value>...] [-l] [-n <value>] [--no-color] [--password <value>] [--path <value>]
-    [-s <value>] [-t <value>] [--verbose]
+  $ shopify theme rename [--alias <value>] [-d] [-e <value>...] [-l] [-n <value>] [--no-color] [--password
+    <value>] [--path <value>] [-s <value>] [-t <value>] [--verbose]
 
 FLAGS
   -d, --development             [env: SHOPIFY_FLAG_DEVELOPMENT] Rename your development theme.
@@ -3132,6 +3148,7 @@ FLAGS
   -s, --store=<value>           [env: SHOPIFY_FLAG_STORE] Store URL. It can be the store prefix (example) or the full
                                 myshopify.com URL (example.myshopify.com, https://example.myshopify.com).
   -t, --theme=<value>           [env: SHOPIFY_FLAG_THEME_ID] Theme ID or name of the remote theme.
+      --alias=<value>           [env: SHOPIFY_FLAG_AUTH_ALIAS] Alias of the Shopify account to use for authentication.
       --no-color                [env: SHOPIFY_FLAG_NO_COLOR] Disable color output.
       --password=<value>        [env: SHOPIFY_CLI_THEME_TOKEN] Password generated from the Theme Access app or an Admin
                                 API token.
@@ -3154,13 +3171,14 @@ Creates a shareable, unpublished, and new theme on your theme library with a ran
 
 ```
 USAGE
-  $ shopify theme share [-e <value>...] [--listing <value>] [--no-color] [--password <value>] [--path <value>]
-    [-s <value>] [--verbose]
+  $ shopify theme share [--alias <value>] [-e <value>...] [--listing <value>] [--no-color] [--password <value>]
+    [--path <value>] [-s <value>] [--verbose]
 
 FLAGS
   -e, --environment=<value>...  [env: SHOPIFY_FLAG_ENVIRONMENT] The environment to apply to the current command.
   -s, --store=<value>           [env: SHOPIFY_FLAG_STORE] Store URL. It can be the store prefix (example) or the full
                                 myshopify.com URL (example.myshopify.com, https://example.myshopify.com).
+      --alias=<value>           [env: SHOPIFY_FLAG_AUTH_ALIAS] Alias of the Shopify account to use for authentication.
       --listing=<value>         [env: SHOPIFY_FLAG_LISTING] The listing preset to use for multi-preset themes. Applies
                                 preset files from listings/[preset-name] directory.
       --no-color                [env: SHOPIFY_FLAG_NO_COLOR] Disable color output.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -112,11 +112,13 @@ Build the app, including extensions.
 
 ```
 USAGE
-  $ shopify app build [--client-id <value> | -c <value>] [--no-color] [--path <value>] [--reset | ]
-    [--skip-dependencies-installation] [--verbose]
+  $ shopify app build [--auth-alias <value>] [--client-id <value> | -c <value>] [--no-color] [--path <value>]
+    [--reset | ] [--skip-dependencies-installation] [--verbose]
 
 FLAGS
   -c, --config=<value>                  [env: SHOPIFY_FLAG_APP_CONFIG] The name of the app configuration.
+      --auth-alias=<value>              [env: SHOPIFY_FLAG_AUTH_ALIAS] Alias of the Shopify account to use for
+                                        authentication.
       --client-id=<value>               [env: SHOPIFY_FLAG_CLIENT_ID] The Client ID of your app.
       --no-color                        [env: SHOPIFY_FLAG_NO_COLOR] Disable color output.
       --path=<value>                    [env: SHOPIFY_FLAG_PATH] The path to your app directory.
@@ -143,18 +145,19 @@ Cancel a bulk operation.
 
 ```
 USAGE
-  $ shopify app bulk cancel --id <value> [--client-id <value> | -c <value>] [--no-color] [--path <value>] [--reset |
-    ] [-s <value>] [--verbose]
+  $ shopify app bulk cancel --id <value> [--auth-alias <value>] [--client-id <value> | -c <value>] [--no-color]
+    [--path <value>] [--reset | ] [-s <value>] [--verbose]
 
 FLAGS
-  -c, --config=<value>     [env: SHOPIFY_FLAG_APP_CONFIG] The name of the app configuration.
-  -s, --store=<value>      [env: SHOPIFY_FLAG_STORE] The store domain. Must be an existing dev store.
-      --client-id=<value>  [env: SHOPIFY_FLAG_CLIENT_ID] The Client ID of your app.
-      --id=<value>         (required) [env: SHOPIFY_FLAG_ID] The bulk operation ID to cancel (numeric ID or full GID).
-      --no-color           [env: SHOPIFY_FLAG_NO_COLOR] Disable color output.
-      --path=<value>       [env: SHOPIFY_FLAG_PATH] The path to your app directory.
-      --reset              [env: SHOPIFY_FLAG_RESET] Reset all your settings.
-      --verbose            [env: SHOPIFY_FLAG_VERBOSE] Increase the verbosity of the output.
+  -c, --config=<value>      [env: SHOPIFY_FLAG_APP_CONFIG] The name of the app configuration.
+  -s, --store=<value>       [env: SHOPIFY_FLAG_STORE] The store domain. Must be an existing dev store.
+      --auth-alias=<value>  [env: SHOPIFY_FLAG_AUTH_ALIAS] Alias of the Shopify account to use for authentication.
+      --client-id=<value>   [env: SHOPIFY_FLAG_CLIENT_ID] The Client ID of your app.
+      --id=<value>          (required) [env: SHOPIFY_FLAG_ID] The bulk operation ID to cancel (numeric ID or full GID).
+      --no-color            [env: SHOPIFY_FLAG_NO_COLOR] Disable color output.
+      --path=<value>        [env: SHOPIFY_FLAG_PATH] The path to your app directory.
+      --reset               [env: SHOPIFY_FLAG_RESET] Reset all your settings.
+      --verbose             [env: SHOPIFY_FLAG_VERBOSE] Increase the verbosity of the output.
 
 DESCRIPTION
   Cancel a bulk operation.
@@ -168,9 +171,9 @@ Execute bulk operations.
 
 ```
 USAGE
-  $ shopify app bulk execute [--client-id <value> | -c <value>] [--no-color] [--output-file <value> --watch] [--path
-    <value>] [-q <value>] [--query-file <value>] [--reset | ] [-s <value>] [--variable-file <value> | -v <value>...]
-    [--verbose] [--version <value>]
+  $ shopify app bulk execute [--auth-alias <value>] [--client-id <value> | -c <value>] [--no-color] [--output-file
+    <value> --watch] [--path <value>] [-q <value>] [--query-file <value>] [--reset | ] [-s <value>] [--variable-file
+    <value> | -v <value>...] [--verbose] [--version <value>]
 
 FLAGS
   -c, --config=<value>         [env: SHOPIFY_FLAG_APP_CONFIG] The name of the app configuration.
@@ -178,6 +181,7 @@ FLAGS
   -s, --store=<value>          [env: SHOPIFY_FLAG_STORE] The store domain. Must be an existing dev store.
   -v, --variables=<value>...   [env: SHOPIFY_FLAG_VARIABLES] The values for any GraphQL variables in your mutation, in
                                JSON format. Can be specified multiple times.
+      --auth-alias=<value>     [env: SHOPIFY_FLAG_AUTH_ALIAS] Alias of the Shopify account to use for authentication.
       --client-id=<value>      [env: SHOPIFY_FLAG_CLIENT_ID] The Client ID of your app.
       --no-color               [env: SHOPIFY_FLAG_NO_COLOR] Disable color output.
       --output-file=<value>    [env: SHOPIFY_FLAG_OUTPUT_FILE] The file path where results should be written if --watch
@@ -214,19 +218,20 @@ Check the status of bulk operations.
 
 ```
 USAGE
-  $ shopify app bulk status [--client-id <value> | -c <value>] [--id <value>] [--no-color] [--path <value>] [--reset
-    | ] [-s <value>] [--verbose]
+  $ shopify app bulk status [--auth-alias <value>] [--client-id <value> | -c <value>] [--id <value>] [--no-color]
+    [--path <value>] [--reset | ] [-s <value>] [--verbose]
 
 FLAGS
-  -c, --config=<value>     [env: SHOPIFY_FLAG_APP_CONFIG] The name of the app configuration.
-  -s, --store=<value>      [env: SHOPIFY_FLAG_STORE] The store domain. Must be an existing dev store.
-      --client-id=<value>  [env: SHOPIFY_FLAG_CLIENT_ID] The Client ID of your app.
-      --id=<value>         [env: SHOPIFY_FLAG_ID] The bulk operation ID (numeric ID or full GID). If not provided, lists
-                           all bulk operations belonging to this app on this store in the last 7 days.
-      --no-color           [env: SHOPIFY_FLAG_NO_COLOR] Disable color output.
-      --path=<value>       [env: SHOPIFY_FLAG_PATH] The path to your app directory.
-      --reset              [env: SHOPIFY_FLAG_RESET] Reset all your settings.
-      --verbose            [env: SHOPIFY_FLAG_VERBOSE] Increase the verbosity of the output.
+  -c, --config=<value>      [env: SHOPIFY_FLAG_APP_CONFIG] The name of the app configuration.
+  -s, --store=<value>       [env: SHOPIFY_FLAG_STORE] The store domain. Must be an existing dev store.
+      --auth-alias=<value>  [env: SHOPIFY_FLAG_AUTH_ALIAS] Alias of the Shopify account to use for authentication.
+      --client-id=<value>   [env: SHOPIFY_FLAG_CLIENT_ID] The Client ID of your app.
+      --id=<value>          [env: SHOPIFY_FLAG_ID] The bulk operation ID (numeric ID or full GID). If not provided,
+                            lists all bulk operations belonging to this app on this store in the last 7 days.
+      --no-color            [env: SHOPIFY_FLAG_NO_COLOR] Disable color output.
+      --path=<value>        [env: SHOPIFY_FLAG_PATH] The path to your app directory.
+      --reset               [env: SHOPIFY_FLAG_RESET] Reset all your settings.
+      --verbose             [env: SHOPIFY_FLAG_VERBOSE] Increase the verbosity of the output.
 
 DESCRIPTION
   Check the status of bulk operations.
@@ -247,15 +252,17 @@ Fetch your app configuration from the Developer Dashboard.
 
 ```
 USAGE
-  $ shopify app config link [--client-id <value> | -c <value>] [--no-color] [--path <value>] [--reset | ] [--verbose]
+  $ shopify app config link [--auth-alias <value>] [--client-id <value> | -c <value>] [--no-color] [--path <value>]
+    [--reset | ] [--verbose]
 
 FLAGS
-  -c, --config=<value>     [env: SHOPIFY_FLAG_APP_CONFIG] The name of the app configuration.
-      --client-id=<value>  [env: SHOPIFY_FLAG_CLIENT_ID] The Client ID of your app.
-      --no-color           [env: SHOPIFY_FLAG_NO_COLOR] Disable color output.
-      --path=<value>       [env: SHOPIFY_FLAG_PATH] The path to your app directory.
-      --reset              [env: SHOPIFY_FLAG_RESET] Reset all your settings.
-      --verbose            [env: SHOPIFY_FLAG_VERBOSE] Increase the verbosity of the output.
+  -c, --config=<value>      [env: SHOPIFY_FLAG_APP_CONFIG] The name of the app configuration.
+      --auth-alias=<value>  [env: SHOPIFY_FLAG_AUTH_ALIAS] Alias of the Shopify account to use for authentication.
+      --client-id=<value>   [env: SHOPIFY_FLAG_CLIENT_ID] The Client ID of your app.
+      --no-color            [env: SHOPIFY_FLAG_NO_COLOR] Disable color output.
+      --path=<value>        [env: SHOPIFY_FLAG_PATH] The path to your app directory.
+      --reset               [env: SHOPIFY_FLAG_RESET] Reset all your settings.
+      --verbose             [env: SHOPIFY_FLAG_VERBOSE] Increase the verbosity of the output.
 
 DESCRIPTION
   Fetch your app configuration from the Developer Dashboard.
@@ -273,15 +280,17 @@ Refresh an already-linked app configuration without prompts.
 
 ```
 USAGE
-  $ shopify app config pull [--client-id <value> | -c <value>] [--no-color] [--path <value>] [--reset | ] [--verbose]
+  $ shopify app config pull [--auth-alias <value>] [--client-id <value> | -c <value>] [--no-color] [--path <value>]
+    [--reset | ] [--verbose]
 
 FLAGS
-  -c, --config=<value>     [env: SHOPIFY_FLAG_APP_CONFIG] The name of the app configuration.
-      --client-id=<value>  [env: SHOPIFY_FLAG_CLIENT_ID] The Client ID of your app.
-      --no-color           [env: SHOPIFY_FLAG_NO_COLOR] Disable color output.
-      --path=<value>       [env: SHOPIFY_FLAG_PATH] The path to your app directory.
-      --reset              [env: SHOPIFY_FLAG_RESET] Reset all your settings.
-      --verbose            [env: SHOPIFY_FLAG_VERBOSE] Increase the verbosity of the output.
+  -c, --config=<value>      [env: SHOPIFY_FLAG_APP_CONFIG] The name of the app configuration.
+      --auth-alias=<value>  [env: SHOPIFY_FLAG_AUTH_ALIAS] Alias of the Shopify account to use for authentication.
+      --client-id=<value>   [env: SHOPIFY_FLAG_CLIENT_ID] The Client ID of your app.
+      --no-color            [env: SHOPIFY_FLAG_NO_COLOR] Disable color output.
+      --path=<value>        [env: SHOPIFY_FLAG_PATH] The path to your app directory.
+      --reset               [env: SHOPIFY_FLAG_RESET] Reset all your settings.
+      --verbose             [env: SHOPIFY_FLAG_VERBOSE] Increase the verbosity of the output.
 
 DESCRIPTION
   Refresh an already-linked app configuration without prompts.
@@ -304,11 +313,12 @@ ARGUMENTS
   [CONFIG]  The name of the app configuration. Can be 'shopify.app.staging.toml' or simply 'staging'.
 
 FLAGS
-  --client-id=<value>  [env: SHOPIFY_FLAG_CLIENT_ID] The Client ID of your app.
-  --no-color           [env: SHOPIFY_FLAG_NO_COLOR] Disable color output.
-  --path=<value>       [env: SHOPIFY_FLAG_PATH] The path to your app directory.
-  --reset              [env: SHOPIFY_FLAG_RESET] Reset all your settings.
-  --verbose            [env: SHOPIFY_FLAG_VERBOSE] Increase the verbosity of the output.
+  --auth-alias=<value>  [env: SHOPIFY_FLAG_AUTH_ALIAS] Alias of the Shopify account to use for authentication.
+  --client-id=<value>   [env: SHOPIFY_FLAG_CLIENT_ID] The Client ID of your app.
+  --no-color            [env: SHOPIFY_FLAG_NO_COLOR] Disable color output.
+  --path=<value>        [env: SHOPIFY_FLAG_PATH] The path to your app directory.
+  --reset               [env: SHOPIFY_FLAG_RESET] Reset all your settings.
+  --verbose             [env: SHOPIFY_FLAG_VERBOSE] Increase the verbosity of the output.
 
 DESCRIPTION
   Activate an app configuration.
@@ -323,17 +333,18 @@ Validate your app configuration and extensions.
 
 ```
 USAGE
-  $ shopify app config validate [--client-id <value> | -c <value>] [-j] [--no-color] [--path <value>] [--reset | ]
-    [--verbose]
+  $ shopify app config validate [--auth-alias <value>] [--client-id <value> | -c <value>] [-j] [--no-color] [--path
+    <value>] [--reset | ] [--verbose]
 
 FLAGS
-  -c, --config=<value>     [env: SHOPIFY_FLAG_APP_CONFIG] The name of the app configuration.
-  -j, --json               [env: SHOPIFY_FLAG_JSON] Output the result as JSON. Automatically disables color output.
-      --client-id=<value>  [env: SHOPIFY_FLAG_CLIENT_ID] The Client ID of your app.
-      --no-color           [env: SHOPIFY_FLAG_NO_COLOR] Disable color output.
-      --path=<value>       [env: SHOPIFY_FLAG_PATH] The path to your app directory.
-      --reset              [env: SHOPIFY_FLAG_RESET] Reset all your settings.
-      --verbose            [env: SHOPIFY_FLAG_VERBOSE] Increase the verbosity of the output.
+  -c, --config=<value>      [env: SHOPIFY_FLAG_APP_CONFIG] The name of the app configuration.
+  -j, --json                [env: SHOPIFY_FLAG_JSON] Output the result as JSON. Automatically disables color output.
+      --auth-alias=<value>  [env: SHOPIFY_FLAG_AUTH_ALIAS] Alias of the Shopify account to use for authentication.
+      --client-id=<value>   [env: SHOPIFY_FLAG_CLIENT_ID] The Client ID of your app.
+      --no-color            [env: SHOPIFY_FLAG_NO_COLOR] Disable color output.
+      --path=<value>        [env: SHOPIFY_FLAG_PATH] The path to your app directory.
+      --reset               [env: SHOPIFY_FLAG_RESET] Reset all your settings.
+      --verbose             [env: SHOPIFY_FLAG_VERBOSE] Increase the verbosity of the output.
 
 DESCRIPTION
   Validate your app configuration and extensions.
@@ -348,9 +359,9 @@ Deploy your Shopify app.
 
 ```
 USAGE
-  $ shopify app deploy [--client-id <value> | -c <value>] [--message <value>] [--no-build] [--no-color]
-    [--no-release | --allow-updates | --allow-deletes] [--path <value>] [--reset | ] [--source-control-url <value>]
-    [--verbose] [--version <value>]
+  $ shopify app deploy [--auth-alias <value>] [--client-id <value> | -c <value>] [--message <value>]
+    [--no-build] [--no-color] [--no-release | --allow-updates | --allow-deletes] [--path <value>] [--reset | ]
+    [--source-control-url <value>] [--verbose] [--version <value>]
 
 FLAGS
   -c, --config=<value>              [env: SHOPIFY_FLAG_APP_CONFIG] The name of the app configuration.
@@ -360,6 +371,8 @@ FLAGS
       --allow-updates               [env: SHOPIFY_FLAG_ALLOW_UPDATES] Allows adding and updating extensions and
                                     configuration without requiring user confirmation. Recommended option for CI/CD
                                     environments.
+      --auth-alias=<value>          [env: SHOPIFY_FLAG_AUTH_ALIAS] Alias of the Shopify account to use for
+                                    authentication.
       --client-id=<value>           [env: SHOPIFY_FLAG_CLIENT_ID] The Client ID of your app.
       --message=<value>             [env: SHOPIFY_FLAG_MESSAGE] Optional message that will be associated with this
                                     version. This is for internal use only and won't be available externally.
@@ -396,8 +409,8 @@ Run the app.
 
 ```
 USAGE
-  $ shopify app dev [--checkout-cart-url <value>] [--client-id <value> | -c <value>] [--localhost-port
-    <value>] [--no-color] [--no-update] [--notify <value>] [--path <value>] [--reset | ]
+  $ shopify app dev [--auth-alias <value>] [--checkout-cart-url <value>] [--client-id <value> | -c <value>]
+    [--localhost-port <value>] [--no-color] [--no-update] [--notify <value>] [--path <value>] [--reset | ]
     [--skip-dependencies-installation] [-s <value>] [--subscription-product-url <value>] [-t <value>]
     [--theme-app-extension-port <value>] [--use-localhost | [--tunnel-url <value> | ]] [--verbose]
 
@@ -407,6 +420,8 @@ FLAGS
                                           Shopify Plus sandbox store.
   -t, --theme=<value>                     [env: SHOPIFY_FLAG_THEME] Theme ID or name of the theme app extension host
                                           theme.
+      --auth-alias=<value>                [env: SHOPIFY_FLAG_AUTH_ALIAS] Alias of the Shopify account to use for
+                                          authentication.
       --checkout-cart-url=<value>         [env: SHOPIFY_FLAG_CHECKOUT_CART_URL] Resource URL for checkout UI extension.
                                           Format: "/cart/{productVariantID}:{productQuantity}"
       --client-id=<value>                 [env: SHOPIFY_FLAG_CLIENT_ID] The Client ID of your app.
@@ -446,17 +461,18 @@ Cleans up the dev preview from the selected store.
 
 ```
 USAGE
-  $ shopify app dev clean [--client-id <value> | -c <value>] [--no-color] [--path <value>] [--reset | ] [-s
-    <value>] [--verbose]
+  $ shopify app dev clean [--auth-alias <value>] [--client-id <value> | -c <value>] [--no-color] [--path <value>]
+    [--reset | ] [-s <value>] [--verbose]
 
 FLAGS
-  -c, --config=<value>     [env: SHOPIFY_FLAG_APP_CONFIG] The name of the app configuration.
-  -s, --store=<value>      [env: SHOPIFY_FLAG_STORE] Store URL. Must be an existing development store.
-      --client-id=<value>  [env: SHOPIFY_FLAG_CLIENT_ID] The Client ID of your app.
-      --no-color           [env: SHOPIFY_FLAG_NO_COLOR] Disable color output.
-      --path=<value>       [env: SHOPIFY_FLAG_PATH] The path to your app directory.
-      --reset              [env: SHOPIFY_FLAG_RESET] Reset all your settings.
-      --verbose            [env: SHOPIFY_FLAG_VERBOSE] Increase the verbosity of the output.
+  -c, --config=<value>      [env: SHOPIFY_FLAG_APP_CONFIG] The name of the app configuration.
+  -s, --store=<value>       [env: SHOPIFY_FLAG_STORE] Store URL. Must be an existing development store.
+      --auth-alias=<value>  [env: SHOPIFY_FLAG_AUTH_ALIAS] Alias of the Shopify account to use for authentication.
+      --client-id=<value>   [env: SHOPIFY_FLAG_CLIENT_ID] The Client ID of your app.
+      --no-color            [env: SHOPIFY_FLAG_NO_COLOR] Disable color output.
+      --path=<value>        [env: SHOPIFY_FLAG_PATH] The path to your app directory.
+      --reset               [env: SHOPIFY_FLAG_RESET] Reset all your settings.
+      --verbose             [env: SHOPIFY_FLAG_VERBOSE] Increase the verbosity of the output.
 
 DESCRIPTION
   Cleans up the dev preview from the selected store.
@@ -472,17 +488,18 @@ Pull app and extensions environment variables.
 
 ```
 USAGE
-  $ shopify app env pull [--client-id <value> | -c <value>] [--env-file <value>] [--no-color] [--path <value>]
-    [--reset | ] [--verbose]
+  $ shopify app env pull [--auth-alias <value>] [--client-id <value> | -c <value>] [--env-file <value>]
+    [--no-color] [--path <value>] [--reset | ] [--verbose]
 
 FLAGS
-  -c, --config=<value>     [env: SHOPIFY_FLAG_APP_CONFIG] The name of the app configuration.
-      --client-id=<value>  [env: SHOPIFY_FLAG_CLIENT_ID] The Client ID of your app.
-      --env-file=<value>   [env: SHOPIFY_FLAG_ENV_FILE] Specify an environment file to update if the update flag is set
-      --no-color           [env: SHOPIFY_FLAG_NO_COLOR] Disable color output.
-      --path=<value>       [env: SHOPIFY_FLAG_PATH] The path to your app directory.
-      --reset              [env: SHOPIFY_FLAG_RESET] Reset all your settings.
-      --verbose            [env: SHOPIFY_FLAG_VERBOSE] Increase the verbosity of the output.
+  -c, --config=<value>      [env: SHOPIFY_FLAG_APP_CONFIG] The name of the app configuration.
+      --auth-alias=<value>  [env: SHOPIFY_FLAG_AUTH_ALIAS] Alias of the Shopify account to use for authentication.
+      --client-id=<value>   [env: SHOPIFY_FLAG_CLIENT_ID] The Client ID of your app.
+      --env-file=<value>    [env: SHOPIFY_FLAG_ENV_FILE] Specify an environment file to update if the update flag is set
+      --no-color            [env: SHOPIFY_FLAG_NO_COLOR] Disable color output.
+      --path=<value>        [env: SHOPIFY_FLAG_PATH] The path to your app directory.
+      --reset               [env: SHOPIFY_FLAG_RESET] Reset all your settings.
+      --verbose             [env: SHOPIFY_FLAG_VERBOSE] Increase the verbosity of the output.
 
 DESCRIPTION
   Pull app and extensions environment variables.
@@ -499,15 +516,17 @@ Display app and extensions environment variables.
 
 ```
 USAGE
-  $ shopify app env show [--client-id <value> | -c <value>] [--no-color] [--path <value>] [--reset | ] [--verbose]
+  $ shopify app env show [--auth-alias <value>] [--client-id <value> | -c <value>] [--no-color] [--path <value>]
+    [--reset | ] [--verbose]
 
 FLAGS
-  -c, --config=<value>     [env: SHOPIFY_FLAG_APP_CONFIG] The name of the app configuration.
-      --client-id=<value>  [env: SHOPIFY_FLAG_CLIENT_ID] The Client ID of your app.
-      --no-color           [env: SHOPIFY_FLAG_NO_COLOR] Disable color output.
-      --path=<value>       [env: SHOPIFY_FLAG_PATH] The path to your app directory.
-      --reset              [env: SHOPIFY_FLAG_RESET] Reset all your settings.
-      --verbose            [env: SHOPIFY_FLAG_VERBOSE] Increase the verbosity of the output.
+  -c, --config=<value>      [env: SHOPIFY_FLAG_APP_CONFIG] The name of the app configuration.
+      --auth-alias=<value>  [env: SHOPIFY_FLAG_AUTH_ALIAS] Alias of the Shopify account to use for authentication.
+      --client-id=<value>   [env: SHOPIFY_FLAG_CLIENT_ID] The Client ID of your app.
+      --no-color            [env: SHOPIFY_FLAG_NO_COLOR] Disable color output.
+      --path=<value>        [env: SHOPIFY_FLAG_PATH] The path to your app directory.
+      --reset               [env: SHOPIFY_FLAG_RESET] Reset all your settings.
+      --verbose             [env: SHOPIFY_FLAG_VERBOSE] Increase the verbosity of the output.
 
 DESCRIPTION
   Display app and extensions environment variables.
@@ -521,9 +540,9 @@ Execute GraphQL queries and mutations.
 
 ```
 USAGE
-  $ shopify app execute [--client-id <value> | -c <value>] [--no-color] [--output-file <value>] [--path <value>]
-    [-q <value>] [--query-file <value>] [--reset | ] [-s <value>] [--variable-file <value> | -v <value>] [--verbose]
-    [--version <value>]
+  $ shopify app execute [--auth-alias <value>] [--client-id <value> | -c <value>] [--no-color] [--output-file
+    <value>] [--path <value>] [-q <value>] [--query-file <value>] [--reset | ] [-s <value>] [--variable-file <value> |
+    -v <value>] [--verbose] [--version <value>]
 
 FLAGS
   -c, --config=<value>         [env: SHOPIFY_FLAG_APP_CONFIG] The name of the app configuration.
@@ -533,6 +552,7 @@ FLAGS
                                store.
   -v, --variables=<value>      [env: SHOPIFY_FLAG_VARIABLES] The values for any GraphQL variables in your query or
                                mutation, in JSON format.
+      --auth-alias=<value>     [env: SHOPIFY_FLAG_AUTH_ALIAS] Alias of the Shopify account to use for authentication.
       --client-id=<value>      [env: SHOPIFY_FLAG_CLIENT_ID] The Client ID of your app.
       --no-color               [env: SHOPIFY_FLAG_NO_COLOR] Disable color output.
       --output-file=<value>    [env: SHOPIFY_FLAG_OUTPUT_FILE] The file name where results should be written, instead of
@@ -562,15 +582,17 @@ Compile a function to wasm.
 
 ```
 USAGE
-  $ shopify app function build [--client-id <value> | -c <value>] [--no-color] [--path <value>] [--reset | ] [--verbose]
+  $ shopify app function build [--auth-alias <value>] [--client-id <value> | -c <value>] [--no-color] [--path <value>]
+    [--reset | ] [--verbose]
 
 FLAGS
-  -c, --config=<value>     [env: SHOPIFY_FLAG_APP_CONFIG] The name of the app configuration.
-      --client-id=<value>  [env: SHOPIFY_FLAG_CLIENT_ID] The Client ID of your app.
-      --no-color           [env: SHOPIFY_FLAG_NO_COLOR] Disable color output.
-      --path=<value>       [env: SHOPIFY_FLAG_PATH] The path to your function directory.
-      --reset              [env: SHOPIFY_FLAG_RESET] Reset all your settings.
-      --verbose            [env: SHOPIFY_FLAG_VERBOSE] Increase the verbosity of the output.
+  -c, --config=<value>      [env: SHOPIFY_FLAG_APP_CONFIG] The name of the app configuration.
+      --auth-alias=<value>  [env: SHOPIFY_FLAG_AUTH_ALIAS] Alias of the Shopify account to use for authentication.
+      --client-id=<value>   [env: SHOPIFY_FLAG_CLIENT_ID] The Client ID of your app.
+      --no-color            [env: SHOPIFY_FLAG_NO_COLOR] Disable color output.
+      --path=<value>        [env: SHOPIFY_FLAG_PATH] The path to your function directory.
+      --reset               [env: SHOPIFY_FLAG_RESET] Reset all your settings.
+      --verbose             [env: SHOPIFY_FLAG_VERBOSE] Increase the verbosity of the output.
 
 DESCRIPTION
   Compile a function to wasm.
@@ -584,17 +606,18 @@ Print basic information about your function.
 
 ```
 USAGE
-  $ shopify app function info [--client-id <value> | -c <value>] [-j] [--no-color] [--path <value>] [--reset | ]
-    [--verbose]
+  $ shopify app function info [--auth-alias <value>] [--client-id <value> | -c <value>] [-j] [--no-color] [--path
+    <value>] [--reset | ] [--verbose]
 
 FLAGS
-  -c, --config=<value>     [env: SHOPIFY_FLAG_APP_CONFIG] The name of the app configuration.
-  -j, --json               [env: SHOPIFY_FLAG_JSON] Output the result as JSON. Automatically disables color output.
-      --client-id=<value>  [env: SHOPIFY_FLAG_CLIENT_ID] The Client ID of your app.
-      --no-color           [env: SHOPIFY_FLAG_NO_COLOR] Disable color output.
-      --path=<value>       [env: SHOPIFY_FLAG_PATH] The path to your function directory.
-      --reset              [env: SHOPIFY_FLAG_RESET] Reset all your settings.
-      --verbose            [env: SHOPIFY_FLAG_VERBOSE] Increase the verbosity of the output.
+  -c, --config=<value>      [env: SHOPIFY_FLAG_APP_CONFIG] The name of the app configuration.
+  -j, --json                [env: SHOPIFY_FLAG_JSON] Output the result as JSON. Automatically disables color output.
+      --auth-alias=<value>  [env: SHOPIFY_FLAG_AUTH_ALIAS] Alias of the Shopify account to use for authentication.
+      --client-id=<value>   [env: SHOPIFY_FLAG_CLIENT_ID] The Client ID of your app.
+      --no-color            [env: SHOPIFY_FLAG_NO_COLOR] Disable color output.
+      --path=<value>        [env: SHOPIFY_FLAG_PATH] The path to your function directory.
+      --reset               [env: SHOPIFY_FLAG_RESET] Reset all your settings.
+      --verbose             [env: SHOPIFY_FLAG_VERBOSE] Increase the verbosity of the output.
 
 DESCRIPTION
   Print basic information about your function.
@@ -616,21 +639,22 @@ Replays a function run from an app log.
 
 ```
 USAGE
-  $ shopify app function replay [--client-id <value> | -c <value>] [-j] [-l <value>] [--no-color] [--path <value>]
-    [--reset | ] [--verbose] [-w]
+  $ shopify app function replay [--auth-alias <value>] [--client-id <value> | -c <value>] [-j] [-l <value>] [--no-color]
+    [--path <value>] [--reset | ] [--verbose] [-w]
 
 FLAGS
-  -c, --config=<value>     [env: SHOPIFY_FLAG_APP_CONFIG] The name of the app configuration.
-  -j, --json               [env: SHOPIFY_FLAG_JSON] Output the result as JSON. Automatically disables color output.
-  -l, --log=<value>        [env: SHOPIFY_FLAG_LOG] Specifies a log identifier to replay instead of selecting from a
-                           list. The identifier is provided in the output of `shopify app dev` and is the suffix of the
-                           log file name.
-  -w, --[no-]watch         [env: SHOPIFY_FLAG_WATCH] Re-run the function when the source code changes.
-      --client-id=<value>  [env: SHOPIFY_FLAG_CLIENT_ID] The Client ID of your app.
-      --no-color           [env: SHOPIFY_FLAG_NO_COLOR] Disable color output.
-      --path=<value>       [env: SHOPIFY_FLAG_PATH] The path to your function directory.
-      --reset              [env: SHOPIFY_FLAG_RESET] Reset all your settings.
-      --verbose            [env: SHOPIFY_FLAG_VERBOSE] Increase the verbosity of the output.
+  -c, --config=<value>      [env: SHOPIFY_FLAG_APP_CONFIG] The name of the app configuration.
+  -j, --json                [env: SHOPIFY_FLAG_JSON] Output the result as JSON. Automatically disables color output.
+  -l, --log=<value>         [env: SHOPIFY_FLAG_LOG] Specifies a log identifier to replay instead of selecting from a
+                            list. The identifier is provided in the output of `shopify app dev` and is the suffix of the
+                            log file name.
+  -w, --[no-]watch          [env: SHOPIFY_FLAG_WATCH] Re-run the function when the source code changes.
+      --auth-alias=<value>  [env: SHOPIFY_FLAG_AUTH_ALIAS] Alias of the Shopify account to use for authentication.
+      --client-id=<value>   [env: SHOPIFY_FLAG_CLIENT_ID] The Client ID of your app.
+      --no-color            [env: SHOPIFY_FLAG_NO_COLOR] Disable color output.
+      --path=<value>        [env: SHOPIFY_FLAG_PATH] The path to your function directory.
+      --reset               [env: SHOPIFY_FLAG_RESET] Reset all your settings.
+      --verbose             [env: SHOPIFY_FLAG_VERBOSE] Increase the verbosity of the output.
 
 DESCRIPTION
   Replays a function run from an app log.
@@ -646,20 +670,21 @@ Run a function locally for testing.
 
 ```
 USAGE
-  $ shopify app function run [--client-id <value> | -c <value>] [-e <value>] [-i <value>] [-j] [--no-color] [--path
-    <value>] [--reset | ] [--verbose]
+  $ shopify app function run [--auth-alias <value>] [--client-id <value> | -c <value>] [-e <value>] [-i <value>] [-j]
+    [--no-color] [--path <value>] [--reset | ] [--verbose]
 
 FLAGS
-  -c, --config=<value>     [env: SHOPIFY_FLAG_APP_CONFIG] The name of the app configuration.
-  -e, --export=<value>     [env: SHOPIFY_FLAG_EXPORT] Name of the WebAssembly export to invoke.
-  -i, --input=<value>      [env: SHOPIFY_FLAG_INPUT] The input JSON to pass to the function. If omitted, standard input
-                           is used.
-  -j, --json               [env: SHOPIFY_FLAG_JSON] Output the result as JSON. Automatically disables color output.
-      --client-id=<value>  [env: SHOPIFY_FLAG_CLIENT_ID] The Client ID of your app.
-      --no-color           [env: SHOPIFY_FLAG_NO_COLOR] Disable color output.
-      --path=<value>       [env: SHOPIFY_FLAG_PATH] The path to your function directory.
-      --reset              [env: SHOPIFY_FLAG_RESET] Reset all your settings.
-      --verbose            [env: SHOPIFY_FLAG_VERBOSE] Increase the verbosity of the output.
+  -c, --config=<value>      [env: SHOPIFY_FLAG_APP_CONFIG] The name of the app configuration.
+  -e, --export=<value>      [env: SHOPIFY_FLAG_EXPORT] Name of the WebAssembly export to invoke.
+  -i, --input=<value>       [env: SHOPIFY_FLAG_INPUT] The input JSON to pass to the function. If omitted, standard input
+                            is used.
+  -j, --json                [env: SHOPIFY_FLAG_JSON] Output the result as JSON. Automatically disables color output.
+      --auth-alias=<value>  [env: SHOPIFY_FLAG_AUTH_ALIAS] Alias of the Shopify account to use for authentication.
+      --client-id=<value>   [env: SHOPIFY_FLAG_CLIENT_ID] The Client ID of your app.
+      --no-color            [env: SHOPIFY_FLAG_NO_COLOR] Disable color output.
+      --path=<value>        [env: SHOPIFY_FLAG_PATH] The path to your function directory.
+      --reset               [env: SHOPIFY_FLAG_RESET] Reset all your settings.
+      --verbose             [env: SHOPIFY_FLAG_VERBOSE] Increase the verbosity of the output.
 
 DESCRIPTION
   Run a function locally for testing.
@@ -675,17 +700,18 @@ Fetch the latest GraphQL schema for a function.
 
 ```
 USAGE
-  $ shopify app function schema [--client-id <value> | -c <value>] [--no-color] [--path <value>] [--reset | ] [--stdout]
-    [--verbose]
+  $ shopify app function schema [--auth-alias <value>] [--client-id <value> | -c <value>] [--no-color] [--path <value>]
+    [--reset | ] [--stdout] [--verbose]
 
 FLAGS
-  -c, --config=<value>     [env: SHOPIFY_FLAG_APP_CONFIG] The name of the app configuration.
-      --client-id=<value>  [env: SHOPIFY_FLAG_CLIENT_ID] The Client ID of your app.
-      --no-color           [env: SHOPIFY_FLAG_NO_COLOR] Disable color output.
-      --path=<value>       [env: SHOPIFY_FLAG_PATH] The path to your function directory.
-      --reset              [env: SHOPIFY_FLAG_RESET] Reset all your settings.
-      --stdout             [env: SHOPIFY_FLAG_STDOUT] Output the schema to stdout instead of writing to a file.
-      --verbose            [env: SHOPIFY_FLAG_VERBOSE] Increase the verbosity of the output.
+  -c, --config=<value>      [env: SHOPIFY_FLAG_APP_CONFIG] The name of the app configuration.
+      --auth-alias=<value>  [env: SHOPIFY_FLAG_AUTH_ALIAS] Alias of the Shopify account to use for authentication.
+      --client-id=<value>   [env: SHOPIFY_FLAG_CLIENT_ID] The Client ID of your app.
+      --no-color            [env: SHOPIFY_FLAG_NO_COLOR] Disable color output.
+      --path=<value>        [env: SHOPIFY_FLAG_PATH] The path to your function directory.
+      --reset               [env: SHOPIFY_FLAG_RESET] Reset all your settings.
+      --stdout              [env: SHOPIFY_FLAG_STDOUT] Output the schema to stdout instead of writing to a file.
+      --verbose             [env: SHOPIFY_FLAG_VERBOSE] Increase the verbosity of the output.
 
 DESCRIPTION
   Fetch the latest GraphQL schema for a function.
@@ -703,16 +729,17 @@ Generate GraphQL types for a function.
 
 ```
 USAGE
-  $ shopify app function typegen [--client-id <value> | -c <value>] [--no-color] [--path <value>] [--reset | ]
-  [--verbose]
+  $ shopify app function typegen [--auth-alias <value>] [--client-id <value> | -c <value>] [--no-color] [--path <value>]
+    [--reset | ] [--verbose]
 
 FLAGS
-  -c, --config=<value>     [env: SHOPIFY_FLAG_APP_CONFIG] The name of the app configuration.
-      --client-id=<value>  [env: SHOPIFY_FLAG_CLIENT_ID] The Client ID of your app.
-      --no-color           [env: SHOPIFY_FLAG_NO_COLOR] Disable color output.
-      --path=<value>       [env: SHOPIFY_FLAG_PATH] The path to your function directory.
-      --reset              [env: SHOPIFY_FLAG_RESET] Reset all your settings.
-      --verbose            [env: SHOPIFY_FLAG_VERBOSE] Increase the verbosity of the output.
+  -c, --config=<value>      [env: SHOPIFY_FLAG_APP_CONFIG] The name of the app configuration.
+      --auth-alias=<value>  [env: SHOPIFY_FLAG_AUTH_ALIAS] Alias of the Shopify account to use for authentication.
+      --client-id=<value>   [env: SHOPIFY_FLAG_CLIENT_ID] The Client ID of your app.
+      --no-color            [env: SHOPIFY_FLAG_NO_COLOR] Disable color output.
+      --path=<value>        [env: SHOPIFY_FLAG_PATH] The path to your function directory.
+      --reset               [env: SHOPIFY_FLAG_RESET] Reset all your settings.
+      --verbose             [env: SHOPIFY_FLAG_VERBOSE] Increase the verbosity of the output.
 
 DESCRIPTION
   Generate GraphQL types for a function.
@@ -727,21 +754,22 @@ Generate a new app Extension.
 
 ```
 USAGE
-  $ shopify app generate extension [--client-id <value> | -c <value>] [--flavor
+  $ shopify app generate extension [--auth-alias <value>] [--client-id <value> | -c <value>] [--flavor
     vanilla-js|react|typescript|typescript-react|wasm|rust] [-n <value>] [--no-color] [--path <value>] [--reset | ] [-t
     <value>] [--verbose]
 
 FLAGS
-  -c, --config=<value>     [env: SHOPIFY_FLAG_APP_CONFIG] The name of the app configuration.
-  -n, --name=<value>       [env: SHOPIFY_FLAG_NAME] name of your Extension
-  -t, --template=<value>   [env: SHOPIFY_FLAG_EXTENSION_TEMPLATE] Extension template
-      --client-id=<value>  [env: SHOPIFY_FLAG_CLIENT_ID] The Client ID of your app.
-      --flavor=<option>    [env: SHOPIFY_FLAG_FLAVOR] Choose a starting template for your extension, where applicable
-                           <options: vanilla-js|react|typescript|typescript-react|wasm|rust>
-      --no-color           [env: SHOPIFY_FLAG_NO_COLOR] Disable color output.
-      --path=<value>       [env: SHOPIFY_FLAG_PATH] The path to your app directory.
-      --reset              [env: SHOPIFY_FLAG_RESET] Reset all your settings.
-      --verbose            [env: SHOPIFY_FLAG_VERBOSE] Increase the verbosity of the output.
+  -c, --config=<value>      [env: SHOPIFY_FLAG_APP_CONFIG] The name of the app configuration.
+  -n, --name=<value>        [env: SHOPIFY_FLAG_NAME] name of your Extension
+  -t, --template=<value>    [env: SHOPIFY_FLAG_EXTENSION_TEMPLATE] Extension template
+      --auth-alias=<value>  [env: SHOPIFY_FLAG_AUTH_ALIAS] Alias of the Shopify account to use for authentication.
+      --client-id=<value>   [env: SHOPIFY_FLAG_CLIENT_ID] The Client ID of your app.
+      --flavor=<option>     [env: SHOPIFY_FLAG_FLAVOR] Choose a starting template for your extension, where applicable
+                            <options: vanilla-js|react|typescript|typescript-react|wasm|rust>
+      --no-color            [env: SHOPIFY_FLAG_NO_COLOR] Disable color output.
+      --path=<value>        [env: SHOPIFY_FLAG_PATH] The path to your app directory.
+      --reset               [env: SHOPIFY_FLAG_RESET] Reset all your settings.
+      --verbose             [env: SHOPIFY_FLAG_VERBOSE] Increase the verbosity of the output.
 
 DESCRIPTION
   Generate a new app Extension.
@@ -761,19 +789,20 @@ Import metafield and metaobject definitions.
 
 ```
 USAGE
-  $ shopify app import-custom-data-definitions [--client-id <value> | -c <value>] [--include-existing] [--no-color] [--path <value>]
-    [--reset | ] [-s <value>] [--verbose]
+  $ shopify app import-custom-data-definitions [--auth-alias <value>] [--client-id <value> | -c <value>] [--include-existing]
+    [--no-color] [--path <value>] [--reset | ] [-s <value>] [--verbose]
 
 FLAGS
-  -c, --config=<value>     [env: SHOPIFY_FLAG_APP_CONFIG] The name of the app configuration.
-  -s, --store=<value>      [env: SHOPIFY_FLAG_STORE] Store URL. Must be an existing development or Shopify Plus sandbox
-                           store.
-      --client-id=<value>  [env: SHOPIFY_FLAG_CLIENT_ID] The Client ID of your app.
-      --include-existing   [env: SHOPIFY_FLAG_INCLUDE_EXISTING] Include existing declared definitions in the output.
-      --no-color           [env: SHOPIFY_FLAG_NO_COLOR] Disable color output.
-      --path=<value>       [env: SHOPIFY_FLAG_PATH] The path to your app directory.
-      --reset              [env: SHOPIFY_FLAG_RESET] Reset all your settings.
-      --verbose            [env: SHOPIFY_FLAG_VERBOSE] Increase the verbosity of the output.
+  -c, --config=<value>      [env: SHOPIFY_FLAG_APP_CONFIG] The name of the app configuration.
+  -s, --store=<value>       [env: SHOPIFY_FLAG_STORE] Store URL. Must be an existing development or Shopify Plus sandbox
+                            store.
+      --auth-alias=<value>  [env: SHOPIFY_FLAG_AUTH_ALIAS] Alias of the Shopify account to use for authentication.
+      --client-id=<value>   [env: SHOPIFY_FLAG_CLIENT_ID] The Client ID of your app.
+      --include-existing    [env: SHOPIFY_FLAG_INCLUDE_EXISTING] Include existing declared definitions in the output.
+      --no-color            [env: SHOPIFY_FLAG_NO_COLOR] Disable color output.
+      --path=<value>        [env: SHOPIFY_FLAG_PATH] The path to your app directory.
+      --reset               [env: SHOPIFY_FLAG_RESET] Reset all your settings.
+      --verbose             [env: SHOPIFY_FLAG_VERBOSE] Increase the verbosity of the output.
 
 DESCRIPTION
   Import metafield and metaobject definitions.
@@ -788,16 +817,17 @@ Import dashboard-managed extensions into your app.
 
 ```
 USAGE
-  $ shopify app import-extensions [--client-id <value> | -c <value>] [--no-color] [--path <value>] [--reset | ]
-  [--verbose]
+  $ shopify app import-extensions [--auth-alias <value>] [--client-id <value> | -c <value>] [--no-color] [--path <value>]
+    [--reset | ] [--verbose]
 
 FLAGS
-  -c, --config=<value>     [env: SHOPIFY_FLAG_APP_CONFIG] The name of the app configuration.
-      --client-id=<value>  [env: SHOPIFY_FLAG_CLIENT_ID] The Client ID of your app.
-      --no-color           [env: SHOPIFY_FLAG_NO_COLOR] Disable color output.
-      --path=<value>       [env: SHOPIFY_FLAG_PATH] The path to your app directory.
-      --reset              [env: SHOPIFY_FLAG_RESET] Reset all your settings.
-      --verbose            [env: SHOPIFY_FLAG_VERBOSE] Increase the verbosity of the output.
+  -c, --config=<value>      [env: SHOPIFY_FLAG_APP_CONFIG] The name of the app configuration.
+      --auth-alias=<value>  [env: SHOPIFY_FLAG_AUTH_ALIAS] Alias of the Shopify account to use for authentication.
+      --client-id=<value>   [env: SHOPIFY_FLAG_CLIENT_ID] The Client ID of your app.
+      --no-color            [env: SHOPIFY_FLAG_NO_COLOR] Disable color output.
+      --path=<value>        [env: SHOPIFY_FLAG_PATH] The path to your app directory.
+      --reset               [env: SHOPIFY_FLAG_RESET] Reset all your settings.
+      --verbose             [env: SHOPIFY_FLAG_VERBOSE] Increase the verbosity of the output.
 
 DESCRIPTION
   Import dashboard-managed extensions into your app.
@@ -809,19 +839,20 @@ Print basic information about your app and extensions.
 
 ```
 USAGE
-  $ shopify app info [--client-id <value> | -c <value>] [-j] [--no-color] [--path <value>] [--reset | ]
-    [--verbose] [--web-env]
+  $ shopify app info [--auth-alias <value>] [--client-id <value> | -c <value>] [-j] [--no-color] [--path
+    <value>] [--reset | ] [--verbose] [--web-env]
 
 FLAGS
-  -c, --config=<value>     [env: SHOPIFY_FLAG_APP_CONFIG] The name of the app configuration.
-  -j, --json               [env: SHOPIFY_FLAG_JSON] Output the result as JSON. Automatically disables color output.
-      --client-id=<value>  [env: SHOPIFY_FLAG_CLIENT_ID] The Client ID of your app.
-      --no-color           [env: SHOPIFY_FLAG_NO_COLOR] Disable color output.
-      --path=<value>       [env: SHOPIFY_FLAG_PATH] The path to your app directory.
-      --reset              [env: SHOPIFY_FLAG_RESET] Reset all your settings.
-      --verbose            [env: SHOPIFY_FLAG_VERBOSE] Increase the verbosity of the output.
-      --web-env            [env: SHOPIFY_FLAG_OUTPUT_WEB_ENV] Outputs environment variables necessary for running and
-                           deploying web/.
+  -c, --config=<value>      [env: SHOPIFY_FLAG_APP_CONFIG] The name of the app configuration.
+  -j, --json                [env: SHOPIFY_FLAG_JSON] Output the result as JSON. Automatically disables color output.
+      --auth-alias=<value>  [env: SHOPIFY_FLAG_AUTH_ALIAS] Alias of the Shopify account to use for authentication.
+      --client-id=<value>   [env: SHOPIFY_FLAG_CLIENT_ID] The Client ID of your app.
+      --no-color            [env: SHOPIFY_FLAG_NO_COLOR] Disable color output.
+      --path=<value>        [env: SHOPIFY_FLAG_PATH] The path to your app directory.
+      --reset               [env: SHOPIFY_FLAG_RESET] Reset all your settings.
+      --verbose             [env: SHOPIFY_FLAG_VERBOSE] Increase the verbosity of the output.
+      --web-env             [env: SHOPIFY_FLAG_OUTPUT_WEB_ENV] Outputs environment variables necessary for running and
+                            deploying web/.
 
 DESCRIPTION
   Print basic information about your app and extensions.
@@ -842,8 +873,8 @@ Create a new app project
 
 ```
 USAGE
-  $ shopify app init [--flavor <value>] [-n <value>] [--no-color] [--organization-id <value> | [--client-id
-    <value> | ]] [-d npm|yarn|pnpm|bun] [-p <value>] [--template <value>] [--verbose]
+  $ shopify app init [--auth-alias <value>] [--flavor <value>] [-n <value>] [--no-color] [--organization-id
+    <value> | [--client-id <value> | ]] [-d npm|yarn|pnpm|bun] [-p <value>] [--template <value>] [--verbose]
 
 FLAGS
   -d, --package-manager=<option>  [env: SHOPIFY_FLAG_PACKAGE_MANAGER]
@@ -851,6 +882,7 @@ FLAGS
   -n, --name=<value>              [env: SHOPIFY_FLAG_NAME] The name for the new app. When provided, skips the app
                                   selection prompt and creates a new app with this name.
   -p, --path=<value>              [default: ., env: SHOPIFY_FLAG_PATH]
+      --auth-alias=<value>        [env: SHOPIFY_FLAG_AUTH_ALIAS] Alias of the Shopify account to use for authentication.
       --client-id=<value>         [env: SHOPIFY_FLAG_CLIENT_ID] The Client ID of your app. Use this to automatically
                                   link your new project to an existing app. Using this flag avoids the app selection
                                   prompt.
@@ -871,22 +903,23 @@ Stream detailed logs for your Shopify app.
 
 ```
 USAGE
-  $ shopify app logs [--client-id <value> | -c <value>] [-j] [--no-color] [--path <value>] [--reset | ]
-    [--source <value>...] [--status success|failure] [-s <value>...] [--verbose]
+  $ shopify app logs [--auth-alias <value>] [--client-id <value> | -c <value>] [-j] [--no-color] [--path
+    <value>] [--reset | ] [--source <value>...] [--status success|failure] [-s <value>...] [--verbose]
 
 FLAGS
-  -c, --config=<value>     [env: SHOPIFY_FLAG_APP_CONFIG] The name of the app configuration.
-  -j, --json               [env: SHOPIFY_FLAG_JSON] Output the result as JSON. Automatically disables color output.
-  -s, --store=<value>...   [env: SHOPIFY_FLAG_STORE] Store URL. Must be an existing development or Shopify Plus sandbox
-                           store.
-      --client-id=<value>  [env: SHOPIFY_FLAG_CLIENT_ID] The Client ID of your app.
-      --no-color           [env: SHOPIFY_FLAG_NO_COLOR] Disable color output.
-      --path=<value>       [env: SHOPIFY_FLAG_PATH] The path to your app directory.
-      --reset              [env: SHOPIFY_FLAG_RESET] Reset all your settings.
-      --source=<value>...  [env: SHOPIFY_FLAG_SOURCE] Filters output to the specified log source.
-      --status=<option>    [env: SHOPIFY_FLAG_STATUS] Filters output to the specified status (success or failure).
-                           <options: success|failure>
-      --verbose            [env: SHOPIFY_FLAG_VERBOSE] Increase the verbosity of the output.
+  -c, --config=<value>      [env: SHOPIFY_FLAG_APP_CONFIG] The name of the app configuration.
+  -j, --json                [env: SHOPIFY_FLAG_JSON] Output the result as JSON. Automatically disables color output.
+  -s, --store=<value>...    [env: SHOPIFY_FLAG_STORE] Store URL. Must be an existing development or Shopify Plus sandbox
+                            store.
+      --auth-alias=<value>  [env: SHOPIFY_FLAG_AUTH_ALIAS] Alias of the Shopify account to use for authentication.
+      --client-id=<value>   [env: SHOPIFY_FLAG_CLIENT_ID] The Client ID of your app.
+      --no-color            [env: SHOPIFY_FLAG_NO_COLOR] Disable color output.
+      --path=<value>        [env: SHOPIFY_FLAG_PATH] The path to your app directory.
+      --reset               [env: SHOPIFY_FLAG_RESET] Reset all your settings.
+      --source=<value>...   [env: SHOPIFY_FLAG_SOURCE] Filters output to the specified log source.
+      --status=<option>     [env: SHOPIFY_FLAG_STATUS] Filters output to the specified status (success or failure).
+                            <options: success|failure>
+      --verbose             [env: SHOPIFY_FLAG_VERBOSE] Increase the verbosity of the output.
 
 DESCRIPTION
   Stream detailed logs for your Shopify app.
@@ -907,15 +940,17 @@ Print out a list of sources that may be used with the logs command.
 
 ```
 USAGE
-  $ shopify app logs sources [--client-id <value> | -c <value>] [--no-color] [--path <value>] [--reset | ] [--verbose]
+  $ shopify app logs sources [--auth-alias <value>] [--client-id <value> | -c <value>] [--no-color] [--path <value>]
+    [--reset | ] [--verbose]
 
 FLAGS
-  -c, --config=<value>     [env: SHOPIFY_FLAG_APP_CONFIG] The name of the app configuration.
-      --client-id=<value>  [env: SHOPIFY_FLAG_CLIENT_ID] The Client ID of your app.
-      --no-color           [env: SHOPIFY_FLAG_NO_COLOR] Disable color output.
-      --path=<value>       [env: SHOPIFY_FLAG_PATH] The path to your app directory.
-      --reset              [env: SHOPIFY_FLAG_RESET] Reset all your settings.
-      --verbose            [env: SHOPIFY_FLAG_VERBOSE] Increase the verbosity of the output.
+  -c, --config=<value>      [env: SHOPIFY_FLAG_APP_CONFIG] The name of the app configuration.
+      --auth-alias=<value>  [env: SHOPIFY_FLAG_AUTH_ALIAS] Alias of the Shopify account to use for authentication.
+      --client-id=<value>   [env: SHOPIFY_FLAG_CLIENT_ID] The Client ID of your app.
+      --no-color            [env: SHOPIFY_FLAG_NO_COLOR] Disable color output.
+      --path=<value>        [env: SHOPIFY_FLAG_PATH] The path to your app directory.
+      --reset               [env: SHOPIFY_FLAG_RESET] Reset all your settings.
+      --verbose             [env: SHOPIFY_FLAG_VERBOSE] Increase the verbosity of the output.
 
 DESCRIPTION
   Print out a list of sources that may be used with the logs command.
@@ -933,17 +968,19 @@ USAGE
   $ shopify app release --version <version>
 
 FLAGS
-  -c, --config=<value>     [env: SHOPIFY_FLAG_APP_CONFIG] The name of the app configuration.
-      --allow-deletes      [env: SHOPIFY_FLAG_ALLOW_DELETES] Allows removing extensions and configuration without
-                           requiring user confirmation. For CI/CD environments, the recommended flag is --allow-updates.
-      --allow-updates      [env: SHOPIFY_FLAG_ALLOW_UPDATES] Allows adding and updating extensions and configuration
-                           without requiring user confirmation. Recommended option for CI/CD environments.
-      --client-id=<value>  [env: SHOPIFY_FLAG_CLIENT_ID] The Client ID of your app.
-      --no-color           [env: SHOPIFY_FLAG_NO_COLOR] Disable color output.
-      --path=<value>       [env: SHOPIFY_FLAG_PATH] The path to your app directory.
-      --reset              [env: SHOPIFY_FLAG_RESET] Reset all your settings.
-      --verbose            [env: SHOPIFY_FLAG_VERBOSE] Increase the verbosity of the output.
-      --version=<value>    (required) [env: SHOPIFY_FLAG_VERSION] The name of the app version to release.
+  -c, --config=<value>      [env: SHOPIFY_FLAG_APP_CONFIG] The name of the app configuration.
+      --allow-deletes       [env: SHOPIFY_FLAG_ALLOW_DELETES] Allows removing extensions and configuration without
+                            requiring user confirmation. For CI/CD environments, the recommended flag is
+                            --allow-updates.
+      --allow-updates       [env: SHOPIFY_FLAG_ALLOW_UPDATES] Allows adding and updating extensions and configuration
+                            without requiring user confirmation. Recommended option for CI/CD environments.
+      --auth-alias=<value>  [env: SHOPIFY_FLAG_AUTH_ALIAS] Alias of the Shopify account to use for authentication.
+      --client-id=<value>   [env: SHOPIFY_FLAG_CLIENT_ID] The Client ID of your app.
+      --no-color            [env: SHOPIFY_FLAG_NO_COLOR] Disable color output.
+      --path=<value>        [env: SHOPIFY_FLAG_PATH] The path to your app directory.
+      --reset               [env: SHOPIFY_FLAG_RESET] Reset all your settings.
+      --verbose             [env: SHOPIFY_FLAG_VERBOSE] Increase the verbosity of the output.
+      --version=<value>     (required) [env: SHOPIFY_FLAG_VERSION] The name of the app version to release.
 
 DESCRIPTION
   Release an app version.
@@ -957,17 +994,18 @@ List deployed versions of your app.
 
 ```
 USAGE
-  $ shopify app versions list [--client-id <value> | -c <value>] [-j] [--no-color] [--path <value>] [--reset | ]
-    [--verbose]
+  $ shopify app versions list [--auth-alias <value>] [--client-id <value> | -c <value>] [-j] [--no-color] [--path
+    <value>] [--reset | ] [--verbose]
 
 FLAGS
-  -c, --config=<value>     [env: SHOPIFY_FLAG_APP_CONFIG] The name of the app configuration.
-  -j, --json               [env: SHOPIFY_FLAG_JSON] Output the result as JSON. Automatically disables color output.
-      --client-id=<value>  [env: SHOPIFY_FLAG_CLIENT_ID] The Client ID of your app.
-      --no-color           [env: SHOPIFY_FLAG_NO_COLOR] Disable color output.
-      --path=<value>       [env: SHOPIFY_FLAG_PATH] The path to your app directory.
-      --reset              [env: SHOPIFY_FLAG_RESET] Reset all your settings.
-      --verbose            [env: SHOPIFY_FLAG_VERBOSE] Increase the verbosity of the output.
+  -c, --config=<value>      [env: SHOPIFY_FLAG_APP_CONFIG] The name of the app configuration.
+  -j, --json                [env: SHOPIFY_FLAG_JSON] Output the result as JSON. Automatically disables color output.
+      --auth-alias=<value>  [env: SHOPIFY_FLAG_AUTH_ALIAS] Alias of the Shopify account to use for authentication.
+      --client-id=<value>   [env: SHOPIFY_FLAG_CLIENT_ID] The Client ID of your app.
+      --no-color            [env: SHOPIFY_FLAG_NO_COLOR] Disable color output.
+      --path=<value>        [env: SHOPIFY_FLAG_PATH] The path to your app directory.
+      --reset               [env: SHOPIFY_FLAG_RESET] Reset all your settings.
+      --verbose             [env: SHOPIFY_FLAG_VERBOSE] Increase the verbosity of the output.
 
 DESCRIPTION
   List deployed versions of your app.
@@ -981,9 +1019,9 @@ Trigger delivery of a sample webhook topic payload to a designated address.
 
 ```
 USAGE
-  $ shopify app webhook trigger [--address <value>] [--api-version <value>] [--client-id <value> | -c <value>]
-    [--client-secret <value>] [--delivery-method http|google-pub-sub|event-bridge] [--help] [--path <value>] [--reset |
-    ] [--topic <value>]
+  $ shopify app webhook trigger [--address <value>] [--api-version <value>] [--auth-alias <value>] [--client-id <value> |
+    -c <value>] [--client-secret <value>] [--delivery-method http|google-pub-sub|event-bridge] [--help] [--path <value>]
+    [--reset | ] [--topic <value>]
 
 FLAGS
   -c, --config=<value>
@@ -999,6 +1037,9 @@ FLAGS
 
   --api-version=<value>
       [env: SHOPIFY_FLAG_API_VERSION] The API Version of the webhook topic.
+
+  --auth-alias=<value>
+      [env: SHOPIFY_FLAG_AUTH_ALIAS] Alias of the Shopify account to use for authentication.
 
   --client-id=<value>
       [env: SHOPIFY_FLAG_CLIENT_ID] The Client ID of your app.
@@ -1415,29 +1456,25 @@ Builds and deploys a Hydrogen storefront to Oxygen.
 
 ```
 USAGE
-  $ shopify hydrogen deploy [--assets-dir <value>] [--auth-bypass-token-duration <value> --auth-bypass-token]
-    [--build-command <value>] [--entry <value>] [--env <value> | --env-branch <value>] [--env-file <value>] [-f]
-    [--force-client-sourcemap] [--json-output] [--lockfile-check] [--metadata-description <value>] [--metadata-user
-    <value>] [--no-verify] [--path <value>] [--preview] [-s <value>] [-t <value>] [--worker-dir <value>]
+  $ shopify hydrogen deploy [--auth-bypass-token-duration <value> --auth-bypass-token] [--build-command <value>]
+    [--entry <value>] [--env <value> | --env-branch <value>] [--env-file <value>] [-f] [--force-client-sourcemap]
+    [--json-output] [--lockfile-check] [--metadata-description <value>] [--metadata-user <value>] [--no-verify] [--path
+    <value>] [--preview] [-s <value>] [-t <value>]
 
 FLAGS
   -f, --force                               [env: SHOPIFY_HYDROGEN_FLAG_FORCE] Forces a deployment to proceed if there
-                                            are uncommitted changes in its Git repository.
+                                            are uncommited changes in its Git repository.
   -s, --shop=<value>                        [env: SHOPIFY_SHOP] Shop URL. It can be the shop prefix (janes-apparel) or
                                             the full myshopify.com URL (janes-apparel.myshopify.com,
                                             https://janes-apparel.myshopify.com).
   -t, --token=<value>                       [env: SHOPIFY_HYDROGEN_DEPLOYMENT_TOKEN] Oxygen deployment token. Defaults
                                             to the linked storefront's token if available.
-      --assets-dir=<value>                  [env: SHOPIFY_HYDROGEN_FLAG_ASSETS_DIR] Directory containing the client
-                                            assets to deploy, relative to the project root. Defaults to the detected
-                                            Vite client output directory, then falls back to `dist/client`.
       --auth-bypass-token                   [env: AUTH_BYPASS_TOKEN] Generate an authentication bypass token, which can
                                             be used to perform end-to-end tests against the deployment.
       --auth-bypass-token-duration=<value>  [env: AUTH_BYPASS_TOKEN_DURATION] Specify the duration (in hours) up to 12
                                             hours for the authentication bypass token. Defaults to `2`
-      --build-command=<value>               Specify a build command to run before deploying. If not specified, the
-                                            Hydrogen build pipeline will be used. When custom output directories are
-                                            configured, defaults to `node --run build`.
+      --build-command=<value>               Specify a build command to run before deploying. If not specified, `shopify
+                                            hydrogen build` will be used.
       --entry=<value>                       [env: SHOPIFY_HYDROGEN_FLAG_ENTRY] Entry file for the worker. Defaults to
                                             `./server`.
       --env=<value>                         Specifies the environment to perform the operation using its handle. Fetch
@@ -1456,17 +1493,13 @@ FLAGS
                                             `--no-lockfile-check`.
       --metadata-description=<value>        [env: SHOPIFY_HYDROGEN_FLAG_METADATA_DESCRIPTION] Description of the changes
                                             in the deployment. Defaults to the commit message of the latest commit if
-                                            there are no uncommitted changes.
+                                            there are no uncommited changes.
       --metadata-user=<value>               [env: SHOPIFY_HYDROGEN_FLAG_METADATA_USER] User that initiated the
                                             deployment. Will be saved and displayed in the Shopify admin
       --no-verify                           Skip the routability verification step after deployment.
       --path=<value>                        [env: SHOPIFY_HYDROGEN_FLAG_PATH] The path to the directory of the Hydrogen
                                             storefront. Defaults to the current directory where the command is run.
       --preview                             Deploys to the Preview environment.
-      --worker-dir=<value>                  [env: SHOPIFY_HYDROGEN_FLAG_WORKER_DIR] Directory containing the Oxygen
-                                            worker entry point (`index.js` or `index.mjs`), relative to the project
-                                            root. Defaults to the detected Vite server output directory, then falls back
-                                            to `dist/server`.
 
 DESCRIPTION
   Builds and deploys a Hydrogen storefront to Oxygen.
@@ -1587,14 +1620,15 @@ USAGE
     [--typescript]
 
 ARGUMENTS
-  ROUTENAME  (home|page|cart|products|collections|policies|blogs|account|search|robots|sitemap|all) The route to
-             generate. One of home,page,cart,products,collections,policies,blogs,account,search,robots,sitemap,all.
+  ROUTENAME  (home|page|cart|products|collections|policies|blogs|account|search|robots|sitemap|tokenlessApi|all) The
+             route to generate. One of
+             home,page,cart,products,collections,policies,blogs,account,search,robots,sitemap,tokenlessApi,all.
 
 FLAGS
   -f, --force                 [env: SHOPIFY_HYDROGEN_FLAG_FORCE] Overwrites the destination directory and files if they
                               already exist.
-      --adapter=<value>       [env: SHOPIFY_HYDROGEN_FLAG_ADAPTER] React Router adapter used in the route. The default
-                              is `react-router`.
+      --adapter=<value>       [env: SHOPIFY_HYDROGEN_FLAG_ADAPTER] Remix adapter used in the route. The default is
+                              `@shopify/remix-oxygen`.
       --locale-param=<value>  [env: SHOPIFY_HYDROGEN_FLAG_ADAPTER] The param name in Remix routes for the i18n locale,
                               if any. Example: `locale` becomes ($locale).
       --path=<value>          [env: SHOPIFY_HYDROGEN_FLAG_PATH] The path to the directory of the Hydrogen storefront.
@@ -1616,8 +1650,8 @@ USAGE
 FLAGS
   -f, --force                 [env: SHOPIFY_HYDROGEN_FLAG_FORCE] Overwrites the destination directory and files if they
                               already exist.
-      --adapter=<value>       [env: SHOPIFY_HYDROGEN_FLAG_ADAPTER] React Router adapter used in the route. The default
-                              is `react-router`.
+      --adapter=<value>       [env: SHOPIFY_HYDROGEN_FLAG_ADAPTER] Remix adapter used in the route. The default is
+                              `@shopify/remix-oxygen`.
       --locale-param=<value>  [env: SHOPIFY_HYDROGEN_FLAG_ADAPTER] The param name in Remix routes for the i18n locale,
                               if any. Example: `locale` becomes ($locale).
       --path=<value>          [env: SHOPIFY_HYDROGEN_FLAG_PATH] The path to the directory of the Hydrogen storefront.
@@ -2447,7 +2481,7 @@ FLAGS
   -e, --environment=<value>...  [env: SHOPIFY_FLAG_ENVIRONMENT] The environment to apply to the current command.
   -s, --store=<value>           [env: SHOPIFY_FLAG_STORE] Store URL. It can be the store prefix (example) or the full
                                 myshopify.com URL (example.myshopify.com, https://example.myshopify.com).
-      --alias=<value>           [env: SHOPIFY_FLAG_AUTH_ALIAS] Alias of the Shopify account to use for authentication.
+      --auth-alias=<value>      [env: SHOPIFY_FLAG_AUTH_ALIAS] Alias of the Shopify account to use for authentication.
       --no-color                [env: SHOPIFY_FLAG_NO_COLOR] Disable color output.
       --password=<value>        [env: SHOPIFY_CLI_THEME_TOKEN] Password generated from the Theme Access app or an Admin
                                 API token.
@@ -2473,8 +2507,8 @@ Delete remote themes from the connected store. This command can't be undone.
 
 ```
 USAGE
-  $ shopify theme delete [--alias <value>] [-d] [-e <value>...] [-f] [--no-color] [--password <value>] [--path
-    <value>] [-a] [-s <value>] [-t <value>...] [--verbose]
+  $ shopify theme delete [--auth-alias <value>] [-d] [-e <value>...] [-f] [--no-color] [--password <value>]
+    [--path <value>] [-a] [-s <value>] [-t <value>...] [--verbose]
 
 FLAGS
   -a, --show-all                [env: SHOPIFY_FLAG_SHOW_ALL] Include others development themes in theme list.
@@ -2484,7 +2518,7 @@ FLAGS
   -s, --store=<value>           [env: SHOPIFY_FLAG_STORE] Store URL. It can be the store prefix (example) or the full
                                 myshopify.com URL (example.myshopify.com, https://example.myshopify.com).
   -t, --theme=<value>...        [env: SHOPIFY_FLAG_THEME_ID] Theme ID or name of the remote theme.
-      --alias=<value>           [env: SHOPIFY_FLAG_AUTH_ALIAS] Alias of the Shopify account to use for authentication.
+      --auth-alias=<value>      [env: SHOPIFY_FLAG_AUTH_ALIAS] Alias of the Shopify account to use for authentication.
       --no-color                [env: SHOPIFY_FLAG_NO_COLOR] Disable color output.
       --password=<value>        [env: SHOPIFY_CLI_THEME_TOKEN] Password generated from the Theme Access app or an Admin
                                 API token.
@@ -2510,10 +2544,10 @@ Uploads the current theme as a development theme to the connected store, then pr
 
 ```
 USAGE
-  $ shopify theme dev [--alias <value>] [-a] [-e <value>...] [--error-overlay silent|default] [--host <value>]
-    [-x <value>...] [--listing <value>] [--live-reload hot-reload|full-page|off] [--no-color] [-n] [--notify <value>]
-    [-o <value>...] [--open] [--password <value>] [--path <value>] [--port <value>] [--standard-events-inspector] [-s
-    <value>] [--store-password <value>] [-t <value>] [--theme-editor-sync] [--verbose]
+  $ shopify theme dev [-a] [--auth-alias <value>] [-e <value>...] [--error-overlay silent|default] [--host
+    <value>] [-x <value>...] [--listing <value>] [--live-reload hot-reload|full-page|off] [--no-color] [-n] [--notify
+    <value>] [-o <value>...] [--open] [--password <value>] [--path <value>] [--port <value>]
+    [--standard-events-inspector] [-s <value>] [--store-password <value>] [-t <value>] [--theme-editor-sync] [--verbose]
 
 FLAGS
   -a, --allow-live
@@ -2540,7 +2574,7 @@ FLAGS
   -x, --ignore=<value>...
       [env: SHOPIFY_FLAG_IGNORE] Skip hot reloading any files that match the specified pattern.
 
-  --alias=<value>
+  --auth-alias=<value>
       [env: SHOPIFY_FLAG_AUTH_ALIAS] Alias of the Shopify account to use for authentication.
 
   --error-overlay=<option>
@@ -2650,7 +2684,7 @@ FLAGS
   -s, --store=<value>           [env: SHOPIFY_FLAG_STORE] Store URL. It can be the store prefix (example) or the full
                                 myshopify.com URL (example.myshopify.com, https://example.myshopify.com).
   -t, --theme=<value>           [env: SHOPIFY_FLAG_THEME_ID] Theme ID or name of the remote theme.
-      --alias=<value>           [env: SHOPIFY_FLAG_AUTH_ALIAS] Alias of the Shopify account to use for authentication.
+      --auth-alias=<value>      [env: SHOPIFY_FLAG_AUTH_ALIAS] Alias of the Shopify account to use for authentication.
       --no-color                [env: SHOPIFY_FLAG_NO_COLOR] Disable color output.
       --password=<value>        [env: SHOPIFY_CLI_THEME_TOKEN] Password generated from the Theme Access app or an Admin
                                 API token.
@@ -2700,8 +2734,8 @@ Displays information about your theme environment, including your current store.
 
 ```
 USAGE
-  $ shopify theme info [--alias <value>] [-d] [-e <value>...] [-j] [--no-color] [--password <value>] [--path
-    <value>] [-s <value>] [-t <value>] [--verbose]
+  $ shopify theme info [--auth-alias <value>] [-d] [-e <value>...] [-j] [--no-color] [--password <value>]
+    [--path <value>] [-s <value>] [-t <value>] [--verbose]
 
 FLAGS
   -d, --development             [env: SHOPIFY_FLAG_DEVELOPMENT] Retrieve info from your development theme.
@@ -2710,7 +2744,7 @@ FLAGS
   -s, --store=<value>           [env: SHOPIFY_FLAG_STORE] Store URL. It can be the store prefix (example) or the full
                                 myshopify.com URL (example.myshopify.com, https://example.myshopify.com).
   -t, --theme=<value>           [env: SHOPIFY_FLAG_THEME_ID] Theme ID or name of the remote theme.
-      --alias=<value>           [env: SHOPIFY_FLAG_AUTH_ALIAS] Alias of the Shopify account to use for authentication.
+      --auth-alias=<value>      [env: SHOPIFY_FLAG_AUTH_ALIAS] Alias of the Shopify account to use for authentication.
       --no-color                [env: SHOPIFY_FLAG_NO_COLOR] Disable color output.
       --password=<value>        [env: SHOPIFY_CLI_THEME_TOKEN] Password generated from the Theme Access app or an Admin
                                 API token.
@@ -2781,7 +2815,7 @@ Lists the themes in your store, along with their IDs and statuses.
 
 ```
 USAGE
-  $ shopify theme list [--alias <value>] [-e <value>...] [--id <value>] [-j] [--name <value>] [--no-color]
+  $ shopify theme list [--auth-alias <value>] [-e <value>...] [--id <value>] [-j] [--name <value>] [--no-color]
     [--password <value>] [--path <value>] [--role live|unpublished|development] [-s <value>] [--verbose]
 
 FLAGS
@@ -2789,7 +2823,7 @@ FLAGS
   -j, --json                    [env: SHOPIFY_FLAG_JSON] Output the result as JSON. Automatically disables color output.
   -s, --store=<value>           [env: SHOPIFY_FLAG_STORE] Store URL. It can be the store prefix (example) or the full
                                 myshopify.com URL (example.myshopify.com, https://example.myshopify.com).
-      --alias=<value>           [env: SHOPIFY_FLAG_AUTH_ALIAS] Alias of the Shopify account to use for authentication.
+      --auth-alias=<value>      [env: SHOPIFY_FLAG_AUTH_ALIAS] Alias of the Shopify account to use for authentication.
       --id=<value>              [env: SHOPIFY_FLAG_ID] Only list theme with the given ID.
       --name=<value>            [env: SHOPIFY_FLAG_NAME] Only list themes that contain the given name.
       --no-color                [env: SHOPIFY_FLAG_NO_COLOR] Disable color output.
@@ -2811,14 +2845,14 @@ Download metafields definitions from your shop into a local file.
 
 ```
 USAGE
-  $ shopify theme metafields pull [--alias <value>] [-e <value>...] [--no-color] [--password <value>] [--path <value>] [-s
-    <value>] [--verbose]
+  $ shopify theme metafields pull [--auth-alias <value>] [-e <value>...] [--no-color] [--password <value>] [--path <value>]
+    [-s <value>] [--verbose]
 
 FLAGS
   -e, --environment=<value>...  [env: SHOPIFY_FLAG_ENVIRONMENT] The environment to apply to the current command.
   -s, --store=<value>           [env: SHOPIFY_FLAG_STORE] Store URL. It can be the store prefix (example) or the full
                                 myshopify.com URL (example.myshopify.com, https://example.myshopify.com).
-      --alias=<value>           [env: SHOPIFY_FLAG_AUTH_ALIAS] Alias of the Shopify account to use for authentication.
+      --auth-alias=<value>      [env: SHOPIFY_FLAG_AUTH_ALIAS] Alias of the Shopify account to use for authentication.
       --no-color                [env: SHOPIFY_FLAG_NO_COLOR] Disable color output.
       --password=<value>        [env: SHOPIFY_CLI_THEME_TOKEN] Password generated from the Theme Access app or an Admin
                                 API token.
@@ -2840,7 +2874,7 @@ Opens the preview of your remote theme.
 
 ```
 USAGE
-  $ shopify theme open [--alias <value>] [-d] [-E] [-e <value>...] [-l] [--no-color] [--password <value>]
+  $ shopify theme open [--auth-alias <value>] [-d] [-E] [-e <value>...] [-l] [--no-color] [--password <value>]
     [--path <value>] [-s <value>] [-t <value>] [--verbose]
 
 FLAGS
@@ -2851,7 +2885,7 @@ FLAGS
   -s, --store=<value>           [env: SHOPIFY_FLAG_STORE] Store URL. It can be the store prefix (example) or the full
                                 myshopify.com URL (example.myshopify.com, https://example.myshopify.com).
   -t, --theme=<value>           [env: SHOPIFY_FLAG_THEME_ID] Theme ID or name of the remote theme.
-      --alias=<value>           [env: SHOPIFY_FLAG_AUTH_ALIAS] Alias of the Shopify account to use for authentication.
+      --auth-alias=<value>      [env: SHOPIFY_FLAG_AUTH_ALIAS] Alias of the Shopify account to use for authentication.
       --no-color                [env: SHOPIFY_FLAG_NO_COLOR] Disable color output.
       --password=<value>        [env: SHOPIFY_CLI_THEME_TOKEN] Password generated from the Theme Access app or an Admin
                                 API token.
@@ -2909,15 +2943,15 @@ Applies JSON overrides to a theme and returns a preview URL.
 
 ```
 USAGE
-  $ shopify theme preview --overrides <value> -t <value> [--alias <value>] [-e <value>...] [--json] [--no-color]
-    [--open] [--password <value>] [--path <value>] [--preview-id <value>] [-s <value>] [--verbose]
+  $ shopify theme preview --overrides <value> -t <value> [--auth-alias <value>] [-e <value>...] [--json]
+    [--no-color] [--open] [--password <value>] [--path <value>] [--preview-id <value>] [-s <value>] [--verbose]
 
 FLAGS
   -e, --environment=<value>...  [env: SHOPIFY_FLAG_ENVIRONMENT] The environment to apply to the current command.
   -s, --store=<value>           [env: SHOPIFY_FLAG_STORE] Store URL. It can be the store prefix (example) or the full
                                 myshopify.com URL (example.myshopify.com, https://example.myshopify.com).
   -t, --theme=<value>           (required) [env: SHOPIFY_FLAG_THEME_ID] Theme ID or name of the remote theme.
-      --alias=<value>           [env: SHOPIFY_FLAG_AUTH_ALIAS] Alias of the Shopify account to use for authentication.
+      --auth-alias=<value>      [env: SHOPIFY_FLAG_AUTH_ALIAS] Alias of the Shopify account to use for authentication.
       --json                    [env: SHOPIFY_FLAG_JSON] Output the preview URL and identifier as JSON.
       --no-color                [env: SHOPIFY_FLAG_NO_COLOR] Disable color output.
       --open                    [env: SHOPIFY_FLAG_OPEN] Automatically launch the theme preview in your default web
@@ -2955,7 +2989,7 @@ FLAGS
   -s, --store=<value>           [env: SHOPIFY_FLAG_STORE] Store URL. It can be the store prefix (example) or the full
                                 myshopify.com URL (example.myshopify.com, https://example.myshopify.com).
   -t, --theme=<value>           [env: SHOPIFY_FLAG_THEME_ID] Theme ID or name of the remote theme.
-      --alias=<value>           [env: SHOPIFY_FLAG_AUTH_ALIAS] Alias of the Shopify account to use for authentication.
+      --auth-alias=<value>      [env: SHOPIFY_FLAG_AUTH_ALIAS] Alias of the Shopify account to use for authentication.
       --no-color                [env: SHOPIFY_FLAG_NO_COLOR] Disable color output.
       --password=<value>        [env: SHOPIFY_CLI_THEME_TOKEN] Password generated from the Theme Access app or an Admin
                                 API token.
@@ -2981,8 +3015,8 @@ Set a remote theme as the live theme.
 
 ```
 USAGE
-  $ shopify theme publish [--alias <value>] [-e <value>...] [-f] [--no-color] [--password <value>] [--path <value>]
-    [-s <value>] [-t <value>] [--verbose]
+  $ shopify theme publish [--auth-alias <value>] [-e <value>...] [-f] [--no-color] [--password <value>] [--path
+    <value>] [-s <value>] [-t <value>] [--verbose]
 
 FLAGS
   -e, --environment=<value>...  [env: SHOPIFY_FLAG_ENVIRONMENT] The environment to apply to the current command.
@@ -2990,7 +3024,7 @@ FLAGS
   -s, --store=<value>           [env: SHOPIFY_FLAG_STORE] Store URL. It can be the store prefix (example) or the full
                                 myshopify.com URL (example.myshopify.com, https://example.myshopify.com).
   -t, --theme=<value>           [env: SHOPIFY_FLAG_THEME_ID] Theme ID or name of the remote theme.
-      --alias=<value>           [env: SHOPIFY_FLAG_AUTH_ALIAS] Alias of the Shopify account to use for authentication.
+      --auth-alias=<value>      [env: SHOPIFY_FLAG_AUTH_ALIAS] Alias of the Shopify account to use for authentication.
       --no-color                [env: SHOPIFY_FLAG_NO_COLOR] Disable color output.
       --password=<value>        [env: SHOPIFY_CLI_THEME_TOKEN] Password generated from the Theme Access app or an Admin
                                 API token.
@@ -3019,7 +3053,7 @@ Download your remote theme files locally.
 
 ```
 USAGE
-  $ shopify theme pull [--alias <value>] [-d] [-e <value>...] [-x <value>...] [-l] [--no-color] [-n] [-o
+  $ shopify theme pull [--auth-alias <value>] [-d] [-e <value>...] [-x <value>...] [-l] [--no-color] [-n] [-o
     <value>...] [--password <value>] [--path <value>] [-s <value>] [-t <value>] [--verbose]
 
 FLAGS
@@ -3034,7 +3068,7 @@ FLAGS
   -t, --theme=<value>           [env: SHOPIFY_FLAG_THEME_ID] Theme ID or name of the remote theme.
   -x, --ignore=<value>...       [env: SHOPIFY_FLAG_IGNORE] Skip downloading the specified files (Multiple flags
                                 allowed). Wrap the value in double quotes if you're using wildcards.
-      --alias=<value>           [env: SHOPIFY_FLAG_AUTH_ALIAS] Alias of the Shopify account to use for authentication.
+      --auth-alias=<value>      [env: SHOPIFY_FLAG_AUTH_ALIAS] Alias of the Shopify account to use for authentication.
       --no-color                [env: SHOPIFY_FLAG_NO_COLOR] Disable color output.
       --password=<value>        [env: SHOPIFY_CLI_THEME_TOKEN] Password generated from the Theme Access app or an Admin
                                 API token.
@@ -3081,7 +3115,7 @@ FLAGS
   -u, --unpublished                  [env: SHOPIFY_FLAG_UNPUBLISHED] Create a new unpublished theme and push to it.
   -x, --ignore=<value>...            [env: SHOPIFY_FLAG_IGNORE] Skip uploading the specified files (Multiple flags
                                      allowed). Wrap the value in double quotes if you're using wildcards.
-      --alias=<value>                [env: SHOPIFY_FLAG_AUTH_ALIAS] Alias of the Shopify account to use for
+      --auth-alias=<value>           [env: SHOPIFY_FLAG_AUTH_ALIAS] Alias of the Shopify account to use for
                                      authentication.
       --listing=<value>              [env: SHOPIFY_FLAG_LISTING] The listing preset to use for multi-preset themes.
                                      Applies preset files from listings/[preset-name] directory.
@@ -3137,7 +3171,7 @@ Renames an existing theme.
 
 ```
 USAGE
-  $ shopify theme rename [--alias <value>] [-d] [-e <value>...] [-l] [-n <value>] [--no-color] [--password
+  $ shopify theme rename [--auth-alias <value>] [-d] [-e <value>...] [-l] [-n <value>] [--no-color] [--password
     <value>] [--path <value>] [-s <value>] [-t <value>] [--verbose]
 
 FLAGS
@@ -3148,7 +3182,7 @@ FLAGS
   -s, --store=<value>           [env: SHOPIFY_FLAG_STORE] Store URL. It can be the store prefix (example) or the full
                                 myshopify.com URL (example.myshopify.com, https://example.myshopify.com).
   -t, --theme=<value>           [env: SHOPIFY_FLAG_THEME_ID] Theme ID or name of the remote theme.
-      --alias=<value>           [env: SHOPIFY_FLAG_AUTH_ALIAS] Alias of the Shopify account to use for authentication.
+      --auth-alias=<value>      [env: SHOPIFY_FLAG_AUTH_ALIAS] Alias of the Shopify account to use for authentication.
       --no-color                [env: SHOPIFY_FLAG_NO_COLOR] Disable color output.
       --password=<value>        [env: SHOPIFY_CLI_THEME_TOKEN] Password generated from the Theme Access app or an Admin
                                 API token.
@@ -3171,14 +3205,14 @@ Creates a shareable, unpublished, and new theme on your theme library with a ran
 
 ```
 USAGE
-  $ shopify theme share [--alias <value>] [-e <value>...] [--listing <value>] [--no-color] [--password <value>]
-    [--path <value>] [-s <value>] [--verbose]
+  $ shopify theme share [--auth-alias <value>] [-e <value>...] [--listing <value>] [--no-color] [--password
+    <value>] [--path <value>] [-s <value>] [--verbose]
 
 FLAGS
   -e, --environment=<value>...  [env: SHOPIFY_FLAG_ENVIRONMENT] The environment to apply to the current command.
   -s, --store=<value>           [env: SHOPIFY_FLAG_STORE] Store URL. It can be the store prefix (example) or the full
                                 myshopify.com URL (example.myshopify.com, https://example.myshopify.com).
-      --alias=<value>           [env: SHOPIFY_FLAG_AUTH_ALIAS] Alias of the Shopify account to use for authentication.
+      --auth-alias=<value>      [env: SHOPIFY_FLAG_AUTH_ALIAS] Alias of the Shopify account to use for authentication.
       --listing=<value>         [env: SHOPIFY_FLAG_LISTING] The listing preset to use for multi-preset themes. Applies
                                 preset files from listings/[preset-name] directory.
       --no-color                [env: SHOPIFY_FLAG_NO_COLOR] Disable color output.

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -4235,6 +4235,15 @@
       "descriptionWithMarkdown": "Builds and deploys your Hydrogen storefront to Oxygen. Requires an Oxygen deployment token to be set with the `--token` flag or an environment variable (`SHOPIFY_HYDROGEN_DEPLOYMENT_TOKEN`). If the storefront is [linked](https://shopify.dev/docs/api/shopify-cli/hydrogen/hydrogen-link) then the Oxygen deployment token for the linked storefront will be used automatically.",
       "enableJsonFlag": false,
       "flags": {
+        "assets-dir": {
+          "description": "Directory containing the client assets to deploy, relative to the project root. Defaults to the detected Vite client output directory, then falls back to `dist/client`.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_ASSETS_DIR",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "assets-dir",
+          "required": false,
+          "type": "option"
+        },
         "auth-bypass-token": {
           "allowNo": false,
           "description": "Generate an authentication bypass token, which can be used to perform end-to-end tests against the deployment.",
@@ -4256,7 +4265,7 @@
           "type": "option"
         },
         "build-command": {
-          "description": "Specify a build command to run before deploying. If not specified, `shopify hydrogen build` will be used.",
+          "description": "Specify a build command to run before deploying. If not specified, the Hydrogen build pipeline will be used. When custom output directories are configured, defaults to `node --run build`.",
           "hasDynamicHelp": false,
           "multiple": false,
           "name": "build-command",
@@ -4304,7 +4313,7 @@
         "force": {
           "allowNo": false,
           "char": "f",
-          "description": "Forces a deployment to proceed if there are uncommited changes in its Git repository.",
+          "description": "Forces a deployment to proceed if there are uncommitted changes in its Git repository.",
           "env": "SHOPIFY_HYDROGEN_FLAG_FORCE",
           "name": "force",
           "required": false,
@@ -4332,7 +4341,7 @@
           "type": "boolean"
         },
         "metadata-description": {
-          "description": "Description of the changes in the deployment. Defaults to the commit message of the latest commit if there are no uncommited changes.",
+          "description": "Description of the changes in the deployment. Defaults to the commit message of the latest commit if there are no uncommitted changes.",
           "env": "SHOPIFY_HYDROGEN_FLAG_METADATA_DESCRIPTION",
           "hasDynamicHelp": false,
           "multiple": false,
@@ -4405,6 +4414,15 @@
           "hasDynamicHelp": false,
           "multiple": false,
           "name": "token",
+          "required": false,
+          "type": "option"
+        },
+        "worker-dir": {
+          "description": "Directory containing the Oxygen worker entry point (`index.js` or `index.mjs`), relative to the project root. Defaults to the detected Vite server output directory, then falls back to `dist/server`.",
+          "env": "SHOPIFY_HYDROGEN_FLAG_WORKER_DIR",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "worker-dir",
           "required": false,
           "type": "option"
         }
@@ -4737,7 +4755,7 @@
       ],
       "args": {
         "routeName": {
-          "description": "The route to generate. One of home,page,cart,products,collections,policies,blogs,account,search,robots,sitemap,tokenlessApi,all.",
+          "description": "The route to generate. One of home,page,cart,products,collections,policies,blogs,account,search,robots,sitemap,all.",
           "name": "routeName",
           "options": [
             "home",
@@ -4751,7 +4769,6 @@
             "search",
             "robots",
             "sitemap",
-            "tokenlessApi",
             "all"
           ],
           "required": true
@@ -4763,7 +4780,7 @@
       "enableJsonFlag": false,
       "flags": {
         "adapter": {
-          "description": "Remix adapter used in the route. The default is `@shopify/remix-oxygen`.",
+          "description": "React Router adapter used in the route. The default is `react-router`.",
           "env": "SHOPIFY_HYDROGEN_FLAG_ADAPTER",
           "hasDynamicHelp": false,
           "multiple": false,
@@ -4821,7 +4838,7 @@
       "enableJsonFlag": false,
       "flags": {
         "adapter": {
-          "description": "Remix adapter used in the route. The default is `@shopify/remix-oxygen`.",
+          "description": "React Router adapter used in the route. The default is `react-router`.",
           "env": "SHOPIFY_HYDROGEN_FLAG_ADAPTER",
           "hasDynamicHelp": false,
           "multiple": false,

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -6795,6 +6795,14 @@
       "description": "Starts the Shopify Liquid REPL (read-eval-print loop) tool. This tool provides an interactive terminal interface for evaluating Liquid code and exploring Liquid objects, filters, and tags using real store data.\n\n  You can also provide context to the console using a URL, as some Liquid objects are context-specific",
       "descriptionWithMarkdown": "Starts the Shopify Liquid REPL (read-eval-print loop) tool. This tool provides an interactive terminal interface for evaluating Liquid code and exploring Liquid objects, filters, and tags using real store data.\n\n  You can also provide context to the console using a URL, as some Liquid objects are context-specific",
       "flags": {
+        "alias": {
+          "description": "Alias of the Shopify account to use for authentication.",
+          "env": "SHOPIFY_FLAG_AUTH_ALIAS",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "alias",
+          "type": "option"
+        },
         "environment": {
           "char": "e",
           "description": "The environment to apply to the current command.",
@@ -6888,6 +6896,14 @@
       "description": "Deletes a theme from your store.\n\n  You can specify multiple themes by ID. If no theme is specified, then you're prompted to select the theme that you want to delete from the list of themes in your store.\n\n  You're asked to confirm that you want to delete the specified themes before they are deleted. You can skip this confirmation using the `--force` flag.",
       "descriptionWithMarkdown": "Deletes a theme from your store.\n\n  You can specify multiple themes by ID. If no theme is specified, then you're prompted to select the theme that you want to delete from the list of themes in your store.\n\n  You're asked to confirm that you want to delete the specified themes before they are deleted. You can skip this confirmation using the `--force` flag.",
       "flags": {
+        "alias": {
+          "description": "Alias of the Shopify account to use for authentication.",
+          "env": "SHOPIFY_FLAG_AUTH_ALIAS",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "alias",
+          "type": "option"
+        },
         "development": {
           "allowNo": false,
           "char": "d",
@@ -7000,6 +7016,14 @@
       "description": "\n  Uploads the current theme as the specified theme, or a \"development theme\" (https://shopify.dev/docs/themes/tools/cli#development-themes), to a store so you can preview it.\n\nThis command returns the following information:\n\n- A link to your development theme at http://127.0.0.1:9292. This URL can hot reload local changes to CSS and sections, or refresh the entire page when a file changes, enabling you to preview changes in real time using the store's data.\n\n  You can specify a different network interface and port using `--host` and `--port`.\n\n- A link to the \"editor\" (https://shopify.dev/docs/themes/tools/online-editor) for the theme in the Shopify admin.\n\n- A \"preview link\" (https://help.shopify.com/manual/online-store/themes/adding-themes#share-a-theme-preview-with-others) that you can share with other developers.\n\nIf you already have a development theme for your current environment, then this command replaces the development theme with your local theme. You can override this using the `--theme-editor-sync` flag.\n\n> Note: You can't preview checkout customizations using http://127.0.0.1:9292.\n\nDevelopment themes are deleted when you run `shopify auth logout`. If you need a preview link that can be used after you log out, then you should \"share\" (https://shopify.dev/docs/api/shopify-cli/theme/theme-share) your theme or \"push\" (https://shopify.dev/docs/api/shopify-cli/theme/theme-push) to an unpublished theme on your store.\n\nYou can run this command only in a directory that matches the \"default Shopify theme folder structure\" (https://shopify.dev/docs/themes/tools/cli#directory-structure).",
       "descriptionWithMarkdown": "\n  Uploads the current theme as the specified theme, or a [development theme](https://shopify.dev/docs/themes/tools/cli#development-themes), to a store so you can preview it.\n\nThis command returns the following information:\n\n- A link to your development theme at http://127.0.0.1:9292. This URL can hot reload local changes to CSS and sections, or refresh the entire page when a file changes, enabling you to preview changes in real time using the store's data.\n\n  You can specify a different network interface and port using `--host` and `--port`.\n\n- A link to the [editor](https://shopify.dev/docs/themes/tools/online-editor) for the theme in the Shopify admin.\n\n- A [preview link](https://help.shopify.com/manual/online-store/themes/adding-themes#share-a-theme-preview-with-others) that you can share with other developers.\n\nIf you already have a development theme for your current environment, then this command replaces the development theme with your local theme. You can override this using the `--theme-editor-sync` flag.\n\n> Note: You can't preview checkout customizations using http://127.0.0.1:9292.\n\nDevelopment themes are deleted when you run `shopify auth logout`. If you need a preview link that can be used after you log out, then you should [share](https://shopify.dev/docs/api/shopify-cli/theme/theme-share) your theme or [push](https://shopify.dev/docs/api/shopify-cli/theme/theme-push) to an unpublished theme on your store.\n\nYou can run this command only in a directory that matches the [default Shopify theme folder structure](https://shopify.dev/docs/themes/tools/cli#directory-structure).",
       "flags": {
+        "alias": {
+          "description": "Alias of the Shopify account to use for authentication.",
+          "env": "SHOPIFY_FLAG_AUTH_ALIAS",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "alias",
+          "type": "option"
+        },
         "allow-live": {
           "allowNo": false,
           "char": "a",
@@ -7220,6 +7244,14 @@
       "description": "If you want to duplicate your local theme, you need to run `shopify theme push` first.\n\nIf no theme ID is specified, you're prompted to select the theme that you want to duplicate from the list of themes in your store. You're asked to confirm that you want to duplicate the specified theme.\n\nPrompts and confirmations are not shown when duplicate is run in a CI environment or the `--force` flag is used, therefore you must specify a theme ID using the `--theme` flag.\n\nYou can optionally name the duplicated theme using the `--name` flag.\n\nIf you use the `--json` flag, then theme information is returned in JSON format, which can be used as a machine-readable input for scripts or continuous integration.\n\nSample JSON output:\n\n```json\n{\n  \"theme\": {\n    \"id\": 108267175958,\n    \"name\": \"A Duplicated Theme\",\n    \"role\": \"unpublished\",\n    \"shop\": \"mystore.myshopify.com\"\n  }\n}\n```\n\n```json\n{\n  \"message\": \"The theme 'Summer Edition' could not be duplicated due to errors\",\n  \"errors\": [\"Maximum number of themes reached\"],\n  \"requestId\": \"12345-abcde-67890\"\n}\n```",
       "descriptionWithMarkdown": "If you want to duplicate your local theme, you need to run `shopify theme push` first.\n\nIf no theme ID is specified, you're prompted to select the theme that you want to duplicate from the list of themes in your store. You're asked to confirm that you want to duplicate the specified theme.\n\nPrompts and confirmations are not shown when duplicate is run in a CI environment or the `--force` flag is used, therefore you must specify a theme ID using the `--theme` flag.\n\nYou can optionally name the duplicated theme using the `--name` flag.\n\nIf you use the `--json` flag, then theme information is returned in JSON format, which can be used as a machine-readable input for scripts or continuous integration.\n\nSample JSON output:\n\n```json\n{\n  \"theme\": {\n    \"id\": 108267175958,\n    \"name\": \"A Duplicated Theme\",\n    \"role\": \"unpublished\",\n    \"shop\": \"mystore.myshopify.com\"\n  }\n}\n```\n\n```json\n{\n  \"message\": \"The theme 'Summer Edition' could not be duplicated due to errors\",\n  \"errors\": [\"Maximum number of themes reached\"],\n  \"requestId\": \"12345-abcde-67890\"\n}\n```",
       "flags": {
+        "alias": {
+          "description": "Alias of the Shopify account to use for authentication.",
+          "env": "SHOPIFY_FLAG_AUTH_ALIAS",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "alias",
+          "type": "option"
+        },
         "environment": {
           "char": "e",
           "description": "The environment to apply to the current command.",
@@ -7320,6 +7352,14 @@
       "customPluginName": "@shopify/theme",
       "description": "Displays information about your theme environment, including your current store. Can also retrieve information about a specific theme.",
       "flags": {
+        "alias": {
+          "description": "Alias of the Shopify account to use for authentication.",
+          "env": "SHOPIFY_FLAG_AUTH_ALIAS",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "alias",
+          "type": "option"
+        },
         "development": {
           "allowNo": false,
           "char": "d",
@@ -7526,6 +7566,14 @@
       "customPluginName": "@shopify/theme",
       "description": "Lists the themes in your store, along with their IDs and statuses.",
       "flags": {
+        "alias": {
+          "description": "Alias of the Shopify account to use for authentication.",
+          "env": "SHOPIFY_FLAG_AUTH_ALIAS",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "alias",
+          "type": "option"
+        },
         "environment": {
           "char": "e",
           "description": "The environment to apply to the current command.",
@@ -7638,6 +7686,14 @@
       "description": "Retrieves metafields from Shopify Admin.\n\nIf the metafields file already exists, it will be overwritten.",
       "descriptionWithMarkdown": "Retrieves metafields from Shopify Admin.\n\nIf the metafields file already exists, it will be overwritten.",
       "flags": {
+        "alias": {
+          "description": "Alias of the Shopify account to use for authentication.",
+          "env": "SHOPIFY_FLAG_AUTH_ALIAS",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "alias",
+          "type": "option"
+        },
         "environment": {
           "char": "e",
           "description": "The environment to apply to the current command.",
@@ -7719,6 +7775,14 @@
       "description": "Returns links that let you preview the specified theme. The following links are returned:\n\n  - A link to the \"editor\" (https://shopify.dev/docs/themes/tools/online-editor) for the theme in the Shopify admin.\n  - A \"preview link\" (https://help.shopify.com/manual/online-store/themes/adding-themes#share-a-theme-preview-with-others) that you can share with other developers.\n\n  If you don't specify a theme, then you're prompted to select the theme to open from the list of the themes in your store.",
       "descriptionWithMarkdown": "Returns links that let you preview the specified theme. The following links are returned:\n\n  - A link to the [editor](https://shopify.dev/docs/themes/tools/online-editor) for the theme in the Shopify admin.\n  - A [preview link](https://help.shopify.com/manual/online-store/themes/adding-themes#share-a-theme-preview-with-others) that you can share with other developers.\n\n  If you don't specify a theme, then you're prompted to select the theme to open from the list of the themes in your store.",
       "flags": {
+        "alias": {
+          "description": "Alias of the Shopify account to use for authentication.",
+          "env": "SHOPIFY_FLAG_AUTH_ALIAS",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "alias",
+          "type": "option"
+        },
         "development": {
           "allowNo": false,
           "char": "d",
@@ -7870,6 +7934,14 @@
       "description": "Applies a JSON overrides file to a theme and creates or updates a preview. This lets you quickly preview changes.\n\n  The command returns a preview URL and a preview identifier. You can reuse the preview identifier with `--preview-id` to update an existing preview instead of creating a new one.",
       "descriptionWithMarkdown": "Applies a JSON overrides file to a theme and creates or updates a preview. This lets you quickly preview changes.\n\n  The command returns a preview URL and a preview identifier. You can reuse the preview identifier with `--preview-id` to update an existing preview instead of creating a new one.",
       "flags": {
+        "alias": {
+          "description": "Alias of the Shopify account to use for authentication.",
+          "env": "SHOPIFY_FLAG_AUTH_ALIAS",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "alias",
+          "type": "option"
+        },
         "environment": {
           "char": "e",
           "description": "The environment to apply to the current command.",
@@ -7983,6 +8055,14 @@
       "description": "Profile the Shopify Liquid on a given page.\n\n  This command will open a web page with the Speedscope profiler detailing the time spent executing Liquid on the given page.",
       "descriptionWithMarkdown": "Profile the Shopify Liquid on a given page.\n\n  This command will open a web page with the Speedscope profiler detailing the time spent executing Liquid on the given page.",
       "flags": {
+        "alias": {
+          "description": "Alias of the Shopify account to use for authentication.",
+          "env": "SHOPIFY_FLAG_AUTH_ALIAS",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "alias",
+          "type": "option"
+        },
         "environment": {
           "char": "e",
           "description": "The environment to apply to the current command.",
@@ -8094,6 +8174,14 @@
       "description": "Publishes an unpublished theme from your theme library.\n\nIf no theme ID is specified, then you're prompted to select the theme that you want to publish from the list of themes in your store.\n\nYou can run this command only in a directory that matches the \"default Shopify theme folder structure\" (https://shopify.dev/docs/themes/tools/cli#directory-structure).\n\nIf you want to publish your local theme, then you need to run `shopify theme push` first. You're asked to confirm that you want to publish the specified theme. You can skip this confirmation using the `--force` flag.",
       "descriptionWithMarkdown": "Publishes an unpublished theme from your theme library.\n\nIf no theme ID is specified, then you're prompted to select the theme that you want to publish from the list of themes in your store.\n\nYou can run this command only in a directory that matches the [default Shopify theme folder structure](https://shopify.dev/docs/themes/tools/cli#directory-structure).\n\nIf you want to publish your local theme, then you need to run `shopify theme push` first. You're asked to confirm that you want to publish the specified theme. You can skip this confirmation using the `--force` flag.",
       "flags": {
+        "alias": {
+          "description": "Alias of the Shopify account to use for authentication.",
+          "env": "SHOPIFY_FLAG_AUTH_ALIAS",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "alias",
+          "type": "option"
+        },
         "environment": {
           "char": "e",
           "description": "The environment to apply to the current command.",
@@ -8187,6 +8275,14 @@
       "description": "Retrieves theme files from Shopify.\n\nIf no theme is specified, then you're prompted to select the theme to pull from the list of the themes in your store.",
       "descriptionWithMarkdown": "Retrieves theme files from Shopify.\n\nIf no theme is specified, then you're prompted to select the theme to pull from the list of the themes in your store.",
       "flags": {
+        "alias": {
+          "description": "Alias of the Shopify account to use for authentication.",
+          "env": "SHOPIFY_FLAG_AUTH_ALIAS",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "alias",
+          "type": "option"
+        },
         "development": {
           "allowNo": false,
           "char": "d",
@@ -8328,6 +8424,14 @@
       "description": "Uploads your local theme files to Shopify, overwriting the remote version if specified.\n\n  If no theme is specified, then you're prompted to select the theme to overwrite from the list of the themes in your store.\n\n  You can run this command only in a directory that matches the \"default Shopify theme folder structure\" (https://shopify.dev/docs/themes/tools/cli#directory-structure).\n\n  This command returns the following information:\n\n  - A link to the \"editor\" (https://shopify.dev/docs/themes/tools/online-editor) for the theme in the Shopify admin.\n  - A \"preview link\" (https://help.shopify.com/manual/online-store/themes/adding-themes#share-a-theme-preview-with-others) that you can share with others.\n\n  If you use the `--json` flag, then theme information is returned in JSON format, which can be used as a machine-readable input for scripts or continuous integration.\n\n  Sample output:\n\n  ```json\n  {\n    \"theme\": {\n      \"id\": 108267175958,\n      \"name\": \"MyTheme\",\n      \"role\": \"unpublished\",\n      \"shop\": \"mystore.myshopify.com\",\n      \"editor_url\": \"https://mystore.myshopify.com/admin/themes/108267175958/editor\",\n      \"preview_url\": \"https://mystore.myshopify.com/?preview_theme_id=108267175958\"\n    }\n  }\n  ```\n    ",
       "descriptionWithMarkdown": "Uploads your local theme files to Shopify, overwriting the remote version if specified.\n\n  If no theme is specified, then you're prompted to select the theme to overwrite from the list of the themes in your store.\n\n  You can run this command only in a directory that matches the [default Shopify theme folder structure](https://shopify.dev/docs/themes/tools/cli#directory-structure).\n\n  This command returns the following information:\n\n  - A link to the [editor](https://shopify.dev/docs/themes/tools/online-editor) for the theme in the Shopify admin.\n  - A [preview link](https://help.shopify.com/manual/online-store/themes/adding-themes#share-a-theme-preview-with-others) that you can share with others.\n\n  If you use the `--json` flag, then theme information is returned in JSON format, which can be used as a machine-readable input for scripts or continuous integration.\n\n  Sample output:\n\n  ```json\n  {\n    \"theme\": {\n      \"id\": 108267175958,\n      \"name\": \"MyTheme\",\n      \"role\": \"unpublished\",\n      \"shop\": \"mystore.myshopify.com\",\n      \"editor_url\": \"https://mystore.myshopify.com/admin/themes/108267175958/editor\",\n      \"preview_url\": \"https://mystore.myshopify.com/?preview_theme_id=108267175958\"\n    }\n  }\n  ```\n    ",
       "flags": {
+        "alias": {
+          "description": "Alias of the Shopify account to use for authentication.",
+          "env": "SHOPIFY_FLAG_AUTH_ALIAS",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "alias",
+          "type": "option"
+        },
         "allow-live": {
           "allowNo": false,
           "char": "a",
@@ -8536,6 +8640,14 @@
       "description": "Renames a theme in your store.\n\n  If no theme is specified, then you're prompted to select the theme that you want to rename from the list of themes in your store.\n  ",
       "descriptionWithMarkdown": "Renames a theme in your store.\n\n  If no theme is specified, then you're prompted to select the theme that you want to rename from the list of themes in your store.\n  ",
       "flags": {
+        "alias": {
+          "description": "Alias of the Shopify account to use for authentication.",
+          "env": "SHOPIFY_FLAG_AUTH_ALIAS",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "alias",
+          "type": "option"
+        },
         "development": {
           "allowNo": false,
           "char": "d",
@@ -8652,6 +8764,14 @@
       "description": "Uploads your theme as a new, unpublished theme in your theme library. The theme is given a randomized name.\n\n  This command returns a \"preview link\" (https://help.shopify.com/manual/online-store/themes/adding-themes#share-a-theme-preview-with-others) that you can share with others.",
       "descriptionWithMarkdown": "Uploads your theme as a new, unpublished theme in your theme library. The theme is given a randomized name.\n\n  This command returns a [preview link](https://help.shopify.com/manual/online-store/themes/adding-themes#share-a-theme-preview-with-others) that you can share with others.",
       "flags": {
+        "alias": {
+          "description": "Alias of the Shopify account to use for authentication.",
+          "env": "SHOPIFY_FLAG_AUTH_ALIAS",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "alias",
+          "type": "option"
+        },
         "environment": {
           "char": "e",
           "description": "The environment to apply to the current command.",

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -9,6 +9,14 @@
       "description": "This command executes the build script specified in the element's TOML file. You can specify a custom script in the file. To learn about configuration files in Shopify apps, refer to \"App configuration\" (https://shopify.dev/docs/apps/tools/cli/configuration).\n\n  If you're building a \"theme app extension\" (https://shopify.dev/docs/apps/online-store/theme-app-extensions), then running the `build` command runs \"Theme Check\" (https://shopify.dev/docs/themes/tools/theme-check) against your extension to ensure that it's valid.",
       "descriptionWithMarkdown": "This command executes the build script specified in the element's TOML file. You can specify a custom script in the file. To learn about configuration files in Shopify apps, refer to [App configuration](https://shopify.dev/docs/apps/tools/cli/configuration).\n\n  If you're building a [theme app extension](https://shopify.dev/docs/apps/online-store/theme-app-extensions), then running the `build` command runs [Theme Check](https://shopify.dev/docs/themes/tools/theme-check) against your extension to ensure that it's valid.",
       "flags": {
+        "auth-alias": {
+          "description": "Alias of the Shopify account to use for authentication.",
+          "env": "SHOPIFY_FLAG_AUTH_ALIAS",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "auth-alias",
+          "type": "option"
+        },
         "client-id": {
           "description": "The Client ID of your app.",
           "env": "SHOPIFY_FLAG_CLIENT_ID",
@@ -94,6 +102,14 @@
       "customPluginName": "@shopify/app",
       "description": "Cancels a running bulk operation by ID.",
       "flags": {
+        "auth-alias": {
+          "description": "Alias of the Shopify account to use for authentication.",
+          "env": "SHOPIFY_FLAG_AUTH_ALIAS",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "auth-alias",
+          "type": "option"
+        },
         "client-id": {
           "description": "The Client ID of your app.",
           "env": "SHOPIFY_FLAG_CLIENT_ID",
@@ -190,6 +206,14 @@
       "description": "Executes an Admin API GraphQL query or mutation on the specified store, as a bulk operation. Mutations are only allowed on dev stores.\n\n  Bulk operations allow you to process large amounts of data asynchronously. Learn more about \"bulk query operations\" (https://shopify.dev/docs/api/usage/bulk-operations/queries) and \"bulk mutation operations\" (https://shopify.dev/docs/api/usage/bulk-operations/imports).\n\n  Use \"`bulk status`\" (https://shopify.dev/docs/api/shopify-cli/app/app-bulk-status) to check the status of your bulk operations.",
       "descriptionWithMarkdown": "Executes an Admin API GraphQL query or mutation on the specified store, as a bulk operation. Mutations are only allowed on dev stores.\n\n  Bulk operations allow you to process large amounts of data asynchronously. Learn more about [bulk query operations](https://shopify.dev/docs/api/usage/bulk-operations/queries) and [bulk mutation operations](https://shopify.dev/docs/api/usage/bulk-operations/imports).\n\n  Use [`bulk status`](https://shopify.dev/docs/api/shopify-cli/app/app-bulk-status) to check the status of your bulk operations.",
       "flags": {
+        "auth-alias": {
+          "description": "Alias of the Shopify account to use for authentication.",
+          "env": "SHOPIFY_FLAG_AUTH_ALIAS",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "auth-alias",
+          "type": "option"
+        },
         "client-id": {
           "description": "The Client ID of your app.",
           "env": "SHOPIFY_FLAG_CLIENT_ID",
@@ -344,6 +368,14 @@
       "description": "Check the status of a specific bulk operation by ID, or list all bulk operations belonging to this app on this store in the last 7 days.\n\n  Bulk operations allow you to process large amounts of data asynchronously. Learn more about \"bulk query operations\" (https://shopify.dev/docs/api/usage/bulk-operations/queries) and \"bulk mutation operations\" (https://shopify.dev/docs/api/usage/bulk-operations/imports).\n\n  Use \"`bulk execute`\" (https://shopify.dev/docs/api/shopify-cli/app/app-bulk-execute) to start a new bulk operation.",
       "descriptionWithMarkdown": "Check the status of a specific bulk operation by ID, or list all bulk operations belonging to this app on this store in the last 7 days.\n\n  Bulk operations allow you to process large amounts of data asynchronously. Learn more about [bulk query operations](https://shopify.dev/docs/api/usage/bulk-operations/queries) and [bulk mutation operations](https://shopify.dev/docs/api/usage/bulk-operations/imports).\n\n  Use [`bulk execute`](https://shopify.dev/docs/api/shopify-cli/app/app-bulk-execute) to start a new bulk operation.",
       "flags": {
+        "auth-alias": {
+          "description": "Alias of the Shopify account to use for authentication.",
+          "env": "SHOPIFY_FLAG_AUTH_ALIAS",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "auth-alias",
+          "type": "option"
+        },
         "client-id": {
           "description": "The Client ID of your app.",
           "env": "SHOPIFY_FLAG_CLIENT_ID",
@@ -439,6 +471,14 @@
       "description": "Pulls app configuration from the Developer Dashboard and creates or overwrites a configuration file. You can create a new app with this command to start with a default configuration file.\n\n  For more information on the format of the created TOML configuration file, refer to the \"App configuration\" (https://shopify.dev/docs/apps/tools/cli/configuration) page.\n  ",
       "descriptionWithMarkdown": "Pulls app configuration from the Developer Dashboard and creates or overwrites a configuration file. You can create a new app with this command to start with a default configuration file.\n\n  For more information on the format of the created TOML configuration file, refer to the [App configuration](https://shopify.dev/docs/apps/tools/cli/configuration) page.\n  ",
       "flags": {
+        "auth-alias": {
+          "description": "Alias of the Shopify account to use for authentication.",
+          "env": "SHOPIFY_FLAG_AUTH_ALIAS",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "auth-alias",
+          "type": "option"
+        },
         "client-id": {
           "description": "The Client ID of your app.",
           "env": "SHOPIFY_FLAG_CLIENT_ID",
@@ -528,6 +568,14 @@
       "description": "Pulls the latest configuration from the already-linked Shopify app and updates the selected configuration file.\n\nThis command reuses the existing linked app and organization and skips all interactive prompts. Use `--config` to target a specific configuration file, or omit it to use the default one.",
       "descriptionWithMarkdown": "Pulls the latest configuration from the already-linked Shopify app and updates the selected configuration file.\n\nThis command reuses the existing linked app and organization and skips all interactive prompts. Use `--config` to target a specific configuration file, or omit it to use the default one.",
       "flags": {
+        "auth-alias": {
+          "description": "Alias of the Shopify account to use for authentication.",
+          "env": "SHOPIFY_FLAG_AUTH_ALIAS",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "auth-alias",
+          "type": "option"
+        },
         "client-id": {
           "description": "The Client ID of your app.",
           "env": "SHOPIFY_FLAG_CLIENT_ID",
@@ -610,6 +658,14 @@
       "description": "Sets default configuration when you run app-related CLI commands. If you omit the `config-name` parameter, then you'll be prompted to choose from the configuration files in your project.",
       "descriptionWithMarkdown": "Sets default configuration when you run app-related CLI commands. If you omit the `config-name` parameter, then you'll be prompted to choose from the configuration files in your project.",
       "flags": {
+        "auth-alias": {
+          "description": "Alias of the Shopify account to use for authentication.",
+          "env": "SHOPIFY_FLAG_AUTH_ALIAS",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "auth-alias",
+          "type": "option"
+        },
         "client-id": {
           "description": "The Client ID of your app.",
           "env": "SHOPIFY_FLAG_CLIENT_ID",
@@ -679,6 +735,14 @@
       "description": "Validates the selected app configuration file and all extension configurations against their schemas and reports any errors found.",
       "descriptionWithMarkdown": "Validates the selected app configuration file and all extension configurations against their schemas and reports any errors found.",
       "flags": {
+        "auth-alias": {
+          "description": "Alias of the Shopify account to use for authentication.",
+          "env": "SHOPIFY_FLAG_AUTH_ALIAS",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "auth-alias",
+          "type": "option"
+        },
         "client-id": {
           "description": "The Client ID of your app.",
           "env": "SHOPIFY_FLAG_CLIENT_ID",
@@ -781,6 +845,14 @@
           "hidden": false,
           "name": "allow-updates",
           "type": "boolean"
+        },
+        "auth-alias": {
+          "description": "Alias of the Shopify account to use for authentication.",
+          "env": "SHOPIFY_FLAG_AUTH_ALIAS",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "auth-alias",
+          "type": "option"
         },
         "client-id": {
           "description": "The Client ID of your app.",
@@ -906,6 +978,14 @@
       "description": "Builds and previews your app on a dev store, and watches for changes. \"Read more about testing apps locally\" (https://shopify.dev/docs/apps/build/cli-for-apps/test-apps-locally).",
       "descriptionWithMarkdown": "Builds and previews your app on a dev store, and watches for changes. [Read more about testing apps locally](https://shopify.dev/docs/apps/build/cli-for-apps/test-apps-locally).",
       "flags": {
+        "auth-alias": {
+          "description": "Alias of the Shopify account to use for authentication.",
+          "env": "SHOPIFY_FLAG_AUTH_ALIAS",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "auth-alias",
+          "type": "option"
+        },
         "checkout-cart-url": {
           "description": "Resource URL for checkout UI extension. Format: \"/cart/{productVariantID}:{productQuantity}\"",
           "env": "SHOPIFY_FLAG_CHECKOUT_CART_URL",
@@ -1095,6 +1175,14 @@
       "description": "Stop the dev preview that was started with `shopify app dev`.\n\n  It restores the app's active version to the selected development store.\n  ",
       "descriptionWithMarkdown": "Stop the dev preview that was started with `shopify app dev`.\n\n  It restores the app's active version to the selected development store.\n  ",
       "flags": {
+        "auth-alias": {
+          "description": "Alias of the Shopify account to use for authentication.",
+          "env": "SHOPIFY_FLAG_AUTH_ALIAS",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "auth-alias",
+          "type": "option"
+        },
         "client-id": {
           "description": "The Client ID of your app.",
           "env": "SHOPIFY_FLAG_CLIENT_ID",
@@ -1183,6 +1271,14 @@
       "description": "Creates or updates an `.env` files that contains app and app extension environment variables.\n\n  When an existing `.env` file is updated, changes to the variables are displayed in the terminal output. Existing variables and commented variables are preserved.",
       "descriptionWithMarkdown": "Creates or updates an `.env` files that contains app and app extension environment variables.\n\n  When an existing `.env` file is updated, changes to the variables are displayed in the terminal output. Existing variables and commented variables are preserved.",
       "flags": {
+        "auth-alias": {
+          "description": "Alias of the Shopify account to use for authentication.",
+          "env": "SHOPIFY_FLAG_AUTH_ALIAS",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "auth-alias",
+          "type": "option"
+        },
         "client-id": {
           "description": "The Client ID of your app.",
           "env": "SHOPIFY_FLAG_CLIENT_ID",
@@ -1270,6 +1366,14 @@
       "description": "Displays environment variables that can be used to deploy apps and app extensions.",
       "descriptionWithMarkdown": "Displays environment variables that can be used to deploy apps and app extensions.",
       "flags": {
+        "auth-alias": {
+          "description": "Alias of the Shopify account to use for authentication.",
+          "env": "SHOPIFY_FLAG_AUTH_ALIAS",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "auth-alias",
+          "type": "option"
+        },
         "client-id": {
           "description": "The Client ID of your app.",
           "env": "SHOPIFY_FLAG_CLIENT_ID",
@@ -1348,6 +1452,14 @@
       "description": "Executes an Admin API GraphQL query or mutation on the specified store. Mutations are only allowed on dev stores.\n\n  For operations that process large amounts of data, use \"`bulk execute`\" (https://shopify.dev/docs/api/shopify-cli/app/app-bulk-execute) instead.",
       "descriptionWithMarkdown": "Executes an Admin API GraphQL query or mutation on the specified store. Mutations are only allowed on dev stores.\n\n  For operations that process large amounts of data, use [`bulk execute`](https://shopify.dev/docs/api/shopify-cli/app/app-bulk-execute) instead.",
       "flags": {
+        "auth-alias": {
+          "description": "Alias of the Shopify account to use for authentication.",
+          "env": "SHOPIFY_FLAG_AUTH_ALIAS",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "auth-alias",
+          "type": "option"
+        },
         "client-id": {
           "description": "The Client ID of your app.",
           "env": "SHOPIFY_FLAG_CLIENT_ID",
@@ -1492,6 +1604,14 @@
       "description": "Compiles the function in your current directory to WebAssembly (Wasm) for testing purposes.",
       "descriptionWithMarkdown": "Compiles the function in your current directory to WebAssembly (Wasm) for testing purposes.",
       "flags": {
+        "auth-alias": {
+          "description": "Alias of the Shopify account to use for authentication.",
+          "env": "SHOPIFY_FLAG_AUTH_ALIAS",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "auth-alias",
+          "type": "option"
+        },
         "client-id": {
           "description": "The Client ID of your app.",
           "env": "SHOPIFY_FLAG_CLIENT_ID",
@@ -1571,6 +1691,14 @@
       "description": "The information returned includes the following:\n\n  - The function handle\n  - The function name\n  - The function API version\n  - The targeting configuration\n  - The schema path\n  - The WASM path\n  - The function runner path",
       "descriptionWithMarkdown": "The information returned includes the following:\n\n  - The function handle\n  - The function name\n  - The function API version\n  - The targeting configuration\n  - The schema path\n  - The WASM path\n  - The function runner path",
       "flags": {
+        "auth-alias": {
+          "description": "Alias of the Shopify account to use for authentication.",
+          "env": "SHOPIFY_FLAG_AUTH_ALIAS",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "auth-alias",
+          "type": "option"
+        },
         "client-id": {
           "description": "The Client ID of your app.",
           "env": "SHOPIFY_FLAG_CLIENT_ID",
@@ -1659,6 +1787,14 @@
       "description": "Runs the function from your current directory for \"testing purposes\" (https://shopify.dev/docs/apps/functions/testing-and-debugging). To learn how you can monitor and debug functions when errors occur, refer to \"Shopify Functions error handling\" (https://shopify.dev/docs/api/functions/errors).",
       "descriptionWithMarkdown": "Runs the function from your current directory for [testing purposes](https://shopify.dev/docs/apps/functions/testing-and-debugging). To learn how you can monitor and debug functions when errors occur, refer to [Shopify Functions error handling](https://shopify.dev/docs/api/functions/errors).",
       "flags": {
+        "auth-alias": {
+          "description": "Alias of the Shopify account to use for authentication.",
+          "env": "SHOPIFY_FLAG_AUTH_ALIAS",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "auth-alias",
+          "type": "option"
+        },
         "client-id": {
           "description": "The Client ID of your app.",
           "env": "SHOPIFY_FLAG_CLIENT_ID",
@@ -1765,6 +1901,14 @@
       "description": "Runs the function from your current directory for \"testing purposes\" (https://shopify.dev/docs/apps/functions/testing-and-debugging). To learn how you can monitor and debug functions when errors occur, refer to \"Shopify Functions error handling\" (https://shopify.dev/docs/api/functions/errors).",
       "descriptionWithMarkdown": "Runs the function from your current directory for [testing purposes](https://shopify.dev/docs/apps/functions/testing-and-debugging). To learn how you can monitor and debug functions when errors occur, refer to [Shopify Functions error handling](https://shopify.dev/docs/api/functions/errors).",
       "flags": {
+        "auth-alias": {
+          "description": "Alias of the Shopify account to use for authentication.",
+          "env": "SHOPIFY_FLAG_AUTH_ALIAS",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "auth-alias",
+          "type": "option"
+        },
         "client-id": {
           "description": "The Client ID of your app.",
           "env": "SHOPIFY_FLAG_CLIENT_ID",
@@ -1872,6 +2016,14 @@
       "description": "Generates the latest \"GraphQL schema\" (https://shopify.dev/docs/apps/functions/input-output#graphql-schema) for a function in your app. Run this command from the function directory.\n\n  This command uses the API type and version of your function, as defined in your extension TOML file, to generate the latest GraphQL schema. The schema is written to the `schema.graphql` file.",
       "descriptionWithMarkdown": "Generates the latest [GraphQL schema](https://shopify.dev/docs/apps/functions/input-output#graphql-schema) for a function in your app. Run this command from the function directory.\n\n  This command uses the API type and version of your function, as defined in your extension TOML file, to generate the latest GraphQL schema. The schema is written to the `schema.graphql` file.",
       "flags": {
+        "auth-alias": {
+          "description": "Alias of the Shopify account to use for authentication.",
+          "env": "SHOPIFY_FLAG_AUTH_ALIAS",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "auth-alias",
+          "type": "option"
+        },
         "client-id": {
           "description": "The Client ID of your app.",
           "env": "SHOPIFY_FLAG_CLIENT_ID",
@@ -1959,6 +2111,14 @@
       "description": "Creates GraphQL types based on your \"input query\" (https://shopify.dev/docs/apps/functions/input-output#input) for a function. Supports JavaScript functions out of the box, or any language via the `build.typegen_command` configuration.",
       "descriptionWithMarkdown": "Creates GraphQL types based on your [input query](https://shopify.dev/docs/apps/functions/input-output#input) for a function. Supports JavaScript functions out of the box, or any language via the `build.typegen_command` configuration.",
       "flags": {
+        "auth-alias": {
+          "description": "Alias of the Shopify account to use for authentication.",
+          "env": "SHOPIFY_FLAG_AUTH_ALIAS",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "auth-alias",
+          "type": "option"
+        },
         "client-id": {
           "description": "The Client ID of your app.",
           "env": "SHOPIFY_FLAG_CLIENT_ID",
@@ -2038,6 +2198,14 @@
       "description": "Generates a new \"app extension\" (https://shopify.dev/docs/apps/build/app-extensions). For a list of app extensions that you can generate using this command, refer to \"Supported extensions\" (https://shopify.dev/docs/apps/build/app-extensions/list-of-app-extensions).\n\n  Each new app extension is created in a folder under `extensions/`. To learn more about the extensions file structure, refer to \"App structure\" (https://shopify.dev/docs/apps/build/cli-for-apps/app-structure) and the documentation for your extension.\n  ",
       "descriptionWithMarkdown": "Generates a new [app extension](https://shopify.dev/docs/apps/build/app-extensions). For a list of app extensions that you can generate using this command, refer to [Supported extensions](https://shopify.dev/docs/apps/build/app-extensions/list-of-app-extensions).\n\n  Each new app extension is created in a folder under `extensions/`. To learn more about the extensions file structure, refer to [App structure](https://shopify.dev/docs/apps/build/cli-for-apps/app-structure) and the documentation for your extension.\n  ",
       "flags": {
+        "auth-alias": {
+          "description": "Alias of the Shopify account to use for authentication.",
+          "env": "SHOPIFY_FLAG_AUTH_ALIAS",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "auth-alias",
+          "type": "option"
+        },
         "client-id": {
           "description": "The Client ID of your app.",
           "env": "SHOPIFY_FLAG_CLIENT_ID",
@@ -2163,6 +2331,14 @@
       "description": "Import metafield and metaobject definitions from your development store. \"Read more about declarative custom data definitions\" (https://shopify.dev/docs/apps/build/custom-data/declarative-custom-data-definitions).",
       "descriptionWithMarkdown": "Import metafield and metaobject definitions from your development store. [Read more about declarative custom data definitions](https://shopify.dev/docs/apps/build/custom-data/declarative-custom-data-definitions).",
       "flags": {
+        "auth-alias": {
+          "description": "Alias of the Shopify account to use for authentication.",
+          "env": "SHOPIFY_FLAG_AUTH_ALIAS",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "auth-alias",
+          "type": "option"
+        },
         "client-id": {
           "description": "The Client ID of your app.",
           "env": "SHOPIFY_FLAG_CLIENT_ID",
@@ -2256,6 +2432,14 @@
       "customPluginName": "@shopify/app",
       "description": "Import dashboard-managed extensions into your app.",
       "flags": {
+        "auth-alias": {
+          "description": "Alias of the Shopify account to use for authentication.",
+          "env": "SHOPIFY_FLAG_AUTH_ALIAS",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "auth-alias",
+          "type": "option"
+        },
         "client-id": {
           "description": "The Client ID of your app.",
           "env": "SHOPIFY_FLAG_CLIENT_ID",
@@ -2333,6 +2517,14 @@
       "description": "The information returned includes the following:\n\n  - The app and dev store that's used when you run the \"dev\" (https://shopify.dev/docs/api/shopify-cli/app/app-dev) command. You can reset these configurations using \"`dev --reset`\" (https://shopify.dev/docs/api/shopify-cli/app/app-dev#flags-propertydetail-reset).\n  - The \"structure\" (https://shopify.dev/docs/apps/tools/cli/structure) of your app project.\n  - The \"access scopes\" (https://shopify.dev/docs/api/usage) your app has requested.\n  - System information, including the package manager and version of Shopify CLI used in the project.",
       "descriptionWithMarkdown": "The information returned includes the following:\n\n  - The app and dev store that's used when you run the [dev](https://shopify.dev/docs/api/shopify-cli/app/app-dev) command. You can reset these configurations using [`dev --reset`](https://shopify.dev/docs/api/shopify-cli/app/app-dev#flags-propertydetail-reset).\n  - The [structure](https://shopify.dev/docs/apps/tools/cli/structure) of your app project.\n  - The [access scopes](https://shopify.dev/docs/api/usage) your app has requested.\n  - System information, including the package manager and version of Shopify CLI used in the project.",
       "flags": {
+        "auth-alias": {
+          "description": "Alias of the Shopify account to use for authentication.",
+          "env": "SHOPIFY_FLAG_AUTH_ALIAS",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "auth-alias",
+          "type": "option"
+        },
         "client-id": {
           "description": "The Client ID of your app.",
           "env": "SHOPIFY_FLAG_CLIENT_ID",
@@ -2426,6 +2618,14 @@
       },
       "customPluginName": "@shopify/app",
       "flags": {
+        "auth-alias": {
+          "description": "Alias of the Shopify account to use for authentication.",
+          "env": "SHOPIFY_FLAG_AUTH_ALIAS",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "auth-alias",
+          "type": "option"
+        },
         "client-id": {
           "description": "The Client ID of your app. Use this to automatically link your new project to an existing app. Using this flag avoids the app selection prompt.",
           "env": "SHOPIFY_FLAG_CLIENT_ID",
@@ -2545,6 +2745,14 @@
       "description": "\n  Opens a real-time stream of detailed app logs from the selected app and store.\n  Use the `--source` argument to limit output to a particular log source, such as a specific Shopify Function handle. Use the `shopify app logs sources` command to view a list of sources.\n  Use the `--status` argument to filter on status, either `success` or `failure`.\n  ```\n  shopify app logs --status=success --source=extension.discount-function\n  ```\n  ",
       "descriptionWithMarkdown": "\n  Opens a real-time stream of detailed app logs from the selected app and store.\n  Use the `--source` argument to limit output to a particular log source, such as a specific Shopify Function handle. Use the `shopify app logs sources` command to view a list of sources.\n  Use the `--status` argument to filter on status, either `success` or `failure`.\n  ```\n  shopify app logs --status=success --source=extension.discount-function\n  ```\n  ",
       "flags": {
+        "auth-alias": {
+          "description": "Alias of the Shopify account to use for authentication.",
+          "env": "SHOPIFY_FLAG_AUTH_ALIAS",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "auth-alias",
+          "type": "option"
+        },
         "client-id": {
           "description": "The Client ID of your app.",
           "env": "SHOPIFY_FLAG_CLIENT_ID",
@@ -2661,6 +2869,14 @@
       "description": "The output source names can be used with the `--source` argument of `shopify app logs` to filter log output. Currently only function extensions are supported as sources.",
       "descriptionWithMarkdown": "The output source names can be used with the `--source` argument of `shopify app logs` to filter log output. Currently only function extensions are supported as sources.",
       "flags": {
+        "auth-alias": {
+          "description": "Alias of the Shopify account to use for authentication.",
+          "env": "SHOPIFY_FLAG_AUTH_ALIAS",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "auth-alias",
+          "type": "option"
+        },
         "client-id": {
           "description": "The Client ID of your app.",
           "env": "SHOPIFY_FLAG_CLIENT_ID",
@@ -2755,6 +2971,14 @@
           "name": "allow-updates",
           "type": "boolean"
         },
+        "auth-alias": {
+          "description": "Alias of the Shopify account to use for authentication.",
+          "env": "SHOPIFY_FLAG_AUTH_ALIAS",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "auth-alias",
+          "type": "option"
+        },
         "client-id": {
           "description": "The Client ID of your app.",
           "env": "SHOPIFY_FLAG_CLIENT_ID",
@@ -2844,6 +3068,14 @@
       "description": "Lists the deployed app versions. An app version is a snapshot of your app extensions.",
       "descriptionWithMarkdown": "Lists the deployed app versions. An app version is a snapshot of your app extensions.",
       "flags": {
+        "auth-alias": {
+          "description": "Alias of the Shopify account to use for authentication.",
+          "env": "SHOPIFY_FLAG_AUTH_ALIAS",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "auth-alias",
+          "type": "option"
+        },
         "client-id": {
           "description": "The Client ID of your app.",
           "env": "SHOPIFY_FLAG_CLIENT_ID",
@@ -2949,6 +3181,14 @@
           "multiple": false,
           "name": "api-version",
           "required": false,
+          "type": "option"
+        },
+        "auth-alias": {
+          "description": "Alias of the Shopify account to use for authentication.",
+          "env": "SHOPIFY_FLAG_AUTH_ALIAS",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "auth-alias",
           "type": "option"
         },
         "client-id": {
@@ -3365,6 +3605,14 @@
       },
       "customPluginName": "@shopify/app",
       "flags": {
+        "auth-alias": {
+          "description": "Alias of the Shopify account to use for authentication.",
+          "env": "SHOPIFY_FLAG_AUTH_ALIAS",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "auth-alias",
+          "type": "option"
+        },
         "client-id": {
           "description": "The Client ID of your app.",
           "env": "SHOPIFY_FLAG_CLIENT_ID",
@@ -3987,15 +4235,6 @@
       "descriptionWithMarkdown": "Builds and deploys your Hydrogen storefront to Oxygen. Requires an Oxygen deployment token to be set with the `--token` flag or an environment variable (`SHOPIFY_HYDROGEN_DEPLOYMENT_TOKEN`). If the storefront is [linked](https://shopify.dev/docs/api/shopify-cli/hydrogen/hydrogen-link) then the Oxygen deployment token for the linked storefront will be used automatically.",
       "enableJsonFlag": false,
       "flags": {
-        "assets-dir": {
-          "description": "Directory containing the client assets to deploy, relative to the project root. Defaults to the detected Vite client output directory, then falls back to `dist/client`.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_ASSETS_DIR",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "assets-dir",
-          "required": false,
-          "type": "option"
-        },
         "auth-bypass-token": {
           "allowNo": false,
           "description": "Generate an authentication bypass token, which can be used to perform end-to-end tests against the deployment.",
@@ -4017,7 +4256,7 @@
           "type": "option"
         },
         "build-command": {
-          "description": "Specify a build command to run before deploying. If not specified, the Hydrogen build pipeline will be used. When custom output directories are configured, defaults to `node --run build`.",
+          "description": "Specify a build command to run before deploying. If not specified, `shopify hydrogen build` will be used.",
           "hasDynamicHelp": false,
           "multiple": false,
           "name": "build-command",
@@ -4065,7 +4304,7 @@
         "force": {
           "allowNo": false,
           "char": "f",
-          "description": "Forces a deployment to proceed if there are uncommitted changes in its Git repository.",
+          "description": "Forces a deployment to proceed if there are uncommited changes in its Git repository.",
           "env": "SHOPIFY_HYDROGEN_FLAG_FORCE",
           "name": "force",
           "required": false,
@@ -4093,7 +4332,7 @@
           "type": "boolean"
         },
         "metadata-description": {
-          "description": "Description of the changes in the deployment. Defaults to the commit message of the latest commit if there are no uncommitted changes.",
+          "description": "Description of the changes in the deployment. Defaults to the commit message of the latest commit if there are no uncommited changes.",
           "env": "SHOPIFY_HYDROGEN_FLAG_METADATA_DESCRIPTION",
           "hasDynamicHelp": false,
           "multiple": false,
@@ -4166,15 +4405,6 @@
           "hasDynamicHelp": false,
           "multiple": false,
           "name": "token",
-          "required": false,
-          "type": "option"
-        },
-        "worker-dir": {
-          "description": "Directory containing the Oxygen worker entry point (`index.js` or `index.mjs`), relative to the project root. Defaults to the detected Vite server output directory, then falls back to `dist/server`.",
-          "env": "SHOPIFY_HYDROGEN_FLAG_WORKER_DIR",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "worker-dir",
           "required": false,
           "type": "option"
         }
@@ -4507,7 +4737,7 @@
       ],
       "args": {
         "routeName": {
-          "description": "The route to generate. One of home,page,cart,products,collections,policies,blogs,account,search,robots,sitemap,all.",
+          "description": "The route to generate. One of home,page,cart,products,collections,policies,blogs,account,search,robots,sitemap,tokenlessApi,all.",
           "name": "routeName",
           "options": [
             "home",
@@ -4521,6 +4751,7 @@
             "search",
             "robots",
             "sitemap",
+            "tokenlessApi",
             "all"
           ],
           "required": true
@@ -4532,7 +4763,7 @@
       "enableJsonFlag": false,
       "flags": {
         "adapter": {
-          "description": "React Router adapter used in the route. The default is `react-router`.",
+          "description": "Remix adapter used in the route. The default is `@shopify/remix-oxygen`.",
           "env": "SHOPIFY_HYDROGEN_FLAG_ADAPTER",
           "hasDynamicHelp": false,
           "multiple": false,
@@ -4590,7 +4821,7 @@
       "enableJsonFlag": false,
       "flags": {
         "adapter": {
-          "description": "React Router adapter used in the route. The default is `react-router`.",
+          "description": "Remix adapter used in the route. The default is `@shopify/remix-oxygen`.",
           "env": "SHOPIFY_HYDROGEN_FLAG_ADAPTER",
           "hasDynamicHelp": false,
           "multiple": false,
@@ -6795,12 +7026,12 @@
       "description": "Starts the Shopify Liquid REPL (read-eval-print loop) tool. This tool provides an interactive terminal interface for evaluating Liquid code and exploring Liquid objects, filters, and tags using real store data.\n\n  You can also provide context to the console using a URL, as some Liquid objects are context-specific",
       "descriptionWithMarkdown": "Starts the Shopify Liquid REPL (read-eval-print loop) tool. This tool provides an interactive terminal interface for evaluating Liquid code and exploring Liquid objects, filters, and tags using real store data.\n\n  You can also provide context to the console using a URL, as some Liquid objects are context-specific",
       "flags": {
-        "alias": {
+        "auth-alias": {
           "description": "Alias of the Shopify account to use for authentication.",
           "env": "SHOPIFY_FLAG_AUTH_ALIAS",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "alias",
+          "name": "auth-alias",
           "type": "option"
         },
         "environment": {
@@ -6896,12 +7127,12 @@
       "description": "Deletes a theme from your store.\n\n  You can specify multiple themes by ID. If no theme is specified, then you're prompted to select the theme that you want to delete from the list of themes in your store.\n\n  You're asked to confirm that you want to delete the specified themes before they are deleted. You can skip this confirmation using the `--force` flag.",
       "descriptionWithMarkdown": "Deletes a theme from your store.\n\n  You can specify multiple themes by ID. If no theme is specified, then you're prompted to select the theme that you want to delete from the list of themes in your store.\n\n  You're asked to confirm that you want to delete the specified themes before they are deleted. You can skip this confirmation using the `--force` flag.",
       "flags": {
-        "alias": {
+        "auth-alias": {
           "description": "Alias of the Shopify account to use for authentication.",
           "env": "SHOPIFY_FLAG_AUTH_ALIAS",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "alias",
+          "name": "auth-alias",
           "type": "option"
         },
         "development": {
@@ -7016,14 +7247,6 @@
       "description": "\n  Uploads the current theme as the specified theme, or a \"development theme\" (https://shopify.dev/docs/themes/tools/cli#development-themes), to a store so you can preview it.\n\nThis command returns the following information:\n\n- A link to your development theme at http://127.0.0.1:9292. This URL can hot reload local changes to CSS and sections, or refresh the entire page when a file changes, enabling you to preview changes in real time using the store's data.\n\n  You can specify a different network interface and port using `--host` and `--port`.\n\n- A link to the \"editor\" (https://shopify.dev/docs/themes/tools/online-editor) for the theme in the Shopify admin.\n\n- A \"preview link\" (https://help.shopify.com/manual/online-store/themes/adding-themes#share-a-theme-preview-with-others) that you can share with other developers.\n\nIf you already have a development theme for your current environment, then this command replaces the development theme with your local theme. You can override this using the `--theme-editor-sync` flag.\n\n> Note: You can't preview checkout customizations using http://127.0.0.1:9292.\n\nDevelopment themes are deleted when you run `shopify auth logout`. If you need a preview link that can be used after you log out, then you should \"share\" (https://shopify.dev/docs/api/shopify-cli/theme/theme-share) your theme or \"push\" (https://shopify.dev/docs/api/shopify-cli/theme/theme-push) to an unpublished theme on your store.\n\nYou can run this command only in a directory that matches the \"default Shopify theme folder structure\" (https://shopify.dev/docs/themes/tools/cli#directory-structure).",
       "descriptionWithMarkdown": "\n  Uploads the current theme as the specified theme, or a [development theme](https://shopify.dev/docs/themes/tools/cli#development-themes), to a store so you can preview it.\n\nThis command returns the following information:\n\n- A link to your development theme at http://127.0.0.1:9292. This URL can hot reload local changes to CSS and sections, or refresh the entire page when a file changes, enabling you to preview changes in real time using the store's data.\n\n  You can specify a different network interface and port using `--host` and `--port`.\n\n- A link to the [editor](https://shopify.dev/docs/themes/tools/online-editor) for the theme in the Shopify admin.\n\n- A [preview link](https://help.shopify.com/manual/online-store/themes/adding-themes#share-a-theme-preview-with-others) that you can share with other developers.\n\nIf you already have a development theme for your current environment, then this command replaces the development theme with your local theme. You can override this using the `--theme-editor-sync` flag.\n\n> Note: You can't preview checkout customizations using http://127.0.0.1:9292.\n\nDevelopment themes are deleted when you run `shopify auth logout`. If you need a preview link that can be used after you log out, then you should [share](https://shopify.dev/docs/api/shopify-cli/theme/theme-share) your theme or [push](https://shopify.dev/docs/api/shopify-cli/theme/theme-push) to an unpublished theme on your store.\n\nYou can run this command only in a directory that matches the [default Shopify theme folder structure](https://shopify.dev/docs/themes/tools/cli#directory-structure).",
       "flags": {
-        "alias": {
-          "description": "Alias of the Shopify account to use for authentication.",
-          "env": "SHOPIFY_FLAG_AUTH_ALIAS",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "alias",
-          "type": "option"
-        },
         "allow-live": {
           "allowNo": false,
           "char": "a",
@@ -7031,6 +7254,14 @@
           "env": "SHOPIFY_FLAG_ALLOW_LIVE",
           "name": "allow-live",
           "type": "boolean"
+        },
+        "auth-alias": {
+          "description": "Alias of the Shopify account to use for authentication.",
+          "env": "SHOPIFY_FLAG_AUTH_ALIAS",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "auth-alias",
+          "type": "option"
         },
         "environment": {
           "char": "e",
@@ -7244,12 +7475,12 @@
       "description": "If you want to duplicate your local theme, you need to run `shopify theme push` first.\n\nIf no theme ID is specified, you're prompted to select the theme that you want to duplicate from the list of themes in your store. You're asked to confirm that you want to duplicate the specified theme.\n\nPrompts and confirmations are not shown when duplicate is run in a CI environment or the `--force` flag is used, therefore you must specify a theme ID using the `--theme` flag.\n\nYou can optionally name the duplicated theme using the `--name` flag.\n\nIf you use the `--json` flag, then theme information is returned in JSON format, which can be used as a machine-readable input for scripts or continuous integration.\n\nSample JSON output:\n\n```json\n{\n  \"theme\": {\n    \"id\": 108267175958,\n    \"name\": \"A Duplicated Theme\",\n    \"role\": \"unpublished\",\n    \"shop\": \"mystore.myshopify.com\"\n  }\n}\n```\n\n```json\n{\n  \"message\": \"The theme 'Summer Edition' could not be duplicated due to errors\",\n  \"errors\": [\"Maximum number of themes reached\"],\n  \"requestId\": \"12345-abcde-67890\"\n}\n```",
       "descriptionWithMarkdown": "If you want to duplicate your local theme, you need to run `shopify theme push` first.\n\nIf no theme ID is specified, you're prompted to select the theme that you want to duplicate from the list of themes in your store. You're asked to confirm that you want to duplicate the specified theme.\n\nPrompts and confirmations are not shown when duplicate is run in a CI environment or the `--force` flag is used, therefore you must specify a theme ID using the `--theme` flag.\n\nYou can optionally name the duplicated theme using the `--name` flag.\n\nIf you use the `--json` flag, then theme information is returned in JSON format, which can be used as a machine-readable input for scripts or continuous integration.\n\nSample JSON output:\n\n```json\n{\n  \"theme\": {\n    \"id\": 108267175958,\n    \"name\": \"A Duplicated Theme\",\n    \"role\": \"unpublished\",\n    \"shop\": \"mystore.myshopify.com\"\n  }\n}\n```\n\n```json\n{\n  \"message\": \"The theme 'Summer Edition' could not be duplicated due to errors\",\n  \"errors\": [\"Maximum number of themes reached\"],\n  \"requestId\": \"12345-abcde-67890\"\n}\n```",
       "flags": {
-        "alias": {
+        "auth-alias": {
           "description": "Alias of the Shopify account to use for authentication.",
           "env": "SHOPIFY_FLAG_AUTH_ALIAS",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "alias",
+          "name": "auth-alias",
           "type": "option"
         },
         "environment": {
@@ -7352,12 +7583,12 @@
       "customPluginName": "@shopify/theme",
       "description": "Displays information about your theme environment, including your current store. Can also retrieve information about a specific theme.",
       "flags": {
-        "alias": {
+        "auth-alias": {
           "description": "Alias of the Shopify account to use for authentication.",
           "env": "SHOPIFY_FLAG_AUTH_ALIAS",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "alias",
+          "name": "auth-alias",
           "type": "option"
         },
         "development": {
@@ -7566,12 +7797,12 @@
       "customPluginName": "@shopify/theme",
       "description": "Lists the themes in your store, along with their IDs and statuses.",
       "flags": {
-        "alias": {
+        "auth-alias": {
           "description": "Alias of the Shopify account to use for authentication.",
           "env": "SHOPIFY_FLAG_AUTH_ALIAS",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "alias",
+          "name": "auth-alias",
           "type": "option"
         },
         "environment": {
@@ -7686,12 +7917,12 @@
       "description": "Retrieves metafields from Shopify Admin.\n\nIf the metafields file already exists, it will be overwritten.",
       "descriptionWithMarkdown": "Retrieves metafields from Shopify Admin.\n\nIf the metafields file already exists, it will be overwritten.",
       "flags": {
-        "alias": {
+        "auth-alias": {
           "description": "Alias of the Shopify account to use for authentication.",
           "env": "SHOPIFY_FLAG_AUTH_ALIAS",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "alias",
+          "name": "auth-alias",
           "type": "option"
         },
         "environment": {
@@ -7775,12 +8006,12 @@
       "description": "Returns links that let you preview the specified theme. The following links are returned:\n\n  - A link to the \"editor\" (https://shopify.dev/docs/themes/tools/online-editor) for the theme in the Shopify admin.\n  - A \"preview link\" (https://help.shopify.com/manual/online-store/themes/adding-themes#share-a-theme-preview-with-others) that you can share with other developers.\n\n  If you don't specify a theme, then you're prompted to select the theme to open from the list of the themes in your store.",
       "descriptionWithMarkdown": "Returns links that let you preview the specified theme. The following links are returned:\n\n  - A link to the [editor](https://shopify.dev/docs/themes/tools/online-editor) for the theme in the Shopify admin.\n  - A [preview link](https://help.shopify.com/manual/online-store/themes/adding-themes#share-a-theme-preview-with-others) that you can share with other developers.\n\n  If you don't specify a theme, then you're prompted to select the theme to open from the list of the themes in your store.",
       "flags": {
-        "alias": {
+        "auth-alias": {
           "description": "Alias of the Shopify account to use for authentication.",
           "env": "SHOPIFY_FLAG_AUTH_ALIAS",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "alias",
+          "name": "auth-alias",
           "type": "option"
         },
         "development": {
@@ -7934,12 +8165,12 @@
       "description": "Applies a JSON overrides file to a theme and creates or updates a preview. This lets you quickly preview changes.\n\n  The command returns a preview URL and a preview identifier. You can reuse the preview identifier with `--preview-id` to update an existing preview instead of creating a new one.",
       "descriptionWithMarkdown": "Applies a JSON overrides file to a theme and creates or updates a preview. This lets you quickly preview changes.\n\n  The command returns a preview URL and a preview identifier. You can reuse the preview identifier with `--preview-id` to update an existing preview instead of creating a new one.",
       "flags": {
-        "alias": {
+        "auth-alias": {
           "description": "Alias of the Shopify account to use for authentication.",
           "env": "SHOPIFY_FLAG_AUTH_ALIAS",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "alias",
+          "name": "auth-alias",
           "type": "option"
         },
         "environment": {
@@ -8055,12 +8286,12 @@
       "description": "Profile the Shopify Liquid on a given page.\n\n  This command will open a web page with the Speedscope profiler detailing the time spent executing Liquid on the given page.",
       "descriptionWithMarkdown": "Profile the Shopify Liquid on a given page.\n\n  This command will open a web page with the Speedscope profiler detailing the time spent executing Liquid on the given page.",
       "flags": {
-        "alias": {
+        "auth-alias": {
           "description": "Alias of the Shopify account to use for authentication.",
           "env": "SHOPIFY_FLAG_AUTH_ALIAS",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "alias",
+          "name": "auth-alias",
           "type": "option"
         },
         "environment": {
@@ -8174,12 +8405,12 @@
       "description": "Publishes an unpublished theme from your theme library.\n\nIf no theme ID is specified, then you're prompted to select the theme that you want to publish from the list of themes in your store.\n\nYou can run this command only in a directory that matches the \"default Shopify theme folder structure\" (https://shopify.dev/docs/themes/tools/cli#directory-structure).\n\nIf you want to publish your local theme, then you need to run `shopify theme push` first. You're asked to confirm that you want to publish the specified theme. You can skip this confirmation using the `--force` flag.",
       "descriptionWithMarkdown": "Publishes an unpublished theme from your theme library.\n\nIf no theme ID is specified, then you're prompted to select the theme that you want to publish from the list of themes in your store.\n\nYou can run this command only in a directory that matches the [default Shopify theme folder structure](https://shopify.dev/docs/themes/tools/cli#directory-structure).\n\nIf you want to publish your local theme, then you need to run `shopify theme push` first. You're asked to confirm that you want to publish the specified theme. You can skip this confirmation using the `--force` flag.",
       "flags": {
-        "alias": {
+        "auth-alias": {
           "description": "Alias of the Shopify account to use for authentication.",
           "env": "SHOPIFY_FLAG_AUTH_ALIAS",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "alias",
+          "name": "auth-alias",
           "type": "option"
         },
         "environment": {
@@ -8275,12 +8506,12 @@
       "description": "Retrieves theme files from Shopify.\n\nIf no theme is specified, then you're prompted to select the theme to pull from the list of the themes in your store.",
       "descriptionWithMarkdown": "Retrieves theme files from Shopify.\n\nIf no theme is specified, then you're prompted to select the theme to pull from the list of the themes in your store.",
       "flags": {
-        "alias": {
+        "auth-alias": {
           "description": "Alias of the Shopify account to use for authentication.",
           "env": "SHOPIFY_FLAG_AUTH_ALIAS",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "alias",
+          "name": "auth-alias",
           "type": "option"
         },
         "development": {
@@ -8424,14 +8655,6 @@
       "description": "Uploads your local theme files to Shopify, overwriting the remote version if specified.\n\n  If no theme is specified, then you're prompted to select the theme to overwrite from the list of the themes in your store.\n\n  You can run this command only in a directory that matches the \"default Shopify theme folder structure\" (https://shopify.dev/docs/themes/tools/cli#directory-structure).\n\n  This command returns the following information:\n\n  - A link to the \"editor\" (https://shopify.dev/docs/themes/tools/online-editor) for the theme in the Shopify admin.\n  - A \"preview link\" (https://help.shopify.com/manual/online-store/themes/adding-themes#share-a-theme-preview-with-others) that you can share with others.\n\n  If you use the `--json` flag, then theme information is returned in JSON format, which can be used as a machine-readable input for scripts or continuous integration.\n\n  Sample output:\n\n  ```json\n  {\n    \"theme\": {\n      \"id\": 108267175958,\n      \"name\": \"MyTheme\",\n      \"role\": \"unpublished\",\n      \"shop\": \"mystore.myshopify.com\",\n      \"editor_url\": \"https://mystore.myshopify.com/admin/themes/108267175958/editor\",\n      \"preview_url\": \"https://mystore.myshopify.com/?preview_theme_id=108267175958\"\n    }\n  }\n  ```\n    ",
       "descriptionWithMarkdown": "Uploads your local theme files to Shopify, overwriting the remote version if specified.\n\n  If no theme is specified, then you're prompted to select the theme to overwrite from the list of the themes in your store.\n\n  You can run this command only in a directory that matches the [default Shopify theme folder structure](https://shopify.dev/docs/themes/tools/cli#directory-structure).\n\n  This command returns the following information:\n\n  - A link to the [editor](https://shopify.dev/docs/themes/tools/online-editor) for the theme in the Shopify admin.\n  - A [preview link](https://help.shopify.com/manual/online-store/themes/adding-themes#share-a-theme-preview-with-others) that you can share with others.\n\n  If you use the `--json` flag, then theme information is returned in JSON format, which can be used as a machine-readable input for scripts or continuous integration.\n\n  Sample output:\n\n  ```json\n  {\n    \"theme\": {\n      \"id\": 108267175958,\n      \"name\": \"MyTheme\",\n      \"role\": \"unpublished\",\n      \"shop\": \"mystore.myshopify.com\",\n      \"editor_url\": \"https://mystore.myshopify.com/admin/themes/108267175958/editor\",\n      \"preview_url\": \"https://mystore.myshopify.com/?preview_theme_id=108267175958\"\n    }\n  }\n  ```\n    ",
       "flags": {
-        "alias": {
-          "description": "Alias of the Shopify account to use for authentication.",
-          "env": "SHOPIFY_FLAG_AUTH_ALIAS",
-          "hasDynamicHelp": false,
-          "multiple": false,
-          "name": "alias",
-          "type": "option"
-        },
         "allow-live": {
           "allowNo": false,
           "char": "a",
@@ -8439,6 +8662,14 @@
           "env": "SHOPIFY_FLAG_ALLOW_LIVE",
           "name": "allow-live",
           "type": "boolean"
+        },
+        "auth-alias": {
+          "description": "Alias of the Shopify account to use for authentication.",
+          "env": "SHOPIFY_FLAG_AUTH_ALIAS",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "auth-alias",
+          "type": "option"
         },
         "development": {
           "allowNo": false,
@@ -8640,12 +8871,12 @@
       "description": "Renames a theme in your store.\n\n  If no theme is specified, then you're prompted to select the theme that you want to rename from the list of themes in your store.\n  ",
       "descriptionWithMarkdown": "Renames a theme in your store.\n\n  If no theme is specified, then you're prompted to select the theme that you want to rename from the list of themes in your store.\n  ",
       "flags": {
-        "alias": {
+        "auth-alias": {
           "description": "Alias of the Shopify account to use for authentication.",
           "env": "SHOPIFY_FLAG_AUTH_ALIAS",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "alias",
+          "name": "auth-alias",
           "type": "option"
         },
         "development": {
@@ -8764,12 +8995,12 @@
       "description": "Uploads your theme as a new, unpublished theme in your theme library. The theme is given a randomized name.\n\n  This command returns a \"preview link\" (https://help.shopify.com/manual/online-store/themes/adding-themes#share-a-theme-preview-with-others) that you can share with others.",
       "descriptionWithMarkdown": "Uploads your theme as a new, unpublished theme in your theme library. The theme is given a randomized name.\n\n  This command returns a [preview link](https://help.shopify.com/manual/online-store/themes/adding-themes#share-a-theme-preview-with-others) that you can share with others.",
       "flags": {
-        "alias": {
+        "auth-alias": {
           "description": "Alias of the Shopify account to use for authentication.",
           "env": "SHOPIFY_FLAG_AUTH_ALIAS",
           "hasDynamicHelp": false,
           "multiple": false,
-          "name": "alias",
+          "name": "auth-alias",
           "type": "option"
         },
         "environment": {

--- a/packages/create-app/oclif.manifest.json
+++ b/packages/create-app/oclif.manifest.json
@@ -6,6 +6,14 @@
       "args": {
       },
       "flags": {
+        "auth-alias": {
+          "description": "Alias of the Shopify account to use for authentication.",
+          "env": "SHOPIFY_FLAG_AUTH_ALIAS",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "auth-alias",
+          "type": "option"
+        },
         "client-id": {
           "description": "The Client ID of your app. Use this to automatically link your new project to an existing app. Using this flag avoids the app selection prompt.",
           "env": "SHOPIFY_FLAG_CLIENT_ID",

--- a/packages/theme/src/cli/commands/theme/dev.ts
+++ b/packages/theme/src/cli/commands/theme/dev.ts
@@ -192,14 +192,17 @@ You can run this command only in a directory that matches the [default Shopify t
       notify: flags.notify,
     })
 
-    await metafieldsPull({
-      path: flags.path,
-      password: flags.password,
-      store: flags.store,
-      force: flags.force,
-      verbose: flags.verbose,
-      noColor: flags['no-color'],
-      silent: true,
-    })
+    await metafieldsPull(
+      {
+        path: flags.path,
+        password: flags.password,
+        store: flags.store,
+        force: flags.force,
+        verbose: flags.verbose,
+        noColor: flags['no-color'],
+        silent: true,
+      },
+      adminSession,
+    )
   }
 }

--- a/packages/theme/src/cli/commands/theme/duplicate.ts
+++ b/packages/theme/src/cli/commands/theme/duplicate.ts
@@ -1,10 +1,8 @@
-import {ensureThemeStore} from '../../utilities/theme-store.js'
 import {themeFlags} from '../../flags.js'
 import ThemeCommand from '../../utilities/theme-command.js'
 import {duplicate} from '../../services/duplicate.js'
 import {Flags} from '@oclif/core'
 import {globalFlags, jsonFlag} from '@shopify/cli-kit/node/cli'
-import {ensureAuthenticatedThemes} from '@shopify/cli-kit/node/session'
 
 export default class Duplicate extends ThemeCommand {
   static summary = 'Duplicates a theme from your theme library.'
@@ -59,6 +57,7 @@ Sample JSON output:
       env: 'SHOPIFY_FLAG_NAME',
     }),
     store: themeFlags.store,
+    alias: themeFlags.alias,
     environment: themeFlags.environment,
     force: Flags.boolean({
       char: 'f',
@@ -69,8 +68,7 @@ Sample JSON output:
 
   async run(): Promise<void> {
     const {flags} = await this.parse(Duplicate)
-    const store = ensureThemeStore(flags)
-    const adminSession = await ensureAuthenticatedThemes(store, flags.password)
+    const adminSession = await this.createSession(flags)
 
     await duplicate(adminSession, flags.theme, flags)
   }

--- a/packages/theme/src/cli/commands/theme/duplicate.ts
+++ b/packages/theme/src/cli/commands/theme/duplicate.ts
@@ -1,4 +1,4 @@
-import {themeFlags} from '../../flags.js'
+import {themeAuthenticationFlags} from '../../flags.js'
 import ThemeCommand from '../../utilities/theme-command.js'
 import {duplicate} from '../../services/duplicate.js'
 import {Flags} from '@oclif/core'
@@ -45,7 +45,7 @@ Sample JSON output:
   static flags = {
     ...globalFlags,
     ...jsonFlag,
-    password: themeFlags.password,
+    ...themeAuthenticationFlags,
     theme: Flags.string({
       char: 't',
       description: 'Theme ID or name of the remote theme.',
@@ -56,9 +56,6 @@ Sample JSON output:
       description: 'Name of the newly duplicated theme.',
       env: 'SHOPIFY_FLAG_NAME',
     }),
-    store: themeFlags.store,
-    alias: themeFlags.alias,
-    environment: themeFlags.environment,
     force: Flags.boolean({
       char: 'f',
       description: 'Force the duplicate operation to run without prompts or confirmations.',

--- a/packages/theme/src/cli/commands/theme/metafields/pull.ts
+++ b/packages/theme/src/cli/commands/theme/metafields/pull.ts
@@ -4,6 +4,7 @@ import ThemeCommand, {RequiredFlags} from '../../../utilities/theme-command.js'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
 import {Flags} from '@oclif/core'
 import {InferredFlags} from '@oclif/core/interfaces'
+import {AdminSession} from '@shopify/cli-kit/node/session'
 
 type MetafieldsFlags = InferredFlags<typeof MetafieldsPull.flags>
 
@@ -29,7 +30,7 @@ If the metafields file already exists, it will be overwritten.`
 
   static multiEnvironmentsFlags: RequiredFlags = null
 
-  async command(flags: MetafieldsFlags) {
+  async command(flags: MetafieldsFlags, adminSession?: AdminSession) {
     const args: MetafieldsPullFlags = {
       path: flags.path,
       password: flags.password,
@@ -39,6 +40,6 @@ If the metafields file already exists, it will be overwritten.`
       noColor: flags['no-color'],
     }
 
-    await metafieldsPull(args)
+    await metafieldsPull(args, adminSession)
   }
 }

--- a/packages/theme/src/cli/flags.ts
+++ b/packages/theme/src/cli/flags.ts
@@ -42,6 +42,10 @@ export const themeFlags = {
     description: 'Password generated from the Theme Access app or an Admin API token.',
     env: 'SHOPIFY_CLI_THEME_TOKEN',
   }),
+  alias: Flags.string({
+    description: 'Alias of the Shopify account to use for authentication.',
+    env: 'SHOPIFY_FLAG_AUTH_ALIAS',
+  }),
   store: Flags.string({
     char: 's',
     description:

--- a/packages/theme/src/cli/flags.ts
+++ b/packages/theme/src/cli/flags.ts
@@ -42,7 +42,7 @@ export const themeFlags = {
     description: 'Password generated from the Theme Access app or an Admin API token.',
     env: 'SHOPIFY_CLI_THEME_TOKEN',
   }),
-  alias: Flags.string({
+  'auth-alias': Flags.string({
     description: 'Alias of the Shopify account to use for authentication.',
     env: 'SHOPIFY_FLAG_AUTH_ALIAS',
   }),
@@ -60,6 +60,13 @@ export const themeFlags = {
     env: 'SHOPIFY_FLAG_ENVIRONMENT',
     multiple: true,
   }),
+}
+
+export const themeAuthenticationFlags = {
+  password: themeFlags.password,
+  store: themeFlags.store,
+  'auth-alias': themeFlags['auth-alias'],
+  environment: themeFlags.environment,
 }
 
 const globQuotesDescription = "Wrap the value in double quotes if you're using wildcards."

--- a/packages/theme/src/cli/services/metafields-pull.ts
+++ b/packages/theme/src/cli/services/metafields-pull.ts
@@ -58,11 +58,11 @@ export interface MetafieldsPullFlags {
  *
  * @param flags - All flags are optional.
  */
-export async function metafieldsPull(flags: MetafieldsPullFlags): Promise<void> {
+export async function metafieldsPull(flags: MetafieldsPullFlags, session?: AdminSession): Promise<void> {
   configureCLIEnvironment({verbose: flags.verbose, noColor: flags.noColor})
 
   const store = ensureThemeStore({store: flags.store})
-  const adminSession = await ensureAuthenticatedThemes(store, flags.password)
+  const adminSession = session ?? (await ensureAuthenticatedThemes(store, flags.password))
 
   await executeMetafieldsPull(adminSession, {
     path: flags.path ?? cwd(),

--- a/packages/theme/src/cli/utilities/theme-command.test.ts
+++ b/packages/theme/src/cli/utilities/theme-command.test.ts
@@ -2,7 +2,7 @@ import ThemeCommand, {RequiredFlags} from './theme-command.js'
 import {ensureThemeStore} from './theme-store.js'
 import {describe, vi, expect, test, beforeEach} from 'vitest'
 import {Config, Flags} from '@oclif/core'
-import {AdminSession, ensureAuthenticatedThemes} from '@shopify/cli-kit/node/session'
+import {AdminSession, ensureAuthenticatedThemes, findSessionIdByAlias} from '@shopify/cli-kit/node/session'
 import {
   getCurrentStoredStoreAppSession,
   listCurrentStoredStoreAppSessions,
@@ -41,6 +41,9 @@ class TestThemeCommand extends ThemeCommand {
     }),
     password: Flags.string({
       env: 'SHOPIFY_FLAG_PASSWORD',
+    }),
+    alias: Flags.string({
+      env: 'SHOPIFY_FLAG_AUTH_ALIAS',
     }),
     path: Flags.string({
       env: 'SHOPIFY_FLAG_PATH',
@@ -192,6 +195,7 @@ describe('ThemeCommand', () => {
     vi.mocked(ensureAuthenticatedThemes).mockResolvedValue(mockSession)
     vi.mocked(getCurrentStoredStoreAppSession).mockReturnValue(undefined)
     vi.mocked(listCurrentStoredStoreAppSessions).mockReturnValue([])
+    vi.mocked(findSessionIdByAlias).mockResolvedValue(undefined)
     vi.mocked(fileExistsSync).mockReturnValue(true)
   })
 
@@ -424,6 +428,35 @@ describe('ThemeCommand', () => {
       const command = new TestThemeCommand([], CommandConfig)
 
       await expect(command.run()).rejects.toThrow('cache read failed')
+    })
+
+    test('passes a resolved account alias to authentication without selecting it globally', async () => {
+      // Given
+      vi.mocked(findSessionIdByAlias).mockResolvedValue('user-id-for-work')
+
+      await CommandConfig.load()
+      const command = new TestThemeCommand(['--store', 'test-store.myshopify.com', '--alias', 'work'], CommandConfig)
+
+      // When
+      await command.run()
+
+      // Then
+      expect(findSessionIdByAlias).toHaveBeenCalledWith('work')
+      expect(ensureAuthenticatedThemes).toHaveBeenCalledWith('test-store.myshopify.com', undefined, [], {
+        sessionId: 'user-id-for-work',
+      })
+      expect(command.commandCalls).toHaveLength(1)
+    })
+
+    test('throws when account alias does not match a stored session', async () => {
+      // Given
+      vi.mocked(findSessionIdByAlias).mockResolvedValue(undefined)
+
+      await CommandConfig.load()
+      const command = new TestThemeCommand(['--store', 'test-store.myshopify.com', '--alias', 'missing'], CommandConfig)
+
+      // When/Then
+      await expect(command.run()).rejects.toThrow('No authenticated account found for alias')
       expect(ensureAuthenticatedThemes).not.toHaveBeenCalled()
     })
 

--- a/packages/theme/src/cli/utilities/theme-command.test.ts
+++ b/packages/theme/src/cli/utilities/theme-command.test.ts
@@ -42,7 +42,7 @@ class TestThemeCommand extends ThemeCommand {
     password: Flags.string({
       env: 'SHOPIFY_FLAG_PASSWORD',
     }),
-    alias: Flags.string({
+    'auth-alias': Flags.string({
       env: 'SHOPIFY_FLAG_AUTH_ALIAS',
     }),
     path: Flags.string({
@@ -435,7 +435,10 @@ describe('ThemeCommand', () => {
       vi.mocked(findSessionIdByAlias).mockResolvedValue('user-id-for-work')
 
       await CommandConfig.load()
-      const command = new TestThemeCommand(['--store', 'test-store.myshopify.com', '--alias', 'work'], CommandConfig)
+      const command = new TestThemeCommand(
+        ['--store', 'test-store.myshopify.com', '--auth-alias', 'work'],
+        CommandConfig,
+      )
 
       // When
       await command.run()
@@ -453,7 +456,10 @@ describe('ThemeCommand', () => {
       vi.mocked(findSessionIdByAlias).mockResolvedValue(undefined)
 
       await CommandConfig.load()
-      const command = new TestThemeCommand(['--store', 'test-store.myshopify.com', '--alias', 'missing'], CommandConfig)
+      const command = new TestThemeCommand(
+        ['--store', 'test-store.myshopify.com', '--auth-alias', 'missing'],
+        CommandConfig,
+      )
 
       // When/Then
       await expect(command.run()).rejects.toThrow('No authenticated account found for alias')

--- a/packages/theme/src/cli/utilities/theme-command.ts
+++ b/packages/theme/src/cli/utilities/theme-command.ts
@@ -147,6 +147,24 @@ export default abstract class ThemeCommand extends Command {
   }
 
   /**
+   * Create an unauthenticated session object from store and password
+   * @param flags - The environment flags containing store and password
+   * @returns The unauthenticated session object
+   */
+  protected async createSession(flags: FlagValues, storeAuthSession?: AdminSession, lookupStoreAuthSession = true) {
+    const store = ensureThemeStore({store: flags.store as string | undefined})
+    const password = flags.password as string | undefined
+    const authAlias = flags['auth-alias'] as string | undefined
+    const sessionId = !password && authAlias ? await this.sessionIdFromAlias(authAlias) : undefined
+
+    if (password) return ensureAuthenticatedThemes(store, password)
+    if (sessionId) return ensureAuthenticatedThemes(store, password, [], {sessionId})
+
+    const storedSession = lookupStoreAuthSession ? await this.storeAuthSessionForTheme({store}) : undefined
+    return storeAuthSession ?? storedSession ?? ensureAuthenticatedThemes(store, password)
+  }
+
+  /**
    * Create a map of environments from the shopify.theme.toml file
    * @param environments - Names of environments to load
    * @param flags - Flags provided via the CLI or by default
@@ -302,7 +320,7 @@ export default abstract class ThemeCommand extends Command {
             try {
               const store = flags.store as string
               await useThemeStoreContext(store, async () => {
-                const session = requiresAuth ? await this.createSession(flags, storeAuthSession) : undefined
+                const session = requiresAuth ? await this.createSession(flags, storeAuthSession, false) : undefined
 
                 const commandName = this.constructor.name.toLowerCase()
                 recordEvent(`theme-command:${commandName}:multi-env:authenticated`)
@@ -345,27 +363,6 @@ export default abstract class ThemeCommand extends Command {
     })
 
     return groups
-  }
-
-  /**
-   * Create an unauthenticated session object from store and password
-   * @param flags - The environment flags containing store and password
-   * @returns The unauthenticated session object
-   */
-  private async createSession(flags: FlagValues, storeAuthSession?: AdminSession) {
-    const store = ensureThemeStore({store: flags.store as string | undefined})
-    const password = flags.password as string | undefined
-    const alias = flags.alias as string | undefined
-    const sessionId = !password && alias ? await this.sessionIdFromAlias(alias) : undefined
-    const session = password
-      ? await ensureAuthenticatedThemes(store, password)
-      : sessionId
-        ? await ensureAuthenticatedThemes(store, password, [], {sessionId})
-        : (storeAuthSession ??
-          (await this.storeAuthSessionForTheme({store})) ??
-          (await ensureAuthenticatedThemes(store, password)))
-
-    return session
   }
 
   private async storeAuthSessionForTheme(flags: FlagValues): Promise<AdminSession | undefined> {

--- a/packages/theme/src/cli/utilities/theme-command.ts
+++ b/packages/theme/src/cli/utilities/theme-command.ts
@@ -5,7 +5,12 @@ import {useThemeStoreContext} from '../services/local-storage.js'
 import {hashString} from '@shopify/cli-kit/node/crypto'
 import {Input} from '@oclif/core/interfaces'
 import Command, {ArgOutput, FlagOutput, noDefaultsOptions} from '@shopify/cli-kit/node/base-command'
-import {AdminSession, ensureAuthenticatedThemes, setLastSeenUserId} from '@shopify/cli-kit/node/session'
+import {
+  AdminSession,
+  ensureAuthenticatedThemes,
+  findSessionIdByAlias,
+  setLastSeenUserId,
+} from '@shopify/cli-kit/node/session'
 import {
   getCurrentStoredStoreAppSession,
   listCurrentStoredStoreAppSessions,
@@ -23,6 +28,7 @@ import {AbortController} from '@shopify/cli-kit/node/abort'
 import {AbortError} from '@shopify/cli-kit/node/error'
 import {recordEvent, compileData} from '@shopify/cli-kit/node/analytics'
 import {addPublicMetadata, addSensitiveMetadata} from '@shopify/cli-kit/node/metadata'
+import {outputContent, outputToken} from '@shopify/cli-kit/node/output'
 import {cwd, joinPath, resolvePath} from '@shopify/cli-kit/node/path'
 import {fileExistsSync} from '@shopify/cli-kit/node/fs'
 import {normalizeStoreFqdn} from '@shopify/cli-kit/node/context/fqdn'
@@ -349,11 +355,15 @@ export default abstract class ThemeCommand extends Command {
   private async createSession(flags: FlagValues, storeAuthSession?: AdminSession) {
     const store = ensureThemeStore({store: flags.store as string | undefined})
     const password = flags.password as string | undefined
+    const alias = flags.alias as string | undefined
+    const sessionId = !password && alias ? await this.sessionIdFromAlias(alias) : undefined
     const session = password
       ? await ensureAuthenticatedThemes(store, password)
-      : (storeAuthSession ??
-        (await this.storeAuthSessionForTheme({store})) ??
-        (await ensureAuthenticatedThemes(store, password)))
+      : sessionId
+        ? await ensureAuthenticatedThemes(store, password, [], {sessionId})
+        : (storeAuthSession ??
+          (await this.storeAuthSessionForTheme({store})) ??
+          (await ensureAuthenticatedThemes(store, password)))
 
     return session
   }
@@ -436,6 +446,17 @@ export default abstract class ThemeCommand extends Command {
 
     const expandedScopes = this.expandImpliedStoreAuthScopes(scopes)
     return this.storeAuthScopes().every((scope) => expandedScopes.has(scope))
+  }
+
+  private async sessionIdFromAlias(alias: string): Promise<string> {
+    const sessionId = await findSessionIdByAlias(alias)
+    if (!sessionId) {
+      throw new AbortError(
+        outputContent`No authenticated account found for alias ${outputToken.yellow(alias)}.`,
+        outputContent`Run ${outputToken.genericShellCommand(`shopify auth login --alias ${alias}`)} first.`,
+      )
+    }
+    return sessionId
   }
 
   /**

--- a/packages/theme/src/cli/utilities/theme-environment/dev-server-session.test.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/dev-server-session.test.ts
@@ -109,6 +109,33 @@ describe('dev server session', async () => {
         noPrompt: true,
       })
     })
+
+    test('passes selected account session ID to admin and storefront refreshes', async () => {
+      // Given
+      const selectedAdminSession = {...adminSession, sessionId: 'user-id-for-work'}
+      vi.mocked(ensureAuthenticatedStorefront).mockResolvedValue('storefront_token')
+      vi.mocked(getStorefrontSessionCookies).mockResolvedValue({
+        _shopify_essential: ':AABBCCDDEEFFGGHH==123:',
+        storefront_digest: 'digest_value',
+      })
+      vi.mocked(ensureAuthenticatedThemes).mockResolvedValue({
+        token: 'token_1',
+        storeFqdn,
+        sessionId: 'user-id-for-work',
+      })
+
+      // When
+      await fetchDevServerSession(themeId, selectedAdminSession, 'admin-password')
+
+      // Then
+      const authenticationOptions = {
+        forceRefresh: false,
+        noPrompt: true,
+        sessionId: 'user-id-for-work',
+      }
+      expect(ensureAuthenticatedThemes).toHaveBeenCalledWith(storeFqdn, 'admin-password', [], authenticationOptions)
+      expect(ensureAuthenticatedStorefront).toHaveBeenCalledWith([], 'admin-password', authenticationOptions)
+    })
   })
 
   describe('initializeDevServerSession', async () => {

--- a/packages/theme/src/cli/utilities/theme-environment/dev-server-session.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/dev-server-session.ts
@@ -67,12 +67,14 @@ export async function fetchDevServerSession(
   storefrontPassword?: string,
 ): Promise<DevServerSession> {
   const baseUrl = buildBaseStorefrontUrl(adminSession)
-
-  const session = await ensureAuthenticatedThemes(adminSession.storeFqdn, adminPassword, [], {
+  const authenticationOptions = {
     forceRefresh: false,
     noPrompt: true,
-  })
-  const storefrontToken = await ensureAuthenticatedStorefront([], adminPassword, {forceRefresh: false, noPrompt: true})
+    ...(adminSession.sessionId ? {sessionId: adminSession.sessionId} : {}),
+  }
+
+  const session = await ensureAuthenticatedThemes(adminSession.storeFqdn, adminPassword, [], authenticationOptions)
+  const storefrontToken = await ensureAuthenticatedStorefront([], adminPassword, authenticationOptions)
   const sessionCookies = await getStorefrontSessionCookiesWithVerification(
     baseUrl,
     themeId,


### PR DESCRIPTION
## What changed

- Added non-mutating account-session selection in cli-kit auth via an explicit `sessionId` option.
- Exposed a public `findSessionIdByAlias(alias)` helper for resolving account aliases without changing the current global session.
- Renamed the command flag from `--alias` to `--auth-alias` while keeping `SHOPIFY_FLAG_AUTH_ALIAS`.
- Wired `--auth-alias` through Shopify theme commands and app commands that perform authenticated platform lookups.
- Kept explicit alias-backed developer platform clients separate from the default client singletons so aliased auth does not contaminate the normal global session path.
- Regenerated command docs, README, and oclif manifests.
- Added patch changesets for `@shopify/cli-kit`, `@shopify/theme`, and `@shopify/app`.

## Why

Theme and app commands previously relied on the globally selected CLI account session. This allows commands like:

```bash
shopify theme pull --store example.myshopify.com --auth-alias work
shopify app deploy --auth-alias work
```

without mutating the current global CLI session.

## Validation

- `pnpm vitest run packages/cli-kit/src/private/node/session.test.ts packages/cli-kit/src/public/node/session.test.ts packages/theme/src/cli/utilities/theme-command.test.ts packages/theme/src/cli/utilities/theme-environment/dev-server-session.test.ts packages/theme/src/cli/services/metafields-pull.test.ts` passed: 5 files, 98 tests.
- `pnpm vitest run packages/theme/src/cli/utilities/theme-command.test.ts packages/app/src/cli/utilities/auth-alias.test.ts packages/app/src/cli/services/app-context.test.ts packages/app/src/cli/commands/app/init.test.ts packages/app/src/cli/utilities/execute-command-helpers.test.ts packages/app/src/cli/utilities/developer-platform-client/app-management-client.test.ts packages/app/src/cli/utilities/developer-platform-client/partners-client.test.ts packages/app/src/cli/services/dev/processes/theme-app-extension.test.ts packages/app/src/cli/utilities/extensions/fetch-product-variant.test.ts packages/app/src/cli/services/function/common.test.ts` passed: 10 files, 164 tests.
- `pnpm nx run app:type-check` passed.
- `pnpm nx run theme:type-check` passed.
- `pnpm nx run app:lint` passed.
- `pnpm nx run theme:lint` passed.
- `pnpm nx run cli-kit:lint` passed.
- `pnpm refresh-manifests` passed.
- `pnpm refresh-readme` passed.
- `pnpm refresh-code-documentation` passed.
- `pnpm build-dev-docs` passed.
- `git diff --check` passed.

Notes:

- Sandboxed vitest runs that touch local-storage can fail on macOS preference-file permissions under `~/Library/Preferences`; rerunning with filesystem access passed.