### PR TITLE
Remove preview store user ID prefix

### DIFF
--- a/packages/store/src/cli/services/store/create/preview/index.test.ts
+++ b/packages/store/src/cli/services/store/create/preview/index.test.ts
@@ -1,4 +1,4 @@
-import {PREVIEW_USER_ID_PREFIX, createPreviewStoreCommand} from './index.js'
+import {createPreviewStoreCommand} from './index.js'
 import {STORE_AUTH_APP_CLIENT_ID} from '../../auth/config.js'
 import {describe, expect, test, vi} from 'vitest'
 
@@ -28,7 +28,7 @@ describe('preview store create service', () => {
     expect(setStoredStoreAppSession).toHaveBeenCalledWith({
       store: 'x12y45z.myshopify.com',
       clientId: STORE_AUTH_APP_CLIENT_ID,
-      userId: `${PREVIEW_USER_ID_PREFIX}placeholder-uuid`,
+      userId: 'placeholder-uuid',
       accessToken: 'shpat_token',
       scopes: ['read_themes', 'write_themes'],
       acquiredAt: '2026-06-08T12:00:00.000Z',
@@ -44,7 +44,7 @@ describe('preview store create service', () => {
     })
     expect(recordStoreFqdnMetadata).toHaveBeenCalledOnce()
     expect(recordStoreFqdnMetadata).toHaveBeenCalledWith('x12y45z.myshopify.com', true, '123')
-    expect(setLastSeenUserId).toHaveBeenCalledWith(`${PREVIEW_USER_ID_PREFIX}placeholder-uuid`)
+    expect(setLastSeenUserId).toHaveBeenCalledWith('placeholder-uuid')
     expect(result).toEqual({
       status: 'success',
       message:
@@ -79,10 +79,8 @@ describe('preview store create service', () => {
       },
     )
 
-    expect(setStoredStoreAppSession).toHaveBeenCalledWith(
-      expect.objectContaining({userId: `${PREVIEW_USER_ID_PREFIX}123`, scopes: []}),
-    )
-    expect(setLastSeenUserId).toHaveBeenCalledWith(`${PREVIEW_USER_ID_PREFIX}123`)
+    expect(setStoredStoreAppSession).toHaveBeenCalledWith(expect.objectContaining({userId: '123', scopes: []}))
+    expect(setLastSeenUserId).toHaveBeenCalledWith('123')
   })
 
   test('passes client options to the create request', async () => {
@@ -132,7 +130,7 @@ describe('preview store create service', () => {
     )
 
     expect(setStoredStoreAppSession).toHaveBeenCalledOnce()
-    expect(setLastSeenUserId).toHaveBeenCalledWith(`${PREVIEW_USER_ID_PREFIX}123`)
+    expect(setLastSeenUserId).toHaveBeenCalledWith('123')
     expect(recordStoreFqdnMetadata).toHaveBeenCalledOnce()
     expect(recordStoreFqdnMetadata).toHaveBeenCalledWith('x12y45z.myshopify.com', true, '123')
     expect(result.status).toBe('success')

--- a/packages/store/src/cli/services/store/create/preview/index.ts
+++ b/packages/store/src/cli/services/store/create/preview/index.ts
@@ -4,8 +4,6 @@ import {recordStoreFqdnMetadata} from '../../attribution.js'
 import {setStoredStoreAppSession} from '@shopify/cli-kit/node/store-auth-session'
 import {setLastSeenUserId} from '@shopify/cli-kit/node/session'
 
-export const PREVIEW_USER_ID_PREFIX = 'preview:'
-
 interface CreatePreviewStoreInput {
   name?: string
   country?: string
@@ -57,7 +55,7 @@ export async function createPreviewStoreCommand(
 }
 
 function previewUserId(response: PreviewStoreCreateResponse): string {
-  return `${PREVIEW_USER_ID_PREFIX}${response.placeholderAccountUuid ?? response.shop.id}`
+  return response.placeholderAccountUuid ?? response.shop.id
 }
 
 async function persistPreviewStoreSession(

--- a/packages/store/src/cli/services/store/info/index.test.ts
+++ b/packages/store/src/cli/services/store/info/index.test.ts
@@ -153,7 +153,7 @@ describe('getStoreInfo', () => {
     vi.mocked(getCurrentStoredStoreAppSession).mockReturnValueOnce({
       store: SHOP,
       clientId: STORE_AUTH_APP_CLIENT_ID,
-      userId: 'preview:placeholder-uuid',
+      userId: 'placeholder-uuid',
       accessToken: 'shpat_preview_token',
       scopes: [],
       acquiredAt: '2026-06-08T12:00:00.000Z',
@@ -177,7 +177,7 @@ describe('getStoreInfo', () => {
     expect(fetchDestinationsContext).not.toHaveBeenCalled()
     expect(fetchOrganizationShop).not.toHaveBeenCalled()
     expect(recordStoreFqdnMetadata).toHaveBeenCalledWith(SHOP, true, '123')
-    expect(setLastSeenUserId).toHaveBeenCalledWith('preview:placeholder-uuid')
+    expect(setLastSeenUserId).toHaveBeenCalledWith('placeholder-uuid')
     expect(getPreviewStore).toHaveBeenCalledWith({
       shopId: '123',
       adminApiToken: 'shpat_preview_token',
@@ -200,7 +200,7 @@ describe('getStoreInfo', () => {
       vi.mocked(getCurrentStoredStoreAppSession).mockReturnValueOnce({
         store: SHOP,
         clientId: STORE_AUTH_APP_CLIENT_ID,
-        userId: 'preview:placeholder-uuid',
+        userId: 'placeholder-uuid',
         accessToken: 'shpat_preview_token',
         // Preview stores are preapproved for a large, fixed scope catalog; the re-auth message
         // should not dump the whole list back at the user (see the placeholder assertion below).
@@ -237,7 +237,7 @@ describe('getStoreInfo', () => {
     vi.mocked(getCurrentStoredStoreAppSession).mockReturnValueOnce({
       store: SHOP,
       clientId: STORE_AUTH_APP_CLIENT_ID,
-      userId: 'preview:placeholder-uuid',
+      userId: 'placeholder-uuid',
       accessToken: 'shpat_preview_token',
       scopes: ['read_products'],
       acquiredAt: '2026-06-08T12:00:00.000Z',
@@ -262,7 +262,7 @@ describe('getStoreInfo', () => {
     vi.mocked(getCurrentStoredStoreAppSession).mockReturnValueOnce({
       store: SHOP,
       clientId: STORE_AUTH_APP_CLIENT_ID,
-      userId: 'preview:placeholder-uuid',
+      userId: 'placeholder-uuid',
       accessToken: 'shpat_preview_token',
       scopes: ['read_themes', 'write_themes'],
       acquiredAt: '2026-06-08T12:00:00.000Z',
@@ -290,7 +290,7 @@ describe('getStoreInfo', () => {
     vi.mocked(getCurrentStoredStoreAppSession).mockReturnValueOnce({
       store: SHOP,
       clientId: STORE_AUTH_APP_CLIENT_ID,
-      userId: 'preview:placeholder-uuid',
+      userId: 'placeholder-uuid',
       accessToken: 'shpat_preview_token',
       scopes: [],
       acquiredAt: '2026-06-08T12:00:00.000Z',
@@ -566,7 +566,7 @@ The CLI is currently unable to prompt for reauthentication.`)
     mockStoreAuthFallback()
     vi.mocked(loadStoredStoreSession).mockResolvedValue({
       ...STORED_SESSION,
-      userId: 'preview:placeholder-uuid',
+      userId: 'placeholder-uuid',
       kind: 'preview',
       scopes: ['read_products', 'write_products', 'read_themes'],
     })


### PR DESCRIPTION
### WHY are these changes introduced?

Preview-store identities are already scoped by the store-auth session metadata (`kind: 'preview'` and the `preview` payload), so the stored `userId` does not need an additional `preview:` string prefix.

Removing the prefix makes the analytics identity match the actual placeholder account UUID returned by the preview-store backend, or the shop id fallback when no placeholder account UUID is available.

Stacked on top of #8005, this means preview-store `store info` / `store open` analytics use the unprefixed store-auth identity selected from the local store-auth cache.

### WHAT is this pull request doing?

Changes preview-store session creation from:

```ts
`preview:${response.placeholderAccountUuid ?? response.shop.id}`
```

to:

```ts
response.placeholderAccountUuid ?? response.shop.id
```

and updates tests to expect unprefixed preview-store user IDs in:

- preview store creation
- preview-store `getStoreInfo` paths that set analytics identity

### How to test your changes?

```bash
pnpm test packages/store/src/cli/services/store/create/preview/index.test.ts packages/store/src/cli/services/store/info/index.test.ts
```

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible documentation changes
- [x] I've considered analytics changes to measure impact
- [x] No changeset: this changes internal analytics/storage identity formatting only and has no visible CLI behavior change.
