### PR TITLE
[Tests] Replace filesystem mock with real sparse file in bundle tests

### DIFF
--- a/packages/app/src/cli/services/bundle.test.ts
+++ b/packages/app/src/cli/services/bundle.test.ts
@@ -2,10 +2,11 @@ import {writeManifestToBundle, compressBundle, uploadToGCS, BUNDLE_EXCLUSION_PAT
 import {AppInterface} from '../models/app/app.js'
 import {describe, test, expect, vi} from 'vitest'
 import {joinPath} from '@shopify/cli-kit/node/path'
-import {inTemporaryDirectory, mkdir, writeFile, readFile, fileSize} from '@shopify/cli-kit/node/fs'
+import {inTemporaryDirectory, mkdir, writeFile, readFile} from '@shopify/cli-kit/node/fs'
 import {brotliCompress, zip} from '@shopify/cli-kit/node/archiver'
 import {AbortError} from '@shopify/cli-kit/node/error'
 import {fetch} from '@shopify/cli-kit/node/http'
+import {truncate} from 'node:fs/promises'
 
 vi.mock('@shopify/cli-kit/node/archiver', () => {
   return {
@@ -17,11 +18,6 @@ vi.mock('@shopify/cli-kit/node/archiver', () => {
 vi.mock('@shopify/cli-kit/node/http', async (importActual) => {
   const actual: any = await importActual()
   return {...actual, fetch: vi.fn()}
-})
-
-vi.mock('@shopify/cli-kit/node/fs', async (importActual) => {
-  const actual: any = await importActual()
-  return {...actual, fileSize: vi.fn(actual.fileSize)}
 })
 
 describe('writeManifestToBundle', () => {
@@ -227,11 +223,11 @@ describe('uploadToGCS', () => {
 
   test('aborts with a helpful error when the bundle exceeds the 100 MB upload limit', async () => {
     await inTemporaryDirectory(async (tmpDir) => {
-      // Given — mock the reported size so CI doesn't have to allocate 101 MB on disk.
+      // Given — allocate a 101 MB sparse file so we don't actually use disk space but it reports the right size.
       const bundlePath = joinPath(tmpDir, 'huge.zip')
       await writeFile(bundlePath, 'placeholder')
       const oneHundredOneMb = 101 * 1024 * 1024
-      vi.mocked(fileSize).mockResolvedValueOnce(oneHundredOneMb).mockResolvedValueOnce(oneHundredOneMb)
+      await truncate(bundlePath, oneHundredOneMb)
       vi.mocked(fetch).mockResolvedValue({} as never)
 
       // When / Then


### PR DESCRIPTION
### WHY are these changes introduced?

The current tests for app bundling mock the filesystem to simulate large file sizes. This is an anti-pattern that can lead to fragile tests and hides the actual behavior of the filesystem utilities. Using real temporary directories and sparse files provides more robust verification of bundle size limits.

### WHAT is this pull request doing?

- Removes the module-level mock for `@shopify/cli-kit/node/fs` in `packages/app/src/cli/services/bundle.test.ts`.
- Updates the large bundle upload test to use `truncate` from `node:fs/promises` to create a real 101 MB sparse file.
- Ensures the test exercises the real `fileSize` utility from `@shopify/cli-kit/node/fs`.

### How to test your changes?

CI

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [8432853696511868224](https://jules.google.com/task/8432853696511868224) started by @gonzaloriestra*