### PR TITLE
Rework release config diff to compare version against active version

### DIFF
--- a/packages/app/src/cli/services/context/breakdown-extensions.ts
+++ b/packages/app/src/cli/services/context/breakdown-extensions.ts
@@ -15,7 +15,7 @@ import {ExtensionSpecification, isAppConfigSpecification} from '../../models/ext
 import {rewriteConfiguration} from '../app/write-app-configuration-file.js'
 import {AppConfigurationUsedByCli} from '../../models/extensions/specifications/types/app_config.js'
 import {removeTrailingSlash} from '../../models/extensions/specifications/validation/common.js'
-import {deepCompare, deepDifference} from '@shopify/cli-kit/common/object'
+import {deepCompare, deepCompareWithOrderInsensitiveArrays, deepDifference} from '@shopify/cli-kit/common/object'
 import {zod} from '@shopify/cli-kit/node/schema'
 
 export interface ConfigExtensionIdentifiersBreakdown {
@@ -418,4 +418,59 @@ function loadDashboardIdentifiersBreakdown(currentRegistrations: RemoteSource[],
     toUpdate: [],
     unchanged: toUpdate,
   }
+}
+
+export function configExtensionsIdentifiersReleaseBreakdown({
+  localApp,
+  versionAppModules,
+  activeAppVersion,
+}: {
+  localApp: AppInterface
+  versionAppModules: AppModuleVersion[]
+  activeAppVersion?: AppVersion
+}) {
+  if (localApp.allExtensions.filter((extension) => extension.isAppConfigExtension).length === 0) return
+  const versionConfig = remoteAppConfigurationExtensionContent(
+    versionAppModules,
+    localApp.specifications ?? [],
+    localApp.remoteFlags,
+  )
+  const activeConfig = remoteAppConfigurationExtensionContent(
+    activeAppVersion?.appModuleVersions ?? [],
+    localApp.specifications ?? [],
+    localApp.remoteFlags,
+  )
+  return buildConfigExtensionIdentifiersBreakdown(versionConfig, activeConfig)
+}
+
+function buildConfigExtensionIdentifiersBreakdown(
+  localConfig: {[key: string]: unknown},
+  remoteConfig: {[key: string]: unknown},
+): ConfigExtensionIdentifiersBreakdown | undefined {
+  const fieldNames = new Set([...Object.keys(localConfig), ...Object.keys(remoteConfig)])
+  if (fieldNames.size === 0) return undefined
+
+  const breakdown: ConfigExtensionIdentifiersBreakdown = {
+    existingFieldNames: [],
+    existingUpdatedFieldNames: [],
+    newFieldNames: [],
+    deletedFieldNames: [],
+  }
+
+  for (const fieldName of fieldNames) {
+    const localValue = localConfig[fieldName]
+    const remoteValue = remoteConfig[fieldName]
+
+    if (localValue === undefined) {
+      breakdown.deletedFieldNames.push(fieldName)
+    } else if (remoteValue === undefined) {
+      breakdown.newFieldNames.push(fieldName)
+    } else if (deepCompareWithOrderInsensitiveArrays(localValue, remoteValue)) {
+      breakdown.existingFieldNames.push(fieldName)
+    } else {
+      breakdown.existingUpdatedFieldNames.push(fieldName)
+    }
+  }
+
+  return breakdown
 }

--- a/packages/app/src/cli/services/release.test.ts
+++ b/packages/app/src/cli/services/release.test.ts
@@ -1,6 +1,6 @@
 import {release} from './release.js'
 import {
-  configExtensionsIdentifiersBreakdown,
+  configExtensionsIdentifiersReleaseBreakdown,
   extensionsIdentifiersReleaseBreakdown,
 } from './context/breakdown-extensions.js'
 import {testAppLinked, testDeveloperPlatformClient} from '../models/app/app.test-data.js'
@@ -148,7 +148,7 @@ async function testRelease(
 ) {
   // Given
   vi.mocked(extensionsIdentifiersReleaseBreakdown).mockResolvedValue(buildExtensionsBreakdown())
-  vi.mocked(configExtensionsIdentifiersBreakdown).mockResolvedValue(buildConfigExtensionsBreakdown())
+  vi.mocked(configExtensionsIdentifiersReleaseBreakdown).mockReturnValue(buildConfigExtensionsBreakdown())
 
   await release({
     app,

--- a/packages/app/src/cli/services/release.ts
+++ b/packages/app/src/cli/services/release.ts
@@ -1,5 +1,5 @@
 import {
-  configExtensionsIdentifiersBreakdown,
+  configExtensionsIdentifiersReleaseBreakdown,
   extensionsIdentifiersReleaseBreakdown,
 } from './context/breakdown-extensions.js'
 import {AppLinkedInterface} from '../models/app/app.js'
@@ -41,15 +41,11 @@ export async function release(options: ReleaseOptions) {
     remoteApp,
     options.version,
   )
-  const configExtensionIdentifiersBreakdown = await configExtensionsIdentifiersBreakdown({
-    developerPlatformClient,
-    apiKey: remoteApp.apiKey,
+
+  const configExtensionIdentifiersBreakdown = configExtensionsIdentifiersReleaseBreakdown({
     localApp: app,
-    remoteApp,
-    versionAppModules: versionDetails.appModuleVersions.map((appModuleVersion) => ({
-      ...appModuleVersion,
-    })),
-    release: true,
+    versionAppModules: versionDetails.appModuleVersions,
+    activeAppVersion: await developerPlatformClient.activeAppVersion(remoteApp),
   })
   const confirmed = await deployOrReleaseConfirmationPrompt({
     configExtensionIdentifiersBreakdown,
@@ -59,6 +55,7 @@ export async function release(options: ReleaseOptions) {
     allowUpdates: options.force || options.allowUpdates,
     allowDeletes: options.force || options.allowDeletes,
   })
+
   if (!confirmed) throw new AbortSilentError()
   interface Context {
     appRelease: AppReleaseSchema


### PR DESCRIPTION
> **Part 5 of 8** — splitting #8040.

### WHY are these changes introduced?

Both `release` and the new `deploy` classification need to diff app configuration between two module sets. This introduces that shared primitive and adopts it in `release`, independently of the `deploy` change.

### WHAT is this pull request doing?

- Adds `buildConfigExtensionIdentifiersBreakdown` (a plain local-vs-remote field diff using the order-insensitive array comparison from #8044) and `configExtensionsIdentifiersReleaseBreakdown`.
- Switches `release` to them: the config breakdown now compares the version being released against the app's active version instead of re-fetching remote configuration.

Only affects the `release` command; the shared helper is reused by #8055.

⚠️ Changes how the `release` config diff is computed/displayed — consider a `patch` changeset.

### How to test your changes?

`pnpm --filter @shopify/app exec vitest run src/cli/services/release.test.ts src/cli/services/context/breakdown-extensions.test.ts`
