### PR TITLE
Add unified Shopify umbrella skill

### DIFF
--- a/.agents/skills/shopify/SKILL.md
+++ b/.agents/skills/shopify/SKILL.md
@@ -13,6 +13,16 @@ Never answer from memory or write Shopify code from assumption. Shopify APIs, sc
 
 ## Pattern
 
+Every `shopify` command is discoverable and self-documenting — never guess a command name or a flag. List the full command tree with `shopify commands` (add `--tree` for a nested view), and append `--help` at any level for a description of a command, its subcommands, and its flags:
+
+```bash
+shopify commands          # every available command
+shopify app --help        # a topic's subcommands
+shopify doc search --help # one command's flags
+```
+
+Use this to confirm the exact surface of any command in this skill — including whether `shopify validate` and its topics exist in the installed version — before you run it.
+
 ### 1) Search the docs first — mandatory, non-skippable
 
 Before producing any answer, query, mutation, component, config, or scaffold, search shopify.dev:
@@ -68,6 +78,7 @@ shopify validate [topic]
 ## Gotchas
 
 - Both brackets are required. Skipping the doc search is the most common failure — do it first, every time, even for questions that look trivial. Validation is not "best effort"; the task is complete only when `shopify validate [topic]` is clean.
+- Don't guess command names or flags. The command surface changes between versions — `shopify commands` lists what exists and `<command> --help` documents its flags. Confirm there before running, especially for `shopify validate`.
 - `--api-name` narrows recall; if results look thin or miss the point, drop the flag and search across all APIs.
 - `shopify doc search` returns ranked chunks, not a full page. When a chunk points at a page you need in full, follow up with `shopify doc fetch --url`.
 - Match the API version between search and output; mixing versions produces subtly wrong fields.

--- a/.agents/skills/shopify/SKILL.md
+++ b/.agents/skills/shopify/SKILL.md
@@ -65,20 +65,31 @@ For a bare docs question that fits no family, answer straight from `shopify doc 
 
 ### 3) Validate the outcome last — mandatory, non-skippable
 
-After the work is complete, validate the final outcome for the surface you touched:
+Validation is always required, but *what* you validate depends on the outcome you produced. Identify which outcome it is, then apply the matching rule. In both cases use the topic that matches the surface you worked on (for example `shopify validate functions`, `shopify validate theme`, `shopify validate config`); the topics in the table are illustrative — run `shopify validate --help` for the current list.
 
-```bash
-shopify validate [topic]
-```
+**Outcome A — a chat reply containing an example (nothing written to disk).**
+The example you show the user must be a *complete, fully valid* artifact — never a fragment and never placeholder syntax:
 
-- Use the topic for what you produced (for example `shopify validate functions`, `shopify validate theme`, `shopify validate config`). The topics in the table are illustrative — run `shopify validate --help` for the current list.
-- Read everything it reports, **resolve every finding**, and re-run until it passes clean.
-- Do not present the task as finished while `shopify validate` reports outstanding issues. An unresolved finding means the task is not done.
+- No elisions or placeholders: no `...`, `// rest here`, `<your-value>`, `YOUR_TOKEN`, `TODO`, or omitted required fields. Every id, import, field, and closing brace is real and present.
+- It must stand alone: the user could copy it verbatim and it would parse and run as-is.
+- Prove it before sending. Write the example to a temporary file, run the appropriate `shopify validate [topic]` against that file, resolve anything it reports, then delete the temp file. Do not present an example you have not validated this way.
+
+**Outcome B — a change on the filesystem (files created or modified).**
+Validate *every* file you touched, each with the validation appropriate to that file's surface:
+
+- Run `shopify validate [topic]` for every surface your change spans — if you touched a Function and a theme file, validate both `functions` and `theme`. Validating one and stopping is not enough.
+- Do not validate only the "main" file while skipping the config, manifest, or generated files the same change modified.
+
+For either outcome:
+
+- Read everything validation reports, **resolve every finding**, and re-run until it passes clean.
+- Do not present the task as finished while validation reports outstanding issues. An unresolved finding means the task is not done.
 
 ## Gotchas
 
 - Both brackets are required. Skipping the doc search is the most common failure — do it first, every time, even for questions that look trivial. Validation is not "best effort"; the task is complete only when `shopify validate [topic]` is clean.
 - Don't guess command names or flags. The command surface changes between versions — `shopify commands` lists what exists and `<command> --help` documents its flags. Confirm there before running, especially for `shopify validate`.
+- A code example in a chat reply is an outcome too. A snippet with `...` or placeholder values is not "done" — write it to a temp file and validate it exactly like a committed file before you show it.
 - `--api-name` narrows recall; if results look thin or miss the point, drop the flag and search across all APIs.
 - `shopify doc search` returns ranked chunks, not a full page. When a chunk points at a page you need in full, follow up with `shopify doc fetch --url`.
 - Match the API version between search and output; mixing versions produces subtly wrong fields.

--- a/.agents/skills/shopify/SKILL.md
+++ b/.agents/skills/shopify/SKILL.md
@@ -28,11 +28,11 @@ Use this to confirm the exact surface of any command in this skill — including
 Before producing any answer, query, mutation, component, config, or scaffold, search shopify.dev:
 
 ```bash
-shopify doc search --query "<what you are building>" [--api-name admin|storefront|customer|partner|payments|functions|hydrogen|liquid|...] [--api-version latest|2025-10|...]
+shopify doc search --query "<what you are building>" [--api-name <api>] [--api-version latest|2025-10|...]
 ```
 
 - It queries the shopify.dev vector store and prints the most relevant documentation chunks as JSON.
-- Pass `--api-name` to scope to a surface; omit it to search across ALL APIs — that omission is the intended generic discovery / fallback path.
+- `--api-name` is an optional narrowing hint, not a required parameter. Its documented values are `admin`, `storefront`, `hydrogen`, and `functions` (`shopify doc search --help` shows these examples). The valid set is defined by shopify.dev, not the CLI, which does not validate the flag: **unrecognized values are silently ignored** — unlike `--api-version`, where an invalid value errors and lists the valid ones. So never invent an API name (there is no `polaris`, for example): pass `--api-name` only when you are confident the value is a real shopify.dev API, and omit it otherwise. Searching across ALL APIs is the supported default and the generic fallback.
 - Pass `--api-version latest` unless the task pins a version (for example `2025-10`).
 - Refine the query and re-run until the returned chunks genuinely cover the task. Thin or off-topic results mean you are not ready to answer yet.
 
@@ -54,8 +54,8 @@ Pick the family the task falls into, build to the docs you just retrieved, and s
 | Custom data | Metafields & metaobjects definitions/schemas extending products, customers, etc. | `--query "metaobject definition" --api-name admin` | `custom-data` |
 | Functions | Discount, cart/checkout validation, cart transform, delivery & payment customization, order routing location rule, fulfillment constraints, pickup/local delivery option generators | `--query "product discount function" --api-name functions` | `functions` |
 | Storefronts | Hydrogen recipes (B2B, bundles, combined listings, custom cart method, metaobjects, markets, subscriptions, infinite scroll, GTM, Partytown, third-party caching) and Storefront GraphQL cart operations | `--query "cart lines add" --api-name hydrogen` | `hydrogen` / `storefront` |
-| Themes | Liquid sections, blocks, snippets, and theme schemas | `--query "section schema settings" --api-name liquid` | `theme` |
-| Admin & extension UI | Polaris App Home embedded admin UI, plus Admin, Checkout, Customer Account, and POS UI extensions (scaffold via CLI) | `--query "checkout ui extension targets"` | `polaris` / `admin-extension` / `checkout-extension` / `customer-account-extension` / `pos-ui` |
+| Themes | Liquid sections, blocks, snippets, and theme schemas | `--query "liquid section schema settings"` | `theme` |
+| Admin & extension UI | Polaris App Home embedded admin UI, plus Admin, Checkout, Customer Account, and POS UI extensions (scaffold via CLI) | `--query "checkout ui extension targets"` | `app-home` / `admin-extension` / `checkout-extension` / `customer-account-extension` / `pos-ui` |
 | Onboarding | Developer setup (scaffold app/theme/project, create a dev store, set up a Partner account) and merchant setup (start selling, try before an account, `shopify store create preview`) | `--query "scaffold app dev store"` | `onboarding` |
 | CLI operations | Validate config on disk (`shopify.app.toml`, `shopify.extension.toml`); run store workflows (`shopify store auth`/`execute`); store-scoped reads/writes by handle/SKU/location on a named myshopify.com domain | `--query "app configuration toml"` | `config` |
 | Commerce (UCP) | UCP CLI: find/compare/buy/track products, `ucp profile init`, `ucp doctor`, carts, checkout, orders, merchant-hosted handoff fallback | `--query "ucp checkout order"` | `ucp` |
@@ -90,7 +90,7 @@ For either outcome:
 - Both brackets are required. Skipping the doc search is the most common failure — do it first, every time, even for questions that look trivial. Validation is not "best effort"; the task is complete only when `shopify validate [topic]` is clean.
 - Don't guess command names or flags. The command surface changes between versions — `shopify commands` lists what exists and `<command> --help` documents its flags. Confirm there before running, especially for `shopify validate`.
 - A code example in a chat reply is an outcome too. A snippet with `...` or placeholder values is not "done" — write it to a temp file and validate it exactly like a committed file before you show it.
-- `--api-name` narrows recall; if results look thin or miss the point, drop the flag and search across all APIs.
+- `--api-name` is optional and unvalidated: shopify.dev silently ignores a value it doesn't recognize, so a wrong name quietly returns unscoped results instead of erroring — you won't be warned. Only pass values you are sure of; when unsure, omit it and search all APIs. (`--api-version` is stricter — an invalid version errors and lists the valid ones.)
 - `shopify doc search` returns ranked chunks, not a full page. When a chunk points at a page you need in full, follow up with `shopify doc fetch --url`.
 - Match the API version between search and output; mixing versions produces subtly wrong fields.
 - "Polaris" alone means **App Home** (the embedded admin app UI); treat it as an extension only when the task names Admin, Checkout, Customer Account, or POS.

--- a/.agents/skills/shopify/SKILL.md
+++ b/.agents/skills/shopify/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: shopify
-description: 'For any Shopify build, dev, or commerce task; match liberally. Use when: writing Admin, Storefront, Customer Account, Partner, or Payments Apps GraphQL queries/mutations; modeling custom data (metafields, metaobjects); Shopify Functions (discounts, cart/checkout validation, cart transform, delivery/payment customization, order routing, fulfillment constraints, pickup/local delivery generators); Hydrogen storefront recipes or Storefront GraphQL carts; Liquid themes (sections, blocks, snippets, schemas); Polaris App Home plus admin, checkout, customer-account, POS UI extensions; onboarding developers (scaffold app/theme/dev store, Partner account) or merchants (start selling, preview store); Shopify CLI: validate shopify.app.toml/shopify.extension.toml, run store auth/execute, read/write store data by handle/SKU/location on myshopify.com; UCP commerce (find/compare/buy/track products, carts, checkout, orders); App Store pre-submission review; or searching shopify.dev docs (any API).'
+description: 'Any Shopify or commerce task; start here. Admin/Storefront/Customer/Partner/Payments GraphQL, metafields, Functions, Hydrogen, Liquid themes, Polaris, admin/checkout/customer-account/POS extensions, CLI, onboarding, UCP, App Store review, dev docs.'
 ---
 
 # Shopify

--- a/.agents/skills/shopify/SKILL.md
+++ b/.agents/skills/shopify/SKILL.md
@@ -46,7 +46,7 @@ shopify doc fetch --url <shopify.dev url> [--output <file>]
 
 ### 2) Do the work for the matching family
 
-Pick the family the task falls into, build to the docs you just retrieved, and scaffold new apps, themes, or extensions through the CLI generators (for example `shopify app generate extension`, `shopify theme init`) rather than hand-writing boilerplate. Follow this repo's conventions: named exports, side-effect-free modules, and existing patterns first — look for a helper in `@shopify/cli-kit` before writing your own. Leave no TODOs, FIXMEs, or placeholders.
+Pick the family the task falls into, build to the docs you just retrieved, and scaffold new apps, themes, or extensions through the CLI generators (for example `shopify app generate extension`, `shopify theme init`) rather than hand-writing boilerplate. Follow this repo's conventions: named exports, side-effect-free modules, and existing patterns first — look for a helper in `@shopify/cli` before writing your own. Leave no TODOs, FIXMEs, or placeholders.
 
 | Family | Covers | Representative doc-search query | Validate topic (illustrative) |
 |---|---|---|---|

--- a/.agents/skills/shopify/SKILL.md
+++ b/.agents/skills/shopify/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: shopify
+description: 'For any Shopify build, dev, or commerce task; match liberally. Use when: writing Admin, Storefront, Customer Account, Partner, or Payments Apps GraphQL queries/mutations; modeling custom data (metafields, metaobjects); Shopify Functions (discounts, cart/checkout validation, cart transform, delivery/payment customization, order routing, fulfillment constraints, pickup/local delivery generators); Hydrogen storefront recipes or Storefront GraphQL carts; Liquid themes (sections, blocks, snippets, schemas); Polaris App Home plus admin, checkout, customer-account, POS UI extensions; onboarding developers (scaffold app/theme/dev store, Partner account) or merchants (start selling, preview store); Shopify CLI: validate shopify.app.toml/shopify.extension.toml, run store auth/execute, read/write store data by handle/SKU/location on myshopify.com; UCP commerce (find/compare/buy/track products, carts, checkout, orders); App Store pre-submission review; or searching shopify.dev docs (any API).'
+---
+
+# Shopify
+
+Umbrella skill for building on and selling with Shopify. It spans every surface: Admin, Storefront, Customer Account, Partner, and Payments Apps GraphQL APIs, custom data, Functions, Hydrogen storefronts, Liquid themes, Polaris App Home, Admin/Checkout/Customer Account/POS UI extensions, developer and merchant onboarding, CLI operations, UCP commerce, and App Store review. Two steps are mandatory on every task and must never be skipped: **search the docs first**, **validate the outcome last**. Match liberally: if a request touches Shopify at all, use this skill.
+
+## Principle
+
+Never answer from memory or write Shopify code from assumption. Shopify APIs, schemas, extension targets, and CLI config change every release, so recalled details are frequently stale. Ground the work in current documentation, then prove the result with the validator. Skipping either bracket is a defect, even for a change that "looks obvious."
+
+## Pattern
+
+### 1) Search the docs first — mandatory, non-skippable
+
+Before producing any answer, query, mutation, component, config, or scaffold, search shopify.dev:
+
+```bash
+shopify doc search --query "<what you are building>" [--api-name admin|storefront|customer|partner|payments|functions|hydrogen|liquid|...] [--api-version latest|2025-10|...]
+```
+
+- It queries the shopify.dev vector store and prints the most relevant documentation chunks as JSON.
+- Pass `--api-name` to scope to a surface; omit it to search across ALL APIs — that omission is the intended generic discovery / fallback path.
+- Pass `--api-version latest` unless the task pins a version (for example `2025-10`).
+- Refine the query and re-run until the returned chunks genuinely cover the task. Thin or off-topic results mean you are not ready to answer yet.
+
+To read a full referenced page verbatim, pull it as Markdown:
+
+```bash
+shopify doc fetch --url <shopify.dev url> [--output <file>]
+```
+
+`shopify doc search` is the default discovery path and the fallback for ANY Shopify topic, including surfaces not in the table below. When unsure which family applies, search first, then decide.
+
+### 2) Do the work for the matching family
+
+Pick the family the task falls into, build to the docs you just retrieved, and scaffold new apps, themes, or extensions through the CLI generators (for example `shopify app generate extension`, `shopify theme init`) rather than hand-writing boilerplate. Follow this repo's conventions: named exports, side-effect-free modules, and existing patterns first — look for a helper in `@shopify/cli-kit` before writing your own. Leave no TODOs, FIXMEs, or placeholders.
+
+| Family | Covers | Representative doc-search query | Validate topic (illustrative) |
+|---|---|---|---|
+| GraphQL APIs | Admin, Storefront, Customer Account, Partner, Payments Apps queries & mutations; apps/integrations extending the admin | `--query "create product" --api-name admin` | `admin` / `storefront` / `customer` / `partner` / `payments` |
+| Custom data | Metafields & metaobjects definitions/schemas extending products, customers, etc. | `--query "metaobject definition" --api-name admin` | `custom-data` |
+| Functions | Discount, cart/checkout validation, cart transform, delivery & payment customization, order routing location rule, fulfillment constraints, pickup/local delivery option generators | `--query "product discount function" --api-name functions` | `functions` |
+| Storefronts | Hydrogen recipes (B2B, bundles, combined listings, custom cart method, metaobjects, markets, subscriptions, infinite scroll, GTM, Partytown, third-party caching) and Storefront GraphQL cart operations | `--query "cart lines add" --api-name hydrogen` | `hydrogen` / `storefront` |
+| Themes | Liquid sections, blocks, snippets, and theme schemas | `--query "section schema settings" --api-name liquid` | `theme` |
+| Admin & extension UI | Polaris App Home embedded admin UI, plus Admin, Checkout, Customer Account, and POS UI extensions (scaffold via CLI) | `--query "checkout ui extension targets"` | `polaris` / `admin-extension` / `checkout-extension` / `customer-account-extension` / `pos-ui` |
+| Onboarding | Developer setup (scaffold app/theme/project, create a dev store, set up a Partner account) and merchant setup (start selling, try before an account, `shopify store create preview`) | `--query "scaffold app dev store"` | `onboarding` |
+| CLI operations | Validate config on disk (`shopify.app.toml`, `shopify.extension.toml`); run store workflows (`shopify store auth`/`execute`); store-scoped reads/writes by handle/SKU/location on a named myshopify.com domain | `--query "app configuration toml"` | `config` |
+| Commerce (UCP) | UCP CLI: find/compare/buy/track products, `ucp profile init`, `ucp doctor`, carts, checkout, orders, merchant-hosted handoff fallback | `--query "ucp checkout order"` | `ucp` |
+| App Store review | Pre-submission compliance check of an app's codebase; surface likely review issues before submitting | `--query "app store review requirements"` | `app-store-review` |
+
+For a bare docs question that fits no family, answer straight from `shopify doc search` / `shopify doc fetch` results.
+
+### 3) Validate the outcome last — mandatory, non-skippable
+
+After the work is complete, validate the final outcome for the surface you touched:
+
+```bash
+shopify validate [topic]
+```
+
+- Use the topic for what you produced (for example `shopify validate functions`, `shopify validate theme`, `shopify validate config`). The topics in the table are illustrative — run `shopify validate --help` for the current list.
+- Read everything it reports, **resolve every finding**, and re-run until it passes clean.
+- Do not present the task as finished while `shopify validate` reports outstanding issues. An unresolved finding means the task is not done.
+
+## Gotchas
+
+- Both brackets are required. Skipping the doc search is the most common failure — do it first, every time, even for questions that look trivial. Validation is not "best effort"; the task is complete only when `shopify validate [topic]` is clean.
+- `--api-name` narrows recall; if results look thin or miss the point, drop the flag and search across all APIs.
+- `shopify doc search` returns ranked chunks, not a full page. When a chunk points at a page you need in full, follow up with `shopify doc fetch --url`.
+- Match the API version between search and output; mixing versions produces subtly wrong fields.
+- "Polaris" alone means **App Home** (the embedded admin app UI); treat it as an extension only when the task names Admin, Checkout, Customer Account, or POS.
+- Developer onboarding (scaffold app/theme/project, create a dev store, Partner account) is not merchant onboarding (start selling online, first store, `shopify store create preview`) — search for the one the user actually means.
+- App Store review is read-only analysis of the codebase — report likely blockers; do not silently rewrite the app.
+- Store-scoped CLI reads/writes (`shopify store auth`/`execute`, reads/writes by handle/SKU/location on a named myshopify.com domain) act on real store data — confirm the target domain before running them.
+
+## Examples
+
+- "Write an Admin mutation to create a metafield definition." → `shopify doc search --query "metafield definition create mutation" --api-name admin`, write the mutation, then `shopify validate admin` and resolve any findings.
+- "Add a discount Function." → `shopify doc search --query "product discount function" --api-name functions`, implement `run` against the retrieved input query, then `shopify validate functions`.
+- "Fetch orders in the customer account." → search `--api-name customer`, build the query, then `shopify validate customer`.
+- "Scaffold a checkout UI extension." → search checkout extension targets, generate via the CLI, implement the target, then `shopify validate checkout-extension`.
+- "Help me start selling on Shopify." → merchant onboarding: search `--query "start selling create preview store"` (no `--api-name`), guide the preview/first store setup, then validate the store setup.
+- "Is my app ready to submit to the App Store?" → search app store review requirements, inspect the codebase, then `shopify validate app-store-review`.
+- "Buy this product with UCP." → search `--query "ucp checkout"`, run the flow, then `shopify validate ucp`.

--- a/.agents/skills/shopify/SKILL.md
+++ b/.agents/skills/shopify/SKILL.md
@@ -102,7 +102,7 @@ For either outcome:
 
 - "Write an Admin mutation to create a metafield definition." → `shopify doc search --query "metafield definition create mutation" --api-name admin`, write the mutation, then `shopify validate admin` and resolve any findings.
 - "Add a discount Function." → `shopify doc search --query "product discount function" --api-name functions`, implement `run` against the retrieved input query, then `shopify validate functions`.
-- "Fetch orders in the customer account." → search `--api-name customer`, build the query, then `shopify validate customer`.
+- "Fetch orders in the customer account." → `shopify doc search --query "customer account api orders"` (no `--api-name` unless you confirm a valid one), build the query, then `shopify validate customer`.
 - "Scaffold a checkout UI extension." → search checkout extension targets, generate via the CLI, implement the target, then `shopify validate checkout-extension`.
 - "Help me start selling on Shopify." → merchant onboarding: search `--query "start selling create preview store"` (no `--api-name`), guide the preview/first store setup, then validate the store setup.
 - "Is my app ready to submit to the App Store?" → search app store review requirements, inspect the codebase, then `shopify validate app-store-review`.


### PR DESCRIPTION
## What

Adds a single umbrella skill at `.agents/skills/shopify/SKILL.md` that consolidates the use cases of all 20 skills in [Shopify/Shopify-AI-Toolkit `skills/`](https://github.com/Shopify/Shopify-AI-Toolkit/tree/main/skills).

## Description (995 chars, under the 1024 limit)

Matches **liberally** across every Shopify surface so it triggers on essentially any Shopify build/dev/merchant/commerce task:

- Admin / Storefront / Customer Account / Partner / Payments Apps GraphQL
- Custom data (metafields, metaobjects)
- Shopify Functions (discounts, cart/checkout validation, cart transform, delivery/payment customization, order routing, fulfillment constraints, delivery generators)
- Hydrogen recipes & Storefront GraphQL carts
- Liquid themes (sections, blocks, snippets, schemas)
- Polaris App Home + Admin / Checkout / Customer-Account / POS UI extensions
- Developer & merchant onboarding
- Shopify CLI config validation and store workflows
- UCP commerce
- App Store pre-submission review
- shopify.dev docs search (any API)

## Body

Enforces two mandatory, non-skippable steps on every task:

1. **Search dev docs first** — `shopify doc search --query "..." [--api-name ...] [--api-version ...]` (with `shopify doc fetch --url` for full pages). This command already ships in `packages/cli/src/cli/commands/doc/`.
2. **Validate the outcome last** — `shopify validate [topic]`, resolving every finding and re-running until clean.

> Note: `shopify validate [topic]` does **not** exist yet — it's referenced as a to-be-made command. Topic names in the body are illustrative and point to `shopify validate --help` for the real list.

A family table maps each surface to a representative doc-search query and validate topic; Gotchas and Examples reinforce both brackets.

## Notes

- No changeset: this is agent tooling with no user-visible CLI behavior change.
- Follow-up candidate: implement the `shopify validate [topic]` command referenced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)