### PR TITLE
Cache Admin API scopes returned by preview store creation

### DIFF
--- a/packages/store/src/cli/services/store/create/preview/client.test.ts
+++ b/packages/store/src/cli/services/store/create/preview/client.test.ts
@@ -80,6 +80,7 @@ describe('preview store client', () => {
         shop: {id: 123, name: 'Lavender Candles', domain: 'x12y45z.myshopify.com'},
         placeholder_account_uuid: 'placeholder-uuid',
         admin_api_token: 'shpat_token',
+        admin_api_scopes: ['read_themes', 'write_themes'],
         access_url: 'https://app.shopify.com/auth/preview-store?token=access-token',
       }),
     )
@@ -106,8 +107,38 @@ describe('preview store client', () => {
       shop: {id: '123', name: 'Lavender Candles', domain: 'x12y45z.myshopify.com'},
       placeholderAccountUuid: 'placeholder-uuid',
       adminApiToken: 'shpat_token',
+      adminApiScopes: ['read_themes', 'write_themes'],
       accessUrl: 'https://app.shopify.com/auth/preview-store?token=access-token',
     })
+  })
+
+  test('rejects the response when the backend omits admin API scopes', async () => {
+    vi.mocked(shopifyFetch).mockResolvedValueOnce(
+      response(201, {
+        shop: {id: 123, name: 'My Store', domain: 'x.myshopify.com'},
+        admin_api_token: 'shpat_token',
+        access_url: 'https://app.shopify.com/auth/preview-store?token=access-token',
+      }),
+    )
+
+    await expect(createPreviewStore({}, {storage: inMemoryStorage('instance-1')})).rejects.toThrow(
+      'Preview store creation response is missing required fields.',
+    )
+  })
+
+  test('drops non-string admin API scopes', async () => {
+    vi.mocked(shopifyFetch).mockResolvedValueOnce(
+      response(201, {
+        shop: {id: 123, name: 'My Store', domain: 'x.myshopify.com'},
+        admin_api_token: 'shpat_token',
+        admin_api_scopes: ['read_themes', 42, null, 'write_themes'],
+        access_url: 'https://app.shopify.com/auth/preview-store?token=access-token',
+      }),
+    )
+
+    const got = await createPreviewStore({}, {storage: inMemoryStorage('instance-1')})
+
+    expect(got.adminApiScopes).toEqual(['read_themes', 'write_themes'])
   })
 
   test('omits name and country variables when absent', async () => {
@@ -115,6 +146,7 @@ describe('preview store client', () => {
       response(201, {
         shop: {id: 123, name: 'My Store', domain: 'x.myshopify.com'},
         admin_api_token: 'shpat_token',
+        admin_api_scopes: ['read_themes', 'write_themes'],
         access_url: 'https://app.shopify.com/auth/preview-store?token=access-token',
       }),
     )

--- a/packages/store/src/cli/services/store/create/preview/client.ts
+++ b/packages/store/src/cli/services/store/create/preview/client.ts
@@ -40,6 +40,7 @@ export interface PreviewStoreCreateResponse {
   shop: PreviewStoreResponseShop
   placeholderAccountUuid?: string
   adminApiToken: string
+  adminApiScopes: string[]
   accessUrl: string
 }
 
@@ -53,6 +54,7 @@ interface RawPreviewStoreCreateResponse {
   shop?: RawPreviewStoreResponseShop
   placeholder_account_uuid?: unknown
   admin_api_token?: unknown
+  admin_api_scopes?: unknown
   access_url?: unknown
 }
 
@@ -320,8 +322,13 @@ function narrowCreateResponse(parsed: RawPreviewStoreCreateResponse): PreviewSto
   const accessUrl = typeof parsed.access_url === 'string' ? parsed.access_url : undefined
   const placeholderAccountUuid =
     typeof parsed.placeholder_account_uuid === 'string' ? parsed.placeholder_account_uuid : undefined
+  // The backend always returns `admin_api_scopes` for the granted Admin API token, so it is a
+  // required field. We still filter out any non-string entries defensively.
+  const adminApiScopes = Array.isArray(parsed.admin_api_scopes)
+    ? parsed.admin_api_scopes.filter((scope): scope is string => typeof scope === 'string')
+    : undefined
 
-  if (!id || !name || !domain || !adminApiToken || !accessUrl) {
+  if (!id || !name || !domain || !adminApiToken || !accessUrl || !adminApiScopes) {
     throw new AbortError(
       'Preview store creation response is missing required fields.',
       `Got: ${JSON.stringify(redactPreviewStoreResponse(parsed)).slice(0, 500)}`,
@@ -331,6 +338,7 @@ function narrowCreateResponse(parsed: RawPreviewStoreCreateResponse): PreviewSto
   return {
     shop: {id, name, domain},
     adminApiToken,
+    adminApiScopes,
     accessUrl,
     ...(placeholderAccountUuid ? {placeholderAccountUuid} : {}),
   }

--- a/packages/store/src/cli/services/store/create/preview/index.test.ts
+++ b/packages/store/src/cli/services/store/create/preview/index.test.ts
@@ -15,6 +15,7 @@ describe('preview store create service', () => {
           shop: {id: '123', name: 'Lavender Candles', domain: 'x12y45z.myshopify.com'},
           placeholderAccountUuid: 'placeholder-uuid',
           adminApiToken: 'shpat_token',
+          adminApiScopes: ['read_themes', 'write_themes'],
           accessUrl: 'https://app.shopify.com/auth/preview-store?token=access-token',
         })),
         setStoredStoreAppSession,
@@ -29,7 +30,7 @@ describe('preview store create service', () => {
       clientId: STORE_AUTH_APP_CLIENT_ID,
       userId: `${PREVIEW_USER_ID_PREFIX}placeholder-uuid`,
       accessToken: 'shpat_token',
-      scopes: [],
+      scopes: ['read_themes', 'write_themes'],
       acquiredAt: '2026-06-08T12:00:00.000Z',
       kind: 'preview',
       preview: {
@@ -68,6 +69,7 @@ describe('preview store create service', () => {
         createPreviewStore: vi.fn(async () => ({
           shop: {id: '123', name: 'Lavender Candles', domain: 'x12y45z.myshopify.com'},
           adminApiToken: 'shpat_token',
+          adminApiScopes: [],
           accessUrl: 'https://app.shopify.com/auth/preview-store?token=access-token',
         })),
         setStoredStoreAppSession,
@@ -78,7 +80,7 @@ describe('preview store create service', () => {
     )
 
     expect(setStoredStoreAppSession).toHaveBeenCalledWith(
-      expect.objectContaining({userId: `${PREVIEW_USER_ID_PREFIX}123`}),
+      expect.objectContaining({userId: `${PREVIEW_USER_ID_PREFIX}123`, scopes: []}),
     )
     expect(setLastSeenUserId).toHaveBeenCalledWith(`${PREVIEW_USER_ID_PREFIX}123`)
   })
@@ -88,6 +90,7 @@ describe('preview store create service', () => {
     const createPreviewStore = vi.fn(async () => ({
       shop: {id: '123', name: 'Lavender Candles', domain: 'x12y45z.myshopify.com'},
       adminApiToken: 'shpat_token',
+      adminApiScopes: [],
       accessUrl: 'https://app.shopify.com/auth/preview-store?token=access-token',
     }))
 
@@ -118,6 +121,7 @@ describe('preview store create service', () => {
         createPreviewStore: vi.fn(async () => ({
           shop: {id: '123', name: 'Lavender Candles', domain: 'x12y45z.myshopify.com'},
           adminApiToken: 'shpat_token',
+          adminApiScopes: [],
           accessUrl: 'https://app.shopify.com/auth/preview-store?token=access-token',
         })),
         setStoredStoreAppSession,

--- a/packages/store/src/cli/services/store/create/preview/index.ts
+++ b/packages/store/src/cli/services/store/create/preview/index.ts
@@ -73,7 +73,7 @@ async function persistPreviewStoreSession(
     clientId: STORE_AUTH_APP_CLIENT_ID,
     userId,
     accessToken: response.adminApiToken,
-    scopes: [],
+    scopes: response.adminApiScopes,
     acquiredAt,
     kind: 'preview',
     preview: {


### PR DESCRIPTION
### WHY are these changes introduced?

Preview stores aren't a logged-in experience, so the Admin API scopes granted to their token are fixed at creation time — there's no OAuth flow to grant more later. Following [shop/world#869091](https://github.com/shop/world/pull/869091), the preview store creation API now returns an `admin_api_scopes` field alongside the `admin_api_token`. The CLI needs to capture and persist those scopes (just like `store auth` stashes granted scopes) so later commands can surface what the token is actually allowed to do.

This is the first PR in a stack:
1. **#7948 (this PR)** — Cache the Admin API scopes returned by preview store creation.
2. **#7949** — Surface those scopes in `store info --json`.
3. **#7950** — Exit `store auth` early for preview stores, listing the preapproved scopes.

### WHAT is this pull request doing?

- `client.ts`: parse the new `admin_api_scopes` field from the preview store create response into `adminApiScopes: string[]` on `PreviewStoreCreateResponse`. The field is treated as **required** (assuming an updated backend) — a response missing it throws `"Preview store creation response is missing required fields."`, consistent with the other required fields. Non-string entries are filtered out defensively, and an empty array is accepted.
- `index.ts`: persist `response.adminApiScopes` into the local `StoredStoreAppSession` cache (`scopes:`) instead of the previously hardcoded empty array, mirroring how `store auth` caches granted scopes.

No changeset — preview stores aren't released yet, and this only changes cached data (no user-visible behavior).

### How to test your changes?

1. Create a preview store from the CLI against a backend that returns `admin_api_scopes`.
2. Confirm the cached store-auth session for that store now carries the returned scopes.

Unit tests cover: parsing the scopes, rejecting a response that omits the field, dropping non-string entries, and persisting the scopes into the session cache.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [x] The change is user-facing — I've identified the correct bump type and added a changeset. _(N/A — preview stores aren't released; no user-visible behavior.)_
