### PR TITLE
Fix malformed local storage recovery

### DIFF
--- a/.changeset/resilient-local-storage-json.md
+++ b/.changeset/resilient-local-storage-json.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': patch
+---
+
+Recover from BOM-prefixed or malformed Shopify CLI local storage.

--- a/packages/cli-kit/src/public/node/local-storage.test.ts
+++ b/packages/cli-kit/src/public/node/local-storage.test.ts
@@ -1,6 +1,7 @@
 import {LocalStorage} from './local-storage.js'
-import {inTemporaryDirectory} from './fs.js'
+import {inTemporaryDirectory, readFile, writeFile} from './fs.js'
 import {AbortError} from './error.js'
+import {joinPath} from './path.js'
 import * as fs from './fs.js'
 import {describe, expect, test, vi} from 'vitest'
 
@@ -60,6 +61,36 @@ describe('storage', () => {
       // Then
       expect(got).toEqual('test')
       expect(got2).toEqual(undefined)
+    })
+  })
+
+  test('reads values from JSON prefixed with a byte order mark', async () => {
+    await inTemporaryDirectory(async (cwd) => {
+      // Given
+      await writeFile(joinPath(cwd, 'config.json'), '\uFEFF{"testValue":"test"}')
+
+      // When
+      const storage = new LocalStorage<TestSchema>({cwd})
+
+      // Then
+      expect(storage.get('testValue')).toEqual('test')
+    })
+  })
+
+  test('recovers from malformed JSON on the next write', async () => {
+    await inTemporaryDirectory(async (cwd) => {
+      // Given
+      const configPath = joinPath(cwd, 'config.json')
+      await writeFile(configPath, '{"testValue":')
+
+      // When
+      const storage = new LocalStorage<TestSchema>({cwd})
+      const valueBeforeRecovery = storage.get('testValue')
+      storage.set('testValue', 'recovered')
+
+      // Then
+      expect(valueBeforeRecovery).toBeUndefined()
+      expect(JSON.parse(await readFile(configPath))).toEqual({testValue: 'recovered'})
     })
   })
 })

--- a/packages/cli-kit/src/public/node/local-storage.ts
+++ b/packages/cli-kit/src/public/node/local-storage.ts
@@ -4,6 +4,12 @@ import {dirname} from './path.js'
 import {TokenItem} from './ui.js'
 import Config from 'conf'
 
+function deserializeJson<T>(value: string): T {
+  // Some Windows editors encode UTF-8 files with a byte order mark, which JSON.parse does not accept.
+  const valueWithoutByteOrderMark = value.replace(/^\uFEFF/, '')
+  return JSON.parse(valueWithoutByteOrderMark) as T
+}
+
 /**
  * A wrapper around the `conf` package that provides a strongly-typed interface
  * for accessing the local storage.
@@ -13,7 +19,11 @@ export class LocalStorage<T extends Record<string, any>> {
   private readonly config: Config<T>
 
   constructor(options: {projectName?: string; cwd?: string}) {
-    this.config = new Config<T>(options)
+    this.config = new Config<T>({
+      ...options,
+      clearInvalidConfig: true,
+      deserialize: deserializeJson<T>,
+    })
   }
 
   /**


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/shop/issues/issues/68394

<!--
  Context about the problem that's being addressed.
-->

### WHAT is this pull request doing?

Strip byte order marks before parsing local storage JSON and allow invalid config to reset so store-auth-aware commands recover instead of crashing. Add filesystem-backed regression coverage for both cases.

Fixes errors like `Error: Unexpected token '﻿', "﻿{} " is not valid JSON`

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
  You can post a comment with `/snapit` to generate a snapshot of the changes to be tested.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`
