### PR TITLE
[Refactor] Modernize errorHandler with async/await and early returns

### DIFF
--- a/packages/cli-kit/src/public/node/error-handler.ts
+++ b/packages/cli-kit/src/public/node/error-handler.ts
@@ -36,17 +36,16 @@ export async function errorHandler(
     if (error.message && error.message !== '') {
       outputInfo(`✨  ${error.message}`)
     }
-  } else if (error instanceof AbortSilentError) {
-    /* empty */
-  } else {
-    return errorMapper(error)
-      .then((error) => {
-        return handler(error)
-      })
-      .then((mappedError) => {
-        return reportError(mappedError, config)
-      })
+    return
   }
+
+  if (error instanceof AbortSilentError) {
+    return
+  }
+
+  const mappedError = await errorMapper(error)
+  await handler(mappedError)
+  await reportError(mappedError, config)
 }
 
 const reportError = async (error: unknown, config?: Interfaces.Config): Promise<void> => {


### PR DESCRIPTION
This PR refactors the `errorHandler` function in `packages/cli-kit/src/public/node/error-handler.ts` to use `async/await` and early returns, replacing a nested `if/else` and `.then()` promise chain. This improves readability and maintainability without changing observable behavior.

---
*PR created automatically by Jules for task [13786756588856414539](https://jules.google.com/task/13786756588856414539) started by @gonzaloriestra*