### PR TITLE
[Performance] Memoize cwd() in path.ts

### DIFF
--- a/packages/cli-kit/src/public/node/path.test.ts
+++ b/packages/cli-kit/src/public/node/path.test.ts
@@ -1,5 +1,5 @@
-import {relativizePath, normalizePath, cwd, sniffForPath, commonParentDirectory} from './path.js'
-import {describe, test, expect} from 'vitest'
+import {relativizePath, normalizePath, cwd, sniffForPath, commonParentDirectory, _resetCwd} from './path.js'
+import {describe, test, expect, vi, beforeEach} from 'vitest'
 
 describe('relativize', () => {
   test('relativizes the path', () => {
@@ -16,12 +16,41 @@ describe('relativize', () => {
 })
 
 describe('cwd', () => {
+  beforeEach(() => {
+    _resetCwd()
+  })
+
   test.runIf(process.env.INIT_CWD)('returns the initial cwd where the command has been called', () => {
     // Given
     const path = cwd()
 
     // Then
     expect(path).toStrictEqual(normalizePath(process.env.INIT_CWD!))
+  })
+
+  test('memoizes the result', () => {
+    // Given
+    const processCwdSpy = vi.spyOn(process, 'cwd').mockReturnValue('/computed/path')
+    const originalInitCwd = process.env.INIT_CWD
+    delete process.env.INIT_CWD
+
+    // When
+    const firstCall = cwd()
+    const secondCall = cwd()
+
+    // Then
+    expect(firstCall).toBe(normalizePath('/computed/path'))
+    expect(secondCall).toBe(normalizePath('/computed/path'))
+    expect(processCwdSpy).toHaveBeenCalledTimes(1)
+
+    // Resetting
+    _resetCwd()
+    cwd()
+    expect(processCwdSpy).toHaveBeenCalledTimes(2)
+
+    // Restore
+    process.env.INIT_CWD = originalInitCwd
+    processCwdSpy.mockRestore()
   })
 })
 

--- a/packages/cli-kit/src/public/node/path.ts
+++ b/packages/cli-kit/src/public/node/path.ts
@@ -166,6 +166,11 @@ export function moduleDirectory(moduleURL: string | URL): string {
 }
 
 /**
+ * Memoized value for the current working directory.
+ */
+let memoizedCwd: string | undefined
+
+/**
  * When running a script using `npm run`, something interesting happens. If the current
  * folder does not have a `package.json` or a `node_modules` folder, npm will traverse
  * the directory tree upwards until it finds one. Then it will run the script and set
@@ -175,8 +180,18 @@ export function moduleDirectory(moduleURL: string | URL): string {
  * @returns The path to the current working directory.
  */
 export function cwd(): string {
+  if (memoizedCwd) return memoizedCwd
   // eslint-disable-next-line @shopify/cli/no-process-cwd
-  return normalize(process.env.INIT_CWD || process.cwd()) // eslint-disable-line @typescript-eslint/prefer-nullish-coalescing -- empty env var should fall through
+  memoizedCwd = normalize(process.env.INIT_CWD || process.cwd()) // eslint-disable-line @typescript-eslint/prefer-nullish-coalescing -- empty env var should fall through
+  return memoizedCwd
+}
+
+/**
+ * Resets the memoized value of the current working directory.
+ * This is useful for testing purposes.
+ */
+export function _resetCwd(): void {
+  memoizedCwd = undefined
 }
 
 /**


### PR DESCRIPTION
### WHY are these changes introduced?

The `cwd()` function in `packages/cli-kit/src/public/node/path.ts` is a high-frequency call site, used extensively for path relativization and other filesystem-related operations. Currently, it performs environment variable lookups and executes path normalization on every invocation. 

By memoizing the result, we eliminate redundant computations. Since the initial working directory (especially when derived from `INIT_CWD`) is static for the lifetime of a CLI command execution, this optimization is safe and provides a small but cumulative performance boost across the entire toolset.

### WHAT is this pull request doing?

- Memoizes the result of `cwd()` in `packages/cli-kit/src/public/node/path.ts`.
- Introduces an exported `_resetCwd()` utility to allow resetting the cache for test isolation.
- Adds unit tests to verify memoization behavior and ensure correct fallback logic.

### How to test your changes?

CI

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [777302513341045207](https://jules.google.com/task/777302513341045207) started by @gonzaloriestra*