### PR TITLE
Avoid hardcoded auth ID hashes in session tests

### DIFF
--- a/packages/cli-kit/src/public/node/session.test.ts
+++ b/packages/cli-kit/src/public/node/session.test.ts
@@ -9,6 +9,7 @@ import {
   setLastSeenUserId,
 } from './session.js'
 
+import {nonRandomUUID} from './crypto.js'
 import {getAppAutomationToken} from './environment.js'
 import {shopifyFetch} from './http.js'
 import {ensureAuthenticated, setLastSeenAuthMethod, setLastSeenUserIdAfterAuth} from '../../private/node/session.js'
@@ -63,7 +64,7 @@ describe('ensureAuthenticatedStorefront', () => {
     // Then
     expect(got).toEqual('theme_access_password')
     expect(setLastSeenAuthMethod).toBeCalledWith('custom_app_token')
-    expect(setLastSeenUserIdAfterAuth).toBeCalledWith('dd5e7850-e2de-d283-9c5f-79c8190a19d18b52e0ce')
+    expect(setLastSeenUserIdAfterAuth).toBeCalledWith(nonRandomUUID('theme_access_password'))
   })
 
   test('returns the password if provided, and auth method is theme_access_token', async () => {
@@ -73,7 +74,7 @@ describe('ensureAuthenticatedStorefront', () => {
     // Then
     expect(got).toEqual('shptka_theme_access_password')
     expect(setLastSeenAuthMethod).toBeCalledWith('theme_access_token')
-    expect(setLastSeenUserIdAfterAuth).toBeCalledWith('730a64df-ab2c-3d92-8b11-76a66aadee947aa5c1ce')
+    expect(setLastSeenUserIdAfterAuth).toBeCalledWith(nonRandomUUID('shptka_theme_access_password'))
   })
 
   test('throws error if there is no storefront token', async () => {
@@ -190,7 +191,7 @@ describe('ensureAuthenticatedTheme', () => {
     // Then
     expect(got).toEqual({token: 'password', storeFqdn: 'mystore.myshopify.com'})
     expect(setLastSeenAuthMethod).toBeCalledWith('custom_app_token')
-    expect(setLastSeenUserIdAfterAuth).toBeCalledWith('f5c7086f-320b-3b93-bcdc-a2296adbec02d71eb733')
+    expect(setLastSeenUserIdAfterAuth).toBeCalledWith(nonRandomUUID('password'))
   })
 
   test('returns the password when is provided and theme_access_token', async () => {
@@ -200,7 +201,7 @@ describe('ensureAuthenticatedTheme', () => {
     // Then
     expect(got).toEqual({token: 'shptka_password', storeFqdn: 'mystore.myshopify.com'})
     expect(setLastSeenAuthMethod).toBeCalledWith('theme_access_token')
-    expect(setLastSeenUserIdAfterAuth).toBeCalledWith('e3d08cca-4e68-504a-00ec-23e2cea12a6340bb257b')
+    expect(setLastSeenUserIdAfterAuth).toBeCalledWith(nonRandomUUID('shptka_password'))
   })
 })
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #0000

The session tests duplicated the exact output of `nonRandomUUID(...)` for password-backed auth flows. When the derived value changes, the tests fail with stale long string literals even though the production behavior is still to pass the derived ID through.

### WHAT is this pull request doing?

Updates the expectations to call `nonRandomUUID(...)` with the same input password used by the code under test, so the tests assert the behavior without duplicating generated hashes.

### How to test your changes?

Validated locally:

```sh
pnpm vitest packages/cli-kit/src/public/node/session.test.ts --run
pnpm exec prettier --check packages/cli-kit/src/public/node/session.test.ts
```

### Post-release steps

None.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [x] The change is not user-facing; no changeset is needed
