### PR TITLE
[Refactor] Improve packageManagerFromUserAgent readability

### DIFF
--- a/packages/cli-kit/src/public/node/node-package-manager.ts
+++ b/packages/cli-kit/src/public/node/node-package-manager.ts
@@ -95,16 +95,8 @@ export class FindUpAndReadPackageJsonNotFoundError extends BugError {
  * @returns The dependency manager
  */
 export function packageManagerFromUserAgent(env = process.env): PackageManager {
-  if (env.npm_config_user_agent?.includes('yarn')) {
-    return 'yarn'
-  } else if (env.npm_config_user_agent?.includes('pnpm')) {
-    return 'pnpm'
-  } else if (env.npm_config_user_agent?.includes('bun')) {
-    return 'bun'
-  } else if (env.npm_config_user_agent?.includes('npm')) {
-    return 'npm'
-  }
-  return 'unknown'
+  const userAgent = env.npm_config_user_agent
+  return (['yarn', 'pnpm', 'bun', 'npm'] as const).find((pm) => userAgent?.includes(pm)) ?? 'unknown'
 }
 
 function hasBunLockfileSync(directory: string): boolean {


### PR DESCRIPTION
### WHY are these changes introduced?

The current implementation of `packageManagerFromUserAgent` uses an imperative `if/else` chain which is less readable.

### WHAT is this pull request doing?

Refactors the `if/else` chain in `packageManagerFromUserAgent` to use a declarative `.find()` approach on a prioritized array of package manager names.

### How to test your changes?

CI

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`


---
*PR created automatically by Jules for task [14880623049842474169](https://jules.google.com/task/14880623049842474169) started by @gonzaloriestra*