### PR TITLE
Fix Changesets config after dev console removal

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -11,7 +11,6 @@
     "@shopify/create-app",
     "@shopify/cli-kit",
     "@shopify/theme",
-    "@shopify/ui-extensions-dev-console-app",
     "@shopify/plugin-cloudflare",
     "@shopify/plugin-did-you-mean"
   ]],


### PR DESCRIPTION
### WHY are these changes introduced?

PR #8033 removed `@shopify/ui-extensions-dev-console-app`, but the deleted package remained in the Changesets fixed package group. This causes `/snapit` and other Changesets commands to fail while validating the configuration.

### WHAT is this pull request doing?

Removes the stale `@shopify/ui-extensions-dev-console-app` entry from `.changeset/config.json`.

### How to test your changes?

1. Run `pnpm exec changeset status`.
2. Confirm Changesets validates the configuration successfully.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`