### PR TITLE
[Tests] Add global-context unit tests

### DIFF
--- a/packages/cli-kit/src/public/node/global-context.test.ts
+++ b/packages/cli-kit/src/public/node/global-context.test.ts
@@ -1,0 +1,20 @@
+import {getCurrentCommandId, setCurrentCommandId} from './global-context.js'
+import {describe, expect, test} from 'vitest'
+
+describe('global-context', () => {
+  test('returns empty string by default for command ID', () => {
+    // When/Then
+    expect(getCurrentCommandId()).toBe('')
+  })
+
+  test('sets and gets the current command ID correctly', () => {
+    // Given
+    const testCommandId = 'my-test-command'
+
+    // When
+    setCurrentCommandId(testCommandId)
+
+    // Then
+    expect(getCurrentCommandId()).toBe(testCommandId)
+  })
+})


### PR DESCRIPTION
### WHY are these changes introduced?

This PR introduces unit tests for the global-context utility `global-context.ts` to cover missing test gaps.

### WHAT is this pull request doing?

Adds unit tests in `packages/cli-kit/src/public/node/global-context.test.ts` to assert:
- Default command ID is empty string.
- Command ID can be successfully set and retrieved.

### How to test your changes?

CI

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [15863495855493472193](https://jules.google.com/task/15863495855493472193) started by @gonzaloriestra*