### PR TITLE
[Refactor] Declarative construction of config info body

### DIFF
--- a/packages/app/src/cli/services/format-config-info-body.ts
+++ b/packages/app/src/cli/services/format-config-info-body.ts
@@ -39,26 +39,26 @@ export function formatConfigInfoBody({
   includeConfigOnDeploy,
   messages,
 }: FormatConfigInfoBodyOptions): TokenItem {
-  const items = [`App:             ${appName}`]
-  if (org) items.unshift(`Org:             ${org}`)
-  if (devStores && devStores.length > 0) {
-    devStores.forEach((storeUrl) => items.push(`Dev store:       ${storeUrl}`))
-  }
-  if (updateURLs) items.push(`Update URLs:     ${updateURLs}`)
-  if (includeConfigOnDeploy !== undefined) items.push(`Include config:  ${includeConfigOnDeploy ? 'Yes' : 'No'}`)
+  const items = [
+    ...(org ? [`Org:             ${org}`] : []),
+    `App:             ${appName}`,
+    ...(devStores ?? []).map((storeUrl) => `Dev store:       ${storeUrl}`),
+    ...(updateURLs ? [`Update URLs:     ${updateURLs}`] : []),
+    ...(includeConfigOnDeploy === undefined ? [] : [`Include config:  ${includeConfigOnDeploy ? 'Yes' : 'No'}`]),
+  ]
 
-  let body: Token[] = [{list: {items}}]
+  const body: Token[] = [{list: {items}}]
 
-  if (messages && messages.length) {
-    for (let index = 0; index < messages.length; index++) {
-      const message = messages[index]
+  if (messages && messages.length > 0) {
+    const messageTokens = messages.flatMap((message, index) => {
+      if (message && message.length > 0) {
+        const separator = index === 0 ? '\n' : '\n\n'
+        return [separator, ...message]
+      }
+      return []
+    })
 
-      if (!message || message.length === 0) continue
-
-      const separator = index === 0 ? '\n' : '\n\n'
-
-      body = body.concat(separator, message)
-    }
+    return [...body, ...messageTokens]
   }
 
   return body


### PR DESCRIPTION
### WHY are these changes introduced?

The `formatConfigInfoBody` function used an imperative style with multiple `push`, `unshift` calls, and a `for` loop to build its output. Refactoring it to a declarative style makes the code more readable and maintainable.

### WHAT is this pull request doing?

- Replaces imperative array construction of the `items` list with a declarative array literal using spread syntax.
- Replaces the `for` loop used for processing `messages` with a `flatMap` call.
- Maintains exact string formatting and separator logic (verified by existing tests).

### How to test your changes?

CI

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [7394684360109543773](https://jules.google.com/task/7394684360109543773) started by @gonzaloriestra*