### PR TITLE
Type preview store client test double

### DIFF
--- a/packages/store/src/cli/services/store/create/preview/index.test.ts
+++ b/packages/store/src/cli/services/store/create/preview/index.test.ts
@@ -1,6 +1,7 @@
 import {createPreviewStoreCommand} from './index.js'
 import {STORE_AUTH_APP_CLIENT_ID} from '../../auth/config.js'
 import {describe, expect, test, vi} from 'vitest'
+import type {PreviewStoreClientOptions} from './client.js'
 
 describe('preview store create service', () => {
   test('persists the created preview store in the store-auth cache', async () => {
@@ -84,7 +85,7 @@ describe('preview store create service', () => {
   })
 
   test('passes client options to the create request', async () => {
-    const client = {} as any
+    const client: PreviewStoreClientOptions = {}
     const createPreviewStore = vi.fn(async () => ({
       shop: {id: '123', name: 'Lavender Candles', domain: 'x12y45z.myshopify.com'},
       adminApiToken: 'shpat_token',


### PR DESCRIPTION
### WHY are these changes introduced?

A preview-store create service test used `as any` for a client options test double even though a narrow exported type is available.

### WHAT is this pull request doing?

Imports `PreviewStoreClientOptions` as a type and uses it for the test client object instead of casting to `any`.

### How to test your changes?

```bash
pnpm nx run cli-kit:build --skip-nx-cache
pnpm nx run organizations:build --skip-nx-cache
pnpm --dir packages/store vitest src/cli/services/store/create/preview/index.test.ts
pnpm --dir packages/store type-check
pnpm --dir packages/store lint
```

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [x] This change is not user-facing; no changeset is needed.
