### PR TITLE
[Performance] Memoize isWsl result

### DIFF
--- a/packages/cli-kit/src/public/node/system.test.ts
+++ b/packages/cli-kit/src/public/node/system.test.ts
@@ -393,3 +393,32 @@ describe('readStdinString', () => {
     await expect(got).rejects.toThrow('Stdin input exceeded the maximum allowed size.')
   })
 })
+
+describe('isWsl', () => {
+  test('memoizes the result', async () => {
+    // Given
+    // We need to use the real isWsl but since it's already exported from system.js
+    // we can check if it returns the same promise.
+
+    // When
+    const promise1 = system.isWsl()
+    const promise2 = system.isWsl()
+
+    // Then
+    expect(promise1).toBe(promise2)
+    await promise1
+  })
+
+  test('can be reset', async () => {
+    // Given
+    const promise1 = system.isWsl()
+
+    // When
+    ;(system as any)._resetIsWsl()
+    const promise2 = system.isWsl()
+
+    // Then
+    expect(promise1).not.toBe(promise2)
+    await Promise.all([promise1, promise2])
+  })
+})

--- a/packages/cli-kit/src/public/node/system.ts
+++ b/packages/cli-kit/src/public/node/system.ts
@@ -355,13 +355,28 @@ export function isCI(): boolean {
 }
 
 /**
+ * Memoized value for the WSL check.
+ */
+let memoizedIsWsl: Promise<boolean> | undefined
+
+/**
  * Check if the current environment is a WSL environment.
  *
  * @returns True if the current environment is a WSL environment.
  */
-export async function isWsl(): Promise<boolean> {
-  const wsl = await import('is-wsl')
-  return wsl.default
+export function isWsl(): Promise<boolean> {
+  return (memoizedIsWsl ??= (async () => {
+    const wsl = await import('is-wsl')
+    return wsl.default
+  })())
+}
+
+/**
+ * Resets the memoized value of isWsl.
+ * This is only used for testing.
+ */
+export function _resetIsWsl() {
+  memoizedIsWsl = undefined
 }
 
 /**


### PR DESCRIPTION
### Goals
Implement a small performance optimization by memoizing the `isWsl` check result.

### Changes
- Modified `packages/cli-kit/src/public/node/system.ts` to memoize the promise returned by `isWsl`.
- Added `_resetIsWsl` for testing.
- Added regression tests in `packages/cli-kit/src/public/node/system.test.ts`.

### Performance Impact
Avoids repeated dynamic imports and environment detection logic for WSL. This saves a small amount of CPU and I/O on every call after the first one.

### How to test your changes?
CI

---
*PR created automatically by Jules for task [7833433675125110132](https://jules.google.com/task/7833433675125110132) started by @gonzaloriestra*