### PR TITLE
[Refactor] Use flatMap for flattening TOML patch entries

### DIFF
--- a/packages/cli-kit/src/public/node/toml/toml-file.test.ts
+++ b/packages/cli-kit/src/public/node/toml/toml-file.test.ts
@@ -83,6 +83,39 @@ describe('TomlFile', () => {
       })
     })
 
+    test('sets deeply nested values', async () => {
+      await inTemporaryDirectory(async (dir) => {
+        const path = joinPath(dir, 'test.toml')
+        await writeFile(path, '[access.admin]\ndirect_api_mode = "online"\n')
+
+        const file = await TomlFile.read(path)
+        await file.patch({access: {admin: {direct_api_mode: 'offline'}}})
+
+        expect(file.content).toStrictEqual({access: {admin: {direct_api_mode: 'offline'}}})
+      })
+    })
+
+    test('sets multiple nested branches at once', async () => {
+      await inTemporaryDirectory(async (dir) => {
+        const path = joinPath(dir, 'test.toml')
+        await writeFile(
+          path,
+          ['[access.admin]', 'direct_api_mode = "online"', '', '[webhooks]', 'api_version = "2023-07"', ''].join('\n'),
+        )
+
+        const file = await TomlFile.read(path)
+        await file.patch({
+          access: {admin: {direct_api_mode: 'offline'}},
+          webhooks: {api_version: '2024-01'},
+        })
+
+        expect(file.content).toStrictEqual({
+          access: {admin: {direct_api_mode: 'offline'}},
+          webhooks: {api_version: '2024-01'},
+        })
+      })
+    })
+
     test('creates intermediate tables', async () => {
       await inTemporaryDirectory(async (dir) => {
         const path = joinPath(dir, 'test.toml')
@@ -135,6 +168,20 @@ describe('TomlFile', () => {
 
         const content = file.content as {auth: {redirect_urls: string[]}}
         expect(content.auth.redirect_urls).toStrictEqual(['https://new.com', 'https://other.com'])
+      })
+    })
+
+    test('removes a nested value when it is set to undefined', async () => {
+      await inTemporaryDirectory(async (dir) => {
+        const path = joinPath(dir, 'test.toml')
+        await writeFile(path, '[build]\ndev_store_url = "store.myshopify.com"\ninclude_config_on_deploy = true\n')
+
+        const file = await TomlFile.read(path)
+        await file.patch({build: {include_config_on_deploy: undefined}})
+
+        const build = file.content.build as {[key: string]: unknown}
+        expect(build.dev_store_url).toBe('store.myshopify.com')
+        expect(build.include_config_on_deploy).toBeUndefined()
       })
     })
   })

--- a/packages/cli-kit/src/public/node/toml/toml-file.ts
+++ b/packages/cli-kit/src/public/node/toml/toml-file.ts
@@ -160,14 +160,11 @@ export class TomlFile {
  * @returns Flattened patch entries.
  */
 function flattenToPatchEntries(obj: {[key: string]: unknown}, prefix: string[] = []): [string[], TomlPatchValue][] {
-  const entries: [string[], TomlPatchValue][] = []
-  for (const [key, value] of Object.entries(obj)) {
+  return Object.entries(obj).flatMap(([key, value]) => {
     const path = [...prefix, key]
     if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
-      entries.push(...flattenToPatchEntries(value as {[key: string]: unknown}, path))
-    } else {
-      entries.push([path, value as TomlPatchValue])
+      return flattenToPatchEntries(value as {[key: string]: unknown}, path)
     }
-  }
-  return entries
+    return [[path, value as TomlPatchValue]]
+  })
 }


### PR DESCRIPTION
### WHY are these changes introduced?

The current implementation of `flattenToPatchEntries` uses an imperative `for...of` loop with `entries.push`. Refactoring it to use a declarative `flatMap` approach makes the code more idiomatic and readable.

### WHAT is this pull request doing?

Refactors `flattenToPatchEntries` in `packages/cli-kit/src/public/node/toml/toml-file.ts` to use `Object.entries(obj).flatMap(...)`.

### How to test your changes?

CI

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [139978933092872357](https://jules.google.com/task/139978933092872357) started by @gonzaloriestra*