### PR TITLE
[codex] Fix --path parsing for paths containing equals signs

### DIFF
--- a/.changeset/preserve-path-flag-equals.md
+++ b/.changeset/preserve-path-flag-equals.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': patch
+---
+
+Preserve equals signs in project paths passed with `--path=`.

--- a/packages/cli-kit/src/public/node/path.test.ts
+++ b/packages/cli-kit/src/public/node/path.test.ts
@@ -92,4 +92,15 @@ describe('sniffForPath', () => {
     // Then
     expect(path).toStrictEqual('/path/to/project')
   })
+
+  test('returns the entire path if it contains =', () => {
+    // Given
+    const argv = ['node', 'script.js', '--path=/path/to/project=name']
+
+    // When
+    const path = sniffForPath(argv)
+
+    // Then
+    expect(path).toStrictEqual('/path/to/project=name')
+  })
 })

--- a/packages/cli-kit/src/public/node/path.ts
+++ b/packages/cli-kit/src/public/node/path.ts
@@ -188,8 +188,9 @@ export function cwd(): string {
 export function sniffForPath(argv = process.argv): string | undefined {
   const pathFlagIndex = argv.indexOf('--path')
   if (pathFlagIndex === -1) {
-    const pathArg = argv.find((arg) => arg.startsWith('--path='))
-    return pathArg?.split('=')[1]
+    const pathFlagPrefix = '--path='
+    const pathArg = argv.find((arg) => arg.startsWith(pathFlagPrefix))
+    return pathArg?.slice(pathFlagPrefix.length)
   }
   const pathFlag = argv[pathFlagIndex + 1]
   if (!pathFlag || pathFlag.startsWith('-')) return


### PR DESCRIPTION
﻿### WHY are these changes introduced?

`sniffForPath()` parsed the `--path=<value>` form with `split('=')[1]`. Paths containing an equals sign were truncated after the first path segment, which could make project-local detection and upgrade resolution use the wrong directory.

### WHAT is this pull request doing?

- Extract the path by removing the known `--path=` prefix, preserving the remainder verbatim.
- Add a regression test for a path containing an equals sign.
- Add a patch changeset for `@shopify/cli-kit`.

### How to test your changes?

```sh
pnpm vitest run packages/cli-kit/src/public/node/path.test.ts packages/cli-kit/src/public/node/is-global.test.ts packages/cli-kit/src/public/node/upgrade.test.ts
pnpm eslint packages/cli-kit/src/public/node/path.ts packages/cli-kit/src/public/node/path.test.ts
pnpm nx run cli-kit:type-check --skip-nx-cache
pnpm nx run cli-kit:build --skip-nx-cache
pnpm exec changeset status --since=origin/main
git diff --check
```

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible documentation changes; none are needed
- [x] I've considered analytics changes; none are needed
- [x] The change is user-facing and includes a patch changeset
