### PR TITLE
[Performance] Memoize ciPlatform function

### DIFF
--- a/packages/cli-kit/src/public/node/context/local.test.ts
+++ b/packages/cli-kit/src/public/node/context/local.test.ts
@@ -10,6 +10,7 @@ import {
   macAddress,
   getThemeKitAccessDomain,
   opentelemetryDomain,
+  _resetCIPlatformCache,
 } from './local.js'
 import {fileExists} from '../fs.js'
 import {exec} from '../system.js'
@@ -252,6 +253,10 @@ describe('cloudEnvironment', () => {
 })
 
 describe('ciPlatform', () => {
+  afterEach(() => {
+    _resetCIPlatformCache()
+  })
+
   test('should return isCI false for non-CI environment', () => {
     // Given
     const nonCIResult = ciPlatform({})
@@ -338,6 +343,39 @@ describe('ciPlatform', () => {
       name: 'azure',
       metadata: {},
     })
+  })
+
+  test('should return memoized data when env is process.env', () => {
+    // Given
+    const originalEnv = process.env
+    try {
+      process.env = {CI: 'true', GITHUB_ACTION: '1'} as any
+      const firstResult = ciPlatform()
+
+      // When
+      process.env = {CI: 'false'} as any
+      const secondResult = ciPlatform()
+
+      // Then
+      expect(secondResult).toBe(firstResult)
+      expect(secondResult.isCI).toBe(true)
+    } finally {
+      process.env = originalEnv
+    }
+  })
+
+  test('should NOT return memoized data when env is NOT process.env', () => {
+    // Given
+    const env1 = {CI: 'true', GITHUB_ACTION: '1'}
+    const env2 = {CI: 'false'}
+    const firstResult = ciPlatform(env1)
+
+    // When
+    const secondResult = ciPlatform(env2)
+
+    // Then
+    expect(secondResult).not.toBe(firstResult)
+    expect(secondResult.isCI).toBe(false)
   })
 })
 

--- a/packages/cli-kit/src/public/node/context/local.ts
+++ b/packages/cli-kit/src/public/node/context/local.ts
@@ -45,6 +45,14 @@ let memoizedIsVerbose: boolean | undefined
 let memoizedIsUnitTest: boolean | undefined
 
 /**
+ * Memoized value for the CI platform check.
+ */
+let memoizedCIPlatform:
+  | {isCI: true; name: string; metadata: Metadata}
+  | {isCI: false; name?: undefined; metadata?: undefined}
+  | undefined
+
+/**
  * Returns true if the CLI is running in debug mode.
  *
  * @param env - The environment variables from the environment of the current process.
@@ -247,6 +255,14 @@ export async function hasGit(): Promise<boolean> {
 }
 
 /**
+ * Resets the memoized CI platform value.
+ * This is useful for testing purposes.
+ */
+export function _resetCIPlatformCache(): void {
+  memoizedCIPlatform = undefined
+}
+
+/**
  * Gets info on the CI platform the CLI is running on, if applicable.
  *
  * @param env - The environment variables from the environment of the current process.
@@ -255,6 +271,10 @@ export async function hasGit(): Promise<boolean> {
 export function ciPlatform(
   env = process.env,
 ): {isCI: true; name: string; metadata: Metadata} | {isCI: false; name?: undefined; metadata?: undefined} {
+  if (env === process.env && memoizedCIPlatform !== undefined) {
+    return memoizedCIPlatform
+  }
+  let result: {isCI: true; name: string; metadata: Metadata} | {isCI: false; name?: undefined; metadata?: undefined}
   if (isTruthy(env.CI)) {
     let name = 'unknown'
     if (isSet(env.BITBUCKET_BUILD_NUMBER)) {
@@ -269,21 +289,26 @@ export function ciPlatform(
       name = 'buildkite'
     }
 
-    return {
+    result = {
       isCI: true,
       name,
       metadata: getCIMetadata(name, env),
     }
   } else if (isTruthy(env.TF_BUILD)) {
-    return {
+    result = {
       isCI: true,
       name: 'azure',
       metadata: getCIMetadata('azure', env),
     }
+  } else {
+    result = {
+      isCI: false,
+    }
   }
-  return {
-    isCI: false,
+  if (env === process.env) {
+    memoizedCIPlatform = result
   }
+  return result
 }
 
 /**


### PR DESCRIPTION
### Why is this change necessary?
The `ciPlatform` function is called frequently, especially during analytics collection, and performs multiple environment variable lookups and metadata assembly. Since these environment variables are static during a single CLI command execution, caching the result improves performance by avoiding repeated work.

### How to test your changes?
CI

### Checkbox
- [ ] I've added a [changeset](https://github.com/shopify/cli/blob/main/CONTRIBUTING.md#changesets) (if applicable)
- [ ] I've updated the [documentation](https://github.com/shopify/cli/blob/main/CONTRIBUTING.md#documentation) (if applicable)

### Expected performance impact
Eliminates redundant environment variable scans and metadata object creation in high-frequency analytics paths. While the absolute time saved per call is small (micro-optimizations), the cumulative effect across all commands (which all report analytics) contributes to a snappier CLI experience.

---
*PR created automatically by Jules for task [2348603642377422416](https://jules.google.com/task/2348603642377422416) started by @gonzaloriestra*