### PR TITLE
[Refactor] Modernize errorHandler with async/await and early returns

### DIFF
--- a/packages/cli-kit/src/public/node/error-handler.ts
+++ b/packages/cli-kit/src/public/node/error-handler.ts
@@ -36,17 +36,16 @@ export async function errorHandler(
     if (error.message && error.message !== '') {
       outputInfo(`✨  ${error.message}`)
     }
-  } else if (error instanceof AbortSilentError) {
-    /* empty */
-  } else {
-    return errorMapper(error)
-      .then((error) => {
-        return handler(error)
-      })
-      .then((mappedError) => {
-        return reportError(mappedError, config)
-      })
+    return
   }
+
+  if (error instanceof AbortSilentError) {
+    return
+  }
+
+  const mappedError = await errorMapper(error)
+  const handledError = await handler(mappedError)
+  return reportError(handledError, config)
 }
 
 const reportError = async (error: unknown, config?: Interfaces.Config): Promise<void> => {


### PR DESCRIPTION
Refactor the errorHandler function in packages/cli-kit/src/public/node/error-handler.ts to use async/await and early returns instead of the existing promise chain, improving readability and maintainability while preserving identical runtime behavior.

---
*PR created automatically by Jules for task [8572945783005093535](https://jules.google.com/task/8572945783005093535) started by @gonzaloriestra*