### PR TITLE
[Performance] Memoize hasGit check

### DIFF
--- a/packages/cli-kit/src/public/node/context/local.test.ts
+++ b/packages/cli-kit/src/public/node/context/local.test.ts
@@ -5,6 +5,7 @@ import {
   isShopify,
   isTerminalInteractive,
   isUnitTest,
+  _resetHasGit,
   analyticsDisabled,
   cloudEnvironment,
   macAddress,
@@ -123,6 +124,10 @@ describe('isShopify', () => {
 })
 
 describe('hasGit', () => {
+  afterEach(() => {
+    _resetHasGit()
+  })
+
   test('returns false if git --version errors', async () => {
     // Given
     vi.mocked(exec).mockRejectedValue(new Error('git not found'))
@@ -143,6 +148,44 @@ describe('hasGit', () => {
 
     // Then
     expect(got).toBeTruthy()
+  })
+
+  test('memoizes the result', async () => {
+    // Given
+    vi.mocked(exec).mockResolvedValue(undefined)
+
+    // When
+    await hasGit()
+    await hasGit()
+
+    // Then
+    expect(exec).toHaveBeenCalledTimes(1)
+  })
+
+  test('returns the same promise instance', async () => {
+    // Given
+    vi.mocked(exec).mockResolvedValue(undefined)
+
+    // When
+    const promise1 = hasGit()
+    const promise2 = hasGit()
+
+    // Then
+    expect(promise1).toBe(promise2)
+    await expect(promise1).resolves.toBe(true)
+  })
+
+  test('clears the cache when _resetHasGit is called', async () => {
+    // Given
+    vi.mocked(exec).mockResolvedValue(undefined)
+
+    // When
+    await hasGit()
+    _resetHasGit()
+    await hasGit()
+
+    // Then
+    expect(exec).toHaveBeenCalledTimes(2)
   })
 })
 

--- a/packages/cli-kit/src/public/node/context/local.ts
+++ b/packages/cli-kit/src/public/node/context/local.ts
@@ -45,6 +45,11 @@ let memoizedIsVerbose: boolean | undefined
 let memoizedIsUnitTest: boolean | undefined
 
 /**
+ * Memoized value for the hasGit check.
+ */
+let memoizedHasGit: Promise<boolean> | undefined
+
+/**
  * Returns true if the CLI is running in debug mode.
  *
  * @param env - The environment variables from the environment of the current process.
@@ -236,14 +241,28 @@ export function cloudEnvironment(env: NodeJS.ProcessEnv = process.env): {
  *
  * @returns A promise that resolves with the value.
  */
-export async function hasGit(): Promise<boolean> {
-  try {
-    await lazyExec('git', ['--version'])
-    return true
-    // eslint-disable-next-line no-catch-all/no-catch-all
-  } catch {
-    return false
+export function hasGit(): Promise<boolean> {
+  if (memoizedHasGit !== undefined) {
+    return memoizedHasGit
   }
+  memoizedHasGit = (async () => {
+    try {
+      await lazyExec('git', ['--version'])
+      return true
+      // eslint-disable-next-line no-catch-all/no-catch-all
+    } catch {
+      return false
+    }
+  })()
+  return memoizedHasGit
+}
+
+/**
+ * Resets the memoized value for the hasGit check.
+ * This is only used for testing purposes.
+ */
+export function _resetHasGit(): void {
+  memoizedHasGit = undefined
 }
 
 /**


### PR DESCRIPTION
### WHY are these changes introduced?

The `hasGit` check runs `git --version`, which is a shell command. Redundant executions of this check during a single CLI command lifecycle add unnecessary overhead.

### WHAT is this pull request doing?

Memoizes the result of `hasGit` using a module-level promise. This ensures that `git --version` is executed at most once per process, and concurrent calls return the same promise.

Expected performance impact: Reduces process execution overhead by avoiding redundant `git --version` calls.

### How to test your changes?

CI

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [5396090806031353117](https://jules.google.com/task/5396090806031353117) started by @gonzaloriestra*