### PR TITLE
Wait an event loop turn in binary download test

### DIFF
--- a/packages/app/src/cli/services/function/binaries.test.ts
+++ b/packages/app/src/cli/services/function/binaries.test.ts
@@ -29,6 +29,12 @@ vi.mock('@shopify/cli-kit/node/http', async () => {
   }
 })
 
+async function waitForNextEventLoopTurn() {
+  await new Promise<void>((resolve) => {
+    setImmediate(resolve)
+  })
+}
+
 describe('javy', () => {
   test('properties are set correctly', () => {
     expect(javy.name).toBe('javy')
@@ -211,7 +217,7 @@ describe('javy', () => {
     const secondDownload = downloadBinary(javy).then(() => {
       secondResolved = true
     })
-    await Promise.resolve()
+    await waitForNextEventLoopTurn()
 
     // Then — second download should be blocked waiting for first
     expect(secondResolved).toBe(false)


### PR DESCRIPTION
### WHY are these changes introduced?

No issue; test reliability maintenance.

The binary download concurrency test now avoids fixed sleeps on `main`, but it still uses a bare microtask flush before asserting that the second download remains blocked. Waiting for an explicit event-loop turn better matches the async filesystem boundary the test is exercising.

### WHAT is this pull request doing?

Adds a small `waitForNextEventLoopTurn` test helper and uses it before asserting the second binary download has not resolved while the first download is still blocked.

### How to test your changes?

- `pnpm test packages/app/src/cli/services/function/binaries.test.ts`
- `pnpm --filter @shopify/app lint`
- `pnpm --filter @shopify/app type-check`

### Post-release steps

None.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`
