### PR TITLE
[Refactor] Use early returns in createDotEnvFileLine

### DIFF
--- a/packages/cli-kit/src/public/node/dot-env.ts
+++ b/packages/cli-kit/src/public/node/dot-env.ts
@@ -130,14 +130,15 @@ export function createDotEnvFileLine(key: string, value?: string, quote?: string
   if (quote) {
     return `${key}=${quote}${value}${quote}`
   }
-  if (value?.includes('\n')) {
-    const quoteCharacter = ['"', "'", '`'].find((char) => !value.includes(char))
 
-    if (!quoteCharacter) {
-      throw new AbortError(`The environment file patch has an env value that can't be surrounded by quotes: ${value}`)
-    }
-
-    return `${key}=${quoteCharacter}${value}${quoteCharacter}`
+  if (!value?.includes('\n')) {
+    return `${key}=${value}`
   }
-  return `${key}=${value}`
+
+  const quoteCharacter = ['"', "'", '`'].find((char) => !value.includes(char))
+  if (!quoteCharacter) {
+    throw new AbortError(`The environment file patch has an env value that can't be surrounded by quotes: ${value}`)
+  }
+
+  return `${key}=${quoteCharacter}${value}${quoteCharacter}`
 }


### PR DESCRIPTION
### WHY are these changes introduced?

This is part of our ongoing effort to make the codebase clearer, simpler, and more readable.

### WHAT is this pull request doing?

Refactors `createDotEnvFileLine` in `packages/cli-kit/src/public/node/dot-env.ts` to use early return guard clauses instead of nested `if` statements, keeping the logic identical and preserving all existing behavior.

### How to test your changes?

CI

### Post-release steps

N/A

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [2918847660578356433](https://jules.google.com/task/2918847660578356433) started by @gonzaloriestra*