### PR TITLE
Test should-render target mappings for product configuration extensions

### DIFF
--- a/packages/app/src/cli/models/extensions/specifications/ui_extension.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/ui_extension.test.ts
@@ -14,6 +14,18 @@ import * as output from '@shopify/cli-kit/node/output'
 import type {NewExtensionPointSchemaType} from '../schemas.js'
 
 describe('ui_extension', async () => {
+  describe('getShouldRenderTarget', () => {
+    test.each([
+      ['admin.product-details.configuration.render', 'admin.product-details.configuration.should-render'],
+      [
+        'admin.product-variant-details.configuration.render',
+        'admin.product-variant-details.configuration.should-render',
+      ],
+    ])('converts %s to %s', (target, expectedTarget) => {
+      expect(getShouldRenderTarget(target)).toBe(expectedTarget)
+    })
+  })
+
   interface GetUIExtensionProps {
     directory: string
     apiVersion?: string


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/shop/issues-on-ramps/issues/900

The CLI target mapping needs regression coverage for the two product configuration surfaces that expose a `render` target with a corresponding `should-render` target. UI Extensions https://github.com/Shopify/ui-extensions/pull/4600 and Core https://github.com/shop/issues-on-ramps/issues/899 are separate dependencies for this work.

### WHAT is this pull request doing?

Adds focused tests for `getShouldRenderTarget` covering these target conversions:

- `admin.product-details.configuration.render` → `admin.product-details.configuration.should-render`
- `admin.product-variant-details.configuration.render` → `admin.product-variant-details.configuration.should-render`

UI Extensions https://github.com/Shopify/ui-extensions/pull/4600 and Core https://github.com/shop/issues-on-ramps/issues/899 remain separate dependencies and are not included in this CLI-only change.

### How to test your changes?

- `pnpm --filter @shopify/app vitest run src/cli/models/extensions/specifications/ui_extension.test.ts` — 55 tests passed
- `pnpm --filter @shopify/app type-check` — passed
- `pnpm --filter @shopify/app lint` — passed
- `git diff --check` — passed

### Post-release steps

No post-release steps.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add` (not applicable; test-only change)

