### PR TITLE
[Security] Harden LocalStorage file permissions

### DIFF
--- a/packages/cli-kit/src/public/node/local-storage.ts
+++ b/packages/cli-kit/src/public/node/local-storage.ts
@@ -3,6 +3,7 @@ import {fileHasWritePermissions, unixFileIsOwnedByCurrentUser} from './fs.js'
 import {dirname} from './path.js'
 import {TokenItem} from './ui.js'
 import Config from 'conf'
+import {chmodSync} from 'fs'
 
 /**
  * A wrapper around the `conf` package that provides a strongly-typed interface
@@ -14,6 +15,7 @@ export class LocalStorage<T extends Record<string, any>> {
 
   constructor(options: {projectName?: string; cwd?: string}) {
     this.config = new Config<T>(options)
+    this.ensureRestrictedPermissions()
   }
 
   /**
@@ -44,6 +46,7 @@ export class LocalStorage<T extends Record<string, any>> {
   set<TKey extends keyof T>(key: TKey, value?: T[TKey]): void {
     try {
       this.config.set(key, value)
+      this.ensureRestrictedPermissions()
       // eslint-disable-next-line no-catch-all/no-catch-all
     } catch (error) {
       this.handleError(error, 'set')
@@ -60,6 +63,7 @@ export class LocalStorage<T extends Record<string, any>> {
   delete<TKey extends keyof T>(key: TKey): void {
     try {
       this.config.delete(key)
+      this.ensureRestrictedPermissions()
       // eslint-disable-next-line no-catch-all/no-catch-all
     } catch (error) {
       this.handleError(error, 'delete')
@@ -75,9 +79,24 @@ export class LocalStorage<T extends Record<string, any>> {
   clear(): void {
     try {
       this.config.clear()
+      this.ensureRestrictedPermissions()
       // eslint-disable-next-line no-catch-all/no-catch-all
     } catch (error) {
       this.handleError(error, 'clear')
+    }
+  }
+
+  /**
+   * Ensures the configuration file has restricted permissions (0600),
+   * so it's only readable/writable by the current user.
+   * This is important because the configuration file may contain sensitive information.
+   */
+  private ensureRestrictedPermissions() {
+    try {
+      chmodSync(this.config.path, 0o600)
+      // eslint-disable-next-line no-catch-all/no-catch-all
+    } catch {
+      // If we can't change permissions (e.g. on Windows or file doesn't exist), we ignore the error
     }
   }
 


### PR DESCRIPTION
This PR hardens the `LocalStorage` class by ensuring that the underlying configuration file is created and maintained with restricted permissions (`0600`). This prevents other users on the same system from reading potentially sensitive configuration data or tokens stored by the CLI.

The implementation uses `chmodSync` to set the mode to `0o600` during initialization and after any operation that might cause the file to be recreated (`set`, `delete`, `clear`).

Verification was performed by confirming that configuration files are now created with `0600` permissions on a Linux system, whereas they previously defaulted to more permissive modes (e.g., `0664`). Existing unit tests for `LocalStorage` continue to pass.

---
*PR created automatically by Jules for task [18028481184274082040](https://jules.google.com/task/18028481184274082040) started by @gonzaloriestra*