### PR TITLE
[Tests] Add comprehensive unit tests for tree-kill utility

### DIFF
--- a/packages/cli-kit/src/public/node/tree-kill.test.ts
+++ b/packages/cli-kit/src/public/node/tree-kill.test.ts
@@ -11,16 +11,39 @@ vi.mock('child_process', async () => {
   }
 })
 
+interface SpawnMockOptions {
+  stdoutData?: string
+  exitCode?: number
+}
+
+function createMockProcess(options: SpawnMockOptions) {
+  return {
+    stdout: {
+      on: vi.fn((event: string, cb: Function) => {
+        if (event === 'data' && options.stdoutData !== undefined) {
+          cb(Buffer.from(options.stdoutData))
+        }
+      }),
+    },
+    on: vi.fn((event: string, cb: Function) => {
+      if (event === 'close') {
+        cb(options.exitCode ?? 0)
+      }
+    }),
+  }
+}
+
 describe('treeKill', () => {
   afterEach(() => {
     vi.unstubAllGlobals()
+    // eslint-disable-next-line @shopify/cli/no-vi-manual-mock-clear
+    vi.restoreAllMocks()
   })
 
   test('calls the callback with an error if the PID is not a number (string with digits)', async () => {
     const maliciousPid = '1234; calc.exe'
 
     await new Promise<void>((resolve) => {
-      // Correct signature for treeKill is (pid, signal, killRoot, callback)
       treeKill(maliciousPid, 'SIGTERM', true, (err) => {
         expect(err?.message).toBe('pid must be a number')
         resolve()
@@ -54,5 +77,147 @@ describe('treeKill', () => {
     treeKill(pid)
 
     expect(spawn).toHaveBeenCalledWith('taskkill', ['/pid', '1234', '/T', '/F'])
+  })
+
+  test('win32: calls callback with error if taskkill exits with non-zero code', async () => {
+    vi.stubGlobal('process', {...process, platform: 'win32'})
+    const mockTaskkill = createMockProcess({exitCode: 1})
+    vi.mocked(spawn).mockReturnValue(mockTaskkill as any)
+
+    await new Promise<void>((resolve) => {
+      treeKill('1234', 'SIGTERM', true, (err) => {
+        expect(err?.message).toBe('taskkill exited with code 1')
+        resolve()
+      })
+    })
+  })
+
+  test('darwin: recursively builds process tree and kills all processes', async () => {
+    vi.stubGlobal('process', {...process, platform: 'darwin'})
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true)
+
+    vi.mocked(spawn).mockImplementation((cmd, args) => {
+      const parentPid = args ? args[args.length - 1] : ''
+      if (parentPid === '1234') {
+        return createMockProcess({stdoutData: '1235 child_cmd\n', exitCode: 0}) as any
+      }
+      return createMockProcess({stdoutData: '', exitCode: 1}) as any
+    })
+
+    await new Promise<void>((resolve) => {
+      treeKill('1234', 'SIGTERM', true, (err) => {
+        expect(err).toBeUndefined()
+        resolve()
+      })
+    })
+
+    expect(spawn).toHaveBeenCalledWith('pgrep', ['-lfP', '1234'])
+    expect(spawn).toHaveBeenCalledWith('pgrep', ['-lfP', '1235'])
+    expect(killSpy).toHaveBeenCalledWith(1235, 'SIGTERM')
+    expect(killSpy).toHaveBeenCalledWith(1234, 'SIGTERM')
+  })
+
+  test('linux (default): recursively builds process tree and kills all processes', async () => {
+    vi.stubGlobal('process', {...process, platform: 'linux'})
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true)
+
+    vi.mocked(spawn).mockImplementation((cmd, args) => {
+      const parentPid = args ? args[args.length - 1] : ''
+      if (parentPid === '1234') {
+        return createMockProcess({stdoutData: '1235 child_cmd\n', exitCode: 0}) as any
+      }
+      return createMockProcess({stdoutData: '', exitCode: 1}) as any
+    })
+
+    await new Promise<void>((resolve) => {
+      treeKill('1234', 'SIGINT', true, (err) => {
+        expect(err).toBeUndefined()
+        resolve()
+      })
+    })
+
+    expect(spawn).toHaveBeenCalledWith('ps', ['-o', 'pid command', '--no-headers', '--ppid', '1234'])
+    expect(spawn).toHaveBeenCalledWith('ps', ['-o', 'pid command', '--no-headers', '--ppid', '1235'])
+    expect(killSpy).toHaveBeenCalledWith(1235, 'SIGINT')
+    expect(killSpy).toHaveBeenCalledWith(1234, 'SIGINT')
+  })
+
+  test('darwin: does not kill the root process when killRoot is false', async () => {
+    vi.stubGlobal('process', {...process, platform: 'darwin'})
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true)
+
+    vi.mocked(spawn).mockImplementation((cmd, args) => {
+      const parentPid = args ? args[args.length - 1] : ''
+      if (parentPid === '1234') {
+        return createMockProcess({stdoutData: '1235 child_cmd\n', exitCode: 0}) as any
+      }
+      return createMockProcess({stdoutData: '', exitCode: 1}) as any
+    })
+
+    await new Promise<void>((resolve) => {
+      treeKill('1234', 'SIGTERM', false, (err) => {
+        expect(err).toBeUndefined()
+        resolve()
+      })
+    })
+
+    expect(killSpy).toHaveBeenCalledWith(1235, 'SIGTERM')
+    expect(killSpy).not.toHaveBeenCalledWith(1234, 'SIGTERM')
+  })
+
+  test('darwin: passes error to callback if process.kill throws a non-ESRCH error', async () => {
+    vi.stubGlobal('process', {...process, platform: 'darwin'})
+    const error = new Error('EPERM') as Error & {code?: string}
+    error.code = 'EPERM'
+    vi.spyOn(process, 'kill').mockImplementation(() => {
+      throw error
+    })
+
+    vi.mocked(spawn).mockImplementation((cmd, args) => {
+      const parentPid = args ? args[args.length - 1] : ''
+      if (parentPid === '1234') {
+        return createMockProcess({stdoutData: '1235 child_cmd\n', exitCode: 0}) as any
+      }
+      return createMockProcess({stdoutData: '', exitCode: 1}) as any
+    })
+
+    await new Promise<void>((resolve) => {
+      treeKill('1234', 'SIGTERM', true, (err) => {
+        expect(err).toBe(error)
+        resolve()
+      })
+    })
+  })
+
+  test('darwin: ignores ESRCH errors from process.kill', async () => {
+    vi.stubGlobal('process', {...process, platform: 'darwin'})
+    const error = new Error('ESRCH') as Error & {code?: string}
+    error.code = 'ESRCH'
+    vi.spyOn(process, 'kill').mockImplementation(() => {
+      throw error
+    })
+
+    vi.mocked(spawn).mockImplementation((cmd, args) => {
+      const parentPid = args ? args[args.length - 1] : ''
+      if (parentPid === '1234') {
+        return createMockProcess({stdoutData: '1235 child_cmd\n', exitCode: 0}) as any
+      }
+      return createMockProcess({stdoutData: '', exitCode: 1}) as any
+    })
+
+    await new Promise<void>((resolve) => {
+      treeKill('1234', 'SIGTERM', true, (err) => {
+        expect(err).toBeUndefined()
+        resolve()
+      })
+    })
+  })
+
+  test('uses default callback if none is provided', async () => {
+    vi.stubGlobal('process', {...process, platform: 'win32'})
+    const mockTaskkill = createMockProcess({exitCode: 1})
+    vi.mocked(spawn).mockReturnValue(mockTaskkill as any)
+
+    expect(() => treeKill('1234', 'SIGTERM', true)).not.toThrow()
   })
 })


### PR DESCRIPTION
### WHY are these changes introduced?

Enhance testing coverage and robustness for the `tree-kill` platform-specific process termination utility across Windows, macOS, and Linux/default systems.

### WHAT is this pull request doing?

This PR introduces comprehensive unit tests for `packages/cli-kit/src/public/node/tree-kill.ts` inside `packages/cli-kit/src/public/node/tree-kill.test.ts`. The new test cases verify:
- Win32 taskkill error propagation when taskkill exits with non-zero exit codes.
- Darwin process tree recursion and killing child/parent processes.
- Linux/default platform process tree building and process signaling.
- Correct behavior of skipping the root process when `killRoot` is set to false.
- Process termination error propagation (handling other errors vs ignoring `ESRCH` errors).
- Default callback behavior when a custom callback is not supplied.

### How to test your changes?

CI

### Post-release steps

N/A

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [13728230465409537511](https://jules.google.com/task/13728230465409537511) started by @gonzaloriestra*