### PR TITLE
Require recorded scopes to reuse a store auth session in theme commands

### DIFF
--- a/packages/theme/src/cli/utilities/theme-command.test.ts
+++ b/packages/theme/src/cli/utilities/theme-command.test.ts
@@ -356,7 +356,7 @@ describe('ThemeCommand', () => {
       })
     })
 
-    test('uses a matching store auth cache session when stored scopes are empty', async () => {
+    test('falls back to theme authentication when the stored session has no recorded scopes', async () => {
       vi.mocked(getCurrentStoredStoreAppSession).mockReturnValue({
         store: 'test-store.myshopify.com',
         clientId: 'store-auth-client-id',
@@ -371,10 +371,8 @@ describe('ThemeCommand', () => {
 
       await command.run()
 
-      expect(ensureAuthenticatedThemes).not.toHaveBeenCalled()
-      expect(command.commandCalls[0]).toMatchObject({
-        session: {token: 'shpat_preview_token', storeFqdn: 'test-store.myshopify.com'},
-      })
+      expect(ensureAuthenticatedThemes).toHaveBeenCalledWith('test-store.myshopify.com', undefined)
+      expect(command.commandCalls[0]).toMatchObject({session: mockSession})
     })
 
     test('falls back to theme authentication when matching store auth session lacks required scopes', async () => {

--- a/packages/theme/src/cli/utilities/theme-command.ts
+++ b/packages/theme/src/cli/utilities/theme-command.ts
@@ -447,8 +447,6 @@ export default abstract class ThemeCommand extends Command {
   }
 
   private hasRequiredStoreAuthScopes(sessionScopes: string[], requiredScopes: string[]): boolean {
-    if (sessionScopes.length === 0) return true
-
     const expandedScopes = this.expandImpliedStoreAuthScopes(sessionScopes)
     return requiredScopes.every((scope) => expandedScopes.has(scope))
   }


### PR DESCRIPTION
### WHY are these changes introduced?

Second layer of the `theme dev` store-auth regression fix ([Slack thread](https://shopify.slack.com/archives/C07UJ7UNMTK/p1783604773690349)); stacked on #8183.

`hasRequiredStoreAuthScopes` treated a stored session with **no recorded scopes** as satisfying any requirement (`if (scopes.length === 0) return true`), so `theme pull`/`theme push` could adopt sessions whose actual grant is unknown and fail later with missing-scope errors.

### WHAT is this pull request doing?

- Removes the empty-scopes escape hatch: a stored session must record scopes that satisfy the command's declared requirements to be reused.
- Both `shopify store auth` and `shopify store create preview` always record granted scopes, so an empty scope list means the grant can't be verified — the command now falls back to normal theme authentication instead (graceful, no error).
- Flips the test that pinned the old behavior.

### How to test your changes?

Covered by unit tests (`theme-command.test.ts`): a stored session with `scopes: []` no longer satisfies `theme pull`/`theme push`; the command falls back to `ensureAuthenticatedThemes`.

### Measuring impact

- [x] Existing analytics will cater for this addition
