### PR TITLE
Remove stale no-inline-graphql allowlist entries

### DIFF
--- a/packages/eslint-plugin-cli/rules/no-inline-graphql.js
+++ b/packages/eslint-plugin-cli/rules/no-inline-graphql.js
@@ -116,50 +116,16 @@ module.exports = {
 }
 
 const knownFailures = {
-  'packages/app/src/cli/api/graphql/all_dev_stores_by_org.ts':
-    'f48a44e2dae39f1b33ac685971740e3705f2754de5fdf1d6f1fbb3492bc62be2',
-  'packages/app/src/cli/api/graphql/convert_dev_to_transfer_disabled_store.ts':
-    '0261459f988f5ba947ba52dc90dd049032196595cad5be8b7042ad1d0a22277c',
-  'packages/app/src/cli/api/graphql/current_account_info.ts':
-    'e25977539cec28a33c0c32c75973ac5a78e3b4b5e504aa3d14d01291c5b42c14',
-  'packages/app/src/cli/api/graphql/development_preview.ts':
-    'db9e18b48c6cb6c76f8d03be74b902f8711c08d1512e26ed6e5884cafee62bfe',
-  'packages/app/src/cli/api/graphql/extension_create.ts':
-    'b6df36a09be710c98d49e4fe987fa77f92bafc91a8c1c0305d20f95d8bb013e8',
   'packages/app/src/cli/api/graphql/extension_migrate_app_module.ts':
     '8ec49d9639dd3eabec93caee1c8a0435a1be576c9115476199dfd7c382eacada',
   'packages/app/src/cli/api/graphql/extension_migrate_flow_extension.ts':
     '812944a456b2ae439ebb01a97c19e3e0c445157dd3578bc48b0a8c4cebb6e12e',
   'packages/app/src/cli/api/graphql/extension_migrate_to_ui_extension.ts':
     'dd3fb42d0b9327de627bd02295de9e08087266885777602a34b44bdc460c0285',
-  'packages/app/src/cli/api/graphql/find_app_preview_mode.ts':
-    '8311925b338d4aba1957974bb815cfa8c5d8272226f68b8e74a69d91acc9c8cb',
   'packages/app/src/cli/api/graphql/get_variant_id.ts':
     '805a7d8fb4b66ae23dc45cc37d401350c3d8eab4e262bd90e70afceb48be10de',
-  'packages/app/src/cli/utilities/developer-platform-client/app-management-client/graphql/active-app-release.ts':
-    'e1998153a015f9a7bb392aab6788a10a9afe76220eeb4515e958e679ec667ed1',
-  'packages/app/src/cli/utilities/developer-platform-client/app-management-client/graphql/app-version-by-id.ts':
-    'd0ac3004b177cd97a8f289e67c1ec880df01f2e76816a170ae7718d72bd19e3f',
-  'packages/app/src/cli/utilities/developer-platform-client/app-management-client/graphql/app-versions.ts':
-    'dc862433d890cb282832c726f1eea45bc73ff013b5d81ddede0c80d7e6ce9922',
-  'packages/app/src/cli/utilities/developer-platform-client/app-management-client/graphql/apps.ts':
-    'f35782cdc5ced3259858d3ec17281ca34780e64cb6be627342817a69bfbdb00b',
-  'packages/app/src/cli/utilities/developer-platform-client/app-management-client/graphql/create-app-version.ts':
-    'ec3aec2eeddaf2a9e9e14db04a8652f0d6fd168b74846e3f9212f357d54a97ff',
-  'packages/app/src/cli/utilities/developer-platform-client/app-management-client/graphql/create-app.ts':
-    '48dd2aa539f0712d41ff3fb9674cc8fe279e131f3a8f95ad56f446cfc3e67d9d',
-  'packages/app/src/cli/utilities/developer-platform-client/app-management-client/graphql/create-asset-url.ts':
-    '641e9973f085329b5a3ab3ba9e08106365d01cebceb9a9c0760debb82e4f2e82',
-  'packages/app/src/cli/utilities/developer-platform-client/app-management-client/graphql/organization.ts':
-    '81aa51ec2465be18d8f184820c5965506074a3506865a0064bc3d49d7f4166dd',
   'packages/app/src/cli/utilities/developer-platform-client/app-management-client/graphql/organization_beta_flags.ts':
     'feb27126f3f91bac7af3a6fdbd45b7b70e55c6b8f2e94d2200723baa3fccc3ba',
-  'packages/app/src/cli/utilities/developer-platform-client/app-management-client/graphql/release-version.ts':
-    'f6302376a4d5b06f54caf774dbb9e7cc2a65f5513f23cca4392ddaad903917a1',
-  'packages/app/src/cli/utilities/developer-platform-client/app-management-client/graphql/specifications.ts':
-    '431b569c1bcc2756ad3a16a0678525a3fdd5b9c7776b6f314bb8628ea2be537a',
-  'packages/app/src/cli/utilities/developer-platform-client/app-management-client/graphql/user-info.ts':
-    '8b7f642bb215b93f53a9eb90803a8f9ca8617a75dda8d51c21a06a7574722063',
   'packages/cli-kit/src/private/node/session.ts': '9081e73c91cb5d7cab7b45571ff2ff479ae71cf43672e8f13bda9a2541ff13c3',
   'packages/cli-kit/src/public/node/api/admin.ts': '2186080241b4ab29de8bd2f1176e077a1e71234baffb0802a15b0b82f887c9d1',
 }


### PR DESCRIPTION
> Independent janitorial cleanup, stacked on the PartnersClient cleanup series (#8109 → #8111 → #8115).

### WHY are these changes introduced?

The `no-inline-graphql` eslint rule keeps a `knownFailures` allowlist mapping file paths → content hashes (grandfathered inline-GraphQL exceptions). 17 of its 24 entries point at files that no longer exist — leftovers from earlier app-management and GraphQL refactors (and this cleanup stack). They're dead config: an allowlist entry keyed to a missing file is never consulted by the rule.

### WHAT is this pull request doing?

Remove the 17 stale entries, keeping the 7 whose files still exist. One file changed (`packages/eslint-plugin-cli/rules/no-inline-graphql.js`), −34 lines. No change to lint behavior.

### How to test your changes?

`pnpm nx lint app` passes (the rule's main consumer), and each of the 7 remaining entries corresponds to a file that still exists.

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`
