### PR TITLE
Remove preview store save link request

### DIFF
--- a/.changeset/preview-store-claim-url.md
+++ b/.changeset/preview-store-claim-url.md
@@ -1,5 +1,0 @@
----
-'@shopify/store': minor
----
-
-Fetch and display the claim URL after creating a preview store.

--- a/packages/store/src/cli/commands/store/create/preview.test.ts
+++ b/packages/store/src/cli/commands/store/create/preview.test.ts
@@ -26,7 +26,6 @@ describe('store create preview command', () => {
         subdomain: 'x.myshopify.com',
         country: 'US',
         storefrontUrl: 'https://x.myshopify.com',
-        saveUrl: 'https://admin.shopify.com/store-transfer/accept/claim-token',
       },
     }
     vi.mocked(createPreviewStoreCommand).mockResolvedValueOnce(result)

--- a/packages/store/src/cli/services/store/create/preview/index.test.ts
+++ b/packages/store/src/cli/services/store/create/preview/index.test.ts
@@ -7,9 +7,6 @@ describe('preview store create service', () => {
     const setStoredStoreAppSession = vi.fn()
     const recordStoreFqdnMetadata = vi.fn()
     const setLastSeenUserId = vi.fn()
-    const claimPreviewStore = vi.fn(async () => ({
-      claimUrl: 'https://admin.shopify.com/store-transfer/accept/claim-token',
-    }))
 
     const result = await createPreviewStoreCommand(
       {name: 'Lavender Candles', country: 'US'},
@@ -20,7 +17,6 @@ describe('preview store create service', () => {
           adminApiToken: 'shpat_token',
           accessUrl: 'https://app.shopify.com/auth/preview-store?token=access-token',
         })),
-        claimPreviewStore,
         setStoredStoreAppSession,
         recordStoreFqdnMetadata,
         setLastSeenUserId,
@@ -58,10 +54,8 @@ describe('preview store create service', () => {
         subdomain: 'x12y45z.myshopify.com',
         country: 'US',
         storefrontUrl: 'https://app.shopify.com/auth/preview-store?token=access-token',
-        saveUrl: 'https://admin.shopify.com/store-transfer/accept/claim-token',
       },
     })
-    expect(claimPreviewStore).toHaveBeenCalledWith({shopId: '123', adminApiToken: 'shpat_token'}, undefined)
   })
 
   test('uses the shop id as the preview user id when no placeholder account uuid is returned', async () => {
@@ -76,9 +70,6 @@ describe('preview store create service', () => {
           adminApiToken: 'shpat_token',
           accessUrl: 'https://app.shopify.com/auth/preview-store?token=access-token',
         })),
-        claimPreviewStore: vi.fn(async () => ({
-          claimUrl: 'https://admin.shopify.com/store-transfer/accept/claim-token',
-        })),
         setStoredStoreAppSession,
         recordStoreFqdnMetadata: vi.fn(),
         setLastSeenUserId,
@@ -92,22 +83,18 @@ describe('preview store create service', () => {
     expect(setLastSeenUserId).toHaveBeenCalledWith(`${PREVIEW_USER_ID_PREFIX}123`)
   })
 
-  test('passes client options to both create and claim requests', async () => {
+  test('passes client options to the create request', async () => {
     const client = {} as any
     const createPreviewStore = vi.fn(async () => ({
       shop: {id: '123', name: 'Lavender Candles', domain: 'x12y45z.myshopify.com'},
       adminApiToken: 'shpat_token',
       accessUrl: 'https://app.shopify.com/auth/preview-store?token=access-token',
     }))
-    const claimPreviewStore = vi.fn(async () => ({
-      claimUrl: 'https://admin.shopify.com/store-transfer/accept/claim-token',
-    }))
 
     await createPreviewStoreCommand(
       {client},
       {
         createPreviewStore,
-        claimPreviewStore,
         setStoredStoreAppSession: vi.fn(),
         recordStoreFqdnMetadata: vi.fn(),
         setLastSeenUserId: vi.fn(),
@@ -116,7 +103,6 @@ describe('preview store create service', () => {
     )
 
     expect(createPreviewStore).toHaveBeenCalledWith({name: undefined, country: undefined}, client)
-    expect(claimPreviewStore).toHaveBeenCalledWith({shopId: '123', adminApiToken: 'shpat_token'}, client)
   })
 
   test('persists a store session and returns success when recording store metadata fails', async () => {
@@ -133,9 +119,6 @@ describe('preview store create service', () => {
           shop: {id: '123', name: 'Lavender Candles', domain: 'x12y45z.myshopify.com'},
           adminApiToken: 'shpat_token',
           accessUrl: 'https://app.shopify.com/auth/preview-store?token=access-token',
-        })),
-        claimPreviewStore: vi.fn(async () => ({
-          claimUrl: 'https://admin.shopify.com/store-transfer/accept/claim-token',
         })),
         setStoredStoreAppSession,
         recordStoreFqdnMetadata,
@@ -163,9 +146,6 @@ describe('preview store create service', () => {
           createPreviewStore: vi.fn(async () => {
             throw new Error('Preview store creation failed.')
           }),
-          claimPreviewStore: vi.fn(async () => ({
-            claimUrl: 'https://admin.shopify.com/store-transfer/accept/claim-token',
-          })),
           setStoredStoreAppSession,
           recordStoreFqdnMetadata,
           setLastSeenUserId,

--- a/packages/store/src/cli/services/store/create/preview/index.ts
+++ b/packages/store/src/cli/services/store/create/preview/index.ts
@@ -1,4 +1,4 @@
-import {PreviewStoreClientOptions, PreviewStoreCreateResponse, claimPreviewStore, createPreviewStore} from './client.js'
+import {PreviewStoreClientOptions, PreviewStoreCreateResponse, createPreviewStore} from './client.js'
 import {STORE_AUTH_APP_CLIENT_ID} from '../../auth/config.js'
 import {setStoredStoreAppSession} from '../../auth/session-store.js'
 import {recordStoreFqdnMetadata} from '../../attribution.js'
@@ -14,7 +14,6 @@ interface CreatePreviewStoreInput {
 
 interface CreatePreviewStoreDependencies {
   createPreviewStore: typeof createPreviewStore
-  claimPreviewStore: typeof claimPreviewStore
   setStoredStoreAppSession: typeof setStoredStoreAppSession
   recordStoreFqdnMetadata: typeof recordStoreFqdnMetadata
   setLastSeenUserId: typeof setLastSeenUserId
@@ -30,13 +29,11 @@ export interface CreatePreviewStoreResult {
     subdomain: string
     country?: string
     storefrontUrl: string
-    saveUrl: string
   }
 }
 
 const defaultDependencies: CreatePreviewStoreDependencies = {
   createPreviewStore,
-  claimPreviewStore,
   setStoredStoreAppSession,
   recordStoreFqdnMetadata,
   setLastSeenUserId,
@@ -56,7 +53,7 @@ export async function createPreviewStoreCommand(
     input.client,
   )
 
-  return persistPreviewStoreSession(response, input.country, resolvedDependencies, input.client)
+  return persistPreviewStoreSession(response, input.country, resolvedDependencies)
 }
 
 function previewUserId(response: PreviewStoreCreateResponse): string {
@@ -67,7 +64,6 @@ async function persistPreviewStoreSession(
   response: PreviewStoreCreateResponse,
   country: string | undefined,
   dependencies: CreatePreviewStoreDependencies,
-  client: PreviewStoreClientOptions | undefined,
 ): Promise<CreatePreviewStoreResult> {
   const acquiredAt = dependencies.now().toISOString()
   const userId = previewUserId(response)
@@ -97,11 +93,6 @@ async function persistPreviewStoreSession(
     // Store metadata is best-effort; credentials and access URL are already persisted.
   }
 
-  const claim = await dependencies.claimPreviewStore(
-    {shopId: response.shop.id, adminApiToken: response.adminApiToken},
-    client,
-  )
-
   return {
     status: 'success',
     message:
@@ -112,7 +103,6 @@ async function persistPreviewStoreSession(
       subdomain: response.shop.domain,
       ...(country ? {country} : {}),
       storefrontUrl: response.accessUrl,
-      saveUrl: claim.claimUrl,
     },
   }
 }

--- a/packages/store/src/cli/services/store/create/preview/result.test.ts
+++ b/packages/store/src/cli/services/store/create/preview/result.test.ts
@@ -22,12 +22,11 @@ const result = {
     subdomain: 'x12y45z.myshopify.com',
     country: 'US',
     storefrontUrl: 'https://x12y45z.myshopify.com/?foo=bar',
-    saveUrl: 'https://admin.shopify.com/store-transfer/accept/claim-token',
   },
 }
 
 describe('preview store create result presenter', () => {
-  test('writes JSON output with the storefront and save URLs', () => {
+  test('writes JSON output with the storefront URL', () => {
     writeCreatePreviewStoreResult(result, 'json')
 
     expect(outputResult).toHaveBeenCalledWith(
@@ -42,11 +41,9 @@ describe('preview store create result presenter', () => {
             subdomain: 'x12y45z.myshopify.com',
             country: 'US',
             storefrontUrl: 'https://x12y45z.myshopify.com/?foo=bar',
-            saveUrl: 'https://admin.shopify.com/store-transfer/accept/claim-token',
           },
           next_steps: [
             'Open your store (https://x12y45z.myshopify.com/?foo=bar) to preview the storefront.',
-            'Create an account (https://admin.shopify.com/store-transfer/accept/claim-token) for free to save progress.',
             'Use `shopify store execute --store x12y45z.myshopify.com` to add products, collections, pages, and more.',
             'Use `shopify theme pull --store x12y45z.myshopify.com` and `shopify theme push --store x12y45z.myshopify.com` to edit your store design.',
           ],
@@ -87,16 +84,6 @@ describe('preview store create result presenter', () => {
                       },
                     },
                     ' to preview the storefront.',
-                  ],
-                  [
-                    'Create ',
-                    {
-                      link: {
-                        label: 'an account',
-                        url: 'https://admin.shopify.com/store-transfer/accept/claim-token',
-                      },
-                    },
-                    ' for free to save progress.',
                   ],
                   [
                     'Use ',

--- a/packages/store/src/cli/services/store/create/preview/result.ts
+++ b/packages/store/src/cli/services/store/create/preview/result.ts
@@ -36,10 +36,6 @@ function previewStoreNextSteps(result: CreatePreviewStoreResult): PreviewStoreNe
       text: ['Open ', {link: {label: 'your store', url: result.store.storefrontUrl}}, ' to preview the storefront.'],
     },
     {
-      json: `Create an account (${result.store.saveUrl}) for free to save progress.`,
-      text: ['Create ', {link: {label: 'an account', url: result.store.saveUrl}}, ' for free to save progress.'],
-    },
-    {
       json: `Use \`shopify store execute --store ${result.store.subdomain}\` to add products, collections, pages, and more.`,
       text: [
         'Use ',


### PR DESCRIPTION
### WHY are these changes introduced?

`shopify store create preview` no longer needs to request a claim/save URL immediately after creating the preview store.

### WHAT is this pull request doing?

- Removes the post-create `claimPreviewStore` request from the preview store create service.
- Removes `saveUrl` from the `store create preview` result payload.
- Removes the "Create an account" save-link next step from text and JSON output.
- Deletes the pending claim-URL changeset because that unreleased behavior is being removed.
- Updates focused command/service/presenter tests.

### How to test your changes?

- `pnpm vitest run packages/store/src/cli/services/store/create/preview/index.test.ts packages/store/src/cli/services/store/create/preview/result.test.ts packages/store/src/cli/commands/store/create/preview.test.ts`
- `pnpm --filter @shopify/store build`

### Post-release steps

None.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible documentation changes
- [x] I've considered analytics changes to measure impact
- [x] The change is user-facing — the pending claim-URL changeset was removed because the behavior was unreleased
