### PR TITLE
[Refactor] Improve readability of relativizePath

### DIFF
--- a/packages/cli-kit/src/public/node/path.ts
+++ b/packages/cli-kit/src/public/node/path.ts
@@ -133,14 +133,15 @@ export function commonParentDirectory(first: string, second: string): string {
  * @returns Relativized path.
  */
 export function relativizePath(path: string, dir: string = cwd()): string {
-  const result = commonParentDirectory(path, dir)
+  const commonParent = commonParentDirectory(path, dir)
   const relativePath = relative(dir, path)
-  const relativeComponents = relativePath.split('/').filter((component) => component === '..').length
-  if (result === '/' || relativePath === '' || relativeComponents > 2) {
+  const upLevels = relativePath.split('/').filter((component) => component === '..').length
+
+  if (commonParent === '/' || relativePath === '' || upLevels > 2) {
     return path
-  } else {
-    return relativePath
   }
+
+  return relativePath
 }
 
 /**


### PR DESCRIPTION
### WHY are these changes introduced?

The `relativizePath` function used an imperative `if/else` structure and somewhat cryptic variable names, making it harder to read and maintain than necessary.

### WHAT is this pull request doing?

Refactors `relativizePath` to:
- Use early returns instead of nested logic.
- Use more descriptive variable names (`commonParent`, `upLevels`).
- Improve code clarity without changing observable behavior.

### How to test your changes?

CI

### Post-release steps

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`


---
*PR created automatically by Jules for task [10987431837561304026](https://jules.google.com/task/10987431837561304026) started by @gonzaloriestra*