### PR TITLE
[Security] Harden client ID generation

### DIFF
--- a/packages/ui-extensions-server-kit/src/ExtensionServerClient/ExtensionServerClient.test.ts
+++ b/packages/ui-extensions-server-kit/src/ExtensionServerClient/ExtensionServerClient.test.ts
@@ -188,6 +188,30 @@ describe('ExtensionServerClient', () => {
       expect(client.connection).toBeUndefined()
       expect(mockSocketServer.clients.length).toBe(0)
     })
+
+    test('generates a random UUID for the client id using crypto.randomUUID when available', () => {
+      const uuid = '12345678-1234-1234-1234-123456789012'
+      const randomUUIDSpy = vi.spyOn(globalThis.crypto, 'randomUUID').mockReturnValue(uuid)
+
+      const client = new ExtensionServerClient()
+
+      expect(client.id).toBe(uuid)
+      expect(randomUUIDSpy).toHaveBeenCalled()
+
+      randomUUIDSpy.mockRestore()
+    })
+
+    test('falls back to Math.random for the client id when crypto.randomUUID is not available', () => {
+      const originalCrypto = globalThis.crypto
+      delete (globalThis as any).crypto
+
+      const client = new ExtensionServerClient()
+
+      expect(client.id).toBeDefined()
+      expect(client.id.length).toBeLessThanOrEqual(10)
+
+      globalThis.crypto = originalCrypto
+    })
   })
 
   describe('on()', () => {

--- a/packages/ui-extensions-server-kit/src/ExtensionServerClient/ExtensionServerClient.ts
+++ b/packages/ui-extensions-server-kit/src/ExtensionServerClient/ExtensionServerClient.ts
@@ -32,7 +32,11 @@ export class ExtensionServerClient implements ExtensionServer.Client {
   private uiExtensionsByUuid: Record<string, ExtensionServer.UIExtension> = {}
 
   constructor(options: DeepPartial<ExtensionServer.Options> = {}) {
-    this.id = (Math.random() + 1).toString(36).substring(7)
+    // Use a cryptographically secure random number generator if available to avoid predictable IDs
+    this.id =
+      typeof globalThis.crypto?.randomUUID === 'function'
+        ? globalThis.crypto.randomUUID()
+        : (Math.random() + 1).toString(36).substring(7)
     this.options = getValidatedOptions({
       ...options,
       connection: {


### PR DESCRIPTION
### WHY are these changes introduced?

Hardens the generation of client identifiers to prevent predictability.

### WHAT is this pull request doing?

Replaces `Math.random()` with `globalThis.crypto.randomUUID()` for generating client IDs in `ExtensionServerClient`. This ensures that IDs are cryptographically secure when the environment supports it.

### How to test your changes?

CI

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [8128284611905294970](https://jules.google.com/task/8128284611905294970) started by @gonzaloriestra*