### PR TITLE
Use relative GraphiQL asset paths

### DIFF
--- a/bin/bundling/esbuild-plugin-graphiql-imports.js
+++ b/bin/bundling/esbuild-plugin-graphiql-imports.js
@@ -23,11 +23,10 @@ const resolveGraphiQLAssetHelper = `function resolveGraphiQLAsset(asset) {
 const GraphiQLImportsPlugin = {
   name: 'GraphiQLImportsPlugin',
   setup(build) {
-    // GraphiQL uses require.resolve with paths that won't work with esbuild
-    // We need to replace them with valid paths
-    // graphiql/server.ts uses require.resolve('@shopify/cli-kit/assets/...'). The bundled CLI does not ship
-    // @shopify/cli-kit as a dependency; assets are copied to dist/assets. Rewrite to a resolver that works whether
-    // esbuild emits the GraphiQL server into a top-level shared chunk or a nested command file.
+    // GraphiQL uses require.resolve with paths that won't work after esbuild moves this module.
+    // We need to replace them with valid paths. The bundled CLI copies cli-kit assets to dist/assets,
+    // so rewrite to a resolver that works whether esbuild emits the GraphiQL server into a top-level
+    // shared chunk or a nested command file.
     build.onLoad({filter: /[/\\]graphiql[/\\]server\.[cm]?[jt]s$/}, async (args) => {
       const contents = await readFile(args.path, 'utf8')
       if (!createRequireStatement.test(contents)) {
@@ -41,7 +40,9 @@ const GraphiQLImportsPlugin = {
         contents: contents
           .replace(createRequireStatement, (match) => `${match}\n${resolveGraphiQLAssetHelper}`)
           .replace("require.resolve('@shopify/cli-kit/assets/graphiql/favicon.ico')", "resolveGraphiQLAsset('favicon.ico')")
-          .replace("require.resolve('@shopify/cli-kit/assets/graphiql/style.css')", "resolveGraphiQLAsset('style.css')"),
+          .replace("require.resolve('@shopify/cli-kit/assets/graphiql/style.css')", "resolveGraphiQLAsset('style.css')")
+          .replace("require.resolve('../../../../assets/graphiql/favicon.ico')", "resolveGraphiQLAsset('favicon.ico')")
+          .replace("require.resolve('../../../../assets/graphiql/style.css')", "resolveGraphiQLAsset('style.css')"),
       }
     })
   },

--- a/packages/cli-kit/src/public/node/graphiql/server.ts
+++ b/packages/cli-kit/src/public/node/graphiql/server.ts
@@ -155,9 +155,9 @@ export function setupGraphiQLServer(options: SetupGraphiQLServerOptions): Server
     )
   }
 
-  const faviconPath = require.resolve('@shopify/cli-kit/assets/graphiql/favicon.ico')
+  const faviconPath = require.resolve('../../../../assets/graphiql/favicon.ico')
   const faviconContent = readFileSync(faviconPath)
-  const stylePath = require.resolve('@shopify/cli-kit/assets/graphiql/style.css')
+  const stylePath = require.resolve('../../../../assets/graphiql/style.css')
   const styleContent = readFileSync(stylePath, 'utf8')
 
   app.use(


### PR DESCRIPTION
### WHY are these changes introduced?

No issue.

The `cli-kit` lint job started failing on GraphiQL asset resolution because Nx now rejects resolving files from the same project through the package export path.

### WHAT is this pull request doing?

Resolve the GraphiQL favicon and stylesheet through relative `require.resolve` paths instead of `@shopify/cli-kit/assets/...` package paths.

The CLI bundle step rewrites those asset lookups, so this also updates the GraphiQL bundling plugin to recognize the new relative asset paths.

### How to test your changes?

- `pnpm nx run cli-kit:lint --skip-nx-cache`
- `pnpm nx run cli-kit:type-check --skip-nx-cache`
- `pnpm nx run-many --all --skip-nx-cache --target=build --output-style=stream`
- `pnpm nx run-many --all --skip-nx-cache --target=bundle --output-style=stream`

### Post-release steps

None.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

Not user-facing; no changeset needed.
