### PR TITLE
Fix config link from extension directories

### DIFF
--- a/.changeset/config-link-extension-directory.md
+++ b/.changeset/config-link-extension-directory.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli': patch
+---
+
+Prevent `app config link` from overwriting the root app config when run from an extension directory

--- a/packages/app/src/cli/services/app/config/__snapshots__/link.test.ts.snap
+++ b/packages/app/src/cli/services/app/config/__snapshots__/link.test.ts.snap
@@ -282,6 +282,29 @@ use_legacy_install_flow = true
 "
 `;
 
+exports[`link > prompts for a new config name when linking a new app from an extension directory 1`] = `
+"# Learn more about configuring your app at https://shopify.dev/docs/apps/tools/cli/configuration
+
+client_id = "new-api-key"
+name = "app1"
+application_url = "https://example.com"
+embedded = true
+
+[auth]
+redirect_urls = [ "https://example.com/callback1" ]
+
+[webhooks]
+api_version = "2023-07"
+
+[pos]
+embedded = false
+
+[access_scopes]
+# Learn more at https://shopify.dev/docs/apps/tools/cli/configuration#access_scopes
+use_legacy_install_flow = true
+"
+`;
+
 exports[`link > replace arrays content with the remote one 1`] = `
 "# Learn more about configuring your app at https://shopify.dev/docs/apps/tools/cli/configuration
 

--- a/packages/app/src/cli/services/app/config/link.test.ts
+++ b/packages/app/src/cli/services/app/config/link.test.ts
@@ -15,7 +15,7 @@ import {fetchAppRemoteConfiguration} from '../select-app.js'
 import {DeveloperPlatformClient} from '../../../utilities/developer-platform-client.js'
 import {MinimalAppIdentifiers, OrganizationApp} from '../../../models/organization.js'
 import {beforeEach, describe, expect, test, vi} from 'vitest'
-import {fileExistsSync, inTemporaryDirectory, readFile, writeFileSync} from '@shopify/cli-kit/node/fs'
+import {fileExistsSync, inTemporaryDirectory, mkdir, readFile, writeFileSync} from '@shopify/cli-kit/node/fs'
 import {joinPath} from '@shopify/cli-kit/node/path'
 import {renderSuccess} from '@shopify/cli-kit/node/ui'
 import {outputContent} from '@shopify/cli-kit/node/output'
@@ -511,6 +511,43 @@ describe('link', () => {
         },
       })
       expect(content).toMatchSnapshot()
+    })
+  })
+
+  test('prompts for a new config name when linking a new app from an extension directory', async () => {
+    await inTemporaryDirectory(async (tmp) => {
+      const developerPlatformClient = buildDeveloperPlatformClient()
+      const extensionDirectory = joinPath(tmp, 'extensions', 'discount_function')
+      await mkdir(extensionDirectory)
+      const initialContent = 'client_id = "existing-api-key"\nname = "existing app"\n'
+      writeFileSync(joinPath(tmp, 'shopify.app.toml'), initialContent)
+      const options: LinkOptions = {
+        directory: extensionDirectory,
+        developerPlatformClient,
+      }
+      const localApp = {
+        configPath: joinPath(tmp, 'shopify.app.toml'),
+        configuration: {
+          name: 'existing app',
+          client_id: 'existing-api-key',
+          webhooks: {api_version: '2023-04'},
+          application_url: 'https://myapp.com',
+        } as CurrentAppConfiguration,
+      }
+      await mockLoadOpaqueAppWithApp(tmp, localApp, [], 'current')
+      vi.mocked(fetchOrCreateOrganizationApp).mockResolvedValue(
+        testOrganizationApp({
+          apiKey: 'new-api-key',
+          developerPlatformClient,
+        }),
+      )
+      vi.mocked(selectConfigName).mockResolvedValue('shopify.app.staging.toml')
+
+      await link(options)
+
+      expect(selectConfigName).toHaveBeenCalledWith(tmp, 'app1')
+      expect(await readFile(joinPath(tmp, 'shopify.app.toml'))).toBe(initialContent)
+      expect(await readFile(joinPath(tmp, 'shopify.app.staging.toml'))).toMatchSnapshot()
     })
   })
 

--- a/packages/app/src/cli/services/app/config/link.test.ts
+++ b/packages/app/src/cli/services/app/config/link.test.ts
@@ -546,8 +546,8 @@ describe('link', () => {
       await link(options)
 
       expect(selectConfigName).toHaveBeenCalledWith(tmp, 'app1')
-      expect(await readFile(joinPath(tmp, 'shopify.app.toml'))).toBe(initialContent)
-      expect(await readFile(joinPath(tmp, 'shopify.app.staging.toml'))).toMatchSnapshot()
+      await expect(readFile(joinPath(tmp, 'shopify.app.toml'))).resolves.toBe(initialContent)
+      await expect(readFile(joinPath(tmp, 'shopify.app.staging.toml'))).resolves.toMatchSnapshot()
     })
   })
 

--- a/packages/app/src/cli/services/app/config/link.ts
+++ b/packages/app/src/cli/services/app/config/link.ts
@@ -68,7 +68,7 @@ export default async function link(options: LinkOptions, shouldRenderSuccess = t
   const flags = remoteApp.flags
   const localAppOptions = await loadLocalAppOptions(options, specifications, flags, remoteApp.apiKey)
   const configFileName = await loadConfigurationFileName(remoteApp, options, {
-    appDirectory: localAppOptions.appDirectory,
+    appDirectory: localAppOptions.appDirectory ?? appDirectory,
   })
 
   await logMetadataForLoadedContext(remoteApp, developerPlatformClient.organizationSource)
@@ -304,14 +304,15 @@ async function loadConfigurationFileName(
   const cache = getCachedCommandInfo()
   if (cache?.selectedToml) return cache.selectedToml as AppConfigurationFileName
 
-  const existingTomls = await getTomls(options.directory)
+  const configDirectory = localAppInfo.appDirectory ?? options.directory
+  const existingTomls = await getTomls(configDirectory)
   const currentToml = existingTomls[remoteApp.apiKey]
   if (currentToml) return currentToml
 
   // If no TOML files exist at all, use the default filename without prompting
   if (isEmpty(existingTomls)) return 'shopify.app.toml'
 
-  return selectConfigName(localAppInfo.appDirectory ?? options.directory, remoteApp.title)
+  return selectConfigName(configDirectory, remoteApp.title)
 }
 
 /**


### PR DESCRIPTION
## Why
Running `shopify app config link` from an extension directory could scan the extension folder for app TOMLs, decide none existed, and overwrite the root `shopify.app.toml` when creating a new linked app.

## What
- Use the resolved app root when choosing the config filename.
- Preserve the root prompt behavior when existing app TOMLs are present.
- Add regression coverage for linking a new app from an extension directory.

## Testing
- `pnpm vitest run packages/app/src/cli/services/app/config/link.test.ts`