### PR TITLE
[Tests] Add unit tests for AbortController and AbortSignal

### DIFF
--- a/packages/cli-kit/src/public/node/abort.test.ts
+++ b/packages/cli-kit/src/public/node/abort.test.ts
@@ -1,0 +1,21 @@
+import {AbortController} from './abort.js'
+import {describe, expect, test} from 'vitest'
+
+describe('AbortController', () => {
+  test('correctly sets aborted state on the signal', () => {
+    const controller = new AbortController()
+    expect(controller.signal.aborted).toBe(false)
+
+    controller.abort()
+    expect(controller.signal.aborted).toBe(true)
+  })
+
+  test('correctly carries reason in the signal when aborted', () => {
+    const controller = new AbortController()
+    expect(controller.signal.reason).toBeUndefined()
+
+    const reason = 'test-reason'
+    controller.abort(reason)
+    expect(controller.signal.reason).toBe(reason)
+  })
+})


### PR DESCRIPTION
### WHY are these changes introduced?

The `AbortController` and `AbortSignal` classes in `packages/cli-kit/src/public/node/abort.ts` are wrapper classes without dedicated unit tests, which leaves a small coverage gap.

### WHAT is this pull request doing?

Adds comprehensive unit tests for the `abort.ts` module in `packages/cli-kit/src/public/node/abort.test.ts`, checking:
- `AbortController` and its associated `AbortSignal` correctly initialize without being aborted.
- Instantiating `AbortController` and calling `abort()` correctly updates the `aborted` status of its corresponding `AbortSignal`.
- Calling `abort(reason)` correctly propagates the cancellation reason to the corresponding `AbortSignal`.

### How to test your changes?

CI

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [8501718038938971862](https://jules.google.com/task/8501718038938971862) started by @gonzaloriestra*