### PR TITLE
[Tests] addCursorAndFiltersToAppLogsUrl utility

### DIFF
--- a/packages/cli-kit/src/public/node/api/utilities.test.ts
+++ b/packages/cli-kit/src/public/node/api/utilities.test.ts
@@ -1,0 +1,83 @@
+import {addCursorAndFiltersToAppLogsUrl} from './utilities.js'
+import {describe, expect, test} from 'vitest'
+
+describe('addCursorAndFiltersToAppLogsUrl', () => {
+  test('returns the base URL when no cursor or filters are provided', () => {
+    // Given
+    const baseUrl = 'https://shopify.com/logs'
+
+    // When
+    const got = addCursorAndFiltersToAppLogsUrl(baseUrl)
+
+    // Then
+    expect(got).toBe('https://shopify.com/logs')
+  })
+
+  test('appends the cursor to the URL', () => {
+    // Given
+    const baseUrl = 'https://shopify.com/logs'
+    const cursor = 'cursor123'
+
+    // When
+    const got = addCursorAndFiltersToAppLogsUrl(baseUrl, cursor)
+
+    // Then
+    expect(got).toBe('https://shopify.com/logs?cursor=cursor123')
+  })
+
+  test('appends the status filter to the URL', () => {
+    // Given
+    const baseUrl = 'https://shopify.com/logs'
+    const filters = {status: 'success'}
+
+    // When
+    const got = addCursorAndFiltersToAppLogsUrl(baseUrl, undefined, filters)
+
+    // Then
+    expect(got).toBe('https://shopify.com/logs?status=success')
+  })
+
+  test('appends the source filter to the URL', () => {
+    // Given
+    const baseUrl = 'https://shopify.com/logs'
+    const filters = {source: 'cli'}
+
+    // When
+    const got = addCursorAndFiltersToAppLogsUrl(baseUrl, undefined, filters)
+
+    // Then
+    expect(got).toBe('https://shopify.com/logs?source=cli')
+  })
+
+  test('appends both status and source filters to the URL', () => {
+    // Given
+    const baseUrl = 'https://shopify.com/logs'
+    const filters = {status: 'error', source: 'app'}
+
+    // When
+    const got = addCursorAndFiltersToAppLogsUrl(baseUrl, undefined, filters)
+
+    // Then
+    const url = new URL(got)
+    expect(url.origin + url.pathname).toBe('https://shopify.com/logs')
+    expect(url.searchParams.get('status')).toBe('error')
+    expect(url.searchParams.get('source')).toBe('app')
+  })
+
+  test('appends cursor and all filters to the URL', () => {
+    // Given
+    const baseUrl = 'https://shopify.com/logs'
+    const cursor = 'cursor456'
+    const filters = {status: 'info', source: 'web'}
+
+    // When
+    const got = addCursorAndFiltersToAppLogsUrl(baseUrl, cursor, filters)
+
+    // Then
+    const url = new URL(got)
+    expect(url.origin + url.pathname).toBe('https://shopify.com/logs')
+    expect(url.searchParams.get('cursor')).toBe('cursor456')
+    expect(url.searchParams.get('status')).toBe('info')
+    expect(url.searchParams.get('source')).toBe('web')
+  })
+})


### PR DESCRIPTION
### WHY are these changes introduced?

`addCursorAndFiltersToAppLogsUrl` is currently untested. Adding unit tests ensures its logic for appending cursors and filters to App Log URLs remains correct and prevents regressions.

### WHAT is this pull request doing?

Implemented unit tests for the `addCursorAndFiltersToAppLogsUrl` utility function in `packages/cli-kit/src/public/node/api/utilities.test.ts`.

### How to test your changes?

CI

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`


---
*PR created automatically by Jules for task [6691484537451834266](https://jules.google.com/task/6691484537451834266) started by @gonzaloriestra*