### PR TITLE
[Refactor] Memoize username function

### DIFF
--- a/packages/cli-kit/src/cli/api/graphql/admin/generated/types.d.ts
+++ b/packages/cli-kit/src/cli/api/graphql/admin/generated/types.d.ts
@@ -232,6 +232,8 @@ export type OnlineStoreThemeFilesUserErrorsCode =
   | 'LESS_THAN_OR_EQUAL_TO'
   /** The record with the ID used as the input value couldn't be found. */
   | 'NOT_FOUND'
+  /** Theme contextualization and condition types are not compatible with each other. */
+  | 'THEME_CONTEXTUALIZATION_NOT_COMPATIBLE_WITH_CONDITION_TYPES'
   /** There are theme files with conflicts. */
   | 'THEME_FILES_CONFLICT'
   /** This action is not available on your current plan. Please upgrade to access theme editing features. */

--- a/packages/cli-kit/src/public/node/os.test.ts
+++ b/packages/cli-kit/src/public/node/os.test.ts
@@ -1,7 +1,50 @@
-import {platformAndArch} from './os.js'
-import {describe, test, expect, vi} from 'vitest'
+import {platformAndArch, username, _resetUsernameCache} from './os.js'
+import {describe, test, expect, vi, beforeEach} from 'vitest'
 
 vi.mock('node:process')
+
+describe('username', () => {
+  beforeEach(() => {
+    _resetUsernameCache()
+  })
+
+  test('memoizes the username', async () => {
+    // Given
+    const platform = process.platform
+    const firstPromise = username(platform)
+
+    // When
+    const secondPromise = username(platform)
+
+    // Then
+    expect(firstPromise).toBe(secondPromise)
+    await expect(firstPromise).resolves.toBeDefined()
+  })
+
+  test('returns different promises for different platforms', async () => {
+    // Given
+    const firstPromise = username('darwin')
+
+    // When
+    const secondPromise = username('win32')
+
+    // Then
+    expect(firstPromise).not.toBe(secondPromise)
+  })
+
+  test('resets the cache', async () => {
+    // Given
+    const platform = process.platform
+    const firstPromise = username(platform)
+    _resetUsernameCache()
+
+    // When
+    const secondPromise = username(platform)
+
+    // Then
+    expect(firstPromise).not.toBe(secondPromise)
+  })
+})
 
 describe('platformAndArch', () => {
   test("returns the right architecture when it's x64", () => {

--- a/packages/cli-kit/src/public/node/os.ts
+++ b/packages/cli-kit/src/public/node/os.ts
@@ -5,11 +5,27 @@ import {userInfo as osUserInfo} from 'os'
 // This code has been vendored from https://github.com/sindresorhus/username
 // because adding it as a transtive dependency causes conflicts with other
 // packages that haven't been yet migrated to the latest version.
+let usernamePromise: Promise<string | null> | undefined
+
 /**
  * @param platform - The platform to get the username for. Defaults to the current platform.
  * @returns The username of the current user.
  */
-export async function username(platform: typeof process.platform = process.platform): Promise<string | null> {
+export function username(platform: typeof process.platform = process.platform): Promise<string | null> {
+  if (platform !== process.platform) {
+    return fetchUsername(platform)
+  }
+  return (usernamePromise ??= fetchUsername(platform))
+}
+
+/**
+ * Resets the username cache.
+ */
+export function _resetUsernameCache() {
+  usernamePromise = undefined
+}
+
+async function fetchUsername(platform: typeof process.platform = process.platform): Promise<string | null> {
   outputDebug(outputContent`Obtaining user name...`)
   const environmentVariable = getEnvironmentVariable()
   if (environmentVariable) {


### PR DESCRIPTION
### WHY are these changes introduced?

The `username` function in `@shopify/cli-kit` is used in several places, including during app initialization. Since the username is unlikely to change during the execution of a CLI command, memoizing it avoids repeated system calls (environment variable lookups, `os.userInfo()`, or executing `whoami`/`id`).

### WHAT is this pull request doing?

- Memoizes the result of the `username` function in `packages/cli-kit/src/public/node/os.ts` using a module-level promise.
- Exports a `_resetUsernameCache` function for test isolation.
- Adds unit tests in `packages/cli-kit/src/public/node/os.test.ts` to verify memoization and cache reset behavior.

### How to test your changes?

CI

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [4653242786229501269](https://jules.google.com/task/4653242786229501269) started by @gonzaloriestra*