### PR TITLE
[Security] Harden notifications URL validation

### DIFF
--- a/packages/cli-kit/src/public/node/notifications-system.test.ts
+++ b/packages/cli-kit/src/public/node/notifications-system.test.ts
@@ -1,10 +1,12 @@
 import {
   Notification,
+  fetchNotifications,
   fetchNotificationsInBackground,
   filterNotifications,
   showNotificationsIfNeeded,
 } from './notifications-system.js'
 import {renderError, renderInfo, renderWarning} from './ui.js'
+import {fetch} from './http.js'
 import {sniffForJson} from './path.js'
 import {exec} from './system.js'
 import {cacheRetrieve} from '../../private/node/conf-store.js'
@@ -14,6 +16,7 @@ vi.mock('./ui.js')
 vi.mock('../../private/node/conf-store.js')
 vi.mock('./path.js')
 vi.mock('./system.js')
+vi.mock('./http.js')
 
 const betweenVersins1and2: Notification = {
   id: 'betweenVersins1and2',
@@ -454,5 +457,44 @@ describe('fetchNotificationsInBackground', () => {
       ['/path/to/shopify', 'notifications', 'list', '--ignore-errors'],
       expect.anything(),
     )
+  })
+})
+
+describe('fetchNotifications', () => {
+  test('uses the default URL when SHOPIFY_CLI_NOTIFICATIONS_URL is not secure', async () => {
+    // Given
+    vi.stubEnv('SHOPIFY_CLI_NOTIFICATIONS_URL', 'http://malicious.com/notifications.json')
+    vi.mocked(fetch).mockResolvedValue({
+      status: 200,
+      text: () => Promise.resolve(JSON.stringify({notifications: []})),
+    } as any)
+
+    // When
+    await fetchNotifications()
+
+    // Then
+    expect(fetch).toHaveBeenCalledWith(
+      'https://cdn.shopify.com/static/cli/notifications.json',
+      undefined,
+      expect.anything(),
+    )
+    vi.unstubAllEnvs()
+  })
+
+  test('uses the provided URL when SHOPIFY_CLI_NOTIFICATIONS_URL is secure', async () => {
+    // Given
+    const secureUrl = 'https://my-secure-repo.com/notifications.json'
+    vi.stubEnv('SHOPIFY_CLI_NOTIFICATIONS_URL', secureUrl)
+    vi.mocked(fetch).mockResolvedValue({
+      status: 200,
+      text: () => Promise.resolve(JSON.stringify({notifications: []})),
+    } as any)
+
+    // When
+    await fetchNotifications()
+
+    // Then
+    expect(fetch).toHaveBeenCalledWith(secureUrl, undefined, expect.anything())
+    vi.unstubAllEnvs()
   })
 })

--- a/packages/cli-kit/src/public/node/notifications-system.ts
+++ b/packages/cli-kit/src/public/node/notifications-system.ts
@@ -24,7 +24,25 @@ const COMMANDS_TO_SKIP = [
 ]
 
 function url(): string {
-  return process.env.SHOPIFY_CLI_NOTIFICATIONS_URL ?? URL
+  const envUrl = process.env.SHOPIFY_CLI_NOTIFICATIONS_URL
+  if (envUrl) {
+    try {
+      const parsedUrl = new globalThis.URL(envUrl)
+      // We only allow https for notifications to prevent loading malicious content from insecure sources.
+      if (parsedUrl.protocol === 'https:') {
+        return envUrl
+      }
+      outputDebug(
+        `The notifications URL provided via SHOPIFY_CLI_NOTIFICATIONS_URL (${envUrl}) is not secure (https). Falling back to default.`,
+      )
+      // eslint-disable-next-line no-catch-all/no-catch-all
+    } catch {
+      outputDebug(
+        `The notifications URL provided via SHOPIFY_CLI_NOTIFICATIONS_URL (${envUrl}) is not a valid URL. Falling back to default.`,
+      )
+    }
+  }
+  return URL
 }
 
 const NotificationSchema = zod.object({


### PR DESCRIPTION
This PR hardens the `url()` function in `packages/cli-kit/src/public/node/notifications-system.ts` by adding validation for the `SHOPIFY_CLI_NOTIFICATIONS_URL` environment variable. It ensures that the URL is valid and uses the `https:` protocol, falling back to the default Shopify CDN URL otherwise. This mitigates the risk of loading notifications from insecure or malicious sources. Unit tests have been added to verify this behavior.

---
*PR created automatically by Jules for task [18035364240484933283](https://jules.google.com/task/18035364240484933283) started by @gonzaloriestra*