### PR TITLE
[Refactor] Use early returns in addRecommendedExtensions

### DIFF
--- a/packages/cli-kit/src/public/node/vscode.test.ts
+++ b/packages/cli-kit/src/public/node/vscode.test.ts
@@ -1,5 +1,5 @@
-import {isVSCode} from './vscode.js'
-import {inTemporaryDirectory, mkdir} from './fs.js'
+import {isVSCode, addRecommendedExtensions} from './vscode.js'
+import {inTemporaryDirectory, mkdir, writeFile, readFile, fileExists} from './fs.js'
 import {joinPath} from './path.js'
 import {describe, expect, test} from 'vitest'
 
@@ -16,6 +16,62 @@ describe('isVSCode', () => {
 
       // Then
       expect(got).toEqual(true)
+    })
+  })
+})
+
+describe('addRecommendedExtensions', () => {
+  test('does nothing if the project is not a VSCode project', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      const extensionsPath = joinPath(tmpDir, '.vscode/extensions.json')
+
+      // When
+      await addRecommendedExtensions(tmpDir, ['shopify.theme-check-vscode'])
+
+      // Then
+      await expect(fileExists(extensionsPath)).resolves.toEqual(false)
+    })
+  })
+
+  test('creates extensions.json if missing inside a VSCode project', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      await mkdir(joinPath(tmpDir, '.vscode'))
+      const extensionsPath = joinPath(tmpDir, '.vscode/extensions.json')
+
+      // When
+      await addRecommendedExtensions(tmpDir, ['shopify.theme-check-vscode'])
+
+      // Then
+      await expect(fileExists(extensionsPath)).resolves.toEqual(true)
+      const content = JSON.parse(await readFile(extensionsPath))
+      expect(content).toEqual({
+        recommendations: ['shopify.theme-check-vscode'],
+      })
+    })
+  })
+
+  test('appends recommendations to an existing extensions.json', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      await mkdir(joinPath(tmpDir, '.vscode'))
+      const extensionsPath = joinPath(tmpDir, '.vscode/extensions.json')
+      const initialJson = {
+        recommendations: ['octref.vetur'],
+        otherSetting: true,
+      }
+      await writeFile(extensionsPath, JSON.stringify(initialJson, null, 2))
+
+      // When
+      await addRecommendedExtensions(tmpDir, ['shopify.theme-check-vscode'])
+
+      // Then
+      const content = JSON.parse(await readFile(extensionsPath))
+      expect(content).toEqual({
+        recommendations: ['octref.vetur', 'shopify.theme-check-vscode'],
+        otherSetting: true,
+      })
     })
   })
 })

--- a/packages/cli-kit/src/public/node/vscode.ts
+++ b/packages/cli-kit/src/public/node/vscode.ts
@@ -33,18 +33,20 @@ export async function addRecommendedExtensions(directory: string, recommendation
   outputDebug(outputContent`Adding VSCode recommended extensions at ${outputToken.path(directory)}:
 ${outputToken.json(recommendations)}
   `)
-  const extensionsPath = joinPath(directory, '.vscode/extensions.json')
 
-  if (await isVSCode(directory)) {
-    let originalExtensionsJson = {recommendations: []}
-    if (await fileExists(extensionsPath)) {
-      const originalExtensionsFile = await readFile(extensionsPath)
-      originalExtensionsJson = JSON.parse(originalExtensionsFile)
-    }
-    const newExtensionsJson = {
-      ...originalExtensionsJson,
-      recommendations: [...originalExtensionsJson.recommendations, ...recommendations],
-    }
-    await writeFile(extensionsPath, JSON.stringify(newExtensionsJson, null, 2))
+  if (!(await isVSCode(directory))) {
+    return
   }
+
+  const extensionsPath = joinPath(directory, '.vscode/extensions.json')
+  let originalExtensionsJson = {recommendations: [] as string[]}
+  if (await fileExists(extensionsPath)) {
+    const originalExtensionsFile = await readFile(extensionsPath)
+    originalExtensionsJson = JSON.parse(originalExtensionsFile)
+  }
+  const newExtensionsJson = {
+    ...originalExtensionsJson,
+    recommendations: [...originalExtensionsJson.recommendations, ...recommendations],
+  }
+  await writeFile(extensionsPath, JSON.stringify(newExtensionsJson, null, 2))
 }


### PR DESCRIPTION
### WHY are these changes introduced?

To improve readability and maintainability of the `addRecommendedExtensions` utility function by reducing nested control flow logic.

### WHAT is this pull request doing?

This PR refactors `addRecommendedExtensions` in `packages/cli-kit/src/public/node/vscode.ts` by introducing an early return guard check on `isVSCode(directory)`. 
In addition, we add comprehensive unit tests in `packages/cli-kit/src/public/node/vscode.test.ts` to cover all scenarios:
- The project is not a VSCode project.
- The project is a VSCode project, but `extensions.json` is missing.
- The project is a VSCode project and has an existing `extensions.json`.

### How to test your changes?

CI

### Post-release steps

None.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [5085634989165888783](https://jules.google.com/task/5085634989165888783) started by @gonzaloriestra*