### PR TITLE
[Refactor] Simplify tree-kill callback handling and remove redundant checks

### DIFF
--- a/packages/cli-kit/src/public/node/tree-kill.ts
+++ b/packages/cli-kit/src/public/node/tree-kill.ts
@@ -54,12 +54,8 @@ function adaptedTreeKill(
 
   // Security: Validate that the PID is a number to prevent command injection
   if (!/^\d+$/.test(rootPid)) {
-    if (callback) {
-      callback(new Error('pid must be a number'))
-      return
-    } else {
-      throw new Error('pid must be a number')
-    }
+    callback(new Error('pid must be a number'))
+    return
   }
 
   // A map from parent pid to an array of children pids
@@ -76,12 +72,10 @@ function adaptedTreeKill(
       // Security: Use spawn instead of exec to avoid shell injection when killing processes on Windows
       const taskkill = spawn('taskkill', ['/pid', rootPid, '/T', '/F'])
       taskkill.on('close', (code: number) => {
-        if (callback) {
-          if (code === 0) {
-            callback()
-          } else {
-            callback(new Error(`taskkill exited with code ${code}`))
-          }
+        if (code === 0) {
+          callback()
+        } else {
+          callback(new Error(`taskkill exited with code ${code}`))
         }
       })
       break
@@ -145,18 +139,13 @@ function killAll(
         killed.add(pid)
       }
     })
+    // eslint-disable-next-line no-catch-all/no-catch-all
   } catch (err: unknown) {
-    if (callback) {
-      // @ts-ignore
-      callback(err)
-      return
-    } else {
-      throw err
-    }
+    // @ts-ignore
+    callback(err)
+    return
   }
-  if (callback) {
-    callback()
-  }
+  callback()
 }
 
 /**


### PR DESCRIPTION
### WHY are these changes introduced?

<!--
  Context about the problem that's being addressed.
-->
The internal helper functions `adaptedTreeKill` and `killAll` in `packages/cli-kit/src/public/node/tree-kill.ts` had redundant checks to verify whether `callback` was defined before calling it. However, the `callback` parameter is non-optional in both function signatures and `treeKill` always supplies a callback (defaulting to a log fallback if none is provided). Removing these redundant checks makes the file cleaner, simpler, and easier to maintain.

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->
- Removed redundant `if (callback)` checks in both `adaptedTreeKill` and `killAll`.
- Simplified the control flow using early returns.
- Added appropriate `eslint-disable` directive to satisfy custom ESLint rules regarding catch blocks without rethrows.

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
  You can post a comment with `/snapit` to generate a snapshot of the changes to be tested.
-->
CI

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [11173730342096362835](https://jules.google.com/task/11173730342096362835) started by @gonzaloriestra*