### PR TITLE
[Security] Harden client ID generation in ExtensionServerClient

### DIFF
--- a/packages/ui-extensions-server-kit/src/ExtensionServerClient/ExtensionServerClient.ts
+++ b/packages/ui-extensions-server-kit/src/ExtensionServerClient/ExtensionServerClient.ts
@@ -32,7 +32,8 @@ export class ExtensionServerClient implements ExtensionServer.Client {
   private uiExtensionsByUuid: Record<string, ExtensionServer.UIExtension> = {}
 
   constructor(options: DeepPartial<ExtensionServer.Options> = {}) {
-    this.id = (Math.random() + 1).toString(36).substring(7)
+    // We use a cryptographically secure random generator to prevent ID predictability
+    this.id = globalThis.crypto.randomUUID()
     this.options = getValidatedOptions({
       ...options,
       connection: {


### PR DESCRIPTION
### WHY are these changes introduced?

Addresses a potential predictability issue in client identifier generation by moving away from a non-cryptographically secure PRNG.

### WHAT is this pull request doing?

Hardens the `ExtensionServerClient` by replacing `Math.random()` with `globalThis.crypto.randomUUID()` for unique ID generation.

### How to test your changes?

CI

### Post-release steps

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [13114534747419537156](https://jules.google.com/task/13114534747419537156) started by @gonzaloriestra*