### PR TITLE
Tighten Cloudflare install test mock types

### DIFF
--- a/packages/plugin-cloudflare/src/install-cloudflared.test.ts
+++ b/packages/plugin-cloudflare/src/install-cloudflared.test.ts
@@ -3,7 +3,7 @@ import * as http from '@shopify/cli-kit/node/http'
 import {inTemporaryDirectory, readFile, writeFile, fileExists} from '@shopify/cli-kit/node/fs'
 import {joinPath} from '@shopify/cli-kit/node/path'
 import {describe, expect, test, vi} from 'vitest'
-import {Readable} from 'stream'
+import {Response} from 'node-fetch'
 import {writeFileSync} from 'fs'
 // eslint-disable-next-line no-restricted-imports
 import * as childProcess from 'child_process'
@@ -14,12 +14,9 @@ vi.mock('child_process')
 
 describe('install-cloudflare', () => {
   const mockFetch = (ok = true) => {
-    vi.mocked(http.fetch).mockResolvedValue({
-      ok,
-      status: ok ? 200 : 404,
-      statusText: ok ? 'OK' : 'Not Found',
-      body: Readable.from(['cloudflared content']),
-    } as any)
+    vi.mocked(http.fetch).mockResolvedValue(
+      new Response('cloudflared content', {status: ok ? 200 : 404, statusText: ok ? 'OK' : 'Not Found'}),
+    )
   }
 
   test('install is ignored if SHOPIFY_CLI_IGNORE_CLOUDFLARED is present', async () => {


### PR DESCRIPTION
### WHY are these changes introduced?

No issue.

The Cloudflare installer tests mocked `http.fetch` with a partial response object cast to `any`. The production helper expects the `node-fetch` response shape, so the test can use a real `Response` instead of bypassing types.

### WHAT is this pull request doing?

- Replaces the hand-written partial fetch response with `new Response(...)` from `node-fetch`.
- Removes the `Readable` stream import and the `as any` cast from the fetch mock.
- Preserves the same mocked status/status text and response body content.

### How to test your changes?

- `pnpm --filter @shopify/plugin-cloudflare vitest src/install-cloudflared.test.ts` ✅
- `pnpm --filter @shopify/plugin-cloudflare type-check` ✅
- `pnpm --filter @shopify/plugin-cloudflare lint` ✅
- `git diff --check` ✅

### Post-release steps

None.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [x] The change is not user-facing; no changeset is needed.
