### PR TITLE
Record preview store IDs in command analytics

### DIFF
--- a/packages/cli-kit/src/public/node/monorail.ts
+++ b/packages/cli-kit/src/public/node/monorail.ts
@@ -10,7 +10,7 @@ const url = 'https://monorail-edge.shopifysvc.com/v1/produce'
 type Optional<T> = T | null
 
 // This is the topic name of the main event we log to Monorail, the command tracker
-export const MONORAIL_COMMAND_TOPIC = 'app_cli3_command/1.26'
+export const MONORAIL_COMMAND_TOPIC = 'app_cli3_command/1.28'
 
 export interface Schemas {
   [MONORAIL_COMMAND_TOPIC]: {
@@ -32,6 +32,7 @@ export interface Schemas {
     public: {
       business_platform_id?: Optional<number>
       partner_id?: Optional<number>
+      store_id?: Optional<number>
       command: string
       project_type?: Optional<string>
       time_start: number

--- a/packages/store/src/cli/services/store/attribution.test.ts
+++ b/packages/store/src/cli/services/store/attribution.test.ts
@@ -24,4 +24,15 @@ describe('store command attribution', () => {
     })
     expect(hashString).toHaveBeenCalledWith('shop.myshopify.com')
   })
+
+  test('records the numeric store id when provided', async () => {
+    await recordStoreFqdnMetadata('shop.myshopify.com', true, '123')
+
+    expect(vi.mocked(addPublicMetadata).mock.calls[0]![0]()).toEqual({
+      store_fqdn_hash: 'hashed-store',
+      store_fqdn_validated: true,
+      store_domain: 'shop.myshopify.com',
+      store_id: 123,
+    })
+  })
 })

--- a/packages/store/src/cli/services/store/attribution.ts
+++ b/packages/store/src/cli/services/store/attribution.ts
@@ -1,11 +1,13 @@
 import {hashString} from '@shopify/cli-kit/node/crypto'
 import {addPublicMetadata, addSensitiveMetadata} from '@shopify/cli-kit/node/metadata'
+import {tryParseInt} from '@shopify/cli-kit/common/string'
 
-export async function recordStoreFqdnMetadata(storeFqdn: string, validated: boolean): Promise<void> {
+export async function recordStoreFqdnMetadata(storeFqdn: string, validated: boolean, storeId?: string): Promise<void> {
   await addSensitiveMetadata(() => ({store_fqdn: storeFqdn}))
   await addPublicMetadata(() => ({
     store_fqdn_hash: hashString(storeFqdn),
     store_fqdn_validated: validated,
     store_domain: storeFqdn,
+    store_id: tryParseInt(storeId),
   }))
 }

--- a/packages/store/src/cli/services/store/create/preview/index.test.ts
+++ b/packages/store/src/cli/services/store/create/preview/index.test.ts
@@ -46,7 +46,7 @@ describe('preview store create service', () => {
       },
     })
     expect(recordStoreFqdnMetadata).toHaveBeenCalledOnce()
-    expect(recordStoreFqdnMetadata).toHaveBeenCalledWith('x12y45z.myshopify.com', true)
+    expect(recordStoreFqdnMetadata).toHaveBeenCalledWith('x12y45z.myshopify.com', true, '123')
     expect(setLastSeenUserId).toHaveBeenCalledWith(`${PREVIEW_USER_ID_PREFIX}placeholder-uuid`)
     expect(result).toEqual({
       status: 'success',
@@ -147,7 +147,7 @@ describe('preview store create service', () => {
     expect(setStoredStoreAppSession).toHaveBeenCalledOnce()
     expect(setLastSeenUserId).toHaveBeenCalledWith(`${PREVIEW_USER_ID_PREFIX}123`)
     expect(recordStoreFqdnMetadata).toHaveBeenCalledOnce()
-    expect(recordStoreFqdnMetadata).toHaveBeenCalledWith('x12y45z.myshopify.com', true)
+    expect(recordStoreFqdnMetadata).toHaveBeenCalledWith('x12y45z.myshopify.com', true, '123')
     expect(result.status).toBe('success')
   })
 

--- a/packages/store/src/cli/services/store/create/preview/index.ts
+++ b/packages/store/src/cli/services/store/create/preview/index.ts
@@ -91,7 +91,7 @@ async function persistPreviewStoreSession(
   })
   dependencies.setLastSeenUserId(userId)
   try {
-    await dependencies.recordStoreFqdnMetadata(response.shop.domain, true)
+    await dependencies.recordStoreFqdnMetadata(response.shop.domain, true, response.shop.id)
     // eslint-disable-next-line no-catch-all/no-catch-all
   } catch {
     // Store metadata is best-effort; credentials and access URL are already persisted.

--- a/packages/store/src/cli/services/store/info/index.test.ts
+++ b/packages/store/src/cli/services/store/info/index.test.ts
@@ -173,6 +173,7 @@ describe('getStoreInfo', () => {
 
     expect(fetchDestinationsContext).not.toHaveBeenCalled()
     expect(fetchOrganizationShop).not.toHaveBeenCalled()
+    expect(recordStoreFqdnMetadata).toHaveBeenCalledWith(SHOP, true, '123')
     expect(claimPreviewStore).toHaveBeenCalledWith({
       shopId: '123',
       adminApiToken: 'shpat_preview_token',

--- a/packages/store/src/cli/services/store/info/index.ts
+++ b/packages/store/src/cli/services/store/info/index.ts
@@ -63,6 +63,7 @@ export async function getStoreInfo(options: GetStoreInfoOptions): Promise<StoreI
   const storedSession = getCurrentStoredStoreAppSession(store)
 
   if (isPreviewStoreSession(storedSession)) {
+    await recordStoreFqdnMetadata(storedSession.store, true, storedSession.preview.shopId)
     const previewStoreUrls = await fetchPreviewStoreUrls(storedSession)
     return buildPreviewStoreResult({
       store,


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it's a work in progress
-->

### WHY are these changes introduced?

The CLI currently publishes command analytics to `app_cli3_command/1.26`. A follow-up Monorail schema PR adds `app_cli3_command/1.28` with an optional public `store_id` field:

- https://github.com/Shopify/monorail/pull/24075

<!--
  Context about the problem that's being addressed.
-->

### WHAT is this pull request doing?

Updates the CLI command Monorail schema version to `app_cli3_command/1.28` and records the preview store's numeric shop ID as `store_id` when it is available from preview-store flows.

This records `store_id` for:

- `shopify store create preview`, from the preview store creation response's `shop.id`
- `shopify store info`, when reading a locally stored preview store session's `preview.shopId`

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?

```bash
pnpm --filter @shopify/store vitest src/cli/services/store/attribution.test.ts src/cli/services/store/create/preview/index.test.ts src/cli/services/store/info/index.test.ts
pnpm --filter @shopify/cli-kit vitest src/public/node/monorail.test.ts
pnpm --filter @shopify/cli-kit type-check
pnpm --filter @shopify/cli-kit lint
pnpm --filter @shopify/store type-check
pnpm --filter @shopify/store lint
```

<!--
  Please, provide steps for the reviewer to test your changes locally.
  You can post a comment with `/snapit` to generate a snapshot of the changes to be tested.
-->

### Post-release steps

None.

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`
