### PR TITLE
[Performance] Memoize hasGit check in cli-kit

### DIFF
--- a/packages/cli-kit/src/public/node/context/local.test.ts
+++ b/packages/cli-kit/src/public/node/context/local.test.ts
@@ -9,6 +9,7 @@ import {
   cloudEnvironment,
   macAddress,
   getThemeKitAccessDomain,
+  _resetHasGit,
   opentelemetryDomain,
 } from './local.js'
 import {fileExists} from '../fs.js'
@@ -123,6 +124,10 @@ describe('isShopify', () => {
 })
 
 describe('hasGit', () => {
+  afterEach(() => {
+    _resetHasGit()
+  })
+
   test('returns false if git --version errors', async () => {
     // Given
     vi.mocked(exec).mockRejectedValue(new Error('git not found'))
@@ -132,6 +137,7 @@ describe('hasGit', () => {
 
     // Then
     expect(got).toBeFalsy()
+    expect(exec).toHaveBeenCalledWith('git', ['--version'])
   })
 
   test('returns true if git --version succeeds', async () => {
@@ -143,6 +149,19 @@ describe('hasGit', () => {
 
     // Then
     expect(got).toBeTruthy()
+    expect(exec).toHaveBeenCalledWith('git', ['--version'])
+  })
+
+  test('memoizes the result', async () => {
+    // Given
+    vi.mocked(exec).mockResolvedValue(undefined)
+
+    // When
+    await hasGit()
+    await hasGit()
+
+    // Then
+    expect(exec).toHaveBeenCalledTimes(1)
   })
 })
 

--- a/packages/cli-kit/src/public/node/context/local.ts
+++ b/packages/cli-kit/src/public/node/context/local.ts
@@ -45,6 +45,11 @@ let memoizedIsVerbose: boolean | undefined
 let memoizedIsUnitTest: boolean | undefined
 
 /**
+ * Memoized value for the hasGit check.
+ */
+let memoizedHasGit: Promise<boolean> | undefined
+
+/**
  * Returns true if the CLI is running in debug mode.
  *
  * @param env - The environment variables from the environment of the current process.
@@ -237,13 +242,23 @@ export function cloudEnvironment(env: NodeJS.ProcessEnv = process.env): {
  * @returns A promise that resolves with the value.
  */
 export async function hasGit(): Promise<boolean> {
-  try {
-    await lazyExec('git', ['--version'])
-    return true
-    // eslint-disable-next-line no-catch-all/no-catch-all
-  } catch {
-    return false
-  }
+  return (memoizedHasGit ??= (async () => {
+    try {
+      await lazyExec('git', ['--version'])
+      return true
+      // eslint-disable-next-line no-catch-all/no-catch-all
+    } catch {
+      return false
+    }
+  })())
+}
+
+/**
+ * Resets the memoized hasGit value.
+ * This is useful for testing.
+ */
+export function _resetHasGit(): void {
+  memoizedHasGit = undefined
 }
 
 /**


### PR DESCRIPTION
### WHY are these changes introduced?
The `hasGit` function in `cli-kit` executes `git --version` every time it's called. Spawning a child process is relatively expensive. In commands that perform multiple environment checks or analytics collection, this redundant execution can measurably slow down the CLI.

### WHAT is this pull request doing?
Memoizes the result of `hasGit()` using a module-level promise. This ensures that `git --version` is executed at most once during the CLI's execution. Subsequent calls will return the cached result.
Includes an exported `_resetHasGit()` utility to maintain test isolation.

### How to test your changes?
CI

### Checklist
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible documentation changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct bump type and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [9108386419192763021](https://jules.google.com/task/9108386419192763021) started by @gonzaloriestra*