### PR TITLE
Use preview identity for store open analytics

### DIFF
--- a/packages/store/src/cli/services/store/info/index.test.ts
+++ b/packages/store/src/cli/services/store/info/index.test.ts
@@ -177,6 +177,7 @@ describe('getStoreInfo', () => {
     expect(fetchDestinationsContext).not.toHaveBeenCalled()
     expect(fetchOrganizationShop).not.toHaveBeenCalled()
     expect(recordStoreFqdnMetadata).toHaveBeenCalledWith(SHOP, true, '123')
+    expect(setLastSeenUserId).toHaveBeenCalledWith('preview:placeholder-uuid')
     expect(getPreviewStore).toHaveBeenCalledWith({
       shopId: '123',
       adminApiToken: 'shpat_preview_token',

--- a/packages/store/src/cli/services/store/info/index.ts
+++ b/packages/store/src/cli/services/store/info/index.ts
@@ -65,6 +65,7 @@ export async function getStoreInfo(options: GetStoreInfoOptions): Promise<StoreI
 
   if (isPreviewStoreSession(storedSession)) {
     await recordStoreFqdnMetadata(storedSession.store, true, storedSession.preview.shopId)
+    setLastSeenUserId(storedSession.userId)
     const previewStoreUrls = await fetchPreviewStoreUrls(storedSession)
     return buildPreviewStoreResult({
       store,


### PR DESCRIPTION
### WHY are these changes introduced?

Preview-store commands should attribute command analytics to the store-auth identity selected by `--store` when the command reads that preview store from the local store-auth cache.

`shopify store open --store <preview-store>` goes through `getStoreInfo`, which already records preview store metadata (`store_id`, domain/hash) from the cached preview-store session. However, it did not set the analytics `user_id` from that same cached session, so the Monorail event could fall back to the current CLI user/session instead.

### WHAT is this pull request doing?

When `getStoreInfo` detects a locally stored preview-store session, it now also calls:

```ts
setLastSeenUserId(storedSession.userId)
```

This aligns preview-store `store open` with `store info`: both commands share the same `getStoreInfo` path and now emit analytics using:

- `store_id` from `storedSession.preview.shopId`
- `user_id` from `storedSession.userId`

This only applies to the preview-store cache path. Business Platform-backed store info/open flows continue to use the normal CLI authentication identity.

### How to test your changes?

```bash
pnpm test packages/store/src/cli/services/store/info/index.test.ts
```

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible documentation changes
- [x] I've considered analytics changes to measure impact
- [x] No changeset: this changes internal analytics attribution only and has no user-visible CLI behavior change.
