### PR TITLE
Recover on `store info` after a preview store has been claimed

### DIFF
--- a/.changeset/store-info-preview-claim-reauth.md
+++ b/.changeset/store-info-preview-claim-reauth.md
@@ -1,0 +1,5 @@
+---
+'@shopify/store': patch
+---
+
+Fix `store info` failing with an unhelpful error on a preview store after it has been claimed; it now prompts to run `store auth` to re-authenticate

--- a/packages/store/src/cli/services/store/admin-errors.ts
+++ b/packages/store/src/cli/services/store/admin-errors.ts
@@ -1,4 +1,4 @@
-import {throwReauthenticateStoreAuthError} from './auth/recovery.js'
+import {throwStoredAuthInvalidError} from './auth/recovery.js'
 import {clearStoredStoreAppSession} from '@shopify/cli-kit/node/store-auth-session'
 import {AbortError} from '@shopify/cli-kit/node/error'
 import type {StoredStoreAppSession} from '@shopify/cli-kit/node/store-auth-session'
@@ -66,5 +66,5 @@ export function throwIfStoredStoreAuthIsInvalid(error: unknown, session: StoredS
     clearStoredStoreAppSession(session.store, session.userId)
   }
 
-  throwReauthenticateStoreAuthError(`Stored app authentication for ${session.store} is no longer valid.`, session)
+  throwStoredAuthInvalidError(session)
 }

--- a/packages/store/src/cli/services/store/admin-errors.ts
+++ b/packages/store/src/cli/services/store/admin-errors.ts
@@ -1,4 +1,4 @@
-import {throwReauthenticateStoreAuthError, UNKNOWN_SCOPES_PLACEHOLDER} from './auth/recovery.js'
+import {throwReauthenticateStoreAuthError} from './auth/recovery.js'
 import {clearStoredStoreAppSession} from '@shopify/cli-kit/node/store-auth-session'
 import {AbortError} from '@shopify/cli-kit/node/error'
 import type {StoredStoreAppSession} from '@shopify/cli-kit/node/store-auth-session'
@@ -55,22 +55,16 @@ export function classifyAdminApiError(error: unknown, storeFqdn: string): AbortE
   return undefined
 }
 
-// Preview-store sessions are preapproved for a large, fixed scope catalog (often 30+ scopes).
-// Suggesting the user re-request all of them via `store auth` encourages over-scoping, so a
-// claimed preview store falls back to the same placeholder used when there's no stored auth at
-// all, letting the user choose scopes deliberately instead.
-export function reauthScopesFor(session: StoredStoreAppSession): string {
-  return session.kind === 'preview' ? UNKNOWN_SCOPES_PLACEHOLDER : session.scopes.join(',')
-}
-
 export function throwIfStoredStoreAuthIsInvalid(error: unknown, session: StoredStoreAppSession): void {
   const status = graphQLClientErrorStatus(error)
   if (status !== 401 && status !== 404) return
 
-  clearStoredStoreAppSession(session.store, session.userId)
-  throwReauthenticateStoreAuthError(
-    `Stored app authentication for ${session.store} is no longer valid.`,
-    session.store,
-    reauthScopesFor(session),
-  )
+  // Preview-store sessions are left uncleared: `store auth` overwrites the bucket's
+  // `currentUserId` regardless, and clearing here would make a follow-up `store info` run
+  // fall through to a full interactive login instead of repeating this same actionable message.
+  if (session.kind !== 'preview') {
+    clearStoredStoreAppSession(session.store, session.userId)
+  }
+
+  throwReauthenticateStoreAuthError(`Stored app authentication for ${session.store} is no longer valid.`, session)
 }

--- a/packages/store/src/cli/services/store/admin-errors.ts
+++ b/packages/store/src/cli/services/store/admin-errors.ts
@@ -1,4 +1,4 @@
-import {throwReauthenticateStoreAuthError} from './auth/recovery.js'
+import {throwReauthenticateStoreAuthError, UNKNOWN_SCOPES_PLACEHOLDER} from './auth/recovery.js'
 import {clearStoredStoreAppSession} from '@shopify/cli-kit/node/store-auth-session'
 import {AbortError} from '@shopify/cli-kit/node/error'
 import type {StoredStoreAppSession} from '@shopify/cli-kit/node/store-auth-session'
@@ -55,6 +55,14 @@ export function classifyAdminApiError(error: unknown, storeFqdn: string): AbortE
   return undefined
 }
 
+// Preview-store sessions are preapproved for a large, fixed scope catalog (often 30+ scopes).
+// Suggesting the user re-request all of them via `store auth` encourages over-scoping, so a
+// claimed preview store falls back to the same placeholder used when there's no stored auth at
+// all, letting the user choose scopes deliberately instead.
+export function reauthScopesFor(session: StoredStoreAppSession): string {
+  return session.kind === 'preview' ? UNKNOWN_SCOPES_PLACEHOLDER : session.scopes.join(',')
+}
+
 export function throwIfStoredStoreAuthIsInvalid(error: unknown, session: StoredStoreAppSession): void {
   const status = graphQLClientErrorStatus(error)
   if (status !== 401 && status !== 404) return
@@ -63,6 +71,6 @@ export function throwIfStoredStoreAuthIsInvalid(error: unknown, session: StoredS
   throwReauthenticateStoreAuthError(
     `Stored app authentication for ${session.store} is no longer valid.`,
     session.store,
-    session.scopes.join(','),
+    reauthScopesFor(session),
   )
 }

--- a/packages/store/src/cli/services/store/auth/recovery.test.ts
+++ b/packages/store/src/cli/services/store/auth/recovery.test.ts
@@ -1,0 +1,165 @@
+import {
+  throwStoredStoreAuthError,
+  throwReauthenticateStoreAuthError,
+  throwStoredAuthInvalidError,
+  retryStoreAuthWithPermanentDomainError,
+} from './recovery.js'
+import {STORE_AUTH_APP_CLIENT_ID} from './config.js'
+import {AbortError} from '@shopify/cli-kit/node/error'
+import {describe, expect, test} from 'vitest'
+import type {StoredStoreAppSession} from '@shopify/cli-kit/node/store-auth-session'
+
+const SHOP = 'shop.myshopify.com'
+
+function standardSession(overrides: Partial<StoredStoreAppSession> = {}): StoredStoreAppSession {
+  return {
+    store: SHOP,
+    clientId: STORE_AUTH_APP_CLIENT_ID,
+    userId: '42',
+    accessToken: 'token',
+    scopes: ['read_products', 'write_orders'],
+    acquiredAt: '2026-03-27T00:00:00.000Z',
+    ...overrides,
+  }
+}
+
+function previewSession(overrides: Partial<StoredStoreAppSession> = {}): StoredStoreAppSession {
+  return {
+    ...standardSession({
+      userId: 'preview:placeholder-uuid',
+      // The full preapproved catalog is much larger in practice; a couple of entries are enough
+      // to prove the placeholder is used instead of these.
+      scopes: ['read_products', 'write_products', 'read_themes'],
+    }),
+    kind: 'preview',
+    preview: {
+      shopId: '123',
+      name: 'Lavender Candles',
+      createdAt: '2026-03-27T00:00:00.000Z',
+    },
+    ...overrides,
+  }
+}
+
+describe('throwStoredStoreAuthError', () => {
+  test('reports no stored auth and prompts to authenticate (not re-authenticate) with a scopes placeholder', () => {
+    let captured: AbortError | undefined
+    try {
+      throwStoredStoreAuthError(SHOP)
+      // eslint-disable-next-line no-catch-all/no-catch-all
+    } catch (error) {
+      captured = error as AbortError
+    }
+
+    expect(captured).toMatchObject({
+      message: `No stored app authentication found for ${SHOP}.`,
+      nextSteps: [
+        ['Run', {command: `shopify store auth --store ${SHOP} --scopes <comma-separated-scopes>`}, 'to authenticate'],
+      ],
+    })
+  })
+})
+
+describe('throwReauthenticateStoreAuthError', () => {
+  test('suggests the real scopes for a standard session', () => {
+    let captured: AbortError | undefined
+    try {
+      throwReauthenticateStoreAuthError('Custom message.', standardSession())
+      // eslint-disable-next-line no-catch-all/no-catch-all
+    } catch (error) {
+      captured = error as AbortError
+    }
+
+    expect(captured).toMatchObject({
+      message: 'Custom message.',
+      nextSteps: [
+        [
+          'Run',
+          {command: `shopify store auth --store ${SHOP} --scopes read_products,write_orders`},
+          'to re-authenticate',
+        ],
+      ],
+    })
+  })
+
+  test('suggests a scopes placeholder for a preview session instead of its preapproved catalog', () => {
+    let captured: AbortError | undefined
+    try {
+      throwReauthenticateStoreAuthError('Custom message.', previewSession())
+      // eslint-disable-next-line no-catch-all/no-catch-all
+    } catch (error) {
+      captured = error as AbortError
+    }
+
+    expect(captured).toMatchObject({
+      message: 'Custom message.',
+      nextSteps: [
+        [
+          'Run',
+          {command: `shopify store auth --store ${SHOP} --scopes <comma-separated-scopes>`},
+          'to re-authenticate',
+        ],
+      ],
+    })
+  })
+})
+
+describe('throwStoredAuthInvalidError', () => {
+  test('uses the generic invalid-auth message and real scopes for a standard session', () => {
+    let captured: AbortError | undefined
+    try {
+      throwStoredAuthInvalidError(standardSession())
+      // eslint-disable-next-line no-catch-all/no-catch-all
+    } catch (error) {
+      captured = error as AbortError
+    }
+
+    expect(captured).toMatchObject({
+      message: `Stored app authentication for ${SHOP} is no longer valid.`,
+      nextSteps: [
+        [
+          'Run',
+          {command: `shopify store auth --store ${SHOP} --scopes read_products,write_orders`},
+          'to re-authenticate',
+        ],
+      ],
+    })
+  })
+
+  test('flags a likely claim and suggests a scopes placeholder for a preview session', () => {
+    let captured: AbortError | undefined
+    try {
+      throwStoredAuthInvalidError(previewSession())
+      // eslint-disable-next-line no-catch-all/no-catch-all
+    } catch (error) {
+      captured = error as AbortError
+    }
+
+    expect(captured).toMatchObject({
+      message: `The preview store ${SHOP} has likely been claimed, so its stored authentication is no longer valid.`,
+      nextSteps: [
+        [
+          'Run',
+          {command: `shopify store auth --store ${SHOP} --scopes <comma-separated-scopes>`},
+          'to re-authenticate',
+        ],
+      ],
+    })
+  })
+})
+
+describe('retryStoreAuthWithPermanentDomainError', () => {
+  test('returns (rather than throws) an AbortError pointing at the permanent domain with a scopes placeholder', () => {
+    const error = retryStoreAuthWithPermanentDomainError('permanent-shop.myshopify.com')
+
+    expect(error).toBeInstanceOf(AbortError)
+    expect(error).toMatchObject({
+      message: 'OAuth callback store does not match the requested store.',
+      tryMessage:
+        'Shopify returned permanent-shop.myshopify.com during authentication. Re-run using the permanent store domain:',
+      nextSteps: [
+        [{command: 'shopify store auth --store permanent-shop.myshopify.com --scopes <comma-separated-scopes>'}],
+      ],
+    })
+  })
+})

--- a/packages/store/src/cli/services/store/auth/recovery.ts
+++ b/packages/store/src/cli/services/store/auth/recovery.ts
@@ -8,16 +8,24 @@ function storeAuthCommandNextSteps(store: string, scopes: string) {
   return [[storeAuthCommand(store, scopes)]]
 }
 
+// Folds the instruction into the "Next steps" bullet itself (`Run ... to <purpose>`) instead of
+// repeating it in a separate `tryMessage` line. Passing both a `tryMessage` like "To re-authenticate,
+// run:" and a `nextSteps` list renders as a stuttering "To re-authenticate, run:\nNext steps\n  •
+// shopify store auth ..." — the "Next steps" heading already says what the list is for.
+function storeAuthCommandNextStepsWithPurpose(store: string, scopes: string, purpose: string) {
+  return [['Run', storeAuthCommand(store, scopes), purpose]]
+}
+
 export function throwStoredStoreAuthError(store: string): never {
   throw new AbortError(
     `No stored app authentication found for ${store}.`,
-    'To create stored auth for this store, run:',
-    storeAuthCommandNextSteps(store, '<comma-separated-scopes>'),
+    undefined,
+    storeAuthCommandNextStepsWithPurpose(store, '<comma-separated-scopes>', 'to create stored auth for this store'),
   )
 }
 
 export function throwReauthenticateStoreAuthError(message: string, store: string, scopes: string): never {
-  throw new AbortError(message, 'To re-authenticate, run:', storeAuthCommandNextSteps(store, scopes))
+  throw new AbortError(message, undefined, storeAuthCommandNextStepsWithPurpose(store, scopes, 'to re-authenticate'))
 }
 
 export function retryStoreAuthWithPermanentDomainError(returnedStore: string): AbortError {

--- a/packages/store/src/cli/services/store/auth/recovery.ts
+++ b/packages/store/src/cli/services/store/auth/recovery.ts
@@ -38,6 +38,20 @@ export function throwReauthenticateStoreAuthError(message: string, session: Stor
   )
 }
 
+// A preview store's local session has no way to know it was claimed through the browser claim
+// flow; a 401/404 the first time the stale session is used again is the only signal. Surfacing
+// that possibility is more useful than the generic "no longer valid" message a standard session
+// gets, so every call site that detects an invalid stored session (regardless of which API it
+// hit) should go through here instead of writing its own message.
+export function throwStoredAuthInvalidError(session: StoredStoreAppSession): never {
+  const message =
+    session.kind === 'preview'
+      ? `The preview store ${session.store} has likely been claimed, so its stored authentication is no longer valid.`
+      : `Stored app authentication for ${session.store} is no longer valid.`
+
+  throwReauthenticateStoreAuthError(message, session)
+}
+
 export function retryStoreAuthWithPermanentDomainError(returnedStore: string): AbortError {
   // eslint-disable-next-line @shopify/cli/no-error-factory-functions
   return new AbortError(

--- a/packages/store/src/cli/services/store/auth/recovery.ts
+++ b/packages/store/src/cli/services/store/auth/recovery.ts
@@ -8,24 +8,20 @@ function storeAuthCommandNextSteps(store: string, scopes: string) {
   return [[storeAuthCommand(store, scopes)]]
 }
 
-// Folds the instruction into the "Next steps" bullet itself (`Run ... to <purpose>`) instead of
-// repeating it in a separate `tryMessage` line. Passing both a `tryMessage` like "To re-authenticate,
-// run:" and a `nextSteps` list renders as a stuttering "To re-authenticate, run:\nNext steps\n  •
-// shopify store auth ..." — the "Next steps" heading already says what the list is for.
-function storeAuthCommandNextStepsWithPurpose(store: string, scopes: string, purpose: string) {
-  return [['Run', storeAuthCommand(store, scopes), purpose]]
+function storeAuthCommandNextStepsToReauthenticate(store: string, scopes: string) {
+  return [['Run', storeAuthCommand(store, scopes), 'to re-authenticate']]
 }
 
 export function throwStoredStoreAuthError(store: string): never {
   throw new AbortError(
     `No stored app authentication found for ${store}.`,
     undefined,
-    storeAuthCommandNextStepsWithPurpose(store, '<comma-separated-scopes>', 'to create stored auth for this store'),
+    storeAuthCommandNextStepsToReauthenticate(store, '<comma-separated-scopes>'),
   )
 }
 
 export function throwReauthenticateStoreAuthError(message: string, store: string, scopes: string): never {
-  throw new AbortError(message, undefined, storeAuthCommandNextStepsWithPurpose(store, scopes, 'to re-authenticate'))
+  throw new AbortError(message, undefined, storeAuthCommandNextStepsToReauthenticate(store, scopes))
 }
 
 export function retryStoreAuthWithPermanentDomainError(returnedStore: string): AbortError {

--- a/packages/store/src/cli/services/store/auth/recovery.ts
+++ b/packages/store/src/cli/services/store/auth/recovery.ts
@@ -1,7 +1,7 @@
 import {AbortError} from '@shopify/cli-kit/node/error'
 import type {StoredStoreAppSession} from '@shopify/cli-kit/node/store-auth-session'
 
-export const UNKNOWN_SCOPES_PLACEHOLDER = '<comma-separated-scopes>'
+const UNKNOWN_SCOPES_PLACEHOLDER = '<comma-separated-scopes>'
 
 function storeAuthCommand(store: string, scopes: string): {command: string} {
   return {command: `shopify store auth --store ${store} --scopes ${scopes}`}

--- a/packages/store/src/cli/services/store/auth/recovery.ts
+++ b/packages/store/src/cli/services/store/auth/recovery.ts
@@ -1,5 +1,7 @@
 import {AbortError} from '@shopify/cli-kit/node/error'
 
+export const UNKNOWN_SCOPES_PLACEHOLDER = '<comma-separated-scopes>'
+
 function storeAuthCommand(store: string, scopes: string): {command: string} {
   return {command: `shopify store auth --store ${store} --scopes ${scopes}`}
 }
@@ -16,7 +18,7 @@ export function throwStoredStoreAuthError(store: string): never {
   throw new AbortError(
     `No stored app authentication found for ${store}.`,
     undefined,
-    storeAuthCommandNextStepsToReauthenticate(store, '<comma-separated-scopes>'),
+    storeAuthCommandNextStepsToReauthenticate(store, UNKNOWN_SCOPES_PLACEHOLDER),
   )
 }
 
@@ -29,6 +31,6 @@ export function retryStoreAuthWithPermanentDomainError(returnedStore: string): A
   return new AbortError(
     'OAuth callback store does not match the requested store.',
     `Shopify returned ${returnedStore} during authentication. Re-run using the permanent store domain:`,
-    storeAuthCommandNextSteps(returnedStore, '<comma-separated-scopes>'),
+    storeAuthCommandNextSteps(returnedStore, UNKNOWN_SCOPES_PLACEHOLDER),
   )
 }

--- a/packages/store/src/cli/services/store/auth/recovery.ts
+++ b/packages/store/src/cli/services/store/auth/recovery.ts
@@ -7,8 +7,8 @@ function storeAuthCommand(store: string, scopes: string): {command: string} {
   return {command: `shopify store auth --store ${store} --scopes ${scopes}`}
 }
 
-function storeAuthCommandNextSteps(store: string, scopes: string) {
-  return [[storeAuthCommand(store, scopes)]]
+function storeAuthCommandNextStepsWithUnknownScopes(store: string) {
+  return [[storeAuthCommand(store, UNKNOWN_SCOPES_PLACEHOLDER)]]
 }
 
 function storeAuthCommandNextStepsToReauthenticate(store: string, scopes: string) {
@@ -43,6 +43,6 @@ export function retryStoreAuthWithPermanentDomainError(returnedStore: string): A
   return new AbortError(
     'OAuth callback store does not match the requested store.',
     `Shopify returned ${returnedStore} during authentication. Re-run using the permanent store domain:`,
-    storeAuthCommandNextSteps(returnedStore, UNKNOWN_SCOPES_PLACEHOLDER),
+    storeAuthCommandNextStepsWithUnknownScopes(returnedStore),
   )
 }

--- a/packages/store/src/cli/services/store/auth/recovery.ts
+++ b/packages/store/src/cli/services/store/auth/recovery.ts
@@ -1,4 +1,5 @@
 import {AbortError} from '@shopify/cli-kit/node/error'
+import type {StoredStoreAppSession} from '@shopify/cli-kit/node/store-auth-session'
 
 export const UNKNOWN_SCOPES_PLACEHOLDER = '<comma-separated-scopes>'
 
@@ -14,6 +15,13 @@ function storeAuthCommandNextStepsToReauthenticate(store: string, scopes: string
   return [['Run', storeAuthCommand(store, scopes), 'to re-authenticate']]
 }
 
+// Preview-store sessions are preapproved for a large, fixed scope catalog (often 30+ scopes).
+// Suggesting the user re-request all of them encourages over-scoping, so they get the same
+// placeholder as the "no stored auth" case and choose deliberately instead.
+function reauthScopesFor(session: StoredStoreAppSession): string {
+  return session.kind === 'preview' ? UNKNOWN_SCOPES_PLACEHOLDER : session.scopes.join(',')
+}
+
 export function throwStoredStoreAuthError(store: string): never {
   throw new AbortError(
     `No stored app authentication found for ${store}.`,
@@ -22,8 +30,12 @@ export function throwStoredStoreAuthError(store: string): never {
   )
 }
 
-export function throwReauthenticateStoreAuthError(message: string, store: string, scopes: string): never {
-  throw new AbortError(message, undefined, storeAuthCommandNextStepsToReauthenticate(store, scopes))
+export function throwReauthenticateStoreAuthError(message: string, session: StoredStoreAppSession): never {
+  throw new AbortError(
+    message,
+    undefined,
+    storeAuthCommandNextStepsToReauthenticate(session.store, reauthScopesFor(session)),
+  )
 }
 
 export function retryStoreAuthWithPermanentDomainError(returnedStore: string): AbortError {

--- a/packages/store/src/cli/services/store/auth/recovery.ts
+++ b/packages/store/src/cli/services/store/auth/recovery.ts
@@ -11,8 +11,8 @@ function storeAuthCommandNextStepsWithUnknownScopes(store: string) {
   return [[storeAuthCommand(store, UNKNOWN_SCOPES_PLACEHOLDER)]]
 }
 
-function storeAuthCommandNextStepsToReauthenticate(store: string, scopes: string) {
-  return [['Run', storeAuthCommand(store, scopes), 'to re-authenticate']]
+function storeAuthCommandNextStepsWithPurpose(store: string, scopes: string, purpose: string) {
+  return [['Run', storeAuthCommand(store, scopes), purpose]]
 }
 
 // Preview-store sessions are preapproved for a large, fixed scope catalog (often 30+ scopes).
@@ -26,7 +26,7 @@ export function throwStoredStoreAuthError(store: string): never {
   throw new AbortError(
     `No stored app authentication found for ${store}.`,
     undefined,
-    storeAuthCommandNextStepsToReauthenticate(store, UNKNOWN_SCOPES_PLACEHOLDER),
+    storeAuthCommandNextStepsWithPurpose(store, UNKNOWN_SCOPES_PLACEHOLDER, 'to authenticate'),
   )
 }
 
@@ -34,7 +34,7 @@ export function throwReauthenticateStoreAuthError(message: string, session: Stor
   throw new AbortError(
     message,
     undefined,
-    storeAuthCommandNextStepsToReauthenticate(session.store, reauthScopesFor(session)),
+    storeAuthCommandNextStepsWithPurpose(session.store, reauthScopesFor(session), 'to re-authenticate'),
   )
 }
 

--- a/packages/store/src/cli/services/store/auth/session-lifecycle.test.ts
+++ b/packages/store/src/cli/services/store/auth/session-lifecycle.test.ts
@@ -142,7 +142,13 @@ describe('loadStoredStoreSession', () => {
 
     await expect(loadStoredStoreSession('shop.myshopify.com')).rejects.toMatchObject({
       message: 'Token refresh failed for shop.myshopify.com (HTTP 401).',
-      tryMessage: 'To re-authenticate, run:',
+      nextSteps: [
+        [
+          'Run',
+          {command: 'shopify store auth --store shop.myshopify.com --scopes read_products'},
+          'to re-authenticate',
+        ],
+      ],
     })
     expect(clearStoredStoreAppSession).toHaveBeenCalledWith('shop.myshopify.com', '42')
   })
@@ -167,7 +173,13 @@ describe('loadStoredStoreSession', () => {
 
     await expect(loadStoredStoreSession('shop.myshopify.com')).rejects.toMatchObject({
       message: 'Token refresh returned an invalid response for shop.myshopify.com.',
-      tryMessage: 'To re-authenticate, run:',
+      nextSteps: [
+        [
+          'Run',
+          {command: 'shopify store auth --store shop.myshopify.com --scopes read_products'},
+          'to re-authenticate',
+        ],
+      ],
     })
     expect(clearStoredStoreAppSession).toHaveBeenCalledWith('shop.myshopify.com', '42')
   })

--- a/packages/store/src/cli/services/store/auth/session-lifecycle.test.ts
+++ b/packages/store/src/cli/services/store/auth/session-lifecycle.test.ts
@@ -63,6 +63,13 @@ describe('loadStoredStoreSession', () => {
 
     await expect(loadStoredStoreSession('shop.myshopify.com')).rejects.toMatchObject({
       message: 'No stored app authentication found for shop.myshopify.com.',
+      nextSteps: [
+        [
+          'Run',
+          {command: 'shopify store auth --store shop.myshopify.com --scopes <comma-separated-scopes>'},
+          'to authenticate',
+        ],
+      ],
     })
   })
 

--- a/packages/store/src/cli/services/store/auth/session-lifecycle.ts
+++ b/packages/store/src/cli/services/store/auth/session-lifecycle.ts
@@ -61,11 +61,7 @@ export async function loadStoredStoreSession(store: string): Promise<StoredStore
   }
 
   if (!session.refreshToken) {
-    throwReauthenticateStoreAuthError(
-      `No refresh token stored for ${session.store}.`,
-      session.store,
-      session.scopes.join(','),
-    )
+    throwReauthenticateStoreAuthError(`No refresh token stored for ${session.store}.`, session)
   }
 
   outputDebug(
@@ -84,14 +80,14 @@ export async function loadStoredStoreSession(store: string): Promise<StoredStore
     clearStoredStoreAppSession(session.store, session.userId)
 
     if (error instanceof AbortError && error.message.startsWith(`Token refresh failed for ${session.store} (HTTP `)) {
-      throwReauthenticateStoreAuthError(error.message, session.store, session.scopes.join(','))
+      throwReauthenticateStoreAuthError(error.message, session)
     }
 
     if (
       error instanceof AbortError &&
       error.message === `Token refresh returned an invalid response for ${session.store}.`
     ) {
-      throwReauthenticateStoreAuthError(error.message, session.store, session.scopes.join(','))
+      throwReauthenticateStoreAuthError(error.message, session)
     }
 
     if (error instanceof AbortError && error.message === 'Received an invalid refresh response from Shopify.') {

--- a/packages/store/src/cli/services/store/create/preview/client.test.ts
+++ b/packages/store/src/cli/services/store/create/preview/client.test.ts
@@ -6,6 +6,7 @@ import {
   getOrCreateCliInstanceId,
   previewStoreAuthenticatedHeaders,
   previewStoreCreateHeaders,
+  PreviewStoreRequestError,
 } from './client.js'
 import {shopifyFetch} from '@shopify/cli-kit/node/http'
 import {LocalStorage} from '@shopify/cli-kit/node/local-storage'
@@ -197,6 +198,19 @@ describe('preview store client', () => {
       accessUrl: 'https://app.shopify.com/auth/preview-store?token=fresh-access-token',
       claimUrl: 'https://admin.shopify.com/store-transfer/accept/claim-token',
     })
+  })
+
+  test.each([401, 404])('rejects preview store lookups with a %s-carrying error', async (status) => {
+    vi.mocked(shopifyFetch).mockResolvedValueOnce(response(status, {message: 'Not found'}))
+
+    const error = await getPreviewStore(
+      {shopId: '123', adminApiToken: 'shpat_token'},
+      {storage: inMemoryStorage('instance-1')},
+    ).catch((caught: unknown) => caught)
+
+    expect(error).toBeInstanceOf(PreviewStoreRequestError)
+    expect((error as PreviewStoreRequestError).status).toBe(status)
+    expect((error as PreviewStoreRequestError).message).toBe(`Preview store lookup failed with HTTP ${status}.`)
   })
 
   test('omits the claim URL when the backend degrades it to null', async () => {

--- a/packages/store/src/cli/services/store/create/preview/client.ts
+++ b/packages/store/src/cli/services/store/create/preview/client.ts
@@ -82,6 +82,23 @@ interface RawPreviewStoreErrorResponse {
   message?: string
 }
 
+/**
+ * Thrown by `getPreviewStore` for non-2xx responses so callers can classify the failure (e.g. a
+ * 401/404 that signals the preview store has since been claimed) instead of only seeing a
+ * pre-rendered message string.
+ */
+export class PreviewStoreRequestError extends Error {
+  public readonly status: number
+  public readonly tryMessage?: string
+
+  constructor(status: number, message: string, tryMessage?: string) {
+    super(message)
+    this.name = 'PreviewStoreRequestError'
+    this.status = status
+    this.tryMessage = tryMessage
+  }
+}
+
 export function getOrCreateCliInstanceId(
   storage: LocalStorage<PreviewStoreClientStorageSchema> = clientStorage(),
 ): string {
@@ -175,7 +192,7 @@ export async function getPreviewStore(
   const rawText = await response.text()
   if (!response.ok) {
     const error = previewStoreGetError(response.status, rawText)
-    throw new AbortError(error.message, error.tryMessage)
+    throw new PreviewStoreRequestError(response.status, error.message, error.tryMessage)
   }
 
   let parsed: RawPreviewStoreGetResponse

--- a/packages/store/src/cli/services/store/create/preview/client.ts
+++ b/packages/store/src/cli/services/store/create/preview/client.ts
@@ -87,15 +87,12 @@ interface RawPreviewStoreErrorResponse {
  * 401/404 that signals the preview store has since been claimed) instead of only seeing a
  * pre-rendered message string.
  */
-export class PreviewStoreRequestError extends Error {
+export class PreviewStoreRequestError extends AbortError {
   public readonly status: number
-  public readonly tryMessage?: string
 
   constructor(status: number, message: string, tryMessage?: string) {
-    super(message)
-    this.name = 'PreviewStoreRequestError'
+    super(message, tryMessage ?? null)
     this.status = status
-    this.tryMessage = tryMessage
   }
 }
 

--- a/packages/store/src/cli/services/store/execute/admin-transport.test.ts
+++ b/packages/store/src/cli/services/store/execute/admin-transport.test.ts
@@ -79,8 +79,13 @@ describe('runAdminStoreGraphQLOperation', () => {
 
     await expect(runAdminStoreGraphQLOperation({context, request})).rejects.toMatchObject({
       message: `Stored app authentication for ${store} is no longer valid.`,
-      tryMessage: 'To re-authenticate, run:',
-      nextSteps: [[{command: `shopify store auth --store ${store} --scopes read_products,write_orders`}]],
+      nextSteps: [
+        [
+          'Run',
+          {command: `shopify store auth --store ${store} --scopes read_products,write_orders`},
+          'to re-authenticate',
+        ],
+      ],
     })
     expect(clearStoredStoreAppSession).toHaveBeenCalledWith(store, '42')
   })
@@ -212,8 +217,13 @@ describe('fetchPublicApiVersions', () => {
 
     await expect(fetchPublicApiVersions({adminSession, session})).rejects.toMatchObject({
       message: `Stored app authentication for ${store} is no longer valid.`,
-      tryMessage: 'To re-authenticate, run:',
-      nextSteps: [[{command: `shopify store auth --store ${store} --scopes read_products,write_orders`}]],
+      nextSteps: [
+        [
+          'Run',
+          {command: `shopify store auth --store ${store} --scopes read_products,write_orders`},
+          'to re-authenticate',
+        ],
+      ],
     })
     expect(clearStoredStoreAppSession).toHaveBeenCalledWith(store, '42')
   })

--- a/packages/store/src/cli/services/store/execute/admin-transport.test.ts
+++ b/packages/store/src/cli/services/store/execute/admin-transport.test.ts
@@ -100,6 +100,40 @@ describe('runAdminStoreGraphQLOperation', () => {
     expect(clearStoredStoreAppSession).toHaveBeenCalledWith(store, '42')
   })
 
+  test('also treats a 404 as a stored-auth-no-longer-valid signal', async () => {
+    vi.mocked(graphqlRequest).mockRejectedValue(makeClientErrorLike(404, 'Not Found'))
+    const request = await prepareStoreExecuteRequest({query: 'query { shop { name } }'})
+
+    await expect(runAdminStoreGraphQLOperation({context, request})).rejects.toMatchObject({
+      message: `Stored app authentication for ${store} is no longer valid.`,
+    })
+    expect(clearStoredStoreAppSession).toHaveBeenCalledWith(store, '42')
+  })
+
+  test('does not re-list preapproved scopes when a lingering preview session 401s', async () => {
+    vi.mocked(graphqlRequest).mockRejectedValue({response: {status: 401}})
+    const request = await prepareStoreExecuteRequest({query: 'query { shop { name } }'})
+    const previewContext = {
+      ...context,
+      session: {
+        ...context.session,
+        userId: 'preview:placeholder-uuid',
+        kind: 'preview' as const,
+        scopes: ['read_products', 'write_products', 'read_themes'],
+      },
+    }
+
+    await expect(runAdminStoreGraphQLOperation({context: previewContext, request})).rejects.toMatchObject({
+      nextSteps: [
+        [
+          'Run',
+          {command: `shopify store auth --store ${store} --scopes <comma-separated-scopes>`},
+          'to re-authenticate',
+        ],
+      ],
+    })
+  })
+
   test('throws a GraphQL operation error when errors are returned', async () => {
     vi.mocked(graphqlRequest).mockRejectedValue({response: {errors: [{message: 'Field does not exist'}]}})
     const request = await prepareStoreExecuteRequest({query: 'query { nope }'})
@@ -235,6 +269,26 @@ describe('fetchPublicApiVersions', () => {
       message: `Stored app authentication for ${store} is no longer valid.`,
     })
     expect(clearStoredStoreAppSession).toHaveBeenCalledWith(store, '42')
+  })
+
+  test('does not re-list preapproved scopes when a lingering preview session 401s', async () => {
+    vi.mocked(graphqlRequest).mockRejectedValue(makeClientErrorLike(401, 'Unauthorized'))
+    const previewSession = {
+      ...session,
+      userId: 'preview:placeholder-uuid',
+      kind: 'preview' as const,
+      scopes: ['read_products', 'write_products', 'read_themes'],
+    }
+
+    await expect(fetchPublicApiVersions({adminSession, session: previewSession})).rejects.toMatchObject({
+      nextSteps: [
+        [
+          'Run',
+          {command: `shopify store auth --store ${store} --scopes <comma-separated-scopes>`},
+          'to re-authenticate',
+        ],
+      ],
+    })
   })
 
   test('maps 402 Unavailable Shop to an AbortError without clearing stored auth', async () => {

--- a/packages/store/src/cli/services/store/execute/admin-transport.test.ts
+++ b/packages/store/src/cli/services/store/execute/admin-transport.test.ts
@@ -132,6 +132,7 @@ describe('runAdminStoreGraphQLOperation', () => {
         ],
       ],
     })
+    expect(clearStoredStoreAppSession).not.toHaveBeenCalled()
   })
 
   test('throws a GraphQL operation error when errors are returned', async () => {
@@ -289,6 +290,7 @@ describe('fetchPublicApiVersions', () => {
         ],
       ],
     })
+    expect(clearStoredStoreAppSession).not.toHaveBeenCalled()
   })
 
   test('maps 402 Unavailable Shop to an AbortError without clearing stored auth', async () => {

--- a/packages/store/src/cli/services/store/execute/admin-transport.test.ts
+++ b/packages/store/src/cli/services/store/execute/admin-transport.test.ts
@@ -110,7 +110,7 @@ describe('runAdminStoreGraphQLOperation', () => {
     expect(clearStoredStoreAppSession).toHaveBeenCalledWith(store, '42')
   })
 
-  test('does not re-list preapproved scopes when a lingering preview session 401s', async () => {
+  test('flags a likely claim and does not re-list scopes when a lingering preview session 401s', async () => {
     vi.mocked(graphqlRequest).mockRejectedValue({response: {status: 401}})
     const request = await prepareStoreExecuteRequest({query: 'query { shop { name } }'})
     const previewContext = {
@@ -124,6 +124,7 @@ describe('runAdminStoreGraphQLOperation', () => {
     }
 
     await expect(runAdminStoreGraphQLOperation({context: previewContext, request})).rejects.toMatchObject({
+      message: `The preview store ${store} has likely been claimed, so its stored authentication is no longer valid.`,
       nextSteps: [
         [
           'Run',
@@ -272,7 +273,7 @@ describe('fetchPublicApiVersions', () => {
     expect(clearStoredStoreAppSession).toHaveBeenCalledWith(store, '42')
   })
 
-  test('does not re-list preapproved scopes when a lingering preview session 401s', async () => {
+  test('flags a likely claim and does not re-list scopes when a lingering preview session 401s', async () => {
     vi.mocked(graphqlRequest).mockRejectedValue(makeClientErrorLike(401, 'Unauthorized'))
     const previewSession = {
       ...session,
@@ -282,6 +283,7 @@ describe('fetchPublicApiVersions', () => {
     }
 
     await expect(fetchPublicApiVersions({adminSession, session: previewSession})).rejects.toMatchObject({
+      message: `The preview store ${store} has likely been claimed, so its stored authentication is no longer valid.`,
       nextSteps: [
         [
           'Run',

--- a/packages/store/src/cli/services/store/execute/admin-transport.ts
+++ b/packages/store/src/cli/services/store/execute/admin-transport.ts
@@ -1,11 +1,9 @@
-import {throwReauthenticateStoreAuthError} from '../auth/recovery.js'
 import {
   classifyAdminApiError,
   isGraphQLClientErrorLike,
   throwIfStoredStoreAuthIsInvalid,
   ABORTED_FETCH_MESSAGE_FRAGMENTS,
 } from '../admin-errors.js'
-import {clearStoredStoreAppSession} from '@shopify/cli-kit/node/store-auth-session'
 import {adminUrl} from '@shopify/cli-kit/node/api/admin'
 import {graphqlRequest} from '@shopify/cli-kit/node/api/graphql'
 import {AbortError} from '@shopify/cli-kit/node/error'
@@ -84,14 +82,7 @@ export async function runAdminStoreGraphQLOperation(input: {
       renderOptions: {stdout: process.stderr},
     })
   } catch (error) {
-    if (isGraphQLClientErrorLike(error) && error.response.status === 401) {
-      clearStoredStoreAppSession(input.context.session.store, input.context.session.userId)
-      throwReauthenticateStoreAuthError(
-        `Stored app authentication for ${input.context.session.store} is no longer valid.`,
-        input.context.session.store,
-        input.context.session.scopes.join(','),
-      )
-    }
+    throwIfStoredStoreAuthIsInvalid(error, input.context.session)
 
     // Status-specific classification (e.g. 402 store-unavailable) must run before the
     // generic GraphQL-errors branch, otherwise a 402 response that also carries

--- a/packages/store/src/cli/services/store/info/index.test.ts
+++ b/packages/store/src/cli/services/store/info/index.test.ts
@@ -4,7 +4,7 @@ import {fetchOrganizationShop} from './organization-shop.js'
 import {STORE_AUTH_APP_CLIENT_ID} from '../auth/config.js'
 import {loadStoredStoreSession} from '../auth/session-lifecycle.js'
 import {recordStoreFqdnMetadata} from '../attribution.js'
-import {getPreviewStore} from '../create/preview/client.js'
+import {getPreviewStore, PreviewStoreRequestError} from '../create/preview/client.js'
 import {clearStoredStoreAppSession, getCurrentStoredStoreAppSession} from '@shopify/cli-kit/node/store-auth-session'
 import {AbortError, BugError} from '@shopify/cli-kit/node/error'
 import {adminUrl} from '@shopify/cli-kit/node/api/admin'
@@ -25,7 +25,13 @@ vi.mock('./organization-shop.js')
 vi.mock('../auth/session-lifecycle.js')
 vi.mock('@shopify/cli-kit/node/store-auth-session')
 vi.mock('../attribution.js')
-vi.mock('../create/preview/client.js')
+vi.mock('../create/preview/client.js', async () => {
+  const actual = await vi.importActual<typeof import('../create/preview/client.js')>('../create/preview/client.js')
+  return {
+    ...actual,
+    getPreviewStore: vi.fn(),
+  }
+})
 vi.mock('@shopify/cli-kit/node/api/graphql')
 vi.mock('@shopify/cli-kit/node/session')
 vi.mock('@shopify/cli-kit/node/api/admin', async () => {
@@ -185,6 +191,64 @@ describe('getStoreInfo', () => {
     })
     // The admin URL doesn't resolve for an unclaimed preview store, so it's deliberately omitted.
     expect(result.adminUrl).toBeUndefined()
+  })
+
+  test.each([401, 404])(
+    'clears the stale preview session and prompts re-auth when the preview store lookup returns %s',
+    async (status) => {
+      vi.mocked(getCurrentStoredStoreAppSession).mockReturnValueOnce({
+        store: SHOP,
+        clientId: STORE_AUTH_APP_CLIENT_ID,
+        userId: 'preview:placeholder-uuid',
+        accessToken: 'shpat_preview_token',
+        scopes: ['read_products'],
+        acquiredAt: '2026-06-08T12:00:00.000Z',
+        kind: 'preview',
+        preview: {
+          placeholderAccountUuid: 'placeholder-uuid',
+          shopId: '123',
+          name: 'Lavender Candles',
+          createdAt: '2026-06-08T12:00:00.000Z',
+          accessUrl: 'https://app.shopify.com/auth/preview-store?token=stale-access-token',
+        },
+      })
+      vi.mocked(getPreviewStore).mockRejectedValueOnce(
+        new PreviewStoreRequestError(status, `Preview store lookup failed with HTTP ${status}.`),
+      )
+
+      await expect(getStoreInfo({store: SHOP})).rejects.toMatchObject({
+        message: `The preview store ${SHOP} has likely been claimed, so its stored authentication is no longer valid.`,
+        nextSteps: [
+          ['Run', {command: `shopify store auth --store ${SHOP} --scopes read_products`}, 'to re-authenticate'],
+        ],
+      })
+      expect(clearStoredStoreAppSession).toHaveBeenCalledWith(SHOP, 'preview:placeholder-uuid')
+    },
+  )
+
+  test('rethrows unrelated preview store lookup failures without clearing the session', async () => {
+    vi.mocked(getCurrentStoredStoreAppSession).mockReturnValueOnce({
+      store: SHOP,
+      clientId: STORE_AUTH_APP_CLIENT_ID,
+      userId: 'preview:placeholder-uuid',
+      accessToken: 'shpat_preview_token',
+      scopes: ['read_products'],
+      acquiredAt: '2026-06-08T12:00:00.000Z',
+      kind: 'preview',
+      preview: {
+        placeholderAccountUuid: 'placeholder-uuid',
+        shopId: '123',
+        name: 'Lavender Candles',
+        createdAt: '2026-06-08T12:00:00.000Z',
+        accessUrl: 'https://app.shopify.com/auth/preview-store?token=stale-access-token',
+      },
+    })
+    vi.mocked(getPreviewStore).mockRejectedValueOnce(
+      new PreviewStoreRequestError(500, 'Preview store lookup failed with HTTP 500.'),
+    )
+
+    await expect(getStoreInfo({store: SHOP})).rejects.toThrow('Preview store lookup failed with HTTP 500.')
+    expect(clearStoredStoreAppSession).not.toHaveBeenCalled()
   })
 
   test('surfaces cached Admin API scopes for locally stored preview stores', async () => {
@@ -484,8 +548,9 @@ The CLI is currently unable to prompt for reauthentication.`)
 
     await expect(getStoreInfo({store: SHOP})).rejects.toMatchObject({
       message: `Stored app authentication for ${SHOP} is no longer valid.`,
-      tryMessage: 'To re-authenticate, run:',
-      nextSteps: [[{command: `shopify store auth --store ${SHOP} --scopes read_products`}]],
+      nextSteps: [
+        ['Run', {command: `shopify store auth --store ${SHOP} --scopes read_products`}, 'to re-authenticate'],
+      ],
     })
     expect(clearStoredStoreAppSession).toHaveBeenCalledWith(SHOP, '42')
   })

--- a/packages/store/src/cli/services/store/info/index.test.ts
+++ b/packages/store/src/cli/services/store/info/index.test.ts
@@ -561,7 +561,7 @@ The CLI is currently unable to prompt for reauthentication.`)
     expect(clearStoredStoreAppSession).toHaveBeenCalledWith(SHOP, '42')
   })
 
-  test('does not re-list scopes or clear a lingering preview session that 401s against Admin', async () => {
+  test('flags a likely claim (not a generic invalid-auth error) for a lingering preview session that 401s against Admin', async () => {
     mockStoreAuthFallback()
     vi.mocked(loadStoredStoreSession).mockResolvedValue({
       ...STORED_SESSION,
@@ -572,7 +572,7 @@ The CLI is currently unable to prompt for reauthentication.`)
     vi.mocked(graphqlRequest).mockRejectedValue(makeClientErrorLike(401, 'Unauthorized'))
 
     await expect(getStoreInfo({store: SHOP})).rejects.toMatchObject({
-      message: `Stored app authentication for ${SHOP} is no longer valid.`,
+      message: `The preview store ${SHOP} has likely been claimed, so its stored authentication is no longer valid.`,
       nextSteps: [
         [
           'Run',

--- a/packages/store/src/cli/services/store/info/index.test.ts
+++ b/packages/store/src/cli/services/store/info/index.test.ts
@@ -561,6 +561,29 @@ The CLI is currently unable to prompt for reauthentication.`)
     expect(clearStoredStoreAppSession).toHaveBeenCalledWith(SHOP, '42')
   })
 
+  test('does not re-list scopes or clear a lingering preview session that 401s against Admin', async () => {
+    mockStoreAuthFallback()
+    vi.mocked(loadStoredStoreSession).mockResolvedValue({
+      ...STORED_SESSION,
+      userId: 'preview:placeholder-uuid',
+      kind: 'preview',
+      scopes: ['read_products', 'write_products', 'read_themes'],
+    })
+    vi.mocked(graphqlRequest).mockRejectedValue(makeClientErrorLike(401, 'Unauthorized'))
+
+    await expect(getStoreInfo({store: SHOP})).rejects.toMatchObject({
+      message: `Stored app authentication for ${SHOP} is no longer valid.`,
+      nextSteps: [
+        [
+          'Run',
+          {command: `shopify store auth --store ${SHOP} --scopes <comma-separated-scopes>`},
+          'to re-authenticate',
+        ],
+      ],
+    })
+    expect(clearStoredStoreAppSession).not.toHaveBeenCalled()
+  })
+
   test('also treats Admin 404 as a stored-auth-no-longer-valid signal', async () => {
     mockStoreAuthFallback()
     vi.mocked(graphqlRequest).mockRejectedValue(makeClientErrorLike(404, 'Not Found'))

--- a/packages/store/src/cli/services/store/info/index.test.ts
+++ b/packages/store/src/cli/services/store/info/index.test.ts
@@ -222,10 +222,6 @@ describe('getStoreInfo', () => {
           ['Run', {command: `shopify store auth --store ${SHOP} --scopes read_products`}, 'to re-authenticate'],
         ],
       })
-      // `store auth` overwrites the bucket's `currentUserId` when it stores a fresh session, so
-      // clearing this preview entry first isn't necessary — and not clearing it means repeated
-      // `store info` runs keep producing this same actionable message instead of silently
-      // falling through to a full interactive login on the next attempt.
       expect(clearStoredStoreAppSession).not.toHaveBeenCalled()
     },
   )

--- a/packages/store/src/cli/services/store/info/index.test.ts
+++ b/packages/store/src/cli/services/store/info/index.test.ts
@@ -201,7 +201,9 @@ describe('getStoreInfo', () => {
         clientId: STORE_AUTH_APP_CLIENT_ID,
         userId: 'preview:placeholder-uuid',
         accessToken: 'shpat_preview_token',
-        scopes: ['read_products'],
+        // Preview stores are preapproved for a large, fixed scope catalog; the re-auth message
+        // should not dump the whole list back at the user (see the placeholder assertion below).
+        scopes: ['read_products', 'write_products', 'read_themes'],
         acquiredAt: '2026-06-08T12:00:00.000Z',
         kind: 'preview',
         preview: {
@@ -219,7 +221,11 @@ describe('getStoreInfo', () => {
       await expect(getStoreInfo({store: SHOP})).rejects.toMatchObject({
         message: `The preview store ${SHOP} has likely been claimed, so its stored authentication is no longer valid.`,
         nextSteps: [
-          ['Run', {command: `shopify store auth --store ${SHOP} --scopes read_products`}, 'to re-authenticate'],
+          [
+            'Run',
+            {command: `shopify store auth --store ${SHOP} --scopes <comma-separated-scopes>`},
+            'to re-authenticate',
+          ],
         ],
       })
       expect(clearStoredStoreAppSession).not.toHaveBeenCalled()

--- a/packages/store/src/cli/services/store/info/index.test.ts
+++ b/packages/store/src/cli/services/store/info/index.test.ts
@@ -194,7 +194,7 @@ describe('getStoreInfo', () => {
   })
 
   test.each([401, 404])(
-    'clears the stale preview session and prompts re-auth when the preview store lookup returns %s',
+    'prompts re-auth without clearing the stale preview session when the preview store lookup returns %s',
     async (status) => {
       vi.mocked(getCurrentStoredStoreAppSession).mockReturnValueOnce({
         store: SHOP,
@@ -222,7 +222,11 @@ describe('getStoreInfo', () => {
           ['Run', {command: `shopify store auth --store ${SHOP} --scopes read_products`}, 'to re-authenticate'],
         ],
       })
-      expect(clearStoredStoreAppSession).toHaveBeenCalledWith(SHOP, 'preview:placeholder-uuid')
+      // `store auth` overwrites the bucket's `currentUserId` when it stores a fresh session, so
+      // clearing this preview entry first isn't necessary — and not clearing it means repeated
+      // `store info` runs keep producing this same actionable message instead of silently
+      // falling through to a full interactive login on the next attempt.
+      expect(clearStoredStoreAppSession).not.toHaveBeenCalled()
     },
   )
 

--- a/packages/store/src/cli/services/store/info/index.ts
+++ b/packages/store/src/cli/services/store/info/index.ts
@@ -3,10 +3,11 @@ import {fetchOrganizationShop} from './organization-shop.js'
 import {mapPlanToPublicHandle} from './plan.js'
 import {classifyAdminApiError, throwIfStoredStoreAuthIsInvalid} from '../admin-errors.js'
 import {recordStoreFqdnMetadata} from '../attribution.js'
+import {throwReauthenticateStoreAuthError} from '../auth/recovery.js'
 import {loadStoredStoreSession} from '../auth/session-lifecycle.js'
-import {getPreviewStore} from '../create/preview/client.js'
+import {getPreviewStore, PreviewStoreRequestError} from '../create/preview/client.js'
 import {storeTypeHandle} from '../store-type.js'
-import {getCurrentStoredStoreAppSession} from '@shopify/cli-kit/node/store-auth-session'
+import {clearStoredStoreAppSession, getCurrentStoredStoreAppSession} from '@shopify/cli-kit/node/store-auth-session'
 import {AbortError} from '@shopify/cli-kit/node/error'
 import {adminUrl} from '@shopify/cli-kit/node/api/admin'
 import {graphqlRequest} from '@shopify/cli-kit/node/api/graphql'
@@ -147,13 +148,31 @@ interface PreviewStoreUrls {
 }
 
 async function fetchPreviewStoreUrls(previewSession: PreviewStoreSession): Promise<PreviewStoreUrls> {
-  const previewStore = await getPreviewStore({
-    shopId: previewSession.preview.shopId,
-    adminApiToken: previewSession.accessToken,
-  })
-  return {
-    accessUrl: previewStore.accessUrl,
-    ...(previewStore.claimUrl ? {saveUrl: previewStore.claimUrl} : {}),
+  try {
+    const previewStore = await getPreviewStore({
+      shopId: previewSession.preview.shopId,
+      adminApiToken: previewSession.accessToken,
+    })
+    return {
+      accessUrl: previewStore.accessUrl,
+      ...(previewStore.claimUrl ? {saveUrl: previewStore.claimUrl} : {}),
+    }
+  } catch (error) {
+    // The CLI has no local signal for when a preview store gets claimed through the browser
+    // claim flow; the stored session keeps reporting `kind: 'preview'` forever. A 401/404 from
+    // the preview-stores service is the first indication that the store has moved on and the
+    // cached preview token is no longer valid, so treat it the same way the Admin API paths
+    // treat a stale stored session: clear it and point the user at `store auth`.
+    if (error instanceof PreviewStoreRequestError && (error.status === 401 || error.status === 404)) {
+      clearStoredStoreAppSession(previewSession.store, previewSession.userId)
+      throwReauthenticateStoreAuthError(
+        `The preview store ${previewSession.store} has likely been claimed, so its stored authentication is no longer valid.`,
+        previewSession.store,
+        previewSession.scopes.join(','),
+      )
+    }
+
+    throw error
   }
 }
 

--- a/packages/store/src/cli/services/store/info/index.ts
+++ b/packages/store/src/cli/services/store/info/index.ts
@@ -7,7 +7,7 @@ import {throwReauthenticateStoreAuthError} from '../auth/recovery.js'
 import {loadStoredStoreSession} from '../auth/session-lifecycle.js'
 import {getPreviewStore, PreviewStoreRequestError} from '../create/preview/client.js'
 import {storeTypeHandle} from '../store-type.js'
-import {clearStoredStoreAppSession, getCurrentStoredStoreAppSession} from '@shopify/cli-kit/node/store-auth-session'
+import {getCurrentStoredStoreAppSession} from '@shopify/cli-kit/node/store-auth-session'
 import {AbortError} from '@shopify/cli-kit/node/error'
 import {adminUrl} from '@shopify/cli-kit/node/api/admin'
 import {graphqlRequest} from '@shopify/cli-kit/node/api/graphql'
@@ -161,10 +161,15 @@ async function fetchPreviewStoreUrls(previewSession: PreviewStoreSession): Promi
     // The CLI has no local signal for when a preview store gets claimed through the browser
     // claim flow; the stored session keeps reporting `kind: 'preview'` forever. A 401/404 from
     // the preview-stores service is the first indication that the store has moved on and the
-    // cached preview token is no longer valid, so treat it the same way the Admin API paths
-    // treat a stale stored session: clear it and point the user at `store auth`.
+    // cached preview token is no longer valid.
+    //
+    // Deliberately left uncleared: `store auth` overwrites the bucket's `currentUserId` when it
+    // stores a fresh session, so nothing depends on this preview entry being removed first. And
+    // unlike a standard session's refresh-token flow, there's no automatic-retry loop here that
+    // clearing would protect against. Leaving it in place means every `store info` run before
+    // the user re-authenticates keeps producing this same actionable message, instead of
+    // silently falling through to a full interactive login on the next attempt.
     if (error instanceof PreviewStoreRequestError && (error.status === 401 || error.status === 404)) {
-      clearStoredStoreAppSession(previewSession.store, previewSession.userId)
       throwReauthenticateStoreAuthError(
         `The preview store ${previewSession.store} has likely been claimed, so its stored authentication is no longer valid.`,
         previewSession.store,

--- a/packages/store/src/cli/services/store/info/index.ts
+++ b/packages/store/src/cli/services/store/info/index.ts
@@ -1,7 +1,7 @@
 import {StoreInfoBusinessPlatformStoreNotFoundError, fetchDestinationsContext} from './destinations.js'
 import {fetchOrganizationShop} from './organization-shop.js'
 import {mapPlanToPublicHandle} from './plan.js'
-import {classifyAdminApiError, reauthScopesFor, throwIfStoredStoreAuthIsInvalid} from '../admin-errors.js'
+import {classifyAdminApiError, throwIfStoredStoreAuthIsInvalid} from '../admin-errors.js'
 import {recordStoreFqdnMetadata} from '../attribution.js'
 import {throwReauthenticateStoreAuthError} from '../auth/recovery.js'
 import {loadStoredStoreSession} from '../auth/session-lifecycle.js'
@@ -165,8 +165,7 @@ async function fetchPreviewStoreUrls(previewSession: PreviewStoreSession): Promi
     if (error instanceof PreviewStoreRequestError && (error.status === 401 || error.status === 404)) {
       throwReauthenticateStoreAuthError(
         `The preview store ${previewSession.store} has likely been claimed, so its stored authentication is no longer valid.`,
-        previewSession.store,
-        reauthScopesFor(previewSession),
+        previewSession,
       )
     }
 

--- a/packages/store/src/cli/services/store/info/index.ts
+++ b/packages/store/src/cli/services/store/info/index.ts
@@ -3,7 +3,7 @@ import {fetchOrganizationShop} from './organization-shop.js'
 import {mapPlanToPublicHandle} from './plan.js'
 import {classifyAdminApiError, throwIfStoredStoreAuthIsInvalid} from '../admin-errors.js'
 import {recordStoreFqdnMetadata} from '../attribution.js'
-import {throwReauthenticateStoreAuthError} from '../auth/recovery.js'
+import {throwReauthenticateStoreAuthError, UNKNOWN_SCOPES_PLACEHOLDER} from '../auth/recovery.js'
 import {loadStoredStoreSession} from '../auth/session-lifecycle.js'
 import {getPreviewStore, PreviewStoreRequestError} from '../create/preview/client.js'
 import {storeTypeHandle} from '../store-type.js'
@@ -163,10 +163,13 @@ async function fetchPreviewStoreUrls(previewSession: PreviewStoreSession): Promi
     // isn't needed for `store auth` to take over, and keeping it means every `store info` run
     // keeps producing this same actionable message instead of falling through to a full login.
     if (error instanceof PreviewStoreRequestError && (error.status === 401 || error.status === 404)) {
+      // Preview stores are preapproved for a large, fixed catalog of scopes; blindly suggesting
+      // the user re-request all of them against what's now a live, claimed store would encourage
+      // over-scoping. Point at the placeholder instead so they choose deliberately.
       throwReauthenticateStoreAuthError(
         `The preview store ${previewSession.store} has likely been claimed, so its stored authentication is no longer valid.`,
         previewSession.store,
-        previewSession.scopes.join(','),
+        UNKNOWN_SCOPES_PLACEHOLDER,
       )
     }
 

--- a/packages/store/src/cli/services/store/info/index.ts
+++ b/packages/store/src/cli/services/store/info/index.ts
@@ -1,9 +1,9 @@
 import {StoreInfoBusinessPlatformStoreNotFoundError, fetchDestinationsContext} from './destinations.js'
 import {fetchOrganizationShop} from './organization-shop.js'
 import {mapPlanToPublicHandle} from './plan.js'
-import {classifyAdminApiError, throwIfStoredStoreAuthIsInvalid} from '../admin-errors.js'
+import {classifyAdminApiError, reauthScopesFor, throwIfStoredStoreAuthIsInvalid} from '../admin-errors.js'
 import {recordStoreFqdnMetadata} from '../attribution.js'
-import {throwReauthenticateStoreAuthError, UNKNOWN_SCOPES_PLACEHOLDER} from '../auth/recovery.js'
+import {throwReauthenticateStoreAuthError} from '../auth/recovery.js'
 import {loadStoredStoreSession} from '../auth/session-lifecycle.js'
 import {getPreviewStore, PreviewStoreRequestError} from '../create/preview/client.js'
 import {storeTypeHandle} from '../store-type.js'
@@ -163,13 +163,10 @@ async function fetchPreviewStoreUrls(previewSession: PreviewStoreSession): Promi
     // isn't needed for `store auth` to take over, and keeping it means every `store info` run
     // keeps producing this same actionable message instead of falling through to a full login.
     if (error instanceof PreviewStoreRequestError && (error.status === 401 || error.status === 404)) {
-      // Preview stores are preapproved for a large, fixed catalog of scopes; blindly suggesting
-      // the user re-request all of them against what's now a live, claimed store would encourage
-      // over-scoping. Point at the placeholder instead so they choose deliberately.
       throwReauthenticateStoreAuthError(
         `The preview store ${previewSession.store} has likely been claimed, so its stored authentication is no longer valid.`,
         previewSession.store,
-        UNKNOWN_SCOPES_PLACEHOLDER,
+        reauthScopesFor(previewSession),
       )
     }
 

--- a/packages/store/src/cli/services/store/info/index.ts
+++ b/packages/store/src/cli/services/store/info/index.ts
@@ -3,7 +3,7 @@ import {fetchOrganizationShop} from './organization-shop.js'
 import {mapPlanToPublicHandle} from './plan.js'
 import {classifyAdminApiError, throwIfStoredStoreAuthIsInvalid} from '../admin-errors.js'
 import {recordStoreFqdnMetadata} from '../attribution.js'
-import {throwReauthenticateStoreAuthError} from '../auth/recovery.js'
+import {throwStoredAuthInvalidError} from '../auth/recovery.js'
 import {loadStoredStoreSession} from '../auth/session-lifecycle.js'
 import {getPreviewStore, PreviewStoreRequestError} from '../create/preview/client.js'
 import {storeTypeHandle} from '../store-type.js'
@@ -163,10 +163,7 @@ async function fetchPreviewStoreUrls(previewSession: PreviewStoreSession): Promi
     // isn't needed for `store auth` to take over, and keeping it means every `store info` run
     // keeps producing this same actionable message instead of falling through to a full login.
     if (error instanceof PreviewStoreRequestError && (error.status === 401 || error.status === 404)) {
-      throwReauthenticateStoreAuthError(
-        `The preview store ${previewSession.store} has likely been claimed, so its stored authentication is no longer valid.`,
-        previewSession,
-      )
+      throwStoredAuthInvalidError(previewSession)
     }
 
     throw error

--- a/packages/store/src/cli/services/store/info/index.ts
+++ b/packages/store/src/cli/services/store/info/index.ts
@@ -158,17 +158,10 @@ async function fetchPreviewStoreUrls(previewSession: PreviewStoreSession): Promi
       ...(previewStore.claimUrl ? {saveUrl: previewStore.claimUrl} : {}),
     }
   } catch (error) {
-    // The CLI has no local signal for when a preview store gets claimed through the browser
-    // claim flow; the stored session keeps reporting `kind: 'preview'` forever. A 401/404 from
-    // the preview-stores service is the first indication that the store has moved on and the
-    // cached preview token is no longer valid.
-    //
-    // Deliberately left uncleared: `store auth` overwrites the bucket's `currentUserId` when it
-    // stores a fresh session, so nothing depends on this preview entry being removed first. And
-    // unlike a standard session's refresh-token flow, there's no automatic-retry loop here that
-    // clearing would protect against. Leaving it in place means every `store info` run before
-    // the user re-authenticates keeps producing this same actionable message, instead of
-    // silently falling through to a full interactive login on the next attempt.
+    // The CLI has no local signal for when a preview store gets claimed via the browser; a
+    // 401/404 here is the first indication. The stored session is left uncleared on purpose: it
+    // isn't needed for `store auth` to take over, and keeping it means every `store info` run
+    // keeps producing this same actionable message instead of falling through to a full login.
     if (error instanceof PreviewStoreRequestError && (error.status === 401 || error.status === 404)) {
       throwReauthenticateStoreAuthError(
         `The preview store ${previewSession.store} has likely been claimed, so its stored authentication is no longer valid.`,


### PR DESCRIPTION
## Problem

From [this Slack thread](https://shopify.slack.com/archives/C0B242KDQPN/p1783012223457189): running `shopify store info` (and, it turns out, `shopify store execute`) against a preview store *after* it has been claimed through the browser claim flow throws an unhelpful, non-actionable error instead of pointing the user at `shopify store auth`.

## Root cause

The CLI has no local signal for when a preview store gets claimed — the stored session keeps reporting `kind: 'preview'` forever. `store info` unconditionally takes the preview-session branch for such stores and calls the preview-stores REST service with the (now stale) preview admin token. Once claimed, that service starts rejecting the request, but `getPreviewStore`'s error handling only produced a generic message string with no HTTP status exposed and no recovery guidance.

Verified end-to-end against real stores: created preview stores, claimed them through the actual browser flow, and confirmed the preview-stores service really does return `401 {"error_code":"unauthorized"}` afterward for the cached token — and that the real Admin API (used by `store execute` and `store info`'s Admin fallback) does the same for the same stale token.

## Fix

**Detecting the claim (`store info`)**
- `getPreviewStore` now throws a typed `PreviewStoreRequestError` extending `AbortError` (so an uncaught instance still surfaces as a clean user-facing abort, not an unexpected-bug report) and carrying the HTTP status, so callers can classify the failure instead of only seeing a pre-rendered message string.
- `getStoreInfo`'s preview-session path treats a 401/404 from the preview-stores service as a signal the store has likely been claimed.

**Three distinct, consistent recovery messages** (`recovery.ts`), used everywhere a stored session is found invalid — `store info`'s preview branch, `store info`'s Admin fallback, and `store execute` (both the query/mutation path and the API-version-discovery path):
1. **No stored auth at all** → `"No stored app authentication found for {store}."` — Next steps: `Run ... to authenticate`.
2. **Stored auth exists but is invalid** (standard session) → `"Stored app authentication for {store} is no longer valid."` — Next steps show the **real, previously-granted scopes** and say `to re-authenticate`.
3. **Stored auth exists but is invalid, for a preview store** → `"The preview store {store} has likely been claimed, so its stored authentication is no longer valid."` — Next steps show a `<comma-separated-scopes>` placeholder instead of the real scopes, and say `to re-authenticate`.

Case 3's placeholder matters because preview stores are preapproved for a large, fixed scope catalog (~35 scopes) that nobody deliberately chose — suggesting the user re-request all of them against what's now a live, claimed store encourages over-scoping. Case 2 still shows the real scopes since those *were* a deliberate choice (`store auth --scopes ...`) and echoing them back is a genuine convenience.

Originally case 3 was only reachable via `store info`'s own preview-branch check; `store execute` and `store info`'s Admin fallback shared the same underlying invalid-session detection (`throwIfStoredStoreAuthIsInvalid`) but always fell through to case 2's generic message and full scope list, even for a preview session. Consolidated the message/scope selection into `throwStoredAuthInvalidError(session)` / `reauthScopesFor(session)` in `recovery.ts` so every call site is automatically consistent.

**Deliberately does not clear a lingering preview session on 401/404** (in `throwIfStoredStoreAuthIsInvalid` and `store info`'s own check). I initially had this clearing the session (mirroring how standard-session invalidation is handled), but testing against a real claimed store — and later against a real store hit by `store execute` — showed that's the wrong call for preview sessions:
- `store auth` overwrites the session bucket's `currentUserId` when it stores a fresh session, so nothing depends on the old preview entry being removed first.
- Preview sessions have no refresh-token cycle, so the "avoid repeatedly retrying with a dead refresh token" justification for clearing standard sessions doesn't apply.
- Clearing it caused a real regression twice: a second `store info` run, or a `store execute` run followed by `store info`, would silently fall through to a full interactive Business Platform login instead of repeating the actionable `store auth` guidance. Leaving the (already server-invalidated) session in place keeps every retry consistent. Standard sessions are still cleared as before — this only changes preview-session behavior.

**Cleanup**
- Removed a redundant "Next steps" rendering bug in the shared recovery errors (a separate `tryMessage` like "To re-authenticate, run:" duplicated with the "Next steps" heading); folded into a single bullet: `Run \`shopify store auth ...\` to re-authenticate`.
- Dropped now-dead parameters/exports surfaced along the way (`storeAuthCommandNextSteps`'s unused `scopes` param, an unused `UNKNOWN_SCOPES_PLACEHOLDER` export flagged by `knip`).

## Testing

- Added `PreviewStoreRequestError` coverage in `client.test.ts` (401 and 404, including that it's an `AbortError`).
- Added a dedicated `recovery.test.ts` directly covering `recovery.ts`'s branching logic (scope placeholder selection, message selection, "to authenticate" vs "to re-authenticate"), which had previously only been exercised indirectly through other modules' tests.
- Added `getStoreInfo` coverage for the claimed-preview-store scenario, both via the dedicated preview-stores lookup and via a lingering preview session hitting the Admin fallback.
- Added `store execute` coverage (`admin-transport.test.ts`, both `runAdminStoreGraphQLOperation` and `fetchPublicApiVersions`) for the same lingering-preview-session scenario, with paired tests showing the contrast against a standard invalid session (real scopes shown) right next to the preview case (placeholder shown).
- Added coverage for the "no stored auth" case saying "to authenticate" rather than "to re-authenticate".
- Manually verified live against several real preview stores (created via `shopify store create preview`, claimed via the real browser claim flow and via a corrupted-token shortcut for faster iteration):
  - `store info` and `store execute` now produce identical, consistent messaging for the same claimed store.
  - Running either command repeatedly (or one after the other) no longer degrades into a full interactive login prompt.
  - An unseen store domain correctly says "to authenticate"; a claimed preview store correctly says "to re-authenticate" and omits the full scope list.
- Full `packages/store` unit test suite (358 tests), type-check, lint, and `knip` all pass clean.

## Manual QA / tophatting

1. **No stored auth** — run against a store domain you've never used with this CLI install:
   ```
   shopify store execute --store <unseen-store>.myshopify.com --query "query { shop { name } }"
   ```
   Expect: `No stored app authentication found for ...` and Next steps saying `to authenticate` (not "re-authenticate").

2. **Invalid standard auth** — run `shopify store auth --store <store> --scopes read_products,write_orders` against a real store, then corrupt the stored `accessToken` in `~/Library/Preferences/shopify-cli-store-nodejs/config.json` (or just wait for real expiry), then run `store execute`/`store info` again.
   Expect: `Stored app authentication for ... is no longer valid.`, Next steps show the real scopes (`--scopes read_products,write_orders`), session is cleared afterward.

3. **Claimed preview store**:
   ```
   shopify store create preview
   shopify store info --store <domain> --json   # copy saveUrl, open it, complete the claim in browser
   shopify store info --store <domain>
   shopify store execute --store <domain> --query "query { shop { name } }"
   ```
   Expect both commands: `The preview store ... has likely been claimed, so its stored authentication is no longer valid.`, Next steps show `--scopes <comma-separated-scopes>` (not the full preview grant list). Run either command again — the message should stay identical, not fall back to a browser login prompt. `shopify store auth list` should still show the store until you actually re-authenticate.

## Changeset

Added — this is a user-facing bug fix (`store info` and `store execute` error behavior).

