### PR TITLE
[Tests] os username utility coverage

### DIFF
--- a/packages/cli-kit/src/public/node/os.test.ts
+++ b/packages/cli-kit/src/public/node/os.test.ts
@@ -1,7 +1,18 @@
-import {platformAndArch} from './os.js'
-import {describe, test, expect, vi} from 'vitest'
+import {platformAndArch, username} from './os.js'
+import {execa} from 'execa'
+import {describe, test, expect, vi, beforeEach, afterEach} from 'vitest'
+import {userInfo as osUserInfo} from 'os'
 
 vi.mock('node:process')
+vi.mock('execa')
+vi.mock('os', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('os')>()
+  return {
+    ...actual,
+    userInfo: vi.fn(),
+  }
+})
+vi.mock('./output.js')
 
 describe('platformAndArch', () => {
   test("returns the right architecture when it's x64", () => {
@@ -38,5 +49,140 @@ describe('platformAndArch', () => {
     // Got
     expect(got.platform).toEqual('windows')
     expect(got.arch).toEqual('arm64')
+  })
+})
+
+describe('username', () => {
+  beforeEach(() => {
+    vi.stubEnv('SUDO_USER', '')
+    vi.stubEnv('C9_USER', '')
+    vi.stubEnv('LOGNAME', '')
+    vi.stubEnv('USER', '')
+    vi.stubEnv('LNAME', '')
+    vi.stubEnv('USERNAME', '')
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  test('returns SUDO_USER if set', async () => {
+    vi.stubEnv('SUDO_USER', 'sudo-user-name')
+
+    const got = await username()
+
+    expect(got).toEqual('sudo-user-name')
+    expect(osUserInfo).not.toHaveBeenCalled()
+    expect(execa).not.toHaveBeenCalled()
+  })
+
+  test('returns USER if USER is set and SUDO_USER/C9_USER/LOGNAME are not', async () => {
+    vi.stubEnv('USER', 'user-name')
+
+    const got = await username()
+
+    expect(got).toEqual('user-name')
+    expect(osUserInfo).not.toHaveBeenCalled()
+    expect(execa).not.toHaveBeenCalled()
+  })
+
+  test('returns C9_USER if set and SUDO_USER is not', async () => {
+    vi.stubEnv('C9_USER', 'c9-user-name')
+    const got = await username()
+    expect(got).toEqual('c9-user-name')
+  })
+
+  test('returns LOGNAME if set and SUDO_USER/C9_USER are not', async () => {
+    vi.stubEnv('LOGNAME', 'logname-user-name')
+    const got = await username()
+    expect(got).toEqual('logname-user-name')
+  })
+
+  test('returns LNAME if set and SUDO_USER/C9_USER/LOGNAME/USER are not', async () => {
+    vi.stubEnv('LNAME', 'lname-user-name')
+    const got = await username()
+    expect(got).toEqual('lname-user-name')
+  })
+
+  test('returns USERNAME if set and others are not', async () => {
+    vi.stubEnv('USERNAME', 'username-user-name')
+    const got = await username()
+    expect(got).toEqual('username-user-name')
+  })
+
+  test('returns os.userInfo().username if set and environment variables are not', async () => {
+    vi.mocked(osUserInfo).mockReturnValue({username: 'userInfo-username'} as any)
+
+    const got = await username()
+
+    expect(got).toEqual('userInfo-username')
+    expect(osUserInfo).toHaveBeenCalled()
+    expect(execa).not.toHaveBeenCalled()
+  })
+
+  test('falls back to execa if os.userInfo() throws an error', async () => {
+    vi.mocked(osUserInfo).mockImplementation(() => {
+      throw new Error('userInfo error')
+    })
+    vi.mocked(execa).mockResolvedValue({stdout: 'id-username'} as any)
+
+    const got = await username('linux')
+
+    expect(got).toEqual('id-username')
+    expect(osUserInfo).toHaveBeenCalled()
+    expect(execa).toHaveBeenCalled()
+  })
+
+  test('on win32 platform, queries whoami and cleans domain prefix', async () => {
+    vi.mocked(osUserInfo).mockImplementation(() => {
+      throw new Error('userInfo error')
+    })
+    vi.mocked(execa).mockResolvedValueOnce({stdout: 'MYDOMAIN\\test-win-user'} as any)
+
+    const got = await username('win32')
+
+    expect(got).toEqual('test-win-user')
+    expect(execa).toHaveBeenCalledWith('whoami')
+  })
+
+  test('on non-win32 platform, queries uid and then resolves it to a name', async () => {
+    vi.mocked(osUserInfo).mockImplementation(() => {
+      throw new Error('userInfo error')
+    })
+    vi.mocked(execa)
+      .mockResolvedValueOnce({stdout: '1001'} as any)
+      .mockResolvedValueOnce({stdout: 'posix-user-name'} as any)
+
+    const got = await username('linux')
+
+    expect(got).toEqual('posix-user-name')
+    expect(execa).toHaveBeenCalledWith('id', ['-u'])
+    expect(execa).toHaveBeenCalledWith('id', ['-un', '1001'])
+  })
+
+  test('on non-win32 platform, falls back to id prefix when resolving uid fails', async () => {
+    vi.mocked(osUserInfo).mockImplementation(() => {
+      throw new Error('userInfo error')
+    })
+    vi.mocked(execa)
+      .mockResolvedValueOnce({stdout: '1001'} as any)
+      .mockRejectedValueOnce(new Error('id -un failed'))
+
+    const got = await username('darwin')
+
+    expect(got).toEqual('no-username-1001')
+    expect(execa).toHaveBeenCalledWith('id', ['-u'])
+    expect(execa).toHaveBeenCalledWith('id', ['-un', '1001'])
+  })
+
+  test('returns null when top-level execa throws an error', async () => {
+    vi.mocked(osUserInfo).mockImplementation(() => {
+      throw new Error('userInfo error')
+    })
+    vi.mocked(execa).mockRejectedValueOnce(new Error('whoami failed'))
+
+    const got = await username('win32')
+
+    expect(got).toBeNull()
   })
 })


### PR DESCRIPTION
### WHY are these changes introduced?

Enhance unit test coverage for the `username` utility in `os.ts`. Previously, the module lacked comprehensive tests covering its multiple fallback layers, platform-specific code paths, and logical conditions.

### WHAT is this pull request doing?

This pull request implements thorough unit tests for the `username` utility inside `packages/cli-kit/src/public/node/os.test.ts`. 
Specifically, it covers:
- Early-return check for multiple priority environment variables (`SUDO_USER`, `USER`, `C9_USER`, `LOGNAME`, `LNAME`, `USERNAME`).
- Fallback check of calling `os.userInfo()` when priority environment variables are not set.
- Mocking and verifying the catch block for `os.userInfo()` when it throws an error.
- Checking platform-specific subprocess calls (Windows' `whoami` and Unix's `id -u` / `id -un`) when environment variables and `userInfo` are unavailable or throw errors.
- Verifying the fallback when POSIX name resolution fails (`no-username-<uid>`).
- All original `platformAndArch` tests are preserved.

### How to test your changes?

CI

### Post-release steps

None.

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [10203123816950889352](https://jules.google.com/task/10203123816950889352) started by @gonzaloriestra*