### PR TITLE
[Performance] Memoize isWsl result

### DIFF
--- a/packages/cli-kit/src/public/node/system.test.ts
+++ b/packages/cli-kit/src/public/node/system.test.ts
@@ -393,3 +393,15 @@ describe('readStdinString', () => {
     await expect(got).rejects.toThrow('Stdin input exceeded the maximum allowed size.')
   })
 })
+
+describe('isWsl', () => {
+  test('memoizes the result', async () => {
+    // When
+    const result1 = system.isWsl()
+    const result2 = system.isWsl()
+
+    // Then
+    expect(result1).toBe(result2)
+    await expect(result1).resolves.toBeDefined()
+  })
+})

--- a/packages/cli-kit/src/public/node/system.ts
+++ b/packages/cli-kit/src/public/node/system.ts
@@ -355,13 +355,20 @@ export function isCI(): boolean {
 }
 
 /**
+ * Memoized value for the WSL check.
+ */
+let memoizedIsWsl: Promise<boolean> | undefined
+
+/**
  * Check if the current environment is a WSL environment.
  *
  * @returns True if the current environment is a WSL environment.
  */
-export async function isWsl(): Promise<boolean> {
-  const wsl = await import('is-wsl')
-  return wsl.default
+export function isWsl(): Promise<boolean> {
+  return (memoizedIsWsl ??= (async () => {
+    const wsl = await import('is-wsl')
+    return wsl.default
+  })())
 }
 
 /**


### PR DESCRIPTION
### WHY are these changes introduced?

The `isWsl` function performs a dynamic import and environment check every time it is called. This function is used during analytics reporting, which can happen multiple times during a single command execution. Memoizing the result improves efficiency by avoiding redundant work and imports.

### WHAT is this pull request doing?

This PR memoizes the result of the `isWsl` function in `packages/cli-kit`. Subsequent calls will return the same promise instance, ensuring the underlying check only runs once.

Expected performance impact: Reduced overhead during analytics reporting and any other services that check for WSL status.

### How to test your changes?

CI

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [10809980487485119917](https://jules.google.com/task/10809980487485119917) started by @gonzaloriestra*