### PR TITLE
[Performance] Memoize isStdinPiped in cli-kit

### DIFF
--- a/packages/cli-kit/src/public/node/system.test.ts
+++ b/packages/cli-kit/src/public/node/system.test.ts
@@ -1,6 +1,7 @@
 import * as system from './system.js'
+import {_resetIsStdinPipedCache} from './system.js'
 import {execa} from 'execa'
-import {describe, expect, test, vi} from 'vitest'
+import {beforeEach, describe, expect, test, vi} from 'vitest'
 import which from 'which'
 import {Readable} from 'stream'
 
@@ -14,6 +15,10 @@ vi.mock('fs', async (importOriginal) => {
     ...actual,
     fstatSync: vi.fn(),
   }
+})
+
+beforeEach(() => {
+  _resetIsStdinPipedCache()
 })
 
 describe('captureOutput', () => {
@@ -350,6 +355,18 @@ describe('isStdinPiped', () => {
 
     // Then
     expect(got).toBe(false)
+  })
+
+  test('memoizes the result', () => {
+    // Given
+    vi.mocked(fs.fstatSync).mockReturnValue({isFIFO: () => true, isFile: () => false} as fs.Stats)
+
+    // When
+    system.isStdinPiped()
+    system.isStdinPiped()
+
+    // Then
+    expect(fs.fstatSync).toHaveBeenCalledTimes(1)
   })
 })
 

--- a/packages/cli-kit/src/public/node/system.ts
+++ b/packages/cli-kit/src/public/node/system.ts
@@ -365,6 +365,19 @@ export async function isWsl(): Promise<boolean> {
 }
 
 /**
+ * Memoized value for the stdin piped check.
+ */
+let memoizedIsStdinPiped: boolean | undefined
+
+/**
+ * Reset the memoized value for the stdin piped check.
+ * This is only used for testing.
+ */
+export function _resetIsStdinPipedCache(): void {
+  memoizedIsStdinPiped = undefined
+}
+
+/**
  * Check if stdin has piped data available.
  * This distinguishes between actual piped input (e.g., `echo "query" | cmd`)
  * and non-TTY environments without input (e.g., CI).
@@ -372,13 +385,18 @@ export async function isWsl(): Promise<boolean> {
  * @returns True if stdin is receiving piped data or file redirect, false otherwise.
  */
 export function isStdinPiped(): boolean {
+  if (memoizedIsStdinPiped !== undefined) {
+    return memoizedIsStdinPiped
+  }
+
   try {
     const stats = fstatSync(0)
-    return stats.isFIFO() || stats.isFile()
+    memoizedIsStdinPiped = stats.isFIFO() || stats.isFile()
     // eslint-disable-next-line no-catch-all/no-catch-all
   } catch {
-    return false
+    memoizedIsStdinPiped = false
   }
+  return memoizedIsStdinPiped
 }
 
 /**


### PR DESCRIPTION
### Why is this change needed?

The `isStdinPiped` function performs a synchronous `fstatSync(0)` call to determine if stdin is piped. In a CLI environment, this status remains constant throughout the process execution. Repeated calls to this function (either directly or via other utilities like `readStdinString`) result in redundant system calls.

### How to test your changes?

CI

### Post-deployment steps

None.

---
*PR created automatically by Jules for task [16902672566824217517](https://jules.google.com/task/16902672566824217517) started by @gonzaloriestra*