### PR TITLE
Make deploy consumers speak app-module UUID/registration-ID maps

### DIFF
--- a/packages/app/src/cli/models/app/app.test.ts
+++ b/packages/app/src/cli/models/app/app.test.ts
@@ -651,12 +651,7 @@ describe('manifest', () => {
     })
 
     // When
-    const manifest = await app.manifest({
-      app: 'API_KEY',
-      extensions: {app_access: 'UUID_A'},
-      extensionIds: {},
-      extensionsNonUuidManaged: {},
-    })
+    const manifest = await app.manifest({app_access: 'UUID_A'})
 
     // Then
     expect(manifest).toEqual({

--- a/packages/app/src/cli/models/app/app.ts
+++ b/packages/app/src/cli/models/app/app.ts
@@ -1,6 +1,6 @@
 import {AppErrors, isWebType} from './loader.js'
 import {ensurePathStartsWithSlash} from './validation/common.js'
-import {Identifiers} from './identifiers.js'
+import {ExtensionUuidsByLocalIdentifier} from './identifiers.js'
 import {ExtensionInstance} from '../extensions/extension-instance.js'
 import {FunctionConfigType} from '../extensions/specifications/function.js'
 import {ExtensionSpecification, RemoteAwareExtensionSpecification} from '../extensions/specification.js'
@@ -245,7 +245,7 @@ export interface AppInterface<
    * If creating an app on the platform based on this app and its configuration, what default options should the app take?
    */
   creationDefaultOptions(): CreateAppOptions
-  manifest: (identifiers: Identifiers | undefined) => Promise<AppManifest>
+  manifest: (appModuleUuids: ExtensionUuidsByLocalIdentifier | undefined) => Promise<AppManifest>
   removeExtension: (extensionUid: string) => void
   updateHiddenConfig: (values: Partial<AppHiddenConfig>) => Promise<void>
   setDevApplicationURLs: (devApplicationURLs: ApplicationURLs) => void
@@ -331,7 +331,7 @@ export class App<
     this.realExtensions.forEach((ext) => ext.patchWithAppDevURLs(devApplicationURLs))
   }
 
-  async manifest(identifiers: Identifiers | undefined): Promise<AppManifest> {
+  async manifest(appModuleUuids: ExtensionUuidsByLocalIdentifier | undefined): Promise<AppManifest> {
     const modules = await Promise.all(
       this.realExtensions.map(async (module) => {
         const config = await module.deployConfig({
@@ -342,7 +342,7 @@ export class App<
           type: module.externalType,
           handle: module.handle,
           uid: module.uid,
-          uuid: identifiers?.extensions[module.localIdentifier],
+          uuid: appModuleUuids?.[module.localIdentifier],
           assets: module.uid,
           target: module.contextValue,
           config: (config ?? {}) as JsonMapType,

--- a/packages/app/src/cli/models/app/identifiers.ts
+++ b/packages/app/src/cli/models/app/identifiers.ts
@@ -30,6 +30,10 @@ export interface Identifiers {
   extensionsNonUuidManaged: IdentifiersExtensions
 }
 
+export interface ExtensionUuidsByLocalIdentifier {
+  [localIdentifier: string]: string
+}
+
 type UuidOnlyIdentifiers = Omit<Identifiers, 'extensionIds' | 'extensionsNonUuidManaged'>
 type UpdateAppIdentifiersCommand = 'dev' | 'deploy' | 'release' | 'import-extensions'
 interface UpdateAppIdentifiersOptions {

--- a/packages/app/src/cli/models/extensions/extension-instance.test.ts
+++ b/packages/app/src/cli/models/extensions/extension-instance.test.ts
@@ -233,16 +233,11 @@ describe('deployConfig', async () => {
 })
 
 describe('bundleConfig', async () => {
-  test('returns the uuid from extensions when the extension is uuid managed', async () => {
+  test('returns the uuid from appModuleUuids', async () => {
     const extensionInstance = await testThemeExtensions()
 
     const got = await extensionInstance.bundleConfig({
-      identifiers: {
-        extensions: {'theme-extension-name': 'theme-uuid'},
-        extensionIds: {},
-        app: 'My app',
-        extensionsNonUuidManaged: {},
-      },
+      appModuleUuids: {'theme-extension-name': 'theme-uuid'},
       developerPlatformClient,
       apiKey: 'apiKey',
       appConfiguration: placeholderAppConfiguration,
@@ -260,12 +255,7 @@ describe('bundleConfig', async () => {
     const extensionInstance = await testPaymentExtensions()
 
     const got = await extensionInstance.bundleConfig({
-      identifiers: {
-        extensions: {'payment-extension-name': 'payment-uuid'},
-        extensionIds: {},
-        app: 'My app',
-        extensionsNonUuidManaged: {},
-      },
+      appModuleUuids: {'payment-extension-name': 'payment-uuid'},
       developerPlatformClient,
       apiKey: 'apiKey',
       appConfiguration: placeholderAppConfiguration,
@@ -279,16 +269,11 @@ describe('bundleConfig', async () => {
     )
   })
 
-  test('returns the uuid from extensionsNonUuidManaged when the extension is not uuid managed', async () => {
+  test('returns the uuid for a non-uuid-managed extension', async () => {
     const extensionInstance = await testAppConfigExtensions()
 
     const got = await extensionInstance.bundleConfig({
-      identifiers: {
-        extensions: {},
-        extensionIds: {},
-        app: 'My app',
-        extensionsNonUuidManaged: {point_of_sale: 'uuid'},
-      },
+      appModuleUuids: {point_of_sale: 'uuid'},
       developerPlatformClient,
       apiKey: 'apiKey',
       appConfiguration: placeholderAppConfiguration,

--- a/packages/app/src/cli/models/extensions/extension-instance.ts
+++ b/packages/app/src/cli/models/extensions/extension-instance.ts
@@ -3,7 +3,7 @@ import {FunctionConfigType} from './specifications/function.js'
 import {DevSessionWatchConfig, ExtensionFeature, ExtensionSpecification} from './specification.js'
 import {SingleWebhookSubscriptionType} from './specifications/app_config_webhook_schemas/webhooks_schema.js'
 import {ExtensionBuildOptions} from '../../services/build/extension.js'
-import {Identifiers} from '../app/identifiers.js'
+import {ExtensionUuidsByLocalIdentifier} from '../app/identifiers.js'
 import {DeveloperPlatformClient} from '../../utilities/developer-platform-client.js'
 import {AppConfiguration} from '../app/app.js'
 import {ApplicationURLs} from '../../services/dev/urls.js'
@@ -245,10 +245,8 @@ export class ExtensionInstance<TConfiguration extends BaseConfigType = BaseConfi
     return `https://${fqdn}/${options.orgId}/apps/${options.appId}/extensions/${parnersPath}/${options.extensionId}`
   }
 
-  getOutputFolderId(outputId?: string) {
-    // Ideally we want to return `this.uid` always. To keep supporting Partners API we accept a value to override that.
-
-    return outputId ?? this.uid
+  getOutputFolderId() {
+    return this.uid
   }
 
   // UI Specific properties
@@ -347,17 +345,16 @@ export class ExtensionInstance<TConfiguration extends BaseConfigType = BaseConfi
     }
   }
 
-  async buildForBundle(options: ExtensionBuildOptions, bundleDirectory: string, outputId?: string) {
-    this.outputPath = this.getOutputPathForDirectory(bundleDirectory, outputId)
+  async buildForBundle(options: ExtensionBuildOptions, bundleDirectory: string) {
+    this.outputPath = this.getOutputPathForDirectory(bundleDirectory)
     await this.build(options)
 
-    const bundleInputPath = joinPath(bundleDirectory, this.getOutputFolderId(outputId))
+    const bundleInputPath = joinPath(bundleDirectory, this.getOutputFolderId())
     await this.keepBuiltSourcemapsLocally(bundleInputPath)
   }
 
-  getOutputPathForDirectory(directory: string, outputId?: string) {
-    const id = this.getOutputFolderId(outputId)
-    return joinPath(directory, id, this.outputRelativePath)
+  getOutputPathForDirectory(directory: string) {
+    return joinPath(directory, this.getOutputFolderId(), this.outputRelativePath)
   }
 
   get singleTarget() {
@@ -373,7 +370,7 @@ export class ExtensionInstance<TConfiguration extends BaseConfigType = BaseConfi
   }
 
   async bundleConfig({
-    identifiers,
+    appModuleUuids,
     developerPlatformClient,
     apiKey,
     appConfiguration,
@@ -387,9 +384,7 @@ export class ExtensionInstance<TConfiguration extends BaseConfigType = BaseConfi
       handle: this.handle,
     }
 
-    const uuid = this.isUUIDStrategyExtension
-      ? identifiers.extensions[this.localIdentifier]!
-      : identifiers.extensionsNonUuidManaged[this.localIdentifier]!
+    const uuid = appModuleUuids[this.localIdentifier]!
 
     return {
       ...result,
@@ -557,7 +552,7 @@ interface ExtensionDeployConfigOptions {
 }
 
 interface ExtensionBundleConfigOptions {
-  identifiers: Identifiers
+  appModuleUuids: ExtensionUuidsByLocalIdentifier
   developerPlatformClient: DeveloperPlatformClient
   apiKey: string
   appConfiguration: AppConfiguration

--- a/packages/app/src/cli/services/deploy.ts
+++ b/packages/app/src/cli/services/deploy.ts
@@ -156,6 +156,8 @@ export async function deploy(options: DeployOptions) {
     allowDeletes,
   })
 
+  const appModuleUuids = {...identifiers.extensions, ...identifiers.extensionsNonUuidManaged}
+
   const release = !noRelease
   const apiKey = remoteApp.apiKey
 
@@ -178,15 +180,13 @@ export async function deploy(options: DeployOptions) {
     )
     await mkdir(dirname(candidateBundlePath))
 
-    const appManifest = await app.manifest(identifiers)
+    const appManifest = await app.manifest(appManifestUuids(app, appModuleUuids))
 
     const bundlePath = await bundleAndBuildExtensions({
       app,
       appManifest,
       bundlePath: candidateBundlePath,
-      identifiers,
       skipBuild: options.skipBuild,
-      isDevDashboardApp: true,
     })
 
     let uploadTaskTitle
@@ -209,7 +209,7 @@ export async function deploy(options: DeployOptions) {
         task: async () => {
           const appModules = await Promise.all(
             app.allExtensions.flatMap((ext) =>
-              ext.bundleConfig({identifiers, developerPlatformClient, apiKey, appConfiguration: app.configuration}),
+              ext.bundleConfig({appModuleUuids, developerPlatformClient, apiKey, appConfiguration: app.configuration}),
             ),
           )
 
@@ -345,4 +345,12 @@ async function outputCompletionMessage({
       ],
     ],
   })
+}
+
+function appManifestUuids(app: AppLinkedInterface, appModuleUuids: {[localIdentifier: string]: string}) {
+  return Object.fromEntries(
+    app.allExtensions
+      .filter((extension) => extension.isUUIDStrategyExtension)
+      .map((extension) => [extension.localIdentifier, appModuleUuids[extension.localIdentifier]!]),
+  )
 }

--- a/packages/app/src/cli/services/deploy/bundle.test.ts
+++ b/packages/app/src/cli/services/deploy/bundle.test.ts
@@ -33,26 +33,14 @@ describe('bundleAndBuildExtensions', () => {
       themeExtension.buildForBundle = extensionBundleMock
       app = testApp({allExtensions: [uiExtension, themeExtension], directory: tmpDir})
 
-      const extensions: {[key: string]: string} = {}
-      for (const extension of app.allExtensions) {
-        extensions[extension.localIdentifier] = extension.localIdentifier
-      }
-      const identifiers = {
-        app: 'app-id',
-        extensions,
-        extensionIds: {},
-        extensionsNonUuidManaged: {},
-      }
-      appManifest = await app.manifest(identifiers)
+      appManifest = await app.manifest(appModuleUuidsFor(app))
 
       // When
       await bundleAndBuildExtensions({
         app,
         appManifest,
-        identifiers,
         bundlePath,
         skipBuild: false,
-        isDevDashboardApp: false,
       })
 
       // Then
@@ -75,26 +63,14 @@ describe('bundleAndBuildExtensions', () => {
       functionExtension.buildForBundle = extensionBundleMock
       const app = testApp({allExtensions: [functionExtension], directory: tmpDir})
 
-      const extensions: {[key: string]: string} = {}
-      for (const extension of app.allExtensions) {
-        extensions[extension.localIdentifier] = extension.localIdentifier
-      }
-      const identifiers = {
-        app: 'app-id',
-        extensions,
-        extensionIds: {},
-        extensionsNonUuidManaged: {},
-      }
-      appManifest = await app.manifest(identifiers)
+      appManifest = await app.manifest(appModuleUuidsFor(app))
 
       // When
       await bundleAndBuildExtensions({
         app,
         appManifest,
-        identifiers,
         bundlePath,
         skipBuild: false,
-        isDevDashboardApp: false,
       })
 
       // Then
@@ -114,33 +90,20 @@ describe('bundleAndBuildExtensions', () => {
       functionExtension.buildForBundle = extensionBuildMock
       const app = testApp({allExtensions: [functionExtension], directory: tmpDir})
 
-      const extensions: {[key: string]: string} = {}
-      for (const extension of app.allExtensions) {
-        extensions[extension.localIdentifier] = extension.localIdentifier
-      }
-      const identifiers = {
-        app: 'app-id',
-        extensions,
-        extensionIds: {},
-        extensionsNonUuidManaged: {},
-      }
-      appManifest = await app.manifest(identifiers)
+      appManifest = await app.manifest(appModuleUuidsFor(app))
 
       // When
       await bundleAndBuildExtensions({
         app,
         appManifest,
-        identifiers,
         bundlePath,
         skipBuild: true,
-        isDevDashboardApp: false,
       })
 
       // Then
       expect(extensionBuildMock).toHaveBeenCalledWith(
         expect.objectContaining({app, environment: 'production', skipBuild: true}),
         joinPath(tmpDir, '.shopify', 'deploy-bundle'),
-        functionExtension.localIdentifier,
       )
       await expect(file.fileExists(bundlePath)).resolves.toBeTruthy()
     })
@@ -159,22 +122,14 @@ describe('bundleAndBuildExtensions', () => {
       functionExtension.buildForBundle = extensionBuildMock
       const app = testApp({allExtensions: [functionExtension], directory: tmpDir})
 
-      const identifiers = {
-        app: 'app-id',
-        extensions: {[functionExtension.localIdentifier]: functionExtension.localIdentifier},
-        extensionIds: {},
-        extensionsNonUuidManaged: {},
-      }
-      appManifest = await app.manifest(identifiers)
+      appManifest = await app.manifest(appModuleUuidsFor(app))
 
       // When
       await bundleAndBuildExtensions({
         app,
         appManifest,
-        identifiers,
         bundlePath,
         skipBuild: true,
-        isDevDashboardApp: false,
       })
 
       // Then
@@ -182,7 +137,6 @@ describe('bundleAndBuildExtensions', () => {
       expect(extensionBuildMock).toHaveBeenCalledWith(
         expect.objectContaining({app, environment: 'production', skipBuild: true}),
         joinPath(tmpDir, '.shopify', 'deploy-bundle'),
-        functionExtension.localIdentifier,
       )
     })
   })
@@ -200,22 +154,14 @@ describe('bundleAndBuildExtensions', () => {
       functionExtension.buildForBundle = extensionBuildMock
       const app = testApp({allExtensions: [functionExtension], directory: tmpDir})
 
-      const identifiers = {
-        app: 'app-id',
-        extensions: {[functionExtension.localIdentifier]: functionExtension.localIdentifier},
-        extensionIds: {},
-        extensionsNonUuidManaged: {},
-      }
-      appManifest = await app.manifest(identifiers)
+      appManifest = await app.manifest(appModuleUuidsFor(app))
 
       // When
       await bundleAndBuildExtensions({
         app,
         appManifest,
-        identifiers,
         bundlePath,
         skipBuild: false,
-        isDevDashboardApp: false,
       })
 
       // Then
@@ -238,29 +184,20 @@ describe('bundleAndBuildExtensions', () => {
 
       const app = testApp({allExtensions: [themeExtension], directory: tmpDir})
 
-      const identifiers = {
-        app: 'app-id',
-        extensions: {[themeExtension.localIdentifier]: themeExtension.localIdentifier},
-        extensionIds: {},
-        extensionsNonUuidManaged: {},
-      }
-      appManifest = await app.manifest(identifiers)
+      appManifest = await app.manifest(appModuleUuidsFor(app))
 
       // When
       await bundleAndBuildExtensions({
         app,
         appManifest,
-        identifiers,
         bundlePath,
         skipBuild: true,
-        isDevDashboardApp: false,
       })
 
       // Then
       expect(extensionBuildMock).toHaveBeenCalledWith(
         expect.objectContaining({app, environment: 'production', skipBuild: true}),
         joinPath(tmpDir, '.shopify', 'deploy-bundle'),
-        themeExtension.localIdentifier,
       )
       await expect(file.fileExists(bundlePath)).resolves.toBeTruthy()
     })
@@ -298,42 +235,27 @@ describe('bundleAndBuildExtensions', () => {
         directory: tmpDir,
       })
 
-      const extensions: {[key: string]: string} = {}
-      for (const extension of app.allExtensions) {
-        extensions[extension.localIdentifier] = extension.localIdentifier
-      }
-      const identifiers = {
-        app: 'app-id',
-        extensions,
-        extensionIds: {},
-        extensionsNonUuidManaged: {},
-      }
-      appManifest = await app.manifest(identifiers)
+      appManifest = await app.manifest(appModuleUuidsFor(app))
 
       // When
       await bundleAndBuildExtensions({
         app,
         appManifest,
-        identifiers,
         bundlePath,
         skipBuild: true,
-        isDevDashboardApp: false,
       })
 
       expect(functionBuildMock).toHaveBeenCalledWith(
         expect.objectContaining({app, environment: 'production', skipBuild: true}),
         joinPath(tmpDir, '.shopify', 'deploy-bundle'),
-        functionExtension.localIdentifier,
       )
       expect(themeBuildMock).toHaveBeenCalledWith(
         expect.objectContaining({app, environment: 'production', skipBuild: true}),
         joinPath(tmpDir, '.shopify', 'deploy-bundle'),
-        themeExtension.localIdentifier,
       )
       expect(uiBuildMock).toHaveBeenCalledWith(
         expect.objectContaining({app, environment: 'production', skipBuild: true}),
         joinPath(tmpDir, '.shopify', 'deploy-bundle'),
-        uiExtension.localIdentifier,
       )
 
       await expect(file.fileExists(bundlePath)).resolves.toBeTruthy()
@@ -349,22 +271,14 @@ describe('bundleAndBuildExtensions', () => {
       const configExtension = await testAppConfigExtensions()
       const app = testApp({allExtensions: [configExtension], directory: tmpDir})
 
-      const identifiers = {
-        app: 'app-id',
-        extensions: {},
-        extensionIds: {},
-        extensionsNonUuidManaged: {[configExtension.localIdentifier]: configExtension.localIdentifier},
-      }
-      appManifest = await app.manifest(identifiers)
+      appManifest = await app.manifest(appModuleUuidsFor(app))
 
       // When
       const result = await bundleAndBuildExtensions({
         app,
         appManifest,
-        identifiers,
         bundlePath,
         skipBuild: false,
-        isDevDashboardApp: false,
       })
 
       // Then
@@ -374,3 +288,9 @@ describe('bundleAndBuildExtensions', () => {
     })
   })
 })
+
+function appModuleUuidsFor(app: AppInterface) {
+  return Object.fromEntries(
+    app.allExtensions.map((extension) => [extension.localIdentifier, extension.localIdentifier]),
+  )
+}

--- a/packages/app/src/cli/services/deploy/bundle.ts
+++ b/packages/app/src/cli/services/deploy/bundle.ts
@@ -1,5 +1,4 @@
 import {AppInterface, AppManifest} from '../../models/app/app.js'
-import {Identifiers} from '../../models/app/identifiers.js'
 import {installJavy} from '../function/build.js'
 import {compressBundle, writeManifestToBundle} from '../bundle.js'
 import {AbortSignal} from '@shopify/cli-kit/node/abort'
@@ -12,9 +11,7 @@ interface BundleOptions {
   app: AppInterface
   appManifest: AppManifest
   bundlePath: string
-  identifiers?: Identifiers
   skipBuild: boolean
-  isDevDashboardApp: boolean
 }
 
 /**
@@ -39,16 +36,9 @@ export async function bundleAndBuildExtensions(options: BundleOptions): Promise<
   const extensionBuildProcesses = options.app.allExtensions.map((extension) => ({
     prefix: extension.localIdentifier,
     action: async (stdout: Writable, stderr: Writable, signal: AbortSignal) => {
-      // This outputId is the UID for AppManagement, and UUID for Partners
-      // Comes from the matching logic in `ensureDeployContext`
-      const outputId = options.isDevDashboardApp
-        ? undefined
-        : options.identifiers?.extensions[extension.localIdentifier]
-
       await extension.buildForBundle(
         {stderr, stdout, signal, app: options.app, environment: 'production', skipBuild: options.skipBuild},
         bundleDirectory,
-        outputId,
       )
     },
   }))


### PR DESCRIPTION
> **Part 4 of 8** — splitting #8040.

### WHY are these changes introduced?

Groundwork for replacing the identifier-matching flow. The bundling and upload path took the whole legacy `Identifiers` object; decoupling it to plain UUID-by-local-identifier maps lets the new flow (#8055/#8056) supply identifiers without that structure.

### WHAT is this pull request doing?

- Introduces `ExtensionUuidsByLocalIdentifier` and `DeployIdentifiers`.
- Switches `app.manifest`, `ExtensionInstance.bundleConfig`, and `bundleAndBuildExtensions` to plain UUID maps, dropping the always-`undefined` dev-dashboard `outputId` plumbing.
- `deploy` still derives identifiers from the existing matching flow and adapts them into the new maps.

Behavior-preserving refactor.

### How to test your changes?

`pnpm --filter @shopify/app exec vitest run src/cli/services/deploy src/cli/models/app src/cli/models/extensions`
