### PR TITLE
Add `shopify store open` command

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -84,6 +84,7 @@
 * [`shopify store bulk status`](#shopify-store-bulk-status)
 * [`shopify store execute`](#shopify-store-execute)
 * [`shopify store info`](#shopify-store-info)
+* [`shopify store open`](#shopify-store-open)
 * [`shopify theme check`](#shopify-theme-check)
 * [`shopify theme console`](#shopify-theme-console)
 * [`shopify theme delete`](#shopify-theme-delete)
@@ -2386,6 +2387,28 @@ EXAMPLES
   $ shopify store info --store shop.myshopify.com
 
   $ shopify store info --store shop.myshopify.com --json
+```
+
+## `shopify store open`
+
+Open your Shopify store in the default web browser.
+
+```
+USAGE
+  $ shopify store open -s <value> [--no-color] [--verbose]
+
+FLAGS
+  -s, --store=<value>  (required) [env: SHOPIFY_FLAG_STORE] The myshopify.com domain of the store.
+      --no-color       [env: SHOPIFY_FLAG_NO_COLOR] Disable color output.
+      --verbose        [env: SHOPIFY_FLAG_VERBOSE] Increase the verbosity of the output.
+
+DESCRIPTION
+  Open your Shopify store in the default web browser.
+
+  Opens the storefront for a store you have access to in your default web browser.
+
+EXAMPLES
+  $ shopify store open --store shop.myshopify.com
 ```
 
 ## `shopify theme check`

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -84,7 +84,6 @@
 * [`shopify store bulk status`](#shopify-store-bulk-status)
 * [`shopify store execute`](#shopify-store-execute)
 * [`shopify store info`](#shopify-store-info)
-* [`shopify store open`](#shopify-store-open)
 * [`shopify theme check`](#shopify-theme-check)
 * [`shopify theme console`](#shopify-theme-console)
 * [`shopify theme delete`](#shopify-theme-delete)
@@ -2387,28 +2386,6 @@ EXAMPLES
   $ shopify store info --store shop.myshopify.com
 
   $ shopify store info --store shop.myshopify.com --json
-```
-
-## `shopify store open`
-
-Open your Shopify store in the default web browser.
-
-```
-USAGE
-  $ shopify store open -s <value> [--no-color] [--verbose]
-
-FLAGS
-  -s, --store=<value>  (required) [env: SHOPIFY_FLAG_STORE] The myshopify.com domain of the store.
-      --no-color       [env: SHOPIFY_FLAG_NO_COLOR] Disable color output.
-      --verbose        [env: SHOPIFY_FLAG_VERBOSE] Increase the verbosity of the output.
-
-DESCRIPTION
-  Open your Shopify store in the default web browser.
-
-  Opens the storefront for a store you have access to in your default web browser.
-
-EXAMPLES
-  $ shopify store open --store shop.myshopify.com
 ```
 
 ## `shopify theme check`

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -6617,6 +6617,7 @@
         }
       },
       "hasDynamicHelp": false,
+      "hidden": true,
       "hiddenAliases": [
       ],
       "id": "store:open",

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -6577,6 +6577,55 @@
       "strict": true,
       "summary": "List stores in a Shopify organization."
     },
+    "store:open": {
+      "aliases": [
+      ],
+      "args": {
+      },
+      "customPluginName": "@shopify/store",
+      "description": "Opens the storefront for a store you have access to in your default web browser.",
+      "descriptionWithMarkdown": "Opens the storefront for a store you have access to in your default web browser.",
+      "examples": [
+        "<%= config.bin %> <%= command.id %> --store shop.myshopify.com"
+      ],
+      "flags": {
+        "no-color": {
+          "allowNo": false,
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
+          "type": "boolean"
+        },
+        "store": {
+          "char": "s",
+          "description": "The myshopify.com domain of the store.",
+          "env": "SHOPIFY_FLAG_STORE",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "store",
+          "required": true,
+          "type": "option"
+        },
+        "verbose": {
+          "allowNo": false,
+          "description": "Increase the verbosity of the output.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [
+      ],
+      "id": "store:open",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "summary": "Open your Shopify store in the default web browser."
+    },
     "theme:check": {
       "aliases": [
       ],

--- a/packages/store/src/cli/commands/store/open.test.ts
+++ b/packages/store/src/cli/commands/store/open.test.ts
@@ -1,0 +1,17 @@
+import StoreOpen from './open.js'
+import {openStore} from '../../services/store/open.js'
+import {describe, expect, test, vi} from 'vitest'
+
+vi.mock('../../services/store/open.js')
+
+describe('store open command', () => {
+  test('passes the store flag through to the service', async () => {
+    await StoreOpen.run(['--store', 'shop.myshopify.com'])
+
+    expect(openStore).toHaveBeenCalledWith({store: 'shop.myshopify.com'})
+  })
+
+  test('defines the expected flags', () => {
+    expect(StoreOpen.flags.store).toBeDefined()
+  })
+})

--- a/packages/store/src/cli/commands/store/open.ts
+++ b/packages/store/src/cli/commands/store/open.ts
@@ -4,6 +4,8 @@ import {storeFlags} from '../../flags.js'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
 
 export default class StoreOpen extends StoreCommand {
+  static hidden = true
+
   static summary = 'Open your Shopify store in the default web browser.'
 
   static descriptionWithMarkdown = `Opens the storefront for a store you have access to in your default web browser.`

--- a/packages/store/src/cli/commands/store/open.ts
+++ b/packages/store/src/cli/commands/store/open.ts
@@ -1,0 +1,25 @@
+import {openStore} from '../../services/store/open.js'
+import StoreCommand from '../../utilities/store-command.js'
+import {storeFlags} from '../../flags.js'
+import {globalFlags} from '@shopify/cli-kit/node/cli'
+
+export default class StoreOpen extends StoreCommand {
+  static summary = 'Open your Shopify store in the default web browser.'
+
+  static descriptionWithMarkdown = `Opens the storefront for a store you have access to in your default web browser.`
+
+  static description = this.descriptionWithoutMarkdown()
+
+  static examples = ['<%= config.bin %> <%= command.id %> --store shop.myshopify.com']
+
+  static flags = {
+    ...globalFlags,
+    store: storeFlags.store,
+  }
+
+  public async run(): Promise<void> {
+    const {flags} = await this.parse(StoreOpen)
+
+    await openStore({store: flags.store})
+  }
+}

--- a/packages/store/src/cli/services/store/open.test.ts
+++ b/packages/store/src/cli/services/store/open.test.ts
@@ -1,0 +1,49 @@
+import {openStore} from './open.js'
+import {getStoreInfo} from './info/index.js'
+import {openURL} from '@shopify/cli-kit/node/system'
+import {renderInfo} from '@shopify/cli-kit/node/ui'
+import {beforeEach, describe, expect, test, vi} from 'vitest'
+
+vi.mock('./info/index.js')
+vi.mock('@shopify/cli-kit/node/system')
+vi.mock('@shopify/cli-kit/node/ui')
+
+describe('openStore', () => {
+  beforeEach(() => {
+    vi.mocked(openURL).mockResolvedValue(true)
+  })
+
+  test('opens the canonical storefront URL for a regular store', async () => {
+    vi.mocked(getStoreInfo).mockResolvedValue({subdomain: 'shop.myshopify.com'})
+
+    await openStore({store: 'shop.myshopify.com'})
+
+    expect(getStoreInfo).toHaveBeenCalledWith({store: 'shop.myshopify.com'})
+    expect(openURL).toHaveBeenCalledWith('https://shop.myshopify.com')
+    expect(renderInfo).toHaveBeenCalledWith(
+      expect.objectContaining({headline: expect.stringContaining('Opening the storefront')}),
+    )
+  })
+
+  test('prefers the preview-store access URL when present', async () => {
+    vi.mocked(getStoreInfo).mockResolvedValue({
+      subdomain: 'preview.myshopify.com',
+      accessUrl: 'https://preview.myshopify.com/?token=abc',
+    })
+
+    await openStore({store: 'preview.myshopify.com'})
+
+    expect(openURL).toHaveBeenCalledWith('https://preview.myshopify.com/?token=abc')
+  })
+
+  test('prints the URL manually when the browser does not open', async () => {
+    vi.mocked(getStoreInfo).mockResolvedValue({subdomain: 'shop.myshopify.com'})
+    vi.mocked(openURL).mockResolvedValue(false)
+
+    await openStore({store: 'shop.myshopify.com'})
+
+    expect(renderInfo).toHaveBeenCalledWith(
+      expect.objectContaining({headline: expect.stringContaining("didn't open automatically")}),
+    )
+  })
+})

--- a/packages/store/src/cli/services/store/open.ts
+++ b/packages/store/src/cli/services/store/open.ts
@@ -1,0 +1,48 @@
+import {getStoreInfo} from './info/index.js'
+import {openURL as defaultOpenURL} from '@shopify/cli-kit/node/system'
+import {renderInfo} from '@shopify/cli-kit/node/ui'
+import {outputContent, outputToken} from '@shopify/cli-kit/node/output'
+import type {StoreInfoResult} from './info/types.js'
+
+interface OpenStoreOptions {
+  store: string
+}
+
+interface OpenStoreDependencies {
+  getStoreInfo: typeof getStoreInfo
+  openURL: typeof defaultOpenURL
+}
+
+const defaultDependencies: OpenStoreDependencies = {
+  getStoreInfo,
+  openURL: defaultOpenURL,
+}
+
+/**
+ * Opens a store's storefront in the default browser.
+ */
+export async function openStore(
+  options: OpenStoreOptions,
+  dependencies: Partial<OpenStoreDependencies> = {},
+): Promise<void> {
+  const {getStoreInfo: getInfo, openURL} = {...defaultDependencies, ...dependencies}
+
+  const info = await getInfo({store: options.store})
+  const url = storefrontUrl(info)
+
+  const opened = await openURL(url)
+  if (opened) {
+    renderInfo({headline: `Opening the storefront for ${options.store} in your browser.`})
+    return
+  }
+
+  renderInfo({
+    headline: `Browser didn't open automatically. Open the storefront manually:`,
+    body: [outputContent`${outputToken.link(url, url)}`.value],
+  })
+}
+
+function storefrontUrl(info: StoreInfoResult): string {
+  // Preview stores surface a tokenized access URL; everyone else resolves to the canonical domain.
+  return info.accessUrl ?? `https://${info.subdomain}`
+}

--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -8,6 +8,7 @@ import StoreCreatePreview from './cli/commands/store/create/preview.js'
 import StoreExecute from './cli/commands/store/execute.js'
 import StoreInfo from './cli/commands/store/info.js'
 import StoreList from './cli/commands/store/list.js'
+import StoreOpen from './cli/commands/store/open.js'
 
 export {loadAdminSessionFromStoreAuth} from './cli/services/store/auth/admin-session.js'
 
@@ -22,6 +23,7 @@ const COMMANDS = {
   'store:execute': StoreExecute,
   'store:info': StoreInfo,
   'store:list': StoreList,
+  'store:open': StoreOpen,
 }
 
 export default COMMANDS


### PR DESCRIPTION
### WHY are these changes introduced?

Opening a store today means hunting for the right URL. Agents and humans working with stores (especially preview stores, which surface long tokenized access URLs) need a quick, reliable way to jump straight into a storefront without copying URLs around by hand.

This implements the `shopify store open` design shared in #proj-agentic-store-preview.

### WHAT is this pull request doing?

Adds a new `shopify store open --store <domain>` command that opens a store's storefront in your default browser.

- New command: `packages/store/src/cli/commands/store/open.ts`
- New service `openStore()`: `packages/store/src/cli/services/store/open.ts`
- Registered as `store:open` in `packages/store/src/index.ts`

URL resolution goes through the existing `getStoreInfo` service rather than naively building a URL from the domain string. This matters for preview stores, which expose a tokenized `accessUrl` that can't be reconstructed from the domain alone. Regular stores resolve to `https://<subdomain>`. If the browser can't auto-open (e.g. cloud/headless environments), the command prints a clickable URL instead.

### How to test your changes?

1. `shopify store open --store <your-store>.myshopify.com` — opens the storefront.
2. Try with a preview store — confirm it opens the tokenized access URL.
3. In an environment where the browser can't open, confirm a clickable URL is printed.

Unit tests: `pnpm exec vitest run packages/store/src/cli/services/store/open.test.ts`

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible documentation changes
- [ ] I've considered analytics changes to measure impact
- [x] The change is user-facing — added a `minor` changeset
