### PR TITLE
Remove sleeps from binary download test

### DIFF
--- a/packages/app/src/cli/services/function/binaries.test.ts
+++ b/packages/app/src/cli/services/function/binaries.test.ts
@@ -184,8 +184,13 @@ describe('javy', () => {
     const blockDownload = new Promise<void>((resolve) => {
       resolveDownload = resolve
     })
+    let resolveFetchStarted!: () => void
+    const fetchStarted = new Promise<void>((resolve) => {
+      resolveFetchStarted = resolve
+    })
 
     vi.mocked(fetch).mockImplementation(async () => {
+      resolveFetchStarted()
       await blockDownload
       return new Response(gzipSync('javy binary'))
     })
@@ -194,8 +199,8 @@ describe('javy', () => {
     // Start first download — will block at fetch
     const firstDownload = downloadBinary(javy)
 
-    // Allow first download to reach fetch and register in downloadsInProgress
-    await new Promise((resolve) => setTimeout(resolve, 1))
+    // Wait for first download to reach fetch and register in downloadsInProgress
+    await fetchStarted
 
     // Simulate file appearing on disk (e.g., non-atomic moveFile creating the destination
     // while the download is still tracked as in-progress)
@@ -206,7 +211,7 @@ describe('javy', () => {
     const secondDownload = downloadBinary(javy).then(() => {
       secondResolved = true
     })
-    await new Promise((resolve) => setTimeout(resolve, 1))
+    await Promise.resolve()
 
     // Then — second download should be blocked waiting for first
     expect(secondResolved).toBe(false)


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #0000

The binary download concurrency test used fixed 1ms sleeps to let asynchronous work reach specific checkpoints. That makes the test harder to reason about and more timing-sensitive than necessary.

### WHAT is this pull request doing?

Adds an explicit promise checkpoint for when the mocked `fetch` is reached, then uses a microtask yield before asserting the second download is still waiting for the first in-progress download.

### How to test your changes?

Validated locally:

```sh
pnpm vitest packages/app/src/cli/services/function/binaries.test.ts --run
pnpm exec prettier --check packages/app/src/cli/services/function/binaries.test.ts
```

### Post-release steps

None.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [x] The change is not user-facing; no changeset is needed
