### PR TITLE
Re-enable extension generation E2E

### DIFF
--- a/packages/e2e/tests/app-scaffold.spec.ts
+++ b/packages/e2e/tests/app-scaffold.spec.ts
@@ -99,10 +99,7 @@ test.describe('App scaffold', () => {
     }
   })
 
-  // Extension generation hits businessPlatformOrganizationsRequest which returns 401
-  // even with a valid OAuth session. The Business Platform Organizations API token
-  // exchange needs investigation. OAuth login works, but this specific API rejects it.
-  test.skip('generate extensions and build', async ({cli, env, browserPage}) => {
+  test('generates extensions and builds', async ({cli, env, browserPage}) => {
     test.setTimeout(TEST_TIMEOUT.long)
     requireEnv(env, 'orgId')
 
@@ -127,7 +124,7 @@ test.describe('App scaffold', () => {
       appUrl = devDashboardAppUrl(appDir, env.orgId)
 
       const extensionConfigs = [
-        {name: 'test-product-sub', template: 'product_subscription_ui', flavor: 'react'},
+        {name: 'test-subscription-link', template: 'subscription_link_extension'},
         {name: 'test-theme-ext', template: 'theme_app_extension'},
       ]
 


### PR DESCRIPTION
### WHY are these changes introduced?

The app scaffold E2E suite had a skipped `generate extensions and build` test. The skip was tied to an old `product_subscription_ui` template path that is no longer present in the current extension template list and previously drove the test into Business Platform Organizations gating/auth behavior.

### WHAT is this pull request doing?

Re-enables the E2E and updates the subscription-related generated extension to use the current `subscription_link_extension` template. The test still generates a subscription-related extension plus a theme app extension, then builds the app.

### How to test your changes?

- `cd packages/e2e && pnpm tsc --noEmit`
- `cd packages/e2e && pnpm eslint "setup/**/*.ts" "helpers/**/*.ts" "tests/**/*.ts" "*.ts"`
- `node bin/run-knip-ci.js`

Note: ESLint completed successfully with existing Nx project graph cache warnings for `@nx/enforce-module-boundaries`. The PR E2E job will run the re-enabled network test with CI credentials.

### Post-release steps

None.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [x] The change is not user-facing; no changeset is needed.