### PR TITLE
Poll reverse proxy abort test

### DIFF
--- a/packages/app/src/cli/utilities/app/http-reverse-proxy.test.ts
+++ b/packages/app/src/cli/utilities/app/http-reverse-proxy.test.ts
@@ -83,17 +83,20 @@ describe.sequential.each(each)('http-reverse-proxy for %s', (protocol) => {
     expect(response.headers.get('access-control-allow-headers')).toBe('Content-Type, Authorization')
   })
 
-  test('closes the server when aborted', {retry: 2}, async ({setup}) => {
+  test('closes the server when aborted', async ({setup}) => {
     setup.abortController.abort()
-    // Try the assertion immediately, and if it fails, wait and retry
-    try {
-      await expect(fetch(`${protocol}://localhost:${setup.proxyPort}/path1`, {agent})).rejects.toThrow()
-      // eslint-disable-next-line no-catch-all/no-catch-all
-    } catch (error) {
-      // If the assertion fails, wait a bit and try again
-      await new Promise((resolve) => setTimeout(resolve, 10))
-      await expect(fetch(`${protocol}://localhost:${setup.proxyPort}/path1`, {agent})).rejects.toThrow()
-    }
+
+    await expect
+      .poll(async () => {
+        try {
+          await fetch(`${protocol}://localhost:${setup.proxyPort}/path1`, {agent})
+          return 'open'
+          // eslint-disable-next-line no-catch-all/no-catch-all
+        } catch {
+          return 'closed'
+        }
+      })
+      .toBe('closed')
   })
 })
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #0000

The reverse proxy abort test used a manual try/catch retry with a fixed 10ms sleep after aborting the server. Polling for the expected closed state makes the test less timing-sensitive and removes the explicit sleep.

### WHAT is this pull request doing?

Replaces the manual retry/sleep block with `expect.poll`, which repeatedly checks that requests reject after the abort controller is triggered.

### How to test your changes?

Validated locally:

```sh
pnpm vitest packages/app/src/cli/utilities/app/http-reverse-proxy.test.ts --run
pnpm exec prettier --check packages/app/src/cli/utilities/app/http-reverse-proxy.test.ts
```

### Post-release steps

None.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [x] The change is not user-facing; no changeset is needed
