### PR TITLE
[Refactor] Extract parseEnvNumber helper in environment.ts

### DIFF
--- a/packages/cli-kit/src/public/node/environment.test.ts
+++ b/packages/cli-kit/src/public/node/environment.test.ts
@@ -1,10 +1,12 @@
-import {getAppAutomationToken} from './environment.js'
-import {environmentVariables} from '../../private/node/constants.js'
+import {getAppAutomationToken, getBackendPort, maxRequestTimeForNetworkCallsMs} from './environment.js'
+import {environmentVariables, systemEnvironmentVariables} from '../../private/node/constants.js'
 import {describe, expect, test, beforeEach} from 'vitest'
 
 beforeEach(() => {
   delete process.env[environmentVariables.appAutomationToken]
   delete process.env[environmentVariables.partnersToken]
+  delete process.env[systemEnvironmentVariables.backendPort]
+  delete process.env[environmentVariables.maxRequestTimeForNetworkCalls]
 })
 
 describe('getAppAutomationToken', () => {
@@ -29,5 +31,45 @@ describe('getAppAutomationToken', () => {
 
   test('returns undefined when neither env var is set', () => {
     expect(getAppAutomationToken()).toBeUndefined()
+  })
+})
+
+describe('getBackendPort', () => {
+  test('returns parsed port when set to a valid number', () => {
+    process.env[systemEnvironmentVariables.backendPort] = '8080'
+
+    expect(getBackendPort()).toBe(8080)
+  })
+
+  test('returns undefined when set to an invalid number', () => {
+    process.env[systemEnvironmentVariables.backendPort] = 'invalid-port'
+
+    expect(getBackendPort()).toBeUndefined()
+  })
+
+  test('returns undefined when not set', () => {
+    expect(getBackendPort()).toBeUndefined()
+  })
+})
+
+describe('maxRequestTimeForNetworkCallsMs', () => {
+  test('returns parsed max request time when set to a valid number', () => {
+    const env = {
+      [environmentVariables.maxRequestTimeForNetworkCalls]: '5000',
+    }
+
+    expect(maxRequestTimeForNetworkCallsMs(env)).toBe(5000)
+  })
+
+  test('returns default 30 seconds when set to an invalid number', () => {
+    const env = {
+      [environmentVariables.maxRequestTimeForNetworkCalls]: 'not-a-number',
+    }
+
+    expect(maxRequestTimeForNetworkCallsMs(env)).toBe(30000)
+  })
+
+  test('returns default 30 seconds when not set', () => {
+    expect(maxRequestTimeForNetworkCallsMs({})).toBe(30000)
   })
 })

--- a/packages/cli-kit/src/public/node/environment.ts
+++ b/packages/cli-kit/src/public/node/environment.ts
@@ -37,17 +37,20 @@ export function getOrganization(): string | undefined {
   return getEnvironmentVariables()[environmentVariables.organization]
 }
 
+function parseEnvNumber(value: string | undefined): number | undefined {
+  if (value && !isNaN(Number(value))) {
+    return Number(value)
+  }
+  return undefined
+}
+
 /**
  * Return the backend port value.
  *
  * @returns The port as a number. Undefined otherwise.
  */
 export function getBackendPort(): number | undefined {
-  const backendPort = getEnvironmentVariables()[systemEnvironmentVariables.backendPort]
-  if (backendPort && !isNaN(Number(backendPort))) {
-    return Number(backendPort)
-  }
-  return undefined
+  return parseEnvNumber(getEnvironmentVariables()[systemEnvironmentVariables.backendPort])
 }
 
 /**
@@ -99,10 +102,5 @@ export function skipNetworkLevelRetry(environment = getEnvironmentVariables()): 
  * @returns The maximum request time in milliseconds.
  */
 export function maxRequestTimeForNetworkCallsMs(environment = getEnvironmentVariables()): number {
-  const maxRequestTime = environment[environmentVariables.maxRequestTimeForNetworkCalls]
-  if (maxRequestTime && !isNaN(Number(maxRequestTime))) {
-    return Number(maxRequestTime)
-  }
-  // 30 seconds is the default
-  return 30 * 1000
+  return parseEnvNumber(environment[environmentVariables.maxRequestTimeForNetworkCalls]) ?? 30 * 1000
 }


### PR DESCRIPTION
### WHY are these changes introduced?

To improve codebase readability, maintainability, and reduce code duplication by extracting shared number-parsing environment variable logic in `packages/cli-kit/src/public/node/environment.ts`.

### WHAT is this pull request doing?

Extracted a private `parseEnvNumber` helper function in `packages/cli-kit/src/public/node/environment.ts` which deduplicates number-parsing logic inside `getBackendPort` and `maxRequestTimeForNetworkCallsMs`. Added corresponding unit tests in `packages/cli-kit/src/public/node/environment.test.ts`.

### How to test your changes?

CI

### Post-release steps

None

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [1503683400826785224](https://jules.google.com/task/1503683400826785224) started by @gonzaloriestra*