### PR TITLE
Fix UI extension manifest paths

### DIFF
--- a/packages/app/src/cli/models/extensions/specifications/ui_extension.ts
+++ b/packages/app/src/cli/models/extensions/specifications/ui_extension.ts
@@ -100,7 +100,11 @@ const uiExtensionSpec = createExtensionSpecification({
           id: 'bundle-ui',
           name: 'Bundle UI Extension',
           type: 'bundle_ui',
-          config: {generatesAssetsManifest: true, bundleFolder: 'dist/'},
+          config: {
+            generatesAssetsManifest: true,
+            bundleFolder: 'dist/',
+            skipAssetsManifestWithoutConfigAssetsInProduction: true,
+          },
         },
         {
           id: 'include-ui-extension-assets',

--- a/packages/app/src/cli/services/build/client-steps.ts
+++ b/packages/app/src/cli/services/build/client-steps.ts
@@ -27,6 +27,7 @@ export interface BundleUIStep extends BaseStep {
   readonly config?: {
     readonly generatesAssetsManifest?: boolean
     readonly bundleFolder?: string
+    readonly skipAssetsManifestWithoutConfigAssetsInProduction?: boolean
   }
 }
 

--- a/packages/app/src/cli/services/build/steps/bundle-ui-step.test.ts
+++ b/packages/app/src/cli/services/build/steps/bundle-ui-step.test.ts
@@ -110,4 +110,133 @@ describe('executeBundleUIStep', () => {
       expect(generateManifest.createOrUpdateManifestFile).not.toHaveBeenCalled()
     })
   })
+
+  test('skips production manifest generation when there are no config-driven assets', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      const extensionDir = joinPath(tmpDir, 'extension')
+      const localOutputDir = joinPath(extensionDir, 'dist')
+      const bundleDir = joinPath(tmpDir, 'bundle')
+      const bundleOutputDir = joinPath(bundleDir, 'handle', 'dist')
+
+      await mkdir(localOutputDir)
+      await writeFile(joinPath(localOutputDir, 'handle.js'), 'console.log("hello")')
+
+      const stepWithManifestGate: BundleUIStep = {
+        id: 'bundle-ui',
+        name: 'Bundle UI Extension',
+        type: 'bundle_ui',
+        config: {
+          generatesAssetsManifest: true,
+          bundleFolder: 'dist/',
+          skipAssetsManifestWithoutConfigAssetsInProduction: true,
+        },
+      }
+
+      mockContext.extension.directory = extensionDir
+      mockContext.extension.outputPath = joinPath(bundleDir, 'handle', 'handle.js')
+      mockContext.extension.configuration = {
+        extension_points: [
+          {target: 'admin.product-details.action.render', build_manifest: {assets: {main: {filepath: 'handle.js'}}}},
+        ],
+      } as ExtensionInstance['configuration']
+      vi.mocked(buildExtension.buildUIExtension).mockResolvedValue(joinPath(localOutputDir, 'handle.js'))
+
+      // When
+      await executeBundleUIStep(stepWithManifestGate, mockContext)
+
+      // Then
+      await expect(fileExists(joinPath(bundleOutputDir, 'handle.js'))).resolves.toBe(true)
+      expect(generateManifest.createOrUpdateManifestFile).not.toHaveBeenCalled()
+    })
+  })
+
+  test('keeps production manifest generation when config-driven assets exist', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      const extensionDir = joinPath(tmpDir, 'extension')
+      const localOutputDir = joinPath(extensionDir, 'dist')
+      const bundleDir = joinPath(tmpDir, 'bundle')
+
+      await mkdir(localOutputDir)
+      await writeFile(joinPath(localOutputDir, 'handle.js'), 'console.log("hello")')
+
+      const stepWithManifestGate: BundleUIStep = {
+        id: 'bundle-ui',
+        name: 'Bundle UI Extension',
+        type: 'bundle_ui',
+        config: {
+          generatesAssetsManifest: true,
+          bundleFolder: 'dist/',
+          skipAssetsManifestWithoutConfigAssetsInProduction: true,
+        },
+      }
+
+      mockContext.extension.directory = extensionDir
+      mockContext.extension.outputPath = joinPath(bundleDir, 'handle', 'handle.js')
+      mockContext.extension.configuration = {
+        extension_points: [
+          {
+            target: 'admin.product-details.action.render',
+            tools: './tools.json',
+            build_manifest: {assets: {main: {filepath: 'handle.js'}}},
+          },
+        ],
+      } as ExtensionInstance['configuration']
+      vi.mocked(buildExtension.buildUIExtension).mockResolvedValue(joinPath(localOutputDir, 'handle.js'))
+
+      // When
+      await executeBundleUIStep(stepWithManifestGate, mockContext)
+
+      // Then
+      expect(generateManifest.createOrUpdateManifestFile).toHaveBeenCalledWith(mockContext, {
+        'admin.product-details.action.render': {
+          main: 'dist/handle.js',
+        },
+      })
+    })
+  })
+
+  test('keeps development manifest generation even when there are no config-driven assets', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      const extensionDir = joinPath(tmpDir, 'extension')
+      const localOutputDir = joinPath(extensionDir, 'dist')
+      const bundleDir = joinPath(tmpDir, 'bundle')
+
+      await mkdir(localOutputDir)
+      await writeFile(joinPath(localOutputDir, 'handle.js'), 'console.log("hello")')
+
+      const stepWithManifestGate: BundleUIStep = {
+        id: 'bundle-ui',
+        name: 'Bundle UI Extension',
+        type: 'bundle_ui',
+        config: {
+          generatesAssetsManifest: true,
+          bundleFolder: 'dist/',
+          skipAssetsManifestWithoutConfigAssetsInProduction: true,
+        },
+      }
+
+      mockContext.options.environment = 'development'
+      mockContext.extension.directory = extensionDir
+      mockContext.extension.outputPath = joinPath(bundleDir, 'handle', 'handle.js')
+      mockContext.extension.configuration = {
+        extension_points: [
+          {target: 'admin.product-details.action.render', build_manifest: {assets: {main: {filepath: 'handle.js'}}}},
+        ],
+      } as ExtensionInstance['configuration']
+      vi.mocked(buildExtension.buildUIExtension).mockResolvedValue(joinPath(localOutputDir, 'handle.js'))
+
+      // When
+      await executeBundleUIStep(stepWithManifestGate, mockContext)
+
+      // Then
+      expect(generateManifest.createOrUpdateManifestFile).toHaveBeenCalledWith(mockContext, {
+        'admin.product-details.action.render': {
+          main: 'dist/handle.js',
+        },
+      })
+    })
+  })
 })

--- a/packages/app/src/cli/services/build/steps/bundle-ui-step.ts
+++ b/packages/app/src/cli/services/build/steps/bundle-ui-step.ts
@@ -14,9 +14,8 @@ interface ExtensionPointWithBuildManifest {
  * Executes a bundle_ui build step.
  *
  * Bundles the UI extension using esbuild into the extension's local directory
- * and copies the output to the bundle. When `generatesAssetsManifest` is true,
- * writes built asset entries (from build_manifest) into manifest.json so
- * downstream steps can merge on top.
+ * and copies the output to the bundle. When enabled, writes built asset entries
+ * (from build_manifest) into manifest.json so downstream steps can merge on top.
  */
 export async function executeBundleUIStep(step: BundleUIStep, context: BuildContext): Promise<void> {
   const config = context.extension.configuration
@@ -32,7 +31,7 @@ export async function executeBundleUIStep(step: BundleUIStep, context: BuildCont
 
   await copyFile(localOutputDir, bundleOutputDir)
 
-  if (!step.config?.generatesAssetsManifest) return
+  if (!shouldGenerateAssetsManifest(step, context)) return
 
   if (!Array.isArray(config.extension_points)) return
 
@@ -44,6 +43,37 @@ export async function executeBundleUIStep(step: BundleUIStep, context: BuildCont
   if (Object.keys(entries).length > 0) {
     await createOrUpdateManifestFile(context, entries)
   }
+}
+
+function shouldGenerateAssetsManifest(step: BundleUIStep, context: BuildContext): boolean {
+  if (!step.config?.generatesAssetsManifest) return false
+  if (context.options.environment !== 'production') return true
+  if (!step.config.skipAssetsManifestWithoutConfigAssetsInProduction) return true
+
+  return hasConfigDrivenManifestAssets(context.extension.configuration.extension_points)
+}
+
+function hasConfigDrivenManifestAssets(extensionPoints: unknown): boolean {
+  if (!Array.isArray(extensionPoints)) return false
+
+  return extensionPoints.some((extensionPoint) => {
+    if (!extensionPoint || typeof extensionPoint !== 'object' || Array.isArray(extensionPoint)) return false
+
+    const point = extensionPoint as Record<string, unknown>
+    return (
+      hasManifestAssetValue(point.assets) ||
+      hasManifestAssetValue(point.tools) ||
+      hasManifestAssetValue(point.instructions) ||
+      hasManifestAssetValue(point.intents)
+    )
+  })
+}
+
+function hasManifestAssetValue(value: unknown): boolean {
+  if (typeof value === 'string') return value.length > 0
+  if (Array.isArray(value)) return value.some(hasManifestAssetValue)
+  if (value && typeof value === 'object') return Object.values(value).some(hasManifestAssetValue)
+  return false
 }
 
 /**

--- a/packages/app/src/cli/services/dev/update-extension.test.ts
+++ b/packages/app/src/cli/services/dev/update-extension.test.ts
@@ -75,6 +75,53 @@ describe('updateExtensionDraft()', () => {
     })
   })
 
+  test('uses manifest main path when updating an esbuild extension draft', async () => {
+    const developerPlatformClient: DeveloperPlatformClient = testDeveloperPlatformClient()
+    await inTemporaryDirectory(async (tmpDir) => {
+      const configuration = {
+        runtime_context: 'strict',
+        settings: {type: 'object'},
+        type: 'web_pixel_extension',
+        handle,
+        uid: 'uid1',
+      } as any
+
+      const mockExtension = await testUIExtension({
+        devUUID: '1',
+        configuration,
+        directory: tmpDir,
+        uid: 'uid1',
+      })
+
+      await mkdir(joinPath(tmpDir, 'uid1', 'dist'))
+      await writeFile(
+        joinPath(tmpDir, 'uid1', 'manifest.json'),
+        JSON.stringify({'admin.product-details.action.render': {main: 'dist/mock-handle.js'}}),
+      )
+      await writeFile(joinPath(tmpDir, 'uid1', 'dist', 'mock-handle.js'), 'manifest script content')
+
+      await updateExtensionDraft({
+        extension: mockExtension,
+        developerPlatformClient,
+        apiKey,
+        registrationId,
+        stdout,
+        stderr,
+        appConfiguration: placeholderAppConfiguration,
+        bundlePath: tmpDir,
+      })
+
+      expect(developerPlatformClient.updateExtension).toHaveBeenCalledWith({
+        apiKey,
+        context: '',
+        handle,
+        registrationId,
+        config:
+          '{"runtime_context":"strict","runtime_configuration_definition":{"type":"object"},"serialized_script":"bWFuaWZlc3Qgc2NyaXB0IGNvbnRlbnQ="}',
+      })
+    })
+  })
+
   test('updates draft successfully with context for extension with target', async () => {
     const developerPlatformClient: DeveloperPlatformClient = testDeveloperPlatformClient()
     const mockExtension = await testPaymentExtensions()

--- a/packages/app/src/cli/services/dev/update-extension.ts
+++ b/packages/app/src/cli/services/dev/update-extension.ts
@@ -6,7 +6,8 @@ import {AppConfiguration} from '../../models/app/app.js'
 import {ExtensionInstance} from '../../models/extensions/extension-instance.js'
 import {DeveloperPlatformClient} from '../../utilities/developer-platform-client.js'
 import {themeExtensionConfig} from '../deploy/theme-extension-config.js'
-import {readFile} from '@shopify/cli-kit/node/fs'
+import {fileExists, readFile} from '@shopify/cli-kit/node/fs'
+import {dirname, joinPath} from '@shopify/cli-kit/node/path'
 import {outputInfo} from '@shopify/cli-kit/node/output'
 import {Writable} from 'stream'
 
@@ -32,8 +33,8 @@ export async function updateExtensionDraft({
   bundlePath,
 }: UpdateExtensionDraftOptions) {
   let encodedFile: string | undefined
-  const outputPath = extension.getOutputPathForDirectory(bundlePath)
   if (extension.features.includes('esbuild')) {
+    const outputPath = await getDraftScriptOutputPath(extension, bundlePath)
     const content = await readFile(outputPath)
     if (!content) return
     encodedFile = Buffer.from(content).toString('base64')
@@ -94,5 +95,26 @@ export async function updateExtensionDraft({
   } else {
     const draftUpdateSuccesMessage = extension.draftMessages.successMessage
     if (draftUpdateSuccesMessage) outputInfo(draftUpdateSuccesMessage, stdout)
+  }
+}
+
+async function getDraftScriptOutputPath(extension: ExtensionInstance, bundlePath: string): Promise<string> {
+  const fallbackOutputPath = extension.getOutputPathForDirectory(bundlePath)
+  const buildDirectory = dirname(fallbackOutputPath)
+  const manifestPath = joinPath(buildDirectory, 'manifest.json')
+
+  if (!(await fileExists(manifestPath))) return fallbackOutputPath
+
+  try {
+    const manifest = JSON.parse(await readFile(manifestPath)) as Record<string, {main?: unknown}>
+    const mainPath = Object.values(manifest).find((entry) => typeof entry?.main === 'string')?.main
+
+    return typeof mainPath === 'string' ? joinPath(buildDirectory, mainPath) : fallbackOutputPath
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      throw new Error(`Invalid manifest.json in ${buildDirectory}: ${error.message}`)
+    }
+
+    throw error
   }
 }


### PR DESCRIPTION
## Problem

In the latest released CLI, generic `ui_extension` builds can produce a per-extension `manifest.json` that points at the built JS bundle under `dist/`, for example:

```text
.shopify/dev-bundle/<uuid>/dist/dft-discounts-debugger.js
```

However, the `app dev` draft upload path still used the older convention and tried to upload the script from the bundle root:

```text
ENOENT: no such file or directory, open '.../.shopify/dev-bundle/<uuid>/dft-discounts-debugger.js'
```

So `app dev` builds the file correctly, but then tries to read it from the wrong path during draft upload. Function extensions are not affected because they do not use this generic UI extension `manifest.json` flow; their draft upload path is handled separately as WASM under `dist/index.wasm`.

## What changed

- Read generic `ui_extension` draft upload paths from each extension's `manifest.json`, so `app dev` uploads `dist/<handle>.js` instead of falling back to the old `<handle>.js` path.
- Stop emitting production per-extension `manifest.json` files for generic UI extensions that only contain built JS assets.
- Keep development manifests, and keep production manifests when config-driven assets like tools, instructions, intents, or static assets exist.


## Validation

- `pnpm --filter @shopify/app vitest run src/cli/services/dev/update-extension.test.ts src/cli/services/build/steps/bundle-ui-step.test.ts src/cli/services/build/steps/include-assets-step.test.ts`
- `pnpm --filter @shopify/app lint`
- `pnpm --filter @shopify/app type-check`
