### PR TITLE
[Tests] Add unit tests for flushPromises utility

### DIFF
--- a/packages/cli-kit/src/public/node/promises.test.ts
+++ b/packages/cli-kit/src/public/node/promises.test.ts
@@ -1,0 +1,54 @@
+import {flushPromises} from './promises.js'
+import {describe, expect, test} from 'vitest'
+
+describe('flushPromises', () => {
+  test('waits for microtasks to complete', async () => {
+    // Given
+    let result = ''
+    const _promise = Promise.resolve().then(() => {
+      result += 'microtask'
+    })
+
+    // When
+    await flushPromises()
+    result += ' flushed'
+
+    // Then
+    expect(result).toBe('microtask flushed')
+  })
+
+  test('waits for multiple nested microtasks', async () => {
+    // Given
+    let result = ''
+    const _promise = Promise.resolve()
+      .then(() => {
+        result += '1'
+        return 'intermediate'
+      })
+      .then(() => {
+        result += '2'
+      })
+
+    // When
+    await flushPromises()
+    result += ' flushed'
+
+    // Then
+    expect(result).toBe('12 flushed')
+  })
+
+  test('waits for macrotasks scheduled with setImmediate', async () => {
+    // Given
+    let result = ''
+    setImmediate(() => {
+      result += 'macrotask'
+    })
+
+    // When
+    await flushPromises()
+    result += ' flushed'
+
+    // Then
+    expect(result).toBe('macrotask flushed')
+  })
+})


### PR DESCRIPTION
### WHY are these changes introduced?

The `flushPromises` utility in `@shopify/cli-kit` was identified as lacking dedicated unit tests. Adding these tests ensures the utility correctly handles various asynchronous scenarios, making the codebase safer to change.

### WHAT is this pull request doing?

Introduces `packages/cli-kit/src/public/node/promises.test.ts` which tests:
- Simple microtasks completion.
- Chained/nested microtasks completion.
- Macrotasks scheduled via `setImmediate`.

### How to test your changes?

CI

### Post-release steps

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [10896329056256182399](https://jules.google.com/task/10896329056256182399) started by @gonzaloriestra*