### PR TITLE
Improve theme list ordering: sort newest to oldest within each role group

### DIFF
--- a/.changeset/theme-list-newest-first.md
+++ b/.changeset/theme-list-newest-first.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': minor
+---
+
+Sort theme lists newest to oldest within each role group

--- a/packages/theme/src/cli/utilities/theme-selector/fetch.test.ts
+++ b/packages/theme/src/cli/utilities/theme-selector/fetch.test.ts
@@ -48,10 +48,27 @@ describe('fetchStoreThemes', () => {
     // Then
     expect(themes).toHaveLength(5)
     expect(themes[0]!.name).toBe('theme 3')
-    expect(themes[1]!.name).toBe('theme 1')
-    expect(themes[2]!.name).toBe('theme 4')
-    expect(themes[3]!.name).toBe('theme 5')
-    expect(themes[4]!.name).toBe('theme 7')
+    expect(themes[1]!.name).toBe('theme 4')
+    expect(themes[2]!.name).toBe('theme 1')
+    expect(themes[3]!.name).toBe('theme 7')
+    expect(themes[4]!.name).toBe('theme 5')
+  })
+
+  test('sorts themes newest first within each role group', async () => {
+    // Given
+    vi.mocked(fetchThemes).mockResolvedValue([
+      theme(120, 'development'),
+      theme(3, 'unpublished'),
+      theme(45, 'live'),
+      theme(89, 'unpublished'),
+      theme(7, 'development'),
+    ])
+
+    // When
+    const themes = await fetchStoreThemes(session)
+
+    // Then
+    expect(themes.map((theme) => theme.id)).toEqual([45, 89, 3, 120, 7])
   })
 
   test('throws an error when there are no themes', async () => {

--- a/packages/theme/src/cli/utilities/theme-selector/fetch.ts
+++ b/packages/theme/src/cli/utilities/theme-selector/fetch.ts
@@ -25,13 +25,18 @@ export async function fetchStoreThemes(session: AdminSession) {
     throw new AbortError(`There are no themes in the ${store} store`)
   }
 
-  return themes.sort(byRole)
+  return themes.sort(byRoleThenNewest)
 }
 
 function isRoleAllowed(theme: Theme) {
   return (ALLOWED_ROLES as string[]).includes(theme.role)
 }
 
-function byRole(themeA: Theme, themeB: Theme) {
-  return (ALLOWED_ROLES as string[]).indexOf(themeA.role) - (ALLOWED_ROLES as string[]).indexOf(themeB.role)
+function byRoleThenNewest(themeA: Theme, themeB: Theme) {
+  const roleComparison =
+    (ALLOWED_ROLES as string[]).indexOf(themeA.role) - (ALLOWED_ROLES as string[]).indexOf(themeB.role)
+  if (roleComparison !== 0) return roleComparison
+
+  // Theme IDs increase monotonically, so a higher ID means a newer theme.
+  return themeB.id - themeA.id
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Theme lists shown by the CLI (`theme list` and the interactive theme picker used
by `theme push`, `theme pull`, `theme open`, etc.) display themes in the order
returned by the Admin API, which is creation order — oldest first. On stores with
many themes (e.g. 100+), the newest themes — the ones developers actually need to
see or push to — are at the very bottom, requiring a lot of scrolling and wasted time.

### WHAT is this pull request doing?

Sorts theme lists newest to oldest, while keeping the existing role grouping
(live → unpublished → development).

All theme list displays funnel through `fetchStoreThemes` in
`packages/theme/src/cli/utilities/theme-selector/fetch.ts`, which previously
sorted only by role and let the API's oldest-first order leak through within each
group. The comparator (`byRole` → `byRoleThenNewest`) now adds an ID-descending
tiebreaker — theme IDs increase monotonically, so a higher ID means a newer
theme. No API or schema changes needed.

This changes ordering in one place for both the `theme list` output and every
interactive theme picker (`push`, `pull`, `open`, `publish`, `rename`, `delete`,
`duplicate`, `info`).

### How to test your changes?

1. Run `pnpm shopify theme list --store <store>` against a store with several
   themes — themes should appear newest first within each role group, with the
   live theme at the top.
2. Run `pnpm shopify theme open --store <store>` without `--theme` — the picker
   should list themes newest first within each role group.
3. Unit tests: `pnpm vitest run src/cli/utilities/theme-selector/fetch.test.ts`
   from `packages/theme` — includes a new test asserting newest-first order
   within role groups.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [x] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`
