### PR TITLE
[Performance] Memoize hasGit check

### DIFF
--- a/packages/cli-kit/src/public/node/context/local.test.ts
+++ b/packages/cli-kit/src/public/node/context/local.test.ts
@@ -1,6 +1,7 @@
 import {
   ciPlatform,
   hasGit,
+  _resetHasGit,
   isDevelopment,
   isShopify,
   isTerminalInteractive,
@@ -125,6 +126,7 @@ describe('isShopify', () => {
 describe('hasGit', () => {
   test('returns false if git --version errors', async () => {
     // Given
+    _resetHasGit()
     vi.mocked(exec).mockRejectedValue(new Error('git not found'))
 
     // When
@@ -136,6 +138,7 @@ describe('hasGit', () => {
 
   test('returns true if git --version succeeds', async () => {
     // Given
+    _resetHasGit()
     vi.mocked(exec).mockResolvedValue(undefined)
 
     // When
@@ -143,6 +146,21 @@ describe('hasGit', () => {
 
     // Then
     expect(got).toBeTruthy()
+  })
+
+  test('memoizes the result', async () => {
+    // Given
+    _resetHasGit()
+    vi.mocked(exec).mockResolvedValue(undefined)
+
+    // When
+    await hasGit()
+    await hasGit()
+    const got = await hasGit()
+
+    // Then
+    expect(got).toBeTruthy()
+    expect(vi.mocked(exec)).toHaveBeenCalledTimes(1)
   })
 })
 

--- a/packages/cli-kit/src/public/node/context/local.ts
+++ b/packages/cli-kit/src/public/node/context/local.ts
@@ -232,18 +232,39 @@ export function cloudEnvironment(env: NodeJS.ProcessEnv = process.env): {
 }
 
 /**
+ * Memoized promise for the hasGit check.
+ */
+let hasGitPromise: Promise<boolean> | undefined
+
+/**
  * Returns whether the environment has Git available.
  *
  * @returns A promise that resolves with the value.
  */
-export async function hasGit(): Promise<boolean> {
-  try {
-    await lazyExec('git', ['--version'])
-    return true
-    // eslint-disable-next-line no-catch-all/no-catch-all
-  } catch {
-    return false
+export function hasGit(): Promise<boolean> {
+  if (hasGitPromise) {
+    return hasGitPromise
   }
+
+  hasGitPromise = (async () => {
+    try {
+      await lazyExec('git', ['--version'])
+      return true
+      // eslint-disable-next-line no-catch-all/no-catch-all
+    } catch {
+      return false
+    }
+  })()
+
+  return hasGitPromise
+}
+
+/**
+ * Resets the memoized value for the hasGit check.
+ * This is only intended for use in tests.
+ */
+export function _resetHasGit(): void {
+  hasGitPromise = undefined
 }
 
 /**


### PR DESCRIPTION
### WHY are these changes introduced?

Checking for Git presence via `git --version` is an expensive operation that involves spawning a new process. This check is performed multiple times during the execution of various CLI commands. Since Git's presence is unlikely to change during the execution of a single command, we can memoize the result to improve performance.

### WHAT is this pull request doing?

This PR memoizes the `hasGit` function in `packages/cli-kit/src/public/node/context/local.ts` using a module-level promise.
- Introduced `hasGitPromise` to cache the result.
- Updated `hasGit` to return the cached promise if available.
- Added and exported `_resetHasGit` for test isolation.
- Updated unit tests in `packages/cli-kit/src/public/node/context/local.test.ts` to verify memoization.

### How to test your changes?

CI

### Post-release steps

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [1744815129505296381](https://jules.google.com/task/1744815129505296381) started by @gonzaloriestra*