### PR TITLE
Delay Dependabot updates by seven days

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
       - "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     labels:
       - "dependencies"
     open-pull-requests-limit: 100


### PR DESCRIPTION
### WHY are these changes introduced?

Dependabot can propose newly published package versions before they have had time to receive broader ecosystem validation. A seven-day delay reduces that supply-chain risk.

### WHAT is this pull request doing?

Configures a seven-day cooldown for npm version updates. Dependabot security updates remain unaffected because GitHub does not apply cooldowns to security updates.

### Checklist

- [x] I have considered possible cross-platform impacts; this configuration is platform-independent.
- [x] I have considered documentation changes; none are required.
- [x] I have considered analytics changes; none are required.
- [x] This change is not user-facing, so no changeset is required.