### PR TITLE
Regenerate command tree snapshot

### DIFF
--- a/packages/e2e/data/snapshots/commands.txt
+++ b/packages/e2e/data/snapshots/commands.txt
@@ -98,13 +98,18 @@
 ├─ search
 ├─ store
 │  ├─ auth
+│  │  └─ list
 │  ├─ bulk
 │  │  ├─ cancel
 │  │  ├─ execute
 │  │  └─ status
+│  ├─ create
+│  │  └─ preview
 │  ├─ execute
 │  ├─ graphiql
-│  └─ info
+│  ├─ info
+│  ├─ list
+│  └─ open
 ├─ theme
 │  ├─ check
 │  ├─ console


### PR DESCRIPTION
### WHY are these changes introduced?

The E2E command tree snapshot is stale after new `shopify store` subcommands were added. This causes `shopify commands --tree matches snapshot` to fail in PR CI.

### WHAT is this pull request doing?

Regenerates `packages/e2e/data/snapshots/commands.txt` from latest `origin/main` so it includes the current store command tree.

### How to test your changes?

```bash
pnpm nx run cli:build --skip-nx-cache
pnpm test:regenerate-snapshots
pnpm --dir packages/e2e exec playwright test tests/commands.spec.ts
```

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [x] This change is generated test snapshot maintenance; no changeset is needed.
