### PR TITLE
Escape store auth session keys

### DIFF
--- a/packages/store/src/cli/services/store/auth/config.ts
+++ b/packages/store/src/cli/services/store/auth/config.ts
@@ -7,7 +7,11 @@ export function storeAuthRedirectUri(port: number): string {
 }
 
 export function storeAuthSessionKey(store: string): string {
-  return `${STORE_AUTH_APP_CLIENT_ID}::${store}`
+  return `${STORE_AUTH_APP_CLIENT_ID}::${escapeStoreAuthSessionKeySegment(store)}`
+}
+
+function escapeStoreAuthSessionKeySegment(value: string): string {
+  return value.replace(/\./g, '\\.')
 }
 
 export function maskToken(token: string): string {

--- a/packages/store/src/cli/services/store/auth/session-store.ts
+++ b/packages/store/src/cli/services/store/auth/session-store.ts
@@ -212,26 +212,6 @@ function readRawStoreSessionStorage(storage: LocalStorage<StoreSessionSchema>): 
   return (storage as unknown as {config?: {store?: RawStoreSessionStorage}}).config?.store ?? {}
 }
 
-function collectCurrentStoredStoreAppSessions(
-  storage: LocalStorage<StoreSessionSchema>,
-  store: string,
-  value: unknown,
-  sessions: StoredStoreAppSession[],
-): void {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) return
-
-  const bucket = sanitizeStoredStoreAppSessionBucket(store, value, storage)
-  if (bucket) {
-    const session = bucket.sessionsByUserId[bucket.currentUserId]
-    if (session) sessions.push(session)
-    return
-  }
-
-  for (const [childKey, childValue] of Object.entries(value as RawStoreSessionStorage)) {
-    collectCurrentStoredStoreAppSessions(storage, `${store}.${childKey}`, childValue, sessions)
-  }
-}
-
 /**
  * Internal persistence helper for projecting the current session for every
  * store that has locally stored store auth.
@@ -244,7 +224,10 @@ export function listCurrentStoredStoreAppSessions(
 
   for (const [key, value] of Object.entries(readRawStoreSessionStorage(storage))) {
     if (!key.startsWith(keyPrefix)) continue
-    collectCurrentStoredStoreAppSessions(storage, key.slice(keyPrefix.length), value, sessions)
+
+    const bucket = sanitizeStoredStoreAppSessionBucket(key.slice(keyPrefix.length), value, storage)
+    const session = bucket?.sessionsByUserId[bucket.currentUserId]
+    if (session) sessions.push(session)
   }
 
   return sessions

--- a/packages/store/src/cli/services/store/auth/stored-auth.test.ts
+++ b/packages/store/src/cli/services/store/auth/stored-auth.test.ts
@@ -66,6 +66,39 @@ describe('listStoredStoreAuthSummaries', () => {
     })
   })
 
+  test('persists dotted store domains as a single top-level key', async () => {
+    await inTemporaryDirectory((cwd) => {
+      const storage = new LocalStorage<Record<string, unknown>>({cwd})
+
+      setStoredStoreAppSession(buildSession(), storage as any)
+
+      const rawStorage = (storage as unknown as {config: {store: Record<string, unknown>}}).config.store
+      expect(Object.keys(rawStorage)).toContain(`${STORE_AUTH_APP_CLIENT_ID}::shop.myshopify.com`)
+      expect(listStoredStoreAuthSummaries(storage as any)).toEqual([
+        {
+          store: 'shop.myshopify.com',
+          userId: '42',
+          scopes: ['read_products'],
+          acquiredAt: '2026-03-27T00:00:00.000Z',
+        },
+      ])
+    })
+  })
+
+  test('ignores legacy nested buckets written with unescaped dotted domains', async () => {
+    await inTemporaryDirectory((cwd) => {
+      const storage = new LocalStorage<Record<string, unknown>>({cwd})
+      storage.set(`${STORE_AUTH_APP_CLIENT_ID}::legacy.myshopify.com`, {
+        currentUserId: '42',
+        sessionsByUserId: {
+          '42': buildSession({store: 'legacy.myshopify.com'}),
+        },
+      })
+
+      expect(listStoredStoreAuthSummaries(storage as any)).toEqual([])
+    })
+  })
+
   test('sorts stores alphabetically when auth timestamps match', async () => {
     await inTemporaryDirectory((cwd) => {
       const storage = new LocalStorage<Record<string, unknown>>({cwd})


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
-->

### WHY are these changes introduced?

Follow-up to discussion on #7709 about avoiding recursive crawling of `conf` storage for store-auth sessions.

<!--
  Context about the problem that's being addressed.
-->

### WHAT is this pull request doing?

Escapes dots in store-auth session keys before passing them to `conf`, so a store domain is persisted as one top-level key instead of a nested dotted path. The listing code now scans only top-level store-auth buckets and ignores legacy nested entries.

This intentionally means stores authenticated with the old nested key format may need to be re-authenticated.

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?

```bash
pnpm --filter @shopify/store vitest src/cli/services/store/auth/session-store.test.ts src/cli/services/store/auth/stored-auth.test.ts
pnpm --filter @shopify/store lint
pnpm --filter @shopify/store type-check
```

<!--
  Please, provide steps for the reviewer to test your changes locally.
  You can post a comment with `/snapit` to generate a snapshot of the changes to be tested.
-->

### Post-release steps

None.

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`
