### PR TITLE
[Refactor] Use native timers/promises in sleep

### DIFF
--- a/packages/cli-kit/src/public/node/system.test.ts
+++ b/packages/cli-kit/src/public/node/system.test.ts
@@ -393,3 +393,13 @@ describe('readStdinString', () => {
     await expect(got).rejects.toThrow('Stdin input exceeded the maximum allowed size.')
   })
 })
+
+describe('sleep', () => {
+  test('waits for the specified number of seconds', async () => {
+    vi.useFakeTimers()
+    const sleepPromise = system.sleep(1)
+    await vi.advanceTimersByTimeAsync(1000)
+    await expect(sleepPromise).resolves.toBeUndefined()
+    vi.useRealTimers()
+  })
+})

--- a/packages/cli-kit/src/public/node/system.ts
+++ b/packages/cli-kit/src/public/node/system.ts
@@ -13,6 +13,7 @@ import which from 'which'
 import {delimiter} from 'pathe'
 
 import {fstatSync} from 'fs'
+import {setTimeout} from 'timers/promises'
 import type {Writable, Readable} from 'stream'
 
 /**
@@ -319,9 +320,7 @@ function checkCommandSafety(command: string, _options: {cwd: string}): void {
  * @returns A Promise resolving after the number of seconds.
  */
 export async function sleep(seconds: number): Promise<void> {
-  return new Promise((resolve) => {
-    setTimeout(resolve, 1000 * seconds)
-  })
+  await setTimeout(1000 * seconds)
 }
 
 /**


### PR DESCRIPTION
### WHY are these changes introduced?

The `sleep` utility function in `packages/cli-kit` was using a manual `Promise` wrapper around a callback-based `setTimeout`. Modern Node.js provides a native promisified version of `setTimeout` in the `node:timers/promises` module, which is more idiomatic and maintainable.

### WHAT is this pull request doing?

- Refactors the `sleep` function in `packages/cli-kit/src/public/node/system.ts` to use `setTimeout` from `node:timers/promises`.
- Adds a unit test for the `sleep` function in `packages/cli-kit/src/public/node/system.test.ts` to verify its behavior and ensure correctness.

### How to test your changes?

CI

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [17141589781697498983](https://jules.google.com/task/17141589781697498983) started by @gonzaloriestra*