### PR TITLE
Simplify app event watcher test polling

### DIFF
--- a/packages/app/src/cli/services/dev/app-events/app-event-watcher.test.ts
+++ b/packages/app/src/cli/services/dev/app-events/app-event-watcher.test.ts
@@ -74,28 +74,20 @@ const testAppConfiguration: CurrentAppConfiguration = {
   embedded: true,
 }
 
-/**
- * Waits for the watcher to emit a given event by polling the emit spy.
- * This replaces fragile fixed-timeout waits (setTimeout(10)) that cause flaky tests when the async
- * event processing chain takes longer than expected.
- */
+/** Waits for the watcher to emit a given event. */
 type EmitSpy = MockInstance<(eventName: string | symbol, ...args: unknown[]) => boolean>
 
 async function waitForWatcherEmit(emitSpy: EmitSpy, event: string, timeoutMs = 3000): Promise<void> {
-  await new Promise<void>((resolve, reject) => {
-    const startTime = Date.now()
-    const poll = () => {
-      const emitted = emitSpy.mock.calls.some((call) => call[0] === event)
-      if (emitted) {
-        resolve()
-      } else if (Date.now() - startTime < timeoutMs) {
-        setTimeout(poll, 10)
-      } else {
-        reject(new Error(`Timeout waiting for watcher to emit "${event}" event`))
-      }
-    }
-    poll()
-  })
+  await vi.waitFor(
+    () => {
+      const emittedEvents = emitSpy.mock.calls.map(([eventName]) => String(eventName))
+      expect(
+        emittedEvents,
+        `Expected watcher to emit "${event}". Emitted events: ${emittedEvents.join(', ')}`,
+      ).toContain(event)
+    },
+    {timeout: timeoutMs, interval: 10},
+  )
 }
 
 /** Waits until successful change handling finishes (`emit('all', ...)`). */


### PR DESCRIPTION
### WHY are these changes introduced?

No issue.

The app event watcher tests had a small custom polling loop that duplicated Vitest's wait helper and used a manual `setTimeout`/`Date.now` timeout path. Using the framework helper keeps the test wait behavior simpler and preserves useful timeout diagnostics.

### WHAT is this pull request doing?

- Replaces the custom `waitForWatcherEmit` polling promise with `vi.waitFor`.
- Keeps the same 10ms polling interval and timeout parameter.
- Includes the emitted event names in the assertion message when the expected event is not observed.

### How to test your changes?

- `pnpm --filter @shopify/app vitest src/cli/services/dev/app-events/app-event-watcher.test.ts` ✅
- `pnpm --filter @shopify/app lint` ✅
- `git diff --check` ✅
- `pnpm --filter @shopify/app type-check` ⚠️ attempted; fails on current `origin/main` due existing `@shopify/organizations`/`Organization` type resolution errors outside this diff.

### Post-release steps

None.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [x] The change is not user-facing; no changeset is needed.
