### PR TITLE
[Tests] Improve TOML codec coverage with encodeToml tests

### DIFF
--- a/packages/cli-kit/src/public/node/toml/codec.test.ts
+++ b/packages/cli-kit/src/public/node/toml/codec.test.ts
@@ -1,4 +1,4 @@
-import {decodeToml} from './codec.js'
+import {decodeToml, encodeToml} from './codec.js'
 import {describe, expect, test} from 'vitest'
 
 describe('decodeToml', () => {
@@ -26,5 +26,27 @@ describe('decodeToml', () => {
     `
     const result = decodeToml(input)
     expect(result).toStrictEqual({access: {admin: {direct_api_mode: 'online'}}})
+  })
+})
+
+describe('encodeToml', () => {
+  test('encodes simple key-value pairs into a TOML string', () => {
+    const content = {
+      name: 'app',
+      version: '1.0.0',
+    }
+    const result = encodeToml(content)
+    expect(result).toContain('name = "app"\n')
+    expect(result).toContain('version = "1.0.0"\n')
+  })
+
+  test('encodes nested properties into structured TOML blocks', () => {
+    const content = {
+      webhooks: {
+        api_version: '2023-07',
+      },
+    }
+    const result = encodeToml(content)
+    expect(result).toBe('[webhooks]\napi_version = "2023-07"\n')
   })
 })


### PR DESCRIPTION
Added comprehensive unit tests for `encodeToml` in `packages/cli-kit/src/public/node/toml/codec.test.ts` to improve coverage and prevent regressions, validating simple key-value pairs and structured nested objects/blocks.

---
*PR created automatically by Jules for task [13157068248553567506](https://jules.google.com/task/13157068248553567506) started by @gonzaloriestra*