### PR TITLE
[Refactor] output utility logic

### DIFF
--- a/packages/cli-kit/src/public/node/output.ts
+++ b/packages/cli-kit/src/public/node/output.ts
@@ -144,29 +144,19 @@ export function outputContent(
   strings: TemplateStringsArray,
   ...keys: (ContentToken<unknown> | string)[]
 ): TokenizedString {
-  let output = ``
-  strings.forEach((string, i) => {
-    output += string
-    if (i >= keys.length) {
-      return
-    }
-
-    const token = keys[i]!
+  const output = strings.reduce((acc, string, i) => {
+    const token = keys[i]
+    let tokenValue = ''
 
     if (typeof token === 'string') {
-      output += token
+      tokenValue = token
     } else if (token) {
       const enumTokenOutput = token.output()
-
-      if (Array.isArray(enumTokenOutput)) {
-        enumTokenOutput.forEach((line: string) => {
-          output += line
-        })
-      } else {
-        output += enumTokenOutput
-      }
+      tokenValue = Array.isArray(enumTokenOutput) ? enumTokenOutput.join('') : enumTokenOutput
     }
-  })
+
+    return acc + string + tokenValue
+  }, '')
   return new TokenizedString(output)
 }
 
@@ -442,6 +432,6 @@ export function shouldDisplayColors(_process = process): boolean {
  * @returns The formatted message.
  */
 export function formatSection(title: string, body: string): string {
-  const formattedTitle = `${title.toUpperCase()}${' '.repeat(35 - title.length)}`
+  const formattedTitle = title.toUpperCase().padEnd(35)
   return outputContent`${outputToken.heading(formattedTitle)}\n${body}`.value
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Refactor the output utility logic to use more idiomatic and robust modern JavaScript patterns.

### WHAT is this pull request doing?

- Refactored `outputContent` in `packages/cli-kit/src/public/node/output.ts` to use a declarative `.reduce()` approach and `.join('')` for array tokens.
- Refactored `formatSection` in the same file to use `.padEnd(35)` for idiomatic string padding.

### How to test your changes?

CI

### Post-release steps

N/A

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [10740671485648585031](https://jules.google.com/task/10740671485648585031) started by @gonzaloriestra*