### PR TITLE
Fix storeByDomain connecting to the wrong store on substring domain match

### DIFF
--- a/.changeset/exact-domain-store-lookup.md
+++ b/.changeset/exact-domain-store-lookup.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Fix store lookup by domain to require an exact domain match.

--- a/packages/app/src/cli/utilities/developer-platform-client/app-management-client.test.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/app-management-client.test.ts
@@ -1609,6 +1609,102 @@ describe('storeByDomain', () => {
       },
     })
   })
+
+  test('returns the exact-domain match when the fuzzy search also returns substring matches', async () => {
+    // Given
+    // The Business Platform `accessibleShops` query treats `domain` as a fuzzy `search` argument, so
+    // a request for `example.myshopify.com` also returns `turbo-example.myshopify.com`, and the
+    // backend may rank the wrong (substring superset) store first.
+    const orgGid = 'gid://shopify/Organization/123'
+    const shopDomain = 'example.myshopify.com'
+    const token = 'business-platform-token'
+    const response: FetchStoreByDomainQuery = {
+      organization: {
+        id: orgGid,
+        name: 'Org 123',
+        accessibleShops: {
+          edges: [
+            {
+              node: {
+                id: 'gid://BusinessPlatform/Shop/1',
+                externalId: encodedGidFromShopId('1'),
+                name: 'Turbo Example',
+                storeType: 'APP_DEVELOPMENT',
+                primaryDomain: 'turbo-example.myshopify.com',
+                shortName: 'turbo-example',
+                url: 'https://turbo-example.myshopify.com',
+              },
+            },
+            {
+              node: {
+                id: 'gid://BusinessPlatform/Shop/2',
+                externalId: encodedGidFromShopId('2'),
+                name: 'Example',
+                storeType: 'APP_DEVELOPMENT',
+                primaryDomain: shopDomain,
+                shortName: 'example',
+                url: `https://${shopDomain}`,
+              },
+            },
+          ],
+        },
+        currentUser: {organizationPermissions: ['ondemand_access_to_stores']},
+      },
+    }
+    vi.mocked(businessPlatformOrganizationsRequestDoc).mockResolvedValueOnce(response)
+
+    const client = AppManagementClient.getInstance()
+    client.businessPlatformToken = () => Promise.resolve(token)
+
+    // When
+    const result = await client.storeByDomain(orgGid, shopDomain, ['APP_DEVELOPMENT'])
+
+    // Then
+    expect(result).toMatchObject({
+      shopDomain,
+      shopName: 'Example',
+      storeType: 'APP_DEVELOPMENT',
+    })
+  })
+
+  test('returns undefined when the fuzzy search only returns substring (non-exact) matches', async () => {
+    // Given
+    const orgGid = 'gid://shopify/Organization/123'
+    const shopDomain = 'example.myshopify.com'
+    const token = 'business-platform-token'
+    const response: FetchStoreByDomainQuery = {
+      organization: {
+        id: orgGid,
+        name: 'Org 123',
+        accessibleShops: {
+          edges: [
+            {
+              node: {
+                id: 'gid://BusinessPlatform/Shop/1',
+                externalId: encodedGidFromShopId('1'),
+                name: 'Turbo Example',
+                storeType: 'APP_DEVELOPMENT',
+                primaryDomain: 'turbo-example.myshopify.com',
+                shortName: 'turbo-example',
+                url: 'https://turbo-example.myshopify.com',
+              },
+            },
+          ],
+        },
+        currentUser: {organizationPermissions: []},
+      },
+    }
+    vi.mocked(businessPlatformOrganizationsRequestDoc).mockResolvedValueOnce(response)
+
+    const client = AppManagementClient.getInstance()
+    client.businessPlatformToken = () => Promise.resolve(token)
+
+    // When
+    const result = await client.storeByDomain(orgGid, shopDomain, ['APP_DEVELOPMENT'])
+
+    // Then
+    expect(result).toBeUndefined()
+  })
 })
 
 describe('ensureUserAccessToStore', () => {

--- a/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
@@ -863,7 +863,13 @@ export class AppManagementClient implements DeveloperPlatformClient {
       const provisionable = isStoreProvisionable(org.currentUser?.organizationPermissions ?? [])
       return mapBusinessPlatformStoresToOrganizationStores(nodes, provisionable)
     })
-    return stores[0]
+
+    // `accessibleShops` treats `domain` as a fuzzy, free-text `search` argument, so a domain that is
+    // a substring of another store's domain (e.g. `example.myshopify.com` vs
+    // `turbo-example.myshopify.com`) can return multiple hits. Return only the store whose domain
+    // matches exactly, otherwise we risk connecting to the wrong store.
+    const normalizedDomain = normalizeStoreFqdn(shopDomain)
+    return stores.find((store) => store.shopDomain === normalizedDomain)
   }
 
   async ensureUserAccessToStore(orgId: string, store: OrganizationStore): Promise<void> {


### PR DESCRIPTION
### Why

`AppManagementClient.storeByDomain` used `accessibleShops(search:)` and returned the first fuzzy result. When one store domain is a substring of another, the CLI could connect to the wrong dev store and then cache that store in `dev_store_url`.

### What

- Normalize the requested domain and return only the store whose `shopDomain` matches exactly.
- Preserve the existing not-found path by returning `undefined` when fuzzy results do not include an exact match.
- Add coverage for multi-hit fuzzy results and fuzzy results with no exact-domain match.

### Testing

- `pnpm --filter @shopify/app vitest src/cli/utilities/developer-platform-client/app-management-client.test.ts --run`
