### PR TITLE
Make metadata timer tests deterministic

### DIFF
--- a/packages/cli-kit/src/public/node/metadata.test.ts
+++ b/packages/cli-kit/src/public/node/metadata.test.ts
@@ -1,10 +1,23 @@
 import {createRuntimeMetadataContainer} from './metadata.js'
 import * as errorHandler from './error-handler.js'
-import {sleep} from './system.js'
 import {describe, expect, test, vi} from 'vitest'
 import {performance} from 'node:perf_hooks'
 
 vi.mock('./error-handler.js')
+
+function mockPerformanceClock() {
+  let currentTime = 0
+  const nowSpy = vi.spyOn(performance, 'now').mockImplementation(() => currentTime)
+
+  return {
+    advanceBy(milliseconds: number) {
+      currentTime += milliseconds
+    },
+    restore() {
+      nowSpy.mockRestore()
+    },
+  }
+}
 
 describe('runtime metadata', () => {
   test('can manage data', async () => {
@@ -88,22 +101,31 @@ describe('runtime metadata', () => {
      */
     const container = createRuntimeMetadataContainer<{a: number; b: number; c: number; d: number; e: number}, {}>()
     performance.clearMeasures()
+    const clock = mockPerformanceClock()
 
-    await container.runWithTimer('a')(async () => {
-      await sleep(0.01)
-      await container.runWithTimer('b')(async () => {
-        await sleep(0.01)
-        await container.runWithTimer('c')(async () => {
-          await sleep(0.01)
-        })
-        await container.runWithTimer('d')(async () => {
-          await sleep(0.01)
-          await container.runWithTimer('e')(async () => {
-            await sleep(0.01)
+    try {
+      await container.runWithTimer('a')(async () => {
+        clock.advanceBy(10)
+        await container.runWithTimer('b')(async () => {
+          clock.advanceBy(10)
+          await container.runWithTimer('c')(async () => {
+            clock.advanceBy(10)
           })
+          clock.advanceBy(10)
+          await container.runWithTimer('d')(async () => {
+            clock.advanceBy(10)
+            await container.runWithTimer('e')(async () => {
+              clock.advanceBy(10)
+            })
+            clock.advanceBy(10)
+          })
+          clock.advanceBy(10)
         })
+        clock.advanceBy(10)
       })
-    })
+    } finally {
+      clock.restore()
+    }
 
     // eslint-disable-next-line id-length
     const {a, b, c, d, e} = container.getAllPublicMetadata() as any
@@ -134,6 +156,7 @@ describe('runtime metadata', () => {
   test('can handle when a nested timer fails', async () => {
     const container = createRuntimeMetadataContainer<{a: number; b: number}, {}>()
     performance.clearMeasures()
+    const clock = mockPerformanceClock()
 
     let errorOccurred = false
 
@@ -141,15 +164,17 @@ describe('runtime metadata', () => {
     // inside a timed section, we wouldn't want that to count as active time
     try {
       await container.runWithTimer('a')(async () => {
-        await sleep(0.01)
+        clock.advanceBy(10)
         await container.runWithTimer('b')(async () => {
-          await sleep(0.01)
+          clock.advanceBy(10)
           throw new Error('error inside a nested timed section')
         })
       })
       // eslint-disable-next-line no-catch-all/no-catch-all
     } catch {
       errorOccurred = true
+    } finally {
+      clock.restore()
     }
 
     expect(errorOccurred).toBe(true)


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #0000

The metadata timer tests used short real sleeps to create measurable durations. Those sleeps make the tests depend on scheduler timing even though the behavior under test only needs elapsed `performance.now()` values.

### WHAT is this pull request doing?

Replaces the real sleeps in the nested metadata timer tests with a tiny mocked performance clock. The tests now advance the clock explicitly while keeping the same nested timer structure and performance measure assertions.

No changeset is included because this is test-only maintenance with no user-facing behavior change.

### How to test your changes?

- `pnpm --filter @shopify/cli-kit vitest -- src/public/node/metadata.test.ts`
- `pnpm --filter @shopify/cli-kit type-check`
- `pnpm --filter @shopify/cli-kit lint`
- `git diff --check`

### Post-release steps

None.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [x] This change is not user-facing, so no changeset is required
