### PR TITLE
fix(theme): don't send Bearer token to cart/checkout/account proxy en…

### DIFF
--- a/.changeset/fix-cart-ajax-401.md
+++ b/.changeset/fix-cart-ajax-401.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Fix 401/403 on cart AJAX endpoints during `shopify theme dev`

--- a/packages/theme/src/cli/utilities/theme-environment/proxy.test.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/proxy.test.ts
@@ -630,16 +630,32 @@ describe('dev proxy', () => {
       expect(headers.Authorization).toBeUndefined()
     })
 
-    test('sends Bearer token for theme-extension type', async () => {
+    test('does NOT send Bearer token for theme-extension type', async () => {
       const extCtx = {
         ...tokenCtx,
-        type: 'theme-extensions',
+        type: 'theme-extension',
       } as unknown as DevServerContext
       const event = createH3Event('GET', '/assets/style.css')
       await proxyStorefrontRequest(event, extCtx)
       const [, init] = fetchMock.mock.calls[0] as [URL, RequestInit]
       const headers = init.headers as Record<string, string>
       expect(headers.Authorization).toBeUndefined()
+    })
+
+    test('strips query string before auth check for /cart.js?sections=header', async () => {
+      const event = createH3Event('GET', '/cart.js?sections=header')
+      await proxyStorefrontRequest(event, tokenCtx)
+      const [, init] = fetchMock.mock.calls[0] as [URL, RequestInit]
+      const headers = init.headers as Record<string, string>
+      expect(headers.Authorization).toBeUndefined()
+    })
+
+    test('sends Bearer token for non-CDN paths that are not cart/checkout/account', async () => {
+      const event = createH3Event('GET', '/products/some-product')
+      await proxyStorefrontRequest(event, tokenCtx)
+      const [, init] = fetchMock.mock.calls[0] as [URL, RequestInit]
+      const headers = init.headers as Record<string, string>
+      expect(headers.Authorization).toBe('Bearer sfr-devtools-token')
     })
   })
 

--- a/packages/theme/src/cli/utilities/theme-environment/proxy.test.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/proxy.test.ts
@@ -553,6 +553,96 @@ describe('dev proxy', () => {
     })
   })
 
+  describe('proxyStorefrontRequest — Bearer token auth scoping', () => {
+    let fetchMock: ReturnType<typeof vi.fn>
+    const tokenCtx = {
+      ...ctx,
+      type: 'theme',
+      session: {
+        storeFqdn: 'my-store.myshopify.com',
+        sessionCookies: {},
+        storefrontToken: 'sfr-devtools-token',
+      },
+    } as unknown as DevServerContext
+
+    beforeEach(() => {
+      fetchMock = vi.fn().mockResolvedValue(new Response('OK'))
+      vi.stubGlobal('fetch', fetchMock)
+    })
+
+    afterEach(() => {
+      vi.unstubAllGlobals()
+    })
+
+    test('sends Bearer token for CDN asset requests', async () => {
+      const event = createH3Event('GET', '/cdn/shop/files/style.css')
+      await proxyStorefrontRequest(event, tokenCtx)
+      const [, init] = fetchMock.mock.calls[0] as [URL, RequestInit]
+      const headers = init.headers as Record<string, string>
+      expect(headers.Authorization).toBe('Bearer sfr-devtools-token')
+    })
+
+    test('does NOT send Bearer token for /cart/add.js', async () => {
+      const event = createH3Event('POST', '/cart/add.js')
+      await proxyStorefrontRequest(event, tokenCtx)
+      const [, init] = fetchMock.mock.calls[0] as [URL, RequestInit]
+      const headers = init.headers as Record<string, string>
+      expect(headers.Authorization).toBeUndefined()
+    })
+
+    test('does NOT send Bearer token for /cart.js', async () => {
+      const event = createH3Event('GET', '/cart.js')
+      await proxyStorefrontRequest(event, tokenCtx)
+      const [, init] = fetchMock.mock.calls[0] as [URL, RequestInit]
+      const headers = init.headers as Record<string, string>
+      expect(headers.Authorization).toBeUndefined()
+    })
+
+    test('does NOT send Bearer token for /cart.json', async () => {
+      const event = createH3Event('GET', '/cart.json')
+      await proxyStorefrontRequest(event, tokenCtx)
+      const [, init] = fetchMock.mock.calls[0] as [URL, RequestInit]
+      const headers = init.headers as Record<string, string>
+      expect(headers.Authorization).toBeUndefined()
+    })
+
+    test('does NOT send Bearer token for /cart/', async () => {
+      const event = createH3Event('GET', '/cart/')
+      await proxyStorefrontRequest(event, tokenCtx)
+      const [, init] = fetchMock.mock.calls[0] as [URL, RequestInit]
+      const headers = init.headers as Record<string, string>
+      expect(headers.Authorization).toBeUndefined()
+    })
+
+    test('does NOT send Bearer token for checkout endpoints', async () => {
+      const event = createH3Event('GET', '/checkouts/xyz')
+      await proxyStorefrontRequest(event, tokenCtx)
+      const [, init] = fetchMock.mock.calls[0] as [URL, RequestInit]
+      const headers = init.headers as Record<string, string>
+      expect(headers.Authorization).toBeUndefined()
+    })
+
+    test('does NOT send Bearer token for account endpoints', async () => {
+      const event = createH3Event('GET', '/account/logout')
+      await proxyStorefrontRequest(event, tokenCtx)
+      const [, init] = fetchMock.mock.calls[0] as [URL, RequestInit]
+      const headers = init.headers as Record<string, string>
+      expect(headers.Authorization).toBeUndefined()
+    })
+
+    test('sends Bearer token for theme-extension type', async () => {
+      const extCtx = {
+        ...tokenCtx,
+        type: 'theme-extensions',
+      } as unknown as DevServerContext
+      const event = createH3Event('GET', '/assets/style.css')
+      await proxyStorefrontRequest(event, extCtx)
+      const [, init] = fetchMock.mock.calls[0] as [URL, RequestInit]
+      const headers = init.headers as Record<string, string>
+      expect(headers.Authorization).toBeUndefined()
+    })
+  })
+
   describe('proxyStorefrontRequest — Storefront API passthrough', () => {
     const passthroughCtx = {
       ...ctx,

--- a/packages/theme/src/cli/utilities/theme-environment/proxy.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/proxy.ts
@@ -17,6 +17,9 @@ export const EXTENSION_CDN_PREFIX = '/ext/cdn/'
 
 const API_COLLECT_PATH = '/api/collect'
 const CART_PATTERN = /^\/cart\//
+// Broader than CART_PATTERN (routing) -- covers /cart, /cart.js, /cart.json for auth exclusion.
+// CART_PATTERN only matches /cart/... subpaths to avoid proxying GET /cart (the cart HTML page).
+const CART_SESSION_PATTERN = /^\/cart(\/|\.js|\.json|$)/
 const CHECKOUT_PATTERN = /^\/checkouts\/(?!internal\/)/
 const ACCOUNT_PATTERN = /^\/account(\/login\/multipass(\/[^/]+)?|\/logout)?\/?$/
 const VANITY_CDN_PATTERN = new RegExp(`^${VANITY_CDN_PREFIX}`)
@@ -114,6 +117,18 @@ export function canProxyRequest(event: H3Event) {
   if (extension === '.html' || acceptsType.includes('text/html')) return false
 
   return Boolean(extension) || acceptsType !== '*/*'
+}
+
+// Cart, checkout, and account endpoints use session-cookie auth, not Bearer tokens.
+// CHECKOUT_PATTERN and ACCOUNT_PATTERN are reused from routing because their
+// routing and auth scopes currently align; changes to those patterns should
+// consider the auth implications here.
+function needsBearerToken(path: string): boolean {
+  const [pathname] = path.split('?') as [string]
+  if (CART_SESSION_PATTERN.test(pathname)) return false
+  if (CHECKOUT_PATTERN.test(pathname)) return false
+  if (ACCOUNT_PATTERN.test(pathname)) return false
+  return true
 }
 
 function getStoreFqdnForRegEx(ctx: DevServerContext) {
@@ -344,8 +359,9 @@ export function proxyStorefrontRequest(event: H3Event, ctx: DevServerContext): P
       ...(host === ctx.session.storeFqdn ? ctx.session.crawlerSignatureHeaders : {}),
       referer: url.origin,
       Cookie: buildCookies(ctx.session, {headers}),
-      // Only include Authorization for theme dev, not theme-extensions
-      ...(ctx.type === 'theme' ? {Authorization: `Bearer ${ctx.session.storefrontToken}`} : {}),
+      // Cart, checkout, and account endpoints use cookie-based auth.
+      // Sending a Bearer token causes SFR to select token auth, which lacks cart scopes.
+      ...(ctx.type === 'theme' && needsBearerToken(event.path) ? {Authorization: `Bearer ${ctx.session.storefrontToken}`} : {}),
     })
   }
 

--- a/packages/theme/src/cli/utilities/theme-environment/proxy.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/proxy.ts
@@ -361,7 +361,9 @@ export function proxyStorefrontRequest(event: H3Event, ctx: DevServerContext): P
       Cookie: buildCookies(ctx.session, {headers}),
       // Cart, checkout, and account endpoints use cookie-based auth.
       // Sending a Bearer token causes SFR to select token auth, which lacks cart scopes.
-      ...(ctx.type === 'theme' && needsBearerToken(event.path) ? {Authorization: `Bearer ${ctx.session.storefrontToken}`} : {}),
+      ...(ctx.type === 'theme' && needsBearerToken(event.path)
+        ? {Authorization: `Bearer ${ctx.session.storefrontToken}`}
+        : {}),
     })
   }
 


### PR DESCRIPTION
## Fix cart AJAX authentication in `theme dev` proxy

### WHY are these changes introduced?

Fixes #7568.

When running `shopify theme dev`, Cart AJAX endpoints (such as `/cart/add.js`, `/cart.js`, `/cart.json`, `/cart/change.js`, and `/cart/update.js`) return `401` or `403` responses.

The proxy currently attaches an `Authorization: Bearer <storefrontToken>` header to every request. However, Cart AJAX endpoints authenticate using the storefront session cookie rather than a Storefront API access token. Because the Bearer token is present, SFR attempts token-based authentication instead of cookie-based authentication. The CLI's storefront token does not include the required cart scopes, causing these requests to fail.

This behavior was previously fixed in commit `d0e135b8f`, but was later reverted in `11240b342`. This PR restores the same behavior while adapting the implementation to the current codebase.

### WHAT is this pull request doing?

* Adds a `CART_SESSION_PATTERN` regex to match cart endpoints (`/cart`, `/cart.js`, `/cart.json`, and `/cart/*`).
* Introduces a `needsBearerToken()` helper that determines whether a request should include the `Authorization` header.
* Skips sending the Bearer token for:

  * Cart endpoints
  * Checkout endpoints
  * Customer account endpoints
* Continues sending the Bearer token for all other requests that require Storefront API authentication.
* Adds 9 new unit tests covering authentication behavior for:

  * Cart endpoints
  * Checkout endpoints
  * Customer account endpoints
  * CDN and asset requests
  * Theme extension requests

### How to test your changes?

Run the proxy test suite:

```bash
pnpm vitest run packages/theme/src/cli/utilities/theme-environment/proxy.test.ts
```

Expected result:

* All 47 tests pass.
* Cart AJAX requests no longer return `401`/`403` while running `shopify theme dev`.
* Non-cart requests continue to include the Bearer token and behave as before.

### Post-release steps

None.

### Checklist

* [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
* [x] I've considered possible documentation changes
* [x] I've considered analytics changes to measure impact
* [x] The change is user-facing — this is a bug fix, so a **patch** changeset has been added.
