### PR TITLE
Add order-insensitive deep object comparison to cli-kit

### DIFF
--- a/packages/cli-kit/src/public/common/object.test.ts
+++ b/packages/cli-kit/src/public/common/object.test.ts
@@ -1,6 +1,7 @@
 import {
   compact,
   deepCompare,
+  deepCompareWithOrderInsensitiveArrays,
   deepDifference,
   deepMergeObjects,
   getPathValue,
@@ -112,6 +113,40 @@ describe('deepCompare', () => {
     const result = deepCompare(obj1, obj2)
 
     // Then
+    expect(result).toBeFalsy()
+  })
+})
+
+describe('deepCompareWithOrderInsensitiveArrays', () => {
+  test('returns true when arrays contain the same values in a different order', () => {
+    const first = {
+      webhooks: {
+        subscriptions: [
+          {topic: 'orders/delete', uri: 'https://example.com/orders/delete'},
+          {topic: 'products/update', uri: 'https://example.com/products/update'},
+        ],
+      },
+    }
+    const second = {
+      webhooks: {
+        subscriptions: [
+          {uri: 'https://example.com/products/update', topic: 'products/update'},
+          {uri: 'https://example.com/orders/delete', topic: 'orders/delete'},
+        ],
+      },
+    }
+
+    const result = deepCompareWithOrderInsensitiveArrays(first, second)
+
+    expect(result).toBeTruthy()
+  })
+
+  test('returns false when arrays contain different values', () => {
+    const first = {items: [{id: 1}, {id: 2}]}
+    const second = {items: [{id: 1}, {id: 3}]}
+
+    const result = deepCompareWithOrderInsensitiveArrays(first, second)
+
     expect(result).toBeFalsy()
   })
 })

--- a/packages/cli-kit/src/public/common/object.ts
+++ b/packages/cli-kit/src/public/common/object.ts
@@ -69,6 +69,37 @@ export function deepCompare(one: object, two: object): boolean {
 }
 
 /**
+ * Deeply compares two values and treats arrays as order-insensitive.
+ *
+ * @param one - The first value to be compared.
+ * @param two - The second value to be compared.
+ * @returns True if the normalized values are equal, false otherwise.
+ */
+export function deepCompareWithOrderInsensitiveArrays(one: unknown, two: unknown): boolean {
+  return lodashIsEqual(normalizeOrderInsensitiveArrays(one), normalizeOrderInsensitiveArrays(two))
+}
+
+function normalizeOrderInsensitiveArrays(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(normalizeOrderInsensitiveArrays).sort(compareNormalizedValues)
+  }
+
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value)
+        .sort(([leftKey], [rightKey]) => leftKey.localeCompare(rightKey))
+        .map(([key, nestedValue]) => [key, normalizeOrderInsensitiveArrays(nestedValue)]),
+    )
+  }
+
+  return value ?? {}
+}
+
+function compareNormalizedValues(left: unknown, right: unknown) {
+  return JSON.stringify(left).localeCompare(JSON.stringify(right))
+}
+
+/**
  * Return the difference between two nested objects.
  *
  * @param one - The first object to be compared.


### PR DESCRIPTION
> **Part 1 of 8** — splitting #8040 (refactor of `deploy` extension matching) into a reviewable stack.

### WHY are these changes introduced?

Later PRs render a deploy/release diff by comparing local vs. remote app configuration. Config arrays such as webhook subscriptions can be semantically equal while differing only in element order, so a plain deep-equal reports false differences.

### WHAT is this pull request doing?

Adds `deepCompareWithOrderInsensitiveArrays` (and two private helpers) to `@shopify/cli-kit/common/object` — a deep comparison that treats arrays as unordered. Purely additive; no existing export changes.

### How to test your changes?

`pnpm --filter @shopify/cli-kit exec vitest run src/public/common/object.test.ts`
