### PR TITLE
[Security] use secure PRNG for random array selection

### DIFF
--- a/packages/cli-kit/src/public/common/array.test.ts
+++ b/packages/cli-kit/src/public/common/array.test.ts
@@ -1,5 +1,29 @@
-import {difference, uniq, uniqBy} from './array.js'
+import {difference, takeRandomFromArray, uniq, uniqBy} from './array.js'
 import {describe, test, expect} from 'vitest'
+
+describe('takeRandomFromArray', () => {
+  test('returns an element from the array', () => {
+    // Given
+    const array = [1, 2, 3, 4, 5]
+
+    // When
+    const got = takeRandomFromArray(array)
+
+    // Then
+    expect(array).toContain(got)
+  })
+
+  test('handles arrays of various sizes', () => {
+    // Given
+    const arrays = [[1], [1, 2], [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]]
+
+    // When/Then
+    arrays.forEach((array) => {
+      const got = takeRandomFromArray(array)
+      expect(array).toContain(got)
+    })
+  })
+})
 
 describe('uniqBy', () => {
   test('removes duplicates', () => {

--- a/packages/cli-kit/src/public/common/array.ts
+++ b/packages/cli-kit/src/public/common/array.ts
@@ -9,9 +9,22 @@ import type {List, ValueIteratee} from 'lodash'
  * @returns A random element from the array.
  */
 export function takeRandomFromArray<T>(array: T[]): T {
+  if (array.length === 0) return undefined as T
+
   // We use a cryptographically secure PRNG to ensure the selection is non-predictable.
-  const randomIndex = globalThis.crypto.getRandomValues(new Uint32Array(1))[0]! % array.length
-  return array[randomIndex]!
+  // We use rejection sampling to eliminate modulo bias.
+  const arrayLength = array.length
+  const range = 4294967296
+  const limit = range - (range % arrayLength)
+
+  const buffer = new Uint32Array(1)
+  let randomIndex
+  do {
+    globalThis.crypto.getRandomValues(buffer)
+    randomIndex = buffer[0]!
+  } while (randomIndex >= limit)
+
+  return array[randomIndex % arrayLength]!
 }
 
 /**

--- a/packages/cli-kit/src/public/common/array.ts
+++ b/packages/cli-kit/src/public/common/array.ts
@@ -9,7 +9,9 @@ import type {List, ValueIteratee} from 'lodash'
  * @returns A random element from the array.
  */
 export function takeRandomFromArray<T>(array: T[]): T {
-  return array[Math.floor(Math.random() * array.length)]!
+  // We use a cryptographically secure PRNG to ensure the selection is non-predictable.
+  const randomIndex = globalThis.crypto.getRandomValues(new Uint32Array(1))[0]! % array.length
+  return array[randomIndex]!
 }
 
 /**


### PR DESCRIPTION
### Summary
This PR hardens the `takeRandomFromArray` utility in `@shopify/cli-kit` by replacing the non-cryptographically secure `Math.random()` with `globalThis.crypto.getRandomValues()`.

### Why is this required?
Using a cryptographically secure PRNG ensures that random selections from an array are non-predictable, which is a standard security best practice even for non-sensitive use cases like generating random names.

### How to test your changes?
CI


---
*PR created automatically by Jules for task [14379531815097411834](https://jules.google.com/task/14379531815097411834) started by @gonzaloriestra*