### PR TITLE
Bundle shopify-dev-tools with Shopify CLI

### DIFF
--- a/packages/cli/bin/bundle.js
+++ b/packages/cli/bin/bundle.js
@@ -11,6 +11,7 @@ import ShopifyStacktraceyPlugin from '../../../bin/bundling/esbuild-plugin-stack
 import ShopifyVSCodePlugin from '../../../bin/bundling/esbuild-plugin-vscode.js'
 import GraphiQLImportsPlugin from '../../../bin/bundling/esbuild-plugin-graphiql-imports.js'
 import CliKitDedupPlugin from '../../../bin/bundling/esbuild-plugin-dedup-cli-kit.js'
+import {shopifyDevToolsDataPlugin} from './shopify-dev-tools-data.js'
 
 const require = createRequire(import.meta.url)
 
@@ -38,6 +39,15 @@ const themeUpdaterDataPath = joinPath(themeUpdaterPath, '..', '..', 'data/*')
 
 const hydrogenPath = dirname(require.resolve('@shopify/cli-hydrogen/package.json'))
 const hydrogenAssets = joinPath(hydrogenPath, 'dist/assets/hydrogen/**/*')
+
+const shopifyDevToolsDataPath = joinPath(process.cwd(), '../shopify-dev-tools/dist/data')
+const shopifyDevToolsInternalApiIdsPath = joinPath(
+  process.cwd(),
+  '../shopify-dev-tools/src/internal/internal-api-ids.json',
+)
+const shopifyDevToolsInternalApiIds = Object.values(
+  JSON.parse(readFileSync(shopifyDevToolsInternalApiIdsPath, 'utf8')),
+)
 
 const commandEntryPoints = glob.sync('./src/cli/commands/**/*.ts', {
   ignore: ['**/*.test.ts', '**/*.d.ts'],
@@ -109,6 +119,11 @@ esBuild({
     GraphiQLImportsPlugin,
     ShopifyStacktraceyPlugin,
     CliKitDedupPlugin({require}),
+    shopifyDevToolsDataPlugin({
+      sourceDataDirectory: shopifyDevToolsDataPath,
+      targetDataDirectory: joinPath(process.cwd(), 'dist/data'),
+      internalApiIds: shopifyDevToolsInternalApiIds,
+    }),
     copy({
       // this is equal to process.cwd(), which means we use cwd path as base path to resolve `to` path
       // if not specified, this plugin uses ESBuild.build outdir/outfile options as base path.

--- a/packages/cli/bin/shopify-dev-tools-data.js
+++ b/packages/cli/bin/shopify-dev-tools-data.js
@@ -1,0 +1,30 @@
+import {cpSync, mkdirSync, rmSync, statSync} from 'fs'
+import {basename} from 'path'
+
+const shouldCopyDataPath = (sourcePath, internalApiIds) => {
+  const sourceName = basename(sourcePath)
+
+  if (internalApiIds.some((apiId) => sourceName.includes(apiId))) return false
+  if (statSync(sourcePath).isDirectory()) return true
+
+  return sourceName === 'supported-versions-schema.json' || sourceName === 'index.json' || sourceName.endsWith('.gz')
+}
+
+export const copyShopifyDevToolsData = ({sourceDataDirectory, targetDataDirectory, internalApiIds}) => {
+  rmSync(targetDataDirectory, {recursive: true, force: true})
+  mkdirSync(targetDataDirectory, {recursive: true})
+  cpSync(sourceDataDirectory, targetDataDirectory, {
+    recursive: true,
+    filter: (sourcePath) => shouldCopyDataPath(sourcePath, internalApiIds),
+  })
+}
+
+export const shopifyDevToolsDataPlugin = ({sourceDataDirectory, targetDataDirectory, internalApiIds}) => ({
+  name: 'copy-shopify-dev-tools-data',
+  setup(build) {
+    build.onEnd(({errors}) => {
+      if (errors.length > 0) return
+      copyShopifyDevToolsData({sourceDataDirectory, targetDataDirectory, internalApiIds})
+    })
+  },
+})

--- a/packages/cli/bin/shopify-dev-tools-data.test.js
+++ b/packages/cli/bin/shopify-dev-tools-data.test.js
@@ -1,0 +1,46 @@
+import {existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync} from 'fs'
+import {tmpdir} from 'os'
+import {join} from 'path'
+
+// eslint-disable-next-line import-x/no-extraneous-dependencies
+import {describe, expect, test} from 'vitest'
+
+import {copyShopifyDevToolsData} from './shopify-dev-tools-data.js'
+
+describe('copyShopifyDevToolsData', () => {
+  test('copies runtime data without raw or internal schemas', () => {
+    const temporaryDirectory = mkdtempSync(join(tmpdir(), 'shopify-dev-tools-data-'))
+    const sourceDataDirectory = join(temporaryDirectory, 'source')
+    const targetDataDirectory = join(temporaryDirectory, 'target')
+
+    try {
+      mkdirSync(join(sourceDataDirectory, 'types', 'graphql'), {recursive: true})
+      writeFileSync(join(sourceDataDirectory, 'supported-versions-schema.json'), '{}')
+      writeFileSync(join(sourceDataDirectory, 'admin_2026-07.json.gz'), 'public schema')
+      writeFileSync(join(sourceDataDirectory, 'admin_2026-07.json'), 'raw public schema')
+      writeFileSync(join(sourceDataDirectory, 'bourgeois_unstable.json.gz'), 'internal schema')
+      writeFileSync(join(sourceDataDirectory, 'types', 'index.json'), '{}')
+      writeFileSync(join(sourceDataDirectory, 'types', 'graphql', 'index.d.ts.gz'), 'type declarations')
+      writeFileSync(join(sourceDataDirectory, 'types', 'graphql', 'index.d.ts'), 'raw type declarations')
+      mkdirSync(targetDataDirectory, {recursive: true})
+      writeFileSync(join(targetDataDirectory, 'stale.json.gz'), 'stale data')
+
+      copyShopifyDevToolsData({
+        sourceDataDirectory,
+        targetDataDirectory,
+        internalApiIds: ['bourgeois'],
+      })
+
+      expect(existsSync(join(targetDataDirectory, 'supported-versions-schema.json'))).toBe(true)
+      expect(existsSync(join(targetDataDirectory, 'admin_2026-07.json.gz'))).toBe(true)
+      expect(existsSync(join(targetDataDirectory, 'admin_2026-07.json'))).toBe(false)
+      expect(existsSync(join(targetDataDirectory, 'bourgeois_unstable.json.gz'))).toBe(false)
+      expect(existsSync(join(targetDataDirectory, 'types', 'index.json'))).toBe(true)
+      expect(existsSync(join(targetDataDirectory, 'types', 'graphql', 'index.d.ts.gz'))).toBe(true)
+      expect(existsSync(join(targetDataDirectory, 'types', 'graphql', 'index.d.ts'))).toBe(false)
+      expect(existsSync(join(targetDataDirectory, 'stale.json.gz'))).toBe(false)
+    } finally {
+      rmSync(temporaryDirectory, {recursive: true, force: true})
+    }
+  })
+})

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -65,6 +65,7 @@
     "@shopify/cli-kit": "4.5.0",
     "@shopify/plugin-cloudflare": "4.5.0",
     "@shopify/plugin-did-you-mean": "4.5.0",
+    "@shopify/shopify-dev-tools": "workspace:*",
     "@shopify/theme": "4.5.0",
     "@shopify/cli-hydrogen": "13.0.2",
     "@types/global-agent": "3.0.0",

--- a/packages/cli/project.json
+++ b/packages/cli/project.json
@@ -28,7 +28,8 @@
         "build",
         "cli-kit:generate-version",
         "app:build",
-        "theme:build"
+        "theme:build",
+        "shopify-dev-tools:build"
       ],
       "options": {
         "command": "node bin/bundle",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -334,6 +334,9 @@ importers:
       '@shopify/plugin-did-you-mean':
         specifier: 4.5.0
         version: link:../plugin-did-you-mean
+      '@shopify/shopify-dev-tools':
+        specifier: workspace:*
+        version: link:../shopify-dev-tools
       '@shopify/store':
         specifier: 4.5.0
         version: link:../store


### PR DESCRIPTION
### WHY are these changes introduced?

`shopify-dev-tools` is now owned by the CLI monorepo, but the public CLI package must not acquire a runtime dependency on the restricted Cloudsmith package. Like `dev-mcp`, the CLI should consume it only at build time and ship the runtime data its bundled validators need.

### WHAT is this pull request doing?

- Adds `@shopify/shopify-dev-tools` as a workspace dev dependency and builds it before the CLI bundle.
- Lets the existing esbuild pipeline inline any imported dev-tools code instead of leaving a runtime package dependency.
- Copies compressed schemas, the supported-version catalog, and compressed type assets into `dist/data`.
- Excludes raw and internal-only API data from the public CLI bundle and removes stale copied data before rebuilding.
- Adds focused coverage for the data-copy allowlist.

No changeset: this is internal packaging infrastructure with no CLI behavior change yet.

### How to test your changes?

```sh
pnpm nx lint cli --skip-nx-cache
node_modules/.bin/vitest run packages/cli/bin/shopify-dev-tools-data.test.js --config packages/cli/vite.config.ts
pnpm nx bundle cli --skip-nx-cache
```

After bundling, verify `packages/cli/dist/data` contains public `.json.gz` schemas and `types/index.json`, but no `bourgeois` assets or raw dev-tools schema JSON.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible documentation changes; none are needed
- [x] I've considered analytics changes; none are needed
- [x] This is not a user-facing behavior change, so no changeset is required
