### PR TITLE
[Tests] Cover global-context utility

### DIFF
--- a/packages/cli-kit/src/public/node/global-context.test.ts
+++ b/packages/cli-kit/src/public/node/global-context.test.ts
@@ -1,0 +1,38 @@
+import {getCurrentCommandId, setCurrentCommandId, _resetGlobalContext} from './global-context.js'
+import {describe, expect, test} from 'vitest'
+
+describe('global-context', () => {
+  test('getCurrentCommandId returns an empty string initially', () => {
+    // Given
+    _resetGlobalContext()
+
+    // When
+    const currentCommandId = getCurrentCommandId()
+
+    // Then
+    expect(currentCommandId).toBe('')
+  })
+
+  test('setCurrentCommandId updates the ID correctly', () => {
+    // Given
+    _resetGlobalContext()
+
+    // When
+    setCurrentCommandId('my-test-command')
+
+    // Then
+    expect(getCurrentCommandId()).toBe('my-test-command')
+  })
+
+  test('_resetGlobalContext resets the global context state', () => {
+    // Given
+    setCurrentCommandId('some-command-id')
+    expect(getCurrentCommandId()).toBe('some-command-id')
+
+    // When
+    _resetGlobalContext()
+
+    // Then
+    expect(getCurrentCommandId()).toBe('')
+  })
+})

--- a/packages/cli-kit/src/public/node/global-context.ts
+++ b/packages/cli-kit/src/public/node/global-context.ts
@@ -31,3 +31,10 @@ export function getCurrentCommandId(): string {
 export function setCurrentCommandId(commandId: string): void {
   getGlobalContext().currentCommandId = commandId
 }
+
+/**
+ * Reset the global context (for testing purposes).
+ */
+export function _resetGlobalContext(): void {
+  _globalContext = undefined
+}


### PR DESCRIPTION
### WHY are these changes introduced?

`packages/cli-kit/src/public/node/global-context.ts` had no dedicated unit tests and 0% test coverage.

### WHAT is this pull request doing?

1. Adds `_resetGlobalContext()` in `packages/cli-kit/src/public/node/global-context.ts` to allow safe, clean state reset in unit testing.
2. Creates `packages/cli-kit/src/public/node/global-context.test.ts` to fully cover getter (`getCurrentCommandId`), setter (`setCurrentCommandId`), and reset functionalities.

### How to test your changes?

CI

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [2714055448027004875](https://jules.google.com/task/2714055448027004875) started by @gonzaloriestra*