### PR TITLE
[Performance] Memoize isWsl results

### DIFF
--- a/packages/cli-kit/src/public/node/system.test.ts
+++ b/packages/cli-kit/src/public/node/system.test.ts
@@ -393,3 +393,43 @@ describe('readStdinString', () => {
     await expect(got).rejects.toThrow('Stdin input exceeded the maximum allowed size.')
   })
 })
+
+describe('isWsl', () => {
+  test('returns true when is-wsl is true', async () => {
+    // Given
+    system._resetIsWsl()
+    vi.doMock('is-wsl', () => ({default: true}))
+
+    // When
+    const got = await system.isWsl()
+
+    // Then
+    expect(got).toBe(true)
+  })
+
+  test('returns false when is-wsl is false', async () => {
+    // Given
+    system._resetIsWsl()
+    vi.doMock('is-wsl', () => ({default: false}))
+
+    // When
+    const got = await system.isWsl()
+
+    // Then
+    expect(got).toBe(false)
+  })
+
+  test('memoizes the result', async () => {
+    // Given
+    system._resetIsWsl()
+    vi.doMock('is-wsl', () => ({default: true}))
+
+    // When
+    const result1 = system.isWsl()
+    const result2 = system.isWsl()
+
+    // Then
+    expect(result1).toBe(result2)
+    await expect(result1).resolves.toBe(true)
+  })
+})

--- a/packages/cli-kit/src/public/node/system.ts
+++ b/packages/cli-kit/src/public/node/system.ts
@@ -355,13 +355,28 @@ export function isCI(): boolean {
 }
 
 /**
+ * Memoized promise for the WSL check.
+ */
+let memoizedIsWsl: Promise<boolean> | undefined
+
+/**
  * Check if the current environment is a WSL environment.
  *
  * @returns True if the current environment is a WSL environment.
  */
-export async function isWsl(): Promise<boolean> {
-  const wsl = await import('is-wsl')
-  return wsl.default
+export function isWsl(): Promise<boolean> {
+  return (memoizedIsWsl ??= (async () => {
+    const wsl = await import('is-wsl')
+    return wsl.default
+  })())
+}
+
+/**
+ * Reset the memoized WSL check.
+ * This is used for testing purposes.
+ */
+export function _resetIsWsl(): void {
+  memoizedIsWsl = undefined
 }
 
 /**


### PR DESCRIPTION
### WHY are these changes introduced?

Checking for WSL environment involves a dynamic import which can be expensive if performed repeatedly, especially in high-frequency paths like analytics.

### WHAT is this pull request doing?

Memoizes the result of the `isWsl` check in `@shopify/cli-kit`. Since the WSL status is constant for the duration of the process, we can safely cache the promise of the first check.
Also adds a `_resetIsWsl` helper for unit testing.

Expected performance impact: Reduces redundant dynamic imports and promise allocations for the `is-wsl` package.

### How to test your changes?

CI

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [14944177195766897558](https://jules.google.com/task/14944177195766897558) started by @gonzaloriestra*