### PR TITLE
Avoid hardcoded UID in extension template test

### DIFF
--- a/packages/app/src/cli/services/generate/extension.test.ts
+++ b/packages/app/src/cli/services/generate/extension.test.ts
@@ -266,7 +266,7 @@ describe('initialize a extension', async () => {
           name,
           handle: slugify(name),
           flavor,
-          uid: 'ba7c20a9-578d-6fee-8cd2-044af992dabd92d8bbfe',
+          uid: expect.any(String),
         })
       })
     },


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #0000

The extension template-copy test hardcoded one generated UID. Recent CI showed this can fail when the generated value changes even though the test only needs to verify that template variables include a UID.

### WHAT is this pull request doing?

Replaces the hardcoded UID literal with `expect.any(String)` in the `recursiveLiquidTemplateCopy` expectation.

### How to test your changes?

Validated locally:

```sh
pnpm vitest packages/app/src/cli/services/generate/extension.test.ts --run
pnpm exec prettier --check packages/app/src/cli/services/generate/extension.test.ts
```

### Post-release steps

None.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [x] The change is not user-facing; no changeset is needed
