### PR TITLE
Include run token in E2E dev store names

### DIFF
--- a/packages/e2e/setup/env.ts
+++ b/packages/e2e/setup/env.ts
@@ -134,13 +134,16 @@ const E2E_APP_PREFIXES: Record<string, string> = {
 /**
  * Generate a short E2E app name that can be clustered by GitHub Actions run.
  */
-export function e2eAppName(prefix: string): string {
+export function e2eRunSegment(): string {
   const runId = process.env.GITHUB_RUN_ID
   const runAttempt = process.env.GITHUB_RUN_ATTEMPT ?? '1'
-  const runSegment = runId ? `r${BigInt(runId).toString(36)}a${runAttempt}` : 'local'
+  return runId ? `r${BigInt(runId).toString(36)}a${runAttempt}` : 'local'
+}
+
+export function e2eAppName(prefix: string): string {
   const timestampSegment = Date.now().toString(36)
 
-  return `E2E-${E2E_APP_PREFIXES[prefix] ?? prefix}-${runSegment}-${timestampSegment}`
+  return `E2E-${E2E_APP_PREFIXES[prefix] ?? prefix}-${e2eRunSegment()}-${timestampSegment}`
 }
 
 /**

--- a/packages/e2e/setup/store.ts
+++ b/packages/e2e/setup/store.ts
@@ -2,7 +2,7 @@
 import {appTestFixture} from './app.js'
 import {isVisibleWithin} from './browser.js'
 import {BROWSER_TIMEOUT} from './constants.js'
-import {createLogger, e2eSection} from './env.js'
+import {createLogger, e2eRunSegment, e2eSection} from './env.js'
 import * as fs from 'fs'
 import type {BrowserContext} from './browser.js'
 import type {Locator, Page} from '@playwright/test'
@@ -15,7 +15,8 @@ const log = createLogger('browser')
 
 /** Generate a unique store name for a worker. */
 export function generateStoreName(workerIndex: number): string {
-  return `e2e-w${workerIndex}-${Date.now()}`
+  const timestampSegment = Date.now().toString(36)
+  return `e2e-w${workerIndex}-${e2eRunSegment()}-${timestampSegment}`
 }
 
 interface WorkerCtx {


### PR DESCRIPTION
### WHY are these changes introduced?

E2E app names include the GitHub Actions run token, which lets the post-run cleanup job target only resources from the current run. Dev store names only used the worker index and timestamp, so a current-run store cleanup job could not safely target stores without risking other active runs.

### WHAT is this pull request doing?

Adds a shared E2E run segment helper and includes that segment in generated dev store names. Store names now include the same `r<run-id-base36>a<attempt>` segment as E2E app names.

### How to test your changes?

- `cd packages/e2e && pnpm tsc --noEmit`
- `cd packages/e2e && pnpm eslint "setup/**/*.ts" "helpers/**/*.ts" "tests/**/*.ts" "*.ts"`
- `node bin/run-knip-ci.js`

Note: ESLint completed successfully with existing Nx project graph cache warnings for `@nx/enforce-module-boundaries`.

### Post-release steps

None.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [x] The change is not user-facing; no changeset is needed.