### PR TITLE
[Performance] Memoize getPackageManager result

### DIFF
--- a/packages/cli-kit/src/public/node/node-package-manager.test.ts
+++ b/packages/cli-kit/src/public/node/node-package-manager.test.ts
@@ -23,9 +23,10 @@ import {
   PackageManager,
   npmLockfile,
   lockfilesByManager,
+  _resetPackageManagerCache,
 } from './node-package-manager.js'
 import {captureOutput, exec} from './system.js'
-import {inTemporaryDirectory, mkdir, touchFile, writeFile} from './fs.js'
+import {inTemporaryDirectory, mkdir, removeFile, touchFile, writeFile} from './fs.js'
 import {joinPath, dirname, normalizePath} from './path.js'
 import {inferPackageManagerForGlobalCLI} from './is-global.js'
 import {cacheClear} from '../../private/node/conf-store.js'
@@ -852,6 +853,28 @@ describe('writePackageJSON', () => {
 })
 
 describe('getPackageManager', () => {
+  afterEach(() => {
+    _resetPackageManagerCache()
+  })
+
+  test('memoizes the result', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      await writePackageJSON(tmpDir, {name: 'mock name'})
+      await writeFile(joinPath(tmpDir, 'yarn.lock'), '')
+
+      // When
+      const first = await getPackageManager(tmpDir)
+      // Remove the lockfile to ensure the second call doesn't find it if it's not memoized
+      await removeFile(joinPath(tmpDir, 'yarn.lock'))
+      const second = await getPackageManager(tmpDir)
+
+      // Then
+      expect(first).toEqual('yarn')
+      expect(second).toEqual('yarn')
+    })
+  })
+
   test('finds if npm is being used', async () => {
     await inTemporaryDirectory(async (tmpDir) => {
       // Given — pin NPM in the temp project

--- a/packages/cli-kit/src/public/node/node-package-manager.ts
+++ b/packages/cli-kit/src/public/node/node-package-manager.ts
@@ -2,7 +2,7 @@ import {AbortError, BugError} from './error.js'
 import {AbortController, AbortSignal} from './abort.js'
 import {exec} from './system.js'
 import {fileExists, readFile, writeFile, findPathUp, glob, fileExistsSync} from './fs.js'
-import {dirname, joinPath} from './path.js'
+import {dirname, joinPath, normalizePath} from './path.js'
 import {runWithTimer} from './metadata.js'
 import {inferPackageManagerForGlobalCLI} from './is-global.js'
 import {outputToken, outputContent, outputDebug} from './output.js'
@@ -142,6 +142,19 @@ function packageManagerBinaryCommand(
 }
 
 /**
+ * Memoized value for the package manager.
+ */
+let memoizedPackageManager: Map<string, PackageManager> = new Map()
+
+/**
+ * Resets the memoized package manager cache.
+ * This is useful for unit tests.
+ */
+export function _resetPackageManagerCache(): void {
+  memoizedPackageManager = new Map()
+}
+
+/**
  * Returns the dependency manager used in a directory.
  * Walks upward from `fromDirectory` so workspace packages (e.g. `extensions/my-fn/package.json`)
  * still resolve to the repo root lockfile (`pnpm-lock.yaml`).
@@ -151,24 +164,46 @@ function packageManagerBinaryCommand(
  * @returns The dependency manager
  */
 export async function getPackageManager(fromDirectory: string): Promise<PackageManager> {
+  const normalizedPath = normalizePath(fromDirectory)
+  if (memoizedPackageManager.has(normalizedPath)) {
+    return memoizedPackageManager.get(normalizedPath)!
+  }
+
+  let result: PackageManager = 'npm'
   let current = fromDirectory
   outputDebug(outputContent`Looking for a lockfile in ${outputToken.path(current)}...`)
   while (true) {
-    if (fileExistsSync(joinPath(current, yarnLockfile))) return 'yarn'
-    if (fileExistsSync(joinPath(current, pnpmLockfile)) || fileExistsSync(joinPath(current, pnpmWorkspaceFile))) {
-      return 'pnpm'
+    if (fileExistsSync(joinPath(current, yarnLockfile))) {
+      result = 'yarn'
+      break
     }
-    if (hasBunLockfileSync(current)) return 'bun'
-    if (fileExistsSync(joinPath(current, npmLockfile))) return 'npm'
+    if (fileExistsSync(joinPath(current, pnpmLockfile)) || fileExistsSync(joinPath(current, pnpmWorkspaceFile))) {
+      result = 'pnpm'
+      break
+    }
+    if (hasBunLockfileSync(current)) {
+      result = 'bun'
+      break
+    }
+    if (fileExistsSync(joinPath(current, npmLockfile))) {
+      result = 'npm'
+      break
+    }
     const parent = dirname(current)
-    if (parent === current) break
+    if (parent === current) {
+      const pm: PackageManager = packageManagerFromUserAgent()
+      if (pm === 'unknown') {
+        result = 'npm'
+      } else {
+        result = pm
+      }
+      break
+    }
     current = parent
   }
 
-  const pm: PackageManager = packageManagerFromUserAgent()
-  if (pm !== 'unknown') return pm
-
-  return 'npm'
+  memoizedPackageManager.set(normalizedPath, result)
+  return result
 }
 
 /**


### PR DESCRIPTION
### Why is this change necessary?
The `getPackageManager` function performs a recursive filesystem traversal to find a lockfile, which can be expensive when called repeatedly in deep directory structures or monorepos.

### How to test your changes?
CI

### Post-deployment tasks
None

---
*PR created automatically by Jules for task [14151923874589541598](https://jules.google.com/task/14151923874589541598) started by @gonzaloriestra*