### PR TITLE
Reject invalid store FQDN delimiters

### DIFF
--- a/.changeset/reject-store-domain-delimiters.md
+++ b/.changeset/reject-store-domain-delimiters.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': patch
+---
+
+Parse supported store URLs via `URL.hostname` and reject unsupported domain delimiters before normalizing Shopify store FQDNs.

--- a/packages/cli-kit/src/public/node/context/fqdn.test.ts
+++ b/packages/cli-kit/src/public/node/context/fqdn.test.ts
@@ -191,6 +191,14 @@ describe('normalizeStore', () => {
     expect(got).toEqual('example.myshopify.com')
   })
 
+  test('parses supported store URLs using the URL hostname', async () => {
+    // When
+    const got = normalizeStoreFqdn('https://Example.myshopify.com/admin/')
+
+    // Then
+    expect(got).toEqual('example.myshopify.com')
+  })
+
   test('parses store name without domain', async () => {
     // When
     const got = normalizeStoreFqdn('example')
@@ -249,5 +257,24 @@ describe('normalizeStore', () => {
 
     // Then
     expect(got).toEqual('example.exampleshopify.io.myshopify.com')
+  })
+
+  test.each([
+    'attacker#.myshopify.com',
+    'attacker?.myshopify.com',
+    'attacker/.myshopify.com',
+    'attacker.com/x.myshopify.com',
+    'http://attacker-domain.com#x.myshopify.com',
+    'https://example.myshopify.com/admin?redirect=attacker',
+    '127.0.0.1:8443#.myshopify.com',
+    'attacker.com@x.myshopify.com',
+    '/x.myshopify.com',
+    '/',
+  ])('rejects store values that URL parsers can reinterpret (%s)', (store) => {
+    expect(() => normalizeStoreFqdn(store)).toThrow('Invalid store value')
+  })
+
+  test('rejects URL paths other than /admin', async () => {
+    expect(() => normalizeStoreFqdn('https://example.myshopify.com/themes')).toThrow('Invalid store value')
   })
 })

--- a/packages/cli-kit/src/public/node/context/fqdn.ts
+++ b/packages/cli-kit/src/public/node/context/fqdn.ts
@@ -126,10 +126,10 @@ export async function identityFqdn(): Promise<string> {
  * @returns Normalized store name.
  */
 export function normalizeStoreFqdn(store: string): string {
-  const storeFqdn = store
-    .replace(/^https?:\/\//, '')
-    .replace(/\/$/, '')
-    .replace(/\/admin$/, '')
+  const storeFqdn = parseStoreFqdn(store)
+
+  assertValidStoreFqdn(storeFqdn, store)
+
   const addDomain = (storeFqdn: string) => {
     switch (serviceEnvironment()) {
       case 'local':
@@ -141,6 +141,64 @@ export function normalizeStoreFqdn(store: string): string {
   const containDomain = (storeFqdn: string) =>
     storeFqdn.endsWith('.myshopify.com') || storeFqdn.endsWith('.myshopify.io') || storeFqdn.endsWith('.shop.dev')
   return containDomain(storeFqdn) ? storeFqdn : addDomain(storeFqdn)
+}
+
+const invalidStoreFqdnTryMessage =
+  'Provide a store handle or Shopify store domain, for example "example" or "example.myshopify.com". ' +
+  'Store URLs may only include the optional /admin path.'
+
+function parseStoreFqdn(store: string): string {
+  const trimmedStore = store.trim()
+
+  if (trimmedStore.startsWith('/')) {
+    throw new AbortError(`Invalid store value: ${store}`, invalidStoreFqdnTryMessage)
+  }
+
+  const storeUrl = parseSupportedStoreUrl(
+    /^https?:\/\//i.test(trimmedStore) ? trimmedStore : `https://${trimmedStore}`,
+    store,
+  )
+  return storeUrl.hostname
+}
+
+function parseSupportedStoreUrl(store: string, originalStore: string): URL {
+  let storeUrl: URL
+  try {
+    storeUrl = new URL(store)
+  } catch {
+    throw new AbortError(`Invalid store value: ${originalStore}`, invalidStoreFqdnTryMessage)
+  }
+
+  const supportedPath = storeUrl.pathname === '/' || storeUrl.pathname === '/admin' || storeUrl.pathname === '/admin/'
+  if (
+    !storeUrl.hostname ||
+    storeUrl.username ||
+    storeUrl.password ||
+    storeUrl.port ||
+    storeUrl.search ||
+    storeUrl.hash ||
+    !supportedPath
+  ) {
+    throw new AbortError(`Invalid store value: ${originalStore}`, invalidStoreFqdnTryMessage)
+  }
+
+  return storeUrl
+}
+
+function assertValidStoreFqdn(storeFqdn: string, store: string) {
+  if (storeFqdn.length === 0 || storeFqdn.length > 253) {
+    throw new AbortError(`Invalid store value: ${store}`, invalidStoreFqdnTryMessage)
+  }
+
+  const domainLabels = storeFqdn.split('.')
+  const validStoreDomainLabel = /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/i
+  const validDomain = domainLabels.every((label) => {
+    return label.length > 0 && label.length <= 63 && validStoreDomainLabel.test(label)
+  })
+
+  if (!validDomain) {
+    throw new AbortError(`Invalid store value: ${store}`, invalidStoreFqdnTryMessage)
+  }
 }
 
 /**


### PR DESCRIPTION
### WHY are these changes introduced?

Store inputs are accepted as handles, domains, or supported admin URLs before the CLI builds requests from the normalized FQDN. Normalizing them with string replacements can preserve URL delimiter characters that are interpreted differently by URL parsing later.

This hardens store normalization by resolving supported inputs to a hostname first and rejecting unsupported URL components before the normalized FQDN can be used.

### WHAT is this pull request doing?

- Parses store input through `URL`, adding `https://` for bare handles/domains.
- Uses `url.hostname` as the store-domain candidate.
- Rejects fragments, query strings, credentials, ports, raw leading paths, and paths other than `/`, `/admin`, or `/admin/`.
- Validates hostname labels before returning the normalized store FQDN.
- Adds regression coverage for delimiter-based host confusion cases.
- Adds a patch changeset for `@shopify/cli-kit`.

### How to test your changes?

```sh
git diff --check origin/main...HEAD
git diff --check
pnpm exec vitest run packages/cli-kit/src/public/node/context/fqdn.test.ts
pnpm exec eslint packages/cli-kit/src/public/node/context/fqdn.ts packages/cli-kit/src/public/node/context/fqdn.test.ts
```

### Post-release steps

None.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [x] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

Co-authored-by: Pi AI <noreply@pi.dev>
