### PR TITLE
Clean E2E resources across run attempts

### DIFF
--- a/.github/workflows/tests-pr.yml
+++ b/.github/workflows/tests-pr.yml
@@ -304,7 +304,7 @@ jobs:
           E2E_ORG_ID: ${{ secrets.E2E_ORG_ID }}
         run: |
           RUN_TOKEN=$(node -e "process.stdout.write(BigInt(process.env.GITHUB_RUN_ID).toString(36))")
-          pnpm --filter e2e exec tsx scripts/cleanup-apps.ts --pattern "r${RUN_TOKEN}a${GITHUB_RUN_ATTEMPT}"
+          pnpm --filter e2e exec tsx scripts/cleanup-apps.ts --pattern "r${RUN_TOKEN}"
       - name: Cleanup current-run E2E stores
         env:
           E2E_ACCOUNT_EMAIL: ${{ secrets.E2E_ACCOUNT_EMAIL }}
@@ -312,7 +312,7 @@ jobs:
           E2E_ORG_ID: ${{ secrets.E2E_ORG_ID }}
         run: |
           RUN_TOKEN=$(node -e "process.stdout.write(BigInt(process.env.GITHUB_RUN_ID).toString(36))")
-          pnpm --filter e2e exec tsx scripts/cleanup-stores.ts --pattern "r${RUN_TOKEN}a${GITHUB_RUN_ATTEMPT}"
+          pnpm --filter e2e exec tsx scripts/cleanup-stores.ts --pattern "r${RUN_TOKEN}"
 
   type-diff:
     if: github.event.pull_request.head.repo.full_name == github.repository


### PR DESCRIPTION
### WHY are these changes introduced?

No linked issue.

Current PR E2E cleanup only searches for resources with the exact `GITHUB_RUN_ID` + `GITHUB_RUN_ATTEMPT` segment. If an earlier attempt creates E2E apps or dev stores and is cancelled or fails before cleanup completes, a later rerun searches for a different attempt suffix and misses those leftovers.

### WHAT is this pull request doing?

Updates the PR workflow cleanup pattern to use only the run id segment (`r${RUN_TOKEN}`) for both app and store cleanup. E2E resource names still include the attempt suffix, but cleanup now covers all attempts from the same GitHub run.

### How to test your changes?

- `gt diff --check`
- Parsed `.github/workflows/tests-pr.yml` with Ruby YAML loader.

Expected behavior in CI: cleanup for a rerun of the same workflow run can delete resources created by prior attempts because their names share the same `r<run-id>` prefix.

### Post-release steps

None.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

This is CI-only workflow maintenance, so no changeset is needed.
