### PR TITLE
[Security] Harden takeRandomFromArray with CSPRNG

### DIFF
--- a/packages/cli-kit/src/public/common/array.test.ts
+++ b/packages/cli-kit/src/public/common/array.test.ts
@@ -1,4 +1,4 @@
-import {difference, uniq, uniqBy} from './array.js'
+import {difference, takeRandomFromArray, uniq, uniqBy} from './array.js'
 import {describe, test, expect} from 'vitest'
 
 describe('uniqBy', () => {
@@ -60,5 +60,40 @@ describe('difference', () => {
 
     // Then
     expect(got).toEqual([1])
+  })
+})
+
+describe('takeRandomFromArray', () => {
+  test('returns an element from the array', () => {
+    // Given
+    const array = ['apple', 'banana', 'cherry']
+
+    // When
+    const got = takeRandomFromArray(array)
+
+    // Then
+    expect(array).toContain(got)
+  })
+
+  test('returns the only element from a single-element array', () => {
+    // Given
+    const array = ['apple']
+
+    // When
+    const got = takeRandomFromArray(array)
+
+    // Then
+    expect(got).toBe('apple')
+  })
+
+  test('returns undefined for an empty array', () => {
+    // Given
+    const array: string[] = []
+
+    // When
+    const got = takeRandomFromArray(array)
+
+    // Then
+    expect(got).toBeUndefined()
   })
 })

--- a/packages/cli-kit/src/public/common/array.ts
+++ b/packages/cli-kit/src/public/common/array.ts
@@ -9,7 +9,22 @@ import type {List, ValueIteratee} from 'lodash'
  * @returns A random element from the array.
  */
 export function takeRandomFromArray<T>(array: T[]): T {
-  return array[Math.floor(Math.random() * array.length)]!
+  const length = array.length
+  if (length === 0) {
+    return array[0]!
+  }
+
+  const arrayBuffer = new Uint32Array(1)
+  const maxUint32 = 4294967296
+  const maxMultiple = maxUint32 - (maxUint32 % length)
+
+  let randomValue: number
+  do {
+    globalThis.crypto.getRandomValues(arrayBuffer)
+    randomValue = arrayBuffer[0]!
+  } while (randomValue >= maxMultiple)
+
+  return array[randomValue % length]!
 }
 
 /**


### PR DESCRIPTION
This PR hardens the `takeRandomFromArray` utility function by replacing the insecure `Math.random()` with `globalThis.crypto.getRandomValues()`. 

Key changes:
- Switched to CSPRNG (`globalThis.crypto.getRandomValues`).
- Implemented rejection sampling to eliminate modulo bias.
- Added a guard for empty arrays to prevent errors.
- Added unit tests to verify the fix and ensure no regressions.

---
*PR created automatically by Jules for task [17267358148401281979](https://jules.google.com/task/17267358148401281979) started by @gonzaloriestra*