### PR TITLE
[Refactor] Use flatMap in info service

### DIFF
--- a/packages/app/src/cli/services/info.ts
+++ b/packages/app/src/cli/services/info.ts
@@ -238,7 +238,7 @@ class AppInfo {
         if (relevantExtensions[0]) {
           return this.subtableSection(
             relevantExtensions[0].externalType,
-            relevantExtensions.map((ext) => this.extensionSubSection(ext)).flat(),
+            relevantExtensions.flatMap((ext) => this.extensionSubSection(ext)),
           )
         }
       })


### PR DESCRIPTION
### WHY are these changes introduced?

This refactor improves code readability by using the native `flatMap()` method instead of a combined `map().flat()`. This aligns with modern JavaScript practices and the project's target of ES2020.

### WHAT is this pull request doing?

Replaces `relevantExtensions.map((ext) => this.extensionSubSection(ext)).flat()` with `relevantExtensions.flatMap((ext) => this.extensionSubSection(ext))` in `packages/app/src/cli/services/info.ts`.

### How to test your changes?

CI

### Post-release steps

None.

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (\`patch\` for bug fixes · \`minor\` for new features · \`major\` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with \`pnpm changeset add\`

---
*PR created automatically by Jules for task [2571761045996988060](https://jules.google.com/task/2571761045996988060) started by @gonzaloriestra*