### PR TITLE
[Tests] Add unit tests for showMultipleCLIWarningIfNeeded

### DIFF
--- a/packages/cli-kit/src/public/node/multiple-installation-warning.test.ts
+++ b/packages/cli-kit/src/public/node/multiple-installation-warning.test.ts
@@ -1,0 +1,119 @@
+import {showMultipleCLIWarningIfNeeded} from './multiple-installation-warning.js'
+import {jsonOutputEnabled} from './environment.js'
+import {currentProcessIsGlobal} from './is-global.js'
+import {renderInfo} from './ui.js'
+import {globalCLIVersion, localCLIVersion} from './version.js'
+import {runAtMinimumInterval} from '../../private/node/conf-store.js'
+import {describe, expect, test, vi, beforeEach} from 'vitest'
+
+vi.mock('./environment.js')
+vi.mock('./is-global.js')
+vi.mock('./ui.js')
+vi.mock('./version.js')
+vi.mock('../../private/node/conf-store.js')
+
+describe('showMultipleCLIWarningIfNeeded', () => {
+  beforeEach(() => {
+    vi.mocked(runAtMinimumInterval).mockImplementation(async (_key, _interval, task) => {
+      await task()
+      return true
+    })
+    vi.mocked(jsonOutputEnabled).mockReturnValue(false)
+    vi.mocked(currentProcessIsGlobal).mockReturnValue(false)
+    vi.mocked(globalCLIVersion).mockResolvedValue('3.68.0')
+    vi.mocked(localCLIVersion).mockResolvedValue('3.68.0')
+  })
+
+  test('does not run if @shopify/cli is missing from dependencies', async () => {
+    // Given
+    const dependencies = {}
+
+    // When
+    await showMultipleCLIWarningIfNeeded('dir', dependencies)
+
+    // Then
+    expect(renderInfo).not.toHaveBeenCalled()
+  })
+
+  test('does not run if json output is enabled', async () => {
+    // Given
+    vi.mocked(jsonOutputEnabled).mockReturnValue(true)
+    const dependencies = {'@shopify/cli': '3.68.0'}
+
+    // When
+    await showMultipleCLIWarningIfNeeded('dir', dependencies)
+
+    // Then
+    expect(renderInfo).not.toHaveBeenCalled()
+  })
+
+  test('does not run if global CLIVersion is not available and not in global process', async () => {
+    // Given
+    vi.mocked(globalCLIVersion).mockResolvedValue(undefined)
+    const dependencies = {'@shopify/cli': '3.68.0'}
+
+    // When
+    await showMultipleCLIWarningIfNeeded('dir', dependencies)
+
+    // Then
+    expect(renderInfo).not.toHaveBeenCalled()
+  })
+
+  test('does not run if local CLIVersion is not available and in global process', async () => {
+    // Given
+    vi.mocked(currentProcessIsGlobal).mockReturnValue(true)
+    vi.mocked(localCLIVersion).mockResolvedValue(undefined)
+    const dependencies = {'@shopify/cli': '3.68.0'}
+
+    // When
+    await showMultipleCLIWarningIfNeeded('dir', dependencies)
+
+    // Then
+    expect(renderInfo).not.toHaveBeenCalled()
+  })
+
+  test('renders warning warning with local dependency message when process is not global', async () => {
+    // Given
+    const dependencies = {'@shopify/cli': '3.68.0'}
+
+    // When
+    await showMultipleCLIWarningIfNeeded('dir', dependencies)
+
+    // Then
+    expect(renderInfo).toHaveBeenCalledWith(
+      expect.objectContaining({
+        headline: expect.stringContaining('using local dependency'),
+        body: expect.arrayContaining([
+          expect.stringContaining('A global installation (v3.68.0) and a local dependency (v'),
+        ]),
+      }),
+    )
+  })
+
+  test('renders warning with global installation message when process is global', async () => {
+    // Given
+    vi.mocked(currentProcessIsGlobal).mockReturnValue(true)
+    const dependencies = {'@shopify/cli': '3.68.0'}
+
+    // When
+    await showMultipleCLIWarningIfNeeded('dir', dependencies)
+
+    // Then
+    expect(renderInfo).toHaveBeenCalledWith(
+      expect.objectContaining({
+        headline: expect.stringContaining('using global installation'),
+      }),
+    )
+  })
+
+  test('uses runAtMinimumInterval with correct interval options', async () => {
+    // Given
+    const dependencies = {'@shopify/cli': '3.68.0'}
+
+    // When
+    await showMultipleCLIWarningIfNeeded('dir', dependencies)
+
+    // Then
+    expect(runAtMinimumInterval).toHaveBeenCalledWith('warn-on-multiple-versions', {days: 1}, expect.any(Function))
+  })
+})


### PR DESCRIPTION
### WHY are these changes introduced?

This PR introduces comprehensive unit testing for `showMultipleCLIWarningIfNeeded` in `@shopify/cli-kit` package to improve coverage and safeguard against regressions, adhering to `.agents/automated-tasks/tests.md`.

### WHAT is this pull request doing?

We added tests covering:
- Early-exit when `@shopify/cli` dependency is missing from the passed dependencies.
- Early-exit when JSON output is enabled.
- Early-exit when global CLI version cannot be fetched.
- Early-exit when local CLI version cannot be fetched in global process.
- Renders info warning with local dependency message when process is not global.
- Renders info warning with global installation message when process is global.
- Uses rate-limiting check `runAtMinimumInterval` correctly.

### How to test your changes?

CI

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [17820496270967834501](https://jules.google.com/task/17820496270967834501) started by @gonzaloriestra*