### PR TITLE
Fetch preview store claim URL from GET request in store info

### DIFF
--- a/packages/store/src/cli/services/store/create/preview/client.test.ts
+++ b/packages/store/src/cli/services/store/create/preview/client.test.ts
@@ -213,10 +213,7 @@ describe('preview store client', () => {
       {storage: inMemoryStorage('instance-1')},
     )
 
-    expect(got).toEqual({
-      shop: {id: '123', name: 'Lavender Candles', domain: 'x12y45z.myshopify.com'},
-      accessUrl: 'https://app.shopify.com/auth/preview-store?token=fresh-access-token',
-    })
+    expect(got.claimUrl).toBeUndefined()
   })
 
   test('rejects malformed create responses without leaking the admin API token or access URL', async () => {

--- a/packages/store/src/cli/services/store/create/preview/client.test.ts
+++ b/packages/store/src/cli/services/store/create/preview/client.test.ts
@@ -1,11 +1,10 @@
 import {
   CLI_INSTANCE_HEADER,
   CLI_VERSION_HEADER,
-  claimPreviewStore,
   createPreviewStore,
   getPreviewStore,
   getOrCreateCliInstanceId,
-  previewStoreClaimHeaders,
+  previewStoreAuthenticatedHeaders,
   previewStoreCreateHeaders,
 } from './client.js'
 import {shopifyFetch} from '@shopify/cli-kit/node/http'
@@ -62,8 +61,8 @@ describe('preview store client', () => {
     })
   })
 
-  test('builds claim request headers with the Admin API token', () => {
-    expect(previewStoreClaimHeaders('instance-1', 'shpat_token')).toEqual({
+  test('builds authenticated request headers with the Admin API token', () => {
+    expect(previewStoreAuthenticatedHeaders('instance-1', 'shpat_token')).toEqual({
       Accept: 'application/json',
       'Content-Type': 'application/json',
       'User-Agent': `Shopify CLI; v=${CLI_KIT_VERSION}`,
@@ -171,52 +170,12 @@ describe('preview store client', () => {
     await expect(createPreviewStore({}, {storage: inMemoryStorage('instance-1')})).rejects.toThrow(message)
   })
 
-  test('POSTs to /services/preview-stores/:shop_id/claim with the Admin API token', async () => {
-    vi.mocked(shopifyFetch).mockResolvedValueOnce(
-      response(201, {
-        claim_url: 'https://admin.shopify.com/store-transfer/accept/claim-token',
-      }),
-    )
-
-    const got = await claimPreviewStore(
-      {shopId: '123', adminApiToken: 'shpat_token'},
-      {storage: inMemoryStorage('instance-1')},
-    )
-
-    expect(shopifyFetch).toHaveBeenCalledWith('https://app.shopify.com/services/preview-stores/123/claim', {
-      method: 'POST',
-      headers: expect.objectContaining({
-        [CLI_INSTANCE_HEADER]: 'instance-1',
-        authorization: 'shpat_token',
-        'X-Shopify-Access-Token': 'shpat_token',
-      }),
-      body: JSON.stringify({}),
-    })
-    expect(got).toEqual({
-      claimUrl: 'https://admin.shopify.com/store-transfer/accept/claim-token',
-    })
-  })
-
-  test('sends optional email when requesting a preview store claim URL', async () => {
-    vi.mocked(shopifyFetch).mockResolvedValueOnce(
-      response(201, {
-        claim_url: 'https://admin.shopify.com/store-transfer/accept/claim-token',
-      }),
-    )
-
-    await claimPreviewStore(
-      {shopId: '123', adminApiToken: 'shpat_token', email: 'merchant@example.com'},
-      {storage: inMemoryStorage('instance-1')},
-    )
-
-    expect(vi.mocked(shopifyFetch).mock.calls[0]![1]!.body).toBe(JSON.stringify({email: 'merchant@example.com'}))
-  })
-
   test('GETs /services/preview-stores/:shop_id with the Admin API token', async () => {
     vi.mocked(shopifyFetch).mockResolvedValueOnce(
       response(200, {
         shop: {id: 123, name: 'Lavender Candles', domain: 'x12y45z.myshopify.com'},
         access_url: 'https://app.shopify.com/auth/preview-store?token=fresh-access-token',
+        claim_url: 'https://admin.shopify.com/store-transfer/accept/claim-token',
       }),
     )
 
@@ -233,6 +192,27 @@ describe('preview store client', () => {
         'X-Shopify-Access-Token': 'shpat_token',
       }),
     })
+    expect(got).toEqual({
+      shop: {id: '123', name: 'Lavender Candles', domain: 'x12y45z.myshopify.com'},
+      accessUrl: 'https://app.shopify.com/auth/preview-store?token=fresh-access-token',
+      claimUrl: 'https://admin.shopify.com/store-transfer/accept/claim-token',
+    })
+  })
+
+  test('omits the claim URL when the backend degrades it to null', async () => {
+    vi.mocked(shopifyFetch).mockResolvedValueOnce(
+      response(200, {
+        shop: {id: 123, name: 'Lavender Candles', domain: 'x12y45z.myshopify.com'},
+        access_url: 'https://app.shopify.com/auth/preview-store?token=fresh-access-token',
+        claim_url: null,
+      }),
+    )
+
+    const got = await getPreviewStore(
+      {shopId: '123', adminApiToken: 'shpat_token'},
+      {storage: inMemoryStorage('instance-1')},
+    )
+
     expect(got).toEqual({
       shop: {id: '123', name: 'Lavender Candles', domain: 'x12y45z.myshopify.com'},
       accessUrl: 'https://app.shopify.com/auth/preview-store?token=fresh-access-token',
@@ -291,21 +271,6 @@ describe('preview store client', () => {
     })
     expect(error.tryMessage).not.toContain('access-token')
     expect(error.tryMessage).not.toContain('shpat_token')
-  })
-
-  test('rejects malformed claim responses without leaking returned URLs', async () => {
-    vi.mocked(shopifyFetch).mockResolvedValueOnce(
-      response(201, {
-        claim_url: 123,
-      }),
-    )
-
-    await expect(
-      claimPreviewStore({shopId: '123', adminApiToken: 'shpat_token'}, {storage: inMemoryStorage('instance-1')}),
-    ).rejects.toMatchObject({
-      message: 'Preview store claim URL response is missing required fields.',
-      tryMessage: expect.stringMatching(/"claim_url":"\[REDACTED\]"/),
-    })
   })
 
   test('rejects malformed preview store lookup responses without leaking the access URL', async () => {

--- a/packages/store/src/cli/services/store/create/preview/client.ts
+++ b/packages/store/src/cli/services/store/create/preview/client.ts
@@ -185,7 +185,7 @@ export async function getPreviewStore(
     const message = error instanceof Error ? error.message : 'Unknown error'
     throw new AbortError(
       'Preview store lookup returned a non-JSON response.',
-      `Parse error: ${message}. Body (truncated): ${rawText.slice(0, 500)}`,
+      `Parse error: ${message}. Body (truncated): ${redactPreviewStoreRawText(rawText).slice(0, 500)}`,
     )
   }
 
@@ -252,9 +252,11 @@ function parseErrorBody(rawText: string): RawPreviewStoreErrorResponse {
 
 function previewStoreGetError(status: number, rawText: string): {message: string; tryMessage?: string} {
   const parsed = parseErrorBody(rawText)
+  const redactedRawText = redactPreviewStoreRawText(rawText)
   return {
     message: `Preview store lookup failed with HTTP ${status}.`,
-    tryMessage: parsed.message ?? (rawText.length > 0 ? rawText.slice(0, 1000) : 'No response body returned.'),
+    tryMessage:
+      parsed.message ?? (redactedRawText.length > 0 ? redactedRawText.slice(0, 1000) : 'No response body returned.'),
   }
 }
 

--- a/packages/store/src/cli/services/store/create/preview/client.ts
+++ b/packages/store/src/cli/services/store/create/preview/client.ts
@@ -58,20 +58,6 @@ interface RawPreviewStoreCreateResponse {
   access_url?: unknown
 }
 
-interface PreviewStoreClaimRequest {
-  shopId: string
-  adminApiToken: string
-  email?: string
-}
-
-interface PreviewStoreClaimResponse {
-  claimUrl: string
-}
-
-interface RawPreviewStoreClaimResponse {
-  claim_url?: unknown
-}
-
 interface PreviewStoreGetRequest {
   shopId: string
   adminApiToken: string
@@ -80,11 +66,15 @@ interface PreviewStoreGetRequest {
 interface PreviewStoreGetResponse {
   shop: PreviewStoreResponseShop
   accessUrl: string
+  // The backend mints the claim URL inline; it degrades to null when minting fails, so callers
+  // treat an absent value as "retry later" rather than a hard error.
+  claimUrl?: string
 }
 
 interface RawPreviewStoreGetResponse {
   shop?: RawPreviewStoreResponseShop
   access_url?: unknown
+  claim_url?: unknown
 }
 
 interface RawPreviewStoreErrorResponse {
@@ -117,7 +107,7 @@ export function previewStoreCreateHeaders(cliInstanceId: string): Record<string,
   return previewStoreBaseHeaders(cliInstanceId)
 }
 
-export function previewStoreClaimHeaders(cliInstanceId: string, adminApiToken: string): Record<string, string> {
+export function previewStoreAuthenticatedHeaders(cliInstanceId: string, adminApiToken: string): Record<string, string> {
   return {
     ...previewStoreBaseHeaders(cliInstanceId),
     authorization: adminApiToken,
@@ -170,40 +160,6 @@ export async function createPreviewStore(
   return narrowCreateResponse(parsed)
 }
 
-export async function claimPreviewStore(
-  request: PreviewStoreClaimRequest,
-  options: PreviewStoreRequestOptions = {},
-): Promise<PreviewStoreClaimResponse> {
-  const fqdn = await appManagementFqdn()
-  const url = `https://${fqdn}/services/preview-stores/${encodeURIComponent(request.shopId)}/claim`
-  const body = JSON.stringify({...(request.email ? {email: request.email} : {})})
-
-  const response = await shopifyFetch(url, {
-    method: 'POST',
-    headers: previewStoreClaimHeaders(getOrCreateCliInstanceId(options.storage), request.adminApiToken),
-    body,
-  })
-
-  const rawText = await response.text()
-  if (!response.ok) {
-    const error = previewStoreClaimError(response.status, rawText)
-    throw new AbortError(error.message, error.tryMessage)
-  }
-
-  let parsed: RawPreviewStoreClaimResponse
-  try {
-    parsed = JSON.parse(rawText) as RawPreviewStoreClaimResponse
-  } catch (error) {
-    const message = error instanceof Error ? error.message : 'Unknown error'
-    throw new AbortError(
-      'Preview store claim URL request returned a non-JSON response.',
-      `Parse error: ${message}. Body (truncated): ${redactPreviewStoreRawText(rawText).slice(0, 500)}`,
-    )
-  }
-
-  return narrowClaimResponse(parsed)
-}
-
 export async function getPreviewStore(
   request: PreviewStoreGetRequest,
   options: PreviewStoreRequestOptions = {},
@@ -213,7 +169,7 @@ export async function getPreviewStore(
 
   const response = await shopifyFetch(url, {
     method: 'GET',
-    headers: previewStoreClaimHeaders(getOrCreateCliInstanceId(options.storage), request.adminApiToken),
+    headers: previewStoreAuthenticatedHeaders(getOrCreateCliInstanceId(options.storage), request.adminApiToken),
   })
 
   const rawText = await response.text()
@@ -294,17 +250,6 @@ function parseErrorBody(rawText: string): RawPreviewStoreErrorResponse {
   }
 }
 
-function previewStoreClaimError(status: number, rawText: string): {message: string; tryMessage?: string} {
-  const parsed = parseErrorBody(rawText)
-  const redactedRawText = redactPreviewStoreRawText(rawText)
-
-  return {
-    message: `Preview store claim URL request failed with HTTP ${status}.`,
-    tryMessage:
-      parsed.message ?? (redactedRawText.length > 0 ? redactedRawText.slice(0, 1000) : 'No response body returned.'),
-  }
-}
-
 function previewStoreGetError(status: number, rawText: string): {message: string; tryMessage?: string} {
   const parsed = parseErrorBody(rawText)
   return {
@@ -344,25 +289,13 @@ function narrowCreateResponse(parsed: RawPreviewStoreCreateResponse): PreviewSto
   }
 }
 
-function narrowClaimResponse(parsed: RawPreviewStoreClaimResponse): PreviewStoreClaimResponse {
-  const claimUrl = typeof parsed.claim_url === 'string' ? parsed.claim_url : undefined
-
-  if (!claimUrl) {
-    throw new AbortError(
-      'Preview store claim URL response is missing required fields.',
-      `Got: ${JSON.stringify(redactPreviewStoreClaimResponse(parsed)).slice(0, 500)}`,
-    )
-  }
-
-  return {claimUrl}
-}
-
 function narrowGetResponse(parsed: RawPreviewStoreGetResponse): PreviewStoreGetResponse {
   const shop = parsed.shop
   const id = typeof shop?.id === 'string' || typeof shop?.id === 'number' ? String(shop.id) : undefined
   const name = typeof shop?.name === 'string' ? shop.name : undefined
   const domain = typeof shop?.domain === 'string' ? normalizeStoreFqdn(shop.domain) : undefined
   const accessUrl = typeof parsed.access_url === 'string' ? parsed.access_url : undefined
+  const claimUrl = typeof parsed.claim_url === 'string' ? parsed.claim_url : undefined
 
   if (!id || !name || !domain || !accessUrl) {
     throw new AbortError(
@@ -374,6 +307,7 @@ function narrowGetResponse(parsed: RawPreviewStoreGetResponse): PreviewStoreGetR
   return {
     shop: {id, name, domain},
     accessUrl,
+    ...(claimUrl ? {claimUrl} : {}),
   }
 }
 
@@ -382,13 +316,6 @@ function redactPreviewStoreResponse(parsed: RawPreviewStoreCreateResponse): RawP
     ...parsed,
     ...(parsed.admin_api_token ? {admin_api_token: '[REDACTED]'} : {}),
     ...(parsed.access_url ? {access_url: '[REDACTED]'} : {}),
-  }
-}
-
-function redactPreviewStoreClaimResponse(parsed: RawPreviewStoreClaimResponse): RawPreviewStoreClaimResponse {
-  return {
-    ...parsed,
-    ...(parsed.claim_url ? {claim_url: '[REDACTED]'} : {}),
   }
 }
 
@@ -403,5 +330,6 @@ function redactPreviewStoreGetResponse(parsed: RawPreviewStoreGetResponse): RawP
   return {
     ...parsed,
     ...(parsed.access_url ? {access_url: '[REDACTED]'} : {}),
+    ...(parsed.claim_url ? {claim_url: '[REDACTED]'} : {}),
   }
 }

--- a/packages/store/src/cli/services/store/info/index.test.ts
+++ b/packages/store/src/cli/services/store/info/index.test.ts
@@ -5,7 +5,7 @@ import {STORE_AUTH_APP_CLIENT_ID} from '../auth/config.js'
 import {loadStoredStoreSession} from '../auth/session-lifecycle.js'
 import {clearStoredStoreAppSession, getCurrentStoredStoreAppSession} from '../auth/session-store.js'
 import {recordStoreFqdnMetadata} from '../attribution.js'
-import {claimPreviewStore, getPreviewStore} from '../create/preview/client.js'
+import {getPreviewStore} from '../create/preview/client.js'
 import {AbortError, BugError} from '@shopify/cli-kit/node/error'
 import {adminUrl} from '@shopify/cli-kit/node/api/admin'
 import {graphqlRequest} from '@shopify/cli-kit/node/api/graphql'
@@ -128,7 +128,6 @@ describe('getStoreInfo', () => {
     expect(fetchOrganizationShop).toHaveBeenCalledWith({store: SHOP, organizationId: '149572536', noPrompt: false})
     expect(loadStoredStoreSession).not.toHaveBeenCalled()
     expect(graphqlRequest).not.toHaveBeenCalled()
-    expect(claimPreviewStore).not.toHaveBeenCalled()
     expect(getPreviewStore).not.toHaveBeenCalled()
     expect(result).toEqual({
       id: 'gid://shopify/Shop/72193245184',
@@ -161,12 +160,10 @@ describe('getStoreInfo', () => {
         accessUrl: 'https://app.shopify.com/auth/preview-store?token=stale-access-token',
       },
     })
-    vi.mocked(claimPreviewStore).mockResolvedValueOnce({
-      claimUrl: 'https://admin.shopify.com/store-transfer/accept/claim-token',
-    })
     vi.mocked(getPreviewStore).mockResolvedValueOnce({
       shop: {id: '123', name: 'Lavender Candles', domain: SHOP},
       accessUrl: 'https://app.shopify.com/auth/preview-store?token=fresh-access-token',
+      claimUrl: 'https://admin.shopify.com/store-transfer/accept/claim-token',
     })
 
     const result = await getStoreInfo({store: SHOP})
@@ -174,10 +171,6 @@ describe('getStoreInfo', () => {
     expect(fetchDestinationsContext).not.toHaveBeenCalled()
     expect(fetchOrganizationShop).not.toHaveBeenCalled()
     expect(recordStoreFqdnMetadata).toHaveBeenCalledWith(SHOP, true, '123')
-    expect(claimPreviewStore).toHaveBeenCalledWith({
-      shopId: '123',
-      adminApiToken: 'shpat_preview_token',
-    })
     expect(getPreviewStore).toHaveBeenCalledWith({
       shopId: '123',
       adminApiToken: 'shpat_preview_token',
@@ -211,8 +204,33 @@ describe('getStoreInfo', () => {
         accessUrl: 'https://app.shopify.com/auth/preview-store?token=stale-access-token',
       },
     })
-    vi.mocked(claimPreviewStore).mockResolvedValueOnce({
+    vi.mocked(getPreviewStore).mockResolvedValueOnce({
+      shop: {id: '123', name: 'Lavender Candles', domain: SHOP},
+      accessUrl: 'https://app.shopify.com/auth/preview-store?token=fresh-access-token',
       claimUrl: 'https://admin.shopify.com/store-transfer/accept/claim-token',
+    })
+
+    const result = await getStoreInfo({store: SHOP})
+
+    expect(result.authScopes).toEqual(['read_themes', 'write_themes'])
+  })
+
+  test('omits the save URL when the preview store lookup degrades the claim URL', async () => {
+    vi.mocked(getCurrentStoredStoreAppSession).mockReturnValueOnce({
+      store: SHOP,
+      clientId: STORE_AUTH_APP_CLIENT_ID,
+      userId: 'preview:placeholder-uuid',
+      accessToken: 'shpat_preview_token',
+      scopes: [],
+      acquiredAt: '2026-06-08T12:00:00.000Z',
+      kind: 'preview',
+      preview: {
+        placeholderAccountUuid: 'placeholder-uuid',
+        shopId: '123',
+        name: 'Lavender Candles',
+        createdAt: '2026-06-08T12:00:00.000Z',
+        accessUrl: 'https://app.shopify.com/auth/preview-store?token=stale-access-token',
+      },
     })
     vi.mocked(getPreviewStore).mockResolvedValueOnce({
       shop: {id: '123', name: 'Lavender Candles', domain: SHOP},
@@ -221,7 +239,14 @@ describe('getStoreInfo', () => {
 
     const result = await getStoreInfo({store: SHOP})
 
-    expect(result.authScopes).toEqual(['read_themes', 'write_themes'])
+    expect(result).toEqual({
+      id: 'gid://shopify/Shop/123',
+      displayName: 'Lavender Candles',
+      subdomain: SHOP,
+      accessUrl: 'https://app.shopify.com/auth/preview-store?token=fresh-access-token',
+      authScopes: [],
+    })
+    expect(result.saveUrl).toBeUndefined()
   })
 
   test('prefers BP when store auth exists and BP can resolve the store', async () => {
@@ -245,7 +270,7 @@ describe('getStoreInfo', () => {
       featurePreview: 'extended_variants',
       adminUrl: 'https://admin.shopify.com/store/shop',
     })
-    expect(claimPreviewStore).not.toHaveBeenCalled()
+    expect(getPreviewStore).not.toHaveBeenCalled()
   })
 
   test('falls back to stored store auth when BP cannot resolve a store-auth store', async () => {

--- a/packages/store/src/cli/services/store/info/index.ts
+++ b/packages/store/src/cli/services/store/info/index.ts
@@ -5,7 +5,7 @@ import {classifyAdminApiError, throwIfStoredStoreAuthIsInvalid} from '../admin-e
 import {recordStoreFqdnMetadata} from '../attribution.js'
 import {loadStoredStoreSession} from '../auth/session-lifecycle.js'
 import {getCurrentStoredStoreAppSession} from '../auth/session-store.js'
-import {claimPreviewStore, getPreviewStore} from '../create/preview/client.js'
+import {getPreviewStore} from '../create/preview/client.js'
 import {storeTypeHandle} from '../store-type.js'
 import {AbortError} from '@shopify/cli-kit/node/error'
 import {adminUrl} from '@shopify/cli-kit/node/api/admin'
@@ -143,18 +143,17 @@ function isPreviewStoreSession(session: StoredStoreAppSession | undefined): sess
 
 interface PreviewStoreUrls {
   accessUrl: string
-  saveUrl: string
+  saveUrl?: string
 }
 
 async function fetchPreviewStoreUrls(previewSession: PreviewStoreSession): Promise<PreviewStoreUrls> {
-  const request = {
+  const previewStore = await getPreviewStore({
     shopId: previewSession.preview.shopId,
     adminApiToken: previewSession.accessToken,
-  }
-  const [claim, previewStore] = await Promise.all([claimPreviewStore(request), getPreviewStore(request)])
+  })
   return {
     accessUrl: previewStore.accessUrl,
-    saveUrl: claim.claimUrl,
+    ...(previewStore.claimUrl ? {saveUrl: previewStore.claimUrl} : {}),
   }
 }
 


### PR DESCRIPTION
## What this does

Following backend [shop/world#863938](https://github.com/shop/world/pull/863938), `GET /services/preview-stores/:id` now returns `claim_url` alongside `access_url`. As a result, `shopify store info` no longer needs a separate `POST .../claim` request to obtain the claim ("Save your progress") URL.

This:
- **Makes `store info` faster** — one backend request instead of two (the previous `Promise.all` of `claimPreviewStore` + `getPreviewStore` is now a single `getPreviewStore` call).
- **Deletes the now-redundant claim code path.**

## Changes

**`packages/store/src/cli/services/store/create/preview/client.ts`**
- `getPreviewStore` now reads `claim_url` from the GET response and returns it as an optional `claimUrl`. The backend degrades `claim_url` to `null` on a BP mint failure, so it's treated as absent rather than an error.
- Redaction in the GET error path now also covers `claim_url`.
- Deleted `claimPreviewStore`, `PreviewStoreClaimRequest`, `PreviewStoreClaimResponse`, `RawPreviewStoreClaimResponse`, `narrowClaimResponse`, `previewStoreClaimError`, and `redactPreviewStoreClaimResponse`.
- Renamed `previewStoreClaimHeaders` to `previewStoreAuthenticatedHeaders` (now only used by the authenticated GET).

**`packages/store/src/cli/services/store/info/index.ts`**
- `fetchPreviewStoreUrls` makes a single `getPreviewStore` call; `saveUrl` is populated from `previewStore.claimUrl` when present.

**Tests** — `client.test.ts` and `index.test.ts`: removed dead claim tests, added a `claim_url` assertion to the GET test, and added coverage for the degraded (`null` claim URL leads to no `saveUrl`) path.

## Behavior note

Previously, a claim-mint failure threw and aborted `store info`. Now (matching the backend's intentional design) it degrades gracefully: `store info` still shows the store and access URL, just without the "Save your progress" link.

## No changeset

Preview stores aren't a publicized feature yet, so this change doesn't need a public changelog entry.

## Testing

- 50 tests pass (store/info/index.test.ts + create/preview/client.test.ts)
- nx run store:type-check clean
- ESLint clean on all changed files
