### PR TITLE
Run local CLI rules with Oxlint

### DIFF
--- a/oxlint.json
+++ b/oxlint.json
@@ -7,6 +7,12 @@
     "node",
     "unicorn"
   ],
+  "jsPlugins": [
+    {
+      "name": "@shopify/cli",
+      "specifier": "./packages/eslint-plugin-cli/index.js"
+    }
+  ],
   "categories": {
     "correctness": "off"
   },
@@ -332,6 +338,18 @@
     "node/no-new-require": "error",
     "node/no-path-concat": "error",
     "node/no-exports-assign": "error",
+    "@shopify/cli/command-flags-with-env": "error",
+    "@shopify/cli/command-conventional-flag-env": "error",
+    "@shopify/cli/command-reserved-flags": "error",
+    "@shopify/cli/no-error-factory-functions": "error",
+    "@shopify/cli/no-process-cwd": "error",
+    "@shopify/cli/no-trailing-js-in-cli-kit-imports": "error",
+    "@shopify/cli/no-vi-manual-mock-clear": "error",
+    "@shopify/cli/no-vi-mock-in-callbacks": "error",
+    "@shopify/cli/prompt-message-format": "error",
+    "@shopify/cli/banner-headline-format": "error",
+    "@shopify/cli/required-fields-when-loading-app": "error",
+    "@shopify/cli/no-inline-graphql": "error",
     "typescript/consistent-return": "error",
     "typescript/dot-notation": [
       "error",

--- a/packages/eslint-plugin-cli/rules/no-inline-graphql.js
+++ b/packages/eslint-plugin-cli/rules/no-inline-graphql.js
@@ -33,8 +33,12 @@ function hashFileSync(filePath, algorithm = 'sha256') {
 
 function checkKnownFailuresIfShouldFail(context) {
   const filePath = context.filename || context.getFilename()
-  const relativePath = path.relative(path.resolve(__dirname, '../../../../../../..'), filePath)
-  const fileHash = hashFileSync(filePath)
+  const absoluteFilePath = path.resolve(filePath)
+  const normalizedFilePath = absoluteFilePath.split(path.sep).join('/')
+  const relativePath = Object.keys(knownFailures).find((knownFailurePath) =>
+    normalizedFilePath.endsWith(knownFailurePath),
+  )
+  const fileHash = hashFileSync(absoluteFilePath)
   const shouldFail = !knownFailures[relativePath] || knownFailures[relativePath] !== fileHash
 
   if (shouldFail) {

--- a/packages/eslint-plugin-cli/rules/no-inline-graphql.js
+++ b/packages/eslint-plugin-cli/rules/no-inline-graphql.js
@@ -48,8 +48,12 @@ function hashFileSync(filePath, algorithm = 'sha256') {
 
 function checkKnownFailuresIfShouldFail(context) {
   const filePath = context.filename || context.getFilename()
-  const relativePath = path.relative(path.resolve(__dirname, '../../../../../../..'), filePath)
-  const fileHash = hashFileSync(filePath)
+  const absoluteFilePath = path.resolve(filePath)
+  const normalizedFilePath = absoluteFilePath.split(path.sep).join('/')
+  const relativePath = Object.keys(knownFailures).find((knownFailurePath) =>
+    normalizedFilePath.endsWith(knownFailurePath),
+  )
+  const fileHash = hashFileSync(absoluteFilePath)
   const shouldFail = !knownFailures[relativePath] || knownFailures[relativePath] !== fileHash
 
   if (shouldFail) {


### PR DESCRIPTION
### WHY are these changes introduced?

This is the fourth step of the ESLint-to-Oxlint migration. The repository-local CLI rules were one of the remaining reasons normal linting still needed ESLint.

### WHAT is this pull request doing?

- load the existing `@shopify/eslint-plugin-cli` implementation as an Oxlint JavaScript plugin
- enable all 12 local CLI rules currently active in the flat ESLint configuration
- make all 13 exported local rules available to Oxlint, including the currently disabled bootstrap-import rule
- let the compatibility configuration stop running the migrated local rules in ESLint
- make the `no-inline-graphql` known-failure lookup independent of pnpm installation depth so it works when Oxlint loads the workspace plugin directly

### How to test your changes?

- `pnpm lint:oxlint`
- `pnpm lint`
- full ESLint config against known inline-GraphQL exceptions
- verified normal ESLint effective config disables a migrated local rule
- `node bin/run-knip-ci.js`
- `git diff --check`
