### PR TITLE
[Security] Mask credentials in sanitizeURL

### DIFF
--- a/packages/cli-kit/src/private/node/api/urls.test.ts
+++ b/packages/cli-kit/src/private/node/api/urls.test.ts
@@ -79,4 +79,26 @@ describe('sanitizeURL', () => {
       'https://example.com/?access_token=****&refresh_token=****&device_code=****&subject_token=****&other=keep',
     )
   })
+
+  test('sanitizes credentials in the URL', () => {
+    // Given
+    const url = 'https://username:password@example.com/path'
+
+    // When
+    const sanitizedUrl = sanitizeURL(url)
+
+    // Then
+    expect(sanitizedUrl).toBe('https://****:****@example.com/path')
+  })
+
+  test('sanitizes sensitive query parameters regardless of case', () => {
+    // Given
+    const url = 'https://example.com?Token=abc123&ACCESS_TOKEN=def456'
+
+    // When
+    const sanitizedUrl = sanitizeURL(url)
+
+    // Then
+    expect(sanitizedUrl).toBe('https://example.com/?Token=****&ACCESS_TOKEN=****')
+  })
 })

--- a/packages/cli-kit/src/private/node/api/urls.ts
+++ b/packages/cli-kit/src/private/node/api/urls.ts
@@ -21,9 +21,17 @@ const SENSITIVE_QUERY_PARAMS = [
  */
 export function sanitizeURL(url: string): string {
   const parsedUrl = new URL(url)
-  for (const param of SENSITIVE_QUERY_PARAMS) {
-    if (parsedUrl.searchParams.has(param)) {
-      parsedUrl.searchParams.set(param, '****')
+  if (parsedUrl.username) {
+    parsedUrl.username = '****'
+  }
+  if (parsedUrl.password) {
+    parsedUrl.password = '****'
+  }
+
+  const sensitiveParams = new Set(SENSITIVE_QUERY_PARAMS.map((param) => param.toLowerCase()))
+  for (const [key] of parsedUrl.searchParams.entries()) {
+    if (sensitiveParams.has(key.toLowerCase())) {
+      parsedUrl.searchParams.set(key, '****')
     }
   }
   return parsedUrl.toString()


### PR DESCRIPTION
### WHY are these changes introduced?
To prevent sensitive information from being leaked in logs or user-visible output when URLs are handled.

### WHAT is this pull request doing?
This PR hardens the `sanitizeURL` function in the `cli-kit` package to:
1. Mask basic authentication credentials (username and password) present in the URL.
2. Perform case-insensitive matching for sensitive query parameters to ensure they are correctly redacted even if the case differs from the standard.

### How to test your changes?
CI

### Checklist
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [13438122711117776037](https://jules.google.com/task/13438122711117776037) started by @gonzaloriestra*