### PR TITLE
fix(theme): preserve preview_theme_id on password-protected theme dev sessions

### DIFF
--- a/.changeset/theme-dev-password-preview-swap.md
+++ b/.changeset/theme-dev-password-preview-swap.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Fix "Theme ID mismatch" on password-protected stores during `theme dev` by preserving preview_theme_id in the session cookie

--- a/packages/theme/src/cli/utilities/theme-environment/storefront-session.test.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/storefront-session.test.ts
@@ -57,14 +57,9 @@ describe('Storefront API', () => {
     })
 
     test('retrieves _shopify_essential and storefront_digest cookies when a password is provided', async () => {
-      // Given
+      // Given: POST /password runs first (cold, returns the digest), then the
+      // preview HEAD runs last and owns the final _shopify_essential.
       vi.mocked(shopifyFetch)
-        .mockResolvedValueOnce(
-          response({
-            status: 200,
-            headers: {'set-cookie': '_shopify_essential=:AABBCCDDEEFFGGHH==123:; path=/; HttpOnly'},
-          }),
-        )
         .mockResolvedValueOnce(
           response({
             status: 302,
@@ -72,6 +67,12 @@ describe('Storefront API', () => {
               'set-cookie': 'storefront_digest=digest-value; path=/; HttpOnly',
               location: 'https://example-store.myshopify.com/',
             },
+          }),
+        )
+        .mockResolvedValueOnce(
+          response({
+            status: 200,
+            headers: {'set-cookie': '_shopify_essential=:AABBCCDDEEFFGGHH==123:; path=/; HttpOnly'},
           }),
         )
 
@@ -91,17 +92,17 @@ describe('Storefront API', () => {
       vi.mocked(shopifyFetch)
         .mockResolvedValueOnce(
           response({
-            status: 200,
-            headers: {'set-cookie': '_shopify_essential=:AABBCCDDEEFFGGHH==123:; path=/; HttpOnly'},
-          }),
-        )
-        .mockResolvedValueOnce(
-          response({
             status: 302,
             headers: {
               'set-cookie': 'storefront_digest=digest-value; path=/; HttpOnly',
               location: 'https://example-store.myshopify.com/',
             },
+          }),
+        )
+        .mockResolvedValueOnce(
+          response({
+            status: 200,
+            headers: {'set-cookie': '_shopify_essential=:AABBCCDDEEFFGGHH==123:; path=/; HttpOnly'},
           }),
         )
 
@@ -117,9 +118,10 @@ describe('Storefront API', () => {
         },
       )
 
+      // Password POST runs first, then the preview HEAD.
       expect(shopifyFetch).toHaveBeenNthCalledWith(
         1,
-        'https://example-store.myshopify.com?preview_theme_id=123456&_fd=0&pb=0',
+        'https://example-store.myshopify.com/password',
         expect.objectContaining({
           headers: expect.objectContaining({
             Signature: 'signature-value',
@@ -130,7 +132,7 @@ describe('Storefront API', () => {
       )
       expect(shopifyFetch).toHaveBeenNthCalledWith(
         2,
-        'https://example-store.myshopify.com/password',
+        'https://example-store.myshopify.com?preview_theme_id=123456&_fd=0&pb=0',
         expect.objectContaining({
           headers: expect.objectContaining({
             Signature: 'signature-value',
@@ -139,6 +141,59 @@ describe('Storefront API', () => {
           }),
         }),
       )
+    })
+
+    test('runs POST /password first, then forwards the digest essential to the trailing preview HEAD', async () => {
+      const digestEssential = ':DIGEST==123:'
+      const finalEssential = ':DIGEST+PREVIEW==456:'
+
+      // Given: password POST returns the digest-bearing essential; the preview
+      // HEAD then returns the final essential carrying both fields.
+      vi.mocked(shopifyFetch)
+        .mockResolvedValueOnce(
+          response({
+            status: 302,
+            headers: {
+              'set-cookie': `_shopify_essential=${digestEssential}; path=/; HttpOnly`,
+              location: 'https://example-store.myshopify.com/',
+            },
+          }),
+        )
+        .mockResolvedValueOnce(
+          response({
+            status: 200,
+            headers: {'set-cookie': `_shopify_essential=${finalEssential}; path=/; HttpOnly`},
+          }),
+        )
+
+      // When
+      const cookies = await getStorefrontSessionCookies(
+        'https://example-store.myshopify.com',
+        'example-store.myshopify.com',
+        '123456',
+        'password',
+      )
+
+      // Then: exactly two fetches, in order — POST /password, then the preview HEAD.
+      expect(shopifyFetch).toHaveBeenCalledTimes(2)
+      expect(shopifyFetch).toHaveBeenNthCalledWith(
+        1,
+        'https://example-store.myshopify.com/password',
+        expect.objectContaining({method: 'POST'}),
+      )
+      // The preview HEAD carries the preview_theme_id AND forwards the digest essential.
+      expect(shopifyFetch).toHaveBeenNthCalledWith(
+        2,
+        'https://example-store.myshopify.com?preview_theme_id=123456&_fd=0&pb=0',
+        expect.objectContaining({
+          method: 'HEAD',
+          headers: expect.objectContaining({
+            Cookie: `_shopify_essential=${digestEssential}`,
+          }),
+        }),
+      )
+      // The final cookie is the trailing preview HEAD's essential (both fields).
+      expect(cookies).toEqual({_shopify_essential: finalEssential})
     })
 
     test(`throws an ShopifyEssentialError when _shopify_essential can't be defined`, async () => {
@@ -185,21 +240,13 @@ describe('Storefront API', () => {
     })
 
     test('throws an error when the password is wrong', async () => {
-      // Given
-      vi.mocked(shopifyFetch)
-        .mockResolvedValueOnce(
-          response({
-            status: 200,
-            headers: {'set-cookie': '_shopify_essential=:AABBCCDDEEFFGGHH==123:; path=/; HttpOnly'},
-            text: () => Promise.resolve(''),
-          }),
-        )
-        .mockResolvedValueOnce(
-          response({
-            status: 401,
-            text: () => Promise.resolve(''),
-          }),
-        )
+      // Given: the password POST runs first and rejects the credentials.
+      vi.mocked(shopifyFetch).mockResolvedValueOnce(
+        response({
+          status: 401,
+          text: () => Promise.resolve(''),
+        }),
+      )
 
       // When
       const cookies = getStorefrontSessionCookies(
@@ -255,23 +302,25 @@ describe('Storefront API', () => {
     })
 
     test('handles storefront_digest migration to _shopify_essential cookie', async () => {
-      const originalEssential = ':AABBCCDDEEFFGGHH==123:'
-      const authenticatedEssential = ':NEWESSENTIAL==456:'
+      const digestEssential = ':AABBCCDDEEFFGGHH==123:'
+      const finalEssential = ':NEWESSENTIAL==456:'
 
+      // Given: password POST mints the digest-bearing essential first; the
+      // trailing preview HEAD returns the final essential carrying both fields.
       vi.mocked(shopifyFetch)
-        .mockResolvedValueOnce(
-          response({
-            status: 200,
-            headers: {'set-cookie': `_shopify_essential=${originalEssential}; path=/; HttpOnly`},
-          }),
-        )
         .mockResolvedValueOnce(
           response({
             status: 302,
             headers: {
-              'set-cookie': `_shopify_essential=${authenticatedEssential}; path=/; HttpOnly`,
+              'set-cookie': `_shopify_essential=${digestEssential}; path=/; HttpOnly`,
               location: 'https://example-store.myshopify.com/',
             },
+          }),
+        )
+        .mockResolvedValueOnce(
+          response({
+            status: 200,
+            headers: {'set-cookie': `_shopify_essential=${finalEssential}; path=/; HttpOnly`},
           }),
         )
 
@@ -283,30 +332,32 @@ describe('Storefront API', () => {
         'password',
       )
 
-      // Then
+      // Then: the trailing preview HEAD's essential wins.
       expect(cookies).toEqual({
-        _shopify_essential: authenticatedEssential,
+        _shopify_essential: finalEssential,
       })
     })
 
     test('handles theme kit access with _shopify_essential cookies', async () => {
-      const originalEssential = ':AABBCCDDEEFFGGHH==123:'
-      const authenticatedEssential = ':NEWESSENTIAL==456:'
+      const digestEssential = ':AABBCCDDEEFFGGHH==123:'
+      const finalEssential = ':NEWESSENTIAL==456:'
 
+      // Given: password POST first, preview HEAD last (same order as the
+      // standard flow) even when routed through the theme kit access domain.
       vi.mocked(shopifyFetch)
-        .mockResolvedValueOnce(
-          response({
-            status: 200,
-            headers: {'set-cookie': `_shopify_essential=${originalEssential}; path=/; HttpOnly`},
-          }),
-        )
         .mockResolvedValueOnce(
           response({
             status: 302,
             headers: {
-              'set-cookie': `_shopify_essential=${authenticatedEssential}; path=/; HttpOnly`,
+              'set-cookie': `_shopify_essential=${digestEssential}; path=/; HttpOnly`,
               location: 'https://example-store.myshopify.com/',
             },
+          }),
+        )
+        .mockResolvedValueOnce(
+          response({
+            status: 200,
+            headers: {'set-cookie': `_shopify_essential=${finalEssential}; path=/; HttpOnly`},
           }),
         )
 
@@ -320,19 +371,15 @@ describe('Storefront API', () => {
 
       // Then
       expect(cookies).toEqual({
-        _shopify_essential: authenticatedEssential,
+        _shopify_essential: finalEssential,
       })
     })
 
     test('handles case when storefront_digest is present (non-migrated case)', async () => {
-      // Given: storefront_digest is still being used
+      // Given: storefront_digest is still a standalone cookie. Password POST
+      // runs first and returns only the digest; the trailing preview HEAD
+      // mints the _shopify_essential.
       vi.mocked(shopifyFetch)
-        .mockResolvedValueOnce(
-          response({
-            status: 200,
-            headers: {'set-cookie': '_shopify_essential=:AABBCCDDEEFFGGHH==123:; path=/; HttpOnly'},
-          }),
-        )
         .mockResolvedValueOnce(
           response({
             status: 302,
@@ -340,6 +387,12 @@ describe('Storefront API', () => {
               'set-cookie': 'storefront_digest=digest-value; path=/; HttpOnly',
               location: 'https://example-store.myshopify.com/',
             },
+          }),
+        )
+        .mockResolvedValueOnce(
+          response({
+            status: 200,
+            headers: {'set-cookie': '_shopify_essential=:AABBCCDDEEFFGGHH==123:; path=/; HttpOnly'},
           }),
         )
 
@@ -359,21 +412,13 @@ describe('Storefront API', () => {
     })
 
     test('throws error when pasword page does not return a 302', async () => {
-      // Given: password redirects correctly but _shopify_essential doesn't change (shouldn't happen)
-      const sameEssential = ':AABBCCDDEEFFGGHH==123:'
-
-      vi.mocked(shopifyFetch)
-        .mockResolvedValueOnce(
-          response({
-            status: 200,
-            headers: {'set-cookie': `_shopify_essential=${sameEssential}; path=/; HttpOnly`},
-          }),
-        )
-        .mockResolvedValueOnce(
-          response({
-            status: 200,
-          }),
-        )
+      // Given: the password POST runs first and does not redirect to the
+      // storefront (no 302), so the session cannot be created.
+      vi.mocked(shopifyFetch).mockResolvedValueOnce(
+        response({
+          status: 200,
+        }),
+      )
 
       // When
       const cookies = getStorefrontSessionCookies(

--- a/packages/theme/src/cli/utilities/theme-environment/storefront-session.test.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/storefront-session.test.ts
@@ -2,6 +2,7 @@ import {
   getStorefrontSessionCookies,
   isStorefrontPasswordCorrect,
   isStorefrontPasswordProtected,
+  PreviewSessionError,
   ShopifyEssentialError,
 } from './storefront-session.js'
 import {describe, expect, test, vi} from 'vitest'
@@ -191,14 +192,18 @@ describe('Storefront API', () => {
       expect(cookies).toEqual({_shopify_essential: finalEssential})
     })
 
-    test(`throws an ShopifyEssentialError when _shopify_essential can't be defined`, async () => {
-      // Given
+    test(`throws a PreviewSessionError when the forwarded essential never yields a preview session`, async () => {
+      const digestEssential = ':DIGEST==123:'
+
+      // Given: the password step succeeds, but every preview HEAD attempt comes back without a cookie
       vi.mocked(shopifyFetch)
         .mockResolvedValueOnce(
           response({
-            status: 200,
-            headers: {'set-cookie': ''},
-            text: () => Promise.resolve(''),
+            status: 302,
+            headers: {
+              'set-cookie': `_shopify_essential=${digestEssential}; path=/; HttpOnly`,
+              location: 'https://example-store.myshopify.com/',
+            },
           }),
         )
         .mockResolvedValueOnce(
@@ -218,13 +223,58 @@ describe('Storefront API', () => {
         .mockResolvedValueOnce(
           response({
             status: 200,
-            headers: {'set-cookie': 'storefront_digest=digest-value; path=/; HttpOnly'},
+            headers: {'set-cookie': ''},
+            text: () => Promise.resolve(''),
+          }),
+        )
+        .mockResolvedValueOnce(
+          response({
+            status: 200,
+            headers: {'set-cookie': ''},
             text: () => Promise.resolve(''),
           }),
         )
 
       // When
-      const cookies = getStorefrontSessionCookies('https://example-store.myshopify.com', '123456', 'password')
+      const cookies = getStorefrontSessionCookies(
+        'https://example-store.myshopify.com',
+        'example-store.myshopify.com',
+        '123456',
+        'password',
+      )
+
+      // Then
+      await expect(cookies).rejects.toThrow(
+        new PreviewSessionError(
+          'Your development session could not be created because the theme preview could not be attached to the storefront session.',
+          'Verify the theme exists by running shopify theme list, then try again. If the problem persists, re-run with --verbose and share the request ID with Shopify Support.',
+        ),
+      )
+      // 1 password POST + 4 exhausted preview HEAD attempts, proving the password branch was taken
+      expect(shopifyFetch).toHaveBeenCalledTimes(5)
+    })
+
+    test(`throws a ShopifyEssentialError when no password is involved and _shopify_essential can't be defined`, async () => {
+      // Given: no password step, so no essential is forwarded, and every preview HEAD comes back without a cookie
+      const emptyPreview = () =>
+        response({
+          status: 200,
+          headers: {'set-cookie': ''},
+          text: () => Promise.resolve(''),
+        })
+
+      vi.mocked(shopifyFetch)
+        .mockResolvedValueOnce(emptyPreview())
+        .mockResolvedValueOnce(emptyPreview())
+        .mockResolvedValueOnce(emptyPreview())
+        .mockResolvedValueOnce(emptyPreview())
+
+      // When
+      const cookies = getStorefrontSessionCookies(
+        'https://example-store.myshopify.com',
+        'example-store.myshopify.com',
+        '123456',
+      )
 
       // Then
       await expect(cookies).rejects.toThrow(
@@ -232,6 +282,152 @@ describe('Storefront API', () => {
           'Your development session could not be created because the "_shopify_essential" could not be defined. Please, check your internet connection.',
         ),
       )
+      expect(shopifyFetch).toHaveBeenCalledTimes(4)
+    })
+
+    test('fails fast when the preview HEAD redirects the forwarded essential instead of returning one', async () => {
+      const digestEssential = ':DIGEST==123:'
+
+      // Given: the password step succeeds, then every preview HEAD answers a redirect with no cookie.
+      // The full retry ladder is queued so the call-count assertion below, rather than mock
+      // exhaustion, is what proves the fast-fail.
+      const redirectPreview = () =>
+        response({
+          status: 302,
+          headers: {'set-cookie': ''},
+          text: () => Promise.resolve(''),
+        })
+
+      vi.mocked(shopifyFetch)
+        .mockResolvedValueOnce(
+          response({
+            status: 302,
+            headers: {
+              'set-cookie': `_shopify_essential=${digestEssential}; path=/; HttpOnly`,
+              location: 'https://example-store.myshopify.com/',
+            },
+          }),
+        )
+        .mockResolvedValueOnce(redirectPreview())
+        .mockResolvedValueOnce(redirectPreview())
+        .mockResolvedValueOnce(redirectPreview())
+        .mockResolvedValueOnce(redirectPreview())
+
+      // When
+      const cookies = getStorefrontSessionCookies(
+        'https://example-store.myshopify.com',
+        'example-store.myshopify.com',
+        '123456',
+        'password',
+      )
+
+      // Then
+      await expect(cookies).rejects.toThrow(
+        new PreviewSessionError(
+          'Your development session could not be created because the theme preview could not be attached to the storefront session.',
+          'Verify the theme exists by running shopify theme list, then try again. If the problem persists, re-run with --verbose and share the request ID with Shopify Support.',
+        ),
+      )
+      // 1 password POST + 1 preview HEAD, with no retry ladder
+      expect(shopifyFetch).toHaveBeenCalledTimes(2)
+    })
+
+    test('throws a PreviewSessionError that is not a ShopifyEssentialError', async () => {
+      const digestEssential = ':DIGEST==123:'
+
+      // Given: the full retry ladder is queued so this test only ever fails on the class
+      // assertions below, never on an exhausted mock
+      const redirectPreview = () =>
+        response({
+          status: 302,
+          headers: {'set-cookie': ''},
+          text: () => Promise.resolve(''),
+        })
+
+      vi.mocked(shopifyFetch)
+        .mockResolvedValueOnce(
+          response({
+            status: 302,
+            headers: {
+              'set-cookie': `_shopify_essential=${digestEssential}; path=/; HttpOnly`,
+              location: 'https://example-store.myshopify.com/',
+            },
+          }),
+        )
+        .mockResolvedValueOnce(redirectPreview())
+        .mockResolvedValueOnce(redirectPreview())
+        .mockResolvedValueOnce(redirectPreview())
+        .mockResolvedValueOnce(redirectPreview())
+
+      // When
+      const error = await getStorefrontSessionCookies(
+        'https://example-store.myshopify.com',
+        'example-store.myshopify.com',
+        '123456',
+        'password',
+      ).catch((error: unknown) => error)
+
+      // Then
+      expect(error).toBeInstanceOf(PreviewSessionError)
+      expect(error).toBeInstanceOf(AbortError)
+      expect(error).not.toBeInstanceOf(ShopifyEssentialError)
+    })
+
+    test('forwards the digest essential on every preview HEAD retry', async () => {
+      const digestEssential = ':DIGEST==123:'
+      const finalEssential = ':DIGEST+PREVIEW==456:'
+
+      // Given: the password step succeeds, then the preview HEAD only yields a cookie on the 3rd attempt
+      vi.mocked(shopifyFetch)
+        .mockResolvedValueOnce(
+          response({
+            status: 302,
+            headers: {
+              'set-cookie': `_shopify_essential=${digestEssential}; path=/; HttpOnly`,
+              location: 'https://example-store.myshopify.com/',
+            },
+          }),
+        )
+        .mockResolvedValueOnce(
+          response({
+            status: 200,
+            headers: {'set-cookie': ''},
+            text: () => Promise.resolve(''),
+          }),
+        )
+        .mockResolvedValueOnce(
+          response({
+            status: 200,
+            headers: {'set-cookie': ''},
+            text: () => Promise.resolve(''),
+          }),
+        )
+        .mockResolvedValueOnce(
+          response({
+            status: 200,
+            headers: {'set-cookie': `_shopify_essential=${finalEssential}; path=/; HttpOnly`},
+            text: () => Promise.resolve(''),
+          }),
+        )
+
+      // When
+      const cookies = await getStorefrontSessionCookies(
+        'https://example-store.myshopify.com',
+        'example-store.myshopify.com',
+        '123456',
+        'password',
+      )
+
+      // Then
+      const previewCalls = vi
+        .mocked(shopifyFetch)
+        .mock.calls.filter(([url]) => String(url).includes('preview_theme_id'))
+
+      expect(previewCalls).toHaveLength(3)
+      previewCalls.forEach((call) => {
+        expect(call[1]?.headers).toMatchObject({Cookie: `_shopify_essential=${digestEssential}`})
+      })
+      expect(cookies).toEqual({_shopify_essential: finalEssential})
     })
 
     test('throws an error when the password is wrong', async () => {

--- a/packages/theme/src/cli/utilities/theme-environment/storefront-session.test.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/storefront-session.test.ts
@@ -57,8 +57,7 @@ describe('Storefront API', () => {
     })
 
     test('retrieves _shopify_essential and storefront_digest cookies when a password is provided', async () => {
-      // Given: POST /password runs first (cold, returns the digest), then the
-      // preview HEAD runs last and owns the final _shopify_essential.
+      // Given
       vi.mocked(shopifyFetch)
         .mockResolvedValueOnce(
           response({
@@ -118,7 +117,6 @@ describe('Storefront API', () => {
         },
       )
 
-      // Password POST runs first, then the preview HEAD.
       expect(shopifyFetch).toHaveBeenNthCalledWith(
         1,
         'https://example-store.myshopify.com/password',
@@ -147,8 +145,7 @@ describe('Storefront API', () => {
       const digestEssential = ':DIGEST==123:'
       const finalEssential = ':DIGEST+PREVIEW==456:'
 
-      // Given: password POST returns the digest-bearing essential; the preview
-      // HEAD then returns the final essential carrying both fields.
+      // Given
       vi.mocked(shopifyFetch)
         .mockResolvedValueOnce(
           response({
@@ -174,14 +171,13 @@ describe('Storefront API', () => {
         'password',
       )
 
-      // Then: exactly two fetches, in order — POST /password, then the preview HEAD.
+      // Then
       expect(shopifyFetch).toHaveBeenCalledTimes(2)
       expect(shopifyFetch).toHaveBeenNthCalledWith(
         1,
         'https://example-store.myshopify.com/password',
         expect.objectContaining({method: 'POST'}),
       )
-      // The preview HEAD carries the preview_theme_id AND forwards the digest essential.
       expect(shopifyFetch).toHaveBeenNthCalledWith(
         2,
         'https://example-store.myshopify.com?preview_theme_id=123456&_fd=0&pb=0',
@@ -192,7 +188,6 @@ describe('Storefront API', () => {
           }),
         }),
       )
-      // The final cookie is the trailing preview HEAD's essential (both fields).
       expect(cookies).toEqual({_shopify_essential: finalEssential})
     })
 
@@ -240,7 +235,7 @@ describe('Storefront API', () => {
     })
 
     test('throws an error when the password is wrong', async () => {
-      // Given: the password POST runs first and rejects the credentials.
+      // Given
       vi.mocked(shopifyFetch).mockResolvedValueOnce(
         response({
           status: 401,
@@ -305,8 +300,6 @@ describe('Storefront API', () => {
       const digestEssential = ':AABBCCDDEEFFGGHH==123:'
       const finalEssential = ':NEWESSENTIAL==456:'
 
-      // Given: password POST mints the digest-bearing essential first; the
-      // trailing preview HEAD returns the final essential carrying both fields.
       vi.mocked(shopifyFetch)
         .mockResolvedValueOnce(
           response({
@@ -332,7 +325,7 @@ describe('Storefront API', () => {
         'password',
       )
 
-      // Then: the trailing preview HEAD's essential wins.
+      // Then
       expect(cookies).toEqual({
         _shopify_essential: finalEssential,
       })
@@ -342,8 +335,7 @@ describe('Storefront API', () => {
       const digestEssential = ':AABBCCDDEEFFGGHH==123:'
       const finalEssential = ':NEWESSENTIAL==456:'
 
-      // Given: password POST first, preview HEAD last (same order as the
-      // standard flow) even when routed through the theme kit access domain.
+      // Given
       vi.mocked(shopifyFetch)
         .mockResolvedValueOnce(
           response({
@@ -376,9 +368,7 @@ describe('Storefront API', () => {
     })
 
     test('handles case when storefront_digest is present (non-migrated case)', async () => {
-      // Given: storefront_digest is still a standalone cookie. Password POST
-      // runs first and returns only the digest; the trailing preview HEAD
-      // mints the _shopify_essential.
+      // Given
       vi.mocked(shopifyFetch)
         .mockResolvedValueOnce(
           response({
@@ -411,9 +401,9 @@ describe('Storefront API', () => {
       })
     })
 
-    test('throws error when pasword page does not return a 302', async () => {
-      // Given: the password POST runs first and does not redirect to the
-      // storefront (no 302), so the session cannot be created.
+    test('throws an invalid-password error when POST /password does not redirect to the storefront', async () => {
+      // A correct password submission answers with a 302 back to the storefront.
+      // Here POST /password answers 200 (no redirect), which we treat as a wrong password.
       vi.mocked(shopifyFetch).mockResolvedValueOnce(
         response({
           status: 200,

--- a/packages/theme/src/cli/utilities/theme-environment/storefront-session.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/storefront-session.ts
@@ -10,6 +10,7 @@ import {sleep} from '@shopify/cli-kit/node/system'
 import {recordError, recordEvent} from '@shopify/cli-kit/node/analytics'
 
 export class ShopifyEssentialError extends AbortError {}
+export class PreviewSessionError extends AbortError {}
 
 export async function isStorefrontPasswordProtected(session: AdminSession): Promise<boolean> {
   return passwordProtected(session)
@@ -127,6 +128,16 @@ async function sessionEssentialCookie(
   const setCookies = response.headers.raw()['set-cookie'] ?? []
   const shopifyEssential = getCookie(setCookies, '_shopify_essential')
 
+  outputDebug(
+    `Storefront preview session: status=${response.status}, request_id=${
+      response.headers.get('x-request-id') ?? 'unknown'
+    }, attempt=${retries}, forwarded_essential=${Boolean(
+      incomingEssential,
+    )}, returned_essential=${Boolean(shopifyEssential)}, essential_rotated=${Boolean(
+      incomingEssential && shopifyEssential && incomingEssential !== shopifyEssential,
+    )}`,
+  )
+
   /**
    * SFR should always define a _shopify_essential, so an error at this point
    * is likely a Shopify error or firewall issue.
@@ -139,11 +150,27 @@ async function sessionEssentialCookie(
        -Status: ${response.status}\n`,
     )
 
+    const isRedirect = response.status >= 300 && response.status < 400
+
+    if (incomingEssential && isRedirect) {
+      throw recordError(
+        new PreviewSessionError(
+          'Your development session could not be created because the theme preview could not be attached to the storefront session.',
+          'Verify the theme exists by running shopify theme list, then try again. If the problem persists, re-run with --verbose and share the request ID with Shopify Support.',
+        ),
+      )
+    }
+
     if (retries > 3) {
       throw recordError(
-        new ShopifyEssentialError(
-          'Your development session could not be created because the "_shopify_essential" could not be defined. Please, check your internet connection.',
-        ),
+        incomingEssential
+          ? new PreviewSessionError(
+              'Your development session could not be created because the theme preview could not be attached to the storefront session.',
+              'Verify the theme exists by running shopify theme list, then try again. If the problem persists, re-run with --verbose and share the request ID with Shopify Support.',
+            )
+          : new ShopifyEssentialError(
+              'Your development session could not be created because the "_shopify_essential" could not be defined. Please, check your internet connection.',
+            ),
       )
     }
 
@@ -187,6 +214,12 @@ async function enrichSessionWithStorefrontPassword(
   const setCookies = response.headers.raw()['set-cookie'] ?? []
   const storefrontDigest = getCookie(setCookies, 'storefront_digest')
   const newShopifyEssential = getCookie(setCookies, '_shopify_essential')
+
+  outputDebug(
+    `Storefront password session: status=${response.status}, request_id=${
+      response.headers.get('x-request-id') ?? 'unknown'
+    }, returned_essential=${Boolean(newShopifyEssential)}, returned_digest=${Boolean(storefrontDigest)}`,
+  )
 
   const result: Record<string, string> = {}
 

--- a/packages/theme/src/cli/utilities/theme-environment/storefront-session.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/storefront-session.ts
@@ -69,24 +69,13 @@ export async function getStorefrontSessionCookies(
   recordEvent(`theme-service:storefront-session:is-password-protected:${Boolean(password)}`)
 
   if (!password) {
-    /**
-     * When the store is not password protected, storefront_digest is not
-     * required, so a single preview HEAD mints the session cookie.
-     */
+    // When the store is not password protected, storefront_digest is not required.
     cookieRecord._shopify_essential = await sessionEssentialCookie(storeUrl, themeId, headers)
     return cookieRecord
   }
 
   const storeOrigin = prependHttps(storeFqdn)
 
-  /**
-   * For password-protected stores the session is primed in two ordered steps:
-   *   1. POST /password first (cold) to obtain the digest-bearing session.
-   *   2. HEAD /?preview_theme_id last, forwarding that digest session so SFR
-   *      stamps preview_theme_id into the same _shopify_essential.
-   * Running the preview HEAD last ensures the final cookie carries BOTH the
-   * password digest and the preview theme id.
-   */
   const passwordCookies = await enrichSessionWithStorefrontPassword(storeUrl, storeOrigin, password, headers)
 
   cookieRecord._shopify_essential = await sessionEssentialCookie(
@@ -125,11 +114,6 @@ async function sessionEssentialCookie(
     ...defaultHeaders(),
   }
 
-  /**
-   * When priming a password-protected session, forward the digest-bearing
-   * essential so SFR stamps preview_theme_id into that same cookie instead of
-   * minting a preview-only one.
-   */
   if (incomingEssential) {
     requestHeaders.Cookie = serializeCookies({_shopify_essential: incomingEssential})
   }
@@ -180,11 +164,6 @@ async function enrichSessionWithStorefrontPassword(
 ): Promise<Record<string, string>> {
   const params = new URLSearchParams({password})
 
-  /**
-   * This runs first (cold) for password-protected stores, so it does not carry
-   * a pre-existing _shopify_essential — SFR mints a digest-bearing session on
-   * the response.
-   */
   const requestHeaders = {
     ...headers,
     ...defaultHeaders(),

--- a/packages/theme/src/cli/utilities/theme-environment/storefront-session.ts
+++ b/packages/theme/src/cli/utilities/theme-environment/storefront-session.ts
@@ -65,33 +65,51 @@ export async function getStorefrontSessionCookies(
   headers: Record<string, string> = {},
 ): Promise<Record<string, string>> {
   const cookieRecord: Record<string, string> = {}
-  const shopifyEssential = await sessionEssentialCookie(storeUrl, themeId, headers)
-  const storeOrigin = prependHttps(storeFqdn)
-
-  cookieRecord._shopify_essential = shopifyEssential
 
   recordEvent(`theme-service:storefront-session:is-password-protected:${Boolean(password)}`)
 
   if (!password) {
     /**
      * When the store is not password protected, storefront_digest is not
-     * required.
+     * required, so a single preview HEAD mints the session cookie.
      */
+    cookieRecord._shopify_essential = await sessionEssentialCookie(storeUrl, themeId, headers)
     return cookieRecord
   }
 
-  const additionalCookies = await enrichSessionWithStorefrontPassword(
-    shopifyEssential,
+  const storeOrigin = prependHttps(storeFqdn)
+
+  /**
+   * For password-protected stores the session is primed in two ordered steps:
+   *   1. POST /password first (cold) to obtain the digest-bearing session.
+   *   2. HEAD /?preview_theme_id last, forwarding that digest session so SFR
+   *      stamps preview_theme_id into the same _shopify_essential.
+   * Running the preview HEAD last ensures the final cookie carries BOTH the
+   * password digest and the preview theme id.
+   */
+  const passwordCookies = await enrichSessionWithStorefrontPassword(storeUrl, storeOrigin, password, headers)
+
+  cookieRecord._shopify_essential = await sessionEssentialCookie(
     storeUrl,
-    storeOrigin,
-    password,
+    themeId,
     headers,
+    passwordCookies._shopify_essential,
   )
 
-  return {...cookieRecord, ...additionalCookies}
+  if (passwordCookies.storefront_digest) {
+    cookieRecord.storefront_digest = passwordCookies.storefront_digest
+  }
+
+  return cookieRecord
 }
 
-async function sessionEssentialCookie(storeUrl: string, themeId: string, headers: Record<string, string>, retries = 1) {
+async function sessionEssentialCookie(
+  storeUrl: string,
+  themeId: string,
+  headers: Record<string, string>,
+  incomingEssential?: string,
+  retries = 1,
+) {
   const params = new URLSearchParams({
     preview_theme_id: themeId,
     _fd: '0',
@@ -102,9 +120,18 @@ async function sessionEssentialCookie(storeUrl: string, themeId: string, headers
 
   recordEvent(`theme-service:storefront-session:get-session-essential-cookie`)
 
-  const requestHeaders = {
+  const requestHeaders: Record<string, string> = {
     ...headers,
     ...defaultHeaders(),
+  }
+
+  /**
+   * When priming a password-protected session, forward the digest-bearing
+   * essential so SFR stamps preview_theme_id into that same cookie instead of
+   * minting a preview-only one.
+   */
+  if (incomingEssential) {
+    requestHeaders.Cookie = serializeCookies({_shopify_essential: incomingEssential})
   }
 
   const response = await shopifyFetch(url, {
@@ -139,14 +166,13 @@ async function sessionEssentialCookie(storeUrl: string, themeId: string, headers
     outputDebug('Retrying to obtain the _shopify_essential cookie...')
     await sleep(retries)
 
-    return sessionEssentialCookie(storeUrl, themeId, headers, retries + 1)
+    return sessionEssentialCookie(storeUrl, themeId, headers, incomingEssential, retries + 1)
   }
 
   return shopifyEssential
 }
 
 async function enrichSessionWithStorefrontPassword(
-  shopifyEssential: string,
   storeUrl: string,
   storeOrigin: string,
   password: string,
@@ -154,10 +180,14 @@ async function enrichSessionWithStorefrontPassword(
 ): Promise<Record<string, string>> {
   const params = new URLSearchParams({password})
 
+  /**
+   * This runs first (cold) for password-protected stores, so it does not carry
+   * a pre-existing _shopify_essential — SFR mints a digest-bearing session on
+   * the response.
+   */
   const requestHeaders = {
     ...headers,
     ...defaultHeaders(),
-    Cookie: serializeCookies({_shopify_essential: shopifyEssential}),
   }
 
   const response = await shopifyFetch(`${storeUrl}/password`, {


### PR DESCRIPTION
## What's happening

When you run `theme dev` on a password-protected store, sometimes it shows the live theme instead of the theme you're actually previewing. We have made some fixes to it but are still seeing problems in the dev [forums](https://community.shopify.dev/t/theme-id-mismatch/33427/29)

To set up the session we make two requests, and each one hands back a `_shopify_essential` cookie:
- the preview request → gives a cookie that knows which theme to preview
- the password request → gives a cookie that proves you passed the store password

The problem: we were doing preview first, password second. So the password cookie came back last and overwrote the preview cookie which meant we lost the preview theme and the store just showed the live theme. I believe it only happens sometimes, because the password step doesn't always hand back a new cookie.

## The fix

Just flip the order for password stores:

1. do the password request first, so we get the cookie that proves we're in
2. do the preview request last, passing that cookie along, so the theme id gets
   added on top of it

Now the final cookie has both things it needs, so it always previews the right theme. Same number of requests as before.

## Testing

-Run `theme dev` against a password-protected store confirm it renders the theme.