### PR TITLE
[Tests] Cover app bulk execute command

### DIFF
--- a/packages/app/src/cli/commands/app/bulk/execute.test.ts
+++ b/packages/app/src/cli/commands/app/bulk/execute.test.ts
@@ -1,0 +1,112 @@
+import BulkExecute from './execute.js'
+import {executeBulkOperation} from '../../../services/bulk-operations/execute-bulk-operation.js'
+import {prepareExecuteContext} from '../../../utilities/execute-command-helpers.js'
+import {
+  testAppLinked,
+  testOrganization,
+  testOrganizationApp,
+  testOrganizationStore,
+  testProject,
+} from '../../../models/app/app.test-data.js'
+import {describe, expect, test, vi, beforeEach} from 'vitest'
+
+vi.mock('../../../services/bulk-operations/execute-bulk-operation.js')
+vi.mock('../../../utilities/execute-command-helpers.js')
+
+describe('app bulk execute command', () => {
+  const app = testAppLinked()
+  const remoteApp = testOrganizationApp()
+  const organization = testOrganization()
+  const store = testOrganizationStore({shopDomain: 'shop.myshopify.com'})
+
+  beforeEach(() => {
+    vi.mocked(prepareExecuteContext).mockResolvedValue({
+      appContextResult: {
+        app,
+        remoteApp,
+        developerPlatformClient: remoteApp.developerPlatformClient,
+        organization,
+        specifications: [],
+        project: testProject(),
+        activeConfig: {} as never,
+      },
+      store,
+      query: 'query { shop { name } }',
+    })
+    vi.mocked(executeBulkOperation).mockResolvedValue()
+  })
+
+  test('prepares execution context and calls executeBulkOperation', async () => {
+    // When
+    await BulkExecute.run(['--query', 'query { shop { name } }', '--store', 'shop.myshopify.com'])
+
+    // Then
+    expect(prepareExecuteContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: 'query { shop { name } }',
+        store: 'shop.myshopify.com',
+      }),
+    )
+    expect(executeBulkOperation).toHaveBeenCalledWith({
+      organization,
+      remoteApp,
+      store,
+      query: 'query { shop { name } }',
+      variables: undefined,
+      variableFile: undefined,
+      watch: false,
+      outputFile: undefined,
+    })
+  })
+
+  test('calls executeBulkOperation with variables flag', async () => {
+    // When
+    await BulkExecute.run([
+      '--query',
+      'query { shop { name } }',
+      '--store',
+      'shop.myshopify.com',
+      '--variables',
+      '{"key": "value"}',
+      '--watch',
+      '--output-file',
+      'output.json',
+    ])
+
+    // Then
+    expect(executeBulkOperation).toHaveBeenCalledWith({
+      organization,
+      remoteApp,
+      store,
+      query: 'query { shop { name } }',
+      variables: ['{"key": "value"}'],
+      variableFile: undefined,
+      watch: true,
+      outputFile: 'output.json',
+    })
+  })
+
+  test('calls executeBulkOperation with variable-file flag', async () => {
+    // When
+    await BulkExecute.run([
+      '--query-file',
+      'query.graphql',
+      '--store',
+      'shop.myshopify.com',
+      '--variable-file',
+      'variables.jsonl',
+    ])
+
+    // Then
+    expect(executeBulkOperation).toHaveBeenCalledWith({
+      organization,
+      remoteApp,
+      store,
+      query: 'query { shop { name } }',
+      variables: undefined,
+      variableFile: expect.stringContaining('variables.jsonl'),
+      watch: false,
+      outputFile: undefined,
+    })
+  })
+})


### PR DESCRIPTION
### WHY are these changes introduced?

The `app bulk execute` command was identified as lacking command-level unit tests. Adding these tests reduces the risk of regressions in flag parsing and service integration.

### WHAT is this pull request doing?

- Creates `packages/app/src/cli/commands/app/bulk/execute.test.ts`.
- Implements tests for basic execution, execution with variables and watch flags, and execution using file-based inputs.
- Mocks necessary services and utilities to isolate command behavior.

### How to test your changes?

CI

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [11965133977513333910](https://jules.google.com/task/11965133977513333910) started by @gonzaloriestra*