### PR TITLE
Surface preview store auth scopes in store info --json

### DIFF
--- a/packages/store/src/cli/services/store/info/index.test.ts
+++ b/packages/store/src/cli/services/store/info/index.test.ts
@@ -188,9 +188,40 @@ describe('getStoreInfo', () => {
       subdomain: SHOP,
       accessUrl: 'https://app.shopify.com/auth/preview-store?token=fresh-access-token',
       saveUrl: 'https://admin.shopify.com/store-transfer/accept/claim-token',
+      authScopes: [],
     })
     // The admin URL doesn't resolve for an unclaimed preview store, so it's deliberately omitted.
     expect(result.adminUrl).toBeUndefined()
+  })
+
+  test('surfaces cached Admin API scopes for locally stored preview stores', async () => {
+    vi.mocked(getCurrentStoredStoreAppSession).mockReturnValueOnce({
+      store: SHOP,
+      clientId: STORE_AUTH_APP_CLIENT_ID,
+      userId: 'preview:placeholder-uuid',
+      accessToken: 'shpat_preview_token',
+      scopes: ['read_themes', 'write_themes'],
+      acquiredAt: '2026-06-08T12:00:00.000Z',
+      kind: 'preview',
+      preview: {
+        placeholderAccountUuid: 'placeholder-uuid',
+        shopId: '123',
+        name: 'Lavender Candles',
+        createdAt: '2026-06-08T12:00:00.000Z',
+        accessUrl: 'https://app.shopify.com/auth/preview-store?token=stale-access-token',
+      },
+    })
+    vi.mocked(claimPreviewStore).mockResolvedValueOnce({
+      claimUrl: 'https://admin.shopify.com/store-transfer/accept/claim-token',
+    })
+    vi.mocked(getPreviewStore).mockResolvedValueOnce({
+      shop: {id: '123', name: 'Lavender Candles', domain: SHOP},
+      accessUrl: 'https://app.shopify.com/auth/preview-store?token=fresh-access-token',
+    })
+
+    const result = await getStoreInfo({store: SHOP})
+
+    expect(result.authScopes).toEqual(['read_themes', 'write_themes'])
   })
 
   test('prefers BP when store auth exists and BP can resolve the store', async () => {

--- a/packages/store/src/cli/services/store/info/index.ts
+++ b/packages/store/src/cli/services/store/info/index.ts
@@ -251,7 +251,9 @@ function buildPreviewStoreResult(args: {
     saveUrl: previewStoreUrls.saveUrl,
   }
 
-  return {...compact(fields), subdomain: store} as StoreInfoResult
+  // `authScopes` is always present for preview stores (even when empty) so consumers can rely on the
+  // key to learn which Admin API scopes are preapproved. There's no way to grant more scopes later.
+  return {...compact(fields), subdomain: store, authScopes: previewSession.scopes} as StoreInfoResult
 }
 
 // The BP `ShopifyShopID` scalar is the bare numeric id; the admin GID is derived locally.

--- a/packages/store/src/cli/services/store/info/result.test.ts
+++ b/packages/store/src/cli/services/store/info/result.test.ts
@@ -73,6 +73,13 @@ describe('renderStoreInfoResult', () => {
     expect(renderInfo).not.toHaveBeenCalled()
   })
 
+  test('includes authScopes in the JSON output when present', () => {
+    renderStoreInfoResult(baseResult({authScopes: ['read_themes', 'write_themes']}), 'json')
+
+    const payload = vi.mocked(outputResult).mock.calls[0]?.[0] as string
+    expect(JSON.parse(payload).authScopes).toEqual(['read_themes', 'write_themes'])
+  })
+
   test('renders a Store details section in text format', () => {
     renderStoreInfoResult(baseResult(), 'text')
 

--- a/packages/store/src/cli/services/store/info/types.ts
+++ b/packages/store/src/cli/services/store/info/types.ts
@@ -28,6 +28,10 @@ export interface StoreInfoResult {
   adminUrl?: string
   accessUrl?: string
   saveUrl?: string
+  // Preapproved Admin API access scopes for the store (currently only preview stores, which
+  // cache the scopes granted at creation time). Preview stores aren't a logged-in experience, so
+  // there's no way to grant additional scopes later.
+  authScopes?: string[]
 }
 
 /**


### PR DESCRIPTION
### WHY are these changes introduced?

Preview stores cache the Admin API scopes granted at creation time (see #7948). Since preview stores aren't a logged-in experience, those scopes are fixed and there's no way to grant more later. Consumers — especially agents driving the CLI — need a reliable way to discover which scopes are preapproved without attempting an auth flow that can't work.

Second PR in the stack:
1. **#7948** — Cache the Admin API scopes returned by preview store creation.
2. **#7949 (this PR)** — Surface those scopes in `store info --json`.
3. **#7950** — Exit `store auth` early for preview stores, listing the preapproved scopes.

### WHAT is this pull request doing?

- `types.ts`: add an optional `authScopes?: string[]` field to `StoreInfoResult`, documenting that it carries the preapproved Admin API scopes (currently only for preview stores).
- `info/index.ts`: `buildPreviewStoreResult` now always emits `authScopes` from the cached preview session scopes — even when empty — so `--json` consumers can reliably rely on the key being present.

No changeset — preview stores aren't released yet.

### How to test your changes?

1. Create a preview store from the CLI (so its scopes are cached).
2. Run `shopify store info --store <preview-store> --json`.
3. Confirm the output includes an `authScopes` array with the preapproved scopes.

Unit tests cover: surfacing cached scopes for a locally stored preview store, emitting the key when empty, and including `authScopes` in the JSON output.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [x] The change is user-facing — I've identified the correct bump type and added a changeset. _(N/A — preview stores aren't released yet.)_
