### PR TITLE
[Tests] Add unit tests for app bulk status command

### DIFF
--- a/packages/app/src/cli/commands/app/bulk/status.test.ts
+++ b/packages/app/src/cli/commands/app/bulk/status.test.ts
@@ -1,0 +1,76 @@
+import BulkStatus from './status.js'
+import {getBulkOperationStatus, listBulkOperations} from '../../../services/bulk-operations/bulk-operation-status.js'
+import {prepareAppStoreContext} from '../../../utilities/execute-command-helpers.js'
+import {
+  testAppLinked,
+  testOrganization,
+  testOrganizationApp,
+  testOrganizationStore,
+  testProject,
+} from '../../../models/app/app.test-data.js'
+import {describe, expect, test, vi, beforeEach} from 'vitest'
+
+vi.mock('../../../services/bulk-operations/bulk-operation-status.js')
+vi.mock('../../../utilities/execute-command-helpers.js')
+
+describe('app bulk status command', () => {
+  const app = testAppLinked()
+  const remoteApp = testOrganizationApp()
+  const organization = testOrganization()
+  const store = testOrganizationStore({shopDomain: 'shop.myshopify.com'})
+
+  beforeEach(() => {
+    vi.mocked(prepareAppStoreContext).mockResolvedValue({
+      appContextResult: {
+        app,
+        remoteApp,
+        developerPlatformClient: remoteApp.developerPlatformClient,
+        organization,
+        specifications: [],
+        project: testProject(),
+        activeConfig: {} as never,
+      },
+      store,
+    })
+    vi.mocked(getBulkOperationStatus).mockResolvedValue()
+    vi.mocked(listBulkOperations).mockResolvedValue()
+  })
+
+  test('calls getBulkOperationStatus when id is provided', async () => {
+    // When
+    await BulkStatus.run(['--id', '123', '--store', 'shop.myshopify.com'])
+
+    // Then
+    expect(prepareAppStoreContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: '123',
+        store: 'shop.myshopify.com',
+      }),
+    )
+    expect(getBulkOperationStatus).toHaveBeenCalledWith({
+      organization,
+      storeFqdn: 'shop.myshopify.com',
+      operationId: 'gid://shopify/BulkOperation/123',
+      remoteApp,
+    })
+    expect(listBulkOperations).not.toHaveBeenCalled()
+  })
+
+  test('calls listBulkOperations when id is not provided', async () => {
+    // When
+    await BulkStatus.run(['--store', 'shop.myshopify.com'])
+
+    // Then
+    expect(prepareAppStoreContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        store: 'shop.myshopify.com',
+      }),
+    )
+    expect(listBulkOperations).toHaveBeenCalledWith({
+      organization,
+      storeFqdn: 'shop.myshopify.com',
+      remoteApp,
+    })
+    expect(getBulkOperationStatus).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
### WHY are these changes introduced?

The `app bulk status` command lacked unit tests to verify its flag parsing and service interaction logic.

### WHAT is this pull request doing?

Adds a new test file `packages/app/src/cli/commands/app/bulk/status.test.ts` that covers:
- Calling `getBulkOperationStatus` when an ID is provided.
- Calling `listBulkOperations` when no ID is provided.
- Verification of correct context preparation.

### How to test your changes?

CI

### Post-release steps

None.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`


---
*PR created automatically by Jules for task [5918563884576938740](https://jules.google.com/task/5918563884576938740) started by @gonzaloriestra*