### PR TITLE
Fix webhook subscription UID to omit the literal "undefined" for absent filters

### DIFF
--- a/packages/app/src/cli/models/extensions/extension-instance.test.ts
+++ b/packages/app/src/cli/models/extensions/extension-instance.test.ts
@@ -416,7 +416,7 @@ describe('buildUIDFromStrategy', async () => {
     // Given
     const extensionInstance = await testSingleWebhookSubscriptionExtension()
     // Then
-    expect(extensionInstance.uid).toBe('orders/delete::undefined::https://my-app.com/webhooks')
+    expect(extensionInstance.uid).toBe('orders/delete::::https://my-app.com/webhooks')
   })
 
   test('returns a custom string when strategy is dynamic and it is a webhook subscription extension with filters', async () => {

--- a/packages/app/src/cli/models/extensions/extension-instance.ts
+++ b/packages/app/src/cli/models/extensions/extension-instance.ts
@@ -543,7 +543,7 @@ export class ExtensionInstance<TConfiguration extends BaseConfigType = BaseConfi
         // Related issues: PR #559094 in old Core repo
         if ('topic' in this.configuration && 'uri' in this.configuration) {
           const subscription = this.configuration as unknown as SingleWebhookSubscriptionType
-          return `${subscription.topic}::${subscription.filter}::${subscription.uri}`.substring(0, MAX_UID_LENGTH)
+          return `${subscription.topic}::${subscription.filter ?? ''}::${subscription.uri}`.substring(0, MAX_UID_LENGTH)
         } else {
           return nonRandomUUID(JSON.stringify(this.configuration))
         }


### PR DESCRIPTION
> **Part 3 of 8** — splitting #8040.

### WHY are these changes introduced?

A dynamic-strategy webhook subscription with no `filter` built its UID directly from the value, embedding the literal string `undefined` (`orders/delete::undefined::https://…`). That misrepresents the configuration and feeds into module matching on deploy.

### WHAT is this pull request doing?

Emit an empty segment instead: `orders/delete::::https://…`. One-line fix plus its test.

⚠️ **User-facing:** changes the computed UID for filterless webhook subscriptions — warrants a `patch` changeset.

### How to test your changes?

`pnpm --filter @shopify/app exec vitest run src/cli/models/extensions/extension-instance.test.ts`
