### PR TITLE
[Tests] Refactor build/extension.test.ts to remove fs mocks

### DIFF
--- a/packages/app/src/cli/services/build/extension.test.ts
+++ b/packages/app/src/cli/services/build/extension.test.ts
@@ -4,26 +4,23 @@ import {buildGraphqlTypes, buildJSFunction, runWasmOpt, runTrampoline} from '../
 import {validateSchemaApiVersion} from '../function/schema-version.js'
 import {ExtensionInstance} from '../../models/extensions/extension-instance.js'
 import {FunctionConfigType} from '../../models/extensions/specifications/function.js'
-import {beforeEach, describe, expect, test, vi} from 'vitest'
+import {describe, expect, test, vi} from 'vitest'
 import {exec} from '@shopify/cli-kit/node/system'
 import lockfile from 'proper-lockfile'
 import {AbortError} from '@shopify/cli-kit/node/error'
-import {fileExistsSync, touchFile, writeFile} from '@shopify/cli-kit/node/fs'
+import {inTemporaryDirectory, mkdir, touchFile, writeFile, fileExistsSync} from '@shopify/cli-kit/node/fs'
 import {joinPath} from '@shopify/cli-kit/node/path'
 
 vi.mock('@shopify/cli-kit/node/system')
 vi.mock('../function/build.js')
 vi.mock('../function/schema-version.js')
 vi.mock('proper-lockfile')
-vi.mock('@shopify/cli-kit/node/fs')
 
 describe('buildFunctionExtension', () => {
-  let extension: ExtensionInstance<FunctionConfigType>
-  let stdout: any
-  let stderr: any
-  let signal: any
-  let app: any
-  let releaseLock: any
+  const stdout = {write: vi.fn()}
+  const stderr = {write: vi.fn()}
+  const signal = vi.fn()
+  const app = {}
   const defaultConfig = {
     name: 'MyFunction',
     type: 'product_discounts',
@@ -38,427 +35,538 @@ describe('buildFunctionExtension', () => {
     metafields: [],
   }
 
-  beforeEach(async () => {
-    releaseLock = vi.fn()
-    stdout = vi.fn()
-    stderr = {write: vi.fn()}
-    stdout = {write: vi.fn()}
-    signal = vi.fn()
-    app = {}
-    extension = await testFunctionExtension({config: defaultConfig})
-    vi.mocked(lockfile.lock).mockResolvedValue(releaseLock)
-  })
-
   test('delegates the build to system when the build command is present', async () => {
-    // Given
-    extension.configuration.build!.command = './scripts/build.sh argument'
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      const extension = await testFunctionExtension({
+        config: defaultConfig,
+        dir: tmpDir,
+      })
+      extension.configuration.build!.command = './scripts/build.sh argument'
+      const releaseLock = vi.fn()
+      vi.mocked(lockfile.lock).mockResolvedValue(releaseLock)
 
-    // When
-    await expect(
-      buildFunctionExtension(extension, {
+      // When
+      await expect(
+        buildFunctionExtension(extension, {
+          stdout,
+          stderr,
+          signal,
+          app: app as any,
+          environment: 'production',
+        }),
+      ).resolves.toBeUndefined()
+
+      // Then
+      expect(exec).toHaveBeenCalledWith('./scripts/build.sh', ['argument'], {
         stdout,
         stderr,
+        cwd: extension.directory,
         signal,
-        app,
-        environment: 'production',
-      }),
-    ).resolves.toBeUndefined()
-
-    // Then
-    expect(exec).toHaveBeenCalledWith('./scripts/build.sh', ['argument'], {
-      stdout,
-      stderr,
-      cwd: extension.directory,
-      signal,
+      })
+      expect(releaseLock).toHaveBeenCalled()
     })
-    expect(releaseLock).toHaveBeenCalled()
   })
 
   test('fails when is not a JS function and build command is not present', async () => {
-    // Given
-    extension.configuration.build!.command = undefined
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      const extension = await testFunctionExtension({
+        config: defaultConfig,
+        dir: tmpDir,
+      })
+      extension.configuration.build!.command = undefined
+      const releaseLock = vi.fn()
+      vi.mocked(lockfile.lock).mockResolvedValue(releaseLock)
 
-    // Then
-    await expect(
-      buildFunctionExtension(extension, {
-        stdout,
-        stderr,
-        signal,
-        app,
-        environment: 'production',
-      }),
-    ).rejects.toThrow()
-    expect(releaseLock).toHaveBeenCalled()
+      // Then
+      await expect(
+        buildFunctionExtension(extension, {
+          stdout,
+          stderr,
+          signal,
+          app: app as any,
+          environment: 'production',
+        }),
+      ).rejects.toThrow()
+      expect(releaseLock).toHaveBeenCalled()
+    })
   })
 
   test('succeeds when is a JS function and build command is not present', async () => {
-    // Given
-    extension = await testFunctionExtension({config: defaultConfig, entryPath: 'src/index.js'})
-    extension.configuration.build!.command = undefined
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      const extension = await testFunctionExtension({
+        config: defaultConfig,
+        dir: tmpDir,
+        entryPath: 'src/index.js',
+      })
+      extension.configuration.build!.command = undefined
+      const releaseLock = vi.fn()
+      vi.mocked(lockfile.lock).mockResolvedValue(releaseLock)
 
-    // When
-    await expect(
-      buildFunctionExtension(extension, {
+      // When
+      await expect(
+        buildFunctionExtension(extension, {
+          stdout,
+          stderr,
+          signal,
+          app: app as any,
+          environment: 'production',
+        }),
+      ).resolves.toBeUndefined()
+
+      // Then
+      expect(buildJSFunction).toHaveBeenCalledWith(extension, {
         stdout,
         stderr,
         signal,
         app,
         environment: 'production',
-      }),
-    ).resolves.toBeUndefined()
-
-    // Then
-    expect(buildJSFunction).toHaveBeenCalledWith(extension, {
-      stdout,
-      stderr,
-      signal,
-      app,
-      environment: 'production',
+      })
+      expect(releaseLock).toHaveBeenCalled()
     })
-    expect(releaseLock).toHaveBeenCalled()
   })
 
   test('succeeds when is a JS function and build command is present', async () => {
-    // Given
-    extension = await testFunctionExtension({config: defaultConfig, entryPath: 'src/index.js'})
-    extension.configuration.build!.command = './scripts/build.sh argument'
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      const extension = await testFunctionExtension({
+        config: defaultConfig,
+        dir: tmpDir,
+        entryPath: 'src/index.js',
+      })
+      extension.configuration.build!.command = './scripts/build.sh argument'
+      const releaseLock = vi.fn()
+      vi.mocked(lockfile.lock).mockResolvedValue(releaseLock)
 
-    // When
-    await expect(
-      buildFunctionExtension(extension, {
+      // When
+      await expect(
+        buildFunctionExtension(extension, {
+          stdout,
+          stderr,
+          signal,
+          app: app as any,
+          environment: 'production',
+        }),
+      ).resolves.toBeUndefined()
+
+      // Then
+      expect(exec).toHaveBeenCalledWith('./scripts/build.sh', ['argument'], {
         stdout,
         stderr,
+        cwd: extension.directory,
         signal,
-        app,
-        environment: 'production',
-      }),
-    ).resolves.toBeUndefined()
-
-    // Then
-    expect(exec).toHaveBeenCalledWith('./scripts/build.sh', ['argument'], {
-      stdout,
-      stderr,
-      cwd: extension.directory,
-      signal,
+      })
+      expect(releaseLock).toHaveBeenCalled()
     })
-    expect(releaseLock).toHaveBeenCalled()
   })
 
   test('performs wasm-opt execution by default', async () => {
-    // Given
-    vi.mocked(fileExistsSync).mockResolvedValue(true)
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      const extension = await testFunctionExtension({
+        config: defaultConfig,
+        dir: tmpDir,
+      })
+      const releaseLock = vi.fn()
+      vi.mocked(lockfile.lock).mockResolvedValue(releaseLock)
+      await mkdir(joinPath(tmpDir, 'dist'))
+      await touchFile(joinPath(tmpDir, 'dist/index.wasm'))
 
-    // When
-    await expect(
-      buildFunctionExtension(extension, {
-        stdout,
-        stderr,
-        signal,
-        app,
-        environment: 'production',
-      }),
-    ).resolves.toBeUndefined()
+      // When
+      await expect(
+        buildFunctionExtension(extension, {
+          stdout,
+          stderr,
+          signal,
+          app: app as any,
+          environment: 'production',
+        }),
+      ).resolves.toBeUndefined()
 
-    // Then
-    expect(runWasmOpt).toHaveBeenCalled()
+      // Then
+      expect(runWasmOpt).toHaveBeenCalled()
+    })
   })
 
   test('performs trampoline execution by default', async () => {
-    // Given
-    vi.mocked(fileExistsSync).mockResolvedValue(true)
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      const extension = await testFunctionExtension({
+        config: defaultConfig,
+        dir: tmpDir,
+      })
+      const releaseLock = vi.fn()
+      vi.mocked(lockfile.lock).mockResolvedValue(releaseLock)
+      await mkdir(joinPath(tmpDir, 'dist'))
+      await touchFile(joinPath(tmpDir, 'dist/index.wasm'))
 
-    // When
-    await expect(
-      buildFunctionExtension(extension, {
-        stdout,
-        stderr,
-        signal,
-        app,
-        environment: 'production',
-      }),
-    ).resolves.toBeUndefined()
+      // When
+      await expect(
+        buildFunctionExtension(extension, {
+          stdout,
+          stderr,
+          signal,
+          app: app as any,
+          environment: 'production',
+        }),
+      ).resolves.toBeUndefined()
 
-    // Then
-    expect(runTrampoline).toHaveBeenCalled()
+      // Then
+      expect(runTrampoline).toHaveBeenCalled()
+    })
   })
 
   test('skips wasm-opt execution when the disable-wasm-opt is true', async () => {
-    // Given
-    vi.mocked(fileExistsSync).mockResolvedValue(true)
-    extension.configuration.build!.wasm_opt = false
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      const extension = await testFunctionExtension({
+        config: defaultConfig,
+        dir: tmpDir,
+      })
+      const releaseLock = vi.fn()
+      vi.mocked(lockfile.lock).mockResolvedValue(releaseLock)
+      await mkdir(joinPath(tmpDir, 'dist'))
+      await touchFile(joinPath(tmpDir, 'dist/index.wasm'))
+      extension.configuration.build!.wasm_opt = false
 
-    // When
-    await expect(
-      buildFunctionExtension(extension, {
-        stdout,
-        stderr,
-        signal,
-        app,
-        environment: 'production',
-      }),
-    ).resolves.toBeUndefined()
+      // When
+      await expect(
+        buildFunctionExtension(extension, {
+          stdout,
+          stderr,
+          signal,
+          app: app as any,
+          environment: 'production',
+        }),
+      ).resolves.toBeUndefined()
 
-    // Then
-    expect(runWasmOpt).not.toHaveBeenCalled()
+      // Then
+      expect(runWasmOpt).not.toHaveBeenCalled()
+    })
   })
 
   test('fails when build lock cannot be acquired', async () => {
-    // Given
-    vi.mocked(lockfile.lock).mockRejectedValue('failed to acquire lock')
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      const extension = await testFunctionExtension({
+        config: defaultConfig,
+        dir: tmpDir,
+      })
+      vi.mocked(lockfile.lock).mockRejectedValue(new Error('failed to acquire lock'))
 
-    // Then
-    await expect(
-      buildFunctionExtension(extension, {
-        stdout,
-        stderr,
-        signal,
-        app,
-        environment: 'production',
-      }),
-    ).rejects.toThrow(AbortError)
-    expect(releaseLock).not.toHaveBeenCalled()
+      // Then
+      await expect(
+        buildFunctionExtension(extension, {
+          stdout,
+          stderr,
+          signal,
+          app: app as any,
+          environment: 'production',
+        }),
+      ).rejects.toThrow(AbortError)
+    })
   })
 
   test('handles function with undefined build config', async () => {
-    // Given
-    const configWithoutBuild = {
-      name: 'MyFunction',
-      type: 'product_discounts',
-      description: '',
-      configuration_ui: true,
-      api_version: '2022-07',
-      metafields: [],
-    } as unknown as FunctionConfigType
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      const configWithoutBuild = {
+        name: 'MyFunction',
+        type: 'product_discounts',
+        description: '',
+        configuration_ui: true,
+        api_version: '2022-07',
+        metafields: [],
+      } as unknown as FunctionConfigType
 
-    extension = await testFunctionExtension({config: configWithoutBuild, entryPath: 'src/index.js'})
-    vi.mocked(fileExistsSync).mockResolvedValue(true)
+      const extension = await testFunctionExtension({
+        config: configWithoutBuild,
+        dir: tmpDir,
+        entryPath: 'src/index.js',
+      })
+      const releaseLock = vi.fn()
+      vi.mocked(lockfile.lock).mockResolvedValue(releaseLock)
+      await touchFile(extension.outputPath)
 
-    // When
-    await expect(
-      buildFunctionExtension(extension, {
+      // When
+      await expect(
+        buildFunctionExtension(extension, {
+          stdout,
+          stderr,
+          signal,
+          app: app as any,
+          environment: 'production',
+        }),
+      ).resolves.toBeUndefined()
+
+      // Then
+      expect(buildJSFunction).toHaveBeenCalledWith(extension, {
         stdout,
         stderr,
         signal,
         app,
         environment: 'production',
-      }),
-    ).resolves.toBeUndefined()
-
-    // Then
-    expect(buildJSFunction).toHaveBeenCalledWith(extension, {
-      stdout,
-      stderr,
-      signal,
-      app,
-      environment: 'production',
+      })
+      expect(releaseLock).toHaveBeenCalled()
+      // wasm_opt should not be called when build config is undefined
+      expect(runWasmOpt).not.toHaveBeenCalled()
     })
-    expect(releaseLock).toHaveBeenCalled()
-    // wasm_opt should not be called when build config is undefined
-    expect(runWasmOpt).not.toHaveBeenCalled()
   })
 
   test('runs typegen_command before build for non-JS function', async () => {
-    // Given
-    const configWithTypegen = {
-      name: 'MyFunction',
-      type: 'product_discounts',
-      description: '',
-      build: {
-        command: 'make build',
-        path: 'dist/index.wasm',
-        wasm_opt: true,
-        typegen_command: 'npx shopify-function-codegen --schema schema.graphql',
-      },
-      configuration_ui: true,
-      api_version: '2022-07',
-      metafields: [],
-    }
-    extension = await testFunctionExtension({config: configWithTypegen})
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      const configWithTypegen = {
+        name: 'MyFunction',
+        type: 'product_discounts',
+        description: '',
+        build: {
+          command: 'make build',
+          path: 'dist/index.wasm',
+          wasm_opt: true,
+          typegen_command: 'npx shopify-function-codegen --schema schema.graphql',
+        },
+        configuration_ui: true,
+        api_version: '2022-07',
+        metafields: [],
+      }
+      const extension = await testFunctionExtension({
+        config: configWithTypegen,
+        dir: tmpDir,
+      })
+      const releaseLock = vi.fn()
+      vi.mocked(lockfile.lock).mockResolvedValue(releaseLock)
 
-    // When
-    await expect(
-      buildFunctionExtension(extension, {
+      // When
+      await expect(
+        buildFunctionExtension(extension, {
+          stdout,
+          stderr,
+          signal,
+          app: app as any,
+          environment: 'production',
+        }),
+      ).resolves.toBeUndefined()
+
+      // Then
+      expect(buildGraphqlTypes).toHaveBeenCalledWith(extension, {
         stdout,
         stderr,
         signal,
         app,
         environment: 'production',
-      }),
-    ).resolves.toBeUndefined()
-
-    // Then
-    expect(buildGraphqlTypes).toHaveBeenCalledWith(extension, {
-      stdout,
-      stderr,
-      signal,
-      app,
-      environment: 'production',
-    })
-    expect(exec).toHaveBeenCalledWith('make', ['build'], {
-      stdout,
-      stderr,
-      cwd: extension.directory,
-      signal,
+      })
+      expect(exec).toHaveBeenCalledWith('make', ['build'], {
+        stdout,
+        stderr,
+        cwd: extension.directory,
+        signal,
+      })
     })
   })
 
   test('runs typegen_command before build for JS function with custom build command', async () => {
-    // Given
-    const configWithTypegen = {
-      name: 'MyFunction',
-      type: 'product_discounts',
-      description: '',
-      build: {
-        command: 'make build',
-        path: 'dist/index.wasm',
-        wasm_opt: true,
-        typegen_command: 'custom-typegen --output types.ts',
-      },
-      configuration_ui: true,
-      api_version: '2022-07',
-      metafields: [],
-    }
-    extension = await testFunctionExtension({config: configWithTypegen, entryPath: 'src/index.js'})
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      const configWithTypegen = {
+        name: 'MyFunction',
+        type: 'product_discounts',
+        description: '',
+        build: {
+          command: 'make build',
+          path: 'dist/index.wasm',
+          wasm_opt: true,
+          typegen_command: 'custom-typegen --output types.ts',
+        },
+        configuration_ui: true,
+        api_version: '2022-07',
+        metafields: [],
+      }
+      const extension = await testFunctionExtension({
+        config: configWithTypegen,
+        dir: tmpDir,
+        entryPath: 'src/index.js',
+      })
+      const releaseLock = vi.fn()
+      vi.mocked(lockfile.lock).mockResolvedValue(releaseLock)
 
-    // When
-    await expect(
-      buildFunctionExtension(extension, {
+      // When
+      await expect(
+        buildFunctionExtension(extension, {
+          stdout,
+          stderr,
+          signal,
+          app: app as any,
+          environment: 'production',
+        }),
+      ).resolves.toBeUndefined()
+
+      // Then
+      expect(buildGraphqlTypes).toHaveBeenCalledWith(extension, {
         stdout,
         stderr,
         signal,
         app,
         environment: 'production',
-      }),
-    ).resolves.toBeUndefined()
-
-    // Then
-    expect(buildGraphqlTypes).toHaveBeenCalledWith(extension, {
-      stdout,
-      stderr,
-      signal,
-      app,
-      environment: 'production',
-    })
-    expect(exec).toHaveBeenCalledWith('make', ['build'], {
-      stdout,
-      stderr,
-      cwd: extension.directory,
-      signal,
+      })
+      expect(exec).toHaveBeenCalledWith('make', ['build'], {
+        stdout,
+        stderr,
+        cwd: extension.directory,
+        signal,
+      })
     })
   })
 
   test('does not run typegen when typegen_command is not set', async () => {
-    // Given
-    const configWithoutTypegen = {
-      name: 'MyFunction',
-      type: 'product_discounts',
-      description: '',
-      build: {
-        command: 'make build',
-        path: 'dist/index.wasm',
-        wasm_opt: true,
-      },
-      configuration_ui: true,
-      api_version: '2022-07',
-      metafields: [],
-    }
-    extension = await testFunctionExtension({config: configWithoutTypegen})
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      const configWithoutTypegen = {
+        name: 'MyFunction',
+        type: 'product_discounts',
+        description: '',
+        build: {
+          command: 'make build',
+          path: 'dist/index.wasm',
+          wasm_opt: true,
+        },
+        configuration_ui: true,
+        api_version: '2022-07',
+        metafields: [],
+      }
+      const extension = await testFunctionExtension({
+        config: configWithoutTypegen,
+        dir: tmpDir,
+      })
+      const releaseLock = vi.fn()
+      vi.mocked(lockfile.lock).mockResolvedValue(releaseLock)
 
-    // When
-    await expect(
-      buildFunctionExtension(extension, {
-        stdout,
-        stderr,
-        signal,
-        app,
-        environment: 'production',
-      }),
-    ).resolves.toBeUndefined()
+      // When
+      await expect(
+        buildFunctionExtension(extension, {
+          stdout,
+          stderr,
+          signal,
+          app: app as any,
+          environment: 'production',
+        }),
+      ).resolves.toBeUndefined()
 
-    // Then
-    expect(buildGraphqlTypes).not.toHaveBeenCalled()
+      // Then
+      expect(buildGraphqlTypes).not.toHaveBeenCalled()
+    })
   })
 
   test('handles function with build config but undefined path', async () => {
-    // Given
-    const configWithoutPath = {
-      name: 'MyFunction',
-      type: 'product_discounts',
-      description: '',
-      build: {
-        command: 'make build',
-        wasm_opt: true,
-        // path is undefined
-      },
-      configuration_ui: true,
-      api_version: '2022-07',
-      metafields: [],
-    } as unknown as FunctionConfigType
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      const configWithoutPath = {
+        name: 'MyFunction',
+        type: 'product_discounts',
+        description: '',
+        build: {
+          command: 'make build',
+          wasm_opt: true,
+          // path is undefined
+        },
+        configuration_ui: true,
+        api_version: '2022-07',
+        metafields: [],
+      } as unknown as FunctionConfigType
 
-    extension = await testFunctionExtension({config: configWithoutPath})
-    vi.mocked(fileExistsSync).mockResolvedValue(true)
+      const extension = await testFunctionExtension({
+        config: configWithoutPath,
+        dir: tmpDir,
+      })
+      const releaseLock = vi.fn()
+      vi.mocked(lockfile.lock).mockResolvedValue(releaseLock)
+      await mkdir(joinPath(tmpDir, 'dist'))
+      await touchFile(joinPath(tmpDir, 'dist/index.wasm'))
 
-    // When
-    await expect(
-      buildFunctionExtension(extension, {
+      // When
+      await expect(
+        buildFunctionExtension(extension, {
+          stdout,
+          stderr,
+          signal,
+          app: app as any,
+          environment: 'production',
+        }),
+      ).resolves.toBeUndefined()
+
+      // Then
+      expect(exec).toHaveBeenCalledWith('make', ['build'], {
         stdout,
         stderr,
+        cwd: extension.directory,
         signal,
-        app,
-        environment: 'production',
-      }),
-    ).resolves.toBeUndefined()
-
-    // Then
-    expect(exec).toHaveBeenCalledWith('make', ['build'], {
-      stdout,
-      stderr,
-      cwd: extension.directory,
-      signal,
+      })
+      expect(releaseLock).toHaveBeenCalled()
+      expect(runWasmOpt).toHaveBeenCalled()
     })
-    expect(releaseLock).toHaveBeenCalled()
-    expect(runWasmOpt).toHaveBeenCalled()
   })
 
   test('calls validateSchemaApiVersion with the values from the extension config', async () => {
-    // When
-    await expect(
-      buildFunctionExtension(extension, {
-        stdout,
-        stderr,
-        signal,
-        app,
-        environment: 'production',
-      }),
-    ).resolves.toBeUndefined()
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      const extension = await testFunctionExtension({
+        config: defaultConfig,
+        dir: tmpDir,
+      })
+      const releaseLock = vi.fn()
+      vi.mocked(lockfile.lock).mockResolvedValue(releaseLock)
 
-    // Then
-    expect(validateSchemaApiVersion).toHaveBeenCalledWith({
-      directory: extension.directory,
-      localIdentifier: extension.localIdentifier,
-      apiVersion: extension.configuration.api_version,
+      // When
+      await expect(
+        buildFunctionExtension(extension, {
+          stdout,
+          stderr,
+          signal,
+          app: app as any,
+          environment: 'production',
+        }),
+      ).resolves.toBeUndefined()
+
+      // Then
+      expect(validateSchemaApiVersion).toHaveBeenCalledWith({
+        directory: extension.directory,
+        localIdentifier: extension.localIdentifier,
+        apiVersion: extension.configuration.api_version,
+      })
     })
   })
 
   test('does not rebundle when build.path stays in the default output directory', async () => {
-    // Given
-    extension.configuration.build!.path = 'dist/custom.wasm'
-    vi.mocked(fileExistsSync).mockReturnValue(true)
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      const extension = await testFunctionExtension({
+        config: defaultConfig,
+        dir: tmpDir,
+      })
+      extension.configuration.build!.path = 'dist/custom.wasm'
+      const releaseLock = vi.fn()
+      vi.mocked(lockfile.lock).mockResolvedValue(releaseLock)
+      await mkdir(joinPath(tmpDir, 'dist'))
+      const customWasmPath = joinPath(tmpDir, 'dist/custom.wasm')
+      await touchFile(customWasmPath)
 
-    // When
-    await expect(
-      buildFunctionExtension(extension, {
-        stdout,
-        stderr,
-        signal,
-        app,
-        environment: 'production',
-      }),
-    ).resolves.toBeUndefined()
+      const bundlePath = extension.outputPath
 
-    // Then
-    expect(fileExistsSync).toHaveBeenCalledWith(joinPath(extension.directory, 'dist/custom.wasm'))
-    expect(touchFile).not.toHaveBeenCalled()
-    expect(writeFile).not.toHaveBeenCalled()
+      // When
+      await expect(
+        buildFunctionExtension(extension, {
+          stdout,
+          stderr,
+          signal,
+          app: app as any,
+          environment: 'production',
+        }),
+      ).resolves.toBeUndefined()
+
+      // Then
+      expect(fileExistsSync(bundlePath)).toBe(false)
+    })
   })
 })

--- a/packages/app/src/cli/services/build/extension.test.ts
+++ b/packages/app/src/cli/services/build/extension.test.ts
@@ -2,13 +2,12 @@ import {buildFunctionExtension} from './extension.js'
 import {testFunctionExtension} from '../../models/app/app.test-data.js'
 import {buildGraphqlTypes, buildJSFunction, runWasmOpt, runTrampoline} from '../function/build.js'
 import {validateSchemaApiVersion} from '../function/schema-version.js'
-import {ExtensionInstance} from '../../models/extensions/extension-instance.js'
 import {FunctionConfigType} from '../../models/extensions/specifications/function.js'
 import {describe, expect, test, vi} from 'vitest'
 import {exec} from '@shopify/cli-kit/node/system'
 import lockfile from 'proper-lockfile'
 import {AbortError} from '@shopify/cli-kit/node/error'
-import {inTemporaryDirectory, mkdir, touchFile, writeFile, fileExistsSync} from '@shopify/cli-kit/node/fs'
+import {inTemporaryDirectory, mkdir, touchFile, fileExistsSync} from '@shopify/cli-kit/node/fs'
 import {joinPath} from '@shopify/cli-kit/node/path'
 
 vi.mock('@shopify/cli-kit/node/system')
@@ -49,9 +48,9 @@ describe('buildFunctionExtension', () => {
       // When
       await expect(
         buildFunctionExtension(extension, {
-          stdout,
-          stderr,
-          signal,
+          stdout: stdout as any,
+          stderr: stderr as any,
+          signal: signal as any,
           app: app as any,
           environment: 'production',
         }),
@@ -82,9 +81,9 @@ describe('buildFunctionExtension', () => {
       // Then
       await expect(
         buildFunctionExtension(extension, {
-          stdout,
-          stderr,
-          signal,
+          stdout: stdout as any,
+          stderr: stderr as any,
+          signal: signal as any,
           app: app as any,
           environment: 'production',
         }),
@@ -108,9 +107,9 @@ describe('buildFunctionExtension', () => {
       // When
       await expect(
         buildFunctionExtension(extension, {
-          stdout,
-          stderr,
-          signal,
+          stdout: stdout as any,
+          stderr: stderr as any,
+          signal: signal as any,
           app: app as any,
           environment: 'production',
         }),
@@ -143,9 +142,9 @@ describe('buildFunctionExtension', () => {
       // When
       await expect(
         buildFunctionExtension(extension, {
-          stdout,
-          stderr,
-          signal,
+          stdout: stdout as any,
+          stderr: stderr as any,
+          signal: signal as any,
           app: app as any,
           environment: 'production',
         }),
@@ -177,9 +176,9 @@ describe('buildFunctionExtension', () => {
       // When
       await expect(
         buildFunctionExtension(extension, {
-          stdout,
-          stderr,
-          signal,
+          stdout: stdout as any,
+          stderr: stderr as any,
+          signal: signal as any,
           app: app as any,
           environment: 'production',
         }),
@@ -205,9 +204,9 @@ describe('buildFunctionExtension', () => {
       // When
       await expect(
         buildFunctionExtension(extension, {
-          stdout,
-          stderr,
-          signal,
+          stdout: stdout as any,
+          stderr: stderr as any,
+          signal: signal as any,
           app: app as any,
           environment: 'production',
         }),
@@ -234,9 +233,9 @@ describe('buildFunctionExtension', () => {
       // When
       await expect(
         buildFunctionExtension(extension, {
-          stdout,
-          stderr,
-          signal,
+          stdout: stdout as any,
+          stderr: stderr as any,
+          signal: signal as any,
           app: app as any,
           environment: 'production',
         }),
@@ -259,9 +258,9 @@ describe('buildFunctionExtension', () => {
       // Then
       await expect(
         buildFunctionExtension(extension, {
-          stdout,
-          stderr,
-          signal,
+          stdout: stdout as any,
+          stderr: stderr as any,
+          signal: signal as any,
           app: app as any,
           environment: 'production',
         }),
@@ -293,9 +292,9 @@ describe('buildFunctionExtension', () => {
       // When
       await expect(
         buildFunctionExtension(extension, {
-          stdout,
-          stderr,
-          signal,
+          stdout: stdout as any,
+          stderr: stderr as any,
+          signal: signal as any,
           app: app as any,
           environment: 'production',
         }),
@@ -342,9 +341,9 @@ describe('buildFunctionExtension', () => {
       // When
       await expect(
         buildFunctionExtension(extension, {
-          stdout,
-          stderr,
-          signal,
+          stdout: stdout as any,
+          stderr: stderr as any,
+          signal: signal as any,
           app: app as any,
           environment: 'production',
         }),
@@ -395,9 +394,9 @@ describe('buildFunctionExtension', () => {
       // When
       await expect(
         buildFunctionExtension(extension, {
-          stdout,
-          stderr,
-          signal,
+          stdout: stdout as any,
+          stderr: stderr as any,
+          signal: signal as any,
           app: app as any,
           environment: 'production',
         }),
@@ -446,9 +445,9 @@ describe('buildFunctionExtension', () => {
       // When
       await expect(
         buildFunctionExtension(extension, {
-          stdout,
-          stderr,
-          signal,
+          stdout: stdout as any,
+          stderr: stderr as any,
+          signal: signal as any,
           app: app as any,
           environment: 'production',
         }),
@@ -488,9 +487,9 @@ describe('buildFunctionExtension', () => {
       // When
       await expect(
         buildFunctionExtension(extension, {
-          stdout,
-          stderr,
-          signal,
+          stdout: stdout as any,
+          stderr: stderr as any,
+          signal: signal as any,
           app: app as any,
           environment: 'production',
         }),
@@ -521,9 +520,9 @@ describe('buildFunctionExtension', () => {
       // When
       await expect(
         buildFunctionExtension(extension, {
-          stdout,
-          stderr,
-          signal,
+          stdout: stdout as any,
+          stderr: stderr as any,
+          signal: signal as any,
           app: app as any,
           environment: 'production',
         }),
@@ -557,9 +556,9 @@ describe('buildFunctionExtension', () => {
       // When
       await expect(
         buildFunctionExtension(extension, {
-          stdout,
-          stderr,
-          signal,
+          stdout: stdout as any,
+          stderr: stderr as any,
+          signal: signal as any,
           app: app as any,
           environment: 'production',
         }),


### PR DESCRIPTION
Refactored `packages/app/src/cli/services/build/extension.test.ts` to use real filesystem operations within temporary directories instead of mocking `@shopify/cli-kit/node/fs`. This aligns with the project's testing guidelines and improves test reliability.

### How to test your changes?
CI

---
*PR created automatically by Jules for task [80830962309153810](https://jules.google.com/task/80830962309153810) started by @gonzaloriestra*