### PR TITLE
[Refactor] Use async/await and early returns in errorHandler

### DIFF
--- a/packages/cli-kit/src/public/node/error-handler.ts
+++ b/packages/cli-kit/src/public/node/error-handler.ts
@@ -36,17 +36,16 @@ export async function errorHandler(
     if (error.message && error.message !== '') {
       outputInfo(`✨  ${error.message}`)
     }
-  } else if (error instanceof AbortSilentError) {
-    /* empty */
-  } else {
-    return errorMapper(error)
-      .then((error) => {
-        return handler(error)
-      })
-      .then((mappedError) => {
-        return reportError(mappedError, config)
-      })
+    return
   }
+
+  if (error instanceof AbortSilentError) {
+    return
+  }
+
+  const mappedError = await errorMapper(error)
+  await handler(mappedError)
+  await reportError(mappedError, config)
 }
 
 const reportError = async (error: unknown, config?: Interfaces.Config): Promise<void> => {


### PR DESCRIPTION
### WHY are these changes introduced?

This is a cleanup refactor to improve the readability and maintainability of the `errorHandler` function in `cli-kit`.

### WHAT is this pull request doing?

Refactors `errorHandler` in `packages/cli-kit/src/public/node/error-handler.ts`:
- Replaces a nested `if/else if/else` structure with early return guard clauses.
- Converts a `.then()` promise chain into `async/await` syntax.
- Removes redundant variable shadowing in the promise chain.

### How to test your changes?

CI

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [15958592844892288088](https://jules.google.com/task/15958592844892288088) started by @gonzaloriestra*