### PR TITLE
[Tests] Replace filesystem mocks in asset-ignore.test.ts

### DIFF
--- a/packages/theme/src/cli/utilities/asset-ignore.test.ts
+++ b/packages/theme/src/cli/utilities/asset-ignore.test.ts
@@ -1,17 +1,8 @@
 import {applyIgnoreFilters, getPatternsFromShopifyIgnore} from './asset-ignore.js'
-import {ReadOptions, fileExists, readFile} from '@shopify/cli-kit/node/fs'
-import {test, describe, beforeEach, vi, expect} from 'vitest'
+import {inTemporaryDirectory, writeFile} from '@shopify/cli-kit/node/fs'
+import {joinPath} from '@shopify/cli-kit/node/path'
+import {test, describe, vi, expect} from 'vitest'
 import {renderWarning} from '@shopify/cli-kit/node/ui'
-
-vi.mock('@shopify/cli-kit/node/fs', async () => {
-  const originalFs: any = await vi.importActual('@shopify/cli-kit/node/fs')
-  return {
-    ...originalFs,
-    matchGlob: originalFs.matchGlob,
-    readFile: vi.fn(),
-    fileExists: vi.fn(),
-  }
-})
 
 vi.mock('@shopify/cli-kit/node/ui', () => ({
   renderWarning: vi.fn(),
@@ -31,28 +22,24 @@ describe('asset-ignore', () => {
     {key: 'templates/customers/account.json', checksum: '7777777777777777777777777777777'},
   ]
 
-  /**
-   * Explicitly defining the type of 'readFile' as it returns either
-   * 'Promise<string>' or 'Promise<Buffer>', which are ambiguous to the
-   * TypeScript language server.
-   */
-  const readFileFn = readFile as (path: string, options?: ReadOptions) => Promise<string>
-
-  beforeEach(() => {
-    vi.mocked(fileExists).mockResolvedValue(true)
-    vi.mocked(readFileFn).mockResolvedValue('')
-  })
-
   describe('getPatternsFromShopifyIgnore', () => {
     test('returns an empty array when the .shopifyignore file does not exist', async () => {
-      // Given
-      vi.mocked(fileExists).mockResolvedValue(false)
-      await expect(getPatternsFromShopifyIgnore('tmp')).resolves.toEqual([])
+      await inTemporaryDirectory(async (tmpDir) => {
+        // Given/When
+        const patterns = await getPatternsFromShopifyIgnore(tmpDir)
+
+        // Then
+        expect(patterns).toEqual([])
+      })
     })
 
-    test('returns an empty array when the .shopifyignore file does not exist', async () => {
-      vi.mocked(fileExists).mockResolvedValue(true)
-      vi.mocked(readFileFn).mockResolvedValue(`
+    test('returns an array of patterns when the .shopifyignore file exists', async () => {
+      await inTemporaryDirectory(async (tmpDir) => {
+        // Given
+        const shopifyIgnorePath = joinPath(tmpDir, '.shopifyignore')
+        await writeFile(
+          shopifyIgnorePath,
+          `
         # assets/basic.css
         assets/complex.css
         assets/*.png
@@ -60,18 +47,22 @@ describe('asset-ignore', () => {
         templates/*
         config/*_data.json
         .*settings_schema.json
-      `)
+      `,
+        )
 
-      await expect(getPatternsFromShopifyIgnore('tmp')).resolves.toEqual([
-        'assets/complex.css',
-        'assets/*.png',
-        'sections/*',
-        'templates/*',
-        'config/*_data.json',
-        '.*settings_schema.json',
-      ])
+        // When
+        const patterns = await getPatternsFromShopifyIgnore(tmpDir)
 
-      expect(readFileFn).toHaveBeenLastCalledWith('tmp/.shopifyignore', {encoding: 'utf8'})
+        // Then
+        expect(patterns).toEqual([
+          'assets/complex.css',
+          'assets/*.png',
+          'sections/*',
+          'templates/*',
+          'config/*_data.json',
+          '.*settings_schema.json',
+        ])
+      })
     })
   })
 


### PR DESCRIPTION
### WHY are these changes introduced?

Follow the automated testing protocol to replace filesystem mocks with real operations, improving test reliability and reducing maintenance burden.

### WHAT is this pull request doing?

Refactored `packages/theme/src/cli/utilities/asset-ignore.test.ts` to:
- Use `inTemporaryDirectory` and `writeFile` instead of mocking `@shopify/cli-kit/node/fs`.
- Remove manual mocks for `readFile` and `fileExists`.
- Fix a duplicate test case description.

### How to test your changes?

CI

### Post-release steps

None

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [4844028106710873482](https://jules.google.com/task/4844028106710873482) started by @gonzaloriestra*