### PR TITLE
Bound analytics string fields to prevent Invalid string length crash

### DIFF
--- a/.changeset/analytics-invalid-string-length.md
+++ b/.changeset/analytics-invalid-string-length.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': patch
+---
+
+Bound the length of individual strings recorded in command analytics so serializing the collected data can no longer throw `RangeError: Invalid string length`

--- a/packages/cli-kit/src/private/node/analytics/storage.test.ts
+++ b/packages/cli-kit/src/private/node/analytics/storage.test.ts
@@ -380,6 +380,71 @@ describe('analytics/storage', () => {
     })
   })
 
+  describe('string length bounding', () => {
+    const maxFieldLength = 512
+
+    test('truncates long event names', () => {
+      // When
+      recordEvent('e'.repeat(maxFieldLength + 1000))
+
+      // Then
+      const data = compileData()
+      expect(data.events[0]?.name.length).toBe(maxFieldLength)
+    })
+
+    test('truncates long timing event names', () => {
+      // Given
+      const longEvent = 't'.repeat(maxFieldLength + 1000)
+
+      // When
+      recordTiming(longEvent)
+      recordTiming(longEvent)
+
+      // Then
+      const data = compileData()
+      expect(data.timings[0]?.event.length).toBe(maxFieldLength)
+    })
+
+    test('truncates long retry urls and operations', () => {
+      // When
+      recordRetry('u'.repeat(maxFieldLength + 1000), 'o'.repeat(maxFieldLength + 1000))
+
+      // Then
+      const data = compileData()
+      expect(data.retries[0]?.url.length).toBe(maxFieldLength)
+      expect(data.retries[0]?.operation.length).toBe(maxFieldLength)
+    })
+
+    test('counts retry attempts consistently when fields are truncated', () => {
+      // Given
+      const longUrl = 'u'.repeat(maxFieldLength + 1000)
+      const longOperation = 'o'.repeat(maxFieldLength + 1000)
+
+      // When
+      recordRetry(longUrl, longOperation)
+      recordRetry(longUrl, longOperation)
+
+      // Then
+      const data = compileData()
+      expect(data.retries.length).toBe(2)
+      expect(data.retries[0]?.attempts).toBe(1)
+      expect(data.retries[1]?.attempts).toBe(2)
+    })
+
+    test('keeps compiled data serializable with many oversized entries', () => {
+      // Given
+      const oversized = 'x'.repeat(maxFieldLength + 1000)
+      for (let index = 0; index < 2000; index++) {
+        recordEvent(oversized)
+        recordRetry(oversized, oversized)
+      }
+
+      // When / Then
+      const data = compileData()
+      expect(() => JSON.stringify(data)).not.toThrow()
+    })
+  })
+
   describe('integration tests', () => {
     test('handles complete workflow with all data types', () => {
       // Given

--- a/packages/cli-kit/src/private/node/analytics/storage.ts
+++ b/packages/cli-kit/src/private/node/analytics/storage.ts
@@ -39,6 +39,21 @@ const _runtimeAnalyticsStore = {
   events: new BArray<EventEntry>(),
 }
 
+/**
+ * Caps the length of individual string fields stored in analytics entries.
+ *
+ * Entry counts are bounded by BArray, but a single entry can still carry an
+ * arbitrarily large string (e.g. a retry operation derived from a network error
+ * message). Without this cap, serializing the collected data with JSON.stringify
+ * can exceed V8's maximum string length and throw a `RangeError`
+ * ("Invalid string length"), surfacing as an unhandled error from command analytics.
+ */
+const MAX_FIELD_LENGTH = 512
+
+function truncateField(value: string): string {
+  return value.length > MAX_FIELD_LENGTH ? value.substring(0, MAX_FIELD_LENGTH) : value
+}
+
 export function recordTiming(eventName: string): void {
   const now = Date.now()
 
@@ -54,7 +69,7 @@ export function recordTiming(eventName: string): void {
   const duration = now - startTime
 
   _runtimeAnalyticsStore.timings.push({
-    event: eventName,
+    event: truncateField(eventName),
     duration,
   })
 
@@ -84,24 +99,27 @@ export function recordError(error: unknown): void {
 }
 
 export function recordRetry(url: string, operation: string): void {
+  const truncatedUrl = truncateField(url)
+  const truncatedOperation = truncateField(operation)
+
   const existingEntries = _runtimeAnalyticsStore.retries.filter(
-    (entry) => entry.url === url && entry.operation === operation,
+    (entry) => entry.url === truncatedUrl && entry.operation === truncatedOperation,
   )
   const attemptCount = existingEntries.length + 1
 
   _runtimeAnalyticsStore.retries.push({
-    url,
-    operation,
+    url: truncatedUrl,
+    operation: truncatedOperation,
     attempts: attemptCount,
     timestamp: Date.now(),
   })
 
-  recordEvent(`retry:${operation}:attempt:${attemptCount}`)
+  recordEvent(`retry:${truncatedOperation}:attempt:${attemptCount}`)
 }
 
 export function recordEvent(eventName: string): void {
   _runtimeAnalyticsStore.events.push({
-    name: eventName,
+    name: truncateField(eventName),
     timestamp: Date.now(),
   })
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Command analytics serializes its collected runtime data with `JSON.stringify` (in `ThemeCommand.logAnalyticsData`). The analytics store bounds the number of recorded entries, but not the size of each entry's string fields — e.g. `recordRetry` stores a retry `operation` built from a network error message, and event names are stored verbatim. Over a long-running command these strings can accumulate enough characters that `JSON.stringify` exceeds V8's maximum string length and throws `RangeError: Invalid string length`.

### What is this PR doing?

Bounds the length of individual string fields stored in the analytics collections at record time, so the collected data stays well within a serializable size:

- Adds `MAX_FIELD_LENGTH` and a `truncateField` helper in `storage.ts`.
- Truncates event names, timing event names, and retry url/operation fields. `recordRetry` truncates once up front so attempt counting stays consistent. Error messages were already capped.

### How to test your changes?

New unit tests cover truncation of each field, consistent retry attempt counting under truncation, and a regression asserting `JSON.stringify(compileData())` doesn't throw with many oversized entries.

### Measuring impact

- [x] n/a
