### PR TITLE
[Refactor] Modernize errorHandler in cli-kit

### DIFF
--- a/packages/cli-kit/src/public/node/error-handler.test.ts
+++ b/packages/cli-kit/src/public/node/error-handler.test.ts
@@ -1,5 +1,6 @@
 import {errorHandler, cleanStackFrameFilePath, addBugsnagMetadata, sendErrorToBugsnag} from './error-handler.js'
 import * as metadata from './metadata.js'
+import {reportAnalyticsEvent} from './analytics.js'
 import {ciPlatform, cloudEnvironment, isUnitTest, macAddress} from './context/local.js'
 import {mockAndCaptureOutput} from './testing/output.js'
 import * as error from './error.js'
@@ -38,16 +39,22 @@ vi.mock('@bugsnag/js', () => {
   }
 })
 vi.mock('./cli.js')
+vi.mock('./analytics.js')
+vi.mock('./ui.js')
 vi.mock('./context/local.js')
 vi.mock('../../public/node/crypto.js')
 vi.mock('../../private/node/context/service.js')
 vi.mock('../../private/node/session.js')
-vi.mock('@oclif/core', () => ({
-  settings: {
-    debug: false,
-  },
-  Interfaces: {},
-}))
+vi.mock('@oclif/core', async (importOriginal) => {
+  const actual: any = await importOriginal()
+  return {
+    ...actual,
+    settings: {
+      debug: false,
+    },
+    Interfaces: {},
+  }
+})
 
 beforeEach(() => {
   vi.mocked(ciPlatform).mockReturnValue({isCI: true, name: 'vitest', metadata: {}})
@@ -64,6 +71,29 @@ beforeEach(() => {
 })
 
 describe('errorHandler', async () => {
+  test('handles generic errors', async () => {
+    // Given
+    const mockOutput = mockAndCaptureOutput()
+    const err = new Error('Generic error')
+    const config = {
+      runHook: vi.fn(),
+      plugins: [],
+    } as any
+
+    // When
+    await errorHandler(err, config)
+
+    // Then
+    expect(reportAnalyticsEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        errorMessage: 'Generic error',
+        exitMode: 'unexpected_error',
+      }),
+    )
+    expect(onNotify).toHaveBeenCalled()
+    expect(mockOutput.info()).toMatch('')
+  })
+
   test('finishes the execution without exiting the proccess when cancel execution exception is raised', async () => {
     // Given
     vi.spyOn(process, 'exit').mockResolvedValue(null as never)

--- a/packages/cli-kit/src/public/node/error-handler.ts
+++ b/packages/cli-kit/src/public/node/error-handler.ts
@@ -36,17 +36,15 @@ export async function errorHandler(
     if (error.message && error.message !== '') {
       outputInfo(`✨  ${error.message}`)
     }
-  } else if (error instanceof AbortSilentError) {
-    /* empty */
-  } else {
-    return errorMapper(error)
-      .then((error) => {
-        return handler(error)
-      })
-      .then((mappedError) => {
-        return reportError(mappedError, config)
-      })
+    return
   }
+  if (error instanceof AbortSilentError) {
+    return
+  }
+
+  const intermediateError = await errorMapper(error)
+  const mappedError = await handler(intermediateError)
+  return reportError(mappedError, config)
 }
 
 const reportError = async (error: unknown, config?: Interfaces.Config): Promise<void> => {


### PR DESCRIPTION
### WHY are these changes introduced?

The `errorHandler` function in `@shopify/cli-kit` used a nested `.then()` promise chain and complex `if/else if/else` nesting, which made it harder to read and maintain than modern `async/await` patterns.

### WHAT is this pull request doing?

- Refactors `errorHandler` in `packages/cli-kit/src/public/node/error-handler.ts` to use `async/await`.
- Simplifies the control flow using early returns to flatten the function structure.
- Adds a unit test in `packages/cli-kit/src/public/node/error-handler.test.ts` to verify generic error handling.
- Fixes the `@oclif/core` mock in tests to preserve original exports while overriding settings.

### How to test your changes?

CI

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [5284855694113462077](https://jules.google.com/task/5284855694113462077) started by @gonzaloriestra*