### PR TITLE
Make payments extension capability fields optional

### DIFF
--- a/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/base_payments_app_extension_schema.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/base_payments_app_extension_schema.test.ts
@@ -156,44 +156,9 @@ describe('DeferredPaymentsSchema', () => {
     expect(success).toBe(true)
   })
 
-  test('throws an error if no supports_installments is provided', async () => {
+  test('validates a configuration when optional fields are omitted', async () => {
     // When/Then
-    expect(() =>
-      DeferredPaymentsSchema.parse({
-        ...config,
-        supports_installments: undefined,
-      }),
-    ).toThrowError(
-      new zod.ZodError([
-        {
-          code: zod.ZodIssueCode.invalid_type,
-          expected: 'boolean',
-          received: 'undefined',
-          path: ['supports_installments'],
-          message: 'Required',
-        },
-      ]),
-    )
-  })
-
-  test('throws an error if no supports_deferred_payments is provided', async () => {
-    // When/Then
-    expect(() =>
-      DeferredPaymentsSchema.parse({
-        ...config,
-        supports_deferred_payments: undefined,
-      }),
-    ).toThrowError(
-      new zod.ZodError([
-        {
-          code: zod.ZodIssueCode.invalid_type,
-          expected: 'boolean',
-          received: 'undefined',
-          path: ['supports_deferred_payments'],
-          message: 'Required',
-        },
-      ]),
-    )
+    expect(DeferredPaymentsSchema.parse({})).toEqual({})
   })
 })
 

--- a/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/base_payments_app_extension_schema.ts
+++ b/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/base_payments_app_extension_schema.ts
@@ -49,8 +49,8 @@ export const BuyerLabelSchema = zod.object({
 })
 
 export const DeferredPaymentsSchema = zod.object({
-  supports_installments: zod.boolean(),
-  supports_deferred_payments: zod.boolean(),
+  supports_installments: zod.boolean().optional(),
+  supports_deferred_payments: zod.boolean().optional(),
 })
 
 export const MultipleCaptureSchema = zod.object({

--- a/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/custom_onsite_payments_app_extension_schema.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/custom_onsite_payments_app_extension_schema.test.ts
@@ -112,6 +112,25 @@ describe('CustomOnsitePaymentsAppExtensionSchema', () => {
     )
   })
 
+  test('parses successfully when optional fields are omitted', async () => {
+    // Given
+    const configWithoutOptionalFields = {...config}
+    delete configWithoutOptionalFields.supports_installments
+    delete configWithoutOptionalFields.supports_deferred_payments
+    delete configWithoutOptionalFields.supports_3ds
+
+    // When
+    const result = CustomOnsitePaymentsAppExtensionSchema.safeParse(configWithoutOptionalFields)
+
+    // Then
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data).not.toHaveProperty('supports_installments')
+      expect(result.data).not.toHaveProperty('supports_deferred_payments')
+      expect(result.data).not.toHaveProperty('supports_3ds')
+    }
+  })
+
   test('validates a configuration with valid start_verification_session_url', async () => {
     // Given
     const configWithVerificationUrl = {

--- a/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/custom_onsite_payments_app_extension_schema.ts
+++ b/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/custom_onsite_payments_app_extension_schema.ts
@@ -21,6 +21,7 @@ export const CustomOnsitePaymentsAppExtensionSchema = BasePaymentsAppExtensionSc
   .merge(SupportedBuyerContextsSchema)
   .extend({
     targeting: zod.array(zod.object({target: zod.literal(CUSTOM_ONSITE_TARGET)})).length(1),
+    supports_3ds: zod.boolean().optional(),
     update_payment_session_url: zod.string().url().optional(),
     multiple_capture: zod.boolean().optional(),
     supports_oversell_protection: zod.boolean().optional(),

--- a/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/offsite_payments_app_extension_schema.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/offsite_payments_app_extension_schema.test.ts
@@ -102,6 +102,25 @@ describe('OffsitePaymentsAppExtensionSchema', () => {
     )
   })
 
+  test('parses successfully when optional fields are omitted', async () => {
+    // Given
+    const configWithoutOptionalFields = {...config}
+    delete configWithoutOptionalFields.supports_installments
+    delete configWithoutOptionalFields.supports_deferred_payments
+    delete configWithoutOptionalFields.supports_3ds
+
+    // When
+    const result = OffsitePaymentsAppExtensionSchema.safeParse(configWithoutOptionalFields)
+
+    // Then
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data).not.toHaveProperty('supports_installments')
+      expect(result.data).not.toHaveProperty('supports_deferred_payments')
+      expect(result.data).not.toHaveProperty('supports_3ds')
+    }
+  })
+
   test('returns an error if supports_installments does not match supports_deferred_payments', async () => {
     // When/Then
     expect(() =>

--- a/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/offsite_payments_app_extension_schema.ts
+++ b/packages/app/src/cli/models/extensions/specifications/payments_app_extension_schemas/offsite_payments_app_extension_schema.ts
@@ -21,6 +21,7 @@ export const OffsitePaymentsAppExtensionSchema = BasePaymentsAppExtensionSchema.
   .extend({
     targeting: zod.array(zod.object({target: zod.literal(OFFSITE_TARGET)})).length(1),
     supports_oversell_protection: zod.boolean().optional(),
+    supports_3ds: zod.boolean().optional(),
   })
   .refine((schema) => !schema.supports_oversell_protection || schema.confirmation_callback_url, {
     message: 'Property required when supports_oversell_protection is true',


### PR DESCRIPTION
## What
Makes `supports_installments`, `supports_deferred_payments`, and `supports_3ds` optional in payments app extension TOML config schemas, so partners can omit them.

`supports_3ds` stays required for `credit_card` and `custom_credit_card` extensions.

## Why
Companion to the core change in shop/world#940396 that relaxed the same properties on the server side. Without this CLI-side change, `shopify app deploy` rejects configs that omit these fields even though core now accepts them.
