### PR TITLE
[Performance] Optimize local and remote specifications merging

### DIFF
--- a/packages/app/src/cli/services/generate/fetch-extension-specifications.ts
+++ b/packages/app/src/cli/services/generate/fetch-extension-specifications.ts
@@ -64,10 +64,13 @@ async function mergeLocalAndRemoteSpecs(
   local: ExtensionSpecification[],
   remote: RemoteSpecification[],
 ): Promise<RemoteAwareExtensionSpecification[]> {
+  // Use a Map for O(1) lookups of local specs instead of an O(N) find inside remote.map
+  const localSpecsMap = new Map(local.map((spec) => [spec.identifier, spec]))
+
   // Iterate over the remote specs and merge them with the local ones
   // If the local spec is missing, and the remote one has a validation schema, create a new local spec using contracts
   const updated = remote.map(async (remoteSpec) => {
-    let localSpec = local.find((local) => local.identifier === remoteSpec.identifier)
+    let localSpec = localSpecsMap.get(remoteSpec.identifier)
     if (!localSpec && remoteSpec.validationSchema?.jsonSchema) {
       localSpec = await createRemoteOnlySpecification(remoteSpec, remoteSpec.validationSchema)
     }
@@ -86,12 +89,13 @@ async function mergeLocalAndRemoteSpecs(
 
   const result = getArrayRejectingUndefined<RemoteAwareExtensionSpecification>(await Promise.all(updated))
 
+  // Use a Set for O(1) lookups instead of nested O(N) find searches inside filters
+  const resultIdentifiers = new Set(result.map((spec) => spec.identifier))
+
   // Log the specs that were defined locally but aren't in the result
   // This usually means the spec is a gated one and the caller doesn't have adequate access. Or, we're in a test and
   // the mocked specification set is missing something.
-  const presentLocalMissingRemote = local.filter(
-    (spec) => !result.find((result) => result.identifier === spec.identifier),
-  )
+  const presentLocalMissingRemote = local.filter((spec) => !resultIdentifiers.has(spec.identifier))
   if (presentLocalMissingRemote.length > 0) {
     outputDebug(
       `The following extension specifications were defined locally but not found in the remote specifications: ${presentLocalMissingRemote
@@ -101,9 +105,7 @@ async function mergeLocalAndRemoteSpecs(
     )
   }
 
-  const presentRemoteMissingLocal = remote.filter(
-    (spec) => !result.find((result) => result.identifier === spec.identifier),
-  )
+  const presentRemoteMissingLocal = remote.filter((spec) => !resultIdentifiers.has(spec.identifier))
   if (presentRemoteMissingLocal.length > 0) {
     outputDebug(
       `The following extension specifications were found in the remote specifications but not defined locally: ${presentRemoteMissingLocal


### PR DESCRIPTION
### WHY are these changes introduced?

Merging local and remote extension specifications has been performing multiple nested $O(N)$ lookups, leading to $O(N^2)$ time complexity. With dozens of specification configurations, this creates redundant processing inside the CLI startup path.

### WHAT is this pull request doing?

Refactors `mergeLocalAndRemoteSpecs` to use a `Map` for finding local specifications, and a `Set` for checking specification identifier presence. This reduces the time complexity of the merge algorithm to $O(N)$, resulting in more efficient and faster startup of CLI commands like `app generate extension`, `app dev`, and `app deploy`.

### How to test your changes?

```bash
shopify app generate extension
```

### Post-release steps

<!-- No post-release steps are required. -->

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [6332725731645540200](https://jules.google.com/task/6332725731645540200) started by @gonzaloriestra*