### PR TITLE
[Tests] Add unit tests for app bulk cancel command

### DIFF
--- a/packages/app/src/cli/commands/app/bulk/cancel.test.ts
+++ b/packages/app/src/cli/commands/app/bulk/cancel.test.ts
@@ -1,0 +1,69 @@
+import BulkCancel from './cancel.js'
+import {cancelBulkOperation} from '../../../services/bulk-operations/cancel-bulk-operation.js'
+import {prepareAppStoreContext} from '../../../utilities/execute-command-helpers.js'
+import {
+  testAppLinked,
+  testOrganization,
+  testOrganizationApp,
+  testOrganizationStore,
+  testProject,
+} from '../../../models/app/app.test-data.js'
+import {describe, expect, test, vi, beforeEach} from 'vitest'
+
+vi.mock('../../../services/bulk-operations/cancel-bulk-operation.js')
+vi.mock('../../../utilities/execute-command-helpers.js')
+
+describe('app bulk cancel command', () => {
+  const app = testAppLinked()
+  const remoteApp = testOrganizationApp()
+  const store = testOrganizationStore({shopDomain: 'shop.myshopify.com'})
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(prepareAppStoreContext).mockResolvedValue({
+      appContextResult: {
+        app,
+        remoteApp,
+        developerPlatformClient: remoteApp.developerPlatformClient,
+        organization: testOrganization(),
+        specifications: [],
+        project: testProject(),
+        activeConfig: {} as never,
+      },
+      store,
+    })
+    vi.mocked(cancelBulkOperation).mockResolvedValue()
+  })
+
+  test('prepares app/store context and cancels bulk operation', async () => {
+    // When
+    await BulkCancel.run(['--path', '/tmp/app', '--id', '12345', '--store', 'shop'])
+
+    // Then
+    expect(prepareAppStoreContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: '/tmp/app',
+        id: '12345',
+        store: 'shop.myshopify.com',
+      }),
+    )
+    expect(cancelBulkOperation).toHaveBeenCalledWith({
+      organization: expect.any(Object),
+      storeFqdn: 'shop.myshopify.com',
+      operationId: 'gid://shopify/BulkOperation/12345',
+      remoteApp,
+    })
+  })
+
+  test('passes full GID operation ID correctly', async () => {
+    // When
+    await BulkCancel.run(['--id', 'gid://shopify/BulkOperation/67890', '--store', 'shop'])
+
+    // Then
+    expect(cancelBulkOperation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        operationId: 'gid://shopify/BulkOperation/67890',
+      }),
+    )
+  })
+})

--- a/packages/app/src/cli/commands/app/bulk/cancel.test.ts
+++ b/packages/app/src/cli/commands/app/bulk/cancel.test.ts
@@ -19,7 +19,6 @@ describe('app bulk cancel command', () => {
   const store = testOrganizationStore({shopDomain: 'shop.myshopify.com'})
 
   beforeEach(() => {
-    vi.clearAllMocks()
     vi.mocked(prepareAppStoreContext).mockResolvedValue({
       appContextResult: {
         app,


### PR DESCRIPTION
### Why is this change needed?
The `app bulk cancel` command currently lacks command-level unit tests. This change adds them to ensure flag parsing and service interaction are correctly handled.

### How to test your changes?
CI

---
*PR created automatically by Jules for task [3549839184836701747](https://jules.google.com/task/3549839184836701747) started by @gonzaloriestra*