### PR TITLE
Improve store bulk and app bulk topic descriptions

### DIFF
--- a/.changeset/bulk-topic-descriptions.md
+++ b/.changeset/bulk-topic-descriptions.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli': patch
+---
+
+Improve `store bulk` and `app bulk` topic descriptions in help output

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -109,8 +109,14 @@
       "store": {
         "description": "Work directly with Shopify stores."
       },
+      "store:bulk": {
+        "description": "Run, check, and cancel bulk Admin API operations on a store."
+      },
       "store:create": {
         "description": "Create Shopify stores."
+      },
+      "app:bulk": {
+        "description": "Run, check, and cancel bulk Admin API operations for an app on a store."
       },
       "app:config": {
         "description": "Manage app configuration."


### PR DESCRIPTION
## Summary

Fills in `store:bulk` and `app:bulk` topic descriptions in `packages/cli/package.json`. Without an explicit entry, oclif falls back to the first subcommand's description, which for both topics happened to be `cancel`'s — misleading since the topic also contains `execute` and `status`.

**Before**

```
store bulk    Cancel a bulk operation on a store.
app bulk      Cancel a bulk operation.
```

**After**

```
store bulk    Run, check, and cancel bulk Admin API operations on a store.
app bulk      Run, check, and cancel bulk Admin API operations for an app on a store.
```

## Test plan

- [ ] `node ./packages/cli/bin/dev.js store --help` shows the new `store bulk` description
- [ ] `node ./packages/cli/bin/dev.js app --help` shows the new `app bulk` description