### PR TITLE
[Security] Harden client ID generation in ui-extensions-server-kit

### DIFF
--- a/packages/ui-extensions-server-kit/src/ExtensionServerClient/ExtensionServerClient.ts
+++ b/packages/ui-extensions-server-kit/src/ExtensionServerClient/ExtensionServerClient.ts
@@ -32,7 +32,11 @@ export class ExtensionServerClient implements ExtensionServer.Client {
   private uiExtensionsByUuid: Record<string, ExtensionServer.UIExtension> = {}
 
   constructor(options: DeepPartial<ExtensionServer.Options> = {}) {
-    this.id = (Math.random() + 1).toString(36).substring(7)
+    // We use a cryptographically secure random identifier for the client ID.
+    this.id =
+      typeof globalThis.crypto?.randomUUID === 'function'
+        ? globalThis.crypto.randomUUID()
+        : (Math.random() + 1).toString(36).substring(7)
     this.options = getValidatedOptions({
       ...options,
       connection: {


### PR DESCRIPTION
Hardened the client ID generation in ExtensionServerClient by replacing the insecure Math.random() with globalThis.crypto.randomUUID(). This provides a cryptographically secure identifier when available, with a fallback to the previous method for compatibility with older environments. Robust feature detection is used to ensure stability.

---
*PR created automatically by Jules for task [4252430783561500708](https://jules.google.com/task/4252430783561500708) started by @gonzaloriestra*