### PR TITLE
Halve CLI startup time by not loading the app for non-app commands

### DIFF
--- a/.changeset/faster-cli-startup.md
+++ b/.changeset/faster-cli-startup.md
@@ -1,0 +1,7 @@
+---
+'@shopify/cli-kit': patch
+'@shopify/app': patch
+'@shopify/cli': patch
+---
+
+Reduce CLI startup time by only loading the app when running `app` commands

--- a/packages/app/src/cli/hooks/public_metadata.test.ts
+++ b/packages/app/src/cli/hooks/public_metadata.test.ts
@@ -3,14 +3,18 @@ import {localAppContext} from '../services/app-context.js'
 import metadata from '../metadata.js'
 import {describe, expect, test, vi, beforeEach} from 'vitest'
 import {cwd} from '@shopify/cli-kit/node/path'
+import {setCurrentCommandId} from '@shopify/cli-kit/node/global-context'
 
 vi.mock('../services/app-context.js')
 vi.mock('@shopify/cli-kit/node/path')
+
+const gather = gatherPublicMetadata as () => Promise<unknown>
 
 describe('gatherPublicMetadata', () => {
   beforeEach(() => {
     vi.mocked(cwd).mockReturnValue('/some/app/dir')
     vi.mocked(localAppContext).mockResolvedValue({} as Awaited<ReturnType<typeof localAppContext>>)
+    setCurrentCommandId('app:dev')
   })
 
   test('opportunistically enriches metadata from the current directory and returns the public metadata', async () => {
@@ -18,7 +22,7 @@ describe('gatherPublicMetadata', () => {
     vi.spyOn(metadata, 'getAllPublicMetadata').mockReturnValueOnce({}).mockReturnValue({api_key: 'from-loader'})
 
     // When
-    const result = await (gatherPublicMetadata as () => Promise<unknown>)()
+    const result = await gather()
 
     // Then
     expect(localAppContext).toHaveBeenCalledWith({directory: '/some/app/dir', skipPrompts: true})
@@ -30,7 +34,7 @@ describe('gatherPublicMetadata', () => {
     vi.spyOn(metadata, 'getAllPublicMetadata').mockReturnValue({api_key: 'already-set'})
 
     // When
-    const result = await (gatherPublicMetadata as () => Promise<unknown>)()
+    const result = await gather()
 
     // Then
     expect(localAppContext).not.toHaveBeenCalled()
@@ -43,10 +47,38 @@ describe('gatherPublicMetadata', () => {
     vi.mocked(localAppContext).mockRejectedValue(new Error('not an app'))
 
     // When
-    const result = await (gatherPublicMetadata as () => Promise<unknown>)()
+    const result = await gather()
 
     // Then
     expect(localAppContext).toHaveBeenCalledOnce()
     expect(result).toEqual(metadata.getAllPublicMetadata())
   })
+
+  test('loads the app for the top-level app command', async () => {
+    // Given
+    vi.spyOn(metadata, 'getAllPublicMetadata').mockReturnValue({})
+    setCurrentCommandId('app')
+
+    // When
+    await gather()
+
+    // Then
+    expect(localAppContext).toHaveBeenCalledOnce()
+  })
+
+  test.each(['version', 'theme:dev', 'store:create', 'apps:something', ''])(
+    'does not load the app for the non-app command %s',
+    async (commandId) => {
+      // Given
+      vi.spyOn(metadata, 'getAllPublicMetadata').mockReturnValue({})
+      setCurrentCommandId(commandId)
+
+      // When
+      const result = await gather()
+
+      // Then
+      expect(localAppContext).not.toHaveBeenCalled()
+      expect(result).toEqual(metadata.getAllPublicMetadata())
+    },
+  )
 })

--- a/packages/app/src/cli/hooks/public_metadata.ts
+++ b/packages/app/src/cli/hooks/public_metadata.ts
@@ -1,14 +1,29 @@
 import metadata from '../metadata.js'
-import {localAppContext} from '../services/app-context.js'
 import {FanoutHookFunction} from '@shopify/cli-kit/node/plugins'
 import {cwd} from '@shopify/cli-kit/node/path'
+import {getCurrentCommandId} from '@shopify/cli-kit/node/global-context'
 
 const APP_CONTEXT_METADATA_TIMEOUT_MS = 3000
+
+/**
+ * Loading an app to gather `app_*` analytics only makes sense for `app` commands. Every other
+ * command (`version`, `theme *`, `store *`, ...) would load the whole app graph — which reaches
+ * theme-check and its ohm-js Liquid grammar — to report metadata it can't produce anyway.
+ *
+ * The command id is the canonical oclif id (`app:dev`), set by cli-kit's BaseCommand. It is empty
+ * for commands that don't extend BaseCommand, which are never app commands.
+ */
+function isAppCommand(commandId: string): boolean {
+  return commandId === 'app' || commandId.startsWith('app:')
+}
 
 async function logAppContextMetadata(directory: string): Promise<void> {
   let timer: ReturnType<typeof setTimeout> | undefined
   try {
     if (metadata.getAllPublicMetadata().api_key !== undefined) return
+
+    // Imported lazily so that non-app commands never pay for the app graph.
+    const {localAppContext} = await import('../services/app-context.js')
 
     await Promise.race([
       localAppContext({directory, skipPrompts: true}),
@@ -25,7 +40,9 @@ async function logAppContextMetadata(directory: string): Promise<void> {
 }
 
 const gatherPublicMetadata: FanoutHookFunction<'public_command_metadata', '@shopify/app'> = async () => {
-  await logAppContextMetadata(cwd())
+  if (isAppCommand(getCurrentCommandId())) {
+    await logAppContextMetadata(cwd())
+  }
   return metadata.getAllPublicMetadata()
 }
 

--- a/packages/cli-kit/src/private/node/session.test.ts
+++ b/packages/cli-kit/src/private/node/session.test.ts
@@ -4,10 +4,10 @@ import {
   getLastSeenUserIdAfterAuth,
   OAuthApplications,
   OAuthSession,
-  setCommandSessionId,
   setLastSeenAuthMethod,
   setLastSeenUserIdAfterAuth,
 } from './session.js'
+import {setCommandSessionId} from './session/command-session-id.js'
 import {
   exchangeAccessForApplicationTokens,
   exchangeCustomPartnerToken,

--- a/packages/cli-kit/src/private/node/session.ts
+++ b/packages/cli-kit/src/private/node/session.ts
@@ -13,6 +13,7 @@ import {IdentityToken, Session, Sessions} from './session/schema.js'
 import * as sessionStore from './session/store.js'
 import {pollForDeviceAuthorization, requestDeviceAuthorization} from './session/device-authorization.js'
 import {isThemeAccessSession} from './api/rest.js'
+import {getCommandSessionId} from './session/command-session-id.js'
 import {getCurrentSessionId, setCurrentSessionId} from './conf-store.js'
 import {UserEmailQueryString, UserEmailQuery} from './api/graphql/business-platform-destinations/user-email.js'
 import {outputContent, outputToken, outputDebug, outputCompleted} from '../../public/node/output.js'
@@ -118,7 +119,6 @@ type AuthMethod = 'partners_token' | 'device_auth' | 'theme_access_token' | 'cus
 
 let userId: undefined | string
 let authMethod: AuthMethod = 'none'
-let commandSessionId: string | undefined
 
 /**
  * Retrieves a stable user identifier for analytics, or `'unknown'` if none applies.
@@ -180,10 +180,6 @@ export function setLastSeenAuthMethod(method: AuthMethod) {
   authMethod = method
 }
 
-export function setCommandSessionId(sessionId: string | undefined) {
-  commandSessionId = sessionId
-}
-
 export interface EnsureAuthenticatedAdditionalOptions {
   noPrompt?: boolean
   forceRefresh?: boolean
@@ -215,6 +211,7 @@ export async function ensureAuthenticated(
 
   const sessions = (await sessionStore.fetch()) ?? {}
 
+  const commandSessionId = getCommandSessionId()
   let currentSessionId = forceNewSession ? undefined : (commandSessionId ?? getCurrentSessionId())
   if (!currentSessionId && !commandSessionId) {
     const userIds = Object.keys(sessions[fqdn] ?? {})
@@ -265,7 +262,7 @@ ${outputToken.json(applications)}
   // Save the new session info if it has changed
   if (!isEmpty(newSession)) {
     await sessionStore.store(updatedSessions)
-    if (!commandSessionId) setCurrentSessionId(newSessionId)
+    if (!getCommandSessionId()) setCurrentSessionId(newSessionId)
   }
 
   const tokens = await tokensFor(applications, completeSession)

--- a/packages/cli-kit/src/private/node/session/command-session-id.ts
+++ b/packages/cli-kit/src/private/node/session/command-session-id.ts
@@ -1,0 +1,25 @@
+/**
+ * The session selected for the current command process via `--auth-alias`.
+ *
+ * This lives in its own dependency-free module so that resetting it (the overwhelmingly common
+ * case, where no alias was passed) does not require loading the session/identity/API graph.
+ */
+let commandSessionId: string | undefined
+
+/**
+ * Get the session id selected for the current command, if any.
+ *
+ * @returns The selected session id, or undefined when no alias was selected.
+ */
+export function getCommandSessionId(): string | undefined {
+  return commandSessionId
+}
+
+/**
+ * Select a stored session for the current command process.
+ *
+ * @param sessionId - The session id to select, or undefined to clear the selection.
+ */
+export function setCommandSessionId(sessionId: string | undefined): void {
+  commandSessionId = sessionId
+}

--- a/packages/cli-kit/src/public/node/analytics.ts
+++ b/packages/cli-kit/src/public/node/analytics.ts
@@ -1,4 +1,4 @@
-import {alwaysLogAnalytics, alwaysLogMetrics, analyticsDisabled, isShopify} from './context/local.js'
+import {alwaysLogAnalytics, alwaysLogMetrics, analyticsDisabled, isShopify, isVerbose} from './context/local.js'
 import * as metadata from './metadata.js'
 import {publishMonorailEvent, MONORAIL_COMMAND_TOPIC} from './monorail.js'
 import {fanoutHooks} from './plugins.js'
@@ -44,6 +44,16 @@ interface ReportAnalyticsEventOptions {
  */
 export async function reportAnalyticsEvent(options: ReportAnalyticsEventOptions): Promise<void> {
   try {
+    const skipMonorailAnalytics = !alwaysLogAnalytics() && analyticsDisabled()
+    const skipMetricAnalytics = !alwaysLogMetrics() && analyticsDisabled()
+
+    // Building the payload fans out `public_command_metadata` to every plugin, which for app
+    // commands loads the app. When neither destination will receive anything there is nothing to
+    // build it for -- unless the user asked to see it, in which case we still build it to log it.
+    if (skipMonorailAnalytics && skipMetricAnalytics && !isVerbose()) {
+      return
+    }
+
     const payload = await buildPayload(options)
     if (payload === undefined) {
       // Nothing to log
@@ -63,8 +73,6 @@ export async function reportAnalyticsEvent(options: ReportAnalyticsEventOptions)
       return
     }
 
-    const skipMonorailAnalytics = !alwaysLogAnalytics() && analyticsDisabled()
-    const skipMetricAnalytics = !alwaysLogMetrics() && analyticsDisabled()
     if (skipMonorailAnalytics || skipMetricAnalytics) {
       outputDebug(outputContent`Skipping command analytics, payload: ${outputToken.json(payload)}`)
     }

--- a/packages/cli-kit/src/public/node/base-command.ts
+++ b/packages/cli-kit/src/public/node/base-command.ts
@@ -2,7 +2,6 @@ import {isDevelopment} from './context/local.js'
 import {addPublicMetadata} from './metadata.js'
 import {AbortError} from './error.js'
 import {outputContent, outputResult, outputToken} from './output.js'
-import {setCurrentSessionAlias} from './session.js'
 import {terminalSupportsPrompting} from './system.js'
 import {hashString} from './crypto.js'
 import {isTruthy} from './context/utilities.js'
@@ -106,7 +105,7 @@ abstract class BaseCommand extends Command {
   ): Promise<ParserOutput<TFlags, TGlobalFlags, TArgs> & {argv: string[]}> {
     let result = await super.parse<TFlags, TGlobalFlags, TArgs>(options, argv)
     result = await this.resultWithEnvironment<TFlags, TGlobalFlags, TArgs>(result, options, argv)
-    await setCurrentSessionAlias(result.flags['auth-alias'])
+    await this.selectSessionAlias(result.flags['auth-alias'])
     await addFromParsedFlags(result.flags)
     return {...result, ...{argv: result.argv as string[]}}
   }
@@ -131,6 +130,22 @@ This flag is required in non-interactive terminal environments, such as a CI env
         )
       }
     })
+  }
+
+  /**
+   * Resolving an alias needs the session/identity/API graph, so it is imported on demand. Almost no
+   * invocation passes `--auth-alias`, and clearing the selection only needs the tiny state module.
+   *
+   * @param alias - The account alias passed via `--auth-alias`, if any.
+   */
+  private async selectSessionAlias(alias?: string): Promise<void> {
+    if (alias) {
+      const {setCurrentSessionAlias} = await import('./session.js')
+      await setCurrentSessionAlias(alias)
+      return
+    }
+    const {setCommandSessionId} = await import('../../private/node/session/command-session-id.js')
+    setCommandSessionId(undefined)
   }
 
   private async resultWithEnvironment<

--- a/packages/cli-kit/src/public/node/local-storage.ts
+++ b/packages/cli-kit/src/public/node/local-storage.ts
@@ -67,6 +67,17 @@ export class LocalStorage<T extends Record<string, any>> {
   }
 
   /**
+   * The number of values held in the local storage.
+   *
+   * Useful to avoid an unnecessary write when there is nothing to clear.
+   *
+   * @returns The number of stored keys.
+   */
+  get size(): number {
+    return this.config.size
+  }
+
+  /**
    * Clear the local storage (delete all values).
    *
    * @throws AbortError if a permission error occurs.

--- a/packages/cli-kit/src/public/node/notifications-system.ts
+++ b/packages/cli-kit/src/public/node/notifications-system.ts
@@ -13,6 +13,12 @@ import {NotificationKey, NotificationsKey, cacheRetrieve, cacheStore} from '../.
 
 const URL = 'https://cdn.shopify.com/static/cli/notifications.json'
 const EMPTY_CACHE_MESSAGE = 'Cache is empty'
+/**
+ * How long a cached notifications payload is considered fresh enough to skip the background refresh.
+ * Refreshing spawns a whole extra CLI process, so doing it on literally every command is wasteful for
+ * a static CDN document.
+ */
+const NOTIFICATIONS_REFRESH_INTERVAL_MS = 60 * 60 * 1000
 const COMMANDS_TO_SKIP = [
   'notifications:list',
   'notifications:generate',
@@ -167,6 +173,18 @@ async function cacheNotifications(notifications: string): Promise<void> {
 }
 
 /**
+ * Whether the cached notifications payload is recent enough that refreshing it can be skipped.
+ *
+ * @returns True when a cached payload exists and is younger than the refresh interval.
+ */
+function notificationsCacheIsFresh(): boolean {
+  const cacheKey: NotificationsKey = `notifications-${url()}`
+  const cached = cacheRetrieve(cacheKey)
+  if (cached?.value === undefined) return false
+  return Date.now() - cached.timestamp < NOTIFICATIONS_REFRESH_INTERVAL_MS
+}
+
+/**
  * Fetch notifications in background as a detached process.
  *
  * @param currentCommand - The current Shopify command being run.
@@ -180,6 +198,10 @@ export function fetchNotificationsInBackground(
 ): void {
   if (skipNotifications(currentCommand, environment)) return
   if (!argv[0] || !argv[1]) return
+  if (notificationsCacheIsFresh()) {
+    outputDebug('Notifications cache is still fresh, skipping background refresh')
+    return
+  }
 
   // Run the Shopify command the same way as the current execution
   const nodeBinary = argv[0]

--- a/packages/cli-kit/src/public/node/session.test.ts
+++ b/packages/cli-kit/src/public/node/session.test.ts
@@ -14,12 +14,8 @@ import {
 import {nonRandomUUID} from './crypto.js'
 import {getAppAutomationToken} from './environment.js'
 import {shopifyFetch} from './http.js'
-import {
-  ensureAuthenticated,
-  setCommandSessionId,
-  setLastSeenAuthMethod,
-  setLastSeenUserIdAfterAuth,
-} from '../../private/node/session.js'
+import {ensureAuthenticated, setLastSeenAuthMethod, setLastSeenUserIdAfterAuth} from '../../private/node/session.js'
+import {setCommandSessionId} from '../../private/node/session/command-session-id.js'
 import * as sessionStore from '../../private/node/session/store.js'
 import {ApplicationToken} from '../../private/node/session/schema.js'
 import {
@@ -39,6 +35,7 @@ const partnersToken: ApplicationToken = {
 }
 
 vi.mock('../../private/node/session.js')
+vi.mock('../../private/node/session/command-session-id.js')
 vi.mock('../../private/node/session/exchange.js')
 vi.mock('../../private/node/session/store.js')
 vi.mock('./environment.js')

--- a/packages/cli-kit/src/public/node/session.ts
+++ b/packages/cli-kit/src/public/node/session.ts
@@ -17,10 +17,10 @@ import {
   PartnersAPIScope,
   StorefrontRendererScope,
   ensureAuthenticated,
-  setCommandSessionId,
   setLastSeenAuthMethod,
   setLastSeenUserIdAfterAuth,
 } from '../../private/node/session.js'
+import {setCommandSessionId} from '../../private/node/session/command-session-id.js'
 import {isThemeAccessSession} from '../../private/node/api/rest.js'
 
 /**

--- a/packages/cli-kit/src/public/node/vendor/otel-js/utils/throttle.ts
+++ b/packages/cli-kit/src/public/node/vendor/otel-js/utils/throttle.ts
@@ -61,6 +61,8 @@ export function throttle<T extends (...args: unknown[]) => unknown>(
       lastArgs = null
     } else if (!timeout && trailing !== false) {
       timeout = setTimeout(later, remaining)
+      // A trailing metrics export must never hold the CLI process open waiting to fire.
+      timeout.unref?.()
     }
     return result
   }

--- a/packages/cli/src/hooks/app-init.ts
+++ b/packages/cli/src/hooks/app-init.ts
@@ -8,10 +8,12 @@ import {randomUUID} from 'crypto'
  * LocalStorage class only at call time, and uses Node's native crypto.
  */
 const init: Hook<'init'> = async (_options) => {
-  // Lazy import to clear the command storage (equivalent to clearCachedCommandInfo)
+  // Lazy import to clear the command storage (equivalent to clearCachedCommandInfo).
+  // Clearing writes the file atomically (temp file + rename + fsync), so skip it when the store is
+  // already empty -- which is the case for every command that doesn't touch app command state.
   const {LocalStorage} = await import('@shopify/cli-kit/node/local-storage')
   const store = new LocalStorage({projectName: 'shopify-cli-app-command'})
-  store.clear()
+  if (store.size > 0) store.clear()
 
   // Set a unique run ID so parallel commands don't collide in the cache
   process.env.COMMAND_RUN_ID = randomUUID()


### PR DESCRIPTION
## What

`shopify version` goes from **369 ms → 180 ms (−51%)**. The win applies to every command that isn't an `app` command.

| | before | after | Δ |
|---|---|---|---|
| `version` total | 369 ms | **180 ms** | −189 ms (−51%) |
| `version` tail after output | 199 ms | 8 ms | −191 ms |
| `version` time to first output | 222 ms | 213 ms | −9 ms |
| `app --help` time to first output | 182 ms | 172 ms | −10 ms |
| modules loaded / bytes read | 112 / 8.5 MB | 90 / 6.5 MB | −22 / −2.0 MB |

Measured on `bin/run.js` (the production entry point — `bin/dev.js` sets `SHOPIFY_CLI_ENV=development`, which disables analytics and takes a different path), with `HOME` pointed at a throwaway dir so the 300/day analytics rate limit couldn't skew repeats, 15 runs, load average under 4.

## Why

The dominant cost was the `public_command_metadata` hook. oclif fans it out on **every** command via `analytics.ts`, and `@shopify/app`'s implementation statically imported `localAppContext` — dragging in the whole app graph, including `@shopify/theme-check-common`, whose **ohm-js Liquid grammar is compiled from source at module-evaluation time**. That was ~190 ms of the 199 ms that ran *after* the command had already printed its output.

Making the import dynamic is **not** sufficient: the hook always calls `localAppContext()`, so the import happens anyway. It now gates on `getCurrentCommandId()`, which cli-kit's `BaseCommand` already sets to the canonical oclif id — so no hook signature or fanout plumbing had to change.

## Also included

- **analytics** — check the `analyticsDisabled`/`alwaysLog*` gates *before* `buildPayload()`, so nothing is built when neither destination can receive it. Guarded with `isVerbose()` so `--verbose` still logs the would-be payload.
- **base-command** — import `session.js` on demand, only when `--auth-alias` is passed (`setCurrentSessionAlias(undefined)` returns immediately). `commandSessionId` moves into a new dependency-free `private/node/session/command-session-id.ts` so clearing the selection stays correct without loading the session/identity/API graph. This is the ~10 ms pre-output gain.
- **otel** — `unref()` the throttle timer. It doesn't fire today (`onForceFlush` is called once per process), but a second call within the window would pin the process for up to 5 s.
- **notifications** — skip the background refresh, which spawns a whole extra CLI process, when the cached payload is under an hour old. Previously it spawned on every non-CI command with no freshness check.
- **app-init** — skip the fsync'd atomic write when the store is already empty.

## Trade-off to review

**Non-app commands no longer report `app_*` analytics fields.** They couldn't produce meaningful ones without an app in the working directory, but a non-app command run *inside* an app directory now loses them too. Worth a look from whoever owns those dashboards.

## Testing

- 3790 unit tests pass across `cli-kit`, `app`, `cli`
- `type-check` and `lint` pass across all 13 projects (CI-equivalent, `--skip-nx-cache`)
- `knip` clean; `refresh-code-documentation` produces no churn
- Bundle builds; smoke-tested `version`, `--version`, `app/theme/store/auth/config --help`, `app build --help`, `--verbose`, and `--auth-alias <bad>` (still errors correctly through the lazy import)

Two test files timed out on full-suite runs — different files on different runs, both pass in isolation, both slow timing-based suites (16 s and 26 s of test time against a 5 s per-test limit). Pre-existing flakes.

## Unrelated bug found while measuring

`packages/cli/project.json` declares `build` with `outputs: ["{workspaceRoot}/dist"]` (should be `{projectRoot}/dist`) and `bundle` with no `inputs`/`outputs` at all. nx consequently serves stale bundles: with these changes fully stashed, `dist` still contained the compiled new code. Every number above comes from `rm -rf dist && nx bundle cli --skip-nx-cache`. Not fixed here — it deserves its own PR since touching nx caching could affect CI.

## Dead end worth recording

Stubbing out 1.5 MB of `graphql` + OpenTelemetry + Bugsnag chunks saved **−1.4 ms**. Bytes loaded are nearly free — V8 lazy-parses and the CJS bodies never execute. Only module bodies that actually *run* cost anything, which is why one ohm-js grammar compile outweighed 2 MB of dependencies. Same for the 3.5 MB TypeScript compiler chunk (pulled in by `@oclif/core`'s guarded `require('typescript')`): never executed, ~2 ms. The remaining ~213 ms of pre-output latency lives in `base-command`'s import graph, not in bundle size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
