### PR TITLE
[Security] Harden client ID generation

### DIFF
--- a/packages/ui-extensions-server-kit/src/ExtensionServerClient/ExtensionServerClient.ts
+++ b/packages/ui-extensions-server-kit/src/ExtensionServerClient/ExtensionServerClient.ts
@@ -32,7 +32,11 @@ export class ExtensionServerClient implements ExtensionServer.Client {
   private uiExtensionsByUuid: Record<string, ExtensionServer.UIExtension> = {}
 
   constructor(options: DeepPartial<ExtensionServer.Options> = {}) {
-    this.id = (Math.random() + 1).toString(36).substring(7)
+    // Use a cryptographically secure random number generator if available to prevent predictable client IDs
+    this.id =
+      typeof globalThis.crypto?.randomUUID === 'function'
+        ? globalThis.crypto.randomUUID()
+        : (Math.random() + 1).toString(36).substring(7)
     this.options = getValidatedOptions({
       ...options,
       connection: {


### PR DESCRIPTION
### WHY are these changes introduced?

The current implementation uses a predictable method for generating client identifiers in `ExtensionServerClient`.

### WHAT is this pull request doing?

This PR hardens the client ID generation by using `globalThis.crypto.randomUUID()` where available, which provides a cryptographically secure random identifier.

### How to test your changes?

CI

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [4197720063763446378](https://jules.google.com/task/4197720063763446378) started by @gonzaloriestra*