### PR TITLE
Run E2E cleanup phases independently

### DIFF
--- a/.github/workflows/tests-pr.yml
+++ b/.github/workflows/tests-pr.yml
@@ -292,12 +292,15 @@ jobs:
       - name: Build CLI for cleanup auth
         run: pnpm nx run cli:build --skip-nx-cache
       - name: Prime cleanup auth state
+        continue-on-error: true
         env:
           E2E_ACCOUNT_EMAIL: ${{ secrets.E2E_ACCOUNT_EMAIL }}
           E2E_ACCOUNT_PASSWORD: ${{ secrets.E2E_ACCOUNT_PASSWORD }}
           E2E_ORG_ID: ${{ secrets.E2E_ORG_ID }}
         run: pnpm --filter e2e exec tsx scripts/prime-browser-auth.ts
       - name: Cleanup current-run E2E apps
+        if: ${{ always() }}
+        continue-on-error: true
         env:
           E2E_ACCOUNT_EMAIL: ${{ secrets.E2E_ACCOUNT_EMAIL }}
           E2E_ACCOUNT_PASSWORD: ${{ secrets.E2E_ACCOUNT_PASSWORD }}
@@ -306,6 +309,8 @@ jobs:
           RUN_TOKEN=$(node -e "process.stdout.write(BigInt(process.env.GITHUB_RUN_ID).toString(36))")
           pnpm --filter e2e exec tsx scripts/cleanup-apps.ts --pattern "r${RUN_TOKEN}a${GITHUB_RUN_ATTEMPT}"
       - name: Cleanup current-run E2E stores
+        if: ${{ always() }}
+        continue-on-error: true
         env:
           E2E_ACCOUNT_EMAIL: ${{ secrets.E2E_ACCOUNT_EMAIL }}
           E2E_ACCOUNT_PASSWORD: ${{ secrets.E2E_ACCOUNT_PASSWORD }}


### PR DESCRIPTION
### WHY are these changes introduced?

No linked issue.

The PR E2E cleanup job has separate app and store cleanup phases, but a failure in auth priming or app cleanup can prevent later cleanup steps from running. That leaves stores behind even though the store cleanup script can independently uninstall apps from stores before deleting them.

### WHAT is this pull request doing?

Makes cleanup phases more independent in the PR workflow:

- Allows cleanup auth priming to fail without stopping the job.
- Runs app cleanup with `if: ${{ always() }}` and `continue-on-error: true`.
- Runs store cleanup with `if: ${{ always() }}` and `continue-on-error: true`.

This keeps each cleanup phase best-effort so one failed phase does not block the next phase.

### How to test your changes?

- `gt diff --check`
- Parsed `.github/workflows/tests-pr.yml` with Ruby YAML loader.

Expected behavior in CI: store cleanup still runs even when cleanup auth priming or app cleanup reports a failure.

### Post-release steps

None.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

This is CI-only workflow maintenance, so no changeset is needed.
