### PR TITLE
[Refactor] Optimize and simplify getOrCreateHiddenShopifyFolder

### DIFF
--- a/packages/cli-kit/src/public/node/hidden-folder.ts
+++ b/packages/cli-kit/src/public/node/hidden-folder.ts
@@ -13,13 +13,14 @@ const HIDDEN_FOLDER_NAME = '.shopify'
  */
 export async function getOrCreateHiddenShopifyFolder(directory: string): Promise<string> {
   const hiddenFolder = joinPath(directory, HIDDEN_FOLDER_NAME)
-  const gitignorePath = joinPath(hiddenFolder, '.gitignore')
-  // Check if both the folder and .gitignore exist
-  const [folderExists, gitignoreExists] = await Promise.all([fileExists(hiddenFolder), fileExists(gitignorePath)])
+  const folderExists = await fileExists(hiddenFolder)
   if (!folderExists) {
     outputDebug(outputContent`Creating hidden .shopify folder at ${outputToken.path(hiddenFolder)}...`)
     await mkdir(hiddenFolder)
   }
+
+  const gitignorePath = joinPath(hiddenFolder, '.gitignore')
+  const gitignoreExists = folderExists && (await fileExists(gitignorePath))
   if (!gitignoreExists) {
     outputDebug(outputContent`Creating .gitignore in ${outputToken.path(hiddenFolder)}...`)
     await writeFile(gitignorePath, `# Ignore the entire ${HIDDEN_FOLDER_NAME} directory\n*`)


### PR DESCRIPTION
### WHY are these changes introduced?

In `getOrCreateHiddenShopifyFolder`, checking the existence of both the `.shopify` directory and `.shopify/.gitignore` concurrently is redundant and performs unnecessary I/O when the parent directory does not exist.

### WHAT is this pull request doing?

Refactors `getOrCreateHiddenShopifyFolder` in `packages/cli-kit/src/public/node/hidden-folder.ts` to check folder existence sequentially, bypassing the check for `.gitignore` if the parent folder does not exist.

### How to test your changes?

CI

### Post-release steps

None

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [14472535247966507062](https://jules.google.com/task/14472535247966507062) started by @gonzaloriestra*