### PR TITLE
Recommend Shopify AI Toolkit in generated theme instructions

### DIFF
--- a/.changeset/kind-tools-connect.md
+++ b/.changeset/kind-tools-connect.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Recommend the Shopify AI Toolkit in generated theme instructions

--- a/packages/theme/src/cli/services/init.test.ts
+++ b/packages/theme/src/cli/services/init.test.ts
@@ -175,7 +175,12 @@ describe('createAIInstructions()', () => {
     // Then
     expect(downloadGitRepository).toHaveBeenCalled()
     expect(readFile).toHaveBeenCalledWith('/tmp/ai/github/copilot-instructions.md')
-    expect(writeFile).toHaveBeenCalledWith('/path/to/theme/AGENTS.md', expect.stringContaining('# AGENTS.md'))
+    expect(writeFile).toHaveBeenCalledWith(
+      '/path/to/theme/AGENTS.md',
+      expect.stringContaining(
+        'Use the [Shopify AI Toolkit](https://shopify.dev/docs/apps/build/ai-toolkit) for all Shopify API and platform work.',
+      ),
+    )
     expect(symlink).not.toHaveBeenCalled()
   })
 

--- a/packages/theme/src/cli/services/init.ts
+++ b/packages/theme/src/cli/services/init.ts
@@ -6,6 +6,8 @@ import {AbortError} from '@shopify/cli-kit/node/error'
 
 export const SKELETON_THEME_URL = 'https://github.com/Shopify/skeleton-theme.git'
 const AI_INSTRUCTIONS_REPO_URL = 'https://github.com/Shopify/theme-liquid-docs.git'
+const AI_TOOLKIT_RECOMMENDATION =
+  'Use the [Shopify AI Toolkit](https://shopify.dev/docs/apps/build/ai-toolkit) for all Shopify API and platform work. If missing, install it in the agent host per that page (or `npx skills add Shopify/shopify-ai-toolkit` for skill-compatible hosts).'
 
 const SUPPORTED_AI_INSTRUCTIONS = {
   all: 'All',
@@ -96,7 +98,7 @@ export async function createAIInstructions(themeRoot: string, aiInstruction: AII
             const sourceContent = await readFile(sourcePath)
 
             const agentsPath = joinPath(themeRoot, 'AGENTS.md')
-            const agentsContent = `# AGENTS.md\n\n${sourceContent}`
+            const agentsContent = `# AGENTS.md\n\n${AI_TOOLKIT_RECOMMENDATION}\n\n${sourceContent}`
             await writeFile(agentsPath, agentsContent)
 
             const results = await Promise.all(


### PR DESCRIPTION
## What

- Recommend the Shopify AI Toolkit in the `AGENTS.md` generated by `shopify theme init`.
- Ensure the generated Claude and Copilot adapter files inherit the same recommendation.
- Add a patch changeset for `@shopify/theme`.

## Why

The generated theme instructions require Shopify agent tooling such as `learn_shopify_api`, but do not tell developers how to install it.

Related to https://github.com/shop/issues-develop/issues/22870

## Testing

- `pnpm vitest run packages/theme/src/cli/services/init.test.ts`
- `pnpm eslint packages/theme/src/cli/services/init.ts packages/theme/src/cli/services/init.test.ts`
- `pnpm prettier --check packages/theme/src/cli/services/init.ts packages/theme/src/cli/services/init.test.ts .changeset/kind-tools-connect.md`
- `git diff --check`