### PR TITLE
[Tests] Add coverage for ensureThemeStore utility

### DIFF
--- a/packages/theme/src/cli/utilities/theme-store.test.ts
+++ b/packages/theme/src/cli/utilities/theme-store.test.ts
@@ -1,0 +1,45 @@
+import {ensureThemeStore} from './theme-store.js'
+import {getThemeStore, setThemeStore} from '../services/local-storage.js'
+import {describe, expect, test, vi} from 'vitest'
+import {recordError} from '@shopify/cli-kit/node/analytics'
+
+vi.mock('../services/local-storage.js')
+vi.mock('@shopify/cli-kit/node/analytics')
+
+vi.mocked(recordError).mockImplementation((error) => error)
+
+describe('ensureThemeStore', () => {
+  test('returns the store from flags if provided and sets it in local storage', () => {
+    // Given
+    const flags = {store: 'example.myshopify.com'}
+
+    // When
+    const result = ensureThemeStore(flags)
+
+    // Then
+    expect(result).toBe('example.myshopify.com')
+    expect(setThemeStore).toHaveBeenCalledWith('example.myshopify.com')
+  })
+
+  test('returns the store from local storage if flag is not provided', () => {
+    // Given
+    const flags = {store: undefined}
+    vi.mocked(getThemeStore).mockReturnValue('stored.myshopify.com')
+
+    // When
+    const result = ensureThemeStore(flags)
+
+    // Then
+    expect(result).toBe('stored.myshopify.com')
+    expect(setThemeStore).toHaveBeenCalledWith('stored.myshopify.com')
+  })
+
+  test('throws AbortError if store is not provided and not in local storage', () => {
+    // Given
+    const flags = {store: undefined}
+    vi.mocked(getThemeStore).mockReturnValue(undefined)
+
+    // When / Then
+    expect(() => ensureThemeStore(flags)).toThrow('A store is required')
+  })
+})


### PR DESCRIPTION
### Description

This PR adds unit tests for the `ensureThemeStore` utility in the `@shopify/theme` package. This function is responsible for determining which Shopify store a theme command should act upon, either from a command-line flag or from local storage.

### How to test your changes?

CI


---
*PR created automatically by Jules for task [13678815188741960686](https://jules.google.com/task/13678815188741960686) started by @gonzaloriestra*