### PR TITLE
Update Javy related dependencies

### DIFF
--- a/.changeset/fuzzy-javy-runner.md
+++ b/.changeset/fuzzy-javy-runner.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Update Shopify Functions Javy, Javy plugin, and function-runner binaries.

--- a/packages/app/src/cli/services/function/binaries.test.ts
+++ b/packages/app/src/cli/services/function/binaries.test.ts
@@ -229,9 +229,9 @@ describe('javy', () => {
 
 describe('javy-plugin', () => {
   test('properties are set correctly', () => {
-    expect(javyPlugin.name).toBe('shopify_functions_javy_v3')
+    expect(javyPlugin.name).toBe('shopify_functions_javy_v4')
     expect(javyPlugin.version).match(/^\d+$/)
-    expect(javyPlugin.path).toMatch(/(\/|\\)shopify_functions_javy_v3.wasm$/)
+    expect(javyPlugin.path).toMatch(/(\/|\\)shopify_functions_javy_v4.wasm$/)
   })
 
   test('downloadUrl returns the correct URL', () => {

--- a/packages/app/src/cli/services/function/binaries.ts
+++ b/packages/app/src/cli/services/function/binaries.ts
@@ -11,13 +11,13 @@ import fs from 'node:fs'
 import * as gzip from 'node:zlib'
 import {fileURLToPath} from 'node:url'
 
-export const PREFERRED_FUNCTION_RUNNER_VERSION = '9.1.2'
+export const PREFERRED_FUNCTION_RUNNER_VERSION = '9.2.0'
 
 // Javy dependencies.
-export const PREFERRED_JAVY_VERSION = '7.0.1'
+export const PREFERRED_JAVY_VERSION = '9.0.0'
 // The Javy plugin version should match the plugin version used in the
 // function-runner version specified above.
-export const PREFERRED_JAVY_PLUGIN_VERSION = '3'
+export const PREFERRED_JAVY_PLUGIN_VERSION = '4'
 
 const BINARYEN_VERSION = '123.0.0'
 


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it's a work in progress
-->

### WHY are these changes introduced?

There was a bug identified in the version of QuickJS used by `shopify_functions_javy_v3.wasm` that was fixed in `shopify_functions_javy_v4.wasm`.

### WHAT is this pull request doing?

Updates function-runner, the Javy CLI, and the Functions plugin to the latest versions.

### How to test your changes?

Run `echo "{}" | pnpm shopify app function run --path <path_to_js_function_extension>` and confirm the Function executes. Feel free to substitute the `"{}"` with valid input for the Function to see the Function succeed instead of the function-runner saying the function failed to execute because it was missing some property in the input that it needs to succeed.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [x] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`
