### PR TITLE
Remove did-you-mean lint suppression

### DIFF
--- a/packages/plugin-did-you-mean/src/index.ts
+++ b/packages/plugin-did-you-mean/src/index.ts
@@ -13,19 +13,20 @@ function sanitizeCmd(cmd: string): string {
 }
 
 function relativeScore(commandBigrams: string[], userCommandBigrams: string[]): number {
-  const map: Record<string, number> = {}
-  commandBigrams.forEach((elem) => {
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
-    map[elem] = map[elem] ? map[elem]! + 1 : 1
-  })
-  const result: string[] = []
+  const counts = new Map<string, number>()
+  for (const elem of commandBigrams) {
+    counts.set(elem, (counts.get(elem) ?? 0) + 1)
+  }
+
+  let result = 0
   for (const key of userCommandBigrams) {
-    if (key in map && map[key]! > 0) {
-      result.push(key)
-      map[key] = map[key]! - 1
+    const count = counts.get(key) ?? 0
+    if (count > 0) {
+      result += 1
+      counts.set(key, count - 1)
     }
   }
-  return result.length
+  return result
 }
 
 export function findAlternativeCommand(


### PR DESCRIPTION
### WHY are these changes introduced?

No issue.

The did-you-mean command scoring helper carried a lint suppression for an unnecessary type assertion. This is small maintenance debt in a plugin hook that runs when commands are mistyped.

### WHAT is this pull request doing?

Replace the ad-hoc object counter with a `Map<string, number>` counter so repeated bigrams are counted without non-null assertions or lint disables.

Behavior is unchanged: suggestions are still ranked by shared bigram count, then by shorter command name.

### How to test your changes?

- `pnpm nx run plugin-did-you-mean:lint --skip-nx-cache`
- `pnpm --dir packages/plugin-did-you-mean vitest run src/index.test.ts`

### Post-release steps

None.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

Not user-facing; no changeset needed.
