### PR TITLE
Require confirmation or --force for store delete

### DIFF
--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -6842,9 +6842,18 @@
       "enableJsonFlag": false,
       "examples": [
         "<%= config.bin %> <%= command.id %> --store shop.myshopify.com --organization-id 1234567",
-        "<%= config.bin %> <%= command.id %> --store shop.myshopify.com --organization-id 1234567 --json"
+        "<%= config.bin %> <%= command.id %> --store shop.myshopify.com --organization-id 1234567 --json",
+        "<%= config.bin %> <%= command.id %> --store shop.myshopify.com --organization-id 1234567 --force"
       ],
       "flags": {
+        "force": {
+          "allowNo": false,
+          "char": "f",
+          "description": "Skip confirmation.",
+          "env": "SHOPIFY_FLAG_FORCE",
+          "name": "force",
+          "type": "boolean"
+        },
         "json": {
           "allowNo": false,
           "char": "j",

--- a/packages/store/src/cli/commands/store/delete.test.ts
+++ b/packages/store/src/cli/commands/store/delete.test.ts
@@ -3,6 +3,7 @@ import {deleteDevStore} from '../../services/store/delete/dev.js'
 import {resolveOrganizationForStore} from '../../utilities/store-lookup/organization.js'
 import {AbortError} from '@shopify/cli-kit/node/error'
 import {outputResult} from '@shopify/cli-kit/node/output'
+import {isTTY, renderDangerousConfirmationPrompt} from '@shopify/cli-kit/node/ui'
 import {describe, expect, test, vi, beforeEach} from 'vitest'
 
 vi.mock('../../services/store/delete/dev.js')
@@ -16,10 +17,21 @@ vi.mock('@shopify/cli-kit/node/output', async (importOriginal) => {
   }
 })
 
+vi.mock('@shopify/cli-kit/node/ui', async (importOriginal) => {
+  const actual: Record<string, unknown> = await importOriginal()
+  return {
+    ...actual,
+    isTTY: vi.fn(),
+    renderDangerousConfirmationPrompt: vi.fn(),
+  }
+})
+
 const defaultOrg = {id: '12345', businessName: 'Test Org'}
 
 beforeEach(() => {
   vi.mocked(resolveOrganizationForStore).mockResolvedValue(defaultOrg)
+  vi.mocked(isTTY).mockReturnValue(true)
+  vi.mocked(renderDangerousConfirmationPrompt).mockResolvedValue(true)
 })
 
 describe('store delete command', () => {
@@ -61,6 +73,73 @@ describe('store delete command', () => {
     expect(StoreDelete.flags.store).toBeDefined()
     expect(StoreDelete.flags['organization-id']).toBeDefined()
     expect(StoreDelete.flags.json).toBeDefined()
+    expect(StoreDelete.flags.force).toBeDefined()
+  })
+
+  test('prompts for confirmation with the store domain before deleting', async () => {
+    await StoreDelete.run(['--store', 'my-store.myshopify.com', '--organization-id', '12345'])
+
+    expect(renderDangerousConfirmationPrompt).toHaveBeenCalledWith({
+      message: `Delete development store my-store.myshopify.com? This can't be undone.`,
+      confirmation: 'my-store.myshopify.com',
+    })
+    expect(deleteDevStore).toHaveBeenCalled()
+  })
+
+  test('aborts without deleting when the confirmation prompt is declined', async () => {
+    vi.mocked(renderDangerousConfirmationPrompt).mockResolvedValue(false)
+
+    await expect(StoreDelete.run(['--store', 'my-store.myshopify.com', '--organization-id', '12345'])).rejects.toThrow()
+    expect(deleteDevStore).not.toHaveBeenCalled()
+  })
+
+  test('skips the confirmation prompt when --force is passed', async () => {
+    await StoreDelete.run(['--store', 'my-store.myshopify.com', '--organization-id', '12345', '--force'])
+
+    expect(renderDangerousConfirmationPrompt).not.toHaveBeenCalled()
+    expect(deleteDevStore).toHaveBeenCalled()
+  })
+
+  test('requires --force when the terminal is not interactive', async () => {
+    vi.mocked(isTTY).mockReturnValue(false)
+
+    await expect(StoreDelete.run(['--store', 'my-store.myshopify.com', '--organization-id', '12345'])).rejects.toThrow()
+    expect(renderDangerousConfirmationPrompt).not.toHaveBeenCalled()
+    expect(resolveOrganizationForStore).not.toHaveBeenCalled()
+    expect(deleteDevStore).not.toHaveBeenCalled()
+  })
+
+  test('deletes without prompting when the terminal is not interactive and --force is passed', async () => {
+    vi.mocked(isTTY).mockReturnValue(false)
+
+    await StoreDelete.run(['--store', 'my-store.myshopify.com', '--organization-id', '12345', '--force'])
+
+    expect(renderDangerousConfirmationPrompt).not.toHaveBeenCalled()
+    expect(deleteDevStore).toHaveBeenCalled()
+  })
+
+  test('outputs structured JSON error when --json is active and --force is missing in a non-interactive run', async () => {
+    vi.mocked(isTTY).mockReturnValue(false)
+    const mockExit = vi.spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('process.exit')
+    }) as never)
+
+    await expect(
+      StoreDelete.run(['--store', 'my-store.myshopify.com', '--organization-id', '12345', '--json']),
+    ).rejects.toThrow('process.exit')
+
+    const call = vi.mocked(outputResult).mock.calls[0]![0] as string
+    const parsed = JSON.parse(call)
+    expect(parsed).toEqual({
+      error: true,
+      message: 'Deleting the development store my-store.myshopify.com requires confirmation.',
+      nextSteps: ['Use the `--force` flag to skip confirmation when running non-interactively.'],
+      exitCode: 1,
+    })
+    expect(deleteDevStore).not.toHaveBeenCalled()
+    expect(mockExit).toHaveBeenCalledWith(1)
+
+    mockExit.mockRestore()
   })
 
   test('outputs structured JSON error when --json is active and service throws AbortError', async () => {

--- a/packages/store/src/cli/commands/store/delete.ts
+++ b/packages/store/src/cli/commands/store/delete.ts
@@ -3,8 +3,10 @@ import {storeFlags} from '../../flags.js'
 import {resolveOrganizationForStore} from '../../utilities/store-lookup/organization.js'
 import Command from '@shopify/cli-kit/node/base-command'
 import {globalFlags, jsonFlag} from '@shopify/cli-kit/node/cli'
-import {AbortError} from '@shopify/cli-kit/node/error'
+import {AbortError, AbortSilentError} from '@shopify/cli-kit/node/error'
 import {outputResult} from '@shopify/cli-kit/node/output'
+import {isTTY, renderDangerousConfirmationPrompt} from '@shopify/cli-kit/node/ui'
+import {Flags} from '@oclif/core'
 
 export default class StoreDelete extends Command {
   static hidden = true
@@ -18,6 +20,7 @@ export default class StoreDelete extends Command {
   static examples = [
     '<%= config.bin %> <%= command.id %> --store shop.myshopify.com --organization-id 1234567',
     '<%= config.bin %> <%= command.id %> --store shop.myshopify.com --organization-id 1234567 --json',
+    '<%= config.bin %> <%= command.id %> --store shop.myshopify.com --organization-id 1234567 --force',
   ]
 
   static flags = {
@@ -25,13 +28,35 @@ export default class StoreDelete extends Command {
     ...jsonFlag,
     store: storeFlags.store,
     'organization-id': storeFlags['organization-id'],
+    force: Flags.boolean({
+      char: 'f',
+      description: 'Skip confirmation.',
+      env: 'SHOPIFY_FLAG_FORCE',
+      default: false,
+    }),
   }
 
   async run(): Promise<void> {
     const {flags} = await this.parse(StoreDelete)
 
     try {
+      // Deleting a store is irreversible: in non-interactive runs (CI, agents, piped
+      // input) confirmation is impossible, so an explicit --force is required instead.
+      if (!flags.force && !isTTY()) {
+        throw new AbortError(`Deleting the development store ${flags.store} requires confirmation.`, null, [
+          'Use the `--force` flag to skip confirmation when running non-interactively.',
+        ])
+      }
+
       const organization = await resolveOrganizationForStore(flags.store, flags['organization-id']?.toString())
+
+      if (!flags.force) {
+        const confirmed = await renderDangerousConfirmationPrompt({
+          message: `Delete development store ${flags.store}? This can't be undone.`,
+          confirmation: flags.store,
+        })
+        if (!confirmed) throw new AbortSilentError()
+      }
 
       await deleteDevStore({
         store: flags.store,


### PR DESCRIPTION
### WHY are these changes introduced?

Implements the confirmation UX for `shopify store delete` decided in [shop/issues-develop#22731](https://github.com/shop/issues-develop/issues/22731) and confirmed in [Slack](https://shopify.slack.com/archives/C0B242KDQPN/p1785178321620289): *"store name for interactive, `--force` for noninteractive"* — `renderDangerousConfirmationPrompt` for TTY, `--force` for non-TTY.

Deleting a development store is irreversible; today the command deletes immediately with no guard.

### WHAT is this pull request doing?

- **Interactive (TTY)**: shows `renderDangerousConfirmationPrompt` — the user must type the store domain (e.g. `my-store.myshopify.com`) to confirm; Escape/decline aborts without deleting (`AbortSilentError`, matching `app deploy`'s pattern).
- **Non-interactive (CI/agents/piped)**: requires an explicit `--force`; without it the command exits non-zero **before any network calls**, with the `--force` hint carried in `nextSteps` so it also surfaces in structured `--json` error output.
- **`--force` in TTY** skips the prompt, matching existing force-flag semantics (`-f`, `SHOPIFY_FLAG_FORCE`, "Skip confirmation.").
- Prompting is decided purely by TTY detection (`isTTY` from cli-kit); `--json` remains an output format and doesn't change prompting behavior.
- Regenerates `oclif.manifest.json` (README/dev-docs unchanged — command is hidden).

No changeset: the command is `hidden` and unreleased.

### How to test your changes?

```bash
# TTY: prompts, requires typing the store domain
shopify store delete --store my-store.myshopify.com --organization-id 1234567

# TTY with --force: no prompt
shopify store delete --store my-store.myshopify.com --organization-id 1234567 --force

# non-TTY without --force: exits 1 with clear message (also as JSON with --json)
echo | shopify store delete --store my-store.myshopify.com --organization-id 1234567 --json

# non-TTY with --force: deletes
echo | shopify store delete --store my-store.myshopify.com --organization-id 1234567 --force
```

### Measuring impact

- [x] Existing analytics will cater for this addition
