### PR TITLE
Skip expired store auth sessions in theme commands

### DIFF
--- a/packages/theme/src/cli/utilities/theme-command.test.ts
+++ b/packages/theme/src/cli/utilities/theme-command.test.ts
@@ -17,7 +17,14 @@ import {hashString} from '@shopify/cli-kit/node/crypto'
 import type {Writable} from 'stream'
 
 vi.mock('@shopify/cli-kit/node/session')
-vi.mock('@shopify/cli-kit/node/store-auth-session')
+vi.mock('@shopify/cli-kit/node/store-auth-session', async (importOriginal) => {
+  const original = await importOriginal<typeof import('@shopify/cli-kit/node/store-auth-session')>()
+  return {
+    ...original,
+    getCurrentStoredStoreAppSession: vi.fn(),
+    listCurrentStoredStoreAppSessions: vi.fn(),
+  }
+})
 vi.mock('@shopify/cli-kit/node/environments')
 vi.mock('@shopify/cli-kit/node/ui')
 vi.mock('@shopify/cli-kit/node/metadata', () => ({
@@ -395,7 +402,7 @@ describe('ThemeCommand', () => {
       expect(command.commandCalls[0]).toMatchObject({session: mockSession})
     })
 
-    test('does not check stored store auth cache session expiry', async () => {
+    test('falls back to theme authentication when the stored session is expired', async () => {
       vi.mocked(getCurrentStoredStoreAppSession).mockReturnValue({
         store: 'test-store.myshopify.com',
         clientId: 'store-auth-client-id',
@@ -403,7 +410,27 @@ describe('ThemeCommand', () => {
         accessToken: 'shpat_preview_token',
         scopes: ['read_themes'],
         acquiredAt: '2026-06-08T11:00:00.000Z',
-        expiresAt: '2026-06-08T11:30:00.000Z',
+        expiresAt: new Date(Date.now() - 60 * 1000).toISOString(),
+      })
+
+      await CommandConfig.load()
+      const command = new TestScopedThemeCommand([], CommandConfig)
+
+      await command.run()
+
+      expect(ensureAuthenticatedThemes).toHaveBeenCalledWith('test-store.myshopify.com', undefined)
+      expect(command.commandCalls[0]).toMatchObject({session: mockSession})
+    })
+
+    test('uses a stored session whose expiry is far enough in the future', async () => {
+      vi.mocked(getCurrentStoredStoreAppSession).mockReturnValue({
+        store: 'test-store.myshopify.com',
+        clientId: 'store-auth-client-id',
+        userId: 'preview:123',
+        accessToken: 'shpat_preview_token',
+        scopes: ['read_themes'],
+        acquiredAt: '2026-06-08T11:00:00.000Z',
+        expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
       })
 
       await CommandConfig.load()

--- a/packages/theme/src/cli/utilities/theme-command.ts
+++ b/packages/theme/src/cli/utilities/theme-command.ts
@@ -9,6 +9,7 @@ import Command, {ArgOutput, FlagOutput, noDefaultsOptions} from '@shopify/cli-ki
 import {AdminSession, ensureAuthenticatedThemes, setLastSeenUserId} from '@shopify/cli-kit/node/session'
 import {
   getCurrentStoredStoreAppSession,
+  isSessionExpired,
   listCurrentStoredStoreAppSessions,
   type StoredStoreAppSession,
 } from '@shopify/cli-kit/node/store-auth-session'
@@ -421,6 +422,10 @@ export default abstract class ThemeCommand extends Command {
     storeFqdn: string,
     requiredScopes: string[],
   ): AdminSession | undefined {
+    if (isSessionExpired(storedSession)) {
+      return undefined
+    }
+
     if (!this.hasRequiredStoreAuthScopes(storedSession.scopes, requiredScopes)) {
       return undefined
     }


### PR DESCRIPTION
### WHY are these changes introduced?

Third layer of the `theme dev` store-auth regression fix ([Slack thread](https://shopify.slack.com/archives/C07UJ7UNMTK/p1783604773690349)); stacked on #8184.

Theme commands read stored store-auth sessions with the raw cache accessor and never checked expiry. An expired token was handed to the Admin API, and the resulting 401 was **terminal**: the theme session carries no refresh handler (`adminRequestDoc` only installs one when `'refresh' in session`), and the failure path never falls back to normal authentication. This is the exact shape of the July 8 Enterprise case (401 on `publicApiVersions` that `auth logout` + re-auth couldn't fix).

### WHAT is this pull request doing?

- Skips stored sessions that fail cli-kit's `isSessionExpired` (including its 4-minute refresh margin) and falls back to normal theme authentication.
- Flips the test that pinned the old behavior (`does not check stored store auth cache session expiry`) and adds a positive test for future expiries.
- Switches the test file to a partial module mock so the real `isSessionExpired` implementation runs.

Actual token refresh (the refresh client lives in `@shopify/store`, which `@shopify/theme` deliberately no longer depends on) is left as follow-up work.

### How to test your changes?

Covered by unit tests (`theme-command.test.ts`): a stored session with a past `expiresAt` is skipped and the command authenticates normally; a future `expiresAt` is still reused.

### Measuring impact

- [x] Existing analytics will cater for this addition
