### PR TITLE
[Refactor] Use flatMap and getArrayRejectingUndefined in info service

### DIFF
--- a/packages/app/src/cli/services/info.ts
+++ b/packages/app/src/cli/services/info.ts
@@ -16,7 +16,7 @@ import {
 } from '@shopify/cli-kit/node/output'
 import {AlertCustomSection, InlineToken} from '@shopify/cli-kit/node/ui'
 import {CLI_KIT_VERSION} from '@shopify/cli-kit/common/version'
-import {uniq} from '@shopify/cli-kit/common/array'
+import {getArrayRejectingUndefined, uniq} from '@shopify/cli-kit/common/array'
 
 export type Format = 'json' | 'text'
 export interface InfoOptions {
@@ -232,17 +232,16 @@ class AppInfo {
   extensionsSections(): AlertCustomSection[] {
     const extensions = this.app.allExtensions.filter((ext) => ext.isReturnedAsInfo())
     const types = uniq(extensions.map((ext) => ext.type))
-    return types
-      .map((extensionType: string): AlertCustomSection | undefined => {
-        const relevantExtensions = extensions.filter((extension: ExtensionInstance) => extension.type === extensionType)
-        if (relevantExtensions[0]) {
-          return this.subtableSection(
-            relevantExtensions[0].externalType,
-            relevantExtensions.map((ext) => this.extensionSubSection(ext)).flat(),
-          )
-        }
-      })
-      .filter((section: AlertCustomSection | undefined) => section !== undefined)
+    const sections = types.map((extensionType: string): AlertCustomSection | undefined => {
+      const relevantExtensions = extensions.filter((extension: ExtensionInstance) => extension.type === extensionType)
+      if (relevantExtensions[0]) {
+        return this.subtableSection(
+          relevantExtensions[0].externalType,
+          relevantExtensions.flatMap((ext) => this.extensionSubSection(ext)),
+        )
+      }
+    })
+    return getArrayRejectingUndefined(sections)
   }
 
   extensionSubSection(extension: ExtensionInstance): InlineToken[][] {


### PR DESCRIPTION
### WHY are these changes introduced?

This refactor modernizes the array operations in `packages/app/src/cli/services/info.ts` by replacing the `map().flat()` pattern with `flatMap()` and using the `getArrayRejectingUndefined` utility for cleaner filtering and better type safety.

### WHAT is this pull request doing?

- Replaces `.map((ext) => this.extensionSubSection(ext)).flat()` with `.flatMap((ext) => this.extensionSubSection(ext))` in the `extensionsSections` method.
- Replaces manual filtering of undefined sections with the `getArrayRejectingUndefined` utility.
- Updates imports to include `getArrayRejectingUndefined` from `@shopify/cli-kit/common/array`.

### How to test your changes?

CI

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [17933457429186114135](https://jules.google.com/task/17933457429186114135) started by @gonzaloriestra*