### PR TITLE
[Refactor] Modernize sleep function using node:timers/promises

### DIFF
--- a/packages/cli-kit/src/public/node/system.test.ts
+++ b/packages/cli-kit/src/public/node/system.test.ts
@@ -393,3 +393,19 @@ describe('readStdinString', () => {
     await expect(got).rejects.toThrow('Stdin input exceeded the maximum allowed size.')
   })
 })
+
+describe('sleep', () => {
+  test('waits for the given number of seconds', async () => {
+    // Given
+    vi.useFakeTimers()
+    const seconds = 0.1
+
+    // When
+    const sleepPromise = system.sleep(seconds)
+    await vi.advanceTimersByTimeAsync(seconds * 1000)
+    await sleepPromise
+
+    // Then
+    vi.useRealTimers()
+  })
+})

--- a/packages/cli-kit/src/public/node/system.ts
+++ b/packages/cli-kit/src/public/node/system.ts
@@ -13,6 +13,7 @@ import which from 'which'
 import {delimiter} from 'pathe'
 
 import {fstatSync} from 'fs'
+import {setTimeout} from 'timers/promises'
 import type {Writable, Readable} from 'stream'
 
 /**
@@ -319,9 +320,7 @@ function checkCommandSafety(command: string, _options: {cwd: string}): void {
  * @returns A Promise resolving after the number of seconds.
  */
 export async function sleep(seconds: number): Promise<void> {
-  return new Promise((resolve) => {
-    setTimeout(resolve, 1000 * seconds)
-  })
+  await setTimeout(1000 * seconds)
 }
 
 /**


### PR DESCRIPTION
### WHY are these changes introduced?

The `sleep` function in `packages/cli-kit/src/public/node/system.ts` was using an outdated manual `Promise` wrapper around `setTimeout`. Modernizing it to use `node:timers/promises` makes the code cleaner and leverages native Node.js capabilities.

### WHAT is this pull request doing?

- Imports `setTimeout` from `timers/promises` in `packages/cli-kit/src/public/node/system.ts`.
- Refactors `sleep` to use `await setTimeout(...)`.
- Adds a unit test for `sleep` in `packages/cli-kit/src/public/node/system.test.ts`.

### How to test your changes?

CI

### Post-release steps

None.

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`


---
*PR created automatically by Jules for task [6335028973932666746](https://jules.google.com/task/6335028973932666746) started by @gonzaloriestra*