### PR TITLE
Tighten preview store client test types

### DIFF
--- a/packages/store/src/cli/services/store/create/preview/client.test.ts
+++ b/packages/store/src/cli/services/store/create/preview/client.test.ts
@@ -33,14 +33,26 @@ function response(status: number, body: unknown) {
   } as Awaited<ReturnType<typeof shopifyFetch>>
 }
 
-function inMemoryStorage(initial?: string) {
-  const values = new Map<string, unknown>()
+interface PreviewStoreClientStorageSchema {
+  cliInstanceId?: string
+}
+
+function inMemoryStorage(initial?: string): LocalStorage<PreviewStoreClientStorageSchema> {
+  const values = new Map<keyof PreviewStoreClientStorageSchema, string>()
   if (initial) values.set('cliInstanceId', initial)
   return {
-    get: vi.fn((key: string) => values.get(key) as any),
-    set: vi.fn((key: string, value: unknown) => values.set(key, value)),
-    delete: vi.fn((key: string) => values.delete(key)),
-  } as unknown as LocalStorage<{cliInstanceId?: string}>
+    get: vi.fn((key: keyof PreviewStoreClientStorageSchema) => values.get(key)),
+    set: vi.fn((key: keyof PreviewStoreClientStorageSchema, value?: string) => {
+      if (value === undefined) {
+        values.delete(key)
+      } else {
+        values.set(key, value)
+      }
+    }),
+    delete: vi.fn((key: keyof PreviewStoreClientStorageSchema) => {
+      values.delete(key)
+    }),
+  } as unknown as LocalStorage<PreviewStoreClientStorageSchema>
 }
 
 describe('preview store client', () => {


### PR DESCRIPTION
### WHY are these changes introduced?

No issue.

The preview-store client tests used an `as any` cast in the in-memory storage helper even though the helper only stores a `cliInstanceId` string.

### WHAT is this pull request doing?

Add a narrow test storage schema and type the in-memory storage helper around the `cliInstanceId` key.

The helper now avoids the `as any` cast and more closely matches the `LocalStorage` methods used by the production code.

### How to test your changes?

- `pnpm nx run store:lint --skip-nx-cache`
- `pnpm --dir packages/store vitest run src/cli/services/store/create/preview/client.test.ts`

### Post-release steps

None.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

Not user-facing; no changeset needed.
