### PR TITLE
Add mouse support

### DIFF
--- a/.changeset/clickable-options-and-tabs.md
+++ b/.changeset/clickable-options-and-tabs.md
@@ -1,0 +1,7 @@
+---
+'@shopify/app': minor
+'@shopify/cli': minor
+'@shopify/cli-kit': minor
+---
+
+Enable mouse support for prompts and app dev tabs; hold Option in iTerm2 or Shift elsewhere to select text, or run `shopify config mouse off` to disable it.

--- a/docs-shopify.dev/generated/generated_docs_data_v2.json
+++ b/docs-shopify.dev/generated/generated_docs_data_v2.json
@@ -3167,6 +3167,26 @@
       "value": "export interface configautoupgradestatus {\n\n}"
     }
   },
+  "configmouseoff": {
+    "docs-shopify.dev/commands/interfaces/config-mouse-off.interface.ts": {
+      "filePath": "docs-shopify.dev/commands/interfaces/config-mouse-off.interface.ts",
+      "name": "configmouseoff",
+      "description": "The following flags are available for the `config mouse off` command:",
+      "isPublicDocs": true,
+      "members": [],
+      "value": "export interface configmouseoff {\n\n}"
+    }
+  },
+  "configmouseon": {
+    "docs-shopify.dev/commands/interfaces/config-mouse-on.interface.ts": {
+      "filePath": "docs-shopify.dev/commands/interfaces/config-mouse-on.interface.ts",
+      "name": "configmouseon",
+      "description": "The following flags are available for the `config mouse on` command:",
+      "isPublicDocs": true,
+      "members": [],
+      "value": "export interface configmouseon {\n\n}"
+    }
+  },
   "docfetch": {
     "docs-shopify.dev/commands/interfaces/doc-fetch.interface.ts": {
       "filePath": "docs-shopify.dev/commands/interfaces/doc-fetch.interface.ts",

--- a/packages/app/src/cli/services/dev/ui/components/DevSessionUI.test.tsx
+++ b/packages/app/src/cli/services/dev/ui/components/DevSessionUI.test.tsx
@@ -61,6 +61,10 @@ const initialStatus: DevSessionStatus = {
 
 const onAbort = vi.fn()
 
+function mouseWheelUp(column: number, row: number): string {
+  return `\u001B[<64;${column};${row}M`
+}
+
 describe('DevSessionUI', () => {
   beforeEach(() => {
     mocks.terminalSupportsHyperlinks.mockReturnValue(false)
@@ -405,6 +409,7 @@ describe('DevSessionUI', () => {
         onAbort={onAbort}
       />,
     )
+    await waitForContent(renderInstance, 'third backend message')
 
     const promise = renderInstance.waitUntilExit()
 
@@ -579,6 +584,29 @@ describe('DevSessionUI', () => {
     expect(output).toContain('My Test App')
     expect(output).toContain('https://my-app.ngrok.io')
     expect(output).not.toContain('mystore.myshopify.com')
+
+    renderInstance.unmount()
+  })
+
+  test('temporarily releases mouse reporting when scrolling', async () => {
+    const renderInstance = render(
+      <DevSessionUI
+        processes={[]}
+        abortController={new AbortController()}
+        devSessionStatusManager={devSessionStatusManager}
+        shopFqdn="mystore.myshopify.com"
+        onAbort={onAbort}
+      />,
+      {stdoutIsTTY: true},
+    )
+    const stdoutWrite = vi.spyOn(renderInstance.stdout, 'write')
+
+    await waitForInputsToBeReady()
+    // The row is intentionally outside the rendered UI to cover trackpad gestures
+    // over blank areas of the terminal viewport.
+    await sendInputAndWait(renderInstance, 10, mouseWheelUp(2, 200))
+
+    expect(stdoutWrite).toHaveBeenCalledWith('\u001B[?1003l\u001B[?1002l\u001B[?1000l')
 
     renderInstance.unmount()
   })

--- a/packages/app/src/cli/services/dev/ui/components/DevSessionUI.tsx
+++ b/packages/app/src/cli/services/dev/ui/components/DevSessionUI.tsx
@@ -8,7 +8,7 @@ import {Alert, ConcurrentOutput, Link, LoadingIndicator, TabularData} from '@sho
 import {useAbortSignal} from '@shopify/cli-kit/node/ui/hooks'
 import React, {FunctionComponent, useEffect, useMemo, useState} from 'react'
 import {AbortController, AbortSignal} from '@shopify/cli-kit/node/abort'
-import {Box, Text, useInput, useStdin} from '@shopify/cli-kit/node/ink'
+import {Box, MouseProvider, Text, useInput, useStdin} from '@shopify/cli-kit/node/ink'
 import {handleCtrlC} from '@shopify/cli-kit/node/ui'
 import {openURL, terminalSupportsHyperlinks} from '@shopify/cli-kit/node/system'
 import figures from '@shopify/cli-kit/node/figures'
@@ -242,7 +242,7 @@ const DevSessionUI: FunctionComponent<DevSesionUIProps> = ({
     },
   }
 
-  return (
+  const content = (
     <>
       <ConcurrentOutput
         processes={errorHandledProcesses}
@@ -293,6 +293,14 @@ const DevSessionUI: FunctionComponent<DevSesionUIProps> = ({
         </Box>
       ) : null}
     </>
+  )
+
+  return canUseShortcuts && !isAborted ? (
+    <MouseProvider allowTerminalScrolling trackMouseMovement={false}>
+      {content}
+    </MouseProvider>
+  ) : (
+    content
   )
 }
 

--- a/packages/app/src/cli/services/dev/ui/components/TabPanel.test.tsx
+++ b/packages/app/src/cli/services/dev/ui/components/TabPanel.test.tsx
@@ -1,14 +1,21 @@
 import {TabPanel, Tab} from './TabPanel.js'
 import {
-  render,
+  render as renderUI,
   sendInputAndWait,
   sendInputAndWaitForChange,
+  waitForContent,
   waitForInputsToBeReady,
 } from '@shopify/cli-kit/node/testing/ui'
 import React from 'react'
 import {describe, expect, test, vi} from 'vitest'
 import {unstyled} from '@shopify/cli-kit/node/output'
-import {Text} from '@shopify/cli-kit/node/ink'
+import {MouseProvider, Text} from '@shopify/cli-kit/node/ink'
+
+const render = (element: React.ReactElement) => renderUI(<MouseProvider>{element}</MouseProvider>, {stdoutIsTTY: true})
+
+function mouseClick(column: number, row: number): [string, string] {
+  return [`\u001B[<0;${column};${row}M`, `\u001B[<0;${column};${row}m`]
+}
 
 const mocks = vi.hoisted(() => {
   return {
@@ -105,6 +112,34 @@ describe('TabPanel', () => {
 
     expect(renderInstance.lastFrame()!).toContain('Second tab content')
     expect(renderInstance.lastFrame()!).not.toContain('First tab content')
+
+    renderInstance.unmount()
+  })
+
+  test('switches to a different tab when its header is clicked', async () => {
+    const renderInstance = render(<TabPanel tabs={sampleTabs} initialActiveTab="a" />)
+
+    await waitForInputsToBeReady()
+    await waitForContent(renderInstance, 'Second tab content', () =>
+      mouseClick(20, 2).forEach((input) => renderInstance.stdin.write(input)),
+    )
+
+    expect(renderInstance.lastFrame()).toContain('Second tab content')
+    expect(renderInstance.lastFrame()).not.toContain('First tab content')
+
+    renderInstance.unmount()
+  })
+
+  test('accounts for output rendered before the tab panel', async () => {
+    const renderInstance = render(<TabPanel tabs={sampleTabs} initialActiveTab="a" />)
+
+    await waitForInputsToBeReady()
+    await sendInputAndWait(renderInstance, 60, '\u001B[40;1R')
+    await waitForContent(renderInstance, 'Second tab content', () =>
+      mouseClick(20, 37).forEach((input) => renderInstance.stdin.write(input)),
+    )
+
+    expect(renderInstance.lastFrame()).toContain('Second tab content')
 
     renderInstance.unmount()
   })

--- a/packages/app/src/cli/services/dev/ui/components/TabPanel.tsx
+++ b/packages/app/src/cli/services/dev/ui/components/TabPanel.tsx
@@ -1,5 +1,14 @@
 import React, {useState, useRef, useLayoutEffect} from 'react'
-import {Box, Text, useInput, useStdin, useStdout, measureElement} from '@shopify/cli-kit/node/ink'
+import {
+  Box,
+  Text,
+  useInput,
+  useStdin,
+  useStdout,
+  measureElement,
+  useOnClick,
+  type DOMElement,
+} from '@shopify/cli-kit/node/ink'
 
 export interface Tab {
   label: string
@@ -26,6 +35,27 @@ interface TabPanelProps {
 
 // Using a width less than 100% reduces (but doesn't eliminate) screen artifacts when resizing the terminal
 const TAB_WIDTH_PERCENTAGE = 0.9
+
+interface ClickableTabProps {
+  active?: boolean
+  header: string
+  onClick: () => void
+}
+
+const ClickableTab: React.FunctionComponent<ClickableTabProps> = ({active = false, header, onClick}) => {
+  const tabRef = useRef<DOMElement>(null)
+  useOnClick(tabRef, (event) => {
+    if (event.button === 'left') onClick()
+  })
+
+  return (
+    <Box ref={tabRef}>
+      <Text bold={active} inverse={active} wrap="truncate">
+        {header}
+      </Text>
+    </Box>
+  )
+}
 
 export const TabPanel: React.FunctionComponent<TabPanelProps> = ({tabs, initialActiveTab}) => {
   const {stdout} = useStdout()
@@ -112,6 +142,19 @@ export const TabPanel: React.FunctionComponent<TabPanelProps> = ({tabs, initialA
   const contentTabs = tabsArray.filter((tab) => !tab.action)
   const actionTabs = tabsArray.filter((tab) => tab.action)
 
+  const activateTab = async (tab: TabDisplay) => {
+    if (tab.action) {
+      await tab.action()
+    } else {
+      setActiveTab(tab.inputKey)
+    }
+  }
+
+  const activateTabFromClick = (tab: TabDisplay) => {
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+    activateTab(tab)
+  }
+
   return (
     <>
       <Box
@@ -126,27 +169,25 @@ export const TabPanel: React.FunctionComponent<TabPanelProps> = ({tabs, initialA
         borderTop
       >
         <Box ref={contentTabsRef} flexDirection="row" flexWrap="nowrap" flexShrink={0} marginRight={3}>
-          <Text wrap="truncate-end">
-            {'│'}
-            {contentTabs.map((tab) => {
-              return (
-                <React.Fragment key={tab.inputKey}>
-                  <Text bold={activeTab === tab.inputKey} inverse={activeTab === tab.inputKey} wrap="truncate">
-                    {tab.header}
-                  </Text>
-                  {'│'}
-                </React.Fragment>
-              )
-            })}
-          </Text>
+          <Text>│</Text>
+          {contentTabs.map((tab) => (
+            <React.Fragment key={tab.inputKey}>
+              <ClickableTab
+                active={activeTab === tab.inputKey}
+                header={tab.header}
+                onClick={() => activateTabFromClick(tab)}
+              />
+              <Text>│</Text>
+            </React.Fragment>
+          ))}
         </Box>
         {displayActions && (
           <Box flexGrow={1} justifyContent="flex-end">
             {actionTabs.map((tab, index) => (
-              <Text wrap="truncate" key={tab.inputKey}>
-                ({tab.inputKey}) {tab.label}
-                {index < actionTabs.length - 1 && ' │ '}
-              </Text>
+              <React.Fragment key={tab.inputKey}>
+                <ClickableTab header={`(${tab.inputKey}) ${tab.label}`} onClick={() => activateTabFromClick(tab)} />
+                {index < actionTabs.length - 1 && <Text> │ </Text>}
+              </React.Fragment>
             ))}
           </Box>
         )}

--- a/packages/cli-kit/package.json
+++ b/packages/cli-kit/package.json
@@ -106,6 +106,7 @@
     "@bugsnag/js": "8.9.0",
     "@graphql-typed-document-node/core": "3.2.0",
     "@iarna/toml": "2.2.5",
+    "@ink-tools/ink-mouse": "2.1.0",
     "@oclif/core": "4.8.3",
     "@shopify/polaris": "12.27.0",
     "@shopify/polaris-icons": "8.11.1",

--- a/packages/cli-kit/src/private/node/conf-store.test.ts
+++ b/packages/cli-kit/src/private/node/conf-store.test.ts
@@ -11,7 +11,9 @@ import {
   runAtMinimumInterval,
   getConfigStoreForPartnerStatus,
   getCachedPartnerAccountStatus,
+  getMouseEnabled,
   setCachedPartnerAccountStatus,
+  setMouseEnabled,
   runWithRateLimit,
 } from './conf-store.js'
 import {isLocalEnvironment} from './context/service.js'
@@ -70,6 +72,22 @@ describe('removeSession', () => {
 
       // Then
       expect(config.get('sessionStore')).toEqual(undefined)
+    })
+  })
+})
+
+describe('mouse preference', () => {
+  test('is enabled by default and persists an explicit preference', async () => {
+    await inTemporaryDirectory(async (cwd) => {
+      const config = new LocalStorage<ConfSchema>({cwd})
+
+      expect(getMouseEnabled(config)).toBe(true)
+
+      setMouseEnabled(false, config)
+      expect(getMouseEnabled(config)).toBe(false)
+
+      setMouseEnabled(true, config)
+      expect(getMouseEnabled(config)).toBe(true)
     })
   })
 })

--- a/packages/cli-kit/src/private/node/conf-store.ts
+++ b/packages/cli-kit/src/private/node/conf-store.ts
@@ -33,6 +33,7 @@ export interface ConfSchema {
   currentDevSessionId?: string
   cache?: Cache
   autoUpgradeEnabled?: boolean
+  mouseEnabled?: boolean
 }
 
 let _instance: LocalStorage<ConfSchema> | undefined
@@ -283,6 +284,25 @@ export function getAutoUpgradeEnabled(config: LocalStorage<ConfSchema> = cliKitS
  */
 export function setAutoUpgradeEnabled(enabled: boolean, config: LocalStorage<ConfSchema> = cliKitStore()): void {
   config.set('autoUpgradeEnabled', enabled)
+}
+
+/**
+ * Get mouse interaction preference.
+ * Defaults to true if the preference has never been explicitly set.
+ *
+ * @returns Whether mouse interactions are enabled.
+ */
+export function getMouseEnabled(config: LocalStorage<ConfSchema> = cliKitStore()): boolean {
+  return config.get('mouseEnabled') ?? true
+}
+
+/**
+ * Set mouse interaction preference.
+ *
+ * @param enabled - Whether mouse interactions should be enabled.
+ */
+export function setMouseEnabled(enabled: boolean, config: LocalStorage<ConfSchema> = cliKitStore()): void {
+  config.set('mouseEnabled', enabled)
 }
 
 export function getConfigStoreForPartnerStatus() {

--- a/packages/cli-kit/src/private/node/testing/ui.ts
+++ b/packages/cli-kit/src/private/node/testing/ui.ts
@@ -18,6 +18,7 @@ class Stderr extends EventEmitter {
 
 export class Stdin extends EventEmitter {
   isTTY: boolean
+  isRaw = false
   data: string | null = null
 
   constructor(options: {isTTY?: boolean} = {}) {
@@ -28,10 +29,16 @@ export class Stdin extends EventEmitter {
   write = (data: string) => {
     this.data = data
     this.emit('readable')
+    this.emit('data', data)
   }
 
   setEncoding() {}
-  setRawMode() {}
+  setRawMode(isRaw: boolean) {
+    this.isRaw = isRaw
+  }
+
+  pause() {}
+  resume() {}
   ref() {}
   unref() {}
   read: () => string | null = () => {
@@ -59,10 +66,11 @@ interface RenderOptions {
   stdout?: EventEmitter
   stderr?: EventEmitter
   stdin?: EventEmitter
+  stdoutIsTTY?: boolean
 }
 
 export const render = (tree: ReactElement, options: RenderOptions = {}): Instance => {
-  const stdout = new Stdout({columns: 100})
+  const stdout = Object.assign(new Stdout({columns: 100}), {isTTY: options.stdoutIsTTY ?? false})
   const stderr = new Stderr()
   const stdin = new Stdin()
 

--- a/packages/cli-kit/src/private/node/ui.tsx
+++ b/packages/cli-kit/src/private/node/ui.tsx
@@ -77,10 +77,20 @@ interface Instance {
   unmount: () => void
 }
 
+const mouseTrackingControlSequences = new Set([
+  '\u001B[6n',
+  '\u001B[?1003l\u001B[?1002l\u001B[?1000h',
+  '\u001B[?1003l\u001B[?1002l\u001B[?1000l',
+  '\u001B[?1000h\u001B[?1002h\u001B[?1003h\u001B[?1006h',
+  '\u001B[?1006l\u001B[?1003l\u001B[?1002l\u001B[?1000l',
+])
+const cursorControlSequences = new Set(['\u001B[?25h', '\u001B[?25l'])
+
 export class Stdout extends EventEmitter {
   columns: number
   rows: number
   readonly frames: string[] = []
+  readonly controlSequences: string[] = []
   private _lastFrame?: string
 
   constructor(options: {columns?: number; rows?: number}) {
@@ -90,7 +100,14 @@ export class Stdout extends EventEmitter {
   }
 
   write = (frame: string) => {
+    if (mouseTrackingControlSequences.has(frame)) {
+      this.controlSequences.push(frame)
+      return
+    }
+
     this.frames.push(frame)
+    if (cursorControlSequences.has(frame)) return
+
     // Ink writes `this.lastOutput + '\n'` to stdout during unmount when
     // running in a CI environment (detected via `is-in-ci`).  In debug
     // mode (which tests use), `lastOutput` is never updated, so the write

--- a/packages/cli-kit/src/private/node/ui/components/AutocompletePrompt.test.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/AutocompletePrompt.test.tsx
@@ -4,6 +4,7 @@ import {
   sendInputAndWait,
   sendInputAndWaitForChange,
   sendInputAndWaitForContent,
+  waitFor,
   waitForInputsToBeReady,
   render,
 } from '../../testing/ui.js'
@@ -25,6 +26,10 @@ vi.mock('ink', async () => {
 const ARROW_DOWN = '\u001B[B'
 const ENTER = '\r'
 const DELETE = '\u007F'
+
+function mouseClick(column: number, row: number): [string, string] {
+  return [`\u001B[<0;${column};${row}M`, `\u001B[<0;${column};${row}m`]
+}
 
 const DATABASE = [
   {label: 'first', value: 'first'},
@@ -81,10 +86,13 @@ const DATABASE = [
 
 beforeEach(() => {
   vi.mocked(useStdout).mockReturnValue({
-    stdout: new Stdout({
-      columns: 80,
-      rows: 80,
-    }) as any,
+    stdout: Object.assign(
+      new Stdout({
+        columns: 80,
+        rows: 80,
+      }),
+      {isTTY: true},
+    ) as any,
     write: () => {},
   })
 })
@@ -126,6 +134,41 @@ describe('AutocompletePrompt', async () => {
     `)
 
     expect(onEnter).toHaveBeenCalledWith(items[1]!.value)
+  })
+
+  test('selects an organization from its absolute terminal row', async () => {
+    const onEnter = vi.fn()
+    const organizations = [
+      {label: 'First organization', value: 'first'},
+      {label: 'Second organization', value: 'second'},
+      {label: 'Third organization', value: 'third'},
+      {label: 'Fourth organization', value: 'fourth'},
+      {label: 'Fifth organization', value: 'fifth'},
+      {label: 'Sixth organization', value: 'sixth'},
+    ]
+    const renderInstance = render(
+      <AutocompletePrompt
+        message="Which organization do you want to use?"
+        choices={organizations}
+        onSubmit={onEnter}
+        search={(term) =>
+          Promise.resolve({
+            data: organizations.filter((organization) => organization.label.includes(term)),
+          })
+        }
+        searchDebounceMs={0}
+      />,
+      {stdoutIsTTY: true},
+    )
+
+    await waitForInputsToBeReady()
+    await sendInputAndWait(renderInstance, 60, '\u001B[40;1R')
+    await waitFor(
+      () => mouseClick(4, 32).forEach((input) => renderInstance.stdin.write(input)),
+      () => onEnter.mock.calls.length > 0,
+    )
+
+    expect(onEnter).toHaveBeenCalledWith('second')
   })
 
   test('renders groups', async () => {
@@ -174,7 +217,7 @@ describe('AutocompletePrompt', async () => {
             ninth
             tenth
 
-         [2mPress ↑↓ arrows to select, enter to confirm.[22m
+         [2mPress ↑↓ arrows to select, enter to confirm, or click an option.[22m
       "
     `)
   })
@@ -205,10 +248,10 @@ describe('AutocompletePrompt', async () => {
     expect(renderInstance.lastFrame()).toMatchInlineSnapshot(`
       "?  Associate your project with the org Castile Ventures?
 
-         ┃  \u001b[1mAdd\u001b[22m
+         ┃  [1mAdd[22m
          ┃  • new-ext
          ┃
-         ┃  \u001b[1mRemove\u001b[22m
+         ┃  [1mRemove[22m
          ┃  • integrated-demand-ext
          ┃  • order-discount
 
@@ -217,7 +260,7 @@ describe('AutocompletePrompt', async () => {
          third
          fourth
 
-         [2mPress ↑↓ arrows to select, enter to confirm.[22m
+         [2mPress ↑↓ arrows to select, enter to confirm, or click an option.[22m
       "
     `)
   })
@@ -260,7 +303,7 @@ describe('AutocompletePrompt', async () => {
          third
          fourth
 
-         [2mPress ↑↓ arrows to select, enter to confirm.[22m
+         [2mPress ↑↓ arrows to select, enter to confirm, or click an option.[22m
       "
     `)
   })
@@ -408,7 +451,7 @@ describe('AutocompletePrompt', async () => {
          twenty-fourth                                                               [100m [49m
          twenty-fifth                                                                [100m [49m
 
-         [2mPress ↑↓ arrows to select, enter to confirm.[22m
+         [2mPress ↑↓ arrows to select, enter to confirm, or click an option.[22m
       "
     `)
 
@@ -444,7 +487,7 @@ describe('AutocompletePrompt', async () => {
          th[1mi[22mrty-fifth                                                                [100m [49m
          th[1mi[22mrty-sixth                                                                [100m [49m
 
-         [2mPress ↑↓ arrows to select, enter to confirm.[22m
+         [2mPress ↑↓ arrows to select, enter to confirm, or click an option.[22m
       "
     `)
 
@@ -479,7 +522,7 @@ describe('AutocompletePrompt', async () => {
          twenty-fourth                                                               [100m [49m
          twenty-fifth                                                                [100m [49m
 
-         [2mPress ↑↓ arrows to select, enter to confirm.[22m
+         [2mPress ↑↓ arrows to select, enter to confirm, or click an option.[22m
       "
     `)
 
@@ -516,7 +559,7 @@ describe('AutocompletePrompt', async () => {
          th[1mi[22mrty-fifth                                                                [100m [49m
          th[1mi[22mrty-sixth                                                                [100m [49m
 
-         [2mPress ↑↓ arrows to select, enter to confirm.[22m
+         [2mPress ↑↓ arrows to select, enter to confirm, or click an option.[22m
       "
     `)
 
@@ -579,7 +622,7 @@ describe('AutocompletePrompt', async () => {
          twenty-fourth                                                               [100m [49m
          twenty-fifth                                                                [100m [49m
 
-         [2mPress ↑↓ arrows to select, enter to confirm.[22m
+         [2mPress ↑↓ arrows to select, enter to confirm, or click an option.[22m
       "
     `)
 
@@ -615,7 +658,7 @@ describe('AutocompletePrompt', async () => {
 
 
 
-         [2mPress ↑↓ arrows to select, enter to confirm.[22m
+         [2mPress ↑↓ arrows to select, enter to confirm, or click an option.[22m
       "
     `)
   })
@@ -721,7 +764,7 @@ describe('AutocompletePrompt', async () => {
          th[1mi[22mrty-fifth                                                                [100m [49m
          th[1mi[22mrty-sixth                                                                [100m [49m
 
-         [2mPress ↑↓ arrows to select, enter to confirm.[22m
+         [2mPress ↑↓ arrows to select, enter to confirm, or click an option.[22m
       "
     `)
 
@@ -756,7 +799,7 @@ describe('AutocompletePrompt', async () => {
          twenty-fourth                                                               [100m [49m
          twenty-fifth                                                                [100m [49m
 
-         [2mPress ↑↓ arrows to select, enter to confirm.[22m
+         [2mPress ↑↓ arrows to select, enter to confirm, or click an option.[22m
       "
     `)
   })
@@ -808,7 +851,7 @@ describe('AutocompletePrompt', async () => {
          twenty-fourth                                                               [100m [49m
          twenty-fifth                                                                [100m [49m
 
-         [2mPress ↑↓ arrows to select, enter to confirm.[22m
+         [2mPress ↑↓ arrows to select, enter to confirm, or click an option.[22m
          [1m1-50 of many[22m  Find what you're looking for by typing its name.
       "
     `)
@@ -850,13 +893,13 @@ describe('AutocompletePrompt', async () => {
     expect(renderInstance.lastFrame()).toMatchInlineSnapshot(`
       "?  Associate your project with the org Castile Ventures?   [36m[7mT[27m[2mype to search...[22m[39m
 
-         [1mAutomations[22m                                                                 \u001b[46m \u001b[49m
-         [36m>[39m  [36mfirst[39m                                                                    \u001b[100m \u001b[49m
-            second                                                                   \u001b[100m \u001b[49m
-                                                                                     \u001b[100m \u001b[49m
-         [1mMerchant Admin[22m                                                              \u001b[100m \u001b[49m
+         [1mAutomations[22m                                                                 [46m [49m
+         [36m>[39m  [36mfirst[39m                                                                    [100m [49m
+            second                                                                   [100m [49m
+                                                                                     [100m [49m
+         [1mMerchant Admin[22m                                                              [100m [49m
 
-         [2mPress ↑↓ arrows to select, enter to confirm.[22m
+         [2mPress ↑↓ arrows to select, enter to confirm, or click an option.[22m
          [1m1-10 of many[22m  Find what you're looking for by typing its name.
       "
     `)

--- a/packages/cli-kit/src/private/node/ui/components/Mouse.test.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/Mouse.test.tsx
@@ -1,0 +1,67 @@
+import {MouseProvider, useOnClick} from './Mouse.js'
+import {render, sendInputAndWait, waitForInputsToBeReady} from '../../testing/ui.js'
+import React, {useRef} from 'react'
+import {Box, DOMElement, Text} from 'ink'
+import {beforeEach, describe, expect, test, vi} from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  getMouseEnabled: vi.fn(() => true),
+}))
+
+vi.mock('../../conf-store.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../conf-store.js')>()
+  return {...actual, getMouseEnabled: mocks.getMouseEnabled}
+})
+
+function Clickable({onClick}: {onClick: () => void}) {
+  const ref = useRef<DOMElement>(null)
+  useOnClick(ref, onClick)
+  return (
+    <Box ref={ref}>
+      <Text>Click me</Text>
+    </Box>
+  )
+}
+
+function mouseClick(column: number, row: number): [string, string] {
+  return [`\u001B[<0;${column};${row}M`, `\u001B[<0;${column};${row}m`]
+}
+
+describe('MouseProvider', () => {
+  beforeEach(() => {
+    mocks.getMouseEnabled.mockReturnValue(true)
+  })
+
+  test('handles clicks when mouse interactions are enabled', async () => {
+    const onClick = vi.fn()
+    const renderInstance = render(
+      <MouseProvider>
+        <Clickable onClick={onClick} />
+      </MouseProvider>,
+      {stdoutIsTTY: true},
+    )
+
+    await waitForInputsToBeReady()
+    await sendInputAndWait(renderInstance, 10, ...mouseClick(2, 1))
+
+    expect(onClick).toHaveBeenCalledOnce()
+    renderInstance.unmount()
+  })
+
+  test('ignores clicks when mouse interactions are disabled', async () => {
+    mocks.getMouseEnabled.mockReturnValue(false)
+    const onClick = vi.fn()
+    const renderInstance = render(
+      <MouseProvider>
+        <Clickable onClick={onClick} />
+      </MouseProvider>,
+      {stdoutIsTTY: true},
+    )
+
+    await waitForInputsToBeReady()
+    await sendInputAndWait(renderInstance, 10, ...mouseClick(2, 1))
+
+    expect(onClick).not.toHaveBeenCalled()
+    renderInstance.unmount()
+  })
+})

--- a/packages/cli-kit/src/private/node/ui/components/Mouse.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/Mouse.tsx
@@ -1,0 +1,244 @@
+import {getMouseEnabled} from '../../conf-store.js'
+import React, {createContext, useCallback, useContext, useEffect, useMemo, useRef, useState} from 'react'
+import {Box, DOMElement, useStdin, useStdout} from 'ink'
+import {
+  getBoundingClientRect,
+  getElementDimensions,
+  MouseProvider as InkMouseProvider,
+  useOnClick as useInkOnClick,
+  useOnMouseEnter as useInkOnMouseEnter,
+  type ClickHandler,
+  type ElementRef,
+  type MouseEnterHandler,
+} from '@ink-tools/ink-mouse'
+
+const CURSOR_POSITION_REQUEST = '\u001B[6n'
+// Ink removes the leading escape character before passing terminal input to useInput.
+const CURSOR_POSITION_RESPONSE_PREFIX = '['
+const MOUSE_ORIGIN_QUERY_TIMEOUT_MS = 100
+const MOUSE_LAYOUT_POLL_INTERVAL_MS = 50
+const MOUSE_SCROLL_RELEASE_MS = 1500
+// Mouse tracking modes are mutually exclusive in terminal emulators. After disabling
+// movement modes, explicitly restore basic press/release reporting for clickable tabs.
+const ENABLE_CLICK_ONLY_MOUSE = '\u001B[?1003l\u001B[?1002l\u001B[?1000h'
+const DISABLE_MOUSE_REPORTING = '\u001B[?1003l\u001B[?1002l\u001B[?1000l'
+const SGR_MOUSE_EVENT_PATTERN = new RegExp(`${String.fromCharCode(27)}\\[<(\\d+);\\d+;\\d+[Mm]`, 'gu')
+const MouseOriginContext = createContext(0)
+
+interface MouseProviderProps extends React.PropsWithChildren {
+  allowTerminalScrolling?: boolean
+  trackMouseMovement?: boolean
+}
+
+function getMouseTrackingMode(trackMouseMovement: boolean): string | undefined {
+  if (trackMouseMovement) return undefined
+  return ENABLE_CLICK_ONLY_MOUSE
+}
+
+function containsMouseWheelEvent(data: Buffer | string): boolean {
+  return [...data.toString().matchAll(SGR_MOUSE_EVENT_PATTERN)].some((match) => {
+    const buttonCode = Number(match[1])
+    return buttonCode >= 64 && buttonCode < 128
+  })
+}
+
+function parseCursorPosition(data: Buffer | string): {row: number; column: number} | undefined {
+  const response = data.toString()
+  const responseStart = response.indexOf(CURSOR_POSITION_RESPONSE_PREFIX)
+  const responseEnd = response.indexOf('R', responseStart)
+  if (responseStart === -1 || responseEnd === -1) return undefined
+
+  const [row, column] = response.slice(responseStart + CURSOR_POSITION_RESPONSE_PREFIX.length, responseEnd).split(';')
+  const parsedRow = Number(row)
+  const parsedColumn = Number(column)
+  if (!Number.isInteger(parsedRow) || !Number.isInteger(parsedColumn)) return undefined
+
+  return {row: parsedRow, column: parsedColumn}
+}
+
+function removeSgrMouseResponses(input: string): string {
+  let sanitizedInput = input
+  let responseStart = sanitizedInput.indexOf('[<')
+
+  while (responseStart !== -1) {
+    const pressEnd = sanitizedInput.indexOf('M', responseStart)
+    const releaseEnd = sanitizedInput.indexOf('m', responseStart)
+    const responseEnd = [pressEnd, releaseEnd].filter((index) => index !== -1).sort((left, right) => left - right)[0]
+    if (responseEnd === undefined) break
+
+    const fields = sanitizedInput.slice(responseStart + 2, responseEnd).split(';')
+    const isMouseResponse =
+      fields.length === 3 && fields.every((field) => field.length > 0 && Number.isInteger(Number(field)))
+    if (!isMouseResponse) {
+      responseStart = sanitizedInput.indexOf('[<', responseStart + 1)
+      continue
+    }
+
+    sanitizedInput = sanitizedInput.slice(0, responseStart) + sanitizedInput.slice(responseEnd + 1)
+    responseStart = sanitizedInput.indexOf('[<', responseStart)
+  }
+
+  return sanitizedInput
+}
+
+export function removeTerminalInputResponses(input: string): string {
+  let sanitizedInput = input
+  let responseStart = sanitizedInput.indexOf(CURSOR_POSITION_RESPONSE_PREFIX)
+
+  while (responseStart !== -1) {
+    const responseEnd = sanitizedInput.indexOf('R', responseStart)
+    if (responseEnd === -1) break
+
+    const response = sanitizedInput.slice(responseStart, responseEnd + 1)
+    if (!parseCursorPosition(response)) {
+      responseStart = sanitizedInput.indexOf(CURSOR_POSITION_RESPONSE_PREFIX, responseStart + 1)
+      continue
+    }
+
+    sanitizedInput = sanitizedInput.slice(0, responseStart) + sanitizedInput.slice(responseEnd + 1)
+    responseStart = sanitizedInput.indexOf(CURSOR_POSITION_RESPONSE_PREFIX, responseStart)
+  }
+
+  return removeSgrMouseResponses(sanitizedInput)
+}
+
+export function MouseProvider({children, ...mouseProviderProps}: MouseProviderProps): React.ReactElement {
+  if (getMouseEnabled()) {
+    return <EnabledMouseProvider {...mouseProviderProps}>{children}</EnabledMouseProvider>
+  }
+
+  return (
+    <InkMouseProvider autoEnable={false}>
+      <Box flexDirection="column">{children}</Box>
+    </InkMouseProvider>
+  )
+}
+
+function EnabledMouseProvider({
+  allowTerminalScrolling = false,
+  children,
+  trackMouseMovement = true,
+}: MouseProviderProps): React.ReactElement {
+  const rootRef = useRef<DOMElement>(null)
+  const {stdin} = useStdin()
+  const {stdout} = useStdout()
+  const [verticalOffset, setVerticalOffset] = useState(0)
+  const [rootHeight, setRootHeight] = useState<number>()
+  const scrollReleaseTimeoutRef = useRef<ReturnType<typeof setTimeout>>()
+  const mouseTrackingMode = getMouseTrackingMode(trackMouseMovement)
+
+  useEffect(() => {
+    const measureRoot = () => {
+      const measuredHeight = getElementDimensions(rootRef.current)?.height
+      setRootHeight((currentHeight) => (currentHeight === measuredHeight ? currentHeight : measuredHeight))
+    }
+
+    measureRoot()
+    const interval = setInterval(measureRoot, MOUSE_LAYOUT_POLL_INTERVAL_MS)
+    return () => clearInterval(interval)
+  }, [])
+
+  useEffect(() => {
+    if (!stdin.isTTY || !stdout.isTTY || rootHeight === undefined) return
+
+    const stopListening = () => {
+      clearTimeout(timeout)
+      stdin.off('data', handleCursorPosition)
+    }
+    const handleCursorPosition = (data: Buffer | string) => {
+      const cursorPosition = parseCursorPosition(data)
+      const rootDimensions = getElementDimensions(rootRef.current)
+      if (!cursorPosition || !rootDimensions) return
+
+      const trailingLineOffset = cursorPosition.column === 1 ? 1 : 0
+      setVerticalOffset(Math.max(0, cursorPosition.row - rootDimensions.height - trailingLineOffset))
+      stopListening()
+    }
+
+    stdin.on('data', handleCursorPosition)
+    const timeout = setTimeout(stopListening, MOUSE_ORIGIN_QUERY_TIMEOUT_MS)
+    stdout.write(CURSOR_POSITION_REQUEST)
+
+    return stopListening
+  }, [rootHeight, stdin, stdout])
+
+  useEffect(() => {
+    if (mouseTrackingMode && stdout.isTTY) stdout.write(mouseTrackingMode)
+  }, [mouseTrackingMode, stdout])
+
+  const releaseMouseForTerminalScrolling = useCallback(() => {
+    if (!mouseTrackingMode || !stdout.isTTY) return
+
+    stdout.write(DISABLE_MOUSE_REPORTING)
+    clearTimeout(scrollReleaseTimeoutRef.current)
+    scrollReleaseTimeoutRef.current = setTimeout(() => {
+      stdout.write(mouseTrackingMode)
+    }, MOUSE_SCROLL_RELEASE_MS)
+  }, [mouseTrackingMode, stdout])
+
+  useEffect(() => {
+    return () => clearTimeout(scrollReleaseTimeoutRef.current)
+  }, [])
+
+  useEffect(() => {
+    if (!allowTerminalScrolling || !mouseTrackingMode || !stdin.isTTY) return
+
+    const handleTerminalInput = (data: Buffer | string) => {
+      if (containsMouseWheelEvent(data)) releaseMouseForTerminalScrolling()
+    }
+
+    // Listen to stdin directly so scrolling is detected even when the pointer is
+    // outside the rendered Ink tree, including blank areas of the terminal viewport.
+    stdin.on('data', handleTerminalInput)
+    return () => {
+      stdin.off('data', handleTerminalInput)
+    }
+  }, [allowTerminalScrolling, mouseTrackingMode, releaseMouseForTerminalScrolling, stdin])
+
+  return (
+    <InkMouseProvider>
+      <MouseOriginContext.Provider value={verticalOffset}>
+        <Box ref={rootRef} flexDirection="column">
+          {children}
+        </Box>
+      </MouseOriginContext.Provider>
+    </InkMouseProvider>
+  )
+}
+
+export function useOnClick(ref: ElementRef, handler: ClickHandler | null | undefined): void {
+  const offsetRef = useOffsetRef(ref)
+  useInkOnClick(offsetRef, handler)
+}
+
+export function useOnMouseEnter(ref: ElementRef, handler: MouseEnterHandler | null | undefined): void {
+  const offsetRef = useOffsetRef(ref)
+  useInkOnMouseEnter(offsetRef, handler)
+}
+
+function useOffsetRef(ref: ElementRef): ElementRef {
+  const verticalOffset = useContext(MouseOriginContext)
+  return useMemo<ElementRef>(() => {
+    return {
+      get current() {
+        const element = ref.current as DOMElement | null
+        const bounds = getBoundingClientRect(element)
+        if (!bounds) return null
+
+        return {
+          yogaNode: {
+            getComputedLayout: () => ({
+              left: bounds.left - 1,
+              top: bounds.top - 1 + verticalOffset,
+              // ink-mouse treats right and bottom edges as inclusive. Yoga dimensions
+              // are counts, so subtract one to prevent adjacent terminal cells from overlapping.
+              width: Math.max(0, bounds.width - 1),
+              height: Math.max(0, bounds.height - 1),
+            }),
+          },
+          parentNode: null,
+        }
+      },
+    }
+  }, [ref, verticalOffset])
+}

--- a/packages/cli-kit/src/private/node/ui/components/Prompts/PromptLayout.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/Prompts/PromptLayout.tsx
@@ -1,5 +1,6 @@
 import {InfoTable, InfoTableProps} from './InfoTable.js'
 import {InfoMessage, InfoMessageProps} from './InfoMessage.js'
+import {MouseProvider} from '../Mouse.js'
 import {TokenizedText} from '../TokenizedText.js'
 import {messageWithPunctuation} from '../../utilities.js'
 import {AbortSignal} from '../../../../../public/node/abort.js'
@@ -90,7 +91,9 @@ const PromptLayout = ({
   // Object.keys on an array returns the indices as strings
   const showInfoTable = infoTable && Object.keys(infoTable).length > 0
 
-  return isAborted ? null : (
+  if (isAborted) return null
+
+  const prompt = (
     <Box flexDirection="column" marginBottom={1} ref={wrapperRef}>
       <Box ref={promptAreaRef} flexDirection="column">
         <Box>
@@ -133,6 +136,8 @@ const PromptLayout = ({
       )}
     </Box>
   )
+
+  return state === PromptState.Submitted ? prompt : <MouseProvider>{prompt}</MouseProvider>
 }
 
 export {PromptLayout}

--- a/packages/cli-kit/src/private/node/ui/components/SelectInput.test.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/SelectInput.test.tsx
@@ -1,9 +1,12 @@
 import {SelectInput} from './SelectInput.js'
+import {MouseProvider} from './Mouse.js'
 import {
   sendInputAndWait,
   sendInputAndWaitForChange,
+  waitFor,
+  waitForChange,
   waitForInputsToBeReady,
-  render,
+  render as renderUI,
   getLastFrameAfterUnmount,
 } from '../../testing/ui.js'
 import {platformAndArch} from '../../../../public/node/os.js'
@@ -11,9 +14,47 @@ import {describe, expect, test, vi} from 'vitest'
 
 import React from 'react'
 
+const render = (element: React.ReactElement) => renderUI(<MouseProvider>{element}</MouseProvider>, {stdoutIsTTY: true})
+
 const ARROW_UP = '\u001B[A'
 const ARROW_DOWN = '\u001B[B'
 const ENTER = '\r'
+const CURSOR_POSITION_REQUEST = '\u001B[6n'
+
+function mouseClick(column: number, row: number): [string, string] {
+  return [`\u001B[<0;${column};${row}M`, `\u001B[<0;${column};${row}m`]
+}
+
+function mouseMove(column: number, row: number): string {
+  return `\u001B[<35;${column};${row}M`
+}
+
+async function clickWhenMouseOriginIsReady(
+  renderInstance: ReturnType<typeof render>,
+  onSubmit: ReturnType<typeof vi.fn>,
+  column: number,
+  row: number,
+): Promise<void> {
+  await vi.waitFor(() => {
+    if (onSubmit.mock.calls.length === 0) {
+      mouseClick(column, row).forEach((input) => renderInstance.stdin.write(input))
+    }
+    expect(onSubmit).toHaveBeenCalled()
+  })
+}
+
+async function respondToCursorPositionRequest(
+  renderInstance: ReturnType<typeof render>,
+  requestNumber: number,
+): Promise<void> {
+  await waitFor(
+    () => {},
+    () =>
+      renderInstance.stdout.controlSequences.filter((sequence) => sequence === CURSOR_POSITION_REQUEST).length >=
+      requestNumber,
+  )
+  await sendInputAndWait(renderInstance, 10, '\u001B[40;1R')
+}
 
 describe('SelectInput', async () => {
   test('move up with up arrow key', async () => {
@@ -46,7 +87,7 @@ describe('SelectInput', async () => {
       [36m>[39m  [36mSecond[39m
          Third
 
-         [2mPress ↑↓ arrows to select, enter to confirm.[22m"
+         [2mPress ↑↓ arrows to select, enter to confirm, or click an option.[22m"
     `)
     expect(onChange).toHaveBeenLastCalledWith(items[1])
   })
@@ -79,9 +120,99 @@ describe('SelectInput', async () => {
       [36m>[39m  [36mSecond[39m
          Third
 
-         [2mPress ↑↓ arrows to select, enter to confirm.[22m"
+         [2mPress ↑↓ arrows to select, enter to confirm, or click an option.[22m"
     `)
     expect(onChange).toHaveBeenCalledWith(items[1])
+  })
+
+  test('selects and submits an option when clicked', async () => {
+    const onChange = vi.fn()
+    const onSubmit = vi.fn()
+    const items = [
+      {label: 'First', value: 'first'},
+      {label: 'Second', value: 'second'},
+    ]
+    const renderInstance = render(<SelectInput items={items} onChange={onChange} onSubmit={onSubmit} />)
+
+    await waitForInputsToBeReady()
+    await waitFor(
+      () => mouseClick(4, 2).forEach((input) => renderInstance.stdin.write(input)),
+      () => onChange.mock.calls.some(([item]) => item === items[1]),
+    )
+
+    expect(onChange).toHaveBeenLastCalledWith(items[1])
+    expect(onSubmit).toHaveBeenCalledWith(items[1])
+  })
+
+  test('selects an option when hovered', async () => {
+    const onChange = vi.fn()
+    const items = [
+      {label: 'First', value: 'first'},
+      {label: 'Second', value: 'second'},
+    ]
+    const renderInstance = render(<SelectInput items={items} onChange={onChange} />)
+
+    await waitForInputsToBeReady()
+    await sendInputAndWaitForChange(renderInstance, mouseMove(4, 2))
+
+    expect(renderInstance.lastFrame()).toContain('>')
+    expect(onChange).toHaveBeenLastCalledWith(items[1])
+  })
+
+  test('selects each row at the correct boundary when hovering upward', async () => {
+    const onChange = vi.fn()
+    const items = [
+      {label: 'First', value: 'first'},
+      {label: 'Second', value: 'second'},
+      {label: 'Third', value: 'third'},
+    ]
+    const renderInstance = render(<SelectInput items={items} onChange={onChange} />)
+
+    await waitForInputsToBeReady()
+    await sendInputAndWaitForChange(renderInstance, mouseMove(4, 3))
+    expect(onChange).toHaveBeenLastCalledWith(items[2])
+
+    await sendInputAndWaitForChange(renderInstance, mouseMove(4, 2))
+    expect(onChange).toHaveBeenLastCalledWith(items[1])
+  })
+
+  test('accounts for output rendered before the interactive list', async () => {
+    const onSubmit = vi.fn()
+    const items = [
+      {label: 'First', value: 'first'},
+      {label: 'Second', value: 'second'},
+    ]
+    const renderInstance = render(<SelectInput items={items} onSubmit={onSubmit} />)
+
+    await waitForInputsToBeReady()
+    await respondToCursorPositionRequest(renderInstance, 1)
+    await clickWhenMouseOriginIsReady(renderInstance, onSubmit, 4, 37)
+
+    expect(onSubmit).toHaveBeenCalledWith(items[1])
+  })
+
+  test('recalculates the terminal origin when a list grows after loading', async () => {
+    const onSubmit = vi.fn()
+    let showAllItems = () => {}
+    const initialItems = [
+      {label: 'First', value: 'first'},
+      {label: 'Second', value: 'second'},
+    ]
+    const loadedItems = [...initialItems, {label: 'Third', value: 'third'}, {label: 'Fourth', value: 'fourth'}]
+    const DynamicSelectInput = () => {
+      const [items, setItems] = React.useState(initialItems)
+      showAllItems = () => setItems(loadedItems)
+      return <SelectInput items={items} onSubmit={onSubmit} />
+    }
+    const renderInstance = render(<DynamicSelectInput />)
+
+    await waitForInputsToBeReady()
+    await respondToCursorPositionRequest(renderInstance, 1)
+    await waitForChange(showAllItems, renderInstance.lastFrame)
+    await respondToCursorPositionRequest(renderInstance, 2)
+    await clickWhenMouseOriginIsReady(renderInstance, onSubmit, 4, 35)
+
+    expect(onSubmit).toHaveBeenCalledWith(loadedItems[1])
   })
 
   test('throws an error if a key has more than 1 character', async () => {
@@ -160,7 +291,7 @@ describe('SelectInput', async () => {
          Second
          Tenth
 
-         [2mPress ↑↓ arrows to select, enter to confirm.[22m"
+         [2mPress ↑↓ arrows to select, enter to confirm, or click an option.[22m"
     `)
     expect(onChange).not.toHaveBeenCalled()
   })
@@ -202,7 +333,7 @@ describe('SelectInput', async () => {
             ninth
             tenth
 
-         [2mPress ↑↓ arrows to select, enter to confirm.[22m"
+         [2mPress ↑↓ arrows to select, enter to confirm, or click an option.[22m"
     `)
 
     await waitForInputsToBeReady()
@@ -226,7 +357,7 @@ describe('SelectInput', async () => {
             ninth
             tenth
 
-         [2mPress ↑↓ arrows to select, enter to confirm.[22m"
+         [2mPress ↑↓ arrows to select, enter to confirm, or click an option.[22m"
     `)
     expect(onChange).toHaveBeenLastCalledWith(items[2])
   })
@@ -263,7 +394,7 @@ describe('SelectInput', async () => {
 
 
 
-         [2mPress ↑↓ arrows to select, enter to confirm.[22m"
+         [2mPress ↑↓ arrows to select, enter to confirm, or click an option.[22m"
     `)
     expect(onChange).not.toHaveBeenCalled()
   })
@@ -299,7 +430,7 @@ describe('SelectInput', async () => {
             item3
             item5
 
-         [2mPress ↑↓ arrows to select, enter to confirm.[22m"
+         [2mPress ↑↓ arrows to select, enter to confirm, or click an option.[22m"
     `)
     expect(onChange).not.toHaveBeenCalled()
   })
@@ -332,7 +463,7 @@ describe('SelectInput', async () => {
          Second
          Third
 
-         [2mPress ↑↓ arrows to select, enter to confirm.[22m"
+         [2mPress ↑↓ arrows to select, enter to confirm, or click an option.[22m"
     `)
     expect(onChange).not.toHaveBeenCalled()
   })
@@ -362,7 +493,7 @@ describe('SelectInput', async () => {
       [36m>[39m  [36mSecond[39m
          Third
 
-         [2mPress ↑↓ arrows to select, enter to confirm.[22m"
+         [2mPress ↑↓ arrows to select, enter to confirm, or click an option.[22m"
     `)
   })
 
@@ -398,7 +529,7 @@ describe('SelectInput', async () => {
          Second
          Third
 
-         [2mPress ↑↓ arrows to select, enter to confirm.[22m
+         [2mPress ↑↓ arrows to select, enter to confirm, or click an option.[22m
          [1m1-3 of many[22m  Keep scrolling to see more items"
     `)
   })
@@ -431,7 +562,7 @@ describe('SelectInput', async () => {
          [1mOther[22m                                                                       [100m [49m
             first                                                                    [100m [49m
 
-         [2mPress ↑↓ arrows to select, enter to confirm.[22m"
+         [2mPress ↑↓ arrows to select, enter to confirm, or click an option.[22m"
     `)
 
     await waitForInputsToBeReady()
@@ -453,7 +584,7 @@ describe('SelectInput', async () => {
             first                                                                    [100m [49m
          [36m>[39m  [36msecond[39m                                                                   [100m [49m
 
-         [2mPress ↑↓ arrows to select, enter to confirm.[22m"
+         [2mPress ↑↓ arrows to select, enter to confirm, or click an option.[22m"
     `)
   })
 
@@ -564,7 +695,7 @@ describe('SelectInput', async () => {
          [2mSecond[22m
       [36m>[39m  [36mThird[39m
 
-         [2mPress ↑↓ arrows to select, enter to confirm.[22m"
+         [2mPress ↑↓ arrows to select, enter to confirm, or click an option.[22m"
     `)
 
     await sendInputAndWait(renderInstance, 10, ENTER)
@@ -599,7 +730,7 @@ describe('SelectInput', async () => {
          [2mSecond[22m
          Third
 
-         [2mPress ↑↓ arrows to select, enter to confirm.[22m"
+         [2mPress ↑↓ arrows to select, enter to confirm, or click an option.[22m"
     `)
 
     await waitForInputsToBeReady()
@@ -639,7 +770,7 @@ describe('SelectInput', async () => {
          [2m(s) Second[22m
       [36m>[39m  [36m(t) Third[39m
 
-         [2mPress ↑↓ arrows to select, enter or a shortcut to confirm.[22m"
+         [2mUse ↑↓ to select; press enter, use a shortcut, or click an option.[22m"
     `)
 
     await sendInputAndWait(renderInstance, 10, ENTER)

--- a/packages/cli-kit/src/private/node/ui/components/SelectInput.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/SelectInput.tsx
@@ -1,9 +1,12 @@
 import {Scrollbar} from './Scrollbar.js'
+import {useOnClick, useOnMouseEnter} from './Mouse.js'
+import {getMouseEnabled} from '../../conf-store.js'
 import {handleCtrlC} from '../../ui.js'
 import useLayout from '../hooks/use-layout.js'
 import {useSelectState} from '../hooks/use-select-state.js'
 import React, {useCallback, useEffect} from 'react'
 import {Box, Key, useInput, Text, DOMElement} from 'ink'
+import {type InkMouseEvent} from '@ink-tools/ink-mouse'
 import chalk from 'chalk'
 import figures from 'figures'
 import sortBy from 'lodash/sortBy.js'
@@ -74,6 +77,8 @@ interface ItemProps<T> {
   enableShortcuts: boolean
   hasAnyGroup: boolean
   index: number
+  onClick?: () => void
+  onHover?: () => void
 }
 
 function Item<T>({
@@ -85,7 +90,19 @@ function Item<T>({
   items,
   hasAnyGroup,
   index,
+  onClick,
+  onHover,
 }: ItemProps<T>): React.ReactElement {
+  const itemRef = React.useRef<DOMElement>(null)
+  const handleClick = useCallback(
+    (event: InkMouseEvent) => {
+      if (event.button === 'left') onClick?.()
+    },
+    [onClick],
+  )
+  useOnClick(itemRef, onClick ? handleClick : undefined)
+  useOnMouseEnter(itemRef, onHover)
+
   const label = highlightedLabel(item.label, highlightedTerm)
   let title: string | undefined
   let labelColor
@@ -115,7 +132,7 @@ function Item<T>({
         </Box>
       ) : null}
 
-      <Box key={index} marginLeft={hasAnyGroup ? 3 : 0}>
+      <Box ref={itemRef} key={index} marginLeft={hasAnyGroup ? 3 : 0}>
         <Box marginRight={2}>{isSelected ? <Text color="cyan">{`>`}</Text> : <Text> </Text>}</Box>
         <Text wrap="end" color={labelColor}>
           {showKey ? `(${item.key}) ${label}` : label}
@@ -126,6 +143,18 @@ function Item<T>({
 }
 
 const MAX_AVAILABLE_LINES = 25
+
+function selectInputHelpText(itemsHaveKeys: boolean, mouseEnabled: boolean): string {
+  if (mouseEnabled && itemsHaveKeys) {
+    return `Use ${figures.arrowUp}${figures.arrowDown} to select; press enter, use a shortcut, or click an option.`
+  }
+  if (mouseEnabled) {
+    return `Press ${figures.arrowUp}${figures.arrowDown} arrows to select, enter to confirm, or click an option.`
+  }
+  return `Press ${figures.arrowUp}${figures.arrowDown} arrows to select, enter ${
+    itemsHaveKeys ? 'or a shortcut ' : ''
+  }to confirm.`
+}
 
 function SelectInput<T>({
   items: rawItems,
@@ -146,6 +175,7 @@ function SelectInput<T>({
   ref,
   groupOrder,
 }: SelectInputProps<T>): React.ReactElement | null {
+  const mouseEnabled = getMouseEnabled()
   let noItems = false
 
   if (rawItems.length === 0) {
@@ -222,6 +252,23 @@ function SelectInput<T>({
     [items, onSubmit, state],
   )
 
+  const handleClick = useCallback(
+    (item: Item<T>) => {
+      if (item.disabled) return
+
+      if (onSubmit) onSubmit(item)
+      state.selectOption({option: item})
+    },
+    [onSubmit, state],
+  )
+
+  const handleHover = useCallback(
+    (item: Item<T>) => {
+      if (!item.disabled) state.selectOption({option: item})
+    },
+    [state],
+  )
+
   useInput(
     (input, key) => {
       handleCtrlC(input, key)
@@ -277,6 +324,8 @@ function SelectInput<T>({
                 enableShortcuts={enableShortcuts}
                 hasAnyGroup={hasAnyGroup}
                 index={index}
+                onClick={focus ? () => handleClick(item) : undefined}
+                onHover={focus ? () => handleHover(item) : undefined}
               />
             ))}
           </Box>
@@ -298,11 +347,7 @@ function SelectInput<T>({
             </Box>
           ) : (
             <Box marginLeft={3} flexDirection="column">
-              <Text dimColor>
-                {`Press ${figures.arrowUp}${figures.arrowDown} arrows to select, enter ${
-                  itemsHaveKeys ? 'or a shortcut ' : ''
-                }to confirm.`}
-              </Text>
+              <Text dimColor>{selectInputHelpText(itemsHaveKeys, mouseEnabled)}</Text>
               {hasMorePages ? (
                 <Text>
                   <Text bold>1-{items.length} of many</Text>

--- a/packages/cli-kit/src/private/node/ui/components/SelectPrompt.test.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/SelectPrompt.test.tsx
@@ -105,7 +105,7 @@ describe('SelectPrompt', async () => {
             ninth
             tenth
 
-         [2mPress ↑↓ arrows to select, enter to confirm.[22m
+         [2mPress ↑↓ arrows to select, enter to confirm, or click an option.[22m
       "
     `)
   })
@@ -143,10 +143,10 @@ describe('SelectPrompt', async () => {
     expect(renderInstance.lastFrame()).toMatchInlineSnapshot(`
       "?  Associate your project with the org Castile Ventures?
 
-         ┃  \u001b[1mAdd\u001b[22m
+         ┃  [1mAdd[22m
          ┃  + new-ext
          ┃
-         ┃  \u001b[1mRemove\u001b[22m
+         ┃  [1mRemove[22m
          ┃  - integrated-demand-ext
          ┃  - order-discount [2m(1)[22m
 
@@ -155,7 +155,7 @@ describe('SelectPrompt', async () => {
          third
          fourth
 
-         [2mPress ↑↓ arrows to select, enter to confirm.[22m
+         [2mPress ↑↓ arrows to select, enter to confirm, or click an option.[22m
       "
     `)
   })
@@ -197,7 +197,7 @@ describe('SelectPrompt', async () => {
          third
          fourth
 
-         [2mPress ↑↓ arrows to select, enter to confirm.[22m
+         [2mPress ↑↓ arrows to select, enter to confirm, or click an option.[22m
       "
     `)
   })
@@ -231,7 +231,7 @@ describe('SelectPrompt', async () => {
       >  a
 
 
-         Press ↑↓ arrows to select, enter to confirm.
+         Press ↑↓ arrows to select, enter to confirm, or click an option.
       "
     `)
   })
@@ -253,7 +253,7 @@ describe('SelectPrompt', async () => {
          a
       >  b
 
-         Press ↑↓ arrows to select, enter to confirm.
+         Press ↑↓ arrows to select, enter to confirm, or click an option.
       "
     `)
 
@@ -283,7 +283,7 @@ describe('SelectPrompt', async () => {
       >  a
          b
 
-         Press ↑↓ arrows to select, enter to confirm.
+         Press ↑↓ arrows to select, enter to confirm, or click an option.
       "
     `)
 
@@ -313,7 +313,7 @@ describe('SelectPrompt', async () => {
       >  (a) a
          (b) b
 
-         Press ↑↓ arrows to select, enter or a shortcut to confirm.
+         Use ↑↓ to select; press enter, use a shortcut, or click an option.
       "
     `)
 
@@ -364,7 +364,7 @@ describe('SelectPrompt', async () => {
                                                                                      [100m [49m
          [1mMerchant Admin[22m                                                              [100m [49m
 
-         [2mPress ↑↓ arrows to select, enter to confirm.[22m
+         [2mPress ↑↓ arrows to select, enter to confirm, or click an option.[22m
       "
     `)
   })
@@ -390,7 +390,7 @@ describe('SelectPrompt', async () => {
          yes
       [36m>[39m  [36mno[39m
 
-         [2mPress ↑↓ arrows to select, enter to confirm.[22m
+         [2mPress ↑↓ arrows to select, enter to confirm, or click an option.[22m
       "
     `)
   })
@@ -418,7 +418,7 @@ describe('SelectPrompt', async () => {
          yes
       [36m>[39m  [36mno[39m
 
-         [2mPress ↑↓ arrows to select, enter to confirm.[22m
+         [2mPress ↑↓ arrows to select, enter to confirm, or click an option.[22m
       "
     `)
 
@@ -430,7 +430,7 @@ describe('SelectPrompt', async () => {
       [36m>[39m  [36myes[39m
          no
 
-         [2mPress ↑↓ arrows to select, enter to confirm.[22m
+         [2mPress ↑↓ arrows to select, enter to confirm, or click an option.[22m
       "
     `)
   })
@@ -460,7 +460,7 @@ describe('SelectPrompt', async () => {
       >  a
          b
 
-         Press ↑↓ arrows to select, enter to confirm.
+         Press ↑↓ arrows to select, enter to confirm, or click an option.
       "
     `)
 

--- a/packages/cli-kit/src/private/node/ui/components/TextInput.test.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/TextInput.test.tsx
@@ -126,6 +126,28 @@ describe('TextInput', () => {
     expect(renderInstance.lastFrame()).toMatchInlineSnapshot('"[36mHello[46m█[49m[39m"')
   })
 
+  test('ignores terminal cursor position responses', async () => {
+    const onChange = vi.fn()
+    const renderInstance = render(<TextInput value="" onChange={onChange} />)
+
+    await waitForInputsToBeReady()
+    await sendInputAndWait(renderInstance, 10, '\u001B[40;1R')
+
+    expect(onChange).not.toHaveBeenCalled()
+    expect(renderInstance.lastFrame()).toMatchInlineSnapshot('"[36m[46m█[49m[39m"')
+  })
+
+  test('ignores terminal mouse responses', async () => {
+    const onChange = vi.fn()
+    const renderInstance = render(<TextInput value="" onChange={onChange} />)
+
+    await waitForInputsToBeReady()
+    await sendInputAndWait(renderInstance, 10, '\u001B[<0;4;32M', '\u001B[<0;4;32m')
+
+    expect(onChange).not.toHaveBeenCalled()
+    expect(renderInstance.lastFrame()).toMatchInlineSnapshot('"[36m[46m█[49m[39m"')
+  })
+
   test('onChange', async () => {
     const onChange = vi.fn()
 

--- a/packages/cli-kit/src/private/node/ui/components/TextInput.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/TextInput.tsx
@@ -1,4 +1,5 @@
 /* eslint-disable no-nested-ternary */
+import {removeTerminalInputResponses} from './Mouse.js'
 import {shouldDisplayColors} from '../../../../public/node/output.js'
 import React, {useLayoutEffect, useState} from 'react'
 import {Text, useInput} from 'ink'
@@ -74,7 +75,16 @@ const TextInput: FunctionComponent<TextInputProps> = ({
 
   useInput(
     (input, key) => {
-      if (key.upArrow || key.downArrow || (key.ctrl && input === 'c') || (key.shift && key.tab) || key.return) {
+      const sanitizedInput = removeTerminalInputResponses(input)
+      if (input.length > 0 && sanitizedInput.length === 0) return
+
+      if (
+        key.upArrow ||
+        key.downArrow ||
+        (key.ctrl && sanitizedInput === 'c') ||
+        (key.shift && key.tab) ||
+        key.return
+      ) {
         return
       } else if (key.tab) {
         if (originalValue.length === 0 && placeholderText) {
@@ -105,9 +115,9 @@ const TextInput: FunctionComponent<TextInputProps> = ({
       } else {
         nextValue =
           originalValue.slice(0, clampedCursorOffset) +
-          input +
+          sanitizedInput +
           originalValue.slice(clampedCursorOffset, originalValue.length)
-        nextCursorOffset += input.length
+        nextCursorOffset += sanitizedInput.length
       }
 
       setCursorOffset(nextCursorOffset)

--- a/packages/cli-kit/src/public/node/ink.ts
+++ b/packages/cli-kit/src/public/node/ink.ts
@@ -1,1 +1,3 @@
 export {Box, Text, Static, useInput, useStdin, useStdout, measureElement} from 'ink'
+export type {DOMElement} from 'ink'
+export {MouseProvider, useOnClick, useOnMouseEnter} from '../../private/node/ui/components/Mouse.js'

--- a/packages/cli-kit/src/public/node/mouse.ts
+++ b/packages/cli-kit/src/public/node/mouse.ts
@@ -1,0 +1,3 @@
+import {getMouseEnabled, setMouseEnabled} from '../../private/node/conf-store.js'
+
+export {getMouseEnabled, setMouseEnabled}

--- a/packages/cli-kit/src/public/node/ui.tsx
+++ b/packages/cli-kit/src/public/node/ui.tsx
@@ -269,7 +269,8 @@ export interface RenderSelectPromptOptions<T> extends Omit<SelectPromptProps<T>,
  *       seventh
  *       tenth
  *
- *    Press ↑↓ arrows to select, enter to confirm.
+ *    Press ↑↓ arrows to select, enter to confirm, or click an
+ *    option.
  *
  */
 
@@ -322,8 +323,8 @@ export interface RenderConfirmationPromptOptions extends Pick<
  * >  (y) Yes, confirm changes
  *    (n) Cancel
  *
- *    Press ↑↓ arrows to select, enter or a shortcut to
- *    confirm.
+ *    Use ↑↓ to select; press enter, use a shortcut, or click
+ *    an option.
  *
  */
 export async function renderConfirmationPrompt({
@@ -403,7 +404,8 @@ export interface RenderAutocompleteOptions<T> extends PartialBy<
  *    twenty-fourth
  *    twenty-fifth
  *
- *    Press ↑↓ arrows to select, enter to confirm.
+ *    Press ↑↓ arrows to select, enter to confirm, or click an
+ *    option.
  *
  */
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -40,6 +40,8 @@
 * [`shopify config autoupgrade off`](#shopify-config-autoupgrade-off)
 * [`shopify config autoupgrade on`](#shopify-config-autoupgrade-on)
 * [`shopify config autoupgrade status`](#shopify-config-autoupgrade-status)
+* [`shopify config mouse off`](#shopify-config-mouse-off)
+* [`shopify config mouse on`](#shopify-config-mouse-on)
 * [`shopify doc fetch`](#shopify-doc-fetch)
 * [`shopify doc search`](#shopify-doc-search)
 * [`shopify help [command] [flags]`](#shopify-help-command-flags)
@@ -2128,6 +2130,43 @@ DESCRIPTION
   When auto-upgrade is enabled, Shopify CLI automatically updates to the latest version after each command.
 
   Run `shopify config autoupgrade on` or `shopify config autoupgrade off` to configure it.
+```
+
+## `shopify config mouse off`
+
+Disable mouse interactions in Shopify CLI.
+
+```
+USAGE
+  $ shopify config mouse off
+
+DESCRIPTION
+  Disable mouse interactions in Shopify CLI.
+
+  Disable mouse interactions in Shopify CLI.
+
+  When mouse interactions are disabled, standard terminal text selection and scrolling are restored.
+
+  To enable clickable prompt options and app dev tabs, run `shopify config mouse on`.
+```
+
+## `shopify config mouse on`
+
+Enable mouse interactions in Shopify CLI.
+
+```
+USAGE
+  $ shopify config mouse on
+
+DESCRIPTION
+  Enable mouse interactions in Shopify CLI.
+
+  Enable mouse interactions in Shopify CLI.
+
+  Mouse interactions are enabled by default and allow you to click prompt options and app dev tabs. To select text while
+  they are enabled, hold Option in iTerm2 or Shift in most other terminals while dragging.
+
+  To restore standard terminal text selection and scrolling, run `shopify config mouse off`.
 ```
 
 ## `shopify doc fetch`

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -3748,6 +3748,46 @@
       "strict": true,
       "summary": "Check whether auto-upgrade is enabled, disabled, or not yet configured."
     },
+    "config:mouse:off": {
+      "aliases": [
+      ],
+      "args": {
+      },
+      "description": "Disable mouse interactions in Shopify CLI.\n\n  When mouse interactions are disabled, standard terminal text selection and scrolling are restored.\n\n  To enable clickable prompt options and app dev tabs, run `shopify config mouse on`.\n",
+      "descriptionWithMarkdown": "Disable mouse interactions in Shopify CLI.\n\n  When mouse interactions are disabled, standard terminal text selection and scrolling are restored.\n\n  To enable clickable prompt options and app dev tabs, run `shopify config mouse on`.\n",
+      "enableJsonFlag": false,
+      "flags": {
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [
+      ],
+      "id": "config:mouse:off",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "summary": "Disable mouse interactions in Shopify CLI."
+    },
+    "config:mouse:on": {
+      "aliases": [
+      ],
+      "args": {
+      },
+      "description": "Enable mouse interactions in Shopify CLI.\n\n  Mouse interactions are enabled by default and allow you to click prompt options and app dev tabs. To select text while they are enabled, hold Option in iTerm2 or Shift in most other terminals while dragging.\n\n  To restore standard terminal text selection and scrolling, run `shopify config mouse off`.\n",
+      "descriptionWithMarkdown": "Enable mouse interactions in Shopify CLI.\n\n  Mouse interactions are enabled by default and allow you to click prompt options and app dev tabs. To select text while they are enabled, hold Option in iTerm2 or Shift in most other terminals while dragging.\n\n  To restore standard terminal text selection and scrolling, run `shopify config mouse off`.\n",
+      "enableJsonFlag": false,
+      "flags": {
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [
+      ],
+      "id": "config:mouse:on",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "summary": "Enable mouse interactions in Shopify CLI."
+    },
     "debug:command-flags": {
       "aliases": [
       ],

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -137,6 +137,9 @@
       "config:autocorrect": {
         "description": "Command autocorrection options. If enabled, Shopify CLI will automatically run a corrected version of your command if a correction is available. Off by default."
       },
+      "config:mouse": {
+        "description": "Mouse interaction options. Enabled by default; hold Option in iTerm2 or Shift in most other terminals while dragging to select text."
+      },
       "kitchen-sink": {
         "description": "View the available UI kit components.",
         "hidden": true

--- a/packages/cli/src/cli/commands/config/mouse/constants.ts
+++ b/packages/cli/src/cli/commands/config/mouse/constants.ts
@@ -1,0 +1,4 @@
+export const mouseStatus = {
+  on: 'Mouse interactions on. To select text, hold Option in iTerm2 or Shift in most other terminals while dragging.',
+  off: 'Mouse interactions off.',
+} as const

--- a/packages/cli/src/cli/commands/config/mouse/off.test.ts
+++ b/packages/cli/src/cli/commands/config/mouse/off.test.ts
@@ -1,0 +1,19 @@
+import MouseOff from './off.js'
+import {setMouseEnabled} from '@shopify/cli-kit/node/mouse'
+import {mockAndCaptureOutput} from '@shopify/cli-kit/node/testing/output'
+import {Config} from '@oclif/core'
+import {describe, expect, test, vi} from 'vitest'
+
+vi.mock('@shopify/cli-kit/node/mouse')
+
+describe('MouseOff', () => {
+  test('disables mouse interactions', async () => {
+    const config = new Config({root: __dirname})
+    const outputMock = mockAndCaptureOutput()
+
+    await new MouseOff([], config).run()
+
+    expect(setMouseEnabled).toHaveBeenCalledWith(false)
+    expect(outputMock.info()).toContain('Mouse interactions off.')
+  })
+})

--- a/packages/cli/src/cli/commands/config/mouse/off.ts
+++ b/packages/cli/src/cli/commands/config/mouse/off.ts
@@ -1,0 +1,22 @@
+import {mouseStatus} from './constants.js'
+import {setMouseEnabled} from '@shopify/cli-kit/node/mouse'
+import Command from '@shopify/cli-kit/node/base-command'
+import {renderInfo} from '@shopify/cli-kit/node/ui'
+
+export default class MouseOff extends Command {
+  static summary = 'Disable mouse interactions in Shopify CLI.'
+
+  static descriptionWithMarkdown = `Disable mouse interactions in Shopify CLI.
+
+  When mouse interactions are disabled, standard terminal text selection and scrolling are restored.
+
+  To enable clickable prompt options and app dev tabs, run \`shopify config mouse on\`.
+`
+
+  static description = this.descriptionWithoutMarkdown()
+
+  async run(): Promise<void> {
+    setMouseEnabled(false)
+    renderInfo({body: mouseStatus.off})
+  }
+}

--- a/packages/cli/src/cli/commands/config/mouse/on.test.ts
+++ b/packages/cli/src/cli/commands/config/mouse/on.test.ts
@@ -1,0 +1,21 @@
+import MouseOn from './on.js'
+import {setMouseEnabled} from '@shopify/cli-kit/node/mouse'
+import {mockAndCaptureOutput} from '@shopify/cli-kit/node/testing/output'
+import {Config} from '@oclif/core'
+import {describe, expect, test, vi} from 'vitest'
+
+vi.mock('@shopify/cli-kit/node/mouse')
+
+describe('MouseOn', () => {
+  test('enables mouse interactions', async () => {
+    const config = new Config({root: __dirname})
+    const outputMock = mockAndCaptureOutput()
+
+    await new MouseOn([], config).run()
+
+    expect(setMouseEnabled).toHaveBeenCalledWith(true)
+    expect(outputMock.info()).toContain('Mouse interactions on.')
+    expect(outputMock.info()).toContain('To select text, hold Option in iTerm2 or Shift in')
+    expect(outputMock.info()).toContain('most other terminals while dragging.')
+  })
+})

--- a/packages/cli/src/cli/commands/config/mouse/on.ts
+++ b/packages/cli/src/cli/commands/config/mouse/on.ts
@@ -1,0 +1,22 @@
+import {mouseStatus} from './constants.js'
+import {setMouseEnabled} from '@shopify/cli-kit/node/mouse'
+import Command from '@shopify/cli-kit/node/base-command'
+import {renderInfo} from '@shopify/cli-kit/node/ui'
+
+export default class MouseOn extends Command {
+  static summary = 'Enable mouse interactions in Shopify CLI.'
+
+  static descriptionWithMarkdown = `Enable mouse interactions in Shopify CLI.
+
+  Mouse interactions are enabled by default and allow you to click prompt options and app dev tabs. To select text while they are enabled, hold Option in iTerm2 or Shift in most other terminals while dragging.
+
+  To restore standard terminal text selection and scrolling, run \`shopify config mouse off\`.
+`
+
+  static description = this.descriptionWithoutMarkdown()
+
+  async run(): Promise<void> {
+    setMouseEnabled(true)
+    renderInfo({body: mouseStatus.on})
+  }
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -21,6 +21,8 @@ import ClearCache from './cli/commands/cache/clear.js'
 import AutoupgradeOff from './cli/commands/config/autoupgrade/off.js'
 import AutoupgradeOn from './cli/commands/config/autoupgrade/on.js'
 import AutoupgradeStatus from './cli/commands/config/autoupgrade/status.js'
+import MouseOff from './cli/commands/config/mouse/off.js'
+import MouseOn from './cli/commands/config/mouse/on.js'
 import {createGlobalProxyAgent} from 'global-agent'
 import StoreCommands from '@shopify/store'
 import ThemeCommands from '@shopify/theme'
@@ -170,6 +172,8 @@ export const COMMANDS: any = {
   'config:autoupgrade:off': AutoupgradeOff,
   'config:autoupgrade:on': AutoupgradeOn,
   'config:autoupgrade:status': AutoupgradeStatus,
+  'config:mouse:off': MouseOff,
+  'config:mouse:on': MouseOn,
 }
 
 export default runShopifyCLI

--- a/packages/e2e/data/snapshots/commands.txt
+++ b/packages/e2e/data/snapshots/commands.txt
@@ -46,10 +46,13 @@
 │  │  ├─ off
 │  │  ├─ on
 │  │  └─ status
-│  └─ autoupgrade
+│  ├─ autoupgrade
+│  │  ├─ off
+│  │  ├─ on
+│  │  └─ status
+│  └─ mouse
 │     ├─ off
-│     ├─ on
-│     └─ status
+│     └─ on
 ├─ doc
 │  ├─ fetch
 │  └─ search

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -316,6 +316,9 @@ importers:
       '@iarna/toml':
         specifier: 2.2.5
         version: 2.2.5
+      '@ink-tools/ink-mouse':
+        specifier: 2.1.0
+        version: 2.1.0(ink@6.8.0(@types/react@18.3.12)(react@19.2.4))(react@19.2.4)
       '@oclif/core':
         specifier: 4.8.3
         version: 4.8.3
@@ -2661,6 +2664,13 @@ packages:
 
   '@iarna/toml@2.2.5':
     resolution: {integrity: sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==, tarball: https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz}
+
+  '@ink-tools/ink-mouse@2.1.0':
+    resolution: {integrity: sha512-6EfKsu6R3VYRgRRWsQ7PI5kJy+OsS/VAVhbG+YvUeZePKuHSS2AvstFD5yU/748iQS6wBBENtMoCcBvCjbylog==, tarball: https://registry.npmjs.org/@ink-tools/ink-mouse/-/ink-mouse-2.1.0.tgz}
+    engines: {node: '>=20'}
+    peerDependencies:
+      ink: '>=6'
+      react: '>=17'
 
   '@inquirer/ansi@1.0.2':
     resolution: {integrity: sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==, tarball: https://registry.npmjs.org/@inquirer/ansi/-/ansi-1.0.2.tgz}
@@ -8814,6 +8824,10 @@ packages:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==, tarball: https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz}
     engines: {node: '>=0.4'}
 
+  xterm-mouse@1.0.0:
+    resolution: {integrity: sha512-A+PkxOzlwgnhfeZclQvCNfLIcLbtTyDSgWs//adOYYUKdjhU9Lejot6wbnW5GEyNCWFFkfLHO8wdQ8eg35BMUg==, tarball: https://registry.npmjs.org/xterm-mouse/-/xterm-mouse-1.0.0.tgz}
+    engines: {node: '>=20'}
+
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==, tarball: https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz}
     engines: {node: '>=10'}
@@ -11253,6 +11267,12 @@ snapshots:
   '@humanwhocodes/retry@0.4.3': {}
 
   '@iarna/toml@2.2.5': {}
+
+  '@ink-tools/ink-mouse@2.1.0(ink@6.8.0(@types/react@18.3.12)(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      ink: 6.8.0(@types/react@18.3.12)(react@19.2.4)
+      react: 19.2.4
+      xterm-mouse: 1.0.0
 
   '@inquirer/ansi@1.0.2': {}
 
@@ -18268,6 +18288,8 @@ snapshots:
   xmlchars@2.2.0: {}
 
   xtend@4.0.2: {}
+
+  xterm-mouse@1.0.0: {}
 
   y18n@5.0.8: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -316,6 +316,9 @@ importers:
       '@iarna/toml':
         specifier: 2.2.5
         version: 2.2.5
+      '@ink-tools/ink-mouse':
+        specifier: 2.1.0
+        version: 2.1.0(ink@6.8.0(@types/react@18.3.12)(react@19.2.4))(react@19.2.4)
       '@oclif/core':
         specifier: 4.8.3
         version: 4.8.3
@@ -2653,6 +2656,13 @@ packages:
 
   '@iarna/toml@2.2.5':
     resolution: {integrity: sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==, tarball: https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz}
+
+  '@ink-tools/ink-mouse@2.1.0':
+    resolution: {integrity: sha512-6EfKsu6R3VYRgRRWsQ7PI5kJy+OsS/VAVhbG+YvUeZePKuHSS2AvstFD5yU/748iQS6wBBENtMoCcBvCjbylog==, tarball: https://registry.npmjs.org/@ink-tools/ink-mouse/-/ink-mouse-2.1.0.tgz}
+    engines: {node: '>=20'}
+    peerDependencies:
+      ink: '>=6'
+      react: '>=17'
 
   '@inquirer/ansi@1.0.2':
     resolution: {integrity: sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==, tarball: https://registry.npmjs.org/@inquirer/ansi/-/ansi-1.0.2.tgz}
@@ -8767,6 +8777,10 @@ packages:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==, tarball: https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz}
     engines: {node: '>=0.4'}
 
+  xterm-mouse@1.0.0:
+    resolution: {integrity: sha512-A+PkxOzlwgnhfeZclQvCNfLIcLbtTyDSgWs//adOYYUKdjhU9Lejot6wbnW5GEyNCWFFkfLHO8wdQ8eg35BMUg==, tarball: https://registry.npmjs.org/xterm-mouse/-/xterm-mouse-1.0.0.tgz}
+    engines: {node: '>=20'}
+
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==, tarball: https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz}
     engines: {node: '>=10'}
@@ -11206,6 +11220,12 @@ snapshots:
   '@humanwhocodes/retry@0.4.3': {}
 
   '@iarna/toml@2.2.5': {}
+
+  '@ink-tools/ink-mouse@2.1.0(ink@6.8.0(@types/react@18.3.12)(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      ink: 6.8.0(@types/react@18.3.12)(react@19.2.4)
+      react: 19.2.4
+      xterm-mouse: 1.0.0
 
   '@inquirer/ansi@1.0.2': {}
 
@@ -18219,6 +18239,8 @@ snapshots:
   xmlchars@2.2.0: {}
 
   xtend@4.0.2: {}
+
+  xterm-mouse@1.0.0: {}
 
   y18n@5.0.8: {}
 


### PR DESCRIPTION
### WHY are these changes introduced?

HackDays project: https://vault.shopify.io/hackdays/154/projects/24279-Shopify-CLI-UX-improvements

Shopify CLI prompts and app dev tabs are keyboard-only, making common interactions less direct.

### WHAT is this pull request doing?

Adds shared mouse handling for prompts and app dev tabs, including terminal scrolling support and `shopify config mouse on|off` controls.

https://github.com/user-attachments/assets/cea88f10-ad76-4f42-82f9-b79a6ac7fe76

### How to test your changes?

- `pnpm i -g @shopify/cli@0.0.0-snapshot-20260811121607`
- `shopify app init`
- `shopify app dev`

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [x] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`