### PR TITLE
[Refactor] modernize errorHandler and improve test coverage

### DIFF
--- a/packages/cli-kit/src/public/node/error-handler.test.ts
+++ b/packages/cli-kit/src/public/node/error-handler.test.ts
@@ -87,6 +87,20 @@ describe('errorHandler', async () => {
     expect(outputMock.info()).toMatch('✨  Custom message')
     expect(process.exit).toBeCalledTimes(0)
   })
+
+  test('finishes the execution without exiting the proccess when AbortSilentError is raised', async () => {
+    // Given
+    vi.spyOn(process, 'exit').mockResolvedValue(null as never)
+    const outputMock = mockAndCaptureOutput()
+    outputMock.clear()
+
+    // When
+    await errorHandler(new error.AbortSilentError())
+
+    // Then
+    expect(outputMock.info()).toBe('')
+    expect(process.exit).toBeCalledTimes(0)
+  })
 })
 
 describe('bugsnag stack cleaning', () => {

--- a/packages/cli-kit/src/public/node/error-handler.ts
+++ b/packages/cli-kit/src/public/node/error-handler.ts
@@ -36,17 +36,16 @@ export async function errorHandler(
     if (error.message && error.message !== '') {
       outputInfo(`✨  ${error.message}`)
     }
-  } else if (error instanceof AbortSilentError) {
-    /* empty */
-  } else {
-    return errorMapper(error)
-      .then((error) => {
-        return handler(error)
-      })
-      .then((mappedError) => {
-        return reportError(mappedError, config)
-      })
+    return
   }
+
+  if (error instanceof AbortSilentError) {
+    return
+  }
+
+  const mappedError = await errorMapper(error)
+  await handler(mappedError)
+  await reportError(mappedError, config)
 }
 
 const reportError = async (error: unknown, config?: Interfaces.Config): Promise<void> => {


### PR DESCRIPTION
### WHY are these changes introduced?

The `errorHandler` function in `@shopify/cli-kit` used an older Promise-based pattern with `.then()` chains, which was less readable and more difficult to maintain than modern `async/await`. Additionally, the `AbortSilentError` branch was not explicitly verified by unit tests.

### WHAT is this pull request doing?

- Refactored `errorHandler` in `packages/cli-kit/src/public/node/error-handler.ts` to use `async/await` syntax.
- Flattened the logic using early returns for `CancelExecution` and `AbortSilentError`, reducing nesting.
- Added a new unit test in `packages/cli-kit/src/public/node/error-handler.test.ts` to verify that `AbortSilentError` is handled silently without exiting or logging.
- Improved test isolation in the new test case by explicitly clearing captured output.

### How to test your changes?

CI

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [11091565751469337296](https://jules.google.com/task/11091565751469337296) started by @gonzaloriestra*