### PR TITLE
[Refactor] node-package-manager: modernize dependency argument generation

### DIFF
--- a/packages/cli-kit/src/public/node/node-package-manager.ts
+++ b/packages/cli-kit/src/public/node/node-package-manager.ts
@@ -600,19 +600,13 @@ export async function addNPMDependenciesWithoutVersionIfNeeded(
  * @returns An array with the arguments.
  */
 function argumentsToAddDependenciesWithNPM(dependency: string, type: DependencyType): string[] {
-  let command = ['install']
-  command = command.concat(dependency)
-  switch (type) {
-    case 'dev':
-      command.push('--save-dev')
-      break
-    case 'peer':
-      command.push('--save-peer')
-      break
-    case 'prod':
-      command.push('--save-prod')
-      break
+  const typeFlags: Record<DependencyType, string> = {
+    dev: '--save-dev',
+    peer: '--save-peer',
+    prod: '--save-prod',
   }
+
+  const command = ['install', dependency, typeFlags[type]]
   // NPM adds ^ to the installed version by default. We want to install exact versions unless specified otherwise.
   if (dependency.match(/@\d/g)) {
     command.push('--save-exact')
@@ -628,25 +622,13 @@ function argumentsToAddDependenciesWithNPM(dependency: string, type: DependencyT
  * @returns An array with the arguments.
  */
 function argumentsToAddDependenciesWithYarn(dependencies: string[], type: DependencyType, addAtRoot = false): string[] {
-  let command = ['add']
-
-  if (addAtRoot) {
-    command.push('-W')
+  const typeFlags: Record<DependencyType, string> = {
+    dev: '--dev',
+    peer: '--peer',
+    prod: '--prod',
   }
 
-  command = command.concat(dependencies)
-  switch (type) {
-    case 'dev':
-      command.push('--dev')
-      break
-    case 'peer':
-      command.push('--peer')
-      break
-    case 'prod':
-      command.push('--prod')
-      break
-  }
-  return command
+  return ['add', ...(addAtRoot ? ['-W'] : []), ...dependencies, typeFlags[type]]
 }
 
 /**
@@ -657,26 +639,13 @@ function argumentsToAddDependenciesWithYarn(dependencies: string[], type: Depend
  * @returns An array with the arguments.
  */
 function argumentsToAddDependenciesWithPNPM(dependencies: string[], type: DependencyType, addAtRoot = false): string[] {
-  let command = ['add']
-
-  if (addAtRoot) {
-    command.push('-w')
+  const typeFlags: Record<DependencyType, string> = {
+    dev: '--save-dev',
+    peer: '--save-peer',
+    prod: '--save-prod',
   }
 
-  command = command.concat(dependencies)
-
-  switch (type) {
-    case 'dev':
-      command.push('--save-dev')
-      break
-    case 'peer':
-      command.push('--save-peer')
-      break
-    case 'prod':
-      command.push('--save-prod')
-      break
-  }
-  return command
+  return ['add', ...(addAtRoot ? ['-w'] : []), ...dependencies, typeFlags[type]]
 }
 
 /**
@@ -686,21 +655,13 @@ function argumentsToAddDependenciesWithPNPM(dependencies: string[], type: Depend
  * @returns An array with the arguments.
  */
 function argumentsToAddDependenciesWithBun(dependencies: string[], type: DependencyType): string[] {
-  let command = ['add']
-
-  command = command.concat(dependencies)
-
-  switch (type) {
-    case 'dev':
-      command.push('--development')
-      break
-    case 'peer':
-      command.push('--optional')
-      break
-    case 'prod':
-      break
+  const typeFlags: Partial<Record<DependencyType, string>> = {
+    dev: '--development',
+    peer: '--optional',
   }
-  return command
+
+  const flag = typeFlags[type]
+  return ['add', ...dependencies, ...(flag ? [flag] : [])]
 }
 
 /**


### PR DESCRIPTION
### Description
Refactor the dependency manager argument generation functions in `packages/cli-kit/src/public/node/node-package-manager.ts` to use declarative lookup maps and the spread operator, replacing imperative switch statements and array mutations.

### How to test your changes?
CI

---
*PR created automatically by Jules for task [10241706994235240830](https://jules.google.com/task/10241706994235240830) started by @gonzaloriestra*