### PR TITLE
[Performance] Memoize FQDN lookups

### DIFF
--- a/packages/cli-kit/src/public/node/context/fqdn.test.ts
+++ b/packages/cli-kit/src/public/node/context/fqdn.test.ts
@@ -6,11 +6,16 @@ import {
   businessPlatformFqdn,
   appDevFqdn,
   adminFqdn,
+  _resetFqdns,
 } from './fqdn.js'
 import {Environment, serviceEnvironment} from '../../../private/node/context/service.js'
-import {expect, describe, test, vi} from 'vitest'
+import {expect, describe, test, vi, beforeEach} from 'vitest'
 
 vi.mock('../../../private/node/context/service.js')
+
+beforeEach(() => {
+  _resetFqdns()
+})
 
 vi.mock('../vendor/dev_server/index.js', () => {
   return {

--- a/packages/cli-kit/src/public/node/context/fqdn.ts
+++ b/packages/cli-kit/src/public/node/context/fqdn.ts
@@ -7,20 +7,44 @@ export const NotProvidedStoreFQDNError = new AbortError(
   "Couldn't obtain the Shopify FQDN because the store FQDN was not provided.",
 )
 
+let memoizedPartnersFqdn: Promise<string> | undefined
+let memoizedAdminFqdn: Promise<string> | undefined
+let memoizedAppManagementFqdn: Promise<string> | undefined
+let memoizedDeveloperDashboardFqdn: Promise<string> | undefined
+let memoizedBusinessPlatformFqdn: Promise<string> | undefined
+let memoizedIdentityFqdn: Promise<string> | undefined
+
+/**
+ * This function is used to reset the memoized values of the FQDNs.
+ * It's only used for testing purposes.
+ */
+export function _resetFqdns() {
+  memoizedPartnersFqdn = undefined
+  memoizedAdminFqdn = undefined
+  memoizedAppManagementFqdn = undefined
+  memoizedDeveloperDashboardFqdn = undefined
+  memoizedBusinessPlatformFqdn = undefined
+  memoizedIdentityFqdn = undefined
+}
+
 /**
  * It returns the Partners' API service we should interact with.
  *
  * @returns Fully-qualified domain of the partners service we should interact with.
  */
-export async function partnersFqdn(): Promise<string> {
-  const environment = serviceEnvironment()
-  const productionFqdn = 'partners.shopify.com'
-  switch (environment) {
-    case 'local':
-      return new DevServer('partners').host()
-    default:
-      return productionFqdn
-  }
+export function partnersFqdn(): Promise<string> {
+  if (memoizedPartnersFqdn) return memoizedPartnersFqdn
+  memoizedPartnersFqdn = (async () => {
+    const environment = serviceEnvironment()
+    const productionFqdn = 'partners.shopify.com'
+    switch (environment) {
+      case 'local':
+        return new DevServer('partners').host()
+      default:
+        return productionFqdn
+    }
+  })()
+  return memoizedPartnersFqdn
 }
 
 /**
@@ -28,15 +52,19 @@ export async function partnersFqdn(): Promise<string> {
  *
  * @returns Fully-qualified domain of the Admin service we should interact with.
  */
-export async function adminFqdn(): Promise<string> {
-  const environment = serviceEnvironment()
-  const productionFqdn = 'admin.shopify.com'
-  switch (environment) {
-    case 'local':
-      return new DevServerCore().host('admin')
-    default:
-      return productionFqdn
-  }
+export function adminFqdn(): Promise<string> {
+  if (memoizedAdminFqdn) return memoizedAdminFqdn
+  memoizedAdminFqdn = (async () => {
+    const environment = serviceEnvironment()
+    const productionFqdn = 'admin.shopify.com'
+    switch (environment) {
+      case 'local':
+        return new DevServerCore().host('admin')
+      default:
+        return productionFqdn
+    }
+  })()
+  return memoizedAdminFqdn
 }
 
 /**
@@ -44,15 +72,19 @@ export async function adminFqdn(): Promise<string> {
  *
  * @returns Fully-qualified domain of the App Management service we should interact with.
  */
-export async function appManagementFqdn(): Promise<string> {
-  const environment = serviceEnvironment()
-  const productionFqdn = 'app.shopify.com'
-  switch (environment) {
-    case 'local':
-      return new DevServerCore().host('app')
-    default:
-      return productionFqdn
-  }
+export function appManagementFqdn(): Promise<string> {
+  if (memoizedAppManagementFqdn) return memoizedAppManagementFqdn
+  memoizedAppManagementFqdn = (async () => {
+    const environment = serviceEnvironment()
+    const productionFqdn = 'app.shopify.com'
+    switch (environment) {
+      case 'local':
+        return new DevServerCore().host('app')
+      default:
+        return productionFqdn
+    }
+  })()
+  return memoizedAppManagementFqdn
 }
 
 /**
@@ -75,15 +107,19 @@ export async function appDevFqdn(storeFqdn: string): Promise<string> {
  *
  * @returns Fully-qualified domain of the Developer Dashboard we should interact with.
  */
-export async function developerDashboardFqdn(): Promise<string> {
-  const environment = serviceEnvironment()
-  const productionFqdn = 'dev.shopify.com'
-  switch (environment) {
-    case 'local':
-      return new DevServerCore().host('dev')
-    default:
-      return productionFqdn
-  }
+export function developerDashboardFqdn(): Promise<string> {
+  if (memoizedDeveloperDashboardFqdn) return memoizedDeveloperDashboardFqdn
+  memoizedDeveloperDashboardFqdn = (async () => {
+    const environment = serviceEnvironment()
+    const productionFqdn = 'dev.shopify.com'
+    switch (environment) {
+      case 'local':
+        return new DevServerCore().host('dev')
+      default:
+        return productionFqdn
+    }
+  })()
+  return memoizedDeveloperDashboardFqdn
 }
 
 /**
@@ -91,15 +127,19 @@ export async function developerDashboardFqdn(): Promise<string> {
  *
  * @returns Fully-qualified domain of the partners service we should interact with.
  */
-export async function businessPlatformFqdn(): Promise<string> {
-  const environment = serviceEnvironment()
-  const productionFqdn = 'destinations.shopifysvc.com'
-  switch (environment) {
-    case 'local':
-      return new DevServer('business-platform').host()
-    default:
-      return productionFqdn
-  }
+export function businessPlatformFqdn(): Promise<string> {
+  if (memoizedBusinessPlatformFqdn) return memoizedBusinessPlatformFqdn
+  memoizedBusinessPlatformFqdn = (async () => {
+    const environment = serviceEnvironment()
+    const productionFqdn = 'destinations.shopifysvc.com'
+    switch (environment) {
+      case 'local':
+        return new DevServer('business-platform').host()
+      default:
+        return productionFqdn
+    }
+  })()
+  return memoizedBusinessPlatformFqdn
 }
 
 /**
@@ -107,15 +147,19 @@ export async function businessPlatformFqdn(): Promise<string> {
  *
  * @returns Fully-qualified domain of the Identity service we should interact with.
  */
-export async function identityFqdn(): Promise<string> {
-  const environment = serviceEnvironment()
-  const productionFqdn = 'accounts.shopify.com'
-  switch (environment) {
-    case 'local':
-      return new DevServer('identity').host()
-    default:
-      return productionFqdn
-  }
+export function identityFqdn(): Promise<string> {
+  if (memoizedIdentityFqdn) return memoizedIdentityFqdn
+  memoizedIdentityFqdn = (async () => {
+    const environment = serviceEnvironment()
+    const productionFqdn = 'accounts.shopify.com'
+    switch (environment) {
+      case 'local':
+        return new DevServer('identity').host()
+      default:
+        return productionFqdn
+    }
+  })()
+  return memoizedIdentityFqdn
 }
 
 /**


### PR DESCRIPTION
### WHY are these changes introduced?

Obtaining FQDNs involves environment checks and object instantiation. Since these values are static during the execution of a CLI command, memoizing them avoids redundant work in high-frequency code paths.

### WHAT is this pull request doing?

- Memoizes `partnersFqdn`, `adminFqdn`, `appManagementFqdn`, `developerDashboardFqdn`, `businessPlatformFqdn`, and `identityFqdn` in `packages/cli-kit/src/public/node/context/fqdn.ts`.
- Uses module-level promises to ensure concurrent calls await the same operation.
- Implements `_resetFqdns` for test isolation and updates the test suite to use it.

### How to test your changes?

CI

### Post-release steps

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [4669125025240248383](https://jules.google.com/task/4669125025240248383) started by @gonzaloriestra*