### PR TITLE
Avoid real file watchers in theme-fs tests

### DIFF
--- a/packages/theme/src/cli/utilities/theme-fs.test.ts
+++ b/packages/theme/src/cli/utilities/theme-fs.test.ts
@@ -137,7 +137,8 @@ describe('theme-fs', () => {
         // Given
         const root = tmpDir
         await copyDirectoryContents(joinPath(locationOfThisFile, 'fixtures/theme'), root)
-        const watchSpy = vi.spyOn(chokidar, 'watch')
+        const mockWatcher = new EventEmitter()
+        const watchSpy = vi.spyOn(chokidar, 'watch').mockReturnValue(mockWatcher as any)
 
         // When
         const themeFileSystem = mountThemeFileSystem(root, {listing: 'modern'})
@@ -157,7 +158,8 @@ describe('theme-fs', () => {
         // Given
         const root = tmpDir
         await copyDirectoryContents(joinPath(locationOfThisFile, 'fixtures/theme'), root)
-        const watchSpy = vi.spyOn(chokidar, 'watch')
+        const mockWatcher = new EventEmitter()
+        const watchSpy = vi.spyOn(chokidar, 'watch').mockReturnValue(mockWatcher as any)
 
         // When
         const themeFileSystem = mountThemeFileSystem(root)


### PR DESCRIPTION
### WHY are these changes introduced?

`theme-fs.test.ts` has unit tests that only assert which paths are passed to Chokidar, but they still create a real file watcher. On CI this has failed with Windows `EPERM: operation not permitted, watch` errors after the test file completes.

### WHAT is this pull request doing?

Mocks `chokidar.watch` in the two path-assertion tests so they keep verifying the watched paths without opening a real OS file watcher.

### How to test your changes?

- `pnpm vitest run packages/theme/src/cli/utilities/theme-fs.test.ts`
- `pnpm nx run theme:lint`
- `pnpm nx run theme:type-check`

### Post-release steps

None.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [x] This change is not user-facing and does not need a changeset.
