### PR TITLE
Add Shopify skill install command

### DIFF
--- a/.changeset/install-shopify-skill.md
+++ b/.changeset/install-shopify-skill.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli': patch
+---
+
+Add `shopify skill install` with automatic installation and package-manager selection.

--- a/docs-shopify.dev/generated/generated_docs_data_v2.json
+++ b/docs-shopify.dev/generated/generated_docs_data_v2.json
@@ -4738,6 +4738,26 @@
       "value": "export interface search {\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Increase the verbosity of the output.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
     }
   },
+  "skillinstall": {
+    "docs-shopify.dev/commands/interfaces/skill-install.interface.ts": {
+      "filePath": "docs-shopify.dev/commands/interfaces/skill-install.interface.ts",
+      "name": "skillinstall",
+      "description": "The following flags are available for the `skill install` command:",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "docs-shopify.dev/commands/interfaces/skill-install.interface.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "--package-manager <value>",
+          "value": "string",
+          "description": "The package manager to use to download the latest version of the skills CLI.",
+          "isOptional": true,
+          "environmentValue": "SHOPIFY_FLAG_PACKAGE_MANAGER"
+        }
+      ],
+      "value": "export interface skillinstall {\n  /**\n   * The package manager to use to download the latest version of the skills CLI.\n   * @environment SHOPIFY_FLAG_PACKAGE_MANAGER\n   */\n  '--package-manager <value>'?: string\n}"
+    }
+  },
   "storeauthlist": {
     "docs-shopify.dev/commands/interfaces/store-auth-list.interface.ts": {
       "filePath": "docs-shopify.dev/commands/interfaces/store-auth-list.interface.ts",

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -79,6 +79,7 @@
 * [`shopify plugins unlink [PLUGIN]`](#shopify-plugins-unlink-plugin)
 * [`shopify plugins update`](#shopify-plugins-update)
 * [`shopify search [query]`](#shopify-search-query)
+* [`shopify skill install`](#shopify-skill-install)
 * [`shopify store auth`](#shopify-store-auth)
 * [`shopify store auth list`](#shopify-store-auth-list)
 * [`shopify store bulk cancel`](#shopify-store-bulk-cancel)
@@ -3398,6 +3399,21 @@ EXAMPLES
       shopify search <query>
       # search for a phrase on Shopify.dev
       shopify search "<a search query separated by spaces>"
+```
+
+## `shopify skill install`
+
+Install the Shopify skill for coding agents.
+
+```
+USAGE
+  $ shopify skill install [--package-manager npm|pnpm|yarn|bun]
+
+FLAGS
+  --package-manager=<option>
+      The package manager to use to download the latest version of the skills CLI.
+      [env: SHOPIFY_FLAG_PACKAGE_MANAGER]
+      <options: npm|pnpm|yarn|bun>
 ```
 
 ## `shopify store auth`

--- a/packages/cli/bin/postinstall.js
+++ b/packages/cli/bin/postinstall.js
@@ -1,0 +1,14 @@
+import {spawnSync} from 'node:child_process'
+import {existsSync} from 'node:fs'
+import {fileURLToPath} from 'node:url'
+
+const cliPath = fileURLToPath(new URL('./run.js', import.meta.url))
+const compiledCliPath = fileURLToPath(new URL('../dist/bootstrap.js', import.meta.url))
+
+if (existsSync(compiledCliPath)) {
+  const installation = spawnSync(process.execPath, [cliPath, 'skill', 'install'], {stdio: 'inherit'})
+
+  if (installation.error || installation.status !== 0) {
+    console.warn('The Shopify skill was not installed. Run `shopify skill install` to try again.')
+  }
+}

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -6303,6 +6303,38 @@
       "strict": true,
       "usage": "search [query]"
     },
+    "skill:install": {
+      "aliases": [
+      ],
+      "args": {
+      },
+      "enableJsonFlag": false,
+      "flags": {
+        "package-manager": {
+          "description": "The package manager to use to download the latest version of the skills CLI.",
+          "env": "SHOPIFY_FLAG_PACKAGE_MANAGER",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "package-manager",
+          "options": [
+            "npm",
+            "pnpm",
+            "yarn",
+            "bun"
+          ],
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [
+      ],
+      "id": "skill:install",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "summary": "Install the Shopify skill for coding agents."
+    },
     "store:auth": {
       "aliases": [
       ],

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -35,6 +35,7 @@
   },
   "files": [
     "/assets",
+    "/bin/postinstall.js",
     "/bin/run.cmd",
     "/bin/run.js",
     "/dist",
@@ -47,6 +48,7 @@
     "clean": "nx clean",
     "lint": "nx lint",
     "lint:fix": "nx lint:fix",
+    "postinstall": "node ./bin/postinstall.js",
     "prepack": "NODE_ENV=production node ../../bin/update-bugsnag cli && pnpm oclif manifest && cp ../../README.md README.md",
     "vitest": "vitest",
     "type-check": "nx type-check"
@@ -116,6 +118,9 @@
       },
       "store": {
         "description": "Work directly with Shopify stores."
+      },
+      "skill": {
+        "description": "Manage Shopify skills for coding agents."
       },
       "store:bulk": {
         "description": "Run, check, and cancel bulk Admin API operations on a store."

--- a/packages/cli/src/cli/commands/skill/install.test.ts
+++ b/packages/cli/src/cli/commands/skill/install.test.ts
@@ -8,7 +8,14 @@ vi.mock('@shopify/cli-kit/node/system')
 
 describe('skill install', () => {
   test('infers the package manager', async () => {
-    const skillArguments = ['add', 'Shopify/cli', '--skill', 'shopify', '--global', '--yes']
+    const skillArguments = [
+      'add',
+      'Shopify/cli#feature/shopify-validate-command',
+      '--skill',
+      'shopify',
+      '--global',
+      '--yes',
+    ]
     vi.mocked(inferPackageManager).mockReturnValue('pnpm')
 
     await SkillInstall.run([], import.meta.url)
@@ -25,7 +32,15 @@ describe('skill install', () => {
     expect(inferPackageManager).toHaveBeenCalledWith('bun')
     expect(exec).toHaveBeenCalledWith(
       'bunx',
-      ['skills@latest', 'add', 'Shopify/cli', '--skill', 'shopify', '--global', '--yes'],
+      [
+        'skills@latest',
+        'add',
+        'Shopify/cli#feature/shopify-validate-command',
+        '--skill',
+        'shopify',
+        '--global',
+        '--yes',
+      ],
       {stdio: 'inherit'},
     )
   })

--- a/packages/cli/src/cli/commands/skill/install.test.ts
+++ b/packages/cli/src/cli/commands/skill/install.test.ts
@@ -1,0 +1,43 @@
+import SkillInstall, {skillsCommandForPackageManager} from './install.js'
+import {inferPackageManager} from '@shopify/cli-kit/node/node-package-manager'
+import {exec} from '@shopify/cli-kit/node/system'
+import {describe, expect, test, vi} from 'vitest'
+
+vi.mock('@shopify/cli-kit/node/node-package-manager')
+vi.mock('@shopify/cli-kit/node/system')
+
+describe('skill install', () => {
+  test('infers the package manager', async () => {
+    const skillArguments = ['add', 'Shopify/cli', '--skill', 'shopify', '--global', '--yes']
+    vi.mocked(inferPackageManager).mockReturnValue('pnpm')
+
+    await SkillInstall.run([], import.meta.url)
+
+    expect(inferPackageManager).toHaveBeenCalledWith(undefined)
+    expect(exec).toHaveBeenCalledWith('pnpx', ['skills@latest', ...skillArguments], {stdio: 'inherit'})
+  })
+
+  test('uses the selected package manager', async () => {
+    vi.mocked(inferPackageManager).mockReturnValue('bun')
+
+    await SkillInstall.run(['--package-manager', 'bun'], import.meta.url)
+
+    expect(inferPackageManager).toHaveBeenCalledWith('bun')
+    expect(exec).toHaveBeenCalledWith(
+      'bunx',
+      ['skills@latest', 'add', 'Shopify/cli', '--skill', 'shopify', '--global', '--yes'],
+      {stdio: 'inherit'},
+    )
+  })
+
+  test.each([
+    ['npm', 'npx', ['--yes', 'skills@latest']],
+    ['pnpm', 'pnpx', ['skills@latest']],
+    ['yarn', 'yarn', ['dlx', 'skills@latest']],
+    ['bun', 'bunx', ['skills@latest']],
+    ['homebrew', 'npx', ['--yes', 'skills@latest']],
+    ['unknown', 'npx', ['--yes', 'skills@latest']],
+  ] as const)('maps %s to %s', (packageManager, command, args) => {
+    expect(skillsCommandForPackageManager(packageManager)).toEqual({command, args})
+  })
+})

--- a/packages/cli/src/cli/commands/skill/install.ts
+++ b/packages/cli/src/cli/commands/skill/install.ts
@@ -1,0 +1,41 @@
+import Command from '@shopify/cli-kit/node/base-command'
+import {inferPackageManager, PackageManager} from '@shopify/cli-kit/node/node-package-manager'
+import {exec} from '@shopify/cli-kit/node/system'
+import {Flags} from '@oclif/core'
+
+const shopifySkillArguments = ['add', 'Shopify/cli', '--skill', 'shopify', '--global', '--yes']
+
+export default class SkillInstall extends Command {
+  static summary = 'Install the Shopify skill for coding agents.'
+
+  static flags = {
+    'package-manager': Flags.string({
+      description: 'The package manager to use to download the latest version of the skills CLI.',
+      env: 'SHOPIFY_FLAG_PACKAGE_MANAGER',
+      options: ['npm', 'pnpm', 'yarn', 'bun'],
+    }),
+  }
+
+  async run(): Promise<void> {
+    const {flags} = await this.parse(SkillInstall)
+    const packageManager = inferPackageManager(flags['package-manager'])
+    const skillsCommand = skillsCommandForPackageManager(packageManager)
+
+    await exec(skillsCommand.command, [...skillsCommand.args, ...shopifySkillArguments], {stdio: 'inherit'})
+  }
+}
+
+export function skillsCommandForPackageManager(packageManager: PackageManager): {command: string; args: string[]} {
+  switch (packageManager) {
+    case 'pnpm':
+      return {command: 'pnpx', args: ['skills@latest']}
+    case 'yarn':
+      return {command: 'yarn', args: ['dlx', 'skills@latest']}
+    case 'bun':
+      return {command: 'bunx', args: ['skills@latest']}
+    case 'npm':
+    case 'homebrew':
+    case 'unknown':
+      return {command: 'npx', args: ['--yes', 'skills@latest']}
+  }
+}

--- a/packages/cli/src/cli/commands/skill/install.ts
+++ b/packages/cli/src/cli/commands/skill/install.ts
@@ -3,7 +3,17 @@ import {inferPackageManager, PackageManager} from '@shopify/cli-kit/node/node-pa
 import {exec} from '@shopify/cli-kit/node/system'
 import {Flags} from '@oclif/core'
 
-const shopifySkillArguments = ['add', 'Shopify/cli', '--skill', 'shopify', '--global', '--yes']
+// eslint-disable-next-line no-warning-comments
+// TODO: Point back to 'Shopify/cli' (default branch) before merging. The shopify skill
+// only exists on the feature/shopify-validate-command branch until PR #8142 lands on main.
+const shopifySkillArguments = [
+  'add',
+  'Shopify/cli#feature/shopify-validate-command',
+  '--skill',
+  'shopify',
+  '--global',
+  '--yes',
+]
 
 export default class SkillInstall extends Command {
   static summary = 'Install the Shopify skill for coding agents.'

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -24,6 +24,7 @@ import ValidateComponents from './cli/commands/validate/components.js'
 import ValidateFunctions from './cli/commands/validate/functions.js'
 import ValidateGraphql from './cli/commands/validate/graphql.js'
 import ValidateTheme from './cli/commands/validate/theme.js'
+import SkillInstall from './cli/commands/skill/install.js'
 import {createGlobalProxyAgent} from 'global-agent'
 import StoreCommands from '@shopify/store'
 import ThemeCommands from '@shopify/theme'
@@ -176,6 +177,7 @@ export const COMMANDS: any = {
   'validate:functions': ValidateFunctions,
   'validate:graphql': ValidateGraphql,
   'validate:theme': ValidateTheme,
+  'skill:install': SkillInstall,
 }
 
 export default runShopifyCLI

--- a/packages/e2e/data/snapshots/commands.txt
+++ b/packages/e2e/data/snapshots/commands.txt
@@ -96,6 +96,8 @@
 │  ├─ unlink
 │  └─ update
 ├─ search
+├─ skill
+│  └─ install
 ├─ store
 │  ├─ auth
 │  │  └─ list


### PR DESCRIPTION
## Summary
- add shopify skill install using the latest Skills CLI
- infer the package manager with an explicit override
- install the Shopify skill automatically after CLI installation

## Testing
- focused Vitest
- CLI lint and type-check
- CLI bundle and command snapshot