### PR TITLE
[Tests] Add unit tests for global-context.ts

### DIFF
--- a/packages/cli-kit/src/public/node/global-context.test.ts
+++ b/packages/cli-kit/src/public/node/global-context.test.ts
@@ -1,0 +1,28 @@
+import {getCurrentCommandId, setCurrentCommandId, _resetGlobalContext} from './global-context.js'
+import {describe, expect, test, beforeEach} from 'vitest'
+
+describe('global-context', () => {
+  beforeEach(() => {
+    _resetGlobalContext()
+  })
+
+  test('getCurrentCommandId returns an empty string by default', () => {
+    // When
+    const got = getCurrentCommandId()
+
+    // Then
+    expect(got).toBe('')
+  })
+
+  test('setCurrentCommandId updates the current command ID', () => {
+    // Given
+    const commandId = 'my-command'
+
+    // When
+    setCurrentCommandId(commandId)
+    const got = getCurrentCommandId()
+
+    // Then
+    expect(got).toBe(commandId)
+  })
+})

--- a/packages/cli-kit/src/public/node/global-context.ts
+++ b/packages/cli-kit/src/public/node/global-context.ts
@@ -31,3 +31,11 @@ export function getCurrentCommandId(): string {
 export function setCurrentCommandId(commandId: string): void {
   getGlobalContext().currentCommandId = commandId
 }
+
+/**
+ * Reset the global context.
+ * Useful for tests.
+ */
+export function _resetGlobalContext(): void {
+  _globalContext = undefined
+}


### PR DESCRIPTION
### WHY are these changes introduced?

Follows instructions from .agents/automated-tasks/tests.md to improve test coverage in the `@shopify/cli-kit` package.

### WHAT is this pull request doing?

- Adds a new test file `packages/cli-kit/src/public/node/global-context.test.ts` with unit tests for `getCurrentCommandId` and `setCurrentCommandId`.
- Modifies `packages/cli-kit/src/public/node/global-context.ts` to export a `_resetGlobalContext` utility to ensure test isolation.

### How to test your changes?

CI

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [15390696870768366935](https://jules.google.com/task/15390696870768366935) started by @gonzaloriestra*