### PR TITLE
Avoid leaking filesystem watchers in theme tests

### DIFF
--- a/packages/theme/src/cli/utilities/theme-fs.test.ts
+++ b/packages/theme/src/cli/utilities/theme-fs.test.ts
@@ -137,7 +137,8 @@ describe('theme-fs', () => {
         // Given
         const root = tmpDir
         await copyDirectoryContents(joinPath(locationOfThisFile, 'fixtures/theme'), root)
-        const watchSpy = vi.spyOn(chokidar, 'watch')
+        const mockWatcher = new EventEmitter()
+        const watchSpy = vi.spyOn(chokidar, 'watch').mockReturnValue(mockWatcher as any)
 
         // When
         const themeFileSystem = mountThemeFileSystem(root, {listing: 'modern'})
@@ -157,7 +158,8 @@ describe('theme-fs', () => {
         // Given
         const root = tmpDir
         await copyDirectoryContents(joinPath(locationOfThisFile, 'fixtures/theme'), root)
-        const watchSpy = vi.spyOn(chokidar, 'watch')
+        const mockWatcher = new EventEmitter()
+        const watchSpy = vi.spyOn(chokidar, 'watch').mockReturnValue(mockWatcher as any)
 
         // When
         const themeFileSystem = mountThemeFileSystem(root)


### PR DESCRIPTION
### WHY are these changes introduced?

The Windows Node 22 unit-test shard in #8051 completed all 2,505 assertions successfully, but Vitest reported six unhandled errors afterward:

```
EPERM: operation not permitted, watch
```

Two `theme-fs.test.ts` tests spied on `chokidar.watch` while still creating real filesystem watchers. Their temporary directories could be removed while those watchers remained active, causing asynchronous errors on Windows.

### WHAT is this pull request doing?

Mocks the Chokidar watcher in both directory-selection tests. The tests continue to verify the paths passed to `watch` without opening operating-system watchers.

This commit is cherry-picked from #8009 with its original authorship preserved. This draft should be closed if #8009 merges first.

### How to test your changes?

- `pnpm --filter @shopify/theme vitest run src/cli/utilities/theme-fs.test.ts`
- `pnpm --filter @shopify/theme lint`
- `pnpm --filter @shopify/theme type-check`
- `git diff --check`

### Checklist

- [x] I've considered cross-platform impacts
- [x] No changeset: test-only fix
