### PR TITLE
[Tests] Add coverage for vscode recommendation utility

### DIFF
--- a/packages/cli-kit/src/public/node/vscode.test.ts
+++ b/packages/cli-kit/src/public/node/vscode.test.ts
@@ -1,5 +1,5 @@
-import {isVSCode} from './vscode.js'
-import {inTemporaryDirectory, mkdir} from './fs.js'
+import {addRecommendedExtensions, isVSCode} from './vscode.js'
+import {fileExists, inTemporaryDirectory, mkdir, readFile, writeFile} from './fs.js'
 import {joinPath} from './path.js'
 import {describe, expect, test} from 'vitest'
 
@@ -16,6 +16,65 @@ describe('isVSCode', () => {
 
       // Then
       expect(got).toEqual(true)
+    })
+  })
+})
+
+describe('addRecommendedExtensions', () => {
+  test('does nothing if the directory does not have a .vscode folder', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      const extensionsPath = joinPath(tmpDir, '.vscode/extensions.json')
+
+      // When
+      await addRecommendedExtensions(tmpDir, ['shopify.shopify-cli-extensions'])
+
+      // Then
+      await expect(fileExists(extensionsPath)).resolves.toEqual(false)
+    })
+  })
+
+  test('creates extensions.json with the recommendations if .vscode folder exists but no extensions.json exists', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      await mkdir(joinPath(tmpDir, '.vscode'))
+      const extensionsPath = joinPath(tmpDir, '.vscode/extensions.json')
+
+      // When
+      await addRecommendedExtensions(tmpDir, ['shopify.shopify-cli-extensions'])
+
+      // Then
+      await expect(fileExists(extensionsPath)).resolves.toEqual(true)
+      const content = await readFile(extensionsPath)
+      const parsed = JSON.parse(content)
+      expect(parsed).toEqual({
+        recommendations: ['shopify.shopify-cli-extensions'],
+      })
+    })
+  })
+
+  test('appends recommendations to the existing ones in extensions.json if both .vscode folder and extensions.json exist', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      await mkdir(joinPath(tmpDir, '.vscode'))
+      const extensionsPath = joinPath(tmpDir, '.vscode/extensions.json')
+      const initialJson = {
+        recommendations: ['ms-sarah.another-ext'],
+        otherSetting: true,
+      }
+      await writeFile(extensionsPath, JSON.stringify(initialJson, null, 2))
+
+      // When
+      await addRecommendedExtensions(tmpDir, ['shopify.shopify-cli-extensions'])
+
+      // Then
+      await expect(fileExists(extensionsPath)).resolves.toEqual(true)
+      const content = await readFile(extensionsPath)
+      const parsed = JSON.parse(content)
+      expect(parsed).toEqual({
+        recommendations: ['ms-sarah.another-ext', 'shopify.shopify-cli-extensions'],
+        otherSetting: true,
+      })
     })
   })
 })


### PR DESCRIPTION
### WHY are these changes introduced?

This PR introduces unit tests for the vscode recommended extensions utility `addRecommendedExtensions` to improve test coverage and ensure its correct behavior across potential future refactors.

### WHAT is this pull request doing?

We added three targeted unit test cases in `packages/cli-kit/src/public/node/vscode.test.ts` to fully cover:
1. When the `.vscode` directory does not exist, verifying that no action is taken.
2. When the `.vscode` directory exists but `extensions.json` is missing, verifying it gets created with the expected recommendations.
3. When both exist, verifying that new recommendations are correctly appended without erasing existing ones or other keys in the file.

All tests utilize a real isolated temporary directory and no mocked file system.

### How to test your changes?

CI

### Post-release steps

None.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [14603922283518488159](https://jules.google.com/task/14603922283518488159) started by @gonzaloriestra*