### PR TITLE
[4.5] Fix warning when running theme commands in valid theme directories

### DIFF
--- a/.changeset/fix-theme-directory-warning.md
+++ b/.changeset/fix-theme-directory-warning.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Fix warning when running theme commands in valid theme directories

--- a/packages/theme/src/cli/utilities/theme-fs.test.ts
+++ b/packages/theme/src/cli/utilities/theme-fs.test.ts
@@ -628,6 +628,22 @@ describe('theme-fs', () => {
         expect(result).toBeFalsy()
       })
     })
+
+    test(`returns true for a valid theme directory`, async () => {
+      await inTemporaryDirectory(async (tmpDir) => {
+        // Given
+        const root = tmpDir
+        await mkdir(joinPath(root, 'config'))
+        await mkdir(joinPath(root, 'layout'))
+        await mkdir(joinPath(root, 'templates'))
+
+        // When
+        const result = await hasRequiredThemeDirectories(root)
+
+        // Then
+        expect(result).toBeTruthy()
+      })
+    })
   })
 
   describe('listing functionality', () => {

--- a/packages/theme/src/cli/utilities/theme-fs.ts
+++ b/packages/theme/src/cli/utilities/theme-fs.ts
@@ -547,8 +547,7 @@ export async function hasRequiredThemeDirectories(path: string) {
     }),
   )
 
-  const requiredDirectories = ['config', 'layout', 'sections', 'templates']
-
+  const requiredDirectories = ['config', 'layout', 'templates']
   return requiredDirectories.every((dir) => directories.has(dir))
 }
 


### PR DESCRIPTION
Back-port https://github.com/Shopify/cli/pull/8092