### PR TITLE
[Tests] Add unit tests for isTruthy

### DIFF
--- a/packages/cli-kit/src/public/node/context/utilities.test.ts
+++ b/packages/cli-kit/src/public/node/context/utilities.test.ts
@@ -1,0 +1,48 @@
+import {isTruthy} from './utilities.js'
+import {describe, expect, test} from 'vitest'
+
+describe('isTruthy', () => {
+  test('returns true for "1"', () => {
+    expect(isTruthy('1')).toBe(true)
+  })
+
+  test('returns true for "true"', () => {
+    expect(isTruthy('true')).toBe(true)
+  })
+
+  test('returns true for "TRUE"', () => {
+    expect(isTruthy('TRUE')).toBe(true)
+  })
+
+  test('returns true for "yes"', () => {
+    expect(isTruthy('yes')).toBe(true)
+  })
+
+  test('returns true for "YES"', () => {
+    expect(isTruthy('YES')).toBe(true)
+  })
+
+  test('returns false for "0"', () => {
+    expect(isTruthy('0')).toBe(false)
+  })
+
+  test('returns false for "false"', () => {
+    expect(isTruthy('false')).toBe(false)
+  })
+
+  test('returns false for "no"', () => {
+    expect(isTruthy('no')).toBe(false)
+  })
+
+  test('returns false for undefined', () => {
+    expect(isTruthy(undefined)).toBe(false)
+  })
+
+  test('returns false for an empty string', () => {
+    expect(isTruthy('')).toBe(false)
+  })
+
+  test('returns false for a random string', () => {
+    expect(isTruthy('random')).toBe(false)
+  })
+})


### PR DESCRIPTION
### WHY are these changes introduced?

The `isTruthy` utility function in `packages/cli-kit` was identified as having no dedicated unit tests, despite being used extensively for environment variable parsing across the codebase.

### WHAT is this pull request doing?

This PR adds a new test file `packages/cli-kit/src/public/node/context/utilities.test.ts` with comprehensive unit tests for the `isTruthy` function. It verifies:
- Truthy values: '1', 'true', 'TRUE', 'yes', 'YES'.
- Falsy values: '0', 'false', 'no', `undefined`, empty strings, and random strings.

### How to test your changes?

CI

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [6457867811018968403](https://jules.google.com/task/6457867811018968403) started by @gonzaloriestra*