### PR TITLE
[Tests] Add unit tests for path utility functions

### DIFF
--- a/packages/cli-kit/src/public/node/path.test.ts
+++ b/packages/cli-kit/src/public/node/path.test.ts
@@ -1,5 +1,14 @@
-import {relativizePath, normalizePath, cwd, sniffForPath, commonParentDirectory} from './path.js'
-import {describe, test, expect} from 'vitest'
+import {
+  relativizePath,
+  normalizePath,
+  cwd,
+  sniffForPath,
+  commonParentDirectory,
+  isSubpath,
+  sniffForJson,
+  sanitizeRelativePath,
+} from './path.js'
+import {describe, test, expect, vi} from 'vitest'
 
 describe('relativize', () => {
   test('relativizes the path', () => {
@@ -91,5 +100,61 @@ describe('sniffForPath', () => {
 
     // Then
     expect(path).toStrictEqual('/path/to/project')
+  })
+})
+
+describe('isSubpath', () => {
+  test('returns true if the second path is a subpath of the first path', () => {
+    expect(isSubpath('/foo', '/foo/bar')).toBe(true)
+    expect(isSubpath('/foo', '/foo/bar/baz')).toBe(true)
+  })
+
+  test('returns false if the second path is not a subpath of the first path', () => {
+    expect(isSubpath('/foo', '/bar')).toBe(false)
+    expect(isSubpath('/foo/bar', '/foo')).toBe(false)
+  })
+
+  test('returns true if the paths are identical', () => {
+    expect(isSubpath('/foo', '/foo')).toBe(true)
+  })
+})
+
+describe('sniffForJson', () => {
+  test('returns true if --json is present', () => {
+    expect(sniffForJson(['node', 'script.js', '--json'])).toBe(true)
+  })
+
+  test('returns true if -j is present', () => {
+    expect(sniffForJson(['node', 'script.js', '-j'])).toBe(true)
+  })
+
+  test('returns false if neither is present', () => {
+    expect(sniffForJson(['node', 'script.js', '--other-flag'])).toBe(false)
+  })
+})
+
+describe('sanitizeRelativePath', () => {
+  test('does not modify standard relative paths and does not warn', () => {
+    const warn = vi.fn()
+    expect(sanitizeRelativePath('foo/bar', warn)).toBe('foo/bar')
+    expect(warn).not.toHaveBeenCalled()
+  })
+
+  test('removes double dots and warns', () => {
+    const warn = vi.fn()
+    expect(sanitizeRelativePath('foo/../bar', warn)).toBe('bar')
+    expect(warn).toHaveBeenCalledWith("Warning: path 'foo/../bar' contains '..' traversal — sanitized to 'bar'\n")
+  })
+
+  test('collapses nested double dots to top-level directory and warns', () => {
+    const warn = vi.fn()
+    expect(sanitizeRelativePath('foo/../../bar', warn)).toBe('bar')
+    expect(warn).toHaveBeenCalledWith("Warning: path 'foo/../../bar' contains '..' traversal — sanitized to 'bar'\n")
+  })
+
+  test('handles single dots by collapsing them and does not warn', () => {
+    const warn = vi.fn()
+    expect(sanitizeRelativePath('foo/./bar', warn)).toBe('foo/bar')
+    expect(warn).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
### WHY are these changes introduced?

This pull request addresses a test coverage gap on the `isSubpath`, `sniffForJson`, and `sanitizeRelativePath` functions within the `packages/cli-kit/src/public/node/path.ts` module, making the codebase safer to modify.

### WHAT is this pull request doing?

We added comprehensive unit tests covering:
- `isSubpath` (positive, negative, identical paths)
- `sniffForJson` (detecting `--json`, `-j`, or absence thereof)
- `sanitizeRelativePath` (retaining standard relative paths, warning and collapsing double dot directory traversal segments, and handling single dot paths)

### How to test your changes?

CI

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [2046332310498932967](https://jules.google.com/task/2046332310498932967) started by @gonzaloriestra*