### PR TITLE
[Performance] Memoize firstPartyDev function

### DIFF
--- a/packages/cli-kit/src/public/node/context/local.test.ts
+++ b/packages/cli-kit/src/public/node/context/local.test.ts
@@ -10,6 +10,8 @@ import {
   macAddress,
   getThemeKitAccessDomain,
   opentelemetryDomain,
+  firstPartyDev,
+  _resetFirstPartyDevCache,
 } from './local.js'
 import {fileExists} from '../fs.js'
 import {exec} from '../system.js'
@@ -80,6 +82,62 @@ describe('isUnitTest', () => {
 
     // Then
     expect(got).toBe(true)
+  })
+})
+
+describe('firstPartyDev', () => {
+  afterEach(() => {
+    _resetFirstPartyDevCache()
+  })
+
+  test('returns true when SHOPIFY_CLI_1P_DEV is truthy', () => {
+    // Given
+    const env = {SHOPIFY_CLI_1P_DEV: '1'}
+
+    // When
+    const got = firstPartyDev(env)
+
+    // Then
+    expect(got).toBe(true)
+  })
+
+  test('memoizes the result', () => {
+    // Given
+    const env = process.env
+    const originalValue = env.SHOPIFY_CLI_1P_DEV
+    env.SHOPIFY_CLI_1P_DEV = '1'
+
+    // When
+    const got1 = firstPartyDev()
+    env.SHOPIFY_CLI_1P_DEV = '0'
+    const got2 = firstPartyDev()
+
+    // Then
+    expect(got1).toBe(true)
+    expect(got2).toBe(true)
+
+    // Cleanup
+    env.SHOPIFY_CLI_1P_DEV = originalValue
+  })
+
+  test('resets the cache', () => {
+    // Given
+    const env = process.env
+    const originalValue = env.SHOPIFY_CLI_1P_DEV
+    env.SHOPIFY_CLI_1P_DEV = '1'
+
+    // When
+    const got1 = firstPartyDev()
+    _resetFirstPartyDevCache()
+    env.SHOPIFY_CLI_1P_DEV = '0'
+    const got2 = firstPartyDev()
+
+    // Then
+    expect(got1).toBe(true)
+    expect(got2).toBe(false)
+
+    // Cleanup
+    env.SHOPIFY_CLI_1P_DEV = originalValue
   })
 })
 

--- a/packages/cli-kit/src/public/node/context/local.ts
+++ b/packages/cli-kit/src/public/node/context/local.ts
@@ -45,6 +45,11 @@ let memoizedIsVerbose: boolean | undefined
 let memoizedIsUnitTest: boolean | undefined
 
 /**
+ * Memoized value for the first party dev check.
+ */
+let memoizedFirstPartyDev: boolean | undefined
+
+/**
  * Returns true if the CLI is running in debug mode.
  *
  * @param env - The environment variables from the environment of the current process.
@@ -142,7 +147,17 @@ export function alwaysLogMetrics(env = process.env): boolean {
  * @returns True if SHOPIFY_CLI_1P is truthy.
  */
 export function firstPartyDev(env = process.env): boolean {
+  if (env === process.env) {
+    return (memoizedFirstPartyDev ??= isTruthy(env[environmentVariables.firstPartyDev]))
+  }
   return isTruthy(env[environmentVariables.firstPartyDev])
+}
+
+/**
+ * Resets the memoized value for the first party dev check.
+ */
+export function _resetFirstPartyDevCache(): void {
+  memoizedFirstPartyDev = undefined
 }
 
 /**


### PR DESCRIPTION
### What is this PR?
This PR introduces memoization for the `firstPartyDev` function in `packages/cli-kit/src/public/node/context/local.ts`. This optimization caches the result of the `SHOPIFY_CLI_1P_DEV` environment variable check when called with the default `process.env`. This reduces redundant calls to `isTruthy` and environment lookups during CLI execution.

### Why is it needed?
Performance optimization to reduce redundant environment variable lookups and string parsing in high-frequency execution paths.

### How to test your changes?
CI

### Checkbox
- [ ] I have read the [CONTRIBUTING.md](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md) document.
- [ ] I have added/updated tests for the changes.
- [ ] I have updated the documentation (if applicable).
- [ ] I have followed the [style guide](https://github.com/Shopify/cli/blob/main/docs/style-guide.md).


---
*PR created automatically by Jules for task [9117462479887176241](https://jules.google.com/task/9117462479887176241) started by @gonzaloriestra*