### PR TITLE
[Performance] Memoize isShopify function

### DIFF
--- a/packages/cli-kit/src/public/node/context/local.test.ts
+++ b/packages/cli-kit/src/public/node/context/local.test.ts
@@ -3,6 +3,7 @@ import {
   hasGit,
   isDevelopment,
   isShopify,
+  _resetIsShopify,
   isTerminalInteractive,
   isUnitTest,
   analyticsDisabled,
@@ -119,6 +120,32 @@ describe('isShopify', () => {
 
     // When
     await expect(isShopify()).resolves.toBe(true)
+  })
+
+  test('memoizes the result when using process.env', async () => {
+    // Given
+    _resetIsShopify()
+    vi.mocked(fileExists).mockResolvedValue(true)
+
+    // When
+    await isShopify()
+    await isShopify()
+
+    // Then
+    expect(fileExists).toHaveBeenCalledTimes(1)
+  })
+
+  test('does not memoize the result when using a custom env', async () => {
+    // Given
+    _resetIsShopify()
+    vi.mocked(fileExists).mockResolvedValue(true)
+
+    // When
+    await isShopify({})
+    await isShopify({})
+
+    // Then
+    expect(fileExists).toHaveBeenCalledTimes(2)
   })
 })
 

--- a/packages/cli-kit/src/public/node/context/local.ts
+++ b/packages/cli-kit/src/public/node/context/local.ts
@@ -45,6 +45,11 @@ let memoizedIsVerbose: boolean | undefined
 let memoizedIsUnitTest: boolean | undefined
 
 /**
+ * Memoized value for the isShopify check.
+ */
+let memoizedIsShopify: Promise<boolean> | undefined
+
+/**
  * Returns true if the CLI is running in debug mode.
  *
  * @param env - The environment variables from the environment of the current process.
@@ -76,12 +81,26 @@ export function isVerbose(env = process.env): boolean {
  * @param env - The environment variables from the environment of the current process.
  * @returns True if the CLI is used in a Shopify environment.
  */
-export async function isShopify(env = process.env): Promise<boolean> {
-  if (Object.prototype.hasOwnProperty.call(env, environmentVariables.runAsUser)) {
-    return !isTruthy(env[environmentVariables.runAsUser])
+export function isShopify(env = process.env): Promise<boolean> {
+  const isShopifyLogic = async () => {
+    if (Object.prototype.hasOwnProperty.call(env, environmentVariables.runAsUser)) {
+      return !isTruthy(env[environmentVariables.runAsUser])
+    }
+    return lazyFileExists(pathConstants.executables.dev)
   }
-  const devInstalled = await lazyFileExists(pathConstants.executables.dev)
-  return devInstalled
+
+  if (env === process.env) {
+    return (memoizedIsShopify ??= isShopifyLogic())
+  }
+
+  return isShopifyLogic()
+}
+
+/**
+ * Resets the memoized value for the isShopify check.
+ */
+export function _resetIsShopify(): void {
+  memoizedIsShopify = undefined
 }
 
 /**


### PR DESCRIPTION
### Why is this change necessary?
The `isShopify` function performs a disk I/O check (`fileExists`) to determine if the `dev` executable is present. This check is often called multiple times during a single CLI command execution.

### How does it address the issue?
This PR introduces memoization for the `isShopify` function. When called with the default `process.env`, it stores and returns the same `Promise` for subsequent calls, avoiding redundant file system operations.

### How to test your changes?
CI


---
*PR created automatically by Jules for task [9584385506099802746](https://jules.google.com/task/9584385506099802746) started by @gonzaloriestra*