### PR TITLE
Use preview identity for store open analytics

### DIFF
--- a/packages/store/src/cli/services/store/create/preview/index.test.ts
+++ b/packages/store/src/cli/services/store/create/preview/index.test.ts
@@ -1,4 +1,4 @@
-import {PREVIEW_USER_ID_PREFIX, createPreviewStoreCommand} from './index.js'
+import {createPreviewStoreCommand} from './index.js'
 import {STORE_AUTH_APP_CLIENT_ID} from '../../auth/config.js'
 import {describe, expect, test, vi} from 'vitest'
 
@@ -28,7 +28,7 @@ describe('preview store create service', () => {
     expect(setStoredStoreAppSession).toHaveBeenCalledWith({
       store: 'x12y45z.myshopify.com',
       clientId: STORE_AUTH_APP_CLIENT_ID,
-      userId: `${PREVIEW_USER_ID_PREFIX}placeholder-uuid`,
+      userId: 'placeholder-uuid',
       accessToken: 'shpat_token',
       scopes: ['read_themes', 'write_themes'],
       acquiredAt: '2026-06-08T12:00:00.000Z',
@@ -44,7 +44,7 @@ describe('preview store create service', () => {
     })
     expect(recordStoreFqdnMetadata).toHaveBeenCalledOnce()
     expect(recordStoreFqdnMetadata).toHaveBeenCalledWith('x12y45z.myshopify.com', true, '123')
-    expect(setLastSeenUserId).toHaveBeenCalledWith(`${PREVIEW_USER_ID_PREFIX}placeholder-uuid`)
+    expect(setLastSeenUserId).toHaveBeenCalledWith('placeholder-uuid')
     expect(result).toEqual({
       status: 'success',
       message:
@@ -79,10 +79,8 @@ describe('preview store create service', () => {
       },
     )
 
-    expect(setStoredStoreAppSession).toHaveBeenCalledWith(
-      expect.objectContaining({userId: `${PREVIEW_USER_ID_PREFIX}123`, scopes: []}),
-    )
-    expect(setLastSeenUserId).toHaveBeenCalledWith(`${PREVIEW_USER_ID_PREFIX}123`)
+    expect(setStoredStoreAppSession).toHaveBeenCalledWith(expect.objectContaining({userId: '123', scopes: []}))
+    expect(setLastSeenUserId).toHaveBeenCalledWith('123')
   })
 
   test('passes client options to the create request', async () => {
@@ -132,7 +130,7 @@ describe('preview store create service', () => {
     )
 
     expect(setStoredStoreAppSession).toHaveBeenCalledOnce()
-    expect(setLastSeenUserId).toHaveBeenCalledWith(`${PREVIEW_USER_ID_PREFIX}123`)
+    expect(setLastSeenUserId).toHaveBeenCalledWith('123')
     expect(recordStoreFqdnMetadata).toHaveBeenCalledOnce()
     expect(recordStoreFqdnMetadata).toHaveBeenCalledWith('x12y45z.myshopify.com', true, '123')
     expect(result.status).toBe('success')

--- a/packages/store/src/cli/services/store/create/preview/index.ts
+++ b/packages/store/src/cli/services/store/create/preview/index.ts
@@ -4,8 +4,6 @@ import {recordStoreFqdnMetadata} from '../../attribution.js'
 import {setStoredStoreAppSession} from '@shopify/cli-kit/node/store-auth-session'
 import {setLastSeenUserId} from '@shopify/cli-kit/node/session'
 
-export const PREVIEW_USER_ID_PREFIX = 'preview:'
-
 interface CreatePreviewStoreInput {
   name?: string
   country?: string
@@ -57,7 +55,7 @@ export async function createPreviewStoreCommand(
 }
 
 function previewUserId(response: PreviewStoreCreateResponse): string {
-  return `${PREVIEW_USER_ID_PREFIX}${response.placeholderAccountUuid ?? response.shop.id}`
+  return response.placeholderAccountUuid ?? response.shop.id
 }
 
 async function persistPreviewStoreSession(

--- a/packages/store/src/cli/services/store/info/index.test.ts
+++ b/packages/store/src/cli/services/store/info/index.test.ts
@@ -177,6 +177,7 @@ describe('getStoreInfo', () => {
     expect(fetchDestinationsContext).not.toHaveBeenCalled()
     expect(fetchOrganizationShop).not.toHaveBeenCalled()
     expect(recordStoreFqdnMetadata).toHaveBeenCalledWith(SHOP, true, '123')
+    expect(setLastSeenUserId).toHaveBeenCalledWith('preview:placeholder-uuid')
     expect(getPreviewStore).toHaveBeenCalledWith({
       shopId: '123',
       adminApiToken: 'shpat_preview_token',

--- a/packages/store/src/cli/services/store/info/index.test.ts
+++ b/packages/store/src/cli/services/store/info/index.test.ts
@@ -153,7 +153,7 @@ describe('getStoreInfo', () => {
     vi.mocked(getCurrentStoredStoreAppSession).mockReturnValueOnce({
       store: SHOP,
       clientId: STORE_AUTH_APP_CLIENT_ID,
-      userId: 'preview:placeholder-uuid',
+      userId: 'placeholder-uuid',
       accessToken: 'shpat_preview_token',
       scopes: [],
       acquiredAt: '2026-06-08T12:00:00.000Z',
@@ -177,7 +177,7 @@ describe('getStoreInfo', () => {
     expect(fetchDestinationsContext).not.toHaveBeenCalled()
     expect(fetchOrganizationShop).not.toHaveBeenCalled()
     expect(recordStoreFqdnMetadata).toHaveBeenCalledWith(SHOP, true, '123')
-    expect(setLastSeenUserId).toHaveBeenCalledWith('preview:placeholder-uuid')
+    expect(setLastSeenUserId).toHaveBeenCalledWith('placeholder-uuid')
     expect(getPreviewStore).toHaveBeenCalledWith({
       shopId: '123',
       adminApiToken: 'shpat_preview_token',
@@ -200,7 +200,7 @@ describe('getStoreInfo', () => {
       vi.mocked(getCurrentStoredStoreAppSession).mockReturnValueOnce({
         store: SHOP,
         clientId: STORE_AUTH_APP_CLIENT_ID,
-        userId: 'preview:placeholder-uuid',
+        userId: 'placeholder-uuid',
         accessToken: 'shpat_preview_token',
         // Preview stores are preapproved for a large, fixed scope catalog; the re-auth message
         // should not dump the whole list back at the user (see the placeholder assertion below).
@@ -237,7 +237,7 @@ describe('getStoreInfo', () => {
     vi.mocked(getCurrentStoredStoreAppSession).mockReturnValueOnce({
       store: SHOP,
       clientId: STORE_AUTH_APP_CLIENT_ID,
-      userId: 'preview:placeholder-uuid',
+      userId: 'placeholder-uuid',
       accessToken: 'shpat_preview_token',
       scopes: ['read_products'],
       acquiredAt: '2026-06-08T12:00:00.000Z',
@@ -262,7 +262,7 @@ describe('getStoreInfo', () => {
     vi.mocked(getCurrentStoredStoreAppSession).mockReturnValueOnce({
       store: SHOP,
       clientId: STORE_AUTH_APP_CLIENT_ID,
-      userId: 'preview:placeholder-uuid',
+      userId: 'placeholder-uuid',
       accessToken: 'shpat_preview_token',
       scopes: ['read_themes', 'write_themes'],
       acquiredAt: '2026-06-08T12:00:00.000Z',
@@ -290,7 +290,7 @@ describe('getStoreInfo', () => {
     vi.mocked(getCurrentStoredStoreAppSession).mockReturnValueOnce({
       store: SHOP,
       clientId: STORE_AUTH_APP_CLIENT_ID,
-      userId: 'preview:placeholder-uuid',
+      userId: 'placeholder-uuid',
       accessToken: 'shpat_preview_token',
       scopes: [],
       acquiredAt: '2026-06-08T12:00:00.000Z',
@@ -566,7 +566,7 @@ The CLI is currently unable to prompt for reauthentication.`)
     mockStoreAuthFallback()
     vi.mocked(loadStoredStoreSession).mockResolvedValue({
       ...STORED_SESSION,
-      userId: 'preview:placeholder-uuid',
+      userId: 'placeholder-uuid',
       kind: 'preview',
       scopes: ['read_products', 'write_products', 'read_themes'],
     })

--- a/packages/store/src/cli/services/store/info/index.ts
+++ b/packages/store/src/cli/services/store/info/index.ts
@@ -65,6 +65,7 @@ export async function getStoreInfo(options: GetStoreInfoOptions): Promise<StoreI
 
   if (isPreviewStoreSession(storedSession)) {
     await recordStoreFqdnMetadata(storedSession.store, true, storedSession.preview.shopId)
+    setLastSeenUserId(storedSession.userId)
     const previewStoreUrls = await fetchPreviewStoreUrls(storedSession)
     return buildPreviewStoreResult({
       store,


### PR DESCRIPTION
## Summary
Backports #8005 and #8007 to stable/4.5.

## Testing
- pnpm --filter @shopify/store vitest run src/cli/services/store/info/index.test.ts
- pnpm --filter @shopify/store vitest run src/cli/services/store/info/index.test.ts src/cli/services/store/create/preview/index.test.ts
- pnpm --filter @shopify/store type-check
- pnpm --filter @shopify/store lint