### PR TITLE
[Refactor] Use declarative .map().join() in createGitIgnore

### DIFF
--- a/packages/cli-kit/src/public/node/git.ts
+++ b/packages/cli-kit/src/public/node/git.ts
@@ -89,11 +89,9 @@ export function createGitIgnore(directory: string, template: GitIgnoreTemplate):
   outputDebug(outputContent`Creating .gitignore at ${outputToken.path(directory)}...`)
   const filePath = `${directory}/.gitignore`
 
-  let fileContent = ''
-  for (const [section, lines] of Object.entries(template)) {
-    fileContent += `# ${section}\n`
-    fileContent += `${lines.join('\n')}\n\n`
-  }
+  const fileContent = Object.entries(template)
+    .map(([section, lines]) => `# ${section}\n${lines.join('\n')}\n\n`)
+    .join('')
 
   appendFileSync(filePath, fileContent)
 }


### PR DESCRIPTION
### WHY are these changes introduced?

To improve the readability, maintainability, and code idiom of the `.gitignore` generator logic in `@shopify/cli-kit`.

### WHAT is this pull request doing?

Refactors `createGitIgnore` in `packages/cli-kit/src/public/node/git.ts` to replace the imperative `for...of` loop with string accumulation with a modern, declarative `.map().join('')` chain.

### How to test your changes?

CI

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [2143177345041615277](https://jules.google.com/task/2143177345041615277) started by @gonzaloriestra*