### PR TITLE
[Performance] Memoize username function

### DIFF
--- a/packages/cli-kit/src/public/node/os.test.ts
+++ b/packages/cli-kit/src/public/node/os.test.ts
@@ -1,7 +1,64 @@
-import {platformAndArch} from './os.js'
-import {describe, test, expect, vi} from 'vitest'
+import {platformAndArch, username, _resetUsername} from './os.js'
+import {describe, test, expect, vi, beforeEach} from 'vitest'
+import * as os from 'os'
 
 vi.mock('node:process')
+vi.mock('os', async () => {
+  const actual: any = await vi.importActual('os')
+  return {
+    ...actual,
+    userInfo: vi.fn(),
+  }
+})
+
+describe('username', () => {
+  const originalEnv = process.env
+
+  beforeEach(() => {
+    process.env = {
+      ...originalEnv,
+      SUDO_USER: undefined,
+      C9_USER: undefined,
+      LOGNAME: undefined,
+      USER: undefined,
+      LNAME: undefined,
+      USERNAME: undefined,
+    }
+    _resetUsername()
+    vi.mocked(os.userInfo).mockReturnValue({
+      username: 'testuser',
+      uid: 1,
+      gid: 1,
+      shell: 'shell',
+      homedir: 'home',
+    } as any)
+  })
+
+  test('memoizes the username', async () => {
+    // When
+    const firstCall = username()
+    const secondCall = username()
+
+    // Then
+    await expect(firstCall).resolves.toEqual('testuser')
+    await expect(secondCall).resolves.toEqual('testuser')
+    expect(firstCall).toBe(secondCall)
+    expect(os.userInfo).toHaveBeenCalledTimes(1)
+  })
+
+  test('does not memoize if platform is different', async () => {
+    // When
+    const differentPlatform = process.platform === 'win32' ? 'linux' : 'win32'
+    const firstCall = username(differentPlatform)
+    const secondCall = username(differentPlatform)
+
+    // Then
+    await expect(firstCall).resolves.toEqual('testuser')
+    await expect(secondCall).resolves.toEqual('testuser')
+    expect(firstCall).not.toBe(secondCall)
+    expect(os.userInfo).toHaveBeenCalledTimes(2)
+  })
+})
 
 describe('platformAndArch', () => {
   test("returns the right architecture when it's x64", () => {

--- a/packages/cli-kit/src/public/node/os.ts
+++ b/packages/cli-kit/src/public/node/os.ts
@@ -6,10 +6,22 @@ import {userInfo as osUserInfo} from 'os'
 // because adding it as a transtive dependency causes conflicts with other
 // packages that haven't been yet migrated to the latest version.
 /**
+ * Memoized value for the username check.
+ */
+let memoizedUsername: Promise<string | null> | undefined
+
+/**
  * @param platform - The platform to get the username for. Defaults to the current platform.
  * @returns The username of the current user.
  */
-export async function username(platform: typeof process.platform = process.platform): Promise<string | null> {
+export function username(platform: typeof process.platform = process.platform): Promise<string | null> {
+  if (platform === process.platform) {
+    return (memoizedUsername ??= usernameImplementation(platform))
+  }
+  return usernameImplementation(platform)
+}
+
+async function usernameImplementation(platform: typeof process.platform): Promise<string | null> {
   outputDebug(outputContent`Obtaining user name...`)
   const environmentVariable = getEnvironmentVariable()
   if (environmentVariable) {
@@ -42,6 +54,13 @@ export async function username(platform: typeof process.platform = process.platf
   } catch {
     return null
   }
+}
+
+/**
+ * Resets the memoized username.
+ */
+export function _resetUsername(): void {
+  memoizedUsername = undefined
 }
 
 type PlatformArch = Exclude<typeof process.arch, 'x64' | 'ia32'> | 'amd64' | '386'


### PR DESCRIPTION
### WHY are these changes introduced?

The `username` utility function is used in various parts of the CLI (e.g., in `init` service to set the package author). It performs several checks, including environment variable lookups, `os.userInfo()`, and multiple `execa` calls to `id` or `whoami`. These operations, especially the shell commands, can be relatively slow and are unnecessary to repeat as the username is static during the CLI execution.

### WHAT is this pull request doing?

This PR memoizes the promise returned by the `username` function when it's called for the current process platform. This ensures that the expensive fallback logic is only executed once.

Expected performance impact: Reduces repeated disk I/O and shell command executions for obtaining the current user's name.

### How to test your changes?

CI

### Post-release steps

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [8683647054918010439](https://jules.google.com/task/8683647054918010439) started by @gonzaloriestra*