### PR TITLE
Deprecate shopify search command

### DIFF
--- a/packages/cli/src/cli/commands/search.ts
+++ b/packages/cli/src/cli/commands/search.ts
@@ -4,6 +4,13 @@ import {globalFlags} from '@shopify/cli-kit/node/cli'
 import {Args} from '@oclif/core'
 
 export default class Search extends Command {
+  static state = 'deprecated'
+
+  static deprecationOptions = {
+    message:
+      'The "shopify search" command has been deprecated. Use "shopify doc search" for up-to-date, agent-oriented documentation search.',
+  }
+
   static description =
     'Search shopify.dev for the most relevant content matching a query. Best for discovery — surfacing the relevant pieces of documentation for a topic, rather than retrieving a whole document. To download a full document verbatim, use `doc fetch`.'
 


### PR DESCRIPTION
Deprecates the top-level `shopify search` command and points users to `shopify doc search`