### PR TITLE
[Feature] Refine BLOCKED_HEADERS to include proxy spoofing headers

### DIFF
--- a/packages/cli-kit/src/public/node/graphiql/utilities.ts
+++ b/packages/cli-kit/src/public/node/graphiql/utilities.ts
@@ -15,7 +15,11 @@ const BLOCKED_HEADERS = new Set([
   'trailer',
   'transfer-encoding',
   'upgrade',
-
+  'x-forwarded-for',
+  'x-forwarded-host',
+  'x-forwarded-proto',
+  'x-real-ip',
+  'cf-connecting-ip',
   // Headers the proxy controls
   'host',
   'content-length',


### PR DESCRIPTION
In this pull request I added 'x-forwarded-for', 'x-forwarded-host', 'x-forwarded-proto', 'x-real-ip', 'cf-connecting-ip' to the BLOCKED_HEADERS in `packages/cli-kit/src/public/node/graphiql/utilities.ts` 

### WHY are these changes introduced?

Hardening the local GraphiQL utility against proxy-spoofing and host-header injection attacks. 

Even though this tool runs locally, modern web browsers allow websites (or malicious extensions running in the user's browser) to make cross-origin requests to local ports (`localhost:XXXX`). If a malicious local script or browser tab sends forged proxy headers (`X-Forwarded-For` or `cf-connecting-ip`) to the GraphiQL endpoint, it could bypass internal IP whitelisting or hijack host-routing logic if the developer is routing their CLI through a tunnel (like Cloudflare or ngrok).

Refining the BLOCKED_HEADERS array brings this component in line with standard production-grade HTTP security best practices.


### WHAT is this pull request doing?

Preventing proxy spoofing headers from being sent out from the CLI, this is a very minimalist change after observing potential insecurities in HTTP requests


### Checklist

- [x] I have touched no other code
- [x] Refined the blocked_headers list to follow best-practice

