### PR TITLE
chore(deps): prune stale knip config entries

### DIFF
--- a/package.json
+++ b/package.json
@@ -185,11 +185,7 @@
       ".": {
         "entry": [
           "bin/**/*.js",
-          "configurations/vite.config.ts",
-          "docs-shopify.dev/**/*.ts",
-          "vite.config.ts",
-          "docs/api/cli-kit/**/*.js",
-          "graphql.config.ts"
+          "configurations/vite.config.ts"
         ],
         "ignoreBinaries": [
           "bin/*",
@@ -207,8 +203,7 @@
           "esbuild"
         ],
         "ignore": [
-          "configurations/vite.config.ts",
-          "packages/e2e/scripts/**"
+          "configurations/vite.config.ts"
         ]
       },
       "packages/app": {
@@ -221,9 +216,7 @@
           "**/graphql/**/generated/*.ts"
         ],
         "ignoreDependencies": [
-          "@graphql-typed-document-node/core",
-          "@shopify/plugin-cloudflare",
-          "http-proxy-node16"
+          "@shopify/plugin-cloudflare"
         ],
         "vite": {
           "config": [
@@ -239,9 +232,6 @@
         "ignore": [
           "**/graphql/**/generated/*.ts"
         ],
-        "ignoreDependencies": [
-          "@graphql-typed-document-node/core"
-        ],
         "vite": {
           "config": [
             "vite.config.ts"
@@ -256,9 +246,6 @@
         "project": "**/*.ts!",
         "ignore": [
           "**/graphql/**/generated/*.ts"
-        ],
-        "ignoreDependencies": [
-          "@graphql-typed-document-node/core"
         ],
         "vite": {
           "config": [
@@ -300,7 +287,6 @@
       },
       "packages/plugin-cloudflare": {
         "entry": [
-          "**/{commands,hooks}/**/*.ts!",
           "**/src/*.ts!"
         ],
         "project": "**/*.ts!",
@@ -350,9 +336,6 @@
         "ignoreBinaries": [
           "open"
         ],
-        "ignoreDependencies": [
-          "@graphql-typed-document-node/core"
-        ],
         "vite": {
           "config": [
             "vite.config.ts"
@@ -365,20 +348,13 @@
           "**/scripts/*.ts!",
           "**/src/testing/index.ts"
         ],
-        "project": "**/*.{ts,tsx}!",
-        "ignoreDependencies": [
-          "react-dom"
-        ]
+        "project": "**/*.{ts,tsx}!"
       },
       "packages/ui-extensions-test-utils": {
         "entry": [
           "**/src/index.ts"
         ],
-        "project": "**/*.{ts,tsx}",
-        "ignoreDependencies": [
-          "@types/react-dom",
-          "react-dom"
-        ]
+        "project": "**/*.{ts,tsx}"
       }
     }
   }


### PR DESCRIPTION
## What
Prunes 14 stale entries from the inline `knip` config in root `package.json`. 
<img width="628" height="309" alt="image" src="https://github.com/user-attachments/assets/293af850-acdc-49af-9923-0e8393131f8a" />


## Why
`pnpm knip` was emitting 16 configuration hints flagging its own config as stale. All 14 targeted entries appear obsolete:
- **8 `ignoreDependencies`** were suppressing nothing. The `@graphql-typed-document-node/core` removals are backed by source imports in `packages/app` / `packages/cli-kit`, and by generated GraphQL client imports in `packages/organizations` / `packages/store` that knip still counts even though those generated files are ignored for reporting. The rest are covered by direct imports or peer-dependency usage. `pnpm knip` stays green with `dependencies: "error"`.
- **5 entry patterns were stale**: 3 are unmatched by knip today, and 2 duplicate knip’s built-in defaults.
- **1 `ignore`** (`packages/e2e/scripts/**`) nested inside the already-ignored `packages/e2e` workspace.