### PR TITLE
Suggest `shopify store open` for previewing created preview store

### DIFF
--- a/packages/store/src/cli/services/store/create/preview/result.test.ts
+++ b/packages/store/src/cli/services/store/create/preview/result.test.ts
@@ -26,7 +26,7 @@ const result = {
 }
 
 describe('preview store create result presenter', () => {
-  test('writes JSON output with the storefront URL', () => {
+  test('writes JSON output with the next steps', () => {
     writeCreatePreviewStoreResult(result, 'json')
 
     expect(outputResult).toHaveBeenCalledWith(
@@ -43,7 +43,7 @@ describe('preview store create result presenter', () => {
             storefrontUrl: 'https://x12y45z.myshopify.com/?foo=bar',
           },
           next_steps: [
-            'Open your store (https://x12y45z.myshopify.com/?foo=bar) to preview the storefront.',
+            'Use `shopify store open --store x12y45z.myshopify.com` to preview the storefront.',
             'Use `shopify store execute --store x12y45z.myshopify.com` to add products, collections, pages, and more.',
             'Use `shopify theme pull --store x12y45z.myshopify.com` and `shopify theme push --store x12y45z.myshopify.com` to edit your store design.',
           ],
@@ -70,13 +70,8 @@ describe('preview store create result presenter', () => {
               list: {
                 items: [
                   [
-                    'Open ',
-                    {
-                      link: {
-                        label: 'your store',
-                        url: 'https://x12y45z.myshopify.com/?foo=bar',
-                      },
-                    },
+                    'Use ',
+                    {command: 'shopify store open --store x12y45z.myshopify.com'},
                     ' to preview the storefront.',
                   ],
                   [

--- a/packages/store/src/cli/services/store/create/preview/result.ts
+++ b/packages/store/src/cli/services/store/create/preview/result.ts
@@ -32,8 +32,8 @@ function serializeAsJson(result: CreatePreviewStoreResult) {
 function previewStoreNextSteps(result: CreatePreviewStoreResult): PreviewStoreNextStep[] {
   return [
     {
-      json: `Open your store (${result.store.storefrontUrl}) to preview the storefront.`,
-      text: ['Open ', {link: {label: 'your store', url: result.store.storefrontUrl}}, ' to preview the storefront.'],
+      json: `Use \`shopify store open --store ${result.store.subdomain}\` to preview the storefront.`,
+      text: ['Use ', {command: `shopify store open --store ${result.store.subdomain}`}, ' to preview the storefront.'],
     },
     {
       json: `Use \`shopify store execute --store ${result.store.subdomain}\` to add products, collections, pages, and more.`,


### PR DESCRIPTION
### WHY are these changes introduced?

When `shopify store create preview` finishes, the first suggested next step was to open a raw storefront URL. For preview stores that link can be tokenized/unresolved, and it doesn't give users (or agents) a repeatable, copyable command. Now that `shopify store open` exists, the next-steps output should point at that command so previewing a store is consistent with the other suggested commands (`store execute`, `theme pull/push`).

### WHAT is this pull request doing?

Updates the first next step emitted by `previewStoreNextSteps` in `packages/store/src/cli/services/store/create/preview/result.ts`:

- **Before:** `Open your store (<storefrontUrl>) to preview the storefront.` (rendered a direct link to the storefront URL)
- **After:** ``Use `shopify store open --store <subdomain>` to preview the storefront.`` (rendered as a `command` token in text output, and as the backtick-quoted command in JSON output)

This makes the storefront step a copyable command keyed off the store subdomain, matching the format of the other two next steps.

Tests in `result.test.ts` were updated to assert the new JSON string and the `{command: ...}` text token, and the JSON test case was renamed from "with the storefront URL" to "with the next steps".

### How to test your changes?

1. Run `shopify store create preview` (or run the preview-store result suite).
2. Confirm the first next step reads: ``Use `shopify store open --store <subdomain>` to preview the storefront.``
3. Confirm both text and JSON (`--json`) output reflect the command rather than a storefront URL.
4. `pnpm vitest packages/store/src/cli/services/store/create/preview/result.test.ts`

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible documentation changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — `shopify store open` is still a hidden command, so the suggestion is not yet public; no changeset added.
