### PR TITLE
[Refactor] Use early returns in commonParentDirectory

### DIFF
--- a/packages/cli-kit/src/public/node/path.ts
+++ b/packages/cli-kit/src/public/node/path.ts
@@ -119,7 +119,10 @@ export function commonParentDirectory(first: string, second: string): string {
   while (i < firstParts.length && i < secondParts.length && firstParts[i] === secondParts[i]) {
     i++
   }
-  return i > 1 ? firstParts.slice(0, i).join('/') : '/'
+  if (i <= 1) {
+    return '/'
+  }
+  return firstParts.slice(0, i).join('/')
 }
 
 /**


### PR DESCRIPTION
### WHY are these changes introduced?

<!--
  Context about the problem that's being addressed.
-->
The ternary operator in `commonParentDirectory` can be made more readable and cleaner by adopting an early-return style.

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->
Refactors the return statement of `commonParentDirectory` in `packages/cli-kit/src/public/node/path.ts` to return `/` early if `i <= 1`, then join and return the common components.

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
  You can post a comment with `/snapit` to generate a snapshot of the changes to be tested.
-->
CI

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [16923425015846468447](https://jules.google.com/task/16923425015846468447) started by @gonzaloriestra*