### PR TITLE
[Refactor] Use early return and rename relativeComponents in relativizePath

### DIFF
--- a/packages/cli-kit/src/public/node/path.ts
+++ b/packages/cli-kit/src/public/node/path.ts
@@ -135,12 +135,11 @@ export function commonParentDirectory(first: string, second: string): string {
 export function relativizePath(path: string, dir: string = cwd()): string {
   const result = commonParentDirectory(path, dir)
   const relativePath = relative(dir, path)
-  const relativeComponents = relativePath.split('/').filter((component) => component === '..').length
-  if (result === '/' || relativePath === '' || relativeComponents > 2) {
+  const upLevels = relativePath.split('/').filter((component) => component === '..').length
+  if (result === '/' || relativePath === '' || upLevels > 2) {
     return path
-  } else {
-    return relativePath
   }
+  return relativePath
 }
 
 /**


### PR DESCRIPTION
### WHY are these changes introduced?

Improves code readability and maintainability of path utility functions within `@shopify/cli-kit`.

### WHAT is this pull request doing?

Refactors `relativizePath` in `packages/cli-kit/src/public/node/path.ts` to use an early return instead of an imperative `if/else` block, and renames the variable `relativeComponents` to `upLevels` to reveal its intent more clearly.

### How to test your changes?

CI

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [9727930294855882166](https://jules.google.com/task/9727930294855882166) started by @gonzaloriestra*