### PR TITLE
[Tests] Refactor doc fetch service tests to remove fs mocks

### DIFF
--- a/packages/cli/src/cli/services/commands/doc/fetch.test.ts
+++ b/packages/cli/src/cli/services/commands/doc/fetch.test.ts
@@ -3,12 +3,11 @@ import {describe, expect, test, vi, beforeEach} from 'vitest'
 import {fetch} from '@shopify/cli-kit/node/http'
 import {outputResult} from '@shopify/cli-kit/node/output'
 import {AbortError} from '@shopify/cli-kit/node/error'
-import {mkdir, writeFile} from '@shopify/cli-kit/node/fs'
-import {dirname, resolvePath} from '@shopify/cli-kit/node/path'
+import {fileExists, inTemporaryDirectory, readFile} from '@shopify/cli-kit/node/fs'
+import {joinPath} from '@shopify/cli-kit/node/path'
 
 vi.mock('@shopify/cli-kit/node/http')
 vi.mock('@shopify/cli-kit/node/output')
-vi.mock('@shopify/cli-kit/node/fs')
 
 const okResponse = (body: string) =>
   ({ok: true, status: 200, statusText: 'OK', text: () => Promise.resolve(body)}) as any
@@ -44,12 +43,18 @@ describe('docFetchService', () => {
   })
 
   test('writes the document to the output path instead of stdout', async () => {
-    await docFetchService('https://shopify.dev/docs/api/shopify-cli', 'docs/shopify-cli.md')
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      const outputPath = joinPath(tmpDir, 'docs/shopify-cli.md')
 
-    const expectedPath = resolvePath('docs/shopify-cli.md')
-    expect(mkdir).toHaveBeenCalledWith(dirname(expectedPath))
-    expect(writeFile).toHaveBeenCalledWith(expectedPath, '# Doc')
-    expect(outputResult).not.toHaveBeenCalled()
+      // When
+      await docFetchService('https://shopify.dev/docs/api/shopify-cli', outputPath)
+
+      // Then
+      await expect(fileExists(outputPath)).resolves.toBe(true)
+      await expect(readFile(outputPath)).resolves.toBe('# Doc')
+      expect(outputResult).not.toHaveBeenCalled()
+    })
   })
 
   test('throws when the response is not ok', async () => {


### PR DESCRIPTION
Followed the instructions in `.agents/automated-tasks/tests.md` to replace filesystem mocks with real operations in a temporary directory for `docFetchService` tests in `packages/cli/src/cli/services/commands/doc/fetch.test.ts`.

Changes:
- Removed filesystem mocking in `packages/cli/src/cli/services/commands/doc/fetch.test.ts`.
- Updated `writes the document to the output path instead of stdout` test case to use `inTemporaryDirectory` and `joinPath`.
- Verified file existence and content using `fileExists` and `readFile`.
- Ensured all asynchronous assertions use `.resolves` to satisfy linting requirements.
- Confirmed all tests pass, and linting/type-checking are successful.

---
*PR created automatically by Jules for task [10656394579371662531](https://jules.google.com/task/10656394579371662531) started by @gonzaloriestra*