### PR TITLE
Only treat connection-level failures as transient network errors

### DIFF
--- a/.changeset/fix-telemetry-network-error.md
+++ b/.changeset/fix-telemetry-network-error.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': patch
+---
+
+Fix a telemetry bug that could cause a command to crash during network instability.

--- a/packages/cli-kit/src/private/node/api.test.ts
+++ b/packages/cli-kit/src/private/node/api.test.ts
@@ -604,6 +604,20 @@ describe('retryAwareRequest', () => {
   })
 })
 
+function clientErrorWithUploadPayload(fileBody: string): ClientError {
+  // Mirrors a failed theme file upload: graphql-request embeds the full request
+  // (including uploaded file bodies) and response into ClientError.message.
+  const response = {
+    status: 500,
+    headers: new Map(),
+    errors: [{message: 'Internal Server Error'}],
+  } as unknown as ClientError['response']
+  return new ClientError(response, {
+    query: 'mutation themeFilesUpsert { ... }',
+    variables: {files: [{filename: 'assets/theme.js', body: {type: 'TEXT', value: fileBody}}]},
+  })
+}
+
 describe('isTransientNetworkError', () => {
   test('identifies transient network errors that should be retried', () => {
     const transientErrors = [
@@ -673,6 +687,21 @@ describe('isTransientNetworkError', () => {
     expect(isTransientNetworkError(undefined)).toBe(false)
     expect(isTransientNetworkError({message: 'ENOTFOUND'})).toBe(false)
   })
+
+  test('does not classify a ClientError as transient even when its payload contains transient keywords', () => {
+    // A benign "setTimeout" in uploaded theme JS must not be read as a network timeout.
+    const error = clientErrorWithUploadPayload('window.addEventListener("load", () => setTimeout(boot, 1000))')
+    expect(error.message.toLowerCase()).toContain('timeout')
+    expect(isTransientNetworkError(error)).toBe(false)
+  })
+
+  test('identifies transient errors by structured code even when the message does not match', () => {
+    const reset = Object.assign(new Error('connection problem'), {code: 'ECONNRESET'})
+    expect(isTransientNetworkError(reset)).toBe(true)
+
+    const undiciTimeout = Object.assign(new Error('fetch failed'), {cause: {code: 'UND_ERR_CONNECT_TIMEOUT'}})
+    expect(isTransientNetworkError(undiciTimeout)).toBe(true)
+  })
 })
 
 describe('isNetworkError', () => {
@@ -718,5 +747,11 @@ describe('isNetworkError', () => {
     expect(isNetworkError(null)).toBe(false)
     expect(isNetworkError(undefined)).toBe(false)
     expect(isNetworkError({message: 'certificate error'})).toBe(false)
+  })
+
+  test('does not classify a ClientError as a network error even when its payload contains certificate keywords', () => {
+    const error = clientErrorWithUploadPayload('const CONFIG = {label: "TLS certificate settings"}')
+    expect(error.message.toLowerCase()).toContain('certificate')
+    expect(isNetworkError(error)).toBe(false)
   })
 })

--- a/packages/cli-kit/src/private/node/api.ts
+++ b/packages/cli-kit/src/private/node/api.ts
@@ -74,9 +74,73 @@ type VerboseResponse<T> =
   | UnauthorizedErrorResponse
 
 /**
+ * Connection-level error codes (from Node, node-fetch, or undici) that indicate a
+ * transient network failure worth retrying. Matching on a structured code is far more
+ * reliable than substring-matching an error message, which can also embed unrelated
+ * request/response payloads.
+ */
+const TRANSIENT_NETWORK_ERROR_CODES = new Set([
+  'ECONNRESET',
+  'ECONNABORTED',
+  'ECONNREFUSED',
+  'ENOTFOUND',
+  'ENETUNREACH',
+  'EHOSTUNREACH',
+  'ETIMEDOUT',
+  'EPIPE',
+  'EAI_AGAIN',
+  'EPROTO',
+  'ABORT_ERR',
+  'UND_ERR_CONNECT_TIMEOUT',
+  'UND_ERR_HEADERS_TIMEOUT',
+  'UND_ERR_BODY_TIMEOUT',
+  'UND_ERR_SOCKET',
+])
+
+/**
+ * Message fragments that indicate a transient network failure, used as a fallback when
+ * an error does not expose a structured code.
+ */
+const TRANSIENT_NETWORK_ERROR_MESSAGES = [
+  'socket hang up',
+  'econnreset',
+  'econnaborted',
+  'enotfound',
+  'enetunreach',
+  'network socket disconnected',
+  'etimedout',
+  'econnrefused',
+  'eai_again',
+  'epipe',
+  'the operation was aborted',
+  'timeout',
+  'premature close',
+  'getaddrinfo',
+]
+
+/**
+ * Reads a transient connection-level error code from an error or its `cause`.
+ */
+function transientNetworkErrorCode(error: Error): string | undefined {
+  const candidates: unknown[] = [error, (error as {cause?: unknown}).cause]
+  for (const candidate of candidates) {
+    const code = (candidate as {code?: unknown} | null | undefined)?.code
+    if (typeof code === 'string' && TRANSIENT_NETWORK_ERROR_CODES.has(code.toUpperCase())) {
+      return code
+    }
+  }
+  return undefined
+}
+
+/**
  * Checks if an error is a transient network error that is likely to recover with retries.
  *
  * Use this function for retry logic. Use isNetworkError for error classification.
+ *
+ * Only connection-level failures (no HTTP response received) are treated as transient. A
+ * `ClientError` carries an HTTP response, so it is an application/HTTP-level failure, not a
+ * connection error — and its message embeds the full request/response payload, which must
+ * not be matched against. HTTP-level retryability is handled separately by the caller.
  *
  * Examples of transient errors (worth retrying):
  * - Connection timeouts, resets, and aborts
@@ -85,29 +149,18 @@ type VerboseResponse<T> =
  * - Premature connection closes
  */
 export function isTransientNetworkError(error: unknown): boolean {
-  if (error instanceof Error) {
-    const transientErrorMessages = [
-      'socket hang up',
-      'econnreset',
-      'econnaborted',
-      'enotfound',
-      'enetunreach',
-      'network socket disconnected',
-      'etimedout',
-      'econnrefused',
-      'eai_again',
-      'epipe',
-      'the operation was aborted',
-      'timeout',
-      'premature close',
-      'getaddrinfo',
-    ]
-    const errorMessage = error.message.toLowerCase()
-    const anyMatches = transientErrorMessages.some((issueMessage) => errorMessage.includes(issueMessage))
-    const missingReason = /^request to .* failed, reason:\s*$/.test(errorMessage)
-    return anyMatches || missingReason
+  if (!(error instanceof Error) || error instanceof ClientError) {
+    return false
   }
-  return false
+
+  if (transientNetworkErrorCode(error)) {
+    return true
+  }
+
+  const errorMessage = error.message.toLowerCase()
+  const anyMatches = TRANSIENT_NETWORK_ERROR_MESSAGES.some((issueMessage) => errorMessage.includes(issueMessage))
+  const missingReason = /^request to .* failed, reason:\s*$/.test(errorMessage)
+  return anyMatches || missingReason
 }
 
 /**
@@ -127,14 +180,17 @@ export function isNetworkError(error: unknown): boolean {
     return true
   }
 
-  // Then check for permanent network errors (SSL/TLS/certificate issues)
-  if (error instanceof Error) {
-    const permanentNetworkErrorMessages = ['certificate', 'cert', 'tls', 'ssl', 'altnames']
-    const errorMessage = error.message.toLowerCase()
-    return permanentNetworkErrorMessages.some((issueMessage) => errorMessage.includes(issueMessage))
+  // A ClientError carries an HTTP response, so it is an application/HTTP-level failure
+  // rather than a network error — even if its embedded payload happens to contain words
+  // like "cert" or "ssl".
+  if (!(error instanceof Error) || error instanceof ClientError) {
+    return false
   }
 
-  return false
+  // Then check for permanent network errors (SSL/TLS/certificate issues)
+  const permanentNetworkErrorMessages = ['certificate', 'cert', 'tls', 'ssl', 'altnames']
+  const errorMessage = error.message.toLowerCase()
+  return permanentNetworkErrorMessages.some((issueMessage) => errorMessage.includes(issueMessage))
 }
 
 async function runRequestWithNetworkLevelRetry<T extends {headers: Headers; status: number}>(


### PR DESCRIPTION
### What

`isTransientNetworkError` (and `isNetworkError`) decided whether an error was a network failure by substring-matching the error's `message`. A `graphql-request` `ClientError` embeds the full request/response payload — including uploaded theme file contents — in its message, so a benign token such as `setTimeout` in a theme's JavaScript could be read as a network "timeout".

During `theme dev` this had two consequences:

- HTTP error responses were misclassified as transient and retried at the network level (they should be handled as HTTP errors instead).
- The entire error message (the uploaded file contents) was recorded into command analytics. Over a flaky session this could grow large enough that serializing it exceeded V8's maximum string length, crashing the command with `RangeError: Invalid string length`.

### How

- An error that carries an HTTP response (e.g. `ClientError`) is never treated as a transient or general network error. HTTP-level retryability is handled separately by the request layer.
- Connection-level failures are detected by their error `code` (`ECONNRESET`, `ETIMEDOUT`, `ENOTFOUND`, …), including codes surfaced via `error.cause`, instead of by matching the message text. A message fallback remains for errors that don't expose a code.

### Tests

- A `ClientError` whose payload contains `setTimeout` / `certificate` is no longer classified as a transient/network error.
- Transient errors are identified by their structured `code` even when the message doesn't match.
- Existing message-based detection and certificate/non-network cases are unchanged.
