### PR TITLE
Clean up current-run E2E dev stores

### DIFF
--- a/.github/workflows/tests-pr.yml
+++ b/.github/workflows/tests-pr.yml
@@ -270,17 +270,17 @@ jobs:
           retention-days: 14
 
   e2e-cleanup:
-    name: 'Cleanup current-run E2E apps'
+    name: 'Cleanup current-run E2E resources'
     needs: e2e-tests
     if: ${{ always() && needs.e2e-tests.result != 'skipped' }}
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
     continue-on-error: true
     steps:
       - uses: actions/checkout@v6
         with:
-          repository: ${{ github.event.pull_request.head.repo.full_name || github.event.repository.full_name }}
-          ref: ${{ github.event.pull_request.head.ref || github.event.merge_group.head_ref }}
+          repository: ${{ github.repository }}
+          ref: ${{ github.sha }}
           fetch-depth: 1
       - name: Setup deps
         uses: ./.github/actions/setup-cli-deps
@@ -295,6 +295,14 @@ jobs:
           E2E_ACCOUNT_PASSWORD: ${{ secrets.E2E_ACCOUNT_PASSWORD }}
           E2E_ORG_ID: ${{ secrets.E2E_ORG_ID }}
         run: pnpm --filter e2e exec tsx scripts/prime-browser-auth.ts
+      - name: Cleanup current-run E2E stores
+        env:
+          E2E_ACCOUNT_EMAIL: ${{ secrets.E2E_ACCOUNT_EMAIL }}
+          E2E_ACCOUNT_PASSWORD: ${{ secrets.E2E_ACCOUNT_PASSWORD }}
+          E2E_ORG_ID: ${{ secrets.E2E_ORG_ID }}
+        run: |
+          RUN_TOKEN=$(node -e "process.stdout.write(BigInt(process.env.GITHUB_RUN_ID).toString(36))")
+          pnpm --filter e2e exec tsx scripts/cleanup-stores.ts --pattern "r${RUN_TOKEN}a${GITHUB_RUN_ATTEMPT}"
       - name: Cleanup current-run E2E apps
         env:
           E2E_ACCOUNT_EMAIL: ${{ secrets.E2E_ACCOUNT_EMAIL }}

--- a/packages/e2e/scripts/cleanup-stores.ts
+++ b/packages/e2e/scripts/cleanup-stores.ts
@@ -21,6 +21,7 @@
 
 import {config} from 'dotenv'
 import * as path from 'path'
+import * as fs from 'fs'
 import {fileURLToPath} from 'url'
 import {chromium} from '@playwright/test'
 import {BROWSER_TIMEOUT} from '../setup/constants.js'
@@ -56,6 +57,28 @@ export interface CleanupStoresOptions {
   headed?: boolean
   /** Organization ID (default: from E2E_ORG_ID env) */
   orgId?: string
+  /** Playwright browser storage state path (default: E2E_BROWSER_STATE_PATH or global-auth path) */
+  storageStatePath?: string
+}
+
+function isAccountsShopifyUrl(rawUrl: string): boolean {
+  try {
+    return new URL(rawUrl).hostname === 'accounts.shopify.com'
+    // eslint-disable-next-line no-catch-all/no-catch-all
+  } catch {
+    return false
+  }
+}
+
+function defaultStorageStatePath(): string {
+  const tmpBase = process.env.E2E_TEMP_DIR ?? path.resolve(__dirname, '../../../.e2e-tmp')
+  return path.join(tmpBase, 'global-auth', 'browser-storage-state.json')
+}
+
+function existingStorageStatePath(candidate?: string): string | undefined {
+  return [candidate, process.env.E2E_BROWSER_STATE_PATH, defaultStorageStatePath()].find(
+    (storageStatePath): storageStatePath is string => Boolean(storageStatePath && fs.existsSync(storageStatePath)),
+  )
 }
 
 export async function cleanupStores(opts: CleanupStoresOptions = {}): Promise<void> {
@@ -64,6 +87,7 @@ export async function cleanupStores(opts: CleanupStoresOptions = {}): Promise<vo
   const orgId = opts.orgId ?? (process.env.E2E_ORG_ID ?? '').trim()
   const email = process.env.E2E_ACCOUNT_EMAIL
   const password = process.env.E2E_ACCOUNT_PASSWORD
+  const storageStatePath = existingStorageStatePath(opts.storageStatePath)
 
   console.log('')
   console.log(`[cleanup-stores] Mode:    ${MODE_LABELS[mode]}`)
@@ -71,8 +95,8 @@ export async function cleanupStores(opts: CleanupStoresOptions = {}): Promise<vo
   console.log(`[cleanup-stores] Pattern: "${pattern}"`)
   console.log('')
 
-  if (!email || !password) {
-    throw new Error('E2E_ACCOUNT_EMAIL and E2E_ACCOUNT_PASSWORD are required')
+  if (!storageStatePath && (!email || !password)) {
+    throw new Error('E2E_ACCOUNT_EMAIL and E2E_ACCOUNT_PASSWORD are required when no browser storage state is available')
   }
   if (!orgId) {
     throw new Error('E2E_ORG_ID is required')
@@ -83,6 +107,7 @@ export async function cleanupStores(opts: CleanupStoresOptions = {}): Promise<vo
     extraHTTPHeaders: {
       'X-Shopify-Loadtest-Bf8d22e7-120e-4b5b-906c-39ca9d5499a9': 'true',
     },
+    ...(storageStatePath ? {storageState: storageStatePath} : {}),
   })
   context.setDefaultTimeout(BROWSER_TIMEOUT.max)
   context.setDefaultNavigationTimeout(BROWSER_TIMEOUT.max)
@@ -92,19 +117,28 @@ export async function cleanupStores(opts: CleanupStoresOptions = {}): Promise<vo
   const totalStart = Date.now()
 
   try {
-    // Step 1: Log in
-    console.log('[cleanup-stores] Logging in...')
-    await completeLogin(page, 'https://accounts.shopify.com/lookup', email, password)
-    console.log('[cleanup-stores] Logged in successfully.')
+    // Step 1: Reuse Playwright's global auth storage when available; otherwise log in directly.
+    if (storageStatePath) {
+      console.log('[cleanup-stores] Reusing browser storage state.')
+    } else if (email && password) {
+      console.log('[cleanup-stores] Logging in...')
+      await completeLogin(page, 'https://accounts.shopify.com/lookup', email, password)
+      console.log('[cleanup-stores] Logged in successfully.')
+    }
 
     // Step 2: Navigate to stores page and find matching stores
     console.log('[cleanup-stores] Navigating to stores page...')
     await page.goto(`https://dev.shopify.com/dashboard/${orgId}/stores`, {waitUntil: 'domcontentloaded'})
+    if (isAccountsShopifyUrl(page.url()) && email && password) {
+      console.log('[cleanup-stores] Browser storage state was not accepted; logging in...')
+      await completeLogin(page, page.url(), email, password)
+      await page.goto(`https://dev.shopify.com/dashboard/${orgId}/stores`, {waitUntil: 'domcontentloaded'})
+    }
     await page.waitForTimeout(BROWSER_TIMEOUT.medium)
 
     // Handle account picker
-    const accountButton = page.locator(`text=${email}`).first()
-    if (await accountButton.isVisible({timeout: BROWSER_TIMEOUT.long}).catch(() => false)) {
+    const accountButton = email ? page.locator(`text=${email}`).first() : undefined
+    if (accountButton && (await accountButton.isVisible({timeout: BROWSER_TIMEOUT.long}).catch(() => false))) {
       await accountButton.click()
       await page.waitForTimeout(BROWSER_TIMEOUT.medium)
     }


### PR DESCRIPTION
### WHY are these changes introduced?

After E2E shards finish, CI currently runs a current-run app cleanup job, but dev stores are only cleaned by each test's best-effort teardown. If a teardown is interrupted or flakes, stores can remain behind.

### WHAT is this pull request doing?

Adds current-run dev store cleanup to the post-E2E cleanup job, before app cleanup, using the run token added in the parent PR. Store cleanup now also reuses the primed Playwright browser storage state, matching app cleanup and avoiding an extra Shopify Accounts login when possible.

The cleanup job now checks out `github.sha` from the base repository instead of ephemeral PR/merge-queue head refs, so cleanup is less likely to fail before running when temporary refs disappear.

### How to test your changes?

- `cd packages/e2e && pnpm tsc --noEmit`
- `cd packages/e2e && pnpm eslint "setup/**/*.ts" "helpers/**/*.ts" "tests/**/*.ts" "*.ts"`
- `node bin/run-knip-ci.js`

Note: ESLint completed successfully with existing Nx project graph cache warnings for `@nx/enforce-module-boundaries`. The PR E2E cleanup job will exercise the workflow path in CI.

### Post-release steps

None.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [x] The change is not user-facing; no changeset is needed.