### PR TITLE
[Performance] Memoize cloudEnvironment check

### DIFF
--- a/packages/cli-kit/src/public/node/context/local.test.ts
+++ b/packages/cli-kit/src/public/node/context/local.test.ts
@@ -7,6 +7,7 @@ import {
   isUnitTest,
   analyticsDisabled,
   cloudEnvironment,
+  _resetCloudEnvironmentCache,
   macAddress,
   getThemeKitAccessDomain,
   opentelemetryDomain,
@@ -217,6 +218,10 @@ describe('macAddress', () => {
 })
 
 describe('cloudEnvironment', () => {
+  afterEach(() => {
+    _resetCloudEnvironmentCache()
+  })
+
   test('when codespace environmentreturns correct cloud platform', () => {
     // Given
     const env = {CODESPACES: '1'}
@@ -248,6 +253,51 @@ describe('cloudEnvironment', () => {
 
     // Then
     expect(got.platform).toBe('localhost')
+  })
+
+  test('memoizes the result when using process.env', () => {
+    // Given
+    const originalEnv = process.env
+    const mockEnv = {...process.env, CODESPACES: '1'}
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ;(process as any).env = mockEnv
+
+      // When
+      const got1 = cloudEnvironment()
+      const got2 = cloudEnvironment()
+
+      // Then
+      expect(got1.platform).toBe('codespaces')
+      expect(got1).toBe(got2)
+
+      // And resetting the cache
+      _resetCloudEnvironmentCache()
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ;(process as any).env = {...process.env, GITPOD_WORKSPACE_URL: 'http://custom.gitpod.io'}
+      delete (process.env as any).CODESPACES
+
+      const got3 = cloudEnvironment()
+      expect(got3.platform).toBe('gitpod')
+    } finally {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ;(process as any).env = originalEnv
+    }
+  })
+
+  test('does not memoize when a custom environment is provided', () => {
+    // Given
+    const env1 = {CODESPACES: '1'}
+    const env2 = {GITPOD_WORKSPACE_URL: 'http://custom.gitpod.io'}
+
+    // When
+    const got1 = cloudEnvironment(env1)
+    const got2 = cloudEnvironment(env2)
+
+    // Then
+    expect(got1.platform).toBe('codespaces')
+    expect(got2.platform).toBe('gitpod')
+    expect(got1).not.toBe(got2)
   })
 })
 

--- a/packages/cli-kit/src/public/node/context/local.ts
+++ b/packages/cli-kit/src/public/node/context/local.ts
@@ -45,6 +45,16 @@ let memoizedIsVerbose: boolean | undefined
 let memoizedIsUnitTest: boolean | undefined
 
 /**
+ * Memoized value for the cloud environment check.
+ */
+let memoizedCloudEnvironment:
+  | {
+      platform: 'codespaces' | 'gitpod' | 'cloudShell' | 'localhost'
+      editor: boolean
+    }
+  | undefined
+
+/**
  * Returns true if the CLI is running in debug mode.
  *
  * @param env - The environment variables from the environment of the current process.
@@ -219,16 +229,30 @@ export function cloudEnvironment(env: NodeJS.ProcessEnv = process.env): {
   platform: 'codespaces' | 'gitpod' | 'cloudShell' | 'localhost'
   editor: boolean
 } {
+  if (env === process.env && memoizedCloudEnvironment) {
+    return memoizedCloudEnvironment
+  }
+
+  let result: {
+    platform: 'codespaces' | 'gitpod' | 'cloudShell' | 'localhost'
+    editor: boolean
+  }
+
   if (isSet(env[environmentVariables.codespaces])) {
-    return {platform: 'codespaces', editor: true}
+    result = {platform: 'codespaces', editor: true}
+  } else if (isSet(env[environmentVariables.gitpod])) {
+    result = {platform: 'gitpod', editor: true}
+  } else if (isSet(env[environmentVariables.cloudShell])) {
+    result = {platform: 'cloudShell', editor: true}
+  } else {
+    result = {platform: 'localhost', editor: false}
   }
-  if (isSet(env[environmentVariables.gitpod])) {
-    return {platform: 'gitpod', editor: true}
+
+  if (env === process.env) {
+    memoizedCloudEnvironment = result
   }
-  if (isSet(env[environmentVariables.cloudShell])) {
-    return {platform: 'cloudShell', editor: true}
-  }
-  return {platform: 'localhost', editor: false}
+
+  return result
 }
 
 /**
@@ -326,3 +350,10 @@ export function opentelemetryDomain(env = process.env): string {
 }
 
 export type CIMetadata = Metadata
+
+/**
+ * Resets the cloud environment cache.
+ */
+export function _resetCloudEnvironmentCache(): void {
+  memoizedCloudEnvironment = undefined
+}


### PR DESCRIPTION
### WHY are these changes introduced?

The `cloudEnvironment` function is called multiple times during the CLI execution to identify if it's running in a cloud IDE like Codespaces or Gitpod. These environment checks are static during the process lifetime.

### WHAT is this pull request doing?

This PR memoizes the `cloudEnvironment` function result when using the default `process.env`. It also adds a reset utility for testing purposes.

### How to test your changes?

CI

### Post-release steps

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [5739118917641376805](https://jules.google.com/task/5739118917641376805) started by @gonzaloriestra*