### PR TITLE
Harden E2E config link prompt submit

### DIFF
--- a/packages/e2e/setup/app.ts
+++ b/packages/e2e/setup/app.ts
@@ -285,10 +285,8 @@ export async function configLink(
   // flip the prompt state unexpectedly (e.g. turning a select into search mode).
   const settle = (ms = 50) => new Promise<void>((resolve) => setTimeout(resolve, ms))
   const typeText = async (text: string) => {
-    for (const char of text) {
-      proc.ptyProcess.write(char)
-      await settle(10)
-    }
+    proc.ptyProcess.write(text)
+    await settle(250)
   }
 
   try {
@@ -309,15 +307,17 @@ export async function configLink(
     }
 
     // Wait for "App name" text prompt and submit the desired name.
-    // Important: Ink parses each PTY data event as ONE keypress. If we write
-    // "name\r" in one call, parseKeypress sees the whole string and treats
-    // it as text (not Enter), so the prompt never submits. We must write the
-    // text, wait for it to be consumed, then write \r separately.
+    // Important: Ink parses each PTY data event as ONE keypress. Write the
+    // app name as one text event so characters are not dropped during busy CI
+    // renders, then write Enter separately so it is handled as submission.
+    //
+    // Do not wait for the full app name to appear in PTY output before pressing
+    // Enter: under CI load, Ink's line-clearing renders can make the captured
+    // output miss or reorder prompt echo even when the input was received.
     await proc.waitForOutput('App name', CLI_TIMEOUT.medium)
     await settle()
     await typeText(ctx.appName)
-    await proc.waitForOutput(ctx.appName, CLI_TIMEOUT.medium)
-    await settle()
+    await settle(250)
     proc.sendKey('\r')
 
     const exitCode = await proc.waitForExit(CLI_TIMEOUT.long)


### PR DESCRIPTION
### WHY are these changes introduced?

No issue.

The `app-deploy` E2E test can fail while creating its secondary app through `app config link`. The helper was sending the generated app name as many tiny PTY writes, which can drop characters under busy CI prompt rendering, and it also treated the captured Ink prompt echo as required for progress.

### WHAT is this pull request doing?

Writes the app name as one PTY text event, waits briefly for the input to be consumed, and then submits Enter separately so Ink handles Enter as submission. It also avoids waiting for the full app name echo, because Ink line-clearing can make captured prompt output incomplete even when input was received.

### How to test your changes?

- `pnpm --filter @shopify/e2e lint` ✅
- `cd packages/e2e && pnpm exec tsc --noEmit --project tsconfig.json` ✅
- `git diff --check` ✅
- CI follow-up: `tests/app-deploy.spec.ts:84` passed on this branch. `E2E tests (shard 1/2)` is still red because the separate `dev-hot-reload.spec.ts:42` invalid-config failure remains on `main`; that is fixed separately in #8069.

Not run locally: credentialed Playwright E2E. I also tried `pnpm --filter @shopify/e2e type-check`, but it currently fails before this diff on `origin/main` due unrelated `@shopify/organizations` / `Organization` type resolution errors in `app` and `store` builds.

### Post-release steps

None.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [x] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

Not user-facing; no changeset added.
