### PR TITLE
[Security] Hardened client ID generation

### DIFF
--- a/packages/ui-extensions-server-kit/src/ExtensionServerClient/ExtensionServerClient.ts
+++ b/packages/ui-extensions-server-kit/src/ExtensionServerClient/ExtensionServerClient.ts
@@ -32,7 +32,11 @@ export class ExtensionServerClient implements ExtensionServer.Client {
   private uiExtensionsByUuid: Record<string, ExtensionServer.UIExtension> = {}
 
   constructor(options: DeepPartial<ExtensionServer.Options> = {}) {
-    this.id = (Math.random() + 1).toString(36).substring(7)
+    // Security: Use a cryptographically secure random number generator when available to prevent ID predictability.
+    this.id =
+      typeof globalThis.crypto?.randomUUID === 'function'
+        ? globalThis.crypto.randomUUID()
+        : (Math.random() + 1).toString(36).substring(7)
     this.options = getValidatedOptions({
       ...options,
       connection: {


### PR DESCRIPTION
### WHY are these changes introduced?

The current implementation uses `Math.random()` to generate a client ID, which is not cryptographically secure and can be predictable.

### WHAT is this pull request doing?

This pull request replaces the insecure `Math.random()` based ID generation with `globalThis.crypto.randomUUID()` when available, providing a more secure and unique identifier. A safe fallback is maintained for environments where the `crypto` API is not supported.

### How to test your changes?

CI

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [3125192890537652369](https://jules.google.com/task/3125192890537652369) started by @gonzaloriestra*