### PR TITLE
[Security] Harden client ID generation

### DIFF
--- a/packages/ui-extensions-server-kit/src/ExtensionServerClient/ExtensionServerClient.test.ts
+++ b/packages/ui-extensions-server-kit/src/ExtensionServerClient/ExtensionServerClient.test.ts
@@ -163,6 +163,28 @@ describe('ExtensionServerClient', () => {
   })
 
   describe('initialization', () => {
+    test('uses crypto.randomUUID() when available', () => {
+      const uuid = '12345678-1234-1234-1234-1234567890ab'
+      vi.stubGlobal('crypto', {randomUUID: () => uuid})
+
+      const client = new ExtensionServerClient(defaultOptions)
+
+      expect(client.id).toBe(uuid)
+
+      vi.unstubAllGlobals()
+    })
+
+    test('falls back to Math.random() when crypto.randomUUID() is not available', () => {
+      vi.stubGlobal('crypto', undefined)
+
+      const client = new ExtensionServerClient(defaultOptions)
+
+      expect(client.id).toBeDefined()
+      expect(client.id.length).toBeLessThan(36)
+
+      vi.unstubAllGlobals()
+    })
+
     test('connects to the target websocket', async () => {
       // Create client
       const client = new ExtensionServerClient(defaultOptions)

--- a/packages/ui-extensions-server-kit/src/ExtensionServerClient/ExtensionServerClient.ts
+++ b/packages/ui-extensions-server-kit/src/ExtensionServerClient/ExtensionServerClient.ts
@@ -32,7 +32,10 @@ export class ExtensionServerClient implements ExtensionServer.Client {
   private uiExtensionsByUuid: Record<string, ExtensionServer.UIExtension> = {}
 
   constructor(options: DeepPartial<ExtensionServer.Options> = {}) {
-    this.id = (Math.random() + 1).toString(36).substring(7)
+    this.id =
+      typeof globalThis.crypto?.randomUUID === 'function'
+        ? globalThis.crypto.randomUUID()
+        : (Math.random() + 1).toString(36).substring(7)
     this.options = getValidatedOptions({
       ...options,
       connection: {


### PR DESCRIPTION
### WHY are these changes introduced?
Hardens the client ID generation by using a cryptographically secure random number generator when available.

### WHAT is this pull request doing?
Replaces the insecure `Math.random()` based client ID generation in `ExtensionServerClient` with `globalThis.crypto.randomUUID()` when supported by the environment, maintaining a fallback for compatibility.

### How to test your changes?
CI

### Checklist
- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [16556810634221208946](https://jules.google.com/task/16556810634221208946) started by @gonzaloriestra*