### PR TITLE
[Tests] Replace filesystem mocks with real temp directories in store result tests

### DIFF
--- a/packages/store/src/cli/services/store/execute/result.test.ts
+++ b/packages/store/src/cli/services/store/execute/result.test.ts
@@ -1,10 +1,10 @@
 import {writeOrOutputStoreExecuteResult} from './result.js'
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
-import {writeFile} from '@shopify/cli-kit/node/fs'
+import {inTemporaryDirectory, readFile} from '@shopify/cli-kit/node/fs'
+import {joinPath} from '@shopify/cli-kit/node/path'
 import {renderSuccess} from '@shopify/cli-kit/node/ui'
 import {mockAndCaptureOutput} from '@shopify/cli-kit/node/testing/output'
 
-vi.mock('@shopify/cli-kit/node/fs')
 vi.mock('@shopify/cli-kit/node/ui')
 
 function captureStandardStreams() {
@@ -42,12 +42,19 @@ describe('writeOrOutputStoreExecuteResult', () => {
   })
 
   test('writes results to a file when outputFile is provided', async () => {
-    await writeOrOutputStoreExecuteResult({data: {shop: {name: 'Test shop'}}}, '/tmp/results.json')
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      const resultsPath = joinPath(tmpDir, 'results.json')
 
-    expect(writeFile).toHaveBeenCalledWith('/tmp/results.json', expect.stringContaining('Test shop'))
-    expect(renderSuccess).toHaveBeenCalledWith({
-      headline: 'Operation succeeded.',
-      body: 'Results written to /tmp/results.json',
+      // When
+      await writeOrOutputStoreExecuteResult({data: {shop: {name: 'Test shop'}}}, resultsPath)
+
+      // Then
+      await expect(readFile(resultsPath)).resolves.toContain('Test shop')
+      expect(renderSuccess).toHaveBeenCalledWith({
+        headline: 'Operation succeeded.',
+        body: `Results written to ${resultsPath}`,
+      })
     })
   })
 
@@ -86,9 +93,16 @@ describe('writeOrOutputStoreExecuteResult', () => {
   })
 
   test('suppresses success rendering when writing a file in json mode', async () => {
-    await writeOrOutputStoreExecuteResult({data: {shop: {name: 'Test shop'}}}, '/tmp/results.json', 'json')
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      const resultsPath = joinPath(tmpDir, 'results.json')
 
-    expect(writeFile).toHaveBeenCalledWith('/tmp/results.json', expect.stringContaining('Test shop'))
-    expect(renderSuccess).not.toHaveBeenCalled()
+      // When
+      await writeOrOutputStoreExecuteResult({data: {shop: {name: 'Test shop'}}}, resultsPath, 'json')
+
+      // Then
+      await expect(readFile(resultsPath)).resolves.toContain('Test shop')
+      expect(renderSuccess).not.toHaveBeenCalled()
+    })
   })
 })


### PR DESCRIPTION
This PR improves the test suite for the `@shopify/store` package by removing filesystem mocks in `result.test.ts`.

### Why this change is needed?
The automated task protocol for tests (`.agents/automated-tasks/tests.md`) mandates using real files and directories in temporary directories instead of mocking the filesystem. This makes tests more robust and less coupled to implementation details of how the filesystem is accessed.

### How to test your changes?
CI

### Checklist
- [ ] I have followed the [Testing Guidelines](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#testing-guidelines).
- [ ] I have provided a clear description of the changes.
- [ ] I have updated the documentation (if applicable).
- [ ] I have added tests to cover my changes.
- [ ] I have run `pnpm lint`, `pnpm knip`, `pnpm type-check`, and `pnpm test:unit` and they all pass.


---
*PR created automatically by Jules for task [8876345509233618617](https://jules.google.com/task/8876345509233618617) started by @gonzaloriestra*