### PR TITLE
[Security] Harden takeRandomFromArray with CSPRNG

### DIFF
--- a/packages/cli-kit/src/public/common/array.test.ts
+++ b/packages/cli-kit/src/public/common/array.test.ts
@@ -1,5 +1,29 @@
-import {difference, uniq, uniqBy} from './array.js'
+import {difference, takeRandomFromArray, uniq, uniqBy} from './array.js'
 import {describe, test, expect} from 'vitest'
+
+describe('takeRandomFromArray', () => {
+  test('returns a random element from the array', () => {
+    // Given
+    const array = [1, 2, 3, 4, 5]
+
+    // When
+    const got = takeRandomFromArray(array)
+
+    // Then
+    expect(array).toContain(got)
+  })
+
+  test('returns undefined for an empty array', () => {
+    // Given
+    const array: number[] = []
+
+    // When
+    const got = takeRandomFromArray(array)
+
+    // Then
+    expect(got).toBeUndefined()
+  })
+})
 
 describe('uniqBy', () => {
   test('removes duplicates', () => {

--- a/packages/cli-kit/src/public/common/array.ts
+++ b/packages/cli-kit/src/public/common/array.ts
@@ -10,8 +10,16 @@ import type {List, ValueIteratee} from 'lodash'
  */
 export function takeRandomFromArray<T>(array: T[]): T {
   if (array.length === 0) return array[0]!
-  const randomIndex = globalThis.crypto.getRandomValues(new Uint32Array(1))[0]! % array.length
-  return array[randomIndex]!
+  if (array.length === 1) return array[0]!
+
+  const maxUint32 = 0xffffffff
+  const range = maxUint32 - (maxUint32 % array.length)
+  let randomValue: number
+  do {
+    randomValue = globalThis.crypto.getRandomValues(new Uint32Array(1))[0]!
+  } while (randomValue >= range)
+
+  return array[randomValue % array.length]!
 }
 
 /**

--- a/packages/cli-kit/src/public/common/array.ts
+++ b/packages/cli-kit/src/public/common/array.ts
@@ -9,7 +9,9 @@ import type {List, ValueIteratee} from 'lodash'
  * @returns A random element from the array.
  */
 export function takeRandomFromArray<T>(array: T[]): T {
-  return array[Math.floor(Math.random() * array.length)]!
+  if (array.length === 0) return array[0]!
+  const randomIndex = globalThis.crypto.getRandomValues(new Uint32Array(1))[0]! % array.length
+  return array[randomIndex]!
 }
 
 /**


### PR DESCRIPTION
### WHY are these changes introduced?

The `takeRandomFromArray` utility used `Math.random()`, which is not cryptographically secure. Hardening it with a CSPRNG provides defense-in-depth for this public utility.

### WHAT is this pull request doing?

Replaces `Math.random()` with `globalThis.crypto.getRandomValues()` in `takeRandomFromArray`. Added unit tests for the utility.

### How to test your changes?

CI

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [17998295092342495672](https://jules.google.com/task/17998295092342495672) started by @gonzaloriestra*