### PR TITLE
Remove Partners client selection

### DIFF
--- a/packages/app/src/cli/commands/app/init.test.ts
+++ b/packages/app/src/cli/commands/app/init.test.ts
@@ -1,7 +1,7 @@
 import Init from './init.js'
 import initPrompt from '../../prompts/init/init.js'
 import initService from '../../services/init/init.js'
-import {selectDeveloperPlatformClient} from '../../utilities/developer-platform-client.js'
+import {defaultDeveloperPlatformClient} from '../../utilities/developer-platform-client.js'
 import {selectOrg} from '../../services/context.js'
 import {fetchOrgFromId, NoOrgError} from '../../services/dev/fetch.js'
 import {appNamePrompt, createAsNewAppPrompt, selectAppPrompt} from '../../prompts/dev.js'
@@ -44,7 +44,7 @@ describe('Init command', () => {
       vi.mocked(validateTemplateValue).mockReturnValue(undefined)
       vi.mocked(validateFlavorValue).mockReturnValue(undefined)
       vi.mocked(inferPackageManager).mockReturnValue('npm')
-      vi.mocked(selectDeveloperPlatformClient).mockReturnValue(mockDeveloperPlatformClient)
+      vi.mocked(defaultDeveloperPlatformClient).mockReturnValue(mockDeveloperPlatformClient)
       vi.mocked(selectOrg).mockResolvedValue(mockOrganization)
 
       // Mock the orgAndApps method on the developer platform client
@@ -87,7 +87,7 @@ describe('Init command', () => {
       vi.mocked(validateTemplateValue).mockReturnValue(undefined)
       vi.mocked(validateFlavorValue).mockReturnValue(undefined)
       vi.mocked(inferPackageManager).mockReturnValue('npm')
-      vi.mocked(selectDeveloperPlatformClient).mockReturnValue(mockDeveloperPlatformClient)
+      vi.mocked(defaultDeveloperPlatformClient).mockReturnValue(mockDeveloperPlatformClient)
 
       // Mock fetchOrgFromId to return the organization
       vi.mocked(fetchOrgFromId).mockResolvedValue(mockOrganization)
@@ -149,7 +149,7 @@ describe('Init command', () => {
         vi.mocked(validateTemplateValue).mockReturnValue(undefined)
         vi.mocked(validateFlavorValue).mockReturnValue(undefined)
         vi.mocked(inferPackageManager).mockReturnValue('npm')
-        vi.mocked(selectDeveloperPlatformClient).mockReturnValue(mockDeveloperPlatformClient)
+        vi.mocked(defaultDeveloperPlatformClient).mockReturnValue(mockDeveloperPlatformClient)
 
         // Mock fetchOrgFromId to throw NoOrgError for invalid organization
         vi.mocked(fetchOrgFromId).mockRejectedValue(
@@ -202,7 +202,7 @@ describe('Init command', () => {
       vi.mocked(validateTemplateValue).mockReturnValue(undefined)
       vi.mocked(validateFlavorValue).mockReturnValue(undefined)
       vi.mocked(inferPackageManager).mockReturnValue('npm')
-      vi.mocked(selectDeveloperPlatformClient).mockReturnValue(mockDeveloperPlatformClient)
+      vi.mocked(defaultDeveloperPlatformClient).mockReturnValue(mockDeveloperPlatformClient)
 
       // Mock fetchOrgFromId to return the organization
       vi.mocked(fetchOrgFromId).mockResolvedValue(mockOrganization)

--- a/packages/app/src/cli/commands/app/init.ts
+++ b/packages/app/src/cli/commands/app/init.ts
@@ -1,6 +1,6 @@
 import initPrompt, {visibleTemplates} from '../../prompts/init/init.js'
 import initService from '../../services/init/init.js'
-import {DeveloperPlatformClient, selectDeveloperPlatformClient} from '../../utilities/developer-platform-client.js'
+import {defaultDeveloperPlatformClient, DeveloperPlatformClient} from '../../utilities/developer-platform-client.js'
 import {appFromIdentifiers, selectOrg} from '../../services/context.js'
 import {fetchOrgFromId} from '../../services/dev/fetch.js'
 import AppLinkedCommand, {AppLinkedCommandOutput} from '../../utilities/app-linked-command.js'
@@ -91,7 +91,7 @@ export default class Init extends AppLinkedCommand {
     const name = flags.name ?? (await getAppName(flags.path))
 
     // Force user authentication before prompting.
-    let developerPlatformClient = selectDeveloperPlatformClient()
+    const developerPlatformClient = defaultDeveloperPlatformClient()
     await developerPlatformClient.session()
 
     const promptAnswers = await initPrompt({
@@ -105,7 +105,6 @@ export default class Init extends AppLinkedCommand {
       // If a client-id is provided we don't need to prompt the user and can link directly to that app.
       const selectedApp = await appFromIdentifiers({apiKey: flags['client-id']})
       appName = selectedApp.title
-      developerPlatformClient = selectedApp.developerPlatformClient ?? developerPlatformClient
       selectAppResult = {result: 'existing', app: selectedApp}
     } else {
       let org: Organization
@@ -115,7 +114,6 @@ export default class Init extends AppLinkedCommand {
       } else {
         org = await selectOrg()
       }
-      developerPlatformClient = selectDeveloperPlatformClient({organization: org})
       const {organization, apps, hasMorePages} = await developerPlatformClient.orgAndApps(org.id)
       selectAppResult = await selectAppOrNewAppName(
         flags.name !== undefined,

--- a/packages/app/src/cli/services/app/config/link-service.test.ts
+++ b/packages/app/src/cli/services/app/config/link-service.test.ts
@@ -1,6 +1,6 @@
 import link from './link.js'
 import {testOrganizationApp, testDeveloperPlatformClient} from '../../../models/app/app.test-data.js'
-import {DeveloperPlatformClient, selectDeveloperPlatformClient} from '../../../utilities/developer-platform-client.js'
+import {defaultDeveloperPlatformClient, DeveloperPlatformClient} from '../../../utilities/developer-platform-client.js'
 import {OrganizationApp, OrganizationSource} from '../../../models/organization.js'
 import {appNamePrompt, createAsNewAppPrompt} from '../../../prompts/dev.js'
 import {selectConfigName} from '../../../prompts/config.js'
@@ -83,7 +83,7 @@ api_version = "2024-01"
       writeFileSync(joinPath(tmp, 'package.json'), '{}')
 
       const developerPlatformClient = buildDeveloperPlatformClient()
-      vi.mocked(selectDeveloperPlatformClient).mockReturnValue(developerPlatformClient)
+      vi.mocked(defaultDeveloperPlatformClient).mockReturnValue(developerPlatformClient)
       vi.mocked(createAsNewAppPrompt).mockResolvedValue(true)
       vi.mocked(appNamePrompt).mockResolvedValue('A user provided name')
       vi.mocked(selectOrganizationPrompt).mockResolvedValue({
@@ -176,7 +176,7 @@ api_version = "2025-07"
       writeFileSync(joinPath(tmp, 'package.json'), '{}')
 
       const developerPlatformClient = buildDeveloperPlatformClient()
-      vi.mocked(selectDeveloperPlatformClient).mockReturnValue(developerPlatformClient)
+      vi.mocked(defaultDeveloperPlatformClient).mockReturnValue(developerPlatformClient)
       vi.mocked(createAsNewAppPrompt).mockResolvedValue(true)
       vi.mocked(appNamePrompt).mockResolvedValue('My App')
       vi.mocked(selectOrganizationPrompt).mockResolvedValue({
@@ -224,7 +224,7 @@ required = true
       writeFileSync(joinPath(tmp, 'package.json'), '{}')
 
       const developerPlatformClient = buildDeveloperPlatformClient()
-      vi.mocked(selectDeveloperPlatformClient).mockReturnValue(developerPlatformClient)
+      vi.mocked(defaultDeveloperPlatformClient).mockReturnValue(developerPlatformClient)
       vi.mocked(createAsNewAppPrompt).mockResolvedValue(true)
       vi.mocked(appNamePrompt).mockResolvedValue('My App')
       vi.mocked(selectOrganizationPrompt).mockResolvedValue({

--- a/packages/app/src/cli/services/context.test.ts
+++ b/packages/app/src/cli/services/context.test.ts
@@ -18,11 +18,7 @@ import {
 import {getAppConfigurationFileName, isWebType} from '../models/app/loader.js'
 import {AppLinkedInterface} from '../models/app/app.js'
 import * as loadSpecifications from '../models/extensions/load-specifications.js'
-import {
-  allDeveloperPlatformClients,
-  DeveloperPlatformClient,
-  selectDeveloperPlatformClient,
-} from '../utilities/developer-platform-client.js'
+import {defaultDeveloperPlatformClient, DeveloperPlatformClient} from '../utilities/developer-platform-client.js'
 import {RemoteAwareExtensionSpecification} from '../models/extensions/specification.js'
 import {selectOrganizationPrompt} from '@shopify/organizations'
 import {TomlFile} from '@shopify/cli-kit/node/toml/toml-file'
@@ -187,7 +183,7 @@ describe('ensureDeployContext', () => {
       ...deployOptions(app, false, true),
       developerPlatformClient: buildDeveloperPlatformClient({}),
     }
-    vi.mocked(selectDeveloperPlatformClient).mockReturnValue(options.developerPlatformClient)
+    vi.mocked(defaultDeveloperPlatformClient).mockReturnValue(options.developerPlatformClient)
 
     // When/Then
     await expect(ensureDeployContext(options)).resolves.toBeDefined()
@@ -381,7 +377,7 @@ describe('appFromIdentifiers', () => {
         }),
     })
 
-    vi.mocked(allDeveloperPlatformClients).mockReturnValue([developerPlatformClient])
+    vi.mocked(defaultDeveloperPlatformClient).mockReturnValue(developerPlatformClient)
 
     await expect(
       appFromIdentifiers({
@@ -407,7 +403,7 @@ describe('appFromIdentifiers', () => {
         }),
     })
 
-    vi.mocked(allDeveloperPlatformClients).mockReturnValue([developerPlatformClient])
+    vi.mocked(defaultDeveloperPlatformClient).mockReturnValue(developerPlatformClient)
 
     await expect(
       appFromIdentifiers({

--- a/packages/app/src/cli/services/context.ts
+++ b/packages/app/src/cli/services/context.ts
@@ -10,11 +10,7 @@ import {Organization, OrganizationApp, OrganizationSource, OrganizationStore} fr
 import metadata from '../metadata.js'
 import {getAppConfigurationFileName} from '../models/app/loader.js'
 
-import {
-  allDeveloperPlatformClients,
-  CreateAppOptions,
-  selectDeveloperPlatformClient,
-} from '../utilities/developer-platform-client.js'
+import {CreateAppOptions, defaultDeveloperPlatformClient} from '../utilities/developer-platform-client.js'
 import {selectOrganizationPrompt} from '@shopify/organizations'
 import {TomlFile} from '@shopify/cli-kit/node/toml/toml-file'
 import {isServiceAccount, isUserAccount} from '@shopify/cli-kit/node/session'
@@ -62,26 +58,11 @@ interface AppFromIdOptions {
 }
 
 export const appFromIdentifiers = async (options: AppFromIdOptions): Promise<OrganizationApp> => {
-  const allClients = allDeveloperPlatformClients()
-
-  let app: OrganizationApp | undefined
-  for (const client of allClients) {
-    try {
-      // eslint-disable-next-line no-await-in-loop
-      app = await client.appFromIdentifiers(options.apiKey)
-      if (app) break
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } catch (error: any) {
-      if ('statusCode' in error && error.statusCode === 404) {
-        // We don't want to throw an error if the first client can't find the app. Try the next client.
-        continue
-      }
-      throw error
-    }
-  }
+  const client = defaultDeveloperPlatformClient()
+  const app = await client.appFromIdentifiers(options.apiKey)
 
   if (!app) {
-    const accountInfo = (await allClients[0]?.accountInfo()) ?? {type: 'UnknownAccount'}
+    const accountInfo = (await client.accountInfo()) ?? {type: 'UnknownAccount'}
     let identifier = 'Unknown account'
     let isOrg = false
 
@@ -194,10 +175,10 @@ function renderWarningAboutIncludeConfigOnDeploy() {
 export async function fetchOrCreateOrganizationApp(
   options: CreateAppOptions & {organizationId?: string},
 ): Promise<OrganizationApp> {
+  const developerPlatformClient = defaultDeveloperPlatformClient()
   const org = options.organizationId
-    ? await fetchOrgFromId(options.organizationId, selectDeveloperPlatformClient())
+    ? await fetchOrgFromId(options.organizationId, developerPlatformClient)
     : await selectOrg()
-  const developerPlatformClient = selectDeveloperPlatformClient({organization: org})
   const {organization, apps, hasMorePages} = await developerPlatformClient.orgAndApps(org.id)
   const remoteApp = await selectOrCreateApp(apps, hasMorePages, organization, developerPlatformClient, options)
 

--- a/packages/app/src/cli/services/dev/fetch.test.ts
+++ b/packages/app/src/cli/services/dev/fetch.test.ts
@@ -6,13 +6,11 @@ import {
   testDeveloperPlatformClient,
 } from '../../models/app/app.test-data.js'
 import {DeveloperPlatformClient} from '../../utilities/developer-platform-client.js'
-import {PartnersClient} from '../../utilities/developer-platform-client/partners-client.js'
 import {AppManagementClient} from '../../utilities/developer-platform-client/app-management-client.js'
 import {afterEach, describe, expect, test, vi} from 'vitest'
 import {renderFatalError} from '@shopify/cli-kit/node/ui'
 import {mockAndCaptureOutput} from '@shopify/cli-kit/node/testing/output'
 import {AbortError} from '@shopify/cli-kit/node/error'
-import {blockPartnersAccess} from '@shopify/cli-kit/node/environment'
 
 const ORG1: Organization = {
   id: '1',
@@ -35,9 +33,7 @@ const STORE1: OrganizationStore = {
 }
 
 vi.mock('@shopify/cli-kit/node/api/partners')
-vi.mock('../../utilities/developer-platform-client/partners-client.js')
 vi.mock('../../utilities/developer-platform-client/app-management-client.js')
-vi.mock('@shopify/cli-kit/node/environment')
 
 afterEach(() => {
   mockAndCaptureOutput().clear()
@@ -45,30 +41,8 @@ afterEach(() => {
 })
 
 describe('fetchOrganizations', async () => {
-  test('returns fetched organizations from available developer platform clients', async () => {
+  test('returns fetched organizations from App Management', async () => {
     // Given
-    vi.mocked(blockPartnersAccess).mockReturnValue(false)
-    const partnersClient: PartnersClient = testDeveloperPlatformClient({
-      organizations: () => Promise.resolve([ORG1]),
-    }) as PartnersClient
-    const appManagementClient: AppManagementClient = testDeveloperPlatformClient({
-      organizations: () => Promise.resolve([ORG2]),
-    }) as AppManagementClient
-    vi.mocked(PartnersClient.getInstance).mockReturnValue(partnersClient)
-    vi.mocked(AppManagementClient.getInstance).mockReturnValue(appManagementClient)
-
-    // When
-    const got = await fetchOrganizations()
-
-    // Then
-    expect(got).toEqual([ORG2, ORG1])
-    expect(partnersClient.organizations).toHaveBeenCalled()
-    expect(appManagementClient.organizations).toHaveBeenCalled()
-  })
-
-  test('returns fetched organizations from App Management for 3P development', async () => {
-    // Given
-    vi.mocked(blockPartnersAccess).mockReturnValue(true)
     const appManagementClient: AppManagementClient = testDeveloperPlatformClient({
       organizations: () => Promise.resolve([ORG2]),
     }) as AppManagementClient
@@ -79,13 +53,11 @@ describe('fetchOrganizations', async () => {
 
     // Then
     expect(got).toEqual([ORG2])
-    expect(PartnersClient.getInstance).not.toHaveBeenCalled()
     expect(appManagementClient.organizations).toHaveBeenCalled()
   })
 
   test('throws if there are no organizations', async () => {
     // Given
-    vi.mocked(blockPartnersAccess).mockReturnValue(true)
     const appManagementClient: AppManagementClient = testDeveloperPlatformClient({
       organizations: () => Promise.resolve([]),
     }) as AppManagementClient

--- a/packages/app/src/cli/services/dev/fetch.ts
+++ b/packages/app/src/cli/services/dev/fetch.ts
@@ -3,8 +3,7 @@ import {fetchCurrentAccountInformation} from '../context/partner-account-info.js
 import {
   DeveloperPlatformClient,
   Store,
-  allDeveloperPlatformClients,
-  selectDeveloperPlatformClient,
+  defaultDeveloperPlatformClient,
 } from '../../utilities/developer-platform-client.js'
 import {AccountInfo, isServiceAccount, isUserAccount} from '@shopify/cli-kit/node/session'
 import {AbortError} from '@shopify/cli-kit/node/error'
@@ -76,16 +75,11 @@ export class NoOrgError extends AbortError {
  * @returns List of organizations
  */
 export async function fetchOrganizations(): Promise<Organization[]> {
-  const organizations: Organization[] = []
-  for (const client of allDeveloperPlatformClients()) {
-    // We don't want to run this in parallel because there could be port conflicts
-    // eslint-disable-next-line no-await-in-loop
-    const clientOrganizations = await client.organizations()
-    organizations.push(...clientOrganizations)
-  }
+  const client = defaultDeveloperPlatformClient()
+  const organizations: Organization[] = await client.organizations()
 
   if (organizations.length === 0) {
-    const developerPlatformClient = selectDeveloperPlatformClient()
+    const developerPlatformClient = defaultDeveloperPlatformClient()
     const session = await developerPlatformClient.session()
     const accountInfo = await fetchCurrentAccountInformation(developerPlatformClient, session.userId)
     throw new NoOrgError(accountInfo)

--- a/packages/app/src/cli/utilities/developer-platform-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client.ts
@@ -1,4 +1,3 @@
-import {PartnersClient} from './developer-platform-client/partners-client.js'
 import {AppManagementClient} from './developer-platform-client/app-management-client.js'
 import {
   MinimalAppIdentifiers,
@@ -49,7 +48,6 @@ import {
 import {Store} from '../api/graphql/business-platform-organizations/generated/types.js'
 import {Session} from '@shopify/cli-kit/node/session'
 import {TokenItem} from '@shopify/cli-kit/node/ui'
-import {blockPartnersAccess} from '@shopify/cli-kit/node/environment'
 import {UnauthorizedHandler} from '@shopify/cli-kit/node/api/graphql'
 import {JsonMapType} from '@shopify/cli-kit/node/toml'
 
@@ -64,40 +62,12 @@ export type Paginateable<T> = T & {
   hasMorePages: boolean
 }
 
-interface SelectDeveloperPlatformClientOptions {
-  organization?: Organization
-}
-
 export interface AppVersionIdentifiers {
   appVersionId: number
   versionId: string
 }
 
-export function allDeveloperPlatformClients(): DeveloperPlatformClient[] {
-  const clients: DeveloperPlatformClient[] = []
-
-  clients.push(AppManagementClient.getInstance())
-
-  if (!blockPartnersAccess()) {
-    clients.push(PartnersClient.getInstance())
-  }
-
-  return clients
-}
-
-export function selectDeveloperPlatformClient({
-  organization,
-}: SelectDeveloperPlatformClientOptions = {}): DeveloperPlatformClient {
-  if (organization) return selectDeveloperPlatformClientByOrg(organization)
-  return defaultDeveloperPlatformClient()
-}
-
-function selectDeveloperPlatformClientByOrg(organization: Organization): DeveloperPlatformClient {
-  if (organization.source === OrganizationSource.BusinessPlatform) return AppManagementClient.getInstance()
-  return PartnersClient.getInstance()
-}
-
-function defaultDeveloperPlatformClient(): DeveloperPlatformClient {
+export function defaultDeveloperPlatformClient(): DeveloperPlatformClient {
   return AppManagementClient.getInstance()
 }
 

--- a/packages/cli-kit/src/private/node/constants.ts
+++ b/packages/cli-kit/src/private/node/constants.ts
@@ -44,7 +44,6 @@ export const environmentVariables = {
   otelURL: 'SHOPIFY_CLI_OTEL_EXPORTER_OTLP_ENDPOINT',
   themeKitAccessDomain: 'SHOPIFY_CLI_THEME_KIT_ACCESS_DOMAIN',
   json: 'SHOPIFY_FLAG_JSON',
-  neverUsePartnersApi: 'SHOPIFY_CLI_NEVER_USE_PARTNERS_API',
   skipNetworkLevelRetry: 'SHOPIFY_CLI_SKIP_NETWORK_LEVEL_RETRY',
   maxRequestTimeForNetworkCalls: 'SHOPIFY_CLI_MAX_REQUEST_TIME_FOR_NETWORK_CALLS',
   disableImportScanning: 'SHOPIFY_CLI_DISABLE_IMPORT_SCANNING',

--- a/packages/cli-kit/src/public/node/api/partners.test.ts
+++ b/packages/cli-kit/src/public/node/api/partners.test.ts
@@ -1,8 +1,6 @@
 import {partnersRequest, handleDeprecations} from './partners.js'
 import {graphqlRequest, GraphQLResponse} from './graphql.js'
 import {partnersFqdn} from '../context/fqdn.js'
-import {blockPartnersAccess} from '../environment.js'
-import {BugError} from '../error.js'
 import {setNextDeprecationDate} from '../../../private/node/context/deprecations-store.js'
 
 import {test, vi, expect, describe, beforeEach, beforeAll} from 'vitest'
@@ -10,7 +8,6 @@ import {test, vi, expect, describe, beforeEach, beforeAll} from 'vitest'
 vi.mock('./graphql.js')
 vi.mock('../../../private/node/context/deprecations-store.js')
 vi.mock('../context/fqdn.js')
-vi.mock('../environment.js')
 
 const mockedResult = 'OK'
 const partnersFQDN = 'partners.shopify.com'
@@ -20,7 +17,6 @@ const mockedToken = 'token'
 
 beforeEach(() => {
   vi.mocked(partnersFqdn).mockResolvedValue(partnersFQDN)
-  vi.mocked(blockPartnersAccess).mockReturnValue(false)
 })
 
 describe('partnersRequest', () => {
@@ -42,27 +38,6 @@ describe('partnersRequest', () => {
     })
   })
 
-  test('throws BugError when blockPartnersAccess returns true', async () => {
-    // Given
-    vi.mocked(blockPartnersAccess).mockReturnValue(true)
-
-    // When/Then
-    await expect(partnersRequest('query', mockedToken, {variables: 'variables'})).rejects.toThrow(BugError)
-    expect(blockPartnersAccess).toHaveBeenCalled()
-  })
-
-  test('does not throw when blockPartnersAccess returns false', async () => {
-    // Given
-    vi.mocked(blockPartnersAccess).mockReturnValue(false)
-    vi.mocked(graphqlRequest).mockResolvedValue(mockedResult)
-
-    // When
-    await partnersRequest('query', mockedToken, {variables: 'variables'})
-
-    // Then
-    expect(blockPartnersAccess).toHaveBeenCalled()
-    expect(graphqlRequest).toHaveBeenCalled()
-  })
 })
 
 describe('handleDeprecations', () => {

--- a/packages/cli-kit/src/public/node/api/partners.test.ts
+++ b/packages/cli-kit/src/public/node/api/partners.test.ts
@@ -37,7 +37,6 @@ describe('partnersRequest', () => {
       responseOptions: {onResponse: handleDeprecations},
     })
   })
-
 })
 
 describe('handleDeprecations', () => {

--- a/packages/cli-kit/src/public/node/api/partners.ts
+++ b/packages/cli-kit/src/public/node/api/partners.ts
@@ -11,10 +11,9 @@ import {partnersFqdn} from '../context/fqdn.js'
 import {setNextDeprecationDate} from '../../../private/node/context/deprecations-store.js'
 import {getPackageManager} from '../node-package-manager.js'
 import {cwd} from '../path.js'
-import {AbortError, BugError} from '../error.js'
+import {AbortError} from '../error.js'
 import {formatPackageManagerCommand} from '../output.js'
 import {RequestModeInput} from '../http.js'
-import {blockPartnersAccess} from '../environment.js'
 import Bottleneck from 'bottleneck'
 
 import {Variables} from 'graphql-request'
@@ -34,10 +33,6 @@ const limiter = new Bottleneck({
  * @param token - Partners token.
  */
 async function setupRequest(token: string) {
-  if (blockPartnersAccess()) {
-    throw new BugError('Partners API is no longer available.')
-  }
-
   const api = 'Partners'
   const fqdn = await partnersFqdn()
   const url = `https://${fqdn}/api/cli/graphql`

--- a/packages/cli-kit/src/public/node/environment.ts
+++ b/packages/cli-kit/src/public/node/environment.ts
@@ -77,15 +77,6 @@ export function jsonOutputEnabled(environment = getEnvironmentVariables()): bool
 }
 
 /**
- * If true, the CLI should not use the Partners API.
- *
- * @returns True when the CLI should not use the Partners API.
- */
-export function blockPartnersAccess(): boolean {
-  return isTruthy(getEnvironmentVariables()[environmentVariables.neverUsePartnersApi])
-}
-
-/**
  * If true, the CLI should not use the network level retry.
  *
  * If there is an error when calling a network API that looks like a DNS or connectivity issue, the CLI will by default

--- a/packages/e2e/setup/app.ts
+++ b/packages/e2e/setup/app.ts
@@ -249,13 +249,6 @@ export async function versionsList(
  *                                         In CI mode Ink suppresses prompt frames
  *                                         (only emitted on unmount), so waitForOutput
  *                                         hangs until the process is killed.
- *   SHOPIFY_CLI_NEVER_USE_PARTNERS_API=1 — skip Partners client in fetchOrganizations.
- *                                         Without this, fetchOrganizations iterates
- *                                         AppManagement AND Partners sequentially.
- *                                         Partners requires SHOPIFY_CLI_PARTNERS_TOKEN
- *                                         (not set in OAuth-auth'd tests) and hangs
- *                                         for minutes trying to authenticate. The e2e
- *                                         test org (161686155) lives in AppManagement.
  */
 export async function configLink(
   ctx: CLIContext & {
@@ -276,7 +269,6 @@ export async function configLink(
   const proc = await ctx.cli.spawn(args, {
     env: {
       CI: undefined,
-      SHOPIFY_CLI_NEVER_USE_PARTNERS_API: '1',
     },
   })
 


### PR DESCRIPTION
## What
Remove the remaining Partners client selection path and use App Management as the default developer platform client.

## Testing
- pnpm test packages/app/src/cli/commands/app/init.test.ts packages/app/src/cli/services/context.test.ts packages/app/src/cli/services/dev/fetch.test.ts packages/app/src/cli/services/app/config/link-service.test.ts packages/cli-kit/src/public/node/api/partners.test.ts