### PR TITLE
[Refactor] Use constant lookup map for architectures in platformAndArch

### DIFF
--- a/packages/cli-kit/src/public/node/os.ts
+++ b/packages/cli-kit/src/public/node/os.ts
@@ -46,6 +46,12 @@ export async function username(platform: typeof process.platform = process.platf
 
 type PlatformArch = Exclude<typeof process.arch, 'x64' | 'ia32'> | 'amd64' | '386'
 type PlatformStrings = Exclude<typeof process.platform, 'win32'> | 'windows'
+
+const ARCH_MAP: Record<string, PlatformArch> = {
+  x64: 'amd64',
+  ia32: '386',
+}
+
 /**
  * Returns the platform and architecture.
  * @returns Returns the current platform and architecture.
@@ -57,14 +63,7 @@ export function platformAndArch(
   platform: PlatformStrings
   arch: PlatformArch
 } {
-  let archString: PlatformArch
-  if (arch === 'x64') {
-    archString = 'amd64'
-  } else if (arch === 'ia32') {
-    archString = '386'
-  } else {
-    archString = arch
-  }
+  const archString = ARCH_MAP[arch] ?? (arch as PlatformArch)
   const platformString = (platform.match(/^win.+/) ? 'windows' : platform) as PlatformStrings
   return {platform: platformString, arch: archString}
 }


### PR DESCRIPTION
### WHY are these changes introduced?

This clean-up simplifies and modularizes the CPU architecture determination in `platformAndArch` (part of the `@shopify/cli-kit` workspace). 

### WHAT is this pull request doing?

Refactors `platformAndArch` in `packages/cli-kit/src/public/node/os.ts` by:
1. Extracting the mapping of `x64` to `amd64` and `ia32` to `386` into a clean, top-level lookup constant (`ARCH_MAP`).
2. Eliminating the imperative `if/else` block and using nullish coalescing (`??`) to fallback to the raw architecture string.

No observable behavior changes are introduced.

### How to test your changes?

CI

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [9085943036394304505](https://jules.google.com/task/9085943036394304505) started by @gonzaloriestra*