### PR TITLE
[Security] Harden takeRandomFromArray

### DIFF
--- a/packages/cli-kit/src/public/common/array.test.ts
+++ b/packages/cli-kit/src/public/common/array.test.ts
@@ -1,4 +1,4 @@
-import {difference, uniq, uniqBy} from './array.js'
+import {difference, takeRandomFromArray, uniq, uniqBy} from './array.js'
 import {describe, test, expect} from 'vitest'
 
 describe('uniqBy', () => {
@@ -60,5 +60,40 @@ describe('difference', () => {
 
     // Then
     expect(got).toEqual([1])
+  })
+})
+
+describe('takeRandomFromArray', () => {
+  test('returns a random element from the array', () => {
+    // Given
+    const array = [1, 2, 3, 4, 5]
+
+    // When
+    const got = takeRandomFromArray(array)
+
+    // Then
+    expect(array).toContain(got)
+  })
+
+  test('returns undefined for an empty array', () => {
+    // Given
+    const array: number[] = []
+
+    // When
+    const got = takeRandomFromArray(array)
+
+    // Then
+    expect(got).toBeUndefined()
+  })
+
+  test('handles arrays with a single element', () => {
+    // Given
+    const array = ['only']
+
+    // When
+    const got = takeRandomFromArray(array)
+
+    // Then
+    expect(got).toBe('only')
   })
 })

--- a/packages/cli-kit/src/public/common/array.ts
+++ b/packages/cli-kit/src/public/common/array.ts
@@ -9,7 +9,19 @@ import type {List, ValueIteratee} from 'lodash'
  * @returns A random element from the array.
  */
 export function takeRandomFromArray<T>(array: T[]): T {
-  return array[Math.floor(Math.random() * array.length)]!
+  if (array.length === 0) {
+    return undefined as T
+  }
+  const arrayLength = array.length
+  const maxUint32 = 0xffffffff
+  const limit = maxUint32 - (maxUint32 % arrayLength)
+  const buffer = new Uint32Array(1)
+  let randomNumber: number
+  do {
+    globalThis.crypto.getRandomValues(buffer)
+    randomNumber = buffer[0]!
+  } while (randomNumber >= limit)
+  return array[randomNumber % arrayLength]!
 }
 
 /**


### PR DESCRIPTION
### WHY are these changes introduced?

The `takeRandomFromArray` utility was using `Math.random()`, which is not cryptographically secure and can be predictable. Additionally, using the modulo operator on a random number without rejection sampling can introduce modulo bias.

### WHAT is this pull request doing?

- Replaces `Math.random()` with `globalThis.crypto.getRandomValues()` in `packages/cli-kit/src/public/common/array.ts`.
- Implements rejection sampling to ensure an unbiased, uniform selection of array elements.
- Adds comprehensive unit tests for `takeRandomFromArray` in `packages/cli-kit/src/public/common/array.test.ts`.

### How to test your changes?

CI

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [5710042040880058116](https://jules.google.com/task/5710042040880058116) started by @gonzaloriestra*