### PR TITLE
[Refactor] use uniq and flatMap in app-management-client

### DIFF
--- a/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
@@ -159,6 +159,7 @@ import {
   businessPlatformRequestDoc,
   BusinessPlatformRequestOptions,
 } from '@shopify/cli-kit/node/api/business-platform'
+import {uniq} from '@shopify/cli-kit/common/array'
 import {CLI_KIT_VERSION} from '@shopify/cli-kit/common/version'
 import {encodeGid, numericIdFromEncodedGid, numericIdFromGid} from '@shopify/cli-kit/common/gid'
 import {versionSatisfies} from '@shopify/cli-kit/node/node-package-manager'
@@ -1356,8 +1357,8 @@ export async function allowedTemplates(
   version: string = CLI_KIT_VERSION,
 ): Promise<GatedExtensionTemplate[]> {
   // Extract both types of flags from templates
-  const allBetaFlags = Array.from(new Set(templates.map((ext) => ext.organizationBetaFlags ?? []).flat()))
-  const allExpFlags = Array.from(new Set(templates.map((ext) => ext.organizationExpFlags ?? []).flat()))
+  const allBetaFlags = uniq(templates.flatMap((ext) => ext.organizationBetaFlags ?? []))
+  const allExpFlags = uniq(templates.flatMap((ext) => ext.organizationExpFlags ?? []))
 
   // Fetch both flag types in parallel
   const [enabledBetaFlags, enabledExpFlags] = await Promise.all([


### PR DESCRIPTION
### WHY are these changes introduced?

The current code uses manual deduplication with `new Set()` and manual flattening with `map().flat()`. Using the `uniq` helper and `flatMap` is more idiomatic in this codebase and improves readability.

### WHAT is this pull request doing?

Replaced `Array.from(new Set(templates.map((ext) => ext.organizationBetaFlags ?? []).flat()))` with `uniq(templates.flatMap((ext) => ext.organizationBetaFlags ?? []))` (and similarly for `organizationExpFlags`) in `packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts`.

### How to test your changes?

CI

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [14566272836771070527](https://jules.google.com/task/14566272836771070527) started by @gonzaloriestra*