### PR TITLE
Extract MigrationDeveloperPlatformClient interface

### DIFF
--- a/packages/app/src/cli/models/app/app.test-data.ts
+++ b/packages/app/src/cli/models/app/app.test-data.ts
@@ -34,6 +34,7 @@ import {
   ClientName,
   CreateAppOptions,
   DeveloperPlatformClient,
+  MigrationDeveloperPlatformClient,
   DevSessionCreateOptions,
   DevSessionDeleteOptions,
   DevSessionUpdateOptions,
@@ -1300,8 +1301,12 @@ const appLogsSubscribeResponse: AppLogsSubscribeResponse = {
   },
 }
 
-export function testDeveloperPlatformClient(stubs: Partial<DeveloperPlatformClient> = {}): DeveloperPlatformClient {
-  const clientStub: DeveloperPlatformClient = {
+type TestDeveloperPlatformClient = DeveloperPlatformClient & MigrationDeveloperPlatformClient
+
+export function testDeveloperPlatformClient(
+  stubs: Partial<TestDeveloperPlatformClient> = {},
+): TestDeveloperPlatformClient {
+  const clientStub: TestDeveloperPlatformClient = {
     clientName: ClientName.AppManagement,
     webUiName: 'Test Dashboard',
     organizationSource: OrganizationSource.BusinessPlatform,
@@ -1374,15 +1379,18 @@ export function testDeveloperPlatformClient(stubs: Partial<DeveloperPlatformClie
       ),
     ...stubs,
   }
-  const retVal: Partial<DeveloperPlatformClient> = clientStub
+  const retVal: Partial<TestDeveloperPlatformClient> = clientStub
   for (const [key, value] of Object.entries(clientStub)) {
     if (typeof value === 'function') {
       retVal[
-        key as keyof Omit<DeveloperPlatformClient, 'clientName' | 'webUiName' | 'organizationSource' | 'bundleFormat'>
+        key as keyof Omit<
+          TestDeveloperPlatformClient,
+          'clientName' | 'webUiName' | 'organizationSource' | 'bundleFormat'
+        >
       ] = vi.fn().mockImplementation(value)
     }
   }
-  return retVal as DeveloperPlatformClient
+  return retVal as TestDeveloperPlatformClient
 }
 
 export const testPartnersServiceSession: Session = {

--- a/packages/app/src/cli/services/context/deploy-app-version-migrations.ts
+++ b/packages/app/src/cli/services/context/deploy-app-version-migrations.ts
@@ -10,7 +10,7 @@ import {
   migrateAppModules,
   UIModulesMap,
 } from '../dev/migrate-app-module.js'
-import {DeveloperPlatformClient} from '../../utilities/developer-platform-client.js'
+import {MigrationDeveloperPlatformClient} from '../../utilities/developer-platform-client.js'
 import {PartnersClient} from '../../utilities/developer-platform-client/partners-client.js'
 import {AbortSilentError} from '@shopify/cli-kit/node/error'
 
@@ -94,7 +94,7 @@ function migrationGroup(typesMap: {[key: string]: string[]}, type: string) {
       extensionsToMigrate: Parameters<typeof migrateAppModules>[0]['extensionsToMigrate']
       appId: string
       remoteExtensions: RemoteSource[]
-      migrationClient: DeveloperPlatformClient
+      migrationClient: MigrationDeveloperPlatformClient
     }) => migrateAppModules({...options, type}),
   }
 }

--- a/packages/app/src/cli/services/dev/fetch.test.ts
+++ b/packages/app/src/cli/services/dev/fetch.test.ts
@@ -45,7 +45,7 @@ describe('fetchOrganizations', async () => {
     // Given
     const appManagementClient: AppManagementClient = testDeveloperPlatformClient({
       organizations: () => Promise.resolve([ORG2]),
-    }) as AppManagementClient
+    }) as unknown as AppManagementClient
     vi.mocked(AppManagementClient.getInstance).mockReturnValue(appManagementClient)
 
     // When
@@ -60,7 +60,7 @@ describe('fetchOrganizations', async () => {
     // Given
     const appManagementClient: AppManagementClient = testDeveloperPlatformClient({
       organizations: () => Promise.resolve([]),
-    }) as AppManagementClient
+    }) as unknown as AppManagementClient
     vi.mocked(AppManagementClient.getInstance).mockReturnValue(appManagementClient)
 
     // When

--- a/packages/app/src/cli/services/dev/migrate-app-module.ts
+++ b/packages/app/src/cli/services/dev/migrate-app-module.ts
@@ -1,6 +1,6 @@
 import {LocalSource, RemoteSource} from '../context/identifiers.js'
 import {ExtensionUuidsByLocalIdentifier} from '../../models/app/identifiers.js'
-import {DeveloperPlatformClient} from '../../utilities/developer-platform-client.js'
+import {MigrationDeveloperPlatformClient} from '../../utilities/developer-platform-client.js'
 import {MigrateAppModuleSchema, MigrateAppModuleVariables} from '../../api/graphql/extension_migrate_app_module.js'
 import {MAX_EXTENSION_HANDLE_LENGTH} from '../../models/extensions/schemas.js'
 import {AbortError} from '@shopify/cli-kit/node/error'
@@ -91,7 +91,7 @@ export async function migrateAppModules(options: {
   appId: string
   type: string
   remoteExtensions: RemoteSource[]
-  migrationClient: DeveloperPlatformClient
+  migrationClient: MigrationDeveloperPlatformClient
 }) {
   const {extensionsToMigrate, appId, type, remoteExtensions, migrationClient} = options
 
@@ -123,7 +123,7 @@ async function migrateAppModule(options: {
   registrationId: MigrateAppModuleVariables['registrationId']
   registrationUuid: MigrateAppModuleVariables['registrationUuid']
   type: MigrateAppModuleVariables['type']
-  migrationClient: DeveloperPlatformClient
+  migrationClient: MigrationDeveloperPlatformClient
 }) {
   const {apiKey, registrationId, registrationUuid, type, migrationClient} = options
 

--- a/packages/app/src/cli/services/dev/migrate-flow-extension.ts
+++ b/packages/app/src/cli/services/dev/migrate-flow-extension.ts
@@ -4,14 +4,14 @@ import {
   MigrateFlowExtensionSchema,
   MigrateFlowExtensionVariables,
 } from '../../api/graphql/extension_migrate_flow_extension.js'
-import {DeveloperPlatformClient} from '../../utilities/developer-platform-client.js'
+import {MigrationDeveloperPlatformClient} from '../../utilities/developer-platform-client.js'
 import {AbortError} from '@shopify/cli-kit/node/error'
 
 export async function migrateFlowExtensions(options: {
   extensionsToMigrate: LocalRemoteSource[]
   appId: string
   remoteExtensions: RemoteSource[]
-  migrationClient: DeveloperPlatformClient
+  migrationClient: MigrationDeveloperPlatformClient
 }) {
   const {extensionsToMigrate, appId, remoteExtensions, migrationClient} = options
 
@@ -46,7 +46,7 @@ async function migrateFlowExtension(options: {
   apiKey: MigrateFlowExtensionVariables['apiKey']
   registrationId: MigrateFlowExtensionVariables['registrationId']
   registrationUuid: MigrateFlowExtensionVariables['registrationUuid']
-  migrationClient: DeveloperPlatformClient
+  migrationClient: MigrationDeveloperPlatformClient
 }) {
   const {apiKey, registrationId, registrationUuid, migrationClient} = options
 

--- a/packages/app/src/cli/services/dev/migrate-to-ui-extension.ts
+++ b/packages/app/src/cli/services/dev/migrate-to-ui-extension.ts
@@ -4,14 +4,14 @@ import {
   MigrateToUiExtensionVariables,
 } from '../../api/graphql/extension_migrate_to_ui_extension.js'
 import {RemoteSource} from '../context/identifiers.js'
-import {DeveloperPlatformClient} from '../../utilities/developer-platform-client.js'
+import {MigrationDeveloperPlatformClient} from '../../utilities/developer-platform-client.js'
 import {AbortError} from '@shopify/cli-kit/node/error'
 
 export async function migrateExtensionsToUIExtension(options: {
   extensionsToMigrate: LocalRemoteSource[]
   appId: string
   remoteExtensions: RemoteSource[]
-  migrationClient: DeveloperPlatformClient
+  migrationClient: MigrationDeveloperPlatformClient
 }) {
   const {extensionsToMigrate, appId, remoteExtensions, migrationClient} = options
 
@@ -41,7 +41,7 @@ async function migrateExtensionToUIExtension(options: {
   apiKey: MigrateToUiExtensionVariables['apiKey']
   registrationId: MigrateToUiExtensionVariables['registrationId']
   registrationUuid: MigrateToUiExtensionVariables['registrationUuid']
-  migrationClient: DeveloperPlatformClient
+  migrationClient: MigrationDeveloperPlatformClient
 }) {
   const {apiKey, registrationId, registrationUuid, migrationClient} = options
 

--- a/packages/app/src/cli/utilities/developer-platform-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client.ts
@@ -226,8 +226,6 @@ export interface DeveloperPlatformClient {
   sendSampleWebhook: (input: SendSampleWebhookVariables, organizationId: string) => Promise<SendSampleWebhookSchema>
   apiVersions: (organizationId: string) => Promise<PublicApiVersionsSchema>
   topics: (input: WebhookTopicsVariables, organizationId: string) => Promise<WebhookTopicsSchema>
-  migrateFlowExtension: (input: MigrateFlowExtensionVariables) => Promise<MigrateFlowExtensionSchema>
-  migrateAppModule: (input: MigrateAppModuleVariables) => Promise<MigrateAppModuleSchema>
   updateURLs: (input: UpdateURLsVariables) => Promise<UpdateURLsSchema>
   currentAccountInfo: () => Promise<CurrentAccountInfoQuery>
   targetSchemaDefinition: (
@@ -240,7 +238,6 @@ export interface DeveloperPlatformClient {
     apiKey: string,
     organizationId: string,
   ) => Promise<string | null>
-  migrateToUiExtension: (input: MigrateToUiExtensionVariables) => Promise<MigrateToUiExtensionSchema>
   toExtensionGraphQLType: (input: string) => string
   subscribeToAppLogs: (
     input: AppLogsSubscribeMutationVariables,
@@ -252,6 +249,18 @@ export interface DeveloperPlatformClient {
   devSessionUpdate: (input: DevSessionUpdateOptions) => Promise<DevSessionUpdateMutation>
   devSessionDelete: (input: DevSessionSharedOptions) => Promise<DevSessionDeleteMutation>
   getCreateDevStoreLink: (org: Organization) => Promise<TokenItem>
+}
+
+/**
+ * The legacy extension migrations (Flow, app module, and UI extension) are only implemented by
+ * {@link PartnersClient}; the default {@link AppManagementClient} does not support them. Keeping
+ * these mutations on a dedicated interface lets the migration callers depend on just this surface
+ * rather than the full {@link DeveloperPlatformClient}.
+ */
+export interface MigrationDeveloperPlatformClient {
+  migrateFlowExtension: (input: MigrateFlowExtensionVariables) => Promise<MigrateFlowExtensionSchema>
+  migrateAppModule: (input: MigrateAppModuleVariables) => Promise<MigrateAppModuleSchema>
+  migrateToUiExtension: (input: MigrateToUiExtensionVariables) => Promise<MigrateToUiExtensionSchema>
 }
 
 const inProgressRefreshes = new WeakMap<DeveloperPlatformClient, Promise<string>>()

--- a/packages/app/src/cli/utilities/developer-platform-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client.ts
@@ -263,7 +263,10 @@ export interface MigrationDeveloperPlatformClient {
   migrateToUiExtension: (input: MigrateToUiExtensionVariables) => Promise<MigrateToUiExtensionSchema>
 }
 
-const inProgressRefreshes = new WeakMap<DeveloperPlatformClient, Promise<string>>()
+/** The subset of a developer platform client needed to refresh an expired token. */
+type TokenRefreshableClient = Pick<DeveloperPlatformClient, 'session' | 'unsafeRefreshToken'>
+
+const inProgressRefreshes = new WeakMap<TokenRefreshableClient, Promise<string>>()
 
 /**
  * Creates an unauthorized handler for a developer platform client that will refresh the token
@@ -275,7 +278,7 @@ const inProgressRefreshes = new WeakMap<DeveloperPlatformClient, Promise<string>
  * @returns The unauthorized handler.
  */
 export function createUnauthorizedHandler(
-  client: DeveloperPlatformClient,
+  client: TokenRefreshableClient,
   tokenType: 'default' | 'businessPlatform' = 'default',
 ): UnauthorizedHandler {
   return {

--- a/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
@@ -53,18 +53,9 @@ import {
 } from '../../services/webhook/request-sample.js'
 import {PublicApiVersionsSchema} from '../../services/webhook/request-api-versions.js'
 import {WebhookTopicsSchema, WebhookTopicsVariables} from '../../services/webhook/request-topics.js'
-import {
-  MigrateFlowExtensionSchema,
-  MigrateFlowExtensionVariables,
-} from '../../api/graphql/extension_migrate_flow_extension.js'
 import {UpdateURLsSchema, UpdateURLsVariables} from '../../api/graphql/update_urls.js'
 import {CurrentAccountInfoQuery} from '../../api/graphql/partners/generated/current-account-info.js'
 import {ExtensionTemplate, ExtensionTemplatesResult} from '../../models/app/template.js'
-import {
-  MigrateToUiExtensionVariables,
-  MigrateToUiExtensionSchema,
-} from '../../api/graphql/extension_migrate_to_ui_extension.js'
-import {MigrateAppModuleSchema, MigrateAppModuleVariables} from '../../api/graphql/extension_migrate_app_module.js'
 import {AppHomeSpecIdentifier} from '../../models/extensions/specifications/app_config_app_home.js'
 import {BrandingSpecIdentifier} from '../../models/extensions/specifications/app_config_branding.js'
 import {AppAccessSpecIdentifier} from '../../models/extensions/specifications/app_config_app_access.js'
@@ -935,14 +926,6 @@ export class AppManagementClient implements DeveloperPlatformClient {
     }
   }
 
-  async migrateFlowExtension(_input: MigrateFlowExtensionVariables): Promise<MigrateFlowExtensionSchema> {
-    throw new BugError('Not implemented: migrateFlowExtension')
-  }
-
-  async migrateAppModule(_input: MigrateAppModuleVariables): Promise<MigrateAppModuleSchema> {
-    throw new BugError('Not implemented: migrateAppModule')
-  }
-
   async updateURLs(_input: UpdateURLsVariables): Promise<UpdateURLsSchema> {
     outputDebug('⚠️ updateURLs is not implemented')
     return {appUpdate: {userErrors: []}}
@@ -995,10 +978,6 @@ export class AppManagementClient implements DeveloperPlatformClient {
     } catch (error) {
       throw new AbortError(`Failed to fetch schema definition: ${error}`)
     }
-  }
-
-  async migrateToUiExtension(_input: MigrateToUiExtensionVariables): Promise<MigrateToUiExtensionSchema> {
-    throw new BugError('Not implemented: migrateToUiExtension')
   }
 
   toExtensionGraphQLType(input: string) {


### PR DESCRIPTION
> **PartnersClient cleanup — 1 of 3.** Type-only prep; no behavior change.

### WHY are these changes introduced?

`PartnersClient` is only used in production to run the three legacy extension migrations (Flow, app module, UI extension), yet it implements the full `DeveloperPlatformClient`. Before it can be reduced to a migration-only client (later in the stack), the type surface has to allow a client that implements just the migration slice.

### WHAT is this pull request doing?

- Extract a narrow `MigrationDeveloperPlatformClient` interface (the three `migrate*` methods) and retype the migration call sites (`migrate-flow-extension`, `migrate-app-module`, `migrate-to-ui-extension`, `deploy-app-version-migrations`) to it.
- Remove the three `migrate*` methods from `DeveloperPlatformClient`; `AppManagementClient` drops its three matching "Not implemented" stubs.
- Narrow `createUnauthorizedHandler` to a `TokenRefreshableClient` = `Pick<DeveloperPlatformClient, 'session' | 'unsafeRefreshToken'>`, so a client that no longer implements the full interface can still refresh tokens.

No runtime behavior changes — this only reshapes types.

### How to test your changes?

Type-only refactor. `pnpm nx type-check app` and the existing test suite pass; nothing changes at runtime.

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

