### PR TITLE
[Performance] Memoize terminal capability check for prompting

### DIFF
--- a/packages/cli-kit/src/public/node/base-command.test.ts
+++ b/packages/cli-kit/src/public/node/base-command.test.ts
@@ -6,6 +6,7 @@ import {inTemporaryDirectory, mkdir, writeFile} from './fs.js'
 import {joinPath, resolvePath, cwd} from './path.js'
 import {mockAndCaptureOutput} from './testing/output.js'
 import {unstyled} from './output.js'
+import {_resetTerminalSupportsPromptingCache} from './system.js'
 import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 import {Flags} from '@oclif/core'
 
@@ -20,6 +21,7 @@ beforeEach(() => {
   Object.defineProperty(process.stdin, 'isTTY', {value: true, configurable: true, writable: true})
   Object.defineProperty(process.stdout, 'isTTY', {value: true, configurable: true, writable: true})
   vi.stubEnv('CI', '')
+  _resetTerminalSupportsPromptingCache()
 })
 
 afterEach(() => {
@@ -441,6 +443,7 @@ describe('applying environments', async () => {
   runTestInTmpDir('throws in non-TTY mode when a non-TTY required argument is missing', async (tmpDir: string) => {
     // Given — simulate non-interactive (CI) environment
     vi.stubEnv('CI', 'true')
+    _resetTerminalSupportsPromptingCache()
 
     // When
     await MockCommandWithRequiredFlagInNonTTY.run(['--path', tmpDir])

--- a/packages/cli-kit/src/public/node/system.test.ts
+++ b/packages/cli-kit/src/public/node/system.test.ts
@@ -1,6 +1,6 @@
 import * as system from './system.js'
 import {execa} from 'execa'
-import {describe, expect, test, vi} from 'vitest'
+import {describe, expect, test, vi, beforeEach} from 'vitest'
 import which from 'which'
 import {Readable} from 'stream'
 
@@ -350,6 +350,81 @@ describe('isStdinPiped', () => {
 
     // Then
     expect(got).toBe(false)
+  })
+})
+
+describe('terminalSupportsPrompting', () => {
+  beforeEach(() => {
+    system._resetTerminalSupportsPromptingCache()
+  })
+
+  test('returns true when not in CI and both stdin/stdout are TTY', () => {
+    // Given
+    vi.stubEnv('CI', '')
+    Object.defineProperty(process.stdin, 'isTTY', {value: true, configurable: true})
+    Object.defineProperty(process.stdout, 'isTTY', {value: true, configurable: true})
+
+    // When
+    const got = system.terminalSupportsPrompting()
+
+    // Then
+    expect(got).toBe(true)
+  })
+
+  test('returns false when in CI', () => {
+    // Given
+    vi.stubEnv('CI', 'true')
+    Object.defineProperty(process.stdin, 'isTTY', {value: true, configurable: true})
+    Object.defineProperty(process.stdout, 'isTTY', {value: true, configurable: true})
+
+    // When
+    const got = system.terminalSupportsPrompting()
+
+    // Then
+    expect(got).toBe(false)
+  })
+
+  test('memoizes the result', () => {
+    // Given
+    vi.stubEnv('CI', '')
+    let calls = 0
+    Object.defineProperty(process.stdin, 'isTTY', {
+      get: () => {
+        calls++
+        return true
+      },
+      configurable: true,
+    })
+    Object.defineProperty(process.stdout, 'isTTY', {value: true, configurable: true})
+
+    // When
+    system.terminalSupportsPrompting()
+    system.terminalSupportsPrompting()
+
+    // Then
+    expect(calls).toBe(1)
+  })
+
+  test('reset function clears the cache', () => {
+    // Given
+    vi.stubEnv('CI', '')
+    let calls = 0
+    Object.defineProperty(process.stdin, 'isTTY', {
+      get: () => {
+        calls++
+        return true
+      },
+      configurable: true,
+    })
+    Object.defineProperty(process.stdout, 'isTTY', {value: true, configurable: true})
+
+    // When
+    system.terminalSupportsPrompting()
+    system._resetTerminalSupportsPromptingCache()
+    system.terminalSupportsPrompting()
+
+    // Then
+    expect(calls).toBe(2)
   })
 })
 

--- a/packages/cli-kit/src/public/node/system.ts
+++ b/packages/cli-kit/src/public/node/system.ts
@@ -334,15 +334,26 @@ export function terminalSupportsHyperlinks(): boolean {
 }
 
 /**
+ * Memoized value for the terminal prompting support check.
+ */
+let memoizedTerminalSupportsPrompting: boolean | undefined
+
+/**
  * Check if the standard input and output streams support prompting.
  *
  * @returns True if the standard input and output streams support prompting.
  */
 export function terminalSupportsPrompting(): boolean {
-  if (isTruthy(process.env.CI)) {
-    return false
-  }
-  return Boolean(process.stdin.isTTY && process.stdout.isTTY)
+  return (memoizedTerminalSupportsPrompting ??=
+    !isTruthy(process.env.CI) && Boolean(process.stdin.isTTY && process.stdout.isTTY))
+}
+
+/**
+ * Resets the memoized value for the terminal prompting support check.
+ * This is used for testing purposes.
+ */
+export function _resetTerminalSupportsPromptingCache(): void {
+  memoizedTerminalSupportsPrompting = undefined
 }
 
 /**

--- a/packages/cli-kit/src/public/node/system.ts
+++ b/packages/cli-kit/src/public/node/system.ts
@@ -344,8 +344,13 @@ let memoizedTerminalSupportsPrompting: boolean | undefined
  * @returns True if the standard input and output streams support prompting.
  */
 export function terminalSupportsPrompting(): boolean {
-  return (memoizedTerminalSupportsPrompting ??=
-    !isTruthy(process.env.CI) && Boolean(process.stdin.isTTY && process.stdout.isTTY))
+  if (memoizedTerminalSupportsPrompting === undefined) {
+    const isCi = isTruthy(process.env.CI)
+    const isStdinTTY = Boolean(process.stdin.isTTY)
+    const isStdoutTTY = Boolean(process.stdout.isTTY)
+    memoizedTerminalSupportsPrompting = !isCi && isStdinTTY && isStdoutTTY
+  }
+  return memoizedTerminalSupportsPrompting
 }
 
 /**


### PR DESCRIPTION
Memoized the terminalSupportsPrompting function in packages/cli-kit/src/public/node/system.ts using a module-level variable and the nullish coalescing assignment operator (??=). This optimization eliminates redundant calls to isTruthy(process.env.CI) and TTY checks, improving efficiency in high-frequency execution paths.

Key changes:
- Introduced memoizedTerminalSupportsPrompting variable.
- Updated terminalSupportsPrompting to use the cached value if available.
- Added _resetTerminalSupportsPromptingCache for test isolation.
- Added comprehensive unit tests in packages/cli-kit/src/public/node/system.test.ts.

---
*PR created automatically by Jules for task [5260638415555878059](https://jules.google.com/task/5260638415555878059) started by @gonzaloriestra*