### PR TITLE
[Refactor] platformAndArch lookup in os.ts

### DIFF
--- a/packages/cli-kit/src/public/node/os.ts
+++ b/packages/cli-kit/src/public/node/os.ts
@@ -46,6 +46,12 @@ export async function username(platform: typeof process.platform = process.platf
 
 type PlatformArch = Exclude<typeof process.arch, 'x64' | 'ia32'> | 'amd64' | '386'
 type PlatformStrings = Exclude<typeof process.platform, 'win32'> | 'windows'
+
+const ARCH_MAP: Record<string, PlatformArch> = {
+  x64: 'amd64',
+  ia32: '386',
+}
+
 /**
  * Returns the platform and architecture.
  * @returns Returns the current platform and architecture.
@@ -57,14 +63,7 @@ export function platformAndArch(
   platform: PlatformStrings
   arch: PlatformArch
 } {
-  let archString: PlatformArch
-  if (arch === 'x64') {
-    archString = 'amd64'
-  } else if (arch === 'ia32') {
-    archString = '386'
-  } else {
-    archString = arch
-  }
+  const archString = ARCH_MAP[arch] ?? (arch as PlatformArch)
   const platformString = (platform.match(/^win.+/) ? 'windows' : platform) as PlatformStrings
   return {platform: platformString, arch: archString}
 }


### PR DESCRIPTION
### WHY are these changes introduced?

The imperative if/else block inside `platformAndArch` can be replaced with a modern, declarative constant lookup map and nullish coalescing for improved readability, maintainability, and idiomatic clarity.

### WHAT is this pull request doing?

Refactors `platformAndArch` inside `packages/cli-kit/src/public/node/os.ts`:
- Replaces the if/else-if conditional checks with a static lookup map `ARCH_MAP`.
- Leverages the nullish coalescing operator (`??`) to fall back to the original architecture.

### How to test your changes?

CI

### Post-release steps

None.

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [15413077573623500452](https://jules.google.com/task/15413077573623500452) started by @gonzaloriestra*