### PR TITLE
Handle missing theme write access during theme creation

### DIFF
--- a/.changeset/friendly-theme-create-access-error.md
+++ b/.changeset/friendly-theme-create-access-error.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': patch
+---
+
+Show a friendly error when theme creation is denied by missing theme write access

--- a/packages/cli-kit/src/public/node/themes/api.test.ts
+++ b/packages/cli-kit/src/public/node/themes/api.test.ts
@@ -354,6 +354,19 @@ describe('themeCreate', () => {
       preferredBehaviour: expectedApiOptions,
     })
   })
+
+  test('throws a friendly error when access is denied by a missing theme write access scope', async () => {
+    vi.mocked(adminRequestDoc).mockRejectedValue(
+      themeAccessDeniedError(
+        'The user needs write_themes and an exemption from Shopify to modify themes.',
+        'themeCreate',
+      ),
+    )
+
+    await expect(themeCreate(params, session)).rejects.toThrow(
+      'The authenticated account or access token is missing write_themes and an exemption from Shopify to modify themes.',
+    )
+  })
 })
 
 describe('themeUpdate', () => {
@@ -808,11 +821,11 @@ describe('parseThemeFileContent', () => {
   })
 })
 
-function themeAccessDeniedError(requiredAccess?: string): ClientError {
+function themeAccessDeniedError(requiredAccess?: string, field = 'themes'): ClientError {
   const extensions = requiredAccess ? {code: 'ACCESS_DENIED', requiredAccess} : {code: 'ACCESS_DENIED'}
   const message = requiredAccess
-    ? `Access denied for themes field. Required access: ${requiredAccess}`
-    : 'Access denied for themes field.'
+    ? `Access denied for ${field} field. Required access: ${requiredAccess}`
+    : `Access denied for ${field} field.`
 
   return new ClientError(
     {
@@ -821,7 +834,7 @@ function themeAccessDeniedError(requiredAccess?: string): ClientError {
         {
           message,
           extensions,
-          path: ['themes'],
+          path: [field],
         } as any,
       ],
     },

--- a/packages/cli-kit/src/public/node/themes/api.ts
+++ b/packages/cli-kit/src/public/node/themes/api.ts
@@ -153,7 +153,7 @@ export async function findDevelopmentThemeByName(name: string, session: AdminSes
 export async function themeCreate(params: ThemeParams, session: AdminSession): Promise<Theme | undefined> {
   const themeSource = params.src ?? SkeletonThemeCdn
   recordEvent('theme-api:create-theme')
-  const {themeCreate} = await adminRequestDoc({
+  const {themeCreate} = await requestThemeAdminDoc({
     query: ThemeCreate,
     session,
     variables: {
@@ -684,7 +684,16 @@ function getThemeAccessRequirementForAccessDeniedError(error: ClientError): stri
   const requiredAccess = accessDeniedError.extensions?.requiredAccess
   if (typeof requiredAccess !== 'string') return DEFAULT_THEME_ACCESS_REQUIREMENT
 
-  return requiredAccess.trim().replace(/\.$/, '') || DEFAULT_THEME_ACCESS_REQUIREMENT
+  return formatThemeAccessRequirement(requiredAccess)
+}
+
+function formatThemeAccessRequirement(requiredAccess: string): string {
+  const requirement = requiredAccess
+    .trim()
+    .replace(/\.$/, '')
+    .replace(/^The user needs\s+/i, '')
+
+  return requirement || DEFAULT_THEME_ACCESS_REQUIREMENT
 }
 
 function themeGid(id: number): string {


### PR DESCRIPTION
### WHY are these changes introduced?

When theme commands create a development theme with an account or Admin API token that cannot access `themeCreate`, the Admin GraphQL API returns an `ACCESS_DENIED` error with `requiredAccess` details. `fetchThemes` and related read paths already map this shape to a friendly `AbortError`, but `themeCreate` still called `adminRequestDoc` directly and surfaced the raw GraphQL `ClientError` payload.

This addresses the latest-version `write_themes` / `themeCreate` tail under the linked issue; the broader Observe grouping also contains unrelated GraphQL failures that should be re-scoped separately.

### WHAT is this pull request doing?

- Routes `themeCreate` through the theme Admin request wrapper so missing theme access is reported with the existing friendly next steps.
- Normalizes `requiredAccess` text that starts with `The user needs ...` so the rendered error sentence reads cleanly.
- Adds a focused `themeCreate` regression test.

### How to test your changes?

- `pnpm --filter @shopify/cli-kit vitest run src/public/node/themes/api.test.ts`
- `pnpm --filter @shopify/cli-kit lint`
- `pnpm --filter @shopify/cli-kit type-check`

Resolves: https://github.com/shop/issues/issues/32995

Co-authored-by: Pi AI <noreply@pi.dev>
