### PR TITLE
[Refactor] Use node:timers/promises in sleep function

### DIFF
--- a/packages/cli-kit/src/public/node/system.ts
+++ b/packages/cli-kit/src/public/node/system.ts
@@ -13,6 +13,7 @@ import which from 'which'
 import {delimiter} from 'pathe'
 
 import {fstatSync} from 'fs'
+import {setTimeout} from 'node:timers/promises'
 import type {Writable, Readable} from 'stream'
 
 /**
@@ -319,9 +320,7 @@ function checkCommandSafety(command: string, _options: {cwd: string}): void {
  * @returns A Promise resolving after the number of seconds.
  */
 export async function sleep(seconds: number): Promise<void> {
-  return new Promise((resolve) => {
-    setTimeout(resolve, 1000 * seconds)
-  })
+  await setTimeout(1000 * seconds)
 }
 
 /**


### PR DESCRIPTION
### WHY are these changes introduced?

This is a small cleanup to modernize timer usage in the codebase. Using `node:timers/promises` is more idiomatic and readable than manually wrapping `setTimeout` in a `Promise`.

### WHAT is this pull request doing?

Refactors the `sleep` function in `packages/cli-kit/src/public/node/system.ts` to use `setTimeout` from `node:timers/promises`.

### How to test your changes?

CI

### Post-release steps

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [16918308578321284909](https://jules.google.com/task/16918308578321284909) started by @gonzaloriestra*