### PR TITLE
Fix warning when running theme commands in valid theme directories

### DIFF
--- a/.changeset/fix-theme-directory-warning.md
+++ b/.changeset/fix-theme-directory-warning.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Fix warning when running theme commands in valid theme directories

--- a/.changeset/fix-theme-directory-warning.md
+++ b/.changeset/fix-theme-directory-warning.md
@@ -1,5 +1,0 @@
----
-'@shopify/theme': patch
----
-
-Fix warning when running theme commands in valid theme directories

--- a/packages/theme/src/cli/utilities/theme-fs.test.ts
+++ b/packages/theme/src/cli/utilities/theme-fs.test.ts
@@ -628,6 +628,22 @@ describe('theme-fs', () => {
         expect(result).toBeFalsy()
       })
     })
+
+    test(`returns true for a valid theme directory`, async () => {
+      await inTemporaryDirectory(async (tmpDir) => {
+        // Given
+        const root = tmpDir
+        await mkdir(joinPath(root, 'config'))
+        await mkdir(joinPath(root, 'layout'))
+        await mkdir(joinPath(root, 'templates'))
+
+        // When
+        const result = await hasRequiredThemeDirectories(root)
+
+        // Then
+        expect(result).toBeTruthy()
+      })
+    })
   })
 
   describe('listing functionality', () => {

--- a/packages/theme/src/cli/utilities/theme-fs.ts
+++ b/packages/theme/src/cli/utilities/theme-fs.ts
@@ -547,8 +547,7 @@ export async function hasRequiredThemeDirectories(path: string) {
     }),
   )
 
-  const requiredDirectories = ['config', 'layout', 'sections', 'templates']
-
+  const requiredDirectories = ['config', 'layout', 'templates']
   return requiredDirectories.every((dir) => directories.has(dir))
 }
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fix warning when running theme commands in valid theme directories.

### WHAT is this pull request doing?

Updating the list of required directories.

### Post-release steps

N/A

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [x] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`
