### PR TITLE
Add theme ID search to interactive theme pickers

### DIFF
--- a/.changeset/search-themes-by-id.md
+++ b/.changeset/search-themes-by-id.md
@@ -1,0 +1,6 @@
+---
+'@shopify/cli-kit': minor
+'@shopify/theme': minor
+---
+
+Render searchable autocomplete helper text and show theme IDs in interactive theme pickers.

--- a/packages/cli-kit/src/private/node/ui/components/AutocompletePromptSearch.test.ts
+++ b/packages/cli-kit/src/private/node/ui/components/AutocompletePromptSearch.test.ts
@@ -1,0 +1,32 @@
+import {filterAutocompleteChoices} from './AutocompletePromptSearch.js'
+import {describe, expect, test} from 'vitest'
+
+const choices = [
+  {
+    label: 'Dawn',
+    value: 'dawn',
+    group: 'Unpublished',
+    helperText: '#123456789',
+  },
+  {
+    label: 'Studio',
+    value: 'studio',
+    group: 'Live',
+    helperText: '#987654321',
+  },
+]
+
+describe('filterAutocompleteChoices', () => {
+  test.each([
+    ['label', 'DAWN', 'dawn'],
+    ['group', 'live', 'studio'],
+    ['helper text', '123456789', 'dawn'],
+    ['prefixed helper text', '#987654321', 'studio'],
+  ])('filters by %s case-insensitively', (_criterion, term, expectedValue) => {
+    expect(filterAutocompleteChoices(choices, term).map(({value}) => value)).toEqual([expectedValue])
+  })
+
+  test('returns no choices when the term does not match', () => {
+    expect(filterAutocompleteChoices(choices, 'nonexistent')).toEqual([])
+  })
+})

--- a/packages/cli-kit/src/private/node/ui/components/AutocompletePromptSearch.ts
+++ b/packages/cli-kit/src/private/node/ui/components/AutocompletePromptSearch.ts
@@ -1,0 +1,11 @@
+import {Item as SelectItem} from './SelectInput.js'
+
+export function filterAutocompleteChoices<T>(choices: SelectItem<T>[], term: string): SelectItem<T>[] {
+  const lowerTerm = term.toLowerCase()
+
+  return choices.filter((choice) => {
+    const searchableValues = [choice.label, choice.group, choice.helperText]
+
+    return searchableValues.some((value) => value?.toLowerCase().includes(lowerTerm))
+  })
+}

--- a/packages/cli-kit/src/private/node/ui/components/SelectInput.test.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/SelectInput.test.tsx
@@ -165,6 +165,25 @@ describe('SelectInput', async () => {
     expect(onChange).not.toHaveBeenCalled()
   })
 
+  test('renders helper text and highlights matching terms', () => {
+    const items = [
+      {
+        label: 'Dawn',
+        value: 'dawn',
+        helperText: '#123456789',
+      },
+    ]
+
+    const renderInstance = render(<SelectInput items={items} highlightedTerm="123456789" />)
+
+    expect(renderInstance.lastFrame()).toMatchInlineSnapshot(`
+      "[36m>[39m  [36mDawn[39m[2m #[1m123456789[22m
+
+
+         [2mPress ↑↓ arrows to select, enter to confirm.[22m"
+    `)
+  })
+
   const runningOnWindows = platformAndArch().platform === 'windows'
 
   test.skipIf(runningOnWindows)('support groups', async () => {

--- a/packages/cli-kit/src/private/node/ui/components/SelectInput.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/SelectInput.tsx
@@ -87,6 +87,7 @@ function Item<T>({
   index,
 }: ItemProps<T>): React.ReactElement {
   const label = highlightedLabel(item.label, highlightedTerm)
+  const helperText = item.helperText ? highlightedLabel(item.helperText, highlightedTerm) : undefined
   let title: string | undefined
   let labelColor
 
@@ -120,6 +121,7 @@ function Item<T>({
         <Text wrap="end" color={labelColor}>
           {showKey ? `(${item.key}) ${label}` : label}
         </Text>
+        {helperText ? <Text dimColor>{` ${helperText}`}</Text> : null}
       </Box>
     </Box>
   )

--- a/packages/cli-kit/src/public/node/ui.tsx
+++ b/packages/cli-kit/src/public/node/ui.tsx
@@ -27,6 +27,7 @@ import {SelectPrompt, SelectPromptProps} from '../../private/node/ui/components/
 import {Tasks, Task} from '../../private/node/ui/components/Tasks.js'
 import {TextPrompt, TextPromptProps} from '../../private/node/ui/components/TextPrompt.js'
 import {AutocompletePromptProps, AutocompletePrompt} from '../../private/node/ui/components/AutocompletePrompt.js'
+import {filterAutocompleteChoices} from '../../private/node/ui/components/AutocompletePromptSearch.js'
 import {InfoTableSection} from '../../private/node/ui/components/Prompts/InfoTable.js'
 import {InfoMessageProps} from '../../private/node/ui/components/Prompts/InfoMessage.js'
 import {SingleTask} from '../../private/node/ui/components/SingleTask.js'
@@ -420,11 +421,8 @@ export async function renderAutocompletePrompt<T>(
   const usingDefaultSearch = props.search === undefined
   const newProps = {
     search(term: string) {
-      const lowerTerm = term.toLowerCase()
       return Promise.resolve({
-        data: props.choices.filter((item) => {
-          return item.label.toLowerCase().includes(lowerTerm) || item.group?.toLowerCase().includes(lowerTerm)
-        }),
+        data: filterAutocompleteChoices(props.choices, term),
       })
     },
     ...(usingDefaultSearch ? {searchDebounceMs: 0} : {}),

--- a/packages/theme/src/cli/utilities/theme-selector.test.ts
+++ b/packages/theme/src/cli/utilities/theme-selector.test.ts
@@ -70,6 +70,25 @@ describe('findOrSelectTheme', () => {
     })
   })
 
+  test('adds theme IDs as autocomplete helper text', async () => {
+    // Given
+    const themes = [mockTheme(7, 'development'), mockTheme(8, 'unpublished')]
+    vi.mocked(fetchStoreThemes).mockResolvedValue(themes)
+    vi.mocked(renderAutocompletePrompt).mockResolvedValue(() => Promise.resolve(themes[0]))
+
+    // When
+    await findOrSelectTheme(session, {
+      header: 'Select a theme to open',
+      filter: {},
+    })
+
+    // Then
+    expect(renderAutocompletePrompt).toHaveBeenLastCalledWith({
+      message: 'Select a theme to open',
+      choices: [expect.objectContaining({helperText: '#7'}), expect.objectContaining({helperText: '#8'})],
+    })
+  })
+
   test('returns selected theme when filter is specified', async () => {
     // Given
     vi.mocked(fetchStoreThemes).mockResolvedValue(storeThemes)

--- a/packages/theme/src/cli/utilities/theme-selector.ts
+++ b/packages/theme/src/cli/utilities/theme-selector.ts
@@ -1,7 +1,7 @@
 import {Filter, FilterProps, filterThemes} from './theme-selector/filter.js'
 import {fetchStoreThemes} from './theme-selector/fetch.js'
 import {getDevelopmentTheme} from '../services/local-storage.js'
-import {renderAutocompletePrompt} from '@shopify/cli-kit/node/ui'
+import {renderAutocompletePrompt, type RenderAutocompleteOptions} from '@shopify/cli-kit/node/ui'
 import {AdminSession} from '@shopify/cli-kit/node/session'
 import {capitalize} from '@shopify/cli-kit/common/string'
 import {themeCreate} from '@shopify/cli-kit/node/themes/api'
@@ -44,13 +44,14 @@ export async function findOrSelectTheme(session: AdminSession, options: FindOrSe
   }
 
   const message = options.header ?? ''
-  const choices = themes.map((theme) => {
+  const choices: RenderAutocompleteOptions<() => Promise<Theme>>['choices'] = themes.map((theme) => {
     const currentLabel = theme.id.toString() === getDevelopmentTheme() ? ' [current]' : ''
 
     return {
       value: async () => theme,
       label: `${theme.name}${currentLabel}`,
       group: capitalize(theme.role),
+      helperText: `#${theme.id}`,
     }
   })
 


### PR DESCRIPTION
### WHY are these changes introduced?

Interactive theme pickers already support type-to-search by theme name and role, but theme IDs aren't shown or searchable. Developers who copy an ID from `theme list` therefore can't use it to find a theme in the pickers used by `theme push`, `theme pull`, `theme open`, and related commands.

This complements #8192: that PR improves the default ordering for large theme libraries, while this PR makes specific themes directly searchable by ID.

### WHAT is this pull request doing?

- Renders the existing autocomplete choice `helperText` beside labels in a dimmed style.
- Highlights matching text inside both labels and helper text, so ID matches are visually explained.
- Extends the default autocomplete search to match `helperText` while preserving existing name and group matching.
- Adds each theme's `#`-prefixed ID as helper text, matching the format shown by `theme list`.
- Preserves the existing instant, in-memory search behavior and result ordering.

A theme row now reads like `Dawn #123456789`, with the ID visually subdued unless it contains the active search match.

### How to test your changes?

1. Run `pnpm shopify theme open --store <store>` against a store with more than five themes.
2. Confirm each picker row shows a dimmed `#<theme-id>` after the theme name.
3. Type part of a theme name and confirm name filtering and highlighting still work.
4. Type or paste a theme ID, with and without its `#` prefix, and confirm the matching theme remains and the matching ID text is highlighted.
5. Run the focused automated checks:

```sh
cd packages/cli-kit
pnpm vitest run src/private/node/ui/components/SelectInput.test.tsx src/private/node/ui/components/AutocompletePromptSearch.test.ts src/private/node/ui/components/AutocompletePrompt.test.tsx
pnpm lint
pnpm type-check
pnpm build

cd ../theme
pnpm vitest run src/cli/utilities/theme-selector.test.ts
pnpm lint
pnpm type-check
pnpm build
```

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [x] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`minor`) and added a changeset
