### PR TITLE
[Refactor] Declarative createGitIgnore content construction

### DIFF
--- a/packages/cli-kit/src/public/node/git.ts
+++ b/packages/cli-kit/src/public/node/git.ts
@@ -89,11 +89,9 @@ export function createGitIgnore(directory: string, template: GitIgnoreTemplate):
   outputDebug(outputContent`Creating .gitignore at ${outputToken.path(directory)}...`)
   const filePath = `${directory}/.gitignore`
 
-  let fileContent = ''
-  for (const [section, lines] of Object.entries(template)) {
-    fileContent += `# ${section}\n`
-    fileContent += `${lines.join('\n')}\n\n`
-  }
+  const fileContent = Object.entries(template)
+    .map(([section, lines]) => `# ${section}\n${lines.join('\n')}\n\n`)
+    .join('')
 
   appendFileSync(filePath, fileContent)
 }


### PR DESCRIPTION
### WHY are these changes introduced?

This is part of automated task cleanups to improve codebase readability and maintainability.

### WHAT is this pull request doing?

Refactors `createGitIgnore` in `packages/cli-kit/src/public/node/git.ts` to use a declarative array mapping `.map().join('')` rather than an imperative `for...of` loop with string concatenation.

### How to test your changes?

CI

### Post-release steps

None.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [11382995813698359031](https://jules.google.com/task/11382995813698359031) started by @gonzaloriestra*