### PR TITLE
Fix deploy not working when using --no-build

### DIFF
--- a/.changeset/grumpy-bugs-search.md
+++ b/.changeset/grumpy-bugs-search.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Fix issue when using `--no-build` during deploy

--- a/packages/app/src/cli/models/extensions/extension-instance.test.ts
+++ b/packages/app/src/cli/models/extensions/extension-instance.test.ts
@@ -171,39 +171,6 @@ describe('build', async () => {
       expect(outputFileContent).toEqual('(()=>{})();')
     })
   })
-
-  test('does not copy shopify.extension.toml file when bundling theme extensions', async () => {
-    await inTemporaryDirectory(async (tmpDir) => {
-      // Given
-      const extension = await testThemeExtensions(tmpDir)
-
-      const blocksDir = joinPath(tmpDir, 'blocks')
-      await mkdir(blocksDir)
-
-      await writeFile(joinPath(blocksDir, 'product.liquid'), '<div>Product block</div>')
-      await writeFile(joinPath(tmpDir, 'shopify.extension.toml'), '[extensions]')
-
-      const bundleDirectory = joinPath(tmpDir, 'bundle')
-      await mkdir(bundleDirectory)
-
-      const options: ExtensionBuildOptions = {
-        stdout: new Writable({write: vi.fn()}),
-        stderr: new Writable({write: vi.fn()}),
-        app: testApp(),
-        environment: 'production',
-      }
-
-      // When
-      await extension.copyIntoBundle(options, bundleDirectory, 'uuid')
-
-      // Then
-      const outputTomlPath = joinPath(extension.outputPath, 'shopify.extension.toml')
-      expect(fileExistsSync(outputTomlPath)).toBe(false)
-
-      const outputProductPath = joinPath(extension.outputPath, 'blocks', 'product.liquid')
-      expect(fileExistsSync(outputProductPath)).toBe(true)
-    })
-  })
 })
 
 describe('deployConfig', async () => {

--- a/packages/app/src/cli/models/extensions/extension-instance.ts
+++ b/packages/app/src/cli/models/extensions/extension-instance.ts
@@ -2,8 +2,7 @@ import {BaseConfigType, MAX_EXTENSION_HANDLE_LENGTH, MAX_UID_LENGTH} from './sch
 import {FunctionConfigType} from './specifications/function.js'
 import {DevSessionWatchConfig, ExtensionFeature, ExtensionSpecification} from './specification.js'
 import {SingleWebhookSubscriptionType} from './specifications/app_config_webhook_schemas/webhooks_schema.js'
-import {ExtensionBuildOptions, bundleFunctionExtension} from '../../services/build/extension.js'
-import {bundleThemeExtension} from '../../services/extensions/bundle.js'
+import {ExtensionBuildOptions} from '../../services/build/extension.js'
 import {Identifiers} from '../app/identifiers.js'
 import {DeveloperPlatformClient} from '../../utilities/developer-platform-client.js'
 import {AppConfiguration} from '../app/app.js'
@@ -14,7 +13,7 @@ import {constantize, slugify} from '@shopify/cli-kit/common/string'
 import {hashString, nonRandomUUID} from '@shopify/cli-kit/node/crypto'
 import {partnersFqdn} from '@shopify/cli-kit/node/context/fqdn'
 import {joinPath, normalizePath, resolvePath, relativePath, basename} from '@shopify/cli-kit/node/path'
-import {fileExists, moveFile, glob, copyFile, globSync} from '@shopify/cli-kit/node/fs'
+import {fileExists, moveFile, glob, globSync} from '@shopify/cli-kit/node/fs'
 import {getPathValue} from '@shopify/cli-kit/common/object'
 import {outputDebug} from '@shopify/cli-kit/node/output'
 import {
@@ -361,25 +360,6 @@ export class ExtensionInstance<TConfiguration extends BaseConfigType = BaseConfi
 
     const bundleInputPath = joinPath(bundleDirectory, this.getOutputFolderId(outputId))
     await this.keepBuiltSourcemapsLocally(bundleInputPath)
-  }
-
-  async copyIntoBundle(options: ExtensionBuildOptions, bundleDirectory: string, extensionUuid?: string) {
-    const defaultOutputPath = this.outputPath
-
-    this.outputPath = this.getOutputPathForDirectory(bundleDirectory, extensionUuid)
-
-    if (this.isThemeExtension) {
-      await bundleThemeExtension(this, options)
-    } else if (this.hasDeploySteps) {
-      outputDebug(`Will copy pre-built file from ${defaultOutputPath} to ${this.outputPath}`)
-      if (await fileExists(defaultOutputPath)) {
-        await copyFile(defaultOutputPath, this.outputPath)
-
-        if (this.isFunctionExtension) {
-          await bundleFunctionExtension(this.outputPath, this.outputPath)
-        }
-      }
-    }
   }
 
   getOutputPathForDirectory(directory: string, outputId?: string) {

--- a/packages/app/src/cli/services/build/extension.ts
+++ b/packages/app/src/cli/services/build/extension.ts
@@ -54,6 +54,12 @@ export interface ExtensionBuildOptions {
    * The URL where the app is running.
    */
   appURL?: string
+
+  /**
+   * Dry run, do everything except the actual building.
+   * Useful when running `deploy --no-build`
+   */
+  skipBuild?: boolean
 }
 
 /**
@@ -74,54 +80,56 @@ export async function buildUIExtension(extension: ExtensionInstance, options: Ex
   const localOutputPath = joinPath(extension.directory, buildDirectory, extension.outputRelativePath)
 
   const {main, assets} = extension.getBundleExtensionStdinContent()
-
   const startTime = performance.now()
-  try {
-    await bundleExtension({
-      minify: true,
-      outputPath: localOutputPath,
-      stdin: {
-        contents: main,
-        resolveDir: extension.directory,
-        loader: 'tsx',
-      },
-      environment: options.environment,
-      env,
-      stderr: options.stderr,
-      stdout: options.stdout,
-      sourceMaps: extension.isSourceMapGeneratingExtension,
-    })
-    if (assets) {
-      await Promise.all(
-        assets.map(async (asset) => {
-          await bundleExtension({
-            minify: true,
-            outputPath: joinPath(dirname(localOutputPath), asset.outputFileName),
-            stdin: {
-              contents: asset.content,
-              resolveDir: extension.directory,
-              loader: 'tsx',
-            },
-            environment: options.environment,
-            env,
-            stderr: options.stderr,
-            stdout: options.stdout,
-          })
-        }),
+
+  if (!options.skipBuild) {
+    try {
+      await bundleExtension({
+        minify: true,
+        outputPath: localOutputPath,
+        stdin: {
+          contents: main,
+          resolveDir: extension.directory,
+          loader: 'tsx',
+        },
+        environment: options.environment,
+        env,
+        stderr: options.stderr,
+        stdout: options.stdout,
+        sourceMaps: extension.isSourceMapGeneratingExtension,
+      })
+      if (assets) {
+        await Promise.all(
+          assets.map(async (asset) => {
+            await bundleExtension({
+              minify: true,
+              outputPath: joinPath(dirname(localOutputPath), asset.outputFileName),
+              stdin: {
+                contents: asset.content,
+                resolveDir: extension.directory,
+                loader: 'tsx',
+              },
+              environment: options.environment,
+              env,
+              stderr: options.stderr,
+              stdout: options.stdout,
+            })
+          }),
+        )
+      }
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } catch (extensionBundlingError: any) {
+      // this fails if the app's own source code is broken; wrap such that this isn't flagged as a CLI bug
+      // Preserve esbuild errors array so the dev watcher can format actionable error messages
+      const errorMessage = (extensionBundlingError as Error).message ?? 'Unknown error occurred'
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const newError: any = new AbortError(
+        `Failed to bundle extension ${extension.localIdentifier}. Please check the extension source code for errors.`,
+        errorMessage,
       )
+      newError.errors = extensionBundlingError.errors
+      throw newError
     }
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  } catch (extensionBundlingError: any) {
-    // this fails if the app's own source code is broken; wrap such that this isn't flagged as a CLI bug
-    // Preserve esbuild errors array so the dev watcher can format actionable error messages
-    const errorMessage = (extensionBundlingError as Error).message ?? 'Unknown error occurred'
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const newError: any = new AbortError(
-      `Failed to bundle extension ${extension.localIdentifier}. Please check the extension source code for errors.`,
-      errorMessage,
-    )
-    newError.errors = extensionBundlingError.errors
-    throw newError
   }
 
   await extension.buildValidation({outputPath: localOutputPath})
@@ -169,19 +177,21 @@ export async function buildFunctionExtension(
       apiVersion: functionConfiguration.api_version,
     })
 
-    if (extension.isJavaScript) {
-      await runCommandOrBuildJSFunction(extension, options)
-    } else {
-      await buildOtherFunction(extension, options)
-    }
+    if (!options.skipBuild) {
+      if (extension.isJavaScript) {
+        await runCommandOrBuildJSFunction(extension, options)
+      } else {
+        await buildOtherFunction(extension, options)
+      }
 
-    const wasmOpt = (extension as ExtensionInstance<FunctionConfigType>).configuration.build?.wasm_opt
-    if (fileExistsSync(extension.outputPath) && wasmOpt) {
-      await runWasmOpt(extension.outputPath)
-    }
+      const wasmOpt = (extension as ExtensionInstance<FunctionConfigType>).configuration.build?.wasm_opt
+      if (fileExistsSync(extension.outputPath) && wasmOpt) {
+        await runWasmOpt(extension.outputPath)
+      }
 
-    if (fileExistsSync(extension.outputPath)) {
-      await runTrampoline(extension.outputPath)
+      if (fileExistsSync(extension.outputPath)) {
+        await runTrampoline(extension.outputPath)
+      }
     }
 
     const projectOutputPath = joinPath(extension.directory, extension.outputRelativePath)
@@ -216,7 +226,7 @@ export async function buildFunctionExtension(
   }
 }
 
-export async function bundleFunctionExtension(wasmPath: string, bundlePath: string) {
+async function bundleFunctionExtension(wasmPath: string, bundlePath: string) {
   outputDebug(`Converting WASM from ${wasmPath} to base64 in ${bundlePath}`)
   const base64Contents = await readFile(wasmPath, {encoding: 'base64'})
   await touchFile(bundlePath)

--- a/packages/app/src/cli/services/deploy/bundle.test.ts
+++ b/packages/app/src/cli/services/deploy/bundle.test.ts
@@ -108,12 +108,10 @@ describe('bundleAndBuildExtensions', () => {
       const bundlePath = joinPath(tmpDir, 'bundle.zip')
 
       const functionExtension = await testFunctionExtension()
-      const extensionBuildMock = vi.fn()
-      const extensionCopyIntoBundleMock = vi.fn().mockImplementation(async (options, bundleDirectory, identifiers) => {
+      const extensionBuildMock = vi.fn().mockImplementation(async (options, bundleDirectory, identifiers) => {
         file.writeFileSync(joinPath(bundleDirectory, 'index.wasm'), '')
       })
       functionExtension.buildForBundle = extensionBuildMock
-      functionExtension.copyIntoBundle = extensionCopyIntoBundleMock
       const app = testApp({allExtensions: [functionExtension], directory: tmpDir})
 
       const extensions: {[key: string]: string} = {}
@@ -139,8 +137,11 @@ describe('bundleAndBuildExtensions', () => {
       })
 
       // Then
-      expect(extensionBuildMock).not.toHaveBeenCalled()
-      expect(extensionCopyIntoBundleMock).toHaveBeenCalledTimes(1)
+      expect(extensionBuildMock).toHaveBeenCalledWith(
+        expect.objectContaining({app, environment: 'production', skipBuild: true}),
+        joinPath(tmpDir, '.shopify', 'deploy-bundle'),
+        functionExtension.localIdentifier,
+      )
       await expect(file.fileExists(bundlePath)).resolves.toBeTruthy()
     })
   })
@@ -152,10 +153,10 @@ describe('bundleAndBuildExtensions', () => {
       const mockInstallJavy = vi.mocked(functionBuild.installJavy)
 
       const functionExtension = await testFunctionExtension()
-      const extensionCopyIntoBundleMock = vi.fn().mockImplementation(async (options, bundleDirectory, identifiers) => {
+      const extensionBuildMock = vi.fn().mockImplementation(async (options, bundleDirectory, identifiers) => {
         file.writeFileSync(joinPath(bundleDirectory, 'index.wasm'), '')
       })
-      functionExtension.copyIntoBundle = extensionCopyIntoBundleMock
+      functionExtension.buildForBundle = extensionBuildMock
       const app = testApp({allExtensions: [functionExtension], directory: tmpDir})
 
       const identifiers = {
@@ -178,6 +179,11 @@ describe('bundleAndBuildExtensions', () => {
 
       // Then
       expect(mockInstallJavy).not.toHaveBeenCalled()
+      expect(extensionBuildMock).toHaveBeenCalledWith(
+        expect.objectContaining({app, environment: 'production', skipBuild: true}),
+        joinPath(tmpDir, '.shopify', 'deploy-bundle'),
+        functionExtension.localIdentifier,
+      )
     })
   })
 
@@ -217,21 +223,18 @@ describe('bundleAndBuildExtensions', () => {
     })
   })
 
-  test('handles theme extensions correctly with skipBuild', async () => {
+  test('passes skipBuild to theme extensions', async () => {
     await file.inTemporaryDirectory(async (tmpDir: string) => {
       // Given
       const bundlePath = joinPath(tmpDir, 'bundle.zip')
 
       const themeExtension = await testThemeExtensions()
-      const extensionBuildMock = vi.fn()
-      const extensionCopyIntoBundleMock = vi.fn().mockImplementation(async (options, bundleDirectory, identifiers) => {
-        // Theme extensions would typically copy theme files here
+      const extensionBuildMock = vi.fn().mockImplementation(async (options, bundleDirectory, identifiers) => {
         const themeDir = joinPath(bundleDirectory, themeExtension.uid)
         await file.mkdir(themeDir)
         file.writeFileSync(joinPath(themeDir, 'theme-file.liquid'), '<h1>Theme</h1>')
       })
       themeExtension.buildForBundle = extensionBuildMock
-      themeExtension.copyIntoBundle = extensionCopyIntoBundleMock
 
       const app = testApp({allExtensions: [themeExtension], directory: tmpDir})
 
@@ -254,8 +257,11 @@ describe('bundleAndBuildExtensions', () => {
       })
 
       // Then
-      expect(extensionBuildMock).not.toHaveBeenCalled()
-      expect(extensionCopyIntoBundleMock).toHaveBeenCalledTimes(1)
+      expect(extensionBuildMock).toHaveBeenCalledWith(
+        expect.objectContaining({app, environment: 'production', skipBuild: true}),
+        joinPath(tmpDir, '.shopify', 'deploy-bundle'),
+        themeExtension.localIdentifier,
+      )
       await expect(file.fileExists(bundlePath)).resolves.toBeTruthy()
     })
   })
@@ -270,29 +276,22 @@ describe('bundleAndBuildExtensions', () => {
       const themeExtension = await testThemeExtensions()
       const uiExtension = await testUIExtension({type: 'checkout_ui_extension'})
 
-      // Set up mocks for each extension
-      const functionBuildMock = vi.fn()
-      const functionCopyMock = vi.fn().mockImplementation(async (options, bundleDirectory) => {
+      const functionBuildMock = vi.fn().mockImplementation(async (options, bundleDirectory) => {
         file.writeFileSync(joinPath(bundleDirectory, 'index.wasm'), '')
       })
       functionExtension.buildForBundle = functionBuildMock
-      functionExtension.copyIntoBundle = functionCopyMock
 
-      const themeBuildMock = vi.fn()
-      const themeCopyMock = vi.fn().mockImplementation(async (options, bundleDirectory) => {
+      const themeBuildMock = vi.fn().mockImplementation(async (options, bundleDirectory) => {
         const themeDir = joinPath(bundleDirectory, themeExtension.uid)
         await file.mkdir(themeDir)
         file.writeFileSync(joinPath(themeDir, 'theme.liquid'), '')
       })
       themeExtension.buildForBundle = themeBuildMock
-      themeExtension.copyIntoBundle = themeCopyMock
 
-      const uiBuildMock = vi.fn()
-      const uiCopyMock = vi.fn().mockImplementation(async (options, bundleDirectory) => {
+      const uiBuildMock = vi.fn().mockImplementation(async (options, bundleDirectory) => {
         file.writeFileSync(joinPath(bundleDirectory, 'ui.js'), '')
       })
       uiExtension.buildForBundle = uiBuildMock
-      uiExtension.copyIntoBundle = uiCopyMock
 
       const app = testApp({
         allExtensions: [functionExtension, themeExtension, uiExtension],
@@ -321,15 +320,21 @@ describe('bundleAndBuildExtensions', () => {
         isDevDashboardApp: false,
       })
 
-      // Then - verify none of the build methods were called
-      expect(functionBuildMock).not.toHaveBeenCalled()
-      expect(themeBuildMock).not.toHaveBeenCalled()
-      expect(uiBuildMock).not.toHaveBeenCalled()
-
-      // Verify all copy methods were called
-      expect(functionCopyMock).toHaveBeenCalledTimes(1)
-      expect(themeCopyMock).toHaveBeenCalledTimes(1)
-      expect(uiCopyMock).toHaveBeenCalledTimes(1)
+      expect(functionBuildMock).toHaveBeenCalledWith(
+        expect.objectContaining({app, environment: 'production', skipBuild: true}),
+        joinPath(tmpDir, '.shopify', 'deploy-bundle'),
+        functionExtension.localIdentifier,
+      )
+      expect(themeBuildMock).toHaveBeenCalledWith(
+        expect.objectContaining({app, environment: 'production', skipBuild: true}),
+        joinPath(tmpDir, '.shopify', 'deploy-bundle'),
+        themeExtension.localIdentifier,
+      )
+      expect(uiBuildMock).toHaveBeenCalledWith(
+        expect.objectContaining({app, environment: 'production', skipBuild: true}),
+        joinPath(tmpDir, '.shopify', 'deploy-bundle'),
+        uiExtension.localIdentifier,
+      )
 
       await expect(file.fileExists(bundlePath)).resolves.toBeTruthy()
     })

--- a/packages/app/src/cli/services/deploy/bundle.ts
+++ b/packages/app/src/cli/services/deploy/bundle.ts
@@ -45,19 +45,11 @@ export async function bundleAndBuildExtensions(options: BundleOptions): Promise<
         ? undefined
         : options.identifiers?.extensions[extension.localIdentifier]
 
-      if (options.skipBuild) {
-        await extension.copyIntoBundle(
-          {stderr, stdout, signal, app: options.app, environment: 'production'},
-          bundleDirectory,
-          outputId,
-        )
-      } else {
-        await extension.buildForBundle(
-          {stderr, stdout, signal, app: options.app, environment: 'production'},
-          bundleDirectory,
-          outputId,
-        )
-      }
+      await extension.buildForBundle(
+        {stderr, stdout, signal, app: options.app, environment: 'production', skipBuild: options.skipBuild},
+        bundleDirectory,
+        outputId,
+      )
     },
   }))
 


### PR DESCRIPTION
## Why

`app deploy --no-build` used a separate copy path that no longer matched the extension bundle build path.

## What

- Route deploy bundling through `buildForBundle` and pass `skipBuild` through.
- Make UI and function builders reuse existing output when `skipBuild` is set.
- Remove `copyIntoBundle` and update bundle tests.

## Testing

- `pnpm vitest packages/app/src/cli/services/deploy/bundle.test.ts packages/app/src/cli/models/extensions/extension-instance.test.ts --run`
- `pnpm --filter @shopify/app lint`
- `pnpm --filter @shopify/app type-check`