### PR TITLE
[Security] Harden client ID generation in ExtensionServerClient

### DIFF
--- a/packages/ui-extensions-server-kit/src/ExtensionServerClient/ExtensionServerClient.test.ts
+++ b/packages/ui-extensions-server-kit/src/ExtensionServerClient/ExtensionServerClient.test.ts
@@ -188,6 +188,28 @@ describe('ExtensionServerClient', () => {
       expect(client.connection).toBeUndefined()
       expect(mockSocketServer.clients.length).toBe(0)
     })
+
+    test('uses crypto.randomUUID for id generation when available', () => {
+      const uuid = '12345678-1234-1234-1234-123456789012'
+      vi.stubGlobal('crypto', {
+        randomUUID: () => uuid,
+      })
+
+      const client = new ExtensionServerClient()
+      expect(client.id).toBe(uuid)
+
+      vi.unstubAllGlobals()
+    })
+
+    test('falls back to Math.random for id generation when crypto.randomUUID is not available', () => {
+      vi.stubGlobal('crypto', undefined)
+
+      const client = new ExtensionServerClient()
+      expect(client.id).toBeDefined()
+      expect(client.id.length).toBeGreaterThan(0)
+
+      vi.unstubAllGlobals()
+    })
   })
 
   describe('on()', () => {

--- a/packages/ui-extensions-server-kit/src/ExtensionServerClient/ExtensionServerClient.ts
+++ b/packages/ui-extensions-server-kit/src/ExtensionServerClient/ExtensionServerClient.ts
@@ -32,7 +32,11 @@ export class ExtensionServerClient implements ExtensionServer.Client {
   private uiExtensionsByUuid: Record<string, ExtensionServer.UIExtension> = {}
 
   constructor(options: DeepPartial<ExtensionServer.Options> = {}) {
-    this.id = (Math.random() + 1).toString(36).substring(7)
+    // We use a CSPRNG for ID generation where available to prevent predictability.
+    this.id =
+      typeof globalThis.crypto?.randomUUID === 'function'
+        ? globalThis.crypto.randomUUID()
+        : (Math.random() + 1).toString(36).substring(7)
     this.options = getValidatedOptions({
       ...options,
       connection: {


### PR DESCRIPTION
### WHY are these changes introduced?

The `ExtensionServerClient` was using `Math.random()` for ID generation, which is not cryptographically secure and can lead to predictable identifiers.

### WHAT is this pull request doing?

This PR hardens the client ID generation by using `globalThis.crypto.randomUUID()` (CSPRNG) when available. It maintains a fallback to the original `Math.random()` logic for compatibility with environments that do not support the Web Crypto API.

### How to test your changes?

CI

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [4903850465924769794](https://jules.google.com/task/4903850465924769794) started by @gonzaloriestra*