### PR TITLE
[Refactor] Modernize addResolutionOrOverride in node-package-manager.ts

### DIFF
--- a/packages/cli-kit/src/public/node/node-package-manager.ts
+++ b/packages/cli-kit/src/public/node/node-package-manager.ts
@@ -722,21 +722,15 @@ export async function findUpAndReadPackageJson(fromDirectory: string): Promise<{
 
 export async function addResolutionOrOverride(directory: string, dependencies: Record<string, string>): Promise<void> {
   const packageManager = await getPackageManager(directory)
-  const packageJsonPath = joinPath(directory, 'package.json')
-  const packageJsonContent = await readAndParsePackageJson(packageJsonPath)
+  const packageJsonContent = await readAndParsePackageJson(joinPath(directory, 'package.json'))
 
-  if (packageManager === 'yarn') {
-    packageJsonContent.resolutions = packageJsonContent.resolutions
-      ? {...packageJsonContent.resolutions, ...dependencies}
-      : dependencies
-  }
-  if (packageManager === 'npm' || packageManager === 'pnpm' || packageManager === 'bun') {
-    packageJsonContent.overrides = packageJsonContent.overrides
-      ? {...packageJsonContent.overrides, ...dependencies}
-      : dependencies
+  const key: keyof PackageJson = packageManager === 'yarn' ? 'resolutions' : 'overrides'
+  packageJsonContent[key] = {
+    ...(packageJsonContent[key] as Record<string, string>),
+    ...dependencies,
   }
 
-  await writeFile(packageJsonPath, JSON.stringify(packageJsonContent, null, 2))
+  await writePackageJSON(directory, packageJsonContent)
 }
 
 /**


### PR DESCRIPTION
### WHY are these changes introduced?

Improve code readability and maintainability by using a more declarative approach and leveraging existing helpers.

### WHAT is this pull request doing?

Refactors `addResolutionOrOverride` in `packages/cli-kit/src/public/node/node-package-manager.ts` to:
- Replace imperative `if` blocks for package manager checks with a declarative property lookup for `resolutions` or `overrides`.
- Use the `writePackageJSON` helper instead of manual `writeFile` and `JSON.stringify` calls.

### How to test your changes?

CI

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`


---
*PR created automatically by Jules for task [14636034994671192679](https://jules.google.com/task/14636034994671192679) started by @gonzaloriestra*