### PR TITLE
Fix duplicated package manager issue with create-test-app script

### DIFF
--- a/bin/create-test-app.js
+++ b/bin/create-test-app.js
@@ -191,7 +191,6 @@ program
 
         log(`Creating new app in '${appPath}'...`);
         initArgs.push("--local");
-        initArgs.push(`--package-manager=${nodePackageManager}`);
         await nodeExec(["create-app"], initArgs, defaultOpts);
 
         // there are some bugs with lockfiles and local references


### PR DESCRIPTION
### WHY are these changes introduced?

`./bin/create-test-app.js` fails with `Flag --package-manager can only be specified once` on every local run.

The root `create-app` script in `package.json` was changed in https://github.com/Shopify/cli/pull/7254 to hardcode `--package-manager pnpm`:

```
"create-app": "nx build create-app && node packages/create-app/bin/dev.js --package-manager pnpm"
```

`create-test-app.js` also appended its own `--package-manager=${nodePackageManager}` flag when building the local install args, so the underlying `app:init` command ended up receiving `--package-manager` twice, which oclif rejects.

### WHAT is this pull request doing?

Removes the redundant `--package-manager` flag that `create-test-app.js` was appending for local installs, since the root `create-app` script already supplies it.

### How to test your changes?

```bash
./bin/create-test-app.js
```

Should complete without the `Flag --package-manager can only be specified once` error.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`
