### PR TITLE
Test shopify-dev-tools separately in CI

### DIFF
--- a/.github/workflows/tests-main.yml
+++ b/.github/workflows/tests-main.yml
@@ -60,6 +60,9 @@ jobs:
           POOL_OPTIONS: ${{ matrix.os == 'macos-latest' && '--pool forks' || '' }}
           VITEST_MIN_THREADS: "1"
           VITEST_MAX_THREADS: "4"
+      - name: shopify-dev-tools tests
+        if: ${{ matrix.os == 'ubuntu-latest' && matrix.node == env.DEFAULT_NODE_VERSION }}
+        run: pnpm nx test shopify-dev-tools --skip-nx-cache --output-style=stream
       - name: Send Slack notification on failure
         uses: slackapi/slack-github-action@007b2c3c751a190b6f0f040e47ed024deaa72844 # v1.23.0
         if: ${{ failure() && !cancelled() }}

--- a/.github/workflows/tests-manual.yml
+++ b/.github/workflows/tests-manual.yml
@@ -60,6 +60,8 @@ jobs:
           node-version: ${{ inputs.node-version }}
       - name: Unit tests
         run: pnpm test --output-style=stream
+      - name: shopify-dev-tools tests
+        run: pnpm nx test shopify-dev-tools --skip-nx-cache --output-style=stream
       - name: Setup tmate session
         if: ${{ failure() && inputs.debug-enabled }}
         uses: mxschmitt/action-tmate@35b54afac29c97fb54faba5b513f8fbd1882f113 # v3

--- a/.github/workflows/tests-pr.yml
+++ b/.github/workflows/tests-pr.yml
@@ -207,6 +207,9 @@ jobs:
           SHARD_OPTIONS: ${{ matrix.shard && format('--shard {0}', matrix.shard) || '' }}
           VITEST_MIN_THREADS: "1"
           VITEST_MAX_THREADS: "4"
+      - name: shopify-dev-tools tests
+        if: ${{ matrix.os == 'ubuntu-latest' && matrix.node == env.DEFAULT_NODE_VERSION }}
+        run: pnpm nx test shopify-dev-tools --skip-nx-cache --output-style=stream
 
   unit-tests-gate:
     name: "Unit tests"


### PR DESCRIPTION
### WHY are these changes introduced?

Shopify CLI's root Vitest configuration selects the existing CLI test projects explicitly, so adding `shopify-dev-tools` to Nx does not automatically run its 702 tests in CI.

### WHAT is this pull request doing?

Runs the package's Nx test target separately in:

- PR CI, once on the default Node version and Ubuntu
- Main CI, once on the default Node version and Ubuntu
- Manually triggered test workflows

This preserves the existing cross-platform CLI test matrix without multiplying the package suite across every matrix entry.

### How to test your changes?

```sh
pnpm nx test shopify-dev-tools --skip-nx-cache --output-style=stream
```

The package suite passes 27 files / 702 tests. All three edited workflow files parse as valid YAML.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible documentation changes; none are required
- [x] I've considered analytics changes; none are required
- [x] This changes test coverage only, so no CLI changeset is required
