### PR TITLE
Fix theme check snippet rendering

### DIFF
--- a/.changeset/theme-check-snippet-in-memory.md
+++ b/.changeset/theme-check-snippet-in-memory.md
@@ -1,0 +1,6 @@
+---
+'@shopify/theme': patch
+'@shopify/app': patch
+---
+
+Stop theme check from crashing when a theme file becomes unreadable while the checks run

--- a/packages/app/src/cli/services/build/theme-check.test.ts
+++ b/packages/app/src/cli/services/build/theme-check.test.ts
@@ -1,0 +1,48 @@
+import {runThemeCheck} from './theme-check.js'
+import {inTemporaryDirectory} from '@shopify/cli-kit/node/fs'
+import {Severity, SourceCodeType, themeCheckRun, type Config, type Offense, type Theme} from '@shopify/theme-check-node'
+import {describe, expect, test, vi} from 'vitest'
+
+vi.mock('@shopify/theme-check-node', async () => {
+  const actual: typeof import('@shopify/theme-check-node') = await vi.importActual('@shopify/theme-check-node')
+  return {...actual, themeCheckRun: vi.fn()}
+})
+
+describe('runThemeCheck', () => {
+  test('renders snippets from the in-memory theme', async () => {
+    await inTemporaryDirectory(async (directory) => {
+      const uri = 'file:///file-that-does-not-exist.liquid'
+      const theme: Theme = [
+        {
+          uri,
+          type: SourceCodeType.LiquidHtml,
+          source: 'Line1\nLine2\nLine3',
+          ast: new Error('unparsed'),
+        },
+      ]
+      const offenses: Offense[] = [
+        {
+          type: SourceCodeType.LiquidHtml,
+          check: 'LiquidHTMLSyntaxError',
+          message: 'Attempting to close HtmlElement',
+          uri,
+          severity: Severity.ERROR,
+          start: {index: 0, line: 1, character: 0},
+          end: {index: 10, line: 1, character: 10},
+        },
+      ]
+      const config: Config = {
+        context: 'app',
+        settings: {},
+        checks: [],
+        rootUri: '',
+      }
+      vi.mocked(themeCheckRun).mockResolvedValue({offenses, theme, config})
+
+      const result = await runThemeCheck(directory)
+
+      expect(themeCheckRun).toHaveBeenCalledWith(directory, 'theme-check:theme-app-extension')
+      expect(result).toContain('2  Line2')
+    })
+  })
+})

--- a/packages/app/src/cli/services/build/theme-check.ts
+++ b/packages/app/src/cli/services/build/theme-check.ts
@@ -1,16 +1,28 @@
-import {fileExists, readFileSync} from '@shopify/cli-kit/node/fs'
+import {fileExists} from '@shopify/cli-kit/node/fs'
 import {joinPath} from '@shopify/cli-kit/node/path'
 import {itemToString} from '@shopify/cli-kit/node/output'
 import {TokenItem} from '@shopify/cli-kit/node/ui'
-import {Severity, type Offense, check, path as pathUtils} from '@shopify/theme-check-node'
+import {Severity, type Offense, type Theme, themeCheckRun} from '@shopify/theme-check-node'
+
+/** The contents of every theme file, keyed by its normalized uri. */
+type ThemeSourcesByUri = Map<string, string>
 
 /**
- * Returns a code snippet from a file. All line numbers given MUST be zero indexed
+ * Theme check reads every file before running the checks, so their contents are
+ * already in memory by the time offenses are rendered. Snippets are built from
+ * that copy rather than read from disk again: a file can be deleted, moved, or
+ * become unreadable while the checks run, and re-reading it made the build
+ * crash after all the checks had already passed.
  */
-function getSnippet(uri: string, startLine: number, endLine: number) {
-  const absolutePath = pathUtils.fsPath(uri)
-  const fileContent = readFileSync(absolutePath).toString()
-  const lines = fileContent.split('\n')
+function themeSourcesByUri(theme: Theme): ThemeSourcesByUri {
+  return new Map(theme.map((sourceCode) => [sourceCode.uri, sourceCode.source]))
+}
+
+/**
+ * Returns a code snippet from a file's contents. All line numbers given MUST be zero indexed
+ */
+function getSnippet(source: string, startLine: number, endLine: number) {
+  const lines = source.split('\n')
   const snippetLines = lines.slice(startLine, endLine + 1)
   const isSingleLine = snippetLines.length === 1
 
@@ -45,16 +57,20 @@ function severityToToken(severity: Severity) {
 /**
  * Format theme-check Offenses into a format for cli-kit to output.
  */
-function formatOffenses(offenses: Offense[]): TokenItem {
+function formatOffenses(offenses: Offense[], themeSources: ThemeSourcesByUri): TokenItem {
   const offenseBodies = offenses.map((offense, index) => {
     const {message, uri, start, end, check, severity} = offense
-    // Theme check line numbers are zero indexed, but intuitively 1-indexed
-    const codeSnippet = getSnippet(uri, start.line, end.line)
+    const source = themeSources.get(uri)
+
+    // Theme check line numbers are zero indexed, but intuitively 1-indexed.
+    // The snippet is omitted when the file contents are unavailable, so that a
+    // missing snippet never hides the offense itself.
+    const codeSnippet = source === undefined ? [] : [`\n\n${getSnippet(source, start.line, end.line)}`]
 
     // Ensure enough padding between offenses
     const offensePadding = index === offenses.length - 1 ? '' : '\n\n'
 
-    return [severityToToken(severity), {bold: check}, {subdued: `\n${message}`}, `\n\n${codeSnippet}`, offensePadding]
+    return [severityToToken(severity), {bold: check}, {subdued: `\n${message}`}, ...codeSnippet, offensePadding]
   })
 
   return offenseBodies.flat()
@@ -66,7 +82,7 @@ export async function runThemeCheck(directory: string): Promise<string> {
   // user config; otherwise use the bundled theme-app-extension defaults.
   const hasUserConfig = await fileExists(joinPath(directory, '.theme-check.yml'))
   const configPath = hasUserConfig ? undefined : 'theme-check:theme-app-extension'
-  const offenses = await check(directory, configPath)
-  const formattedOffenses = formatOffenses(offenses)
+  const {offenses, theme} = await themeCheckRun(directory, configPath)
+  const formattedOffenses = formatOffenses(offenses, themeSourcesByUri(theme))
   return itemToString(formattedOffenses)
 }

--- a/packages/theme/src/cli/commands/theme/check.ts
+++ b/packages/theme/src/cli/commands/theme/check.ts
@@ -160,7 +160,7 @@ export async function runThemeCheck(path: string, outputFormat: string, config?:
   const offensesByFile = sortOffenses(offenses)
 
   if (outputFormat === 'text') {
-    renderOffensesText(offensesByFile, path, environment)
+    renderOffensesText(offensesByFile, path, theme, environment)
 
     // Use renderSuccess when theres no offenses
     const render = offenses.length ? renderInfo : renderSuccess

--- a/packages/theme/src/cli/services/check.test.ts
+++ b/packages/theme/src/cli/services/check.test.ts
@@ -7,7 +7,7 @@ import {
   renderOffensesText,
   sortOffenses,
 } from './check.js'
-import {fileExists, readFileSync, writeFile} from '@shopify/cli-kit/node/fs'
+import {fileExists, writeFile} from '@shopify/cli-kit/node/fs'
 import {outputInfo, outputSuccess} from '@shopify/cli-kit/node/output'
 import {renderInfo} from '@shopify/cli-kit/node/ui'
 import {
@@ -18,12 +18,11 @@ import {
   type Offense,
   type Theme,
 } from '@shopify/theme-check-node'
-import {Mock, beforeEach, describe, expect, test, vi} from 'vitest'
+import {beforeEach, describe, expect, test, vi, type Mock} from 'vitest'
 
 vi.mock('@shopify/cli-kit/node/fs', async () => ({
   fileExists: vi.fn(),
   writeFile: vi.fn(),
-  readFileSync: vi.fn(),
 }))
 
 vi.mock('@shopify/cli-kit/node/output', async () => ({
@@ -44,10 +43,7 @@ vi.mock('@shopify/cli-kit/node/ui', async () => ({
 }))
 
 describe('formatOffenses', () => {
-  beforeEach(() => {
-    const readFileMock = readFileSync as Mock
-    readFileMock.mockReturnValue({toString: () => 'Line1\nLine2\nLine3'})
-  })
+  const themeSources = new Map([['file:///path/to/file', 'Line1\nLine2\nLine3']])
 
   test('should format offenses correctly', () => {
     const offenses: Offense[] = [
@@ -62,7 +58,7 @@ describe('formatOffenses', () => {
       },
     ]
 
-    const result = formatOffenses(offenses)
+    const result = formatOffenses(offenses, themeSources)
 
     /**
      * Line numbers are 0-indexed to remain backwards compatible with the ruby theme-check output
@@ -99,7 +95,7 @@ describe('formatOffenses', () => {
       },
     ]
 
-    const result = formatOffenses(offenses)
+    const result = formatOffenses(offenses, themeSources)
 
     expect(result).toEqual([
       {error: '\n[error]:'},
@@ -111,6 +107,29 @@ describe('formatOffenses', () => {
       {bold: 'LiquidHTMLSyntaxError'},
       {subdued: '\nAttempting to close HtmlElement'},
       '\n\n3  Line3',
+      '',
+    ])
+  })
+
+  test('should omit the code snippet when the file contents are unavailable', () => {
+    const offenses: Offense[] = [
+      {
+        type: SourceCodeType.LiquidHtml,
+        check: 'LiquidHTMLSyntaxError',
+        message: 'Attempting to close HtmlElement',
+        uri: 'file:///path/to/file-removed-during-the-run',
+        severity: Severity.ERROR,
+        start: {index: 0, line: 1, character: 0},
+        end: {index: 10, line: 1, character: 10},
+      },
+    ]
+
+    const result = formatOffenses(offenses, themeSources)
+
+    expect(result).toEqual([
+      {error: '\n[error]:'},
+      {bold: 'LiquidHTMLSyntaxError'},
+      {subdued: '\nAttempting to close HtmlElement'},
       '',
     ])
   })
@@ -225,12 +244,16 @@ describe('formatSummary', () => {
 })
 
 describe('renderOffensesText', () => {
-  beforeEach(() => {
-    const readFileMock = readFileSync as Mock
-    readFileMock.mockReturnValue('Line1\nLine2\nLine3')
-  })
-
   test('should call renderInfo for offenses', () => {
+    // The AST is never read when rendering offenses, only the source is
+    const theme: Theme = [
+      {
+        uri: 'file:///path/to/file',
+        type: SourceCodeType.LiquidHtml,
+        source: 'Line1\nLine2\nLine3',
+        ast: new Error('unparsed'),
+      },
+    ]
     const offensesByFile = {
       '/path/to/file': [
         {
@@ -246,7 +269,7 @@ describe('renderOffensesText', () => {
     }
     const themeRootPath = '/path/to'
 
-    renderOffensesText(offensesByFile, themeRootPath)
+    renderOffensesText(offensesByFile, themeRootPath, theme)
 
     expect(renderInfo).toHaveBeenCalledTimes(1)
   })

--- a/packages/theme/src/cli/services/check.ts
+++ b/packages/theme/src/cli/services/check.ts
@@ -1,4 +1,4 @@
-import {fileExists, readFileSync, writeFile} from '@shopify/cli-kit/node/fs'
+import {fileExists, writeFile} from '@shopify/cli-kit/node/fs'
 import {outputResult, outputInfo, outputSuccess} from '@shopify/cli-kit/node/output'
 import {joinPath} from '@shopify/cli-kit/node/path'
 import {renderInfo} from '@shopify/cli-kit/node/ui'
@@ -16,6 +16,9 @@ import {
 import YAML from 'yaml'
 
 type OffenseMap = Record<string, Offense[]>
+
+/** The contents of every theme file, keyed by its normalized uri. */
+type ThemeSourcesByUri = Map<string, string>
 
 interface TransformedOffense {
   check: string
@@ -70,12 +73,22 @@ function severityToLabel(severity: Severity) {
 }
 
 /**
- * Returns a code snippet from a file. All line numbers given MUST be zero indexed
+ * Theme check reads every theme file before running the checks, so their
+ * contents are already in memory by the time offenses are rendered. Snippets
+ * are built from that copy rather than read from disk again: a file can be
+ * deleted, moved, or become unreadable while the checks run (temporary
+ * directories, cloud-synced folders, other processes), and re-reading it made
+ * the command crash after all the checks had already passed.
  */
-function getSnippet(uri: string, startLine: number, endLine: number) {
-  const fsPath = pathUtils.fsPath(uri)
-  const fileContent = readFileSync(fsPath).toString()
-  const lines = fileContent.split('\n')
+function themeSourcesByUri(theme: Theme): ThemeSourcesByUri {
+  return new Map(theme.map((sourceCode) => [sourceCode.uri, sourceCode.source]))
+}
+
+/**
+ * Returns a code snippet from a file's contents. All line numbers given MUST be zero indexed
+ */
+function getSnippet(source: string, startLine: number, endLine: number) {
+  const lines = source.split('\n')
   const snippetLines = lines.slice(startLine, endLine + 1)
   const isSingleLine = snippetLines.length === 1
 
@@ -110,16 +123,20 @@ function severityToToken(severity: Severity) {
 /**
  * Format theme-check Offenses into a format for cli-kit to output.
  */
-export function formatOffenses(offenses: Offense[]) {
+export function formatOffenses(offenses: Offense[], themeSources: ThemeSourcesByUri) {
   const offenseBodies = offenses.map((offense, index) => {
     const {message, uri, start, end, check, severity} = offense
-    // Theme check line numbers are zero indexed, but intuitively 1-indexed
-    const codeSnippet = getSnippet(uri, start.line, end.line)
+    const source = themeSources.get(uri)
+
+    // Theme check line numbers are zero indexed, but intuitively 1-indexed.
+    // The snippet is omitted when the file contents are unavailable, so that a
+    // missing snippet never hides the offense itself.
+    const codeSnippet = source === undefined ? [] : [`\n\n${getSnippet(source, start.line, end.line)}`]
 
     // Ensure enough padding between offenses
     const offensePadding = index === offenses.length - 1 ? '' : '\n\n'
 
-    return [severityToToken(severity), {bold: check}, {subdued: `\n${message}`}, `\n\n${codeSnippet}`, offensePadding]
+    return [severityToToken(severity), {bold: check}, {subdued: `\n${message}`}, ...codeSnippet, offensePadding]
   })
 
   return offenseBodies.flat()
@@ -189,7 +206,13 @@ export function formatSummary(offenses: Offense[], offensesByFile: OffenseMap, t
   return summary
 }
 
-export function renderOffensesText(offensesByFile: OffenseMap, themeRootPath: string, environment?: string) {
+export function renderOffensesText(
+  offensesByFile: OffenseMap,
+  themeRootPath: string,
+  theme: Theme,
+  environment?: string,
+) {
+  const themeSources = themeSourcesByUri(theme)
   const fileNames = Object.keys(offensesByFile).sort()
 
   fileNames.forEach((filePath) => {
@@ -199,7 +222,7 @@ export function renderOffensesText(offensesByFile: OffenseMap, themeRootPath: st
 
     renderInfo({
       headline: environment ? `[${environment}] ${headlineFilePath}` : headlineFilePath,
-      body: formatOffenses(offensesByFile[filePath]!),
+      body: formatOffenses(offensesByFile[filePath]!, themeSources),
     })
   })
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/shop/issues/issues/50148

<!--
  Context about the problem that's being addressed.
-->

### WHAT is this pull request doing?

Render offense snippets from source already loaded by theme check instead of reopening files from disk. This prevents theme checks and app extension builds from failing when files disappear or become unreadable after analysis, while preserving snippets and avoiding redundant synchronous I/O.

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
  You can post a comment with `/snapit` to generate a snapshot of the changes to be tested.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [x] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`
