### PR TITLE
[Refactor] Add comprehensive unit tests for crypto module

### DIFF
--- a/packages/cli-kit/src/public/node/crypto.test.ts
+++ b/packages/cli-kit/src/public/node/crypto.test.ts
@@ -1,4 +1,13 @@
-import {fileHash, hashString, nonRandomUUID} from './crypto.js'
+import {
+  fileHash,
+  hashString,
+  nonRandomUUID,
+  randomHex,
+  base64URLEncode,
+  sha256,
+  randomBytes,
+  randomUUID,
+} from './crypto.js'
 import {describe, expect, test} from 'vitest'
 
 describe('hashString', () => {
@@ -31,5 +40,54 @@ describe('nonRandomUUID', () => {
     const uuid1 = nonRandomUUID('hello')
     const uuid2 = nonRandomUUID('hello2')
     expect(uuid1).not.toEqual(uuid2)
+  })
+})
+
+describe('randomHex', () => {
+  test('generates a random hexadecimal string of the specified size in bytes', () => {
+    const hex1 = randomHex(16)
+    const hex2 = randomHex(16)
+    expect(hex1).not.toEqual(hex2)
+    expect(hex1).toMatch(/^[a-f0-9]{32}$/)
+    expect(hex2).toMatch(/^[a-f0-9]{32}$/)
+  })
+})
+
+describe('base64URLEncode', () => {
+  test('encodes a buffer to base64url format', () => {
+    const buffer = Buffer.from('hello+world/foo=bar')
+    const encoded = base64URLEncode(buffer)
+    expect(encoded).not.toContain('+')
+    expect(encoded).not.toContain('/')
+    expect(encoded).not.toContain('=')
+    expect(encoded).toMatch(/^[A-Za-z0-9_-]+$/)
+  })
+})
+
+describe('sha256', () => {
+  test('generates SHA256 hash buffer of a string', () => {
+    const hash = sha256('hello')
+    expect(hash).toBeInstanceOf(Buffer)
+    expect(hash.length).toBe(32)
+    expect(hash.toString('hex')).toBe('2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824')
+  })
+})
+
+describe('randomBytes', () => {
+  test('generates a buffer of random bytes of the specified size', () => {
+    const bytes1 = randomBytes(16)
+    const bytes2 = randomBytes(16)
+    expect(bytes1).toBeInstanceOf(Buffer)
+    expect(bytes1.length).toBe(16)
+    expect(bytes1).not.toEqual(bytes2)
+  })
+})
+
+describe('randomUUID', () => {
+  test('generates a random UUID string', () => {
+    const uuid1 = randomUUID()
+    const uuid2 = randomUUID()
+    expect(uuid1).not.toEqual(uuid2)
+    expect(uuid1).toMatch(/^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/)
   })
 })


### PR DESCRIPTION
### Description

This PR adds comprehensive unit tests to close the test coverage gaps in the `crypto` utility module under `packages/cli-kit/src/public/node/crypto.ts`.

It specifically introduces unit tests for the following previously untested functions:
- `randomHex`
- `base64URLEncode`
- `sha256`
- `randomBytes`
- `randomUUID`

### How to test your changes?

CI runs all tests. To run the tests locally, run:
```bash
pnpm --filter @shopify/cli-kit vitest run src/public/node/crypto.test.ts
```

---
*PR created automatically by Jules for task [15160769746992583485](https://jules.google.com/task/15160769746992583485) started by @gonzaloriestra*