### PR TITLE
[Refactor] Use flatMap in LinesDiffContentToken

### DIFF
--- a/packages/cli-kit/src/private/node/content-tokens.test.ts
+++ b/packages/cli-kit/src/private/node/content-tokens.test.ts
@@ -1,4 +1,5 @@
-import {LinkContentToken} from './content-tokens.js'
+import {LinkContentToken, LinesDiffContentToken} from './content-tokens.js'
+import colors from '../../public/node/colors.js'
 import {describe, expect, test} from 'vitest'
 
 describe('LinkContentToken', () => {
@@ -18,5 +19,35 @@ describe('LinkContentToken', () => {
 
     // Then
     expect(got.output()).toEqual(fallback)
+  })
+})
+
+describe('LinesDiffContentToken', () => {
+  test('formats added and removed lines correctly', () => {
+    // Given
+    const changes = [
+      {value: 'same\n', count: 1},
+      {value: 'removed\n', count: 1, removed: true},
+      {value: 'added\n', count: 1, added: true},
+    ]
+    const token = new LinesDiffContentToken(changes)
+
+    // When
+    const output = token.output()
+
+    // Then
+    expect(output).toEqual(['same\n', colors.magenta('- removed\n'), colors.green('+ added\n')])
+  })
+
+  test('handles multiple lines in a single change part', () => {
+    // Given
+    const changes = [{value: 'added1\nadded2\n', count: 2, added: true}]
+    const token = new LinesDiffContentToken(changes)
+
+    // When
+    const output = token.output()
+
+    // Then
+    expect(output).toEqual([colors.green('+ added1\n'), colors.green('+ added2\n')])
   })
 })

--- a/packages/cli-kit/src/private/node/content-tokens.ts
+++ b/packages/cli-kit/src/private/node/content-tokens.ts
@@ -63,27 +63,25 @@ export class JsonContentToken extends ContentToken<any> {
 
 export class LinesDiffContentToken extends ContentToken<Change[]> {
   output(): string[] {
-    return this.value
-      .map((part) => {
-        if (part.added) {
-          return part.value
-            .split(/\n/)
-            .filter((line) => line !== '')
-            .map((line) => {
-              return colors.green(`+ ${line}\n`)
-            })
-        } else if (part.removed) {
-          return part.value
-            .split(/\n/)
-            .filter((line) => line !== '')
-            .map((line) => {
-              return colors.magenta(`- ${line}\n`)
-            })
-        } else {
-          return part.value
-        }
-      })
-      .flat()
+    return this.value.flatMap((part) => {
+      if (part.added) {
+        return part.value
+          .split(/\n/)
+          .filter((line) => line !== '')
+          .map((line) => {
+            return colors.green(`+ ${line}\n`)
+          })
+      } else if (part.removed) {
+        return part.value
+          .split(/\n/)
+          .filter((line) => line !== '')
+          .map((line) => {
+            return colors.magenta(`- ${line}\n`)
+          })
+      } else {
+        return part.value
+      }
+    })
   }
 }
 


### PR DESCRIPTION
### WHY are these changes introduced?

Modernizes the code by using the idiomatic `.flatMap()` method instead of chaining `.map().flat()`. This improves readability and follows modern JavaScript patterns.

### WHAT is this pull request doing?

- Refactors `LinesDiffContentToken.output()` in `@shopify/cli-kit` to use `.flatMap()`.
- Adds unit tests for `LinesDiffContentToken` in `content-tokens.test.ts` to ensure correct behavior.
- Cleans up and consolidates imports in `content-tokens.test.ts`.

### How to test your changes?

CI

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [16588474565286965260](https://jules.google.com/task/16588474565286965260) started by @gonzaloriestra*