### PR TITLE
Remove store search support flag

### DIFF
--- a/packages/app/src/cli/models/app/app.test-data.ts
+++ b/packages/app/src/cli/models/app/app.test-data.ts
@@ -1332,7 +1332,6 @@ export function testDeveloperPlatformClient(stubs: Partial<DeveloperPlatformClie
     clientName: ClientName.AppManagement,
     webUiName: 'Test Dashboard',
     supportsAtomicDeployments: false,
-    supportsStoreSearch: false,
     organizationSource: OrganizationSource.BusinessPlatform,
     bundleFormat: 'zip',
     supportsDashboardManagedExtensions: true,
@@ -1416,7 +1415,6 @@ export function testDeveloperPlatformClient(stubs: Partial<DeveloperPlatformClie
           | 'supportsAtomicDeployments'
           | 'clientName'
           | 'webUiName'
-          | 'supportsStoreSearch'
           | 'organizationSource'
           | 'bundleFormat'
           | 'supportsDashboardManagedExtensions'

--- a/packages/app/src/cli/services/dev/select-store.test.ts
+++ b/packages/app/src/cli/services/dev/select-store.test.ts
@@ -238,7 +238,7 @@ describe('selectStore', async () => {
     expect(res).toContain('https://dev.shopify.com/dashboard/1234/stores')
   })
 
-  test('enables backend search if the DeveloperPlatformClient supports it', async () => {
+  test('enables backend search', async () => {
     // Given
     vi.mocked(selectStorePrompt).mockResolvedValueOnce(STORE1)
 
@@ -246,7 +246,7 @@ describe('selectStore', async () => {
     const got = await selectStore(
       {stores: [STORE1, STORE2], hasMorePages: false},
       ORG1,
-      testDeveloperPlatformClient({clientName: ClientName.Partners, supportsStoreSearch: true}),
+      testDeveloperPlatformClient({clientName: ClientName.Partners}),
     )
 
     // Then

--- a/packages/app/src/cli/services/dev/select-store.ts
+++ b/packages/app/src/cli/services/dev/select-store.ts
@@ -30,10 +30,7 @@ export async function selectStore(
   developerPlatformClient: DeveloperPlatformClient,
 ): Promise<OrganizationStore> {
   const showDomainOnPrompt = developerPlatformClient.clientName === ClientName.AppManagement
-  let onSearchForStoresByName
-  if (developerPlatformClient.supportsStoreSearch) {
-    onSearchForStoresByName = async (term: string) => developerPlatformClient.devStoresForOrg(org.id, term)
-  }
+  const onSearchForStoresByName = async (term: string) => developerPlatformClient.devStoresForOrg(org.id, term)
   // If no stores, guide the developer through creating one
   // Then, with a store selected, make sure its transfer-disabled, prompting to convert if needed
   let store = await selectStorePrompt({

--- a/packages/app/src/cli/utilities/developer-platform-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client.ts
@@ -223,7 +223,6 @@ export interface DeveloperPlatformClient {
   readonly clientName: ClientName
   readonly webUiName: string
   readonly supportsAtomicDeployments: boolean
-  readonly supportsStoreSearch: boolean
   readonly organizationSource: OrganizationSource
   readonly bundleFormat: 'zip' | 'br'
   readonly supportsDashboardManagedExtensions: boolean

--- a/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
@@ -193,7 +193,6 @@ export class AppManagementClient implements DeveloperPlatformClient {
   public readonly clientName = ClientName.AppManagement
   public readonly webUiName = 'Developer Dashboard'
   public readonly supportsAtomicDeployments = true
-  public readonly supportsStoreSearch = true
   public readonly organizationSource = OrganizationSource.BusinessPlatform
   public readonly bundleFormat = 'br'
   public readonly supportsDashboardManagedExtensions = false

--- a/packages/app/src/cli/utilities/developer-platform-client/partners-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/partners-client.ts
@@ -199,7 +199,6 @@ export class PartnersClient implements DeveloperPlatformClient {
   public readonly clientName = ClientName.Partners
   public readonly webUiName = 'Partner Dashboard'
   public readonly supportsAtomicDeployments = false
-  public readonly supportsStoreSearch = false
   public readonly organizationSource = OrganizationSource.Partners
   public readonly bundleFormat = 'zip'
   public readonly supportsDashboardManagedExtensions = true


### PR DESCRIPTION
Summary:
- Remove the supportsStoreSearch capability from DeveloperPlatformClient.
- Always pass store-name search to the store selection prompt.
- Clean up test client stubs and store-selection coverage.

Validation:
- pnpm vitest run packages/app/src/cli/services/dev/select-store.test.ts
- pnpm --filter app type-check
- pnpm --filter app lint
- pnpm knip