### PR TITLE
Preserve authorization expiry in payment extension configs

### DIFF
--- a/.changeset/preserve-payment-authorization-expiry.md
+++ b/.changeset/preserve-payment-authorization-expiry.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': minor
+---
+
+Preserve `enforce_authorization_expiry` in payment extension configurations.

--- a/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/base_payments_app_extension_schema.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/base_payments_app_extension_schema.test.ts
@@ -1,5 +1,6 @@
 import {
   BasePaymentsAppExtensionSchema,
+  AuthorizationExpirySchema,
   BuyerLabelSchema,
   ConfirmationSchema,
   DeferredPaymentsSchema,
@@ -191,6 +192,37 @@ describe('DeferredPaymentsSchema', () => {
           received: 'undefined',
           path: ['supports_deferred_payments'],
           message: 'Required',
+        },
+      ]),
+    )
+  })
+})
+
+describe('AuthorizationExpirySchema', () => {
+  test.each([true, false, undefined])('accepts %s', (enforceAuthorizationExpiry) => {
+    // When
+    const {success} = AuthorizationExpirySchema.safeParse({
+      enforce_authorization_expiry: enforceAuthorizationExpiry,
+    })
+
+    // Then
+    expect(success).toBe(true)
+  })
+
+  test('throws an error if enforce_authorization_expiry is not a boolean', () => {
+    // When/Then
+    expect(() =>
+      AuthorizationExpirySchema.parse({
+        enforce_authorization_expiry: 'true',
+      }),
+    ).toThrowError(
+      new zod.ZodError([
+        {
+          code: zod.ZodIssueCode.invalid_type,
+          expected: 'boolean',
+          received: 'string',
+          path: ['enforce_authorization_expiry'],
+          message: 'Expected boolean, received string',
         },
       ]),
     )

--- a/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/base_payments_app_extension_schema.ts
+++ b/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/base_payments_app_extension_schema.ts
@@ -57,6 +57,10 @@ export const MultipleCaptureSchema = zod.object({
   multiple_capture: zod.boolean().optional(),
 })
 
+export const AuthorizationExpirySchema = zod.object({
+  enforce_authorization_expiry: zod.boolean().optional(),
+})
+
 export const ConfirmationSchema = zod.object({
   confirmation_callback_url: zod.string().url().optional(),
   supports_3ds: zod.boolean(),

--- a/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/credit_card_payments_app_extension_schema.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/credit_card_payments_app_extension_schema.test.ts
@@ -26,6 +26,7 @@ const config: CreditCardPaymentsAppExtensionConfigType = {
   test_mode_available: true,
   supports_deferred_payments: false,
   multiple_capture: false,
+  enforce_authorization_expiry: true,
   supports_installments: false,
   targeting: [{target: 'payments.credit-card.render'}],
   api_version: '2022-07',
@@ -48,6 +49,14 @@ describe('CreditCardPaymentsAppExtensionSchema', () => {
 
     // Then
     expect(success).toBe(true)
+  })
+
+  test('preserves enforce_authorization_expiry', () => {
+    // When
+    const result = CreditCardPaymentsAppExtensionSchema.parse(config)
+
+    // Then
+    expect(result.enforce_authorization_expiry).toBe(true)
   })
 
   test('returns an error if no target is provided', async () => {
@@ -208,6 +217,7 @@ describe('creditCardPaymentsAppExtensionDeployConfig', () => {
       confirmation_callback_url: config.confirmation_callback_url,
       merchant_label: config.merchant_label,
       multiple_capture: config.multiple_capture,
+      enforce_authorization_expiry: config.enforce_authorization_expiry,
       supported_countries: config.supported_countries,
       supported_payment_methods: config.supported_payment_methods,
       supported_buyer_contexts: config.supported_buyer_contexts,

--- a/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/credit_card_payments_app_extension_schema.ts
+++ b/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/credit_card_payments_app_extension_schema.ts
@@ -1,6 +1,7 @@
 import {
   BasePaymentsAppExtensionSchema,
   BasePaymentsAppExtensionDeployConfigType,
+  AuthorizationExpirySchema,
   ConfirmationSchema,
   DeferredPaymentsSchema,
   MultipleCaptureSchema,
@@ -16,7 +17,8 @@ export const CREDIT_CARD_TARGET = 'payments.credit-card.render'
 // If updating this limit, also update the limit in the Partners Web Platform (https://github.com/Shopify/partners-web-platform/) - MAX_CHECKOUT_PAYMENT_METHOD_FIELDS
 export const MAX_CHECKOUT_PAYMENT_METHOD_FIELDS = 7
 
-export const CreditCardPaymentsAppExtensionSchema = BasePaymentsAppExtensionSchema.merge(DeferredPaymentsSchema)
+export const CreditCardPaymentsAppExtensionSchema = BasePaymentsAppExtensionSchema.merge(AuthorizationExpirySchema)
+  .merge(DeferredPaymentsSchema)
   .merge(ConfirmationSchema)
   .merge(MultipleCaptureSchema)
   .merge(SupportedBuyerContextsSchema)
@@ -65,6 +67,9 @@ export interface CreditCardPaymentsAppExtensionDeployConfigType extends BasePaym
   // MultipleCaptureSchema
   multiple_capture?: boolean
 
+  // AuthorizationExpirySchema
+  enforce_authorization_expiry?: boolean
+
   // DeferredPaymentsSchema
   supports_deferred_payments: boolean
   supports_installments: boolean
@@ -103,6 +108,7 @@ export function creditCardDeployConfigToCLIConfig(
     void_session_url: config.start_void_session_url,
     confirmation_callback_url: config.confirmation_callback_url,
     multiple_capture: config.multiple_capture,
+    enforce_authorization_expiry: config.enforce_authorization_expiry,
     merchant_label: config.merchant_label,
     supported_countries: config.supported_countries,
     supported_payment_methods: config.supported_payment_methods,
@@ -130,6 +136,7 @@ export async function creditCardPaymentsAppExtensionDeployConfig(
     start_void_session_url: config.void_session_url,
     confirmation_callback_url: config.confirmation_callback_url,
     multiple_capture: config.multiple_capture,
+    enforce_authorization_expiry: config.enforce_authorization_expiry,
     merchant_label: config.merchant_label,
     supported_countries: config.supported_countries,
     supported_payment_methods: config.supported_payment_methods,

--- a/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/custom_credit_card_payments_app_extension_schema.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/custom_credit_card_payments_app_extension_schema.test.ts
@@ -27,6 +27,7 @@ const config: CustomCreditCardPaymentsAppExtensionConfigType = {
   supports_3ds: true,
   test_mode_available: true,
   multiple_capture: true,
+  enforce_authorization_expiry: true,
   encryption_certificate_fingerprint: 'fingerprint',
   api_version: '2022-07',
   checkout_payment_method_fields: [],
@@ -48,6 +49,14 @@ describe('CustomCreditCardPaymentsAppExtensionSchema', () => {
 
     // Then
     expect(success).toBe(true)
+  })
+
+  test('preserves enforce_authorization_expiry', () => {
+    // When
+    const result = CustomCreditCardPaymentsAppExtensionSchema.parse(config)
+
+    // Then
+    expect(result.enforce_authorization_expiry).toBe(true)
   })
 
   test('returns an error if no target is provided', async () => {
@@ -147,6 +156,7 @@ describe('customCreditCardPaymentsAppExtensionDeployConfig', () => {
       start_capture_session_url: config.capture_session_url,
       start_void_session_url: config.void_session_url,
       confirmation_callback_url: config.confirmation_callback_url,
+      enforce_authorization_expiry: config.enforce_authorization_expiry,
       merchant_label: config.merchant_label,
       supports_3ds: config.supports_3ds,
       supported_countries: config.supported_countries,

--- a/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/custom_credit_card_payments_app_extension_schema.ts
+++ b/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/custom_credit_card_payments_app_extension_schema.ts
@@ -1,5 +1,6 @@
 import {
   BasePaymentsAppExtensionSchema,
+  AuthorizationExpirySchema,
   BuyerLabelSchema,
   BasePaymentsAppExtensionDeployConfigType,
   ConfirmationSchema,
@@ -16,7 +17,10 @@ export type CustomCreditCardPaymentsAppExtensionConfigType = zod.infer<
 export const CUSTOM_CREDIT_CARD_TARGET = 'payments.custom-credit-card.render'
 export const MAX_CHECKOUT_PAYMENT_METHOD_FIELDS = 7
 
-export const CustomCreditCardPaymentsAppExtensionSchema = BasePaymentsAppExtensionSchema.merge(BuyerLabelSchema)
+export const CustomCreditCardPaymentsAppExtensionSchema = BasePaymentsAppExtensionSchema.merge(
+  AuthorizationExpirySchema,
+)
+  .merge(BuyerLabelSchema)
   .merge(ConfirmationSchema)
   .merge(SupportedBuyerContextsSchema)
   .required({
@@ -59,6 +63,9 @@ export interface CustomCreditCardPaymentsAppExtensionDeployConfigType extends Ba
   confirmation_callback_url?: string
   supports_3ds: boolean
 
+  // AuthorizationExpirySchema
+  enforce_authorization_expiry?: boolean
+
   multiple_capture: boolean
   checkout_hosted_fields?: string[]
   ui_extension_registration_uuid?: string
@@ -87,6 +94,7 @@ export function customCreditCardDeployConfigToCLIConfig(
     capture_session_url: config.start_capture_session_url,
     void_session_url: config.start_void_session_url,
     confirmation_callback_url: config.confirmation_callback_url,
+    enforce_authorization_expiry: config.enforce_authorization_expiry,
     merchant_label: config.merchant_label,
     supports_3ds: config.supports_3ds,
     supported_countries: config.supported_countries,
@@ -113,6 +121,7 @@ export async function customCreditCardPaymentsAppExtensionDeployConfig(
     start_capture_session_url: config.capture_session_url,
     start_void_session_url: config.void_session_url,
     confirmation_callback_url: config.confirmation_callback_url,
+    enforce_authorization_expiry: config.enforce_authorization_expiry,
     merchant_label: config.merchant_label,
     supports_3ds: config.supports_3ds,
     supported_countries: config.supported_countries,

--- a/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/custom_onsite_payments_app_extension_schema.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/custom_onsite_payments_app_extension_schema.test.ts
@@ -28,6 +28,7 @@ const config: CustomOnsitePaymentsAppExtensionConfigType = {
   supports_deferred_payments: true,
   test_mode_available: true,
   multiple_capture: true,
+  enforce_authorization_expiry: true,
   api_version: '2022-07',
   checkout_payment_method_fields: [],
   modal_payment_method_fields: [],
@@ -48,6 +49,14 @@ describe('CustomOnsitePaymentsAppExtensionSchema', () => {
 
     // Then
     expect(success).toBe(true)
+  })
+
+  test('preserves enforce_authorization_expiry', () => {
+    // When
+    const result = CustomOnsitePaymentsAppExtensionSchema.parse(config)
+
+    // Then
+    expect(result.enforce_authorization_expiry).toBe(true)
   })
 
   test('returns an error if no target is provided', async () => {
@@ -192,6 +201,7 @@ describe('customOnsitePaymentsAppExtensionDeployConfig', () => {
       start_capture_session_url: config.capture_session_url,
       start_void_session_url: config.void_session_url,
       confirmation_callback_url: config.confirmation_callback_url,
+      enforce_authorization_expiry: config.enforce_authorization_expiry,
       update_payment_session_url: config.update_payment_session_url,
       merchant_label: config.merchant_label,
       supports_oversell_protection: config.supports_oversell_protection,

--- a/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/custom_onsite_payments_app_extension_schema.ts
+++ b/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/custom_onsite_payments_app_extension_schema.ts
@@ -1,6 +1,7 @@
 import {
   BasePaymentsAppExtensionSchema,
   BasePaymentsAppExtensionDeployConfigType,
+  AuthorizationExpirySchema,
   BuyerLabelSchema,
   ConfirmationSchema,
   DeferredPaymentsSchema,
@@ -15,7 +16,8 @@ export type CustomOnsitePaymentsAppExtensionConfigType = zod.infer<typeof Custom
 export const CUSTOM_ONSITE_TARGET = 'payments.custom-onsite.render'
 export const MAX_CHECKOUT_PAYMENT_METHOD_FIELDS = 7
 
-export const CustomOnsitePaymentsAppExtensionSchema = BasePaymentsAppExtensionSchema.merge(BuyerLabelSchema)
+export const CustomOnsitePaymentsAppExtensionSchema = BasePaymentsAppExtensionSchema.merge(AuthorizationExpirySchema)
+  .merge(BuyerLabelSchema)
   .merge(DeferredPaymentsSchema)
   .merge(ConfirmationSchema)
   .merge(SupportedBuyerContextsSchema)
@@ -58,6 +60,9 @@ export interface CustomOnsitePaymentsAppExtensionDeployConfigType extends BasePa
   confirmation_callback_url?: string
   supports_3ds: boolean
 
+  // AuthorizationExpirySchema
+  enforce_authorization_expiry?: boolean
+
   // CustomOnsite-specific fields
   start_verification_session_url?: string
   update_payment_session_url?: string
@@ -86,6 +91,7 @@ export function customOnsiteDeployConfigToCLIConfig(
     capture_session_url: config.start_capture_session_url,
     void_session_url: config.start_void_session_url,
     confirmation_callback_url: config.confirmation_callback_url,
+    enforce_authorization_expiry: config.enforce_authorization_expiry,
     update_payment_session_url: config.update_payment_session_url,
     start_verification_session_url: config.start_verification_session_url,
     merchant_label: config.merchant_label,
@@ -116,6 +122,7 @@ export async function customOnsitePaymentsAppExtensionDeployConfig(
     start_capture_session_url: config.capture_session_url,
     start_void_session_url: config.void_session_url,
     confirmation_callback_url: config.confirmation_callback_url,
+    enforce_authorization_expiry: config.enforce_authorization_expiry,
     update_payment_session_url: config.update_payment_session_url,
     start_verification_session_url: config.start_verification_session_url,
     merchant_label: config.merchant_label,

--- a/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/offsite_payments_app_extension_schema.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/offsite_payments_app_extension_schema.test.ts
@@ -21,6 +21,7 @@ const config: OffsitePaymentsAppExtensionConfigType = {
   supports_3ds: false,
   supports_oversell_protection: false,
   test_mode_available: true,
+  enforce_authorization_expiry: true,
   supports_deferred_payments: false,
   supports_installments: false,
   targeting: [{target: 'payments.offsite.render'}],
@@ -41,6 +42,14 @@ describe('OffsitePaymentsAppExtensionSchema', () => {
 
     // Then
     expect(success).toBe(true)
+  })
+
+  test('preserves enforce_authorization_expiry', () => {
+    // When
+    const result = OffsitePaymentsAppExtensionSchema.parse(config)
+
+    // Then
+    expect(result.enforce_authorization_expiry).toBe(true)
   })
 
   test('returns an error if no target is provided', async () => {
@@ -135,6 +144,7 @@ describe('offsitePaymentsAppExtensionDeployConfig', () => {
       start_capture_session_url: config.capture_session_url,
       start_void_session_url: config.void_session_url,
       confirmation_callback_url: config.confirmation_callback_url,
+      enforce_authorization_expiry: config.enforce_authorization_expiry,
       merchant_label: config.merchant_label,
       supported_countries: config.supported_countries,
       supported_payment_methods: config.supported_payment_methods,

--- a/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/offsite_payments_app_extension_schema.ts
+++ b/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/offsite_payments_app_extension_schema.ts
@@ -1,6 +1,7 @@
 import {
   BasePaymentsAppExtensionSchema,
   BasePaymentsAppExtensionDeployConfigType,
+  AuthorizationExpirySchema,
   BuyerLabelSchema,
   ConfirmationSchema,
   DeferredPaymentsSchema,
@@ -13,7 +14,8 @@ export type OffsitePaymentsAppExtensionConfigType = zod.infer<typeof OffsitePaym
 
 export const OFFSITE_TARGET = 'payments.offsite.render'
 
-export const OffsitePaymentsAppExtensionSchema = BasePaymentsAppExtensionSchema.merge(BuyerLabelSchema)
+export const OffsitePaymentsAppExtensionSchema = BasePaymentsAppExtensionSchema.merge(AuthorizationExpirySchema)
+  .merge(BuyerLabelSchema)
   .merge(DeferredPaymentsSchema)
   .merge(ConfirmationSchema)
   .merge(MultipleCaptureSchema)
@@ -33,6 +35,9 @@ export const OffsitePaymentsAppExtensionSchema = BasePaymentsAppExtensionSchema.
 export interface OffsitePaymentsAppExtensionDeployConfigType extends BasePaymentsAppExtensionDeployConfigType {
   // MultipleCaptureSchema
   multiple_capture?: boolean
+
+  // AuthorizationExpirySchema
+  enforce_authorization_expiry?: boolean
 
   // BuyerLabelSchema
   default_buyer_label?: string
@@ -58,6 +63,7 @@ export function offsiteDeployConfigToCLIConfig(
     void_session_url: config.start_void_session_url,
     confirmation_callback_url: config.confirmation_callback_url,
     multiple_capture: config.multiple_capture,
+    enforce_authorization_expiry: config.enforce_authorization_expiry,
     merchant_label: config.merchant_label,
     supported_countries: config.supported_countries,
     supported_payment_methods: config.supported_payment_methods,
@@ -83,6 +89,7 @@ export async function offsitePaymentsAppExtensionDeployConfig(
     start_void_session_url: config.void_session_url,
     confirmation_callback_url: config.confirmation_callback_url,
     multiple_capture: config.multiple_capture,
+    enforce_authorization_expiry: config.enforce_authorization_expiry,
     merchant_label: config.merchant_label,
     supported_countries: config.supported_countries,
     supported_payment_methods: config.supported_payment_methods,

--- a/packages/app/src/cli/services/payments/extension-config-builder.test.ts
+++ b/packages/app/src/cli/services/payments/extension-config-builder.test.ts
@@ -3,13 +3,13 @@ import {ExtensionRegistration} from '../../api/graphql/all_app_extension_registr
 import {describe, expect, test} from 'vitest'
 
 const SAMPLE_OFFSITE_CONFIG =
-  '{"start_payment_session_url":"https://bogus-app/payment-sessions/start","start_refund_session_url":"https://bogus-app/payment-sessions/refund","start_capture_session_url":"https://bogus-app/payment-sessions/capture","start_void_session_url":"https://bogus-app/payment-sessions/void","confirmation_callback_url":"https://bogus-app/payment-sessions/confirm","supported_payment_methods":["visa","master","american_express","discover","diners_club","jcb"],"supported_countries":["GG","AF","AZ","BH"],"test_mode_available":true,"merchant_label":"Offsite Payments App Extension","default_buyer_label":null,"buyer_label_to_locale":null,"supports_3ds":true,"supports_oversell_protection":false,"api_version":"2023-10","supports_installments":true,"supports_deferred_payments":true,"multiple_capture":false,"supported_buyer_contexts":[{"currency":"USD","countries":["US"]}]}'
+  '{"start_payment_session_url":"https://bogus-app/payment-sessions/start","start_refund_session_url":"https://bogus-app/payment-sessions/refund","start_capture_session_url":"https://bogus-app/payment-sessions/capture","start_void_session_url":"https://bogus-app/payment-sessions/void","confirmation_callback_url":"https://bogus-app/payment-sessions/confirm","supported_payment_methods":["visa","master","american_express","discover","diners_club","jcb"],"supported_countries":["GG","AF","AZ","BH"],"test_mode_available":true,"merchant_label":"Offsite Payments App Extension","default_buyer_label":null,"buyer_label_to_locale":null,"supports_3ds":true,"supports_oversell_protection":false,"api_version":"2023-10","supports_installments":true,"supports_deferred_payments":true,"multiple_capture":false,"enforce_authorization_expiry":true,"supported_buyer_contexts":[{"currency":"USD","countries":["US"]}]}'
 const SAMPLE_CREDIT_CARD_CONFIG =
-  '{"start_payment_session_url":"https://test-domain.com/authorize","start_refund_session_url":"https://test-domain.com/refund","start_capture_session_url":"https://test-domain.com/capture","start_void_session_url":"https://test-domain.com/void","confirmation_callback_url":"https://test-domain.com/confirm","supported_payment_methods":["master","visa","jcb","american_express","diners_club"],"supported_countries":["JP"],"test_mode_available":true,"merchant_label":"test-label","supports_3ds":true,"encryption_certificate":{"fingerprint": "fingerprint", "certificate": "certificate"},"api_version":"2023-04","ui_extension_registration_uuid":"3f9d1c40-0f7d-48f9-b802-ca7d302ee8bc","supports_installments":false,"supports_deferred_payments":false,"multiple_capture":false,"supported_buyer_contexts":[{"currency":"USD","countries":["US","CA"]}]}'
+  '{"start_payment_session_url":"https://test-domain.com/authorize","start_refund_session_url":"https://test-domain.com/refund","start_capture_session_url":"https://test-domain.com/capture","start_void_session_url":"https://test-domain.com/void","confirmation_callback_url":"https://test-domain.com/confirm","supported_payment_methods":["master","visa","jcb","american_express","diners_club"],"supported_countries":["JP"],"test_mode_available":true,"merchant_label":"test-label","supports_3ds":true,"encryption_certificate":{"fingerprint": "fingerprint", "certificate": "certificate"},"api_version":"2023-04","ui_extension_registration_uuid":"3f9d1c40-0f7d-48f9-b802-ca7d302ee8bc","supports_installments":false,"supports_deferred_payments":false,"multiple_capture":false,"enforce_authorization_expiry":true,"supported_buyer_contexts":[{"currency":"USD","countries":["US","CA"]}]}'
 const SAMPLE_CUSTOM_CREDIT_CARD_CONFIG =
-  '{"start_payment_session_url":"https://bogus-payment-sessions.shopifycloud.com/bogus/custom_card/payment_sessions","start_refund_session_url":"https://bogus-payment-sessions.shopifycloud.com/bogus/custom_card/refund_sessions","start_capture_session_url":"https://bogus-payment-sessions.shopifycloud.com/bogus/custom_card/capture_sessions","start_void_session_url":"https://bogus-payment-sessions.shopifycloud.com/bogus/custom_card/void_sessions","checkout_payment_method_fields":[{"key":"payment_plan","type":"string","required":true}],"confirmation_callback_url":"https://bogus-payment-sessions.shopifycloud.com/bogus/custom_card/confirm","supported_payment_methods":["visa"],"supported_countries":["CA","MX","US"],"test_mode_available":true,"merchant_label":"Bogus Private Card App","default_buyer_label":null,"buyer_label_to_locale":null,"supports_3ds":false,"encryption_certificate":{"fingerprint":"Test Certificate","certificate":"-----BEGIN CERTIFICATE-----\\nTestString=\\n-----END CERTIFICATE-----"},"api_version":"unstable","ui_extension_registration_uuid":"3f9d1c40-0f7d-48f9-b802-ca7d302ee8bc","checkout_hosted_fields":["name","expiry","verification_value"],"multiple_capture":false,"supported_buyer_contexts":[{"currency":"EUR"}]}'
+  '{"start_payment_session_url":"https://bogus-payment-sessions.shopifycloud.com/bogus/custom_card/payment_sessions","start_refund_session_url":"https://bogus-payment-sessions.shopifycloud.com/bogus/custom_card/refund_sessions","start_capture_session_url":"https://bogus-payment-sessions.shopifycloud.com/bogus/custom_card/capture_sessions","start_void_session_url":"https://bogus-payment-sessions.shopifycloud.com/bogus/custom_card/void_sessions","checkout_payment_method_fields":[{"key":"payment_plan","type":"string","required":true}],"confirmation_callback_url":"https://bogus-payment-sessions.shopifycloud.com/bogus/custom_card/confirm","supported_payment_methods":["visa"],"supported_countries":["CA","MX","US"],"test_mode_available":true,"merchant_label":"Bogus Private Card App","default_buyer_label":null,"buyer_label_to_locale":null,"supports_3ds":false,"encryption_certificate":{"fingerprint":"Test Certificate","certificate":"-----BEGIN CERTIFICATE-----\\nTestString=\\n-----END CERTIFICATE-----"},"api_version":"unstable","ui_extension_registration_uuid":"3f9d1c40-0f7d-48f9-b802-ca7d302ee8bc","checkout_hosted_fields":["name","expiry","verification_value"],"multiple_capture":false,"enforce_authorization_expiry":true,"supported_buyer_contexts":[{"currency":"EUR"}]}'
 const SAMPLE_CUSTOM_ONSITE_CONFIG =
-  '{"start_payment_session_url":"https://test-domain.com/startsession/bogus-pay","start_refund_session_url":"https://test-domain.com/refund","start_capture_session_url":"https://test-domain.com/capture","start_void_session_url":"https://test-domain.com/void","confirmation_callback_url":null,"checkout_payment_method_fields":[{"key":"bogus_customer_document","type":"string","required":true}],"supported_payment_methods":["bogus-pay"],"supported_countries":["BR"],"test_mode_available":true,"merchant_label":"Test Label","default_buyer_label": "Bogus Pay Buyer Label","buyer_label_to_locale":[],"supports_3ds":false,"supports_oversell_protection":false,"api_version":"unstable","ui_extension_registration_uuid":"3f9d1c40-0f7d-48f9-b802-ca7d302ee8bc","multiple_capture":false,"supports_installments":false,"supports_deferred_payments":false}'
+  '{"start_payment_session_url":"https://test-domain.com/startsession/bogus-pay","start_refund_session_url":"https://test-domain.com/refund","start_capture_session_url":"https://test-domain.com/capture","start_void_session_url":"https://test-domain.com/void","confirmation_callback_url":null,"checkout_payment_method_fields":[{"key":"bogus_customer_document","type":"string","required":true}],"supported_payment_methods":["bogus-pay"],"supported_countries":["BR"],"test_mode_available":true,"merchant_label":"Test Label","default_buyer_label": "Bogus Pay Buyer Label","buyer_label_to_locale":[],"supports_3ds":false,"supports_oversell_protection":false,"api_version":"unstable","ui_extension_registration_uuid":"3f9d1c40-0f7d-48f9-b802-ca7d302ee8bc","multiple_capture":false,"enforce_authorization_expiry":true,"supports_installments":false,"supports_deferred_payments":false}'
 const SAMPLE_REDEEMABLE_CONFIG =
   '{"start_payment_session_url":"https://bogus-payment-sessions.shopifycloud.com/bogus/redeemable/payment_sessions","start_refund_session_url":"https://bogus-payment-sessions.shopifycloud.com/bogus/redeemable/refund_sessions","start_capture_session_url":"https://bogus-payment-sessions.shopifycloud.com/bogus/redeemable/capture_sessions","start_void_session_url":"https://bogus-payment-sessions.shopifycloud.com/bogus/redeemable/void_sessions","supported_countries":["CA","MX","US"],"test_mode_available":true,"merchant_label":"Bogus Redeemable Payments App","default_buyer_label":null,"buyer_label_to_locale":null,"api_version":"unstable","ui_extension_registration_uuid":"3f9d1c40-0f7d-48f9-b802-ca7d302ee8bc","supported_payment_methods":["gift-card"],"balance_url":"https://bogus-payment-sessions.shopifycloud.com/bogus/redeemable/retrieve_balance","checkout_payment_method_fields":[{"key":"card_number","type":"string","required":true},{"key":"pin","type":"string","required":true}],"supported_buyer_contexts":[{"currency":"USD","countries":["US"]},{"currency":"GBP"}]}'
 const SAMPLE_CARD_PRESENT_CONFIG =
@@ -85,6 +85,7 @@ describe('extension-config-builder', () => {
           void_session_url: 'https://bogus-app/payment-sessions/void',
           confirmation_callback_url: 'https://bogus-app/payment-sessions/confirm',
           multiple_capture: false,
+          enforce_authorization_expiry: true,
           merchant_label: 'Offsite Payments App Extension',
           supported_countries: ['GG', 'AF', 'AZ', 'BH'],
           supported_payment_methods: ['visa', 'master', 'american_express', 'discover', 'diners_club', 'jcb'],
@@ -133,6 +134,7 @@ describe('extension-config-builder', () => {
           void_session_url: 'https://bogus-app/payment-sessions/void',
           confirmation_callback_url: 'https://bogus-app/payment-sessions/confirm',
           multiple_capture: false,
+          enforce_authorization_expiry: true,
           merchant_label: 'Offsite Payments App Extension',
           supported_countries: ['GG', 'AF', 'AZ', 'BH'],
           supported_payment_methods: ['visa', 'master', 'american_express', 'discover', 'diners_club', 'jcb'],
@@ -180,6 +182,7 @@ describe('extension-config-builder', () => {
           void_session_url: 'https://bogus-app/payment-sessions/void',
           confirmation_callback_url: 'https://bogus-app/payment-sessions/confirm',
           multiple_capture: false,
+          enforce_authorization_expiry: true,
           merchant_label: 'Offsite Payments App Extension',
           supported_countries: ['GG', 'AF', 'AZ', 'BH'],
           supported_payment_methods: ['visa', 'master', 'american_express', 'discover', 'diners_club', 'jcb'],
@@ -233,6 +236,7 @@ describe('extension-config-builder', () => {
           void_session_url: 'https://test-domain.com/void',
           confirmation_callback_url: 'https://test-domain.com/confirm',
           multiple_capture: false,
+          enforce_authorization_expiry: true,
           merchant_label: 'test-label',
           supported_countries: ['JP'],
           supported_payment_methods: ['master', 'visa', 'jcb', 'american_express', 'diners_club'],
@@ -287,6 +291,7 @@ describe('extension-config-builder', () => {
           capture_session_url: 'https://bogus-payment-sessions.shopifycloud.com/bogus/custom_card/capture_sessions',
           void_session_url: 'https://bogus-payment-sessions.shopifycloud.com/bogus/custom_card/void_sessions',
           confirmation_callback_url: 'https://bogus-payment-sessions.shopifycloud.com/bogus/custom_card/confirm',
+          enforce_authorization_expiry: true,
           merchant_label: 'Bogus Private Card App',
           supports_3ds: false,
           supported_countries: ['CA', 'MX', 'US'],
@@ -341,6 +346,7 @@ describe('extension-config-builder', () => {
           capture_session_url: 'https://test-domain.com/capture',
           void_session_url: 'https://test-domain.com/void',
           confirmation_callback_url: null,
+          enforce_authorization_expiry: true,
           update_payment_session_url: undefined,
           start_verification_session_url: undefined,
           merchant_label: 'Test Label',


### PR DESCRIPTION
### WHY are these changes introduced?

Shopify CLI's payment extension schemas don't recognize the optional `enforce_authorization_expiry` field. When the field is present in `shopify.extension.toml`, schema parsing strips it before the deploy configuration is generated.

This prevents payment extensions from preserving their configured authorization-expiry behavior during deployment. The field remains optional, so existing extensions keep their current behavior when it is omitted.

### WHAT is this pull request doing?

## Implementation

- Adds a reusable `AuthorizationExpirySchema` for `enforce_authorization_expiry`.
- Applies it to credit card, custom credit card, custom onsite, and offsite payment extensions.
- Preserves the field in both directions:
  - `shopify.extension.toml` -> deploy configuration
  - existing draft or published configuration -> generated TOML
- Adds schema and transformation coverage for all four extension types.
- Adds a minor changeset for the new optional manifest field.

This PR only updates CLI schema validation and configuration transformation. It does not change authorization-expiry defaults, enable the option for existing extensions, or add it to redeemable or card-present extensions.

### How to test your changes?

```sh
pnpm vitest run \
  packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/base_payments_app_extension_schema.test.ts \
  packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/credit_card_payments_app_extension_schema.test.ts \
  packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/custom_credit_card_payments_app_extension_schema.test.ts \
  packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/custom_onsite_payments_app_extension_schema.test.ts \
  packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/offsite_payments_app_extension_schema.test.ts \
  packages/app/src/cli/services/payments/extension-config-builder.test.ts
```

Result: 67 tests passed. Repository lint and type checks also passed.

### Checklist

- [x] I've considered possible cross-platform impacts. This is platform-independent schema and object transformation code.
- [x] I've considered possible documentation changes. The new field may require payment-extension documentation after release.
- [x] I've considered analytics changes. No analytics changes are required.
- [x] The change is user-facing. It adds a backward-compatible optional manifest field and includes a minor changeset.
