### PR TITLE
Keep hot reload E2E scopes valid

### DIFF
--- a/packages/e2e/tests/dev-hot-reload.spec.ts
+++ b/packages/e2e/tests/dev-hot-reload.spec.ts
@@ -62,10 +62,11 @@ test.describe('Dev hot reload', () => {
       try {
         await proc.waitForOutput(READY_MESSAGE, CLI_TIMEOUT.medium)
 
-        // Edit scopes in the TOML to trigger a reload
+        // Edit a harmless URL field in the TOML to trigger a reload without
+        // invalidating the fixture's webhook scope requirements.
         const tomlPath = path.join(appDir, 'shopify.app.toml')
         const original = fs.readFileSync(tomlPath, 'utf8')
-        const patched = updateTomlValues(original, [[['access_scopes', 'scopes'], 'read_products,write_products']])
+        const patched = updateTomlValues(original, [[['application_url'], 'https://example.com/updated']])
         fs.writeFileSync(tomlPath, patched)
 
         await proc.waitForOutput('App config updated', CLI_TIMEOUT.medium)


### PR DESCRIPTION
### WHY are these changes introduced?

No issue.

The `dev-hot-reload` E2E test edits app config to trigger a TOML reload, but mutating `access_scopes.scopes` can make the fixture invalid because the same fixture includes an `orders/create` webhook subscription that requires `read_orders` or `read_marketplace_orders`. When the dev preview rejects the config, the test times out waiting for `Updated dev preview`.

### WHAT is this pull request doing?

Changes the test to mutate a harmless URL field instead of scopes. This still exercises the TOML reload path without invalidating webhook scope requirements.

### How to test your changes?

- `pnpm --filter @shopify/e2e lint` ✅
- `cd packages/e2e && pnpm exec tsc --noEmit --project tsconfig.json` ✅
- `git diff --check` ✅
- CI follow-up: `tests/dev-hot-reload.spec.ts:42` passed on this branch. `E2E tests (shard 1/2)` is still red because the separate `app-deploy.spec.ts:84` config-link failure remains on `main`; that is fixed separately in #8070.

Not run locally: credentialed Playwright E2E. I also tried `pnpm --filter @shopify/e2e type-check`, but it currently fails before this diff on `origin/main` due unrelated `@shopify/organizations` / `Organization` type resolution errors in `app` and `store` builds.

### Post-release steps

None.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [x] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

Not user-facing; no changeset added.
