### PR TITLE
[Refactor] Modernize archiver utilities with async/await

### DIFF
--- a/packages/cli-kit/src/public/node/archiver.ts
+++ b/packages/cli-kit/src/public/node/archiver.ts
@@ -31,6 +31,7 @@ interface ZipOptions {
  * Windows.
  *
  * @param options - ZipOptions.
+ * @returns A promise that resolves when the directory has been zipped.
  */
 export async function zip(options: ZipOptions): Promise<void> {
   const {inputDirectory, outputZipPath, matchFilePattern = '**/*'} = options
@@ -42,47 +43,39 @@ export async function zip(options: ZipOptions): Promise<void> {
     followSymbolicLinks: false,
   })
 
-  return new Promise((resolve, reject) => {
-    const archive = archiver('zip')
+  const archive = archiver('zip')
+  const output = createWriteStream(outputZipPath)
 
-    const output = createWriteStream(outputZipPath)
-    output.on('close', () => {
-      resolve()
-    })
-    archive.on('error', (error) => {
-      reject(error)
-    })
-    archive.pipe(output)
-
-    const directoriesToAdd = new Set<string>()
-    for (const filePath of pathsToZip) {
-      const fileRelativePath = relativePath(inputDirectory, filePath)
-      collectParentDirectories(fileRelativePath, directoriesToAdd)
-    }
-
-    const sortedDirs = Array.from(directoriesToAdd).sort((left, right) => left.localeCompare(right))
-    for (const dir of sortedDirs) {
-      const dirName = dir.endsWith('/') ? dir : `${dir}/`
-      archive.append(Buffer.alloc(0), {name: dirName})
-    }
-
-    // Read all files immediately before adding to archive to prevent ENOENT errors
-    // Using archive.file() causes lazy loading which fails if files are deleted before finalize()
-    const addFilesPromises = pathsToZip.map(async (filePath) => {
-      await archiveFile(inputDirectory, filePath, archive)
-    })
-
-    // Wait for all files to be read and added before finalizing
-    Promise.all(addFilesPromises)
-      .then(() => {
-        // eslint-disable-next-line @typescript-eslint/no-floating-promises
-        archive.finalize()
-      })
-      .catch((error) => {
-        // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors
-        reject(error)
-      })
+  const archivePromise = new Promise<void>((resolve, reject) => {
+    output.on('close', () => resolve())
+    archive.on('error', (error) => reject(error))
   })
+
+  archive.pipe(output)
+
+  const directoriesToAdd = new Set<string>()
+  for (const filePath of pathsToZip) {
+    const fileRelativePath = relativePath(inputDirectory, filePath)
+    collectParentDirectories(fileRelativePath, directoriesToAdd)
+  }
+
+  const sortedDirs = Array.from(directoriesToAdd).sort((left, right) => left.localeCompare(right))
+  for (const dir of sortedDirs) {
+    const dirName = dir.endsWith('/') ? dir : `${dir}/`
+    archive.append(Buffer.alloc(0), {name: dirName})
+  }
+
+  // Read all files immediately before adding to archive to prevent ENOENT errors
+  // Using archive.file() causes lazy loading which fails if files are deleted before finalize()
+  const addFilesPromises = pathsToZip.map(async (filePath) => {
+    await archiveFile(inputDirectory, filePath, archive)
+  })
+
+  // Wait for all files to be read and added before finalizing
+  await Promise.all(addFilesPromises)
+  await archive.finalize()
+
+  return archivePromise
 }
 
 function collectParentDirectories(fileRelativePath: string, accumulator: Set<string>): void {
@@ -154,34 +147,32 @@ export async function brotliCompress(options: BrotliOptions): Promise<void> {
 
   try {
     // Create tar archive using archiver
-    await new Promise<void>((resolve, reject) => {
-      const archive = archiver('tar')
-      const output = createWriteStream(tempTarPath)
+    const archive = archiver('tar')
+    const output = createWriteStream(tempTarPath)
 
+    const archivePromise = new Promise<void>((resolve, reject) => {
       output.on('close', () => resolve())
       archive.on('error', (error) => reject(error))
-      archive.pipe(output)
-
-      glob(options.matchFilePattern ?? '**/*', {
-        cwd: options.inputDirectory,
-        absolute: true,
-        dot: true,
-        followSymbolicLinks: false,
-      })
-        .then(async (pathsToZip) => {
-          // Read all files immediately to prevent ENOENT errors during race conditions
-          const addFilesPromises = pathsToZip.map(async (filePath) => {
-            await archiveFile(options.inputDirectory, filePath, archive)
-          })
-
-          await Promise.all(addFilesPromises)
-          // eslint-disable-next-line @typescript-eslint/no-floating-promises
-          archive.finalize()
-        })
-        .catch((error) => {
-          reject(error instanceof Error ? error : new Error(String(error)))
-        })
     })
+
+    archive.pipe(output)
+
+    const pathsToZip = await glob(options.matchFilePattern ?? '**/*', {
+      cwd: options.inputDirectory,
+      absolute: true,
+      dot: true,
+      followSymbolicLinks: false,
+    })
+
+    // Read all files immediately to prevent ENOENT errors during race conditions
+    const addFilesPromises = pathsToZip.map(async (filePath) => {
+      await archiveFile(options.inputDirectory, filePath, archive)
+    })
+
+    await Promise.all(addFilesPromises)
+    await archive.finalize()
+
+    await archivePromise
 
     const tarContent = readFileSync(tempTarPath)
     const compressed = brotliCompressSync(tarContent, {


### PR DESCRIPTION
This PR refactors the archiving utilities in `@shopify/cli-kit` to follow modern asynchronous patterns.

### Why:
The previous implementation used manual `Promise` wrappers and `.then()` chains which were more verbose and harder to reason about. Moving to `async/await` makes the control flow clearer, especially when coordinating multiple asynchronous operations like globbing, file reading, and stream finalization.

### Changes:
- **`zip`**: Now uses `async/await` for globbing and file addition. It waits for `archive.finalize()` and the output stream's `close` event before resolving.
- **`brotliCompress`**: Similarly modernized to use `async/await` for the internal tar archive creation step.
- **Documentation**: Added `@returns` to `zip` JSDoc.

### How to test your changes?
CI. (Integration tests in `packages/cli-kit/src/public/node/archiver.integration.test.ts` cover these changes).

---
*PR created automatically by Jules for task [2020363541973881611](https://jules.google.com/task/2020363541973881611) started by @gonzaloriestra*