### PR TITLE
[Security] Mask SHOPIFY_API_SECRET in env commands

### DIFF
--- a/packages/app/src/cli/services/app/env/pull.test.ts
+++ b/packages/app/src/cli/services/app/env/pull.test.ts
@@ -40,7 +40,7 @@ describe('env pull', () => {
       "Created ${filePath}:
 
       SHOPIFY_API_KEY=api-key
-      SHOPIFY_API_SECRET=api-secret
+      SHOPIFY_API_SECRET=***
       SCOPES=my-scope
       "
       `)
@@ -66,15 +66,14 @@ describe('env pull', () => {
       "Updated ${filePath} to be:
 
       SHOPIFY_API_KEY=api-key
-      SHOPIFY_API_SECRET=api-secret
+      SHOPIFY_API_SECRET=***
       SCOPES=my-scope
 
       Here's what changed:
 
       - SHOPIFY_API_KEY=ABC
-      - SHOPIFY_API_SECRET=XYZ
       + SHOPIFY_API_KEY=api-key
-      + SHOPIFY_API_SECRET=api-secret
+      SHOPIFY_API_SECRET=***
       SCOPES=my-scope
         "
       `)

--- a/packages/app/src/cli/services/app/env/pull.ts
+++ b/packages/app/src/cli/services/app/env/pull.ts
@@ -3,7 +3,7 @@ import {AppLinkedInterface, getAppScopes} from '../../../models/app/app.js'
 import {logMetadataForLoadedContext} from '../../context.js'
 
 import {Organization, OrganizationApp} from '../../../models/organization.js'
-import {patchEnvFile} from '@shopify/cli-kit/node/dot-env'
+import {patchEnvFile, parse} from '@shopify/cli-kit/node/dot-env'
 import {diffLines} from 'diff'
 import {fileExists, readFile, writeFile} from '@shopify/cli-kit/node/fs'
 import {OutputMessage, outputContent, outputToken} from '@shopify/cli-kit/node/output'
@@ -33,10 +33,24 @@ export async function pullEnv({app, remoteApp, organization, envFile}: PullEnvOp
     } else {
       await writeFile(envFile, updatedEnvFileContent)
 
-      const diff = diffLines(envFileContent ?? '', updatedEnvFileContent)
+      const maskedUpdatedValues = {
+        ...updatedValues,
+        SHOPIFY_API_SECRET: outputToken.mask(updatedValues.SHOPIFY_API_SECRET ?? '').value,
+      }
+
+      const currentEnvValues = parse(envFileContent)
+      const maskedCurrentValues = {
+        ...currentEnvValues,
+        SHOPIFY_API_SECRET: outputToken.mask(currentEnvValues.SHOPIFY_API_SECRET ?? '').value,
+      }
+
+      const maskedEnvFileContent = patchEnvFile(envFileContent, maskedUpdatedValues)
+      const maskedOldEnvFileContent = patchEnvFile(envFileContent, maskedCurrentValues)
+
+      const diff = diffLines(maskedOldEnvFileContent, maskedEnvFileContent)
       return outputContent`Updated ${outputToken.path(envFile)} to be:
 
-${updatedEnvFileContent}
+${maskedEnvFileContent}
 
 Here's what changed:
 
@@ -48,9 +62,15 @@ ${outputToken.linesDiff(diff)}
 
     await writeFile(envFile, newEnvFileContent)
 
+    const maskedUpdatedValues = {
+      ...updatedValues,
+      SHOPIFY_API_SECRET: outputToken.mask(updatedValues.SHOPIFY_API_SECRET ?? '').value,
+    }
+    const maskedNewEnvFileContent = patchEnvFile(null, maskedUpdatedValues)
+
     return outputContent`Created ${outputToken.path(envFile)}:
 
-${newEnvFileContent}
+${maskedNewEnvFileContent}
 `
   }
 }

--- a/packages/app/src/cli/services/app/env/show.test.ts
+++ b/packages/app/src/cli/services/app/env/show.test.ts
@@ -38,7 +38,7 @@ describe('env show', () => {
     expect(unstyled(stringifyMessage(result))).toMatchInlineSnapshot(`
     "
         SHOPIFY_API_KEY=api-key
-        SHOPIFY_API_SECRET=api-secret
+        SHOPIFY_API_SECRET=***
         SCOPES=my-scope
       "
     `)

--- a/packages/app/src/cli/services/app/env/show.ts
+++ b/packages/app/src/cli/services/app/env/show.ts
@@ -30,7 +30,7 @@ export async function outputEnv(
   } else {
     return outputContent`
     ${outputToken.green('SHOPIFY_API_KEY')}=${remoteApp.apiKey}
-    ${outputToken.green('SHOPIFY_API_SECRET')}=${remoteApp.apiSecretKeys[0]?.secret ?? ''}
+    ${outputToken.green('SHOPIFY_API_SECRET')}=${outputToken.mask(remoteApp.apiSecretKeys[0]?.secret ?? '')}
     ${outputToken.green('SCOPES')}=${getAppScopes(app.configuration)}
   `
   }

--- a/packages/app/src/cli/services/info.test.ts
+++ b/packages/app/src/cli/services/info.test.ts
@@ -97,7 +97,7 @@ describe('info', () => {
       expect(unstyled(stringifyMessage(result))).toMatchInlineSnapshot(`
       "
           SHOPIFY_API_KEY=api-key
-          SHOPIFY_API_SECRET=api-secret
+          SHOPIFY_API_SECRET=***
           SCOPES=my-scope
         "
       `)

--- a/packages/cli-kit/src/public/node/dot-env.ts
+++ b/packages/cli-kit/src/public/node/dot-env.ts
@@ -1,7 +1,7 @@
 import {outputDebug, outputContent, outputToken} from './output.js'
 import {AbortError} from './error.js'
 import {fileExists, readFile, writeFile} from './fs.js'
-import {parse} from 'dotenv'
+import {parse as parseDotEnv} from 'dotenv'
 
 /**
  * This interface represents a .env file.
@@ -30,8 +30,17 @@ export async function readAndParseDotEnv(path: string): Promise<DotEnvFile> {
   const content = await readFile(path)
   return {
     path,
-    variables: parse(content),
+    variables: parseDotEnv(content),
   }
+}
+
+/**
+ * Parses a .env file content.
+ * @param content - .env file contents.
+ * @returns object containing env variables.
+ */
+export function parse(content: string): Record<string, string> {
+  return parseDotEnv(content)
 }
 
 /**

--- a/packages/cli-kit/src/public/node/output.ts
+++ b/packages/cli-kit/src/public/node/output.ts
@@ -92,6 +92,11 @@ export const outputToken = {
   linesDiff(value: Change[]): LinesDiffContentToken {
     return new LinesDiffContentToken(value)
   },
+  mask(value: string): RawContentToken {
+    if (value === '') return new RawContentToken('')
+    if (value.length <= 10) return new RawContentToken('***')
+    return new RawContentToken(`${value.slice(0, 10)}***`)
+  },
 }
 
 /**


### PR DESCRIPTION
### WHY are these changes introduced?

Sensitive credentials like `SHOPIFY_API_SECRET` were previously displayed in cleartext when running `shopify app env show` or `shopify app env pull`. This poses a risk of accidental exposure in terminal logs, CI output, or during screen sharing.

### WHAT is this pull request doing?

This PR implements masking for the `SHOPIFY_API_SECRET` in the following areas:
- The text output of `shopify app env show`.
- The "Created" and "Updated" messages in `shopify app env pull`.
- The console-displayed diff in `shopify app env pull`, ensuring both old and new secrets are masked before comparison.

A new `outputToken.mask` utility is added to `cli-kit` to handle the redaction. It preserves the first 10 characters of the secret for identification purposes.

### How to test your changes?

1. Run `shopify app env show` in an app directory.
2. Run `shopify app env pull` in an app directory.
3. Observe that `SHOPIFY_API_SECRET` is masked in the output.

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`


---
*PR created automatically by Jules for task [14594554072452198801](https://jules.google.com/task/14594554072452198801) started by @gonzaloriestra*