### PR TITLE
Handle non-object flag definitions in lint rule

### DIFF
--- a/packages/eslint-plugin-cli/rules/command-flags-with-env.js
+++ b/packages/eslint-plugin-cli/rules/command-flags-with-env.js
@@ -17,7 +17,11 @@ module.exports = {
             if (!argument) {
               return
             }
-            const properties = argument.properties.map((property) => property.key.name)
+            if (argument.type !== 'ObjectExpression') {
+              return
+            }
+
+            const properties = argument.properties.map((property) => property.key?.name).filter(Boolean)
             if (!properties.includes('env')) {
               context.report(
                 argument,


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #0000

The `@shopify/cli/command-flags-with-env` lint rule assumed every flag helper call receives an object expression. Recent CI runs crashed ESLint entirely when a flag call used a different AST shape, producing `TypeError: Cannot read properties of undefined (reading 'map')` instead of a useful lint result.

### WHAT is this pull request doing?

Adds a guard so the rule only inspects object-expression arguments before reading `properties`, and safely handles property keys that do not expose a `name`.

### How to test your changes?

Validated locally:

```sh
pnpm exec prettier --check packages/eslint-plugin-cli/rules/command-flags-with-env.js
node -e "const rule=require('./packages/eslint-plugin-cli/rules/command-flags-with-env.js'); rule.create({report(){throw new Error('reported')}}).PropertyDefinition({key:{name:'flags'}, value:{properties:[{value:{arguments:[{type:'Identifier'}]}}]}});"
```

### Post-release steps

None.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [x] The change is not user-facing; no changeset is needed
