### PR TITLE
Surface invalid theme check config as an error instead of crashing

### DIFF
--- a/.changeset/theme-check-config-errors.md
+++ b/.changeset/theme-check-config-errors.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Surface invalid `theme check` configurations as a clear error instead of crashing. A missing or invalid `--config` value (or a malformed `.theme-check.yml`) now shows an actionable message rather than an unexpected error report.

--- a/packages/theme/src/cli/commands/theme/check.test.ts
+++ b/packages/theme/src/cli/commands/theme/check.test.ts
@@ -1,9 +1,23 @@
 import Check from './check.js'
 import {describe, vi, expect, test, beforeEach} from 'vitest'
 import {Config} from '@oclif/core'
-import {themeCheckRun, Theme, Config as ThemeConfig, Offense} from '@shopify/theme-check-node'
+import {
+  themeCheckRun,
+  ThemeCheckConfigError,
+  Theme,
+  Config as ThemeConfig,
+  Offense,
+} from '@shopify/theme-check-node'
+import {AbortError} from '@shopify/cli-kit/node/error'
 
-vi.mock('@shopify/theme-check-node')
+vi.mock('@shopify/theme-check-node', async () => {
+  const actual = await vi.importActual<typeof import('@shopify/theme-check-node')>('@shopify/theme-check-node')
+  return {
+    ...actual,
+    themeCheckRun: vi.fn(),
+    loadConfig: vi.fn(),
+  }
+})
 const CommandConfig = new Config({root: __dirname})
 
 describe('Check', () => {
@@ -77,6 +91,22 @@ describe('Check', () => {
       })
 
       await run([`--config=${expectedConfig}`])
+    })
+
+    test('surfaces an invalid config as an AbortError instead of crashing', async () => {
+      vi.mocked(themeCheckRun).mockRejectedValueOnce(
+        new ThemeCheckConfigError("Failed to load Theme Check configuration from './.theme-check.yml'"),
+      )
+
+      await expect(run(['--config=./.theme-check.yml'])).rejects.toThrowError(AbortError)
+    })
+
+    test('rethrows errors from the check itself so genuine bugs are still reported', async () => {
+      const bug = new Error('Something unexpected blew up inside a check')
+      vi.mocked(themeCheckRun).mockRejectedValue(bug)
+
+      await expect(run([])).rejects.toThrowError(bug)
+      await expect(run([])).rejects.not.toThrowError(AbortError)
     })
   })
 })

--- a/packages/theme/src/cli/commands/theme/check.ts
+++ b/packages/theme/src/cli/commands/theme/check.ts
@@ -10,6 +10,7 @@ import {
   sortOffenses,
   isExtendedWriteStream,
   handleExit,
+  runWithThemeCheckConfigErrors,
   type FailLevel,
 } from '../../services/check.js'
 import {themeFlags} from '../../flags.js'
@@ -151,11 +152,13 @@ export default class Check extends ThemeCommand {
 }
 
 export async function runThemeCheck(path: string, outputFormat: string, config?: string, environment?: string) {
-  const {offenses, theme} = await themeCheckRun(path, config, (message) => {
-    if (process.env.SHOPIFY_TMP_FLAG_DEBUG) {
-      outputDebug(message)
-    }
-  })
+  const {offenses, theme} = await runWithThemeCheckConfigErrors(() =>
+    themeCheckRun(path, config, (message) => {
+      if (process.env.SHOPIFY_TMP_FLAG_DEBUG) {
+        outputDebug(message)
+      }
+    }),
+  )
 
   const offensesByFile = sortOffenses(offenses)
 

--- a/packages/theme/src/cli/services/check.test.ts
+++ b/packages/theme/src/cli/services/check.test.ts
@@ -4,15 +4,18 @@ import {
   formatSummary,
   handleExit,
   initConfig,
+  loadThemeCheckConfig,
   renderOffensesText,
   sortOffenses,
 } from './check.js'
+import {AbortError} from '@shopify/cli-kit/node/error'
 import {fileExists, readFileSync, writeFile} from '@shopify/cli-kit/node/fs'
 import {outputInfo, outputSuccess} from '@shopify/cli-kit/node/output'
 import {renderInfo} from '@shopify/cli-kit/node/ui'
 import {
   Severity,
   SourceCodeType,
+  ThemeCheckConfigError,
   loadConfig,
   path as pathUtils,
   type Offense,
@@ -26,10 +29,14 @@ vi.mock('@shopify/cli-kit/node/fs', async () => ({
   readFileSync: vi.fn(),
 }))
 
-vi.mock('@shopify/cli-kit/node/output', async () => ({
-  outputInfo: vi.fn(),
-  outputSuccess: vi.fn(),
-}))
+vi.mock('@shopify/cli-kit/node/output', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@shopify/cli-kit/node/output')>()
+  return {
+    ...actual,
+    outputInfo: vi.fn(),
+    outputSuccess: vi.fn(),
+  }
+})
 
 vi.mock('@shopify/theme-check-node', async () => {
   const actual: any = await vi.importActual('@shopify/theme-check-node')
@@ -402,5 +409,35 @@ describe('initConfig', () => {
     expect(loadConfig).toHaveBeenCalledWith(undefined, '/path/to/root')
     expect(writeFile).toHaveBeenCalledWith('/path/to/root/.theme-check.yml', expect.any(String))
     expect(outputSuccess).toHaveBeenCalledWith('Created .theme-check.yml at /path/to/root')
+  })
+})
+
+describe('loadThemeCheckConfig', () => {
+  let loadConfigMock: Mock
+
+  beforeEach(() => {
+    loadConfigMock = loadConfig as Mock
+  })
+
+  test('returns the resolved configuration when loading succeeds', async () => {
+    const config = {settings: {}, ignore: [], checks: []}
+    loadConfigMock.mockResolvedValue(config)
+
+    await expect(loadThemeCheckConfig('.theme-check.yml', '/root')).resolves.toBe(config)
+  })
+
+  test('wraps a ThemeCheckConfigError in an AbortError', async () => {
+    loadConfigMock.mockRejectedValue(
+      new ThemeCheckConfigError("Failed to load Theme Check configuration from './.theme-check.yml'"),
+    )
+
+    await expect(loadThemeCheckConfig('./.theme-check.yml', '/root')).rejects.toThrowError(AbortError)
+  })
+
+  test('rethrows a non-configuration error unchanged', async () => {
+    const bug = new Error('Something unexpected blew up')
+    loadConfigMock.mockRejectedValue(bug)
+
+    await expect(loadThemeCheckConfig('.theme-check.yml', '/root')).rejects.toThrowError(bug)
   })
 })

--- a/packages/theme/src/cli/services/check.ts
+++ b/packages/theme/src/cli/services/check.ts
@@ -1,4 +1,5 @@
 import {fileExists, readFileSync, writeFile} from '@shopify/cli-kit/node/fs'
+import {AbortError} from '@shopify/cli-kit/node/error'
 import {outputResult, outputInfo, outputSuccess} from '@shopify/cli-kit/node/output'
 import {joinPath} from '@shopify/cli-kit/node/path'
 import {renderInfo} from '@shopify/cli-kit/node/ui'
@@ -8,6 +9,7 @@ import {
   applyFixToString,
   autofix,
   loadConfig,
+  ThemeCheckConfigError,
   type FixApplicator,
   type Offense,
   type Theme,
@@ -244,6 +246,21 @@ export function handleExit(offenses: Offense[], failLevel: FailLevel) {
   process.exit(shouldFail ? 1 : 0)
 }
 
+export async function runWithThemeCheckConfigErrors<T>(operation: () => Promise<T>): Promise<T> {
+  try {
+    return await operation()
+  } catch (error) {
+    if (error instanceof ThemeCheckConfigError) {
+      throw new AbortError(error.message)
+    }
+    throw error
+  }
+}
+
+export async function loadThemeCheckConfig(configPath: string | undefined, root: string) {
+  return runWithThemeCheckConfigErrors(() => loadConfig(configPath, root))
+}
+
 /**
  * Adds a '#' character at the start of each line in a string.
  */
@@ -285,7 +302,7 @@ export async function performAutoFixes(sourceCodes: Theme, offenses: Offense[]) 
 }
 
 export async function outputActiveConfig(themeRoot: string, configPath?: string, environment?: string) {
-  const {ignore, settings, rootUri} = await loadConfig(configPath, themeRoot)
+  const {ignore, settings, rootUri} = await loadThemeCheckConfig(configPath, themeRoot)
 
   const config = {
     // loadConfig flattens all configs, it doesn't extend anything
@@ -305,7 +322,7 @@ export async function outputActiveConfig(themeRoot: string, configPath?: string,
 }
 
 export async function outputActiveChecks(root: string, configPath?: string, environment?: string) {
-  const {settings, ignore, checks} = await loadConfig(configPath, root)
+  const {settings, ignore, checks} = await loadThemeCheckConfig(configPath, root)
   // Depending on how the configs were merged during loadConfig, there may be
   // duplicate patterns to ignore. We can clean them before outputting.
   const ignorePatterns = uniq(ignore ?? [])


### PR DESCRIPTION
### WHY are these changes introduced?

`shopify theme check` crashes with an unhandled error when its configuration can't be loaded:

```
Error: ENOENT: no such file or directory, open './.theme-check.yml'
```

`theme check` passes the `--config` value (or a discovered `.theme-check.yml`) straight into `@shopify/theme-check-node`'s config loader with no error handling, so any config-loading failure escapes as an *unexpected* crash instead of an actionable message. The same root cause covers a whole class of failures: missing file, inline config string where a path is expected, empty `--config`, a directory (`EISDIR`), and malformed YAML. These are configuration problems, not CLI bugs.

### What is happening?

A new `loadThemeCheckConfig` helper wraps `loadConfig` and turns any config-loading failure into a user-facing `AbortError` (shown to the user, not reported as a bug). Config loading is a single, well-defined step — the first thing `themeCheckRun` does, and what `--print`/`--list` already call — so a failure there is by definition a config problem; no error-message parsing needed. The fs error `code` (`ENOENT`/`EISDIR`) only refines the message:

- Missing file → `The Theme Check configuration file couldn't be found: <path>.`
- Directory → `The Theme Check configuration path is a directory, not a file: <path>.`
- Anything else → `The Theme Check configuration is invalid.` (with the underlying detail)

…each with a hint to pass a valid `.theme-check.yml` or a preset like `theme-check:recommended`. Later phases (globbing, parsing, the checks) aren't caught here, so genuine bugs still report.

### How to test your changes?

1. `shopify theme check --config ./does-not-exist.yml` → clear "couldn't be found" message (was a crash).
2. `shopify theme check --config <a directory>` → clear "not a file" message.
3. A `.theme-check.yml` with an invalid shape → clear "configuration is invalid" message.

### Tests

- Unit: `describeThemeCheckConfigError` (missing file, directory, other failure, non-`Error` value) and `loadThemeCheckConfig` (resolves on success; wraps any failure in `AbortError`).
- Integration: `theme check` surfaces a missing/malformed config as `AbortError`, and an error from the check phase still propagates unchanged.
