### PR TITLE
[Performance] Memoize isDevelopment

### DIFF
--- a/packages/cli-kit/src/public/node/context/local.test.ts
+++ b/packages/cli-kit/src/public/node/context/local.test.ts
@@ -5,6 +5,7 @@ import {
   isShopify,
   isTerminalInteractive,
   isUnitTest,
+  _resetIsDevelopmentCache,
   analyticsDisabled,
   cloudEnvironment,
   macAddress,
@@ -84,6 +85,10 @@ describe('isUnitTest', () => {
 })
 
 describe('isDevelopment', () => {
+  afterEach(() => {
+    _resetIsDevelopmentCache()
+  })
+
   test('returns true when SHOPIFY_CLI_ENV is debug', () => {
     // Given
     const env = {SHOPIFY_CLI_ENV: 'development'}
@@ -93,6 +98,28 @@ describe('isDevelopment', () => {
 
     // Then
     expect(got).toBe(true)
+  })
+
+  test('memoizes the result when using process.env', () => {
+    // Given
+    const originalEnv = process.env.SHOPIFY_CLI_ENV
+    process.env.SHOPIFY_CLI_ENV = 'development'
+
+    // When
+    const firstCall = isDevelopment()
+    process.env.SHOPIFY_CLI_ENV = 'production'
+    const secondCall = isDevelopment()
+
+    // Then
+    expect(firstCall).toBe(true)
+    expect(secondCall).toBe(true)
+
+    // Resetting the cache should allow the new value to be picked up
+    _resetIsDevelopmentCache()
+    expect(isDevelopment()).toBe(false)
+
+    // Cleanup
+    process.env.SHOPIFY_CLI_ENV = originalEnv
   })
 })
 

--- a/packages/cli-kit/src/public/node/context/local.ts
+++ b/packages/cli-kit/src/public/node/context/local.ts
@@ -45,12 +45,21 @@ let memoizedIsVerbose: boolean | undefined
 let memoizedIsUnitTest: boolean | undefined
 
 /**
+ * Memoized value for the development check.
+ */
+let memoizedIsDevelopment: boolean | undefined
+
+/**
  * Returns true if the CLI is running in debug mode.
  *
  * @param env - The environment variables from the environment of the current process.
  * @returns True if SHOPIFY_ENV is development.
  */
 export function isDevelopment(env = process.env): boolean {
+  if (env === process.env) {
+    // Memoize the result to avoid repeated env lookups in high-frequency paths.
+    return (memoizedIsDevelopment ??= env[environmentVariables.env] === 'development')
+  }
   return env[environmentVariables.env] === 'development'
 }
 
@@ -326,3 +335,10 @@ export function opentelemetryDomain(env = process.env): string {
 }
 
 export type CIMetadata = Metadata
+
+/**
+ * Resets the memoized value of isDevelopment.
+ */
+export function _resetIsDevelopmentCache(): void {
+  memoizedIsDevelopment = undefined
+}


### PR DESCRIPTION
### WHY are these changes introduced?

Accessing `process.env` in Node.js is slower than standard object property access. `isDevelopment` is frequently checked (e.g., in analytics and logging), making it a candidate for memoization to reduce redundant environment lookups.

### WHAT is this pull request doing?

This PR introduces memoization for the `isDevelopment` function in `@shopify/cli-kit`. It caches the result when the default `process.env` is used, while still allowing custom environment objects (used in tests) to bypass the cache. It also adds a cache reset utility for test isolation.

Expected performance impact: Reduced overhead in high-frequency paths that check for development mode.

### How to test your changes?

CI

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [12416398852737376051](https://jules.google.com/task/12416398852737376051) started by @gonzaloriestra*