### PR TITLE
Recognize Ghostty terminal hyperlinks

### DIFF
--- a/.changeset/clever-ghosts-link.md
+++ b/.changeset/clever-ghosts-link.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': patch
+---
+
+Recognize Ghostty as a terminal that supports clickable hyperlinks

--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
     "@aws-sdk/signature-v4-multi-region": "3.996.31",
     "@aws-sdk/types": "3.973.8",
     "whatwg-url": "14.0.0",
-    "supports-hyperlinks": "3.1.0",
+    "supports-hyperlinks": "3.2.0",
     "@graphql-tools/utils": "10.7.2",
     "@shopify/cli-hydrogen>@shopify/cli-kit": "link:./packages/cli-kit",
     "@shopify/cli-hydrogen>@shopify/plugin-cloudflare": "link:./packages/plugin-cloudflare",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,7 +27,7 @@ overrides:
   '@aws-sdk/signature-v4-multi-region': 3.996.31
   '@aws-sdk/types': 3.973.8
   whatwg-url: 14.0.0
-  supports-hyperlinks: 3.1.0
+  supports-hyperlinks: 3.2.0
   '@graphql-tools/utils': 10.7.2
   '@shopify/cli-hydrogen>@shopify/cli-kit': link:./packages/cli-kit
   '@shopify/cli-hydrogen>@shopify/plugin-cloudflare': link:./packages/plugin-cloudflare
@@ -473,8 +473,8 @@ importers:
         specifier: 7.2.0
         version: 7.2.0
       supports-hyperlinks:
-        specifier: 3.1.0
-        version: 3.1.0
+        specifier: 3.2.0
+        version: 3.2.0
       ts-error:
         specifier: 1.0.6
         version: 1.0.6
@@ -8387,8 +8387,8 @@ packages:
     resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==, tarball: https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz}
     engines: {node: '>=10'}
 
-  supports-hyperlinks@3.1.0:
-    resolution: {integrity: sha512-2rn0BZ+/f7puLOHZm1HOJfwBggfaHXUpPUSSG/SWM4TWp5KCfmNYwnC3hruy2rZlMnmWZ+QAGpZfchu3f3695A==, tarball: https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.1.0.tgz}
+  supports-hyperlinks@3.2.0:
+    resolution: {integrity: sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==, tarball: https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.2.0.tgz}
     engines: {node: '>=14.18'}
 
   supports-preserve-symlinks-flag@1.0.0:
@@ -12159,7 +12159,7 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
       supports-color: 8.1.1
-      supports-hyperlinks: 3.1.0
+      supports-hyperlinks: 3.2.0
       widest-line: 3.1.0
       wordwrap: 1.0.0
       wrap-ansi: 7.0.0
@@ -18417,7 +18417,7 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
-  supports-hyperlinks@3.1.0:
+  supports-hyperlinks@3.2.0:
     dependencies:
       has-flag: 4.0.0
       supports-color: 7.2.0


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #0000

Ghostty supports terminal hyperlinks, but the CLI currently resolves `supports-hyperlinks` to `3.1.0`, which does not recognize `TERM_PROGRAM=ghostty`.

### WHAT is this pull request doing?

Updates the root `supports-hyperlinks` resolution from `3.1.0` to `3.2.0`, which recognizes Ghostty as hyperlink-capable while keeping the CommonJS-compatible API shape used by older transitive consumers.

This intentionally does not update to latest `4.5.0` because that version is ESM-only and would be riskier while `@shopify/cli-hydrogen` still brings in `@oclif/core@3.26.5`.

A patch changeset is included for `@shopify/cli-kit`.

### How to test your changes?

- `pnpm install --frozen-lockfile`
- `pnpm --filter @shopify/cli-kit type-check`
- `pnpm --filter @shopify/cli-kit lint`
- `pnpm --filter @shopify/cli-kit vitest -- src/private/node/ui/components/Link.test.tsx src/private/node/ui/components/TokenizedText.test.tsx src/public/node/ui.test.ts`
- `TERM_PROGRAM=ghostty FORCE_COLOR=1 pnpm --filter @shopify/cli-kit exec node -e "const {supportsHyperlink}=require('supports-hyperlinks'); if (!supportsHyperlink({isTTY:true})) throw new Error('Ghostty should support hyperlinks'); console.log('Ghostty hyperlink support detected')"`
- `git diff --check`

### Post-release steps

None.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [x] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`
