### PR TITLE
[Security] Harden random selection in takeRandomFromArray

### DIFF
--- a/packages/cli-kit/src/public/common/array.test.ts
+++ b/packages/cli-kit/src/public/common/array.test.ts
@@ -1,5 +1,26 @@
-import {difference, uniq, uniqBy} from './array.js'
+import {difference, takeRandomFromArray, uniq, uniqBy} from './array.js'
 import {describe, test, expect} from 'vitest'
+
+describe('takeRandomFromArray', () => {
+  test('returns undefined for an empty array', () => {
+    // When
+    const got = takeRandomFromArray([])
+
+    // Then
+    expect(got).toBeUndefined()
+  })
+
+  test('returns a random element from the array', () => {
+    // Given
+    const array = [1, 2, 3, 4, 5]
+
+    // When
+    const got = takeRandomFromArray(array)
+
+    // Then
+    expect(array).toContain(got)
+  })
+})
 
 describe('uniqBy', () => {
   test('removes duplicates', () => {

--- a/packages/cli-kit/src/public/common/array.ts
+++ b/packages/cli-kit/src/public/common/array.ts
@@ -8,8 +8,24 @@ import type {List, ValueIteratee} from 'lodash'
  * @param array - Array from which we'll select a random item.
  * @returns A random element from the array.
  */
-export function takeRandomFromArray<T>(array: T[]): T {
-  return array[Math.floor(Math.random() * array.length)]!
+export function takeRandomFromArray<T>(array: T[]): T | undefined {
+  if (array.length === 0) {
+    return undefined
+  }
+
+  // Rejection sampling to avoid modulo bias
+  const maxUint32 = 0xffffffff
+  const range = array.length
+  const limit = maxUint32 - (maxUint32 % range)
+
+  const randomBuffer = new Uint32Array(1)
+  let randomValue: number
+  do {
+    globalThis.crypto.getRandomValues(randomBuffer)
+    randomValue = randomBuffer[0]!
+  } while (randomValue >= limit)
+
+  return array[randomValue % range]
 }
 
 /**


### PR DESCRIPTION
This PR hardens the `takeRandomFromArray` utility in `@shopify/cli-kit` by replacing the non-cryptographically secure `Math.random()` with a CSPRNG (`globalThis.crypto.getRandomValues()`). It also implements rejection sampling to eliminate modulo bias, ensuring a truly unbiased distribution. Additionally, the function now safely handles empty arrays by returning `undefined` and updating its type signature accordingly.

---
*PR created automatically by Jules for task [3547986643681095491](https://jules.google.com/task/3547986643681095491) started by @gonzaloriestra*