### PR TITLE
Remove ts-ignore suppressions from payload store tests

### DIFF
--- a/packages/app/src/cli/services/dev/extension/payload/store.test.ts
+++ b/packages/app/src/cli/services/dev/extension/payload/store.test.ts
@@ -169,10 +169,7 @@ describe('ExtensionsPayloadStore()', () => {
 
       // Then
       expect(extensionsPayloadStore.getRawPayload().extensions.length).toEqual(1)
-      expect(extensionsPayloadStore.getRawPayload().extensions[0]?.uuid).toEqual('123')
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
-      expect(extensionsPayloadStore.getRawPayload().extensions[0]?.test).toEqual('value')
+      expect(extensionsPayloadStore.getRawPayload().extensions[0]).toMatchObject({uuid: '123', test: 'value'})
     })
 
     test('deep merge extension points with incoming payload when the target matches', () => {
@@ -204,8 +201,6 @@ describe('ExtensionsPayloadStore()', () => {
       ] as unknown as UIExtensionPayload[])
 
       // Then
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
       expect(extensionsPayloadStore.getRawPayload().extensions[0]).toMatchObject({
         uuid: '123',
         extensionPoints: [


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes none.

The payload store tests used `@ts-ignore` to assert test-only merged payload fields, which made the assertions less type-safe than necessary.

### WHAT is this pull request doing?

Removes the `@ts-ignore` suppressions by asserting the updated extension payload with `toMatchObject` instead of accessing ad-hoc fields directly.

### How to test your changes?

- `pnpm --filter @shopify/app vitest run src/cli/services/dev/extension/payload/store.test.ts`
- `pnpm --filter @shopify/app lint`

Note: `pnpm --filter @shopify/app type-check` was attempted locally but failed on existing `@shopify/organizations` resolution/type errors unrelated to this test-only diff.

### Post-release steps

None.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`
