### PR TITLE
Tweak store info action labels for consistent copy

### DIFF
--- a/.changeset/store-info-data-table.md
+++ b/.changeset/store-info-data-table.md
@@ -2,4 +2,4 @@
 '@shopify/store': patch
 ---
 
-Render `store info` details as a two-column data table and surface store URLs as clickable next-step actions (e.g. "View the storefront.").
+Render `store info` details as a two-column data table and surface store URLs as clickable next-step actions (e.g. "View your store").

--- a/packages/store/src/cli/services/store/info/result.test.ts
+++ b/packages/store/src/cli/services/store/info/result.test.ts
@@ -116,10 +116,10 @@ describe('renderStoreInfoResult', () => {
     const actions = storeActions()
     expect(actions).toEqual([
       {link: {label: 'Manage this store in the Shopify admin', url: 'https://admin.shopify.com/store/acme-widgets'}},
-      {link: {label: 'View the storefront', url: 'https://app.shopify.com/auth/preview-store?token=access-token'}},
+      {link: {label: 'View your store', url: 'https://app.shopify.com/auth/preview-store?token=access-token'}},
       {
         link: {
-          label: 'Save your progress on this store',
+          label: 'Save your store',
           url: 'https://admin.shopify.com/store-transfer/accept/claim-token',
         },
       },

--- a/packages/store/src/cli/services/store/info/result.ts
+++ b/packages/store/src/cli/services/store/info/result.ts
@@ -35,8 +35,8 @@ function storeDetailRows(result: StoreInfoResult): InlineToken[][] {
 function storeActions(result: StoreInfoResult): LinkToken[] {
   const actions: LinkToken[] = []
   pushAction(actions, result.adminUrl, 'Manage this store in the Shopify admin')
-  pushAction(actions, result.accessUrl, 'View the storefront')
-  pushAction(actions, result.saveUrl, 'Save your progress on this store')
+  pushAction(actions, result.accessUrl, 'View your store')
+  pushAction(actions, result.saveUrl, 'Save your store')
   return actions
 }
 


### PR DESCRIPTION
## What this does

Renames the last two `store info` next-step action labels for consistent language:

- `View the storefront` → **View your store**
- `Save your progress on this store` → **Save your store**

(The first action label, "Manage this store in the Shopify admin", is unchanged.)

This follows design feedback in [this thread](https://shopify.slack.com/archives/C0B242KDQPN/p1782392826077199?thread_ts=1782296582.126859&cid=C0B242KDQPN): Kei requested consistent phrasing ("View your store" / "Save your store"), and Nick confirmed "Works for me".

## Changes

- `packages/store/src/cli/services/store/info/result.ts` — updated the two action labels
- `packages/store/src/cli/services/store/info/result.test.ts` — updated expectations
- `.changeset/store-info-data-table.md` — updated the example copy to match (the changeset from #7914 is still unreleased)

## Testing

All 10 tests in `result.test.ts` pass.
