### PR TITLE
Move preview store name into card body instead of a single-row table

### DIFF
--- a/packages/store/src/cli/services/store/create/preview/index.test.ts
+++ b/packages/store/src/cli/services/store/create/preview/index.test.ts
@@ -47,7 +47,7 @@ describe('preview store create service', () => {
     expect(result).toEqual({
       status: 'success',
       message:
-        'Your Shopify store is ready. This store is temporary. Create a free Shopify account to save it and start selling.',
+        'Your Shopify store "Lavender Candles" is ready. This store is temporary. Create a free Shopify account to save it and start selling.',
       store: {
         id: '123',
         name: 'Lavender Candles',

--- a/packages/store/src/cli/services/store/create/preview/index.ts
+++ b/packages/store/src/cli/services/store/create/preview/index.ts
@@ -95,8 +95,7 @@ async function persistPreviewStoreSession(
 
   return {
     status: 'success',
-    message:
-      'Your Shopify store is ready. This store is temporary. Create a free Shopify account to save it and start selling.',
+    message: `Your Shopify store "${response.shop.name}" is ready. This store is temporary. Create a free Shopify account to save it and start selling.`,
     store: {
       id: response.shop.id,
       name: response.shop.name,

--- a/packages/store/src/cli/services/store/create/preview/result.test.ts
+++ b/packages/store/src/cli/services/store/create/preview/result.test.ts
@@ -15,7 +15,7 @@ vi.mock('@shopify/cli-kit/node/ui', async () => {
 const result = {
   status: 'success' as const,
   message:
-    'Your Shopify store is ready. This store is temporary. Create a free Shopify account to save it and start selling.',
+    'Your Shopify store "Lavender Candles" is ready. This store is temporary. Create a free Shopify account to save it and start selling.',
   store: {
     id: '123',
     name: 'Lavender Candles',
@@ -34,7 +34,7 @@ describe('preview store create result presenter', () => {
         {
           status: 'success',
           message:
-            'Your Shopify store is ready. This store is temporary. Create a free Shopify account to save it and start selling.',
+            'Your Shopify store "Lavender Candles" is ready. This store is temporary. Create a free Shopify account to save it and start selling.',
           store: {
             id: '123',
             name: 'Lavender Candles',
@@ -62,13 +62,7 @@ describe('preview store create result presenter', () => {
         headline: 'Store created',
         customSections: [
           {
-            body: {
-              tabularData: [['Name', 'Lavender Candles']],
-              firstColumnSubdued: true,
-            },
-          },
-          {
-            body: 'Your Shopify store is ready. This store is temporary. Create a free Shopify account to save it and start selling.',
+            body: 'Your Shopify store "Lavender Candles" is ready. This store is temporary. Create a free Shopify account to save it and start selling.',
           },
           {
             title: 'Next steps',

--- a/packages/store/src/cli/services/store/create/preview/result.ts
+++ b/packages/store/src/cli/services/store/create/preview/result.ts
@@ -63,12 +63,6 @@ function renderTextResult(result: CreatePreviewStoreResult): void {
     headline: 'Store created',
     customSections: [
       {
-        body: {
-          tabularData: [['Name', result.store.name]],
-          firstColumnSubdued: true,
-        },
-      },
-      {
         body: result.message,
       },
       {


### PR DESCRIPTION
### What

When a preview store is created, the success card rendered the store name in a one-row table:

```
╭─ success ───────────────────────╮
│  Store created                  │
│                                 │
│  Name  Lavender Candles         │
│                                 │
│  Your Shopify store is ready... │
│  ...                            │
╰─────────────────────────────────╯
```

A single-row table looks awkward. This folds the name into the body copy instead, keeping the `Store created` title:

```
╭─ success ──────────────────────────────────────╮
│  Store created                                 │
│                                                │
│  Your Shopify store "My Store" is ready. This  │
│  store is temporary. Create a free Shopify     │
│  account to save it and start selling.         │
│                                                │
│  Next steps                                    │
│    • ...                                       │
╰────────────────────────────────────────────────╯
```

### Why

Per the design discussion: keep the title de-emphasized so auto-generated names (e.g. `My Store`) don't get title-level emphasis, and surface the name in the less-emphasized body text instead.

### Changes

- `index.ts`: result `message` now interpolates the store name — `Your Shopify store "<name>" is ready. ...` (flows into both text and JSON output).
- `result.ts`: removed the single-row `tabularData` section; `Store created` headline unchanged.
- Updated tests for the new wording.

No changeset — preview-store work isn't public yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)