### PR TITLE
Prompt for store create dev flags in TTY, require them in non-TTY

### DIFF
--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -5965,7 +5965,6 @@
           "hasDynamicHelp": false,
           "multiple": false,
           "name": "name",
-          "required": true,
           "type": "option"
         },
         "no-color": {
@@ -5996,7 +5995,6 @@
             "advanced",
             "plus"
           ],
-          "required": true,
           "type": "option"
         },
         "verbose": {

--- a/packages/store/src/cli/commands/store/create/dev.test.ts
+++ b/packages/store/src/cli/commands/store/create/dev.test.ts
@@ -1,10 +1,19 @@
 import StoreCreateDev from './dev.js'
 import {createDevStore} from '../../../services/store/create/dev.js'
+import {storeNamePrompt, storePlanPrompt} from '../../../prompts/store.js'
+import {selectOrg} from '@shopify/organizations'
 import {AbortError} from '@shopify/cli-kit/node/error'
 import {outputResult} from '@shopify/cli-kit/node/output'
-import {describe, expect, test, vi} from 'vitest'
+import {terminalSupportsPrompting} from '@shopify/cli-kit/node/system'
+import {describe, expect, test, vi, beforeEach} from 'vitest'
 
 vi.mock('../../../services/store/create/dev.js')
+vi.mock('../../../prompts/store.js')
+vi.mock('@shopify/cli-kit/node/system')
+
+vi.mock('@shopify/organizations', () => ({
+  selectOrg: vi.fn(),
+}))
 
 vi.mock('@shopify/cli-kit/node/output', async (importOriginal) => {
   const actual: Record<string, unknown> = await importOriginal()
@@ -14,26 +23,21 @@ vi.mock('@shopify/cli-kit/node/output', async (importOriginal) => {
   }
 })
 
+const defaultOrg = {id: '12345', businessName: 'Test Org'}
+
+beforeEach(() => {
+  vi.mocked(selectOrg).mockResolvedValue(defaultOrg)
+  vi.mocked(terminalSupportsPrompting).mockReturnValue(true)
+})
+
 describe('store create dev command', () => {
-  test('passes parsed flags through to the service', async () => {
-    await StoreCreateDev.run(['--name', 'my-test-store', '--plan', 'plus'])
+  test('resolves the organization and passes parsed flags through to the service', async () => {
+    await StoreCreateDev.run(['--name', 'my-test-store', '--plan', 'plus', '--organization-id', '12345'])
 
+    expect(selectOrg).toHaveBeenCalledWith('12345')
     expect(createDevStore).toHaveBeenCalledWith({
       name: 'my-test-store',
-      organizationId: undefined,
-      plan: 'plus',
-      featurePreview: undefined,
-      withDemoData: false,
-      json: false,
-    })
-  })
-
-  test('passes organization-id flag through to the service', async () => {
-    await StoreCreateDev.run(['--name', 'my-test-store', '--organization-id', '12345', '--plan', 'plus'])
-
-    expect(createDevStore).toHaveBeenCalledWith({
-      name: 'my-test-store',
-      organizationId: 12345,
+      organization: defaultOrg,
       plan: 'plus',
       featurePreview: undefined,
       withDemoData: false,
@@ -42,11 +46,11 @@ describe('store create dev command', () => {
   })
 
   test('passes json flag through to the service', async () => {
-    await StoreCreateDev.run(['--name', 'my-test-store', '--json', '--plan', 'plus'])
+    await StoreCreateDev.run(['--name', 'my-test-store', '--json', '--plan', 'plus', '--organization-id', '12345'])
 
     expect(createDevStore).toHaveBeenCalledWith({
       name: 'my-test-store',
-      organizationId: undefined,
+      organization: defaultOrg,
       plan: 'plus',
       featurePreview: undefined,
       withDemoData: false,
@@ -60,6 +64,8 @@ describe('store create dev command', () => {
       'my-test-store',
       '--plan',
       'basic',
+      '--organization-id',
+      '12345',
       '--feature-preview',
       'extended_variants',
       '--with-demo-data',
@@ -67,7 +73,7 @@ describe('store create dev command', () => {
 
     expect(createDevStore).toHaveBeenCalledWith({
       name: 'my-test-store',
-      organizationId: undefined,
+      organization: defaultOrg,
       plan: 'basic',
       featurePreview: 'extended_variants',
       withDemoData: true,
@@ -75,15 +81,59 @@ describe('store create dev command', () => {
     })
   })
 
+  test('prompts for the name when --name is omitted in an interactive environment', async () => {
+    vi.mocked(storeNamePrompt).mockResolvedValue('prompted-store')
+
+    await StoreCreateDev.run(['--organization-id', '12345', '--plan', 'plus'])
+
+    expect(storeNamePrompt).toHaveBeenCalled()
+    expect(createDevStore).toHaveBeenCalledWith(expect.objectContaining({name: 'prompted-store'}))
+  })
+
+  test('prompts for the plan when --plan is omitted in an interactive environment', async () => {
+    vi.mocked(storePlanPrompt).mockResolvedValue('advanced')
+
+    await StoreCreateDev.run(['--organization-id', '12345', '--name', 'my-test-store'])
+
+    expect(storePlanPrompt).toHaveBeenCalled()
+    expect(createDevStore).toHaveBeenCalledWith(expect.objectContaining({plan: 'advanced'}))
+  })
+
+  test('does not prompt when all flags are provided', async () => {
+    await StoreCreateDev.run(['--name', 'my-test-store', '--plan', 'plus', '--organization-id', '12345'])
+
+    expect(storeNamePrompt).not.toHaveBeenCalled()
+    expect(storePlanPrompt).not.toHaveBeenCalled()
+  })
+
   test('rejects an invalid plan value without calling the service', async () => {
-    await expect(StoreCreateDev.run(['--name', 'my-test-store', '--plan', 'enterprise'])).rejects.toThrow()
+    await expect(
+      StoreCreateDev.run(['--name', 'my-test-store', '--plan', 'enterprise', '--organization-id', '12345']),
+    ).rejects.toThrow()
     expect(createDevStore).not.toHaveBeenCalled()
   })
 
-  test('requires the plan flag', async () => {
-    await expect(StoreCreateDev.run(['--name', 'my-test-store'])).rejects.toThrow()
-    expect(createDevStore).not.toHaveBeenCalled()
-  })
+  test.each(['name', 'organization-id', 'plan'])(
+    'fails in a non-interactive environment when --%s is missing',
+    async (missingFlag) => {
+      vi.mocked(terminalSupportsPrompting).mockReturnValue(false)
+      const argv = ['--name', 'my-test-store', '--organization-id', '12345', '--plan', 'plus'].filter(
+        (value, index, all) => {
+          // Drop the missing flag and its value.
+          if (value === `--${missingFlag}`) return false
+          return all[index - 1] !== `--${missingFlag}`
+        },
+      )
+      const mockExit = vi.spyOn(process, 'exit').mockImplementation((() => {
+        throw new Error('process.exit')
+      }) as never)
+
+      await expect(StoreCreateDev.run(argv)).rejects.toThrow()
+      expect(createDevStore).not.toHaveBeenCalled()
+
+      mockExit.mockRestore()
+    },
+  )
 
   test('defines the expected flags', () => {
     expect(StoreCreateDev.flags.name).toBeDefined()
@@ -100,9 +150,9 @@ describe('store create dev command', () => {
       throw new Error('process.exit')
     }) as never)
 
-    await expect(StoreCreateDev.run(['--name', 'my-test-store', '--plan', 'plus', '--json'])).rejects.toThrow(
-      'process.exit',
-    )
+    await expect(
+      StoreCreateDev.run(['--name', 'my-test-store', '--plan', 'plus', '--organization-id', '12345', '--json']),
+    ).rejects.toThrow('process.exit')
 
     const call = vi.mocked(outputResult).mock.calls[0]![0] as string
     const parsed = JSON.parse(call)
@@ -120,14 +170,18 @@ describe('store create dev command', () => {
   test('does not output JSON for non-AbortError even when --json is active', async () => {
     vi.mocked(createDevStore).mockRejectedValueOnce(new Error('unexpected'))
 
-    await expect(StoreCreateDev.run(['--name', 'my-test-store', '--plan', 'plus', '--json'])).rejects.toThrow()
+    await expect(
+      StoreCreateDev.run(['--name', 'my-test-store', '--plan', 'plus', '--organization-id', '12345', '--json']),
+    ).rejects.toThrow()
     expect(vi.mocked(outputResult)).not.toHaveBeenCalled()
   })
 
   test('does not output JSON for AbortError when --json is not active', async () => {
     vi.mocked(createDevStore).mockRejectedValueOnce(new AbortError('Something went wrong'))
 
-    await expect(StoreCreateDev.run(['--name', 'my-test-store', '--plan', 'plus'])).rejects.toThrow()
+    await expect(
+      StoreCreateDev.run(['--name', 'my-test-store', '--plan', 'plus', '--organization-id', '12345']),
+    ).rejects.toThrow()
     expect(vi.mocked(outputResult)).not.toHaveBeenCalled()
   })
 })

--- a/packages/store/src/cli/commands/store/create/dev.ts
+++ b/packages/store/src/cli/commands/store/create/dev.ts
@@ -1,6 +1,8 @@
 import {createDevStore} from '../../../services/store/create/dev.js'
 import {devStorePlanHandles, DevStorePlan} from '../../../services/store/constants.js'
+import {storeNamePrompt, storePlanPrompt} from '../../../prompts/store.js'
 import {storeFlags} from '../../../flags.js'
+import {selectOrg} from '@shopify/organizations'
 import Command from '@shopify/cli-kit/node/base-command'
 import {globalFlags, jsonFlag} from '@shopify/cli-kit/node/cli'
 import {AbortError} from '@shopify/cli-kit/node/error'
@@ -21,14 +23,12 @@ export default class StoreCreateDev extends Command {
     ...jsonFlag,
     name: Flags.string({
       description: 'Name for the new development store.',
-      required: true,
       env: 'SHOPIFY_FLAG_STORE_NAME',
     }),
     'organization-id': storeFlags['organization-id'],
     plan: Flags.string({
       description: 'The Shopify plan to use for the new development store.',
       options: devStorePlanHandles,
-      required: true,
       env: 'SHOPIFY_FLAG_STORE_PLAN',
     }),
     'feature-preview': Flags.string({
@@ -44,11 +44,17 @@ export default class StoreCreateDev extends Command {
 
   async run(): Promise<void> {
     const {flags} = await this.parse(StoreCreateDev)
+    this.failMissingNonTTYFlags(flags, ['name', 'organization-id', 'plan'])
+
+    const organization = await selectOrg(flags['organization-id']?.toString())
+    const name = flags.name ?? (await storeNamePrompt())
+    const plan = (flags.plan as DevStorePlan | undefined) ?? (await storePlanPrompt())
+
     try {
       await createDevStore({
-        name: flags.name,
-        organizationId: flags['organization-id'],
-        plan: flags.plan as DevStorePlan,
+        name,
+        organization,
+        plan,
         featurePreview: flags['feature-preview'],
         withDemoData: flags['with-demo-data'],
         json: flags.json,

--- a/packages/store/src/cli/prompts/store.test.ts
+++ b/packages/store/src/cli/prompts/store.test.ts
@@ -1,0 +1,37 @@
+import {storeNamePrompt, storePlanPrompt} from './store.js'
+import {describe, expect, test, vi} from 'vitest'
+import {renderSelectPrompt, renderTextPrompt} from '@shopify/cli-kit/node/ui'
+
+vi.mock('@shopify/cli-kit/node/ui')
+
+describe('storeNamePrompt', () => {
+  test('asks for the store name and returns the entered value', async () => {
+    vi.mocked(renderTextPrompt).mockResolvedValue('my-store')
+
+    const result = await storeNamePrompt()
+
+    expect(result).toBe('my-store')
+    expect(renderTextPrompt).toHaveBeenCalledWith(
+      expect.objectContaining({message: 'Name for the new development store'}),
+    )
+  })
+})
+
+describe('storePlanPrompt', () => {
+  test('offers every plan handle and returns the selected value', async () => {
+    vi.mocked(renderSelectPrompt).mockResolvedValue('advanced')
+
+    const result = await storePlanPrompt()
+
+    expect(result).toBe('advanced')
+    expect(renderSelectPrompt).toHaveBeenCalledWith({
+      message: 'Which Shopify plan do you want to use?',
+      choices: [
+        {label: 'Basic', value: 'basic'},
+        {label: 'Grow', value: 'grow'},
+        {label: 'Advanced', value: 'advanced'},
+        {label: 'Plus', value: 'plus'},
+      ],
+    })
+  })
+})

--- a/packages/store/src/cli/prompts/store.ts
+++ b/packages/store/src/cli/prompts/store.ts
@@ -1,0 +1,26 @@
+import {DevStorePlan, devStorePlanHandles} from '../services/store/constants.js'
+import {renderSelectPrompt, renderTextPrompt} from '@shopify/cli-kit/node/ui'
+
+/** Human-readable labels for each `--plan` handle, shown in the interactive plan selector. */
+const PLAN_LABELS: {[plan in DevStorePlan]: string} = {
+  basic: 'Basic',
+  grow: 'Grow',
+  advanced: 'Advanced',
+  plus: 'Plus',
+}
+
+export async function storeNamePrompt(): Promise<string> {
+  return renderTextPrompt({
+    message: 'Name for the new development store',
+  })
+}
+
+export async function storePlanPrompt(): Promise<DevStorePlan> {
+  return renderSelectPrompt({
+    message: 'Which Shopify plan do you want to use?',
+    choices: devStorePlanHandles.map((handle) => ({
+      label: PLAN_LABELS[handle],
+      value: handle,
+    })),
+  })
+}

--- a/packages/store/src/cli/services/store/create/dev.test.ts
+++ b/packages/store/src/cli/services/store/create/dev.test.ts
@@ -1,16 +1,11 @@
 import {createDevStore} from './dev.js'
 import {describe, expect, test, vi, beforeEach} from 'vitest'
 
-import {selectOrg} from '@shopify/organizations'
 import {businessPlatformOrganizationsRequestDoc} from '@shopify/cli-kit/node/api/business-platform'
 import {ensureAuthenticatedBusinessPlatform} from '@shopify/cli-kit/node/session'
 import {renderSingleTask, renderSuccess} from '@shopify/cli-kit/node/ui'
 import {outputResult} from '@shopify/cli-kit/node/output'
 import {sleep} from '@shopify/cli-kit/node/system'
-
-vi.mock('@shopify/organizations', () => ({
-  selectOrg: vi.fn(),
-}))
 
 vi.mock('@shopify/cli-kit/node/api/business-platform', () => ({
   businessPlatformOrganizationsRequestDoc: vi.fn(),
@@ -47,7 +42,6 @@ const defaultMutationResult = {
 }
 
 beforeEach(() => {
-  vi.mocked(selectOrg).mockResolvedValue(defaultOrg)
   vi.mocked(ensureAuthenticatedBusinessPlatform).mockResolvedValue('test-token')
   vi.mocked(businessPlatformOrganizationsRequestDoc).mockResolvedValue(defaultMutationResult)
   vi.mocked(renderSingleTask).mockImplementation(async ({task}) => {
@@ -64,9 +58,8 @@ describe('createDevStore', () => {
         organization: {id: '123', storeCreation: {status: 'COMPLETE'}},
       })
 
-    await createDevStore({name: 'test-store', plan: 'plus', json: false})
+    await createDevStore({name: 'test-store', organization: defaultOrg, plan: 'plus', json: false})
 
-    expect(selectOrg).toHaveBeenCalledWith(undefined)
     expect(ensureAuthenticatedBusinessPlatform).toHaveBeenCalled()
     expect(businessPlatformOrganizationsRequestDoc).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -100,7 +93,7 @@ describe('createDevStore', () => {
         organization: {id: '123', storeCreation: {status: 'COMPLETE'}},
       })
 
-    await createDevStore({name: 'test-store', plan, json: false})
+    await createDevStore({name: 'test-store', organization: defaultOrg, plan, json: false})
 
     expect(businessPlatformOrganizationsRequestDoc).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -116,7 +109,13 @@ describe('createDevStore', () => {
         organization: {id: '123', storeCreation: {status: 'COMPLETE'}},
       })
 
-    await createDevStore({name: 'test-store', plan: 'plus', featurePreview: 'extended_variants', json: false})
+    await createDevStore({
+      name: 'test-store',
+      organization: defaultOrg,
+      plan: 'plus',
+      featurePreview: 'extended_variants',
+      json: false,
+    })
 
     expect(businessPlatformOrganizationsRequestDoc).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -132,7 +131,7 @@ describe('createDevStore', () => {
         organization: {id: '123', storeCreation: {status: 'COMPLETE'}},
       })
 
-    await createDevStore({name: 'test-store', plan: 'plus', withDemoData: true, json: false})
+    await createDevStore({name: 'test-store', organization: defaultOrg, plan: 'plus', withDemoData: true, json: false})
 
     expect(businessPlatformOrganizationsRequestDoc).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -150,6 +149,7 @@ describe('createDevStore', () => {
 
     await createDevStore({
       name: 'test-store',
+      organization: defaultOrg,
       plan: 'basic',
       featurePreview: 'extended_variants',
       withDemoData: true,
@@ -168,7 +168,7 @@ describe('createDevStore', () => {
         organization: {id: '123', storeCreation: {status: 'COMPLETE'}},
       })
 
-    await createDevStore({name: 'test-store', plan: 'plus', json: true})
+    await createDevStore({name: 'test-store', organization: defaultOrg, plan: 'plus', json: true})
 
     expect(outputResult).toHaveBeenCalledWith(expect.stringContaining('"domain": "test-store.myshopify.com"'))
     expect(renderSuccess).not.toHaveBeenCalled()
@@ -179,9 +179,9 @@ describe('createDevStore', () => {
       createAppDevelopmentStore: null,
     })
 
-    await expect(createDevStore({name: 'test-store', plan: 'plus', json: false})).rejects.toThrow(
-      'unexpected empty response',
-    )
+    await expect(
+      createDevStore({name: 'test-store', organization: defaultOrg, plan: 'plus', json: false}),
+    ).rejects.toThrow('unexpected empty response')
   })
 
   test('throws AbortError when mutation returns userErrors', async () => {
@@ -193,7 +193,9 @@ describe('createDevStore', () => {
       },
     })
 
-    await expect(createDevStore({name: 'test-store', plan: 'plus', json: false})).rejects.toThrow('Name is taken')
+    await expect(
+      createDevStore({name: 'test-store', organization: defaultOrg, plan: 'plus', json: false}),
+    ).rejects.toThrow('Name is taken')
   })
 
   test('throws AbortError when mutation returns no shopDomain', async () => {
@@ -205,9 +207,9 @@ describe('createDevStore', () => {
       },
     })
 
-    await expect(createDevStore({name: 'test-store', plan: 'plus', json: false})).rejects.toThrow(
-      'no shop domain was returned',
-    )
+    await expect(
+      createDevStore({name: 'test-store', organization: defaultOrg, plan: 'plus', json: false}),
+    ).rejects.toThrow('no shop domain was returned')
   })
 
   test('throws AbortError when polling returns FAILED status', async () => {
@@ -217,9 +219,9 @@ describe('createDevStore', () => {
         organization: {id: '123', storeCreation: {status: 'FAILED'}},
       })
 
-    await expect(createDevStore({name: 'test-store', plan: 'plus', json: false})).rejects.toThrow(
-      'Store creation failed with status: FAILED',
-    )
+    await expect(
+      createDevStore({name: 'test-store', organization: defaultOrg, plan: 'plus', json: false}),
+    ).rejects.toThrow('Store creation failed with status: FAILED')
   })
 
   test('throws AbortError when polling returns TIMED_OUT status', async () => {
@@ -229,9 +231,9 @@ describe('createDevStore', () => {
         organization: {id: '123', storeCreation: {status: 'TIMED_OUT'}},
       })
 
-    await expect(createDevStore({name: 'test-store', plan: 'plus', json: false})).rejects.toThrow(
-      'Store creation failed with status: TIMED_OUT',
-    )
+    await expect(
+      createDevStore({name: 'test-store', organization: defaultOrg, plan: 'plus', json: false}),
+    ).rejects.toThrow('Store creation failed with status: TIMED_OUT')
   })
 
   test('throws AbortError when polling returns USER_ERROR status', async () => {
@@ -241,9 +243,9 @@ describe('createDevStore', () => {
         organization: {id: '123', storeCreation: {status: 'USER_ERROR'}},
       })
 
-    await expect(createDevStore({name: 'test-store', plan: 'plus', json: false})).rejects.toThrow(
-      'Store creation failed with status: USER_ERROR',
-    )
+    await expect(
+      createDevStore({name: 'test-store', organization: defaultOrg, plan: 'plus', json: false}),
+    ).rejects.toThrow('Store creation failed with status: USER_ERROR')
   })
 
   test('throws AbortError when polling times out after 5 minutes', async () => {
@@ -257,21 +259,9 @@ describe('createDevStore', () => {
 
     vi.mocked(businessPlatformOrganizationsRequestDoc).mockResolvedValueOnce(defaultMutationResult)
 
-    await expect(createDevStore({name: 'test-store', plan: 'plus', json: false})).rejects.toThrow(
-      'Store creation timed out after 5 minutes',
-    )
-  })
-
-  test('passes organization-id flag to selectOrg as a string', async () => {
-    vi.mocked(businessPlatformOrganizationsRequestDoc)
-      .mockResolvedValueOnce(defaultMutationResult)
-      .mockResolvedValueOnce({
-        organization: {id: '123', storeCreation: {status: 'COMPLETE'}},
-      })
-
-    await createDevStore({name: 'test-store', plan: 'plus', organizationId: 456, json: false})
-
-    expect(selectOrg).toHaveBeenCalledWith('456')
+    await expect(
+      createDevStore({name: 'test-store', organization: defaultOrg, plan: 'plus', json: false}),
+    ).rejects.toThrow('Store creation timed out after 5 minutes')
   })
 
   test('calls sleep with 2 seconds between polls', async () => {
@@ -284,7 +274,7 @@ describe('createDevStore', () => {
         organization: {id: '123', storeCreation: {status: 'COMPLETE'}},
       })
 
-    await createDevStore({name: 'test-store', plan: 'plus', json: false})
+    await createDevStore({name: 'test-store', organization: defaultOrg, plan: 'plus', json: false})
 
     expect(sleep).toHaveBeenCalledWith(2)
   })
@@ -296,7 +286,7 @@ describe('createDevStore', () => {
         organization: {id: '123', storeCreation: {status: 'COMPLETE'}},
       })
 
-    await createDevStore({name: 'test-store', plan: 'plus', json: false})
+    await createDevStore({name: 'test-store', organization: defaultOrg, plan: 'plus', json: false})
 
     expect(renderSingleTask).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/packages/store/src/cli/services/store/create/dev.ts
+++ b/packages/store/src/cli/services/store/create/dev.ts
@@ -5,7 +5,7 @@ import {
   PollStoreCreation,
   PollStoreCreationQuery,
 } from '../../../api/graphql/business-platform-organizations/generated/poll_store_creation.js'
-import {selectOrg} from '@shopify/organizations'
+import {Organization} from '@shopify/organizations'
 import {businessPlatformOrganizationsRequestDoc} from '@shopify/cli-kit/node/api/business-platform'
 import {ensureAuthenticatedBusinessPlatform} from '@shopify/cli-kit/node/session'
 import {renderSingleTask, renderSuccess} from '@shopify/cli-kit/node/ui'
@@ -19,7 +19,7 @@ const POLL_TIMEOUT_MS = 5 * 60 * 1000
 interface CreateDevStoreOptions {
   name: string
   plan: DevStorePlan
-  organizationId?: number
+  organization: Organization
   featurePreview?: string
   withDemoData?: boolean
   json: boolean
@@ -51,7 +51,7 @@ function friendlyStatus(status: StoreCreationStatus): string {
 }
 
 export async function createDevStore(options: CreateDevStoreOptions): Promise<void> {
-  const org = await selectOrg(options.organizationId?.toString())
+  const {organization: org, name, plan} = options
   const token = await ensureAuthenticatedBusinessPlatform()
   const unauthorizedHandler = businessPlatformTokenRefreshHandler()
 
@@ -60,8 +60,8 @@ export async function createDevStore(options: CreateDevStoreOptions): Promise<vo
     token,
     organizationId: org.id,
     variables: {
-      shopName: options.name,
-      priceLookupKey: DEV_STORE_PLANS[options.plan],
+      shopName: name,
+      priceLookupKey: DEV_STORE_PLANS[plan],
       prepopulateTestData: options.withDemoData ?? false,
       developerPreviewHandle: options.featurePreview,
     },
@@ -127,10 +127,10 @@ export async function createDevStore(options: CreateDevStoreOptions): Promise<vo
       JSON.stringify(
         {
           store: {
-            name: options.name,
+            name,
             domain: shopDomain,
             adminUrl: shopAdminUrl,
-            plan: options.plan,
+            plan,
             ...(options.featurePreview ? {featurePreview: options.featurePreview} : {}),
             demoData: options.withDemoData ?? false,
           },
@@ -145,11 +145,11 @@ export async function createDevStore(options: CreateDevStoreOptions): Promise<vo
     )
   } else {
     renderSuccess({
-      headline: `Development store "${options.name}" created successfully.`,
+      headline: `Development store "${name}" created successfully.`,
       body: [
         `Domain: ${shopDomain}`,
         `Admin: ${shopAdminUrl ?? 'N/A'}`,
-        `Plan: ${options.plan}`,
+        `Plan: ${plan}`,
         ...(options.featurePreview ? [`Feature preview: ${options.featurePreview}`] : []),
         `Demo data: ${options.withDemoData ? 'enabled' : 'disabled'}`,
       ],


### PR DESCRIPTION
### WHY are these changes introduced?

Per the spec, `store create dev` should treat `--organization-id`, `--name`, and `--plan` as required only when there's no TTY to prompt in. Previously `--organization-id` wasn't required at all, and `--name`/`--plan` were always required, so interactive users couldn't be prompted for them.

### WHAT is this pull request doing?

- Makes `--name`, `--organization-id`, and `--plan` required only in non-interactive (non-TTY) environments via `this.failMissingNonTTYFlags(flags, ['name', 'organization-id', 'plan'])`.
- In a TTY, prompts for any missing value:
  - **name** — text prompt
  - **organization-id** — reuses the standard organization selector
  - **plan** — list selector backed by the `PLAN_LABELS` map (Basic / Grow / Advanced / Plus)
- Extracts the prompts into `packages/store/src/cli/prompts/store.ts` (`storeNamePrompt`, `storePlanPrompt`) to match the repo's `prompts/` convention.

### How to test your changes?

- Run `shopify store create dev` in a terminal with no flags → it should prompt for organization, name, and plan.
- Run it in a non-TTY (e.g. piped/CI) without those flags → it should fail listing the missing required flags.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible documentation changes
- [x] I've considered analytics changes to measure impact
- [x] The change is user-facing — `minor` bump, changeset added
