### PR TITLE
[Tests] Add unit tests for logs utility

### DIFF
--- a/packages/cli-kit/src/public/node/logs.test.ts
+++ b/packages/cli-kit/src/public/node/logs.test.ts
@@ -1,0 +1,51 @@
+import {getLogsDir, createLogsDir, writeLog} from './logs.js'
+import {inTemporaryDirectory, fileExists, readFile} from './fs.js'
+import {joinPath} from './path.js'
+import {logsFolder} from '../../private/node/constants.js'
+import {describe, expect, test, vi} from 'vitest'
+
+vi.mock('../../private/node/constants.js')
+
+describe('logs', () => {
+  test('getLogsDir returns the logs directory', () => {
+    // Given
+    vi.mocked(logsFolder).mockReturnValue('/tmp/logs')
+
+    // When
+    const got = getLogsDir()
+
+    // Then
+    expect(got).toBe('/tmp/logs')
+  })
+
+  test('createLogsDir creates a directory inside the logs directory', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      vi.mocked(logsFolder).mockReturnValue(tmpDir)
+      const subDir = 'test-dir'
+
+      // When
+      await createLogsDir(subDir)
+
+      // Then
+      const got = await fileExists(joinPath(tmpDir, subDir))
+      expect(got).toBe(true)
+    })
+  })
+
+  test('writeLog writes the log data to a file inside the logs directory', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      vi.mocked(logsFolder).mockReturnValue(tmpDir)
+      const logFile = 'test-log.txt'
+      const logData = 'test-data'
+
+      // When
+      await writeLog(logFile, logData)
+
+      // Then
+      const got = await readFile(joinPath(tmpDir, logFile))
+      expect(got).toBe(logData)
+    })
+  })
+})


### PR DESCRIPTION
### WHY are these changes introduced?

The `packages/cli-kit/src/public/node/logs.ts` module currently has no dedicated unit tests, leaving its core functionality (getting, creating, and writing logs) uncovered.

### WHAT is this pull request doing?

Introduces unit tests for `getLogsDir`, `createLogsDir`, and `writeLog` in `packages/cli-kit/src/public/node/logs.test.ts`. The tests use real filesystem operations within temporary directories to ensure correctness without mocking the filesystem.

### How to test your changes?

CI

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [8371235244701222105](https://jules.google.com/task/8371235244701222105) started by @gonzaloriestra*