### PR TITLE
[Performance] Memoize isTerminalInteractive

### DIFF
--- a/packages/cli-kit/src/public/node/context/local.test.ts
+++ b/packages/cli-kit/src/public/node/context/local.test.ts
@@ -4,6 +4,7 @@ import {
   isDevelopment,
   isShopify,
   isTerminalInteractive,
+  _resetIsTerminalInteractiveCache,
   isUnitTest,
   analyticsDisabled,
   cloudEnvironment,
@@ -25,6 +26,7 @@ describe('isTerminalInteractive', () => {
   const originalEnv = {...process.env}
 
   afterEach(() => {
+    _resetIsTerminalInteractiveCache()
     process.stdout.isTTY = originalIsTTY
     process.env.TERM = originalEnv.TERM
     if (originalEnv.CI === undefined) {
@@ -67,6 +69,38 @@ describe('isTerminalInteractive', () => {
     process.env.CI = ''
     process.env.TERM = 'xterm-256color'
     expect(isTerminalInteractive()).toBe(false)
+  })
+
+  test('memoizes the result', () => {
+    // Given
+    process.stdout.isTTY = true
+    delete process.env.CI
+    process.env.TERM = 'xterm-256color'
+    const firstResult = isTerminalInteractive()
+
+    // When
+    process.stdout.isTTY = false
+    const secondResult = isTerminalInteractive()
+
+    // Then
+    expect(firstResult).toBe(true)
+    expect(secondResult).toBe(true)
+  })
+
+  test('resets the cache', () => {
+    // Given
+    process.stdout.isTTY = true
+    delete process.env.CI
+    process.env.TERM = 'xterm-256color'
+    isTerminalInteractive()
+
+    // When
+    _resetIsTerminalInteractiveCache()
+    process.stdout.isTTY = false
+    const secondResult = isTerminalInteractive()
+
+    // Then
+    expect(secondResult).toBe(false)
   })
 })
 

--- a/packages/cli-kit/src/public/node/context/local.ts
+++ b/packages/cli-kit/src/public/node/context/local.ts
@@ -17,12 +17,26 @@ async function lazyExec(command: string, args: string[]): Promise<void> {
 }
 
 /**
+ * Memoized value for the terminal interactive check.
+ */
+let memoizedIsTerminalInteractive: boolean | undefined
+
+/**
  * It returns true if the terminal is interactive.
  *
  * @returns True if the terminal is interactive.
  */
 export function isTerminalInteractive(): boolean {
-  return Boolean(process.stdout.isTTY && process.env.TERM !== 'dumb' && !('CI' in process.env))
+  return (memoizedIsTerminalInteractive ??= Boolean(
+    process.stdout.isTTY && process.env.TERM !== 'dumb' && !('CI' in process.env),
+  ))
+}
+
+/**
+ * Resets the memoized value for the terminal interactive check.
+ */
+export function _resetIsTerminalInteractiveCache(): void {
+  memoizedIsTerminalInteractive = undefined
 }
 
 /**


### PR DESCRIPTION
Memoize the `isTerminalInteractive` function in `@shopify/cli-kit` to avoid redundant environment variable and stream property lookups. Added a reset utility for test isolation.

---
*PR created automatically by Jules for task [151826568706229761](https://jules.google.com/task/151826568706229761) started by @gonzaloriestra*