### PR TITLE
Run current-run E2E app cleanup in CI

### DIFF
--- a/.github/workflows/tests-pr.yml
+++ b/.github/workflows/tests-pr.yml
@@ -254,6 +254,16 @@ jobs:
           E2E_STORE_FQDN: ${{ secrets.E2E_STORE_FQDN }}
           E2E_ORG_ID: ${{ secrets.E2E_ORG_ID }}
         run: pnpm exec playwright test --shard ${{ matrix.shard }}
+      - name: Cleanup current-run E2E apps
+        if: ${{ always() }}
+        continue-on-error: true
+        env:
+          E2E_ACCOUNT_EMAIL: ${{ secrets.E2E_ACCOUNT_EMAIL }}
+          E2E_ACCOUNT_PASSWORD: ${{ secrets.E2E_ACCOUNT_PASSWORD }}
+          E2E_ORG_ID: ${{ secrets.E2E_ORG_ID }}
+        run: |
+          RUN_TOKEN=$(node -e "process.stdout.write(BigInt(process.env.GITHUB_RUN_ID).toString(36))")
+          pnpm --filter e2e exec tsx scripts/cleanup-apps.ts --pattern "r${RUN_TOKEN}a${GITHUB_RUN_ATTEMPT}"
       - name: Upload Playwright report
         uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}


### PR DESCRIPTION
### WHY are these changes introduced?

E2E tests can leave real Dev Dashboard apps behind when teardown is skipped or fails. The previous workflow did not run a post-test app cleanup step, so leftovers accumulated in the shared E2E organization.

Stacked on #7926: the cleanup pattern relies on the run-aware app names introduced by the parent PR.

### WHAT is this pull request doing?

Adds an `always()` cleanup step after the E2E test command that computes the same compact run token as the E2E app-name helper and runs:

```bash
RUN_TOKEN=$(node -e "process.stdout.write(BigInt(process.env.GITHUB_RUN_ID).toString(36))")
pnpm --filter e2e exec tsx scripts/cleanup-apps.ts --pattern "r${RUN_TOKEN}a${GITHUB_RUN_ATTEMPT}"
```

The step targets only apps created by the current GitHub Actions run attempt and is marked `continue-on-error: true` so cleanup flakiness does not hide the original E2E result.

### How to test your changes?

- `git diff --check`
- Inspect `.github/workflows/tests-pr.yml` and confirm the cleanup step is after `Run E2E tests` with `if: ${{ always() }}`.
- In CI, verify the `Cleanup current-run E2E apps` step runs for E2E shards even if the test command fails.

### Post-release steps

None.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [x] The change is not user-facing, so no changeset is needed
