### PR TITLE
[Tests] Refactor asset-ignore tests to use real filesystem

### DIFF
--- a/packages/theme/src/cli/utilities/asset-ignore.test.ts
+++ b/packages/theme/src/cli/utilities/asset-ignore.test.ts
@@ -1,17 +1,7 @@
 import {applyIgnoreFilters, getPatternsFromShopifyIgnore} from './asset-ignore.js'
-import {ReadOptions, fileExists, readFile} from '@shopify/cli-kit/node/fs'
-import {test, describe, beforeEach, vi, expect} from 'vitest'
+import {inTemporaryDirectory, writeFile} from '@shopify/cli-kit/node/fs'
+import {test, describe, vi, expect} from 'vitest'
 import {renderWarning} from '@shopify/cli-kit/node/ui'
-
-vi.mock('@shopify/cli-kit/node/fs', async () => {
-  const originalFs: any = await vi.importActual('@shopify/cli-kit/node/fs')
-  return {
-    ...originalFs,
-    matchGlob: originalFs.matchGlob,
-    readFile: vi.fn(),
-    fileExists: vi.fn(),
-  }
-})
 
 vi.mock('@shopify/cli-kit/node/ui', () => ({
   renderWarning: vi.fn(),
@@ -31,47 +21,38 @@ describe('asset-ignore', () => {
     {key: 'templates/customers/account.json', checksum: '7777777777777777777777777777777'},
   ]
 
-  /**
-   * Explicitly defining the type of 'readFile' as it returns either
-   * 'Promise<string>' or 'Promise<Buffer>', which are ambiguous to the
-   * TypeScript language server.
-   */
-  const readFileFn = readFile as (path: string, options?: ReadOptions) => Promise<string>
-
-  beforeEach(() => {
-    vi.mocked(fileExists).mockResolvedValue(true)
-    vi.mocked(readFileFn).mockResolvedValue('')
-  })
-
   describe('getPatternsFromShopifyIgnore', () => {
     test('returns an empty array when the .shopifyignore file does not exist', async () => {
-      // Given
-      vi.mocked(fileExists).mockResolvedValue(false)
-      await expect(getPatternsFromShopifyIgnore('tmp')).resolves.toEqual([])
+      await inTemporaryDirectory(async (tmpDir) => {
+        // When/Then
+        await expect(getPatternsFromShopifyIgnore(tmpDir)).resolves.toEqual([])
+      })
     })
 
-    test('returns an empty array when the .shopifyignore file does not exist', async () => {
-      vi.mocked(fileExists).mockResolvedValue(true)
-      vi.mocked(readFileFn).mockResolvedValue(`
-        # assets/basic.css
-        assets/complex.css
-        assets/*.png
-        sections/*
-        templates/*
-        config/*_data.json
-        .*settings_schema.json
-      `)
+    test('returns patterns from .shopifyignore when it exists', async () => {
+      await inTemporaryDirectory(async (tmpDir) => {
+        // Given
+        const content = `
+          # assets/basic.css
+          assets/complex.css
+          assets/*.png
+          sections/*
+          templates/*
+          config/*_data.json
+          .*settings_schema.json
+        `
+        await writeFile(`${tmpDir}/.shopifyignore`, content)
 
-      await expect(getPatternsFromShopifyIgnore('tmp')).resolves.toEqual([
-        'assets/complex.css',
-        'assets/*.png',
-        'sections/*',
-        'templates/*',
-        'config/*_data.json',
-        '.*settings_schema.json',
-      ])
-
-      expect(readFileFn).toHaveBeenLastCalledWith('tmp/.shopifyignore', {encoding: 'utf8'})
+        // When/Then
+        await expect(getPatternsFromShopifyIgnore(tmpDir)).resolves.toEqual([
+          'assets/complex.css',
+          'assets/*.png',
+          'sections/*',
+          'templates/*',
+          'config/*_data.json',
+          '.*settings_schema.json',
+        ])
+      })
     })
   })
 


### PR DESCRIPTION
Refactored `packages/theme/src/cli/utilities/asset-ignore.test.ts` to replace filesystem mocks with real operations using `inTemporaryDirectory` and `writeFile`. This makes the tests more robust and aligns with the project's testing standards.

---
*PR created automatically by Jules for task [8912396214291889262](https://jules.google.com/task/8912396214291889262) started by @gonzaloriestra*