### PR TITLE
Document required non-interactive app flags

### DIFF
--- a/docs-shopify.dev/generated/generated_docs_data_v2.json
+++ b/docs-shopify.dev/generated/generated_docs_data_v2.json
@@ -432,7 +432,7 @@
           "syntaxKind": "PropertySignature",
           "name": "--client-id <value>",
           "value": "string",
-          "description": "The Client ID of your app.",
+          "description": "The Client ID of your app. Required if non interactive.",
           "isOptional": true,
           "environmentValue": "SHOPIFY_FLAG_CLIENT_ID"
         },
@@ -500,7 +500,7 @@
           "environmentValue": "SHOPIFY_FLAG_APP_CONFIG"
         }
       ],
-      "value": "export interface appconfiglink {\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--auth-alias <value>'?: string\n\n  /**\n   * The Client ID of your app.\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * The name of the app configuration file to create or overwrite.\n   * @environment SHOPIFY_FLAG_APP_CONFIG_FILE_NAME\n   */\n  '--file-name <value>'?: string\n\n  /**\n   * Overwrite an existing configuration file without prompting.\n   * @environment SHOPIFY_FLAG_FORCE\n   */\n  '--force'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your app directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Reset all your settings.\n   * @environment SHOPIFY_FLAG_RESET\n   */\n  '--reset'?: ''\n\n  /**\n   * Increase the verbosity of the output. May include sensitive data.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+      "value": "export interface appconfiglink {\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--auth-alias <value>'?: string\n\n  /**\n   * The Client ID of your app. Required if non interactive.\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * The name of the app configuration file to create or overwrite.\n   * @environment SHOPIFY_FLAG_APP_CONFIG_FILE_NAME\n   */\n  '--file-name <value>'?: string\n\n  /**\n   * Overwrite an existing configuration file without prompting.\n   * @environment SHOPIFY_FLAG_FORCE\n   */\n  '--force'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your app directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Reset all your settings.\n   * @environment SHOPIFY_FLAG_RESET\n   */\n  '--reset'?: ''\n\n  /**\n   * Increase the verbosity of the output. May include sensitive data.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
     }
   },
   "appconfigpull": {
@@ -737,7 +737,7 @@
           "syntaxKind": "PropertySignature",
           "name": "--allow-deletes",
           "value": "''",
-          "description": "Allows removing extensions and configuration without requiring user confirmation. For CI/CD environments, the recommended flag is --allow-updates.",
+          "description": "Allows removing extensions and configuration without requiring user confirmation. For CI/CD environments, the recommended flag is --allow-updates. In non-interactive environments, provide this flag, --allow-updates, or --no-release.",
           "isOptional": true,
           "environmentValue": "SHOPIFY_FLAG_ALLOW_DELETES"
         },
@@ -746,7 +746,7 @@
           "syntaxKind": "PropertySignature",
           "name": "--allow-updates",
           "value": "''",
-          "description": "Allows adding and updating extensions and configuration without requiring user confirmation. Recommended option for CI/CD environments.",
+          "description": "Allows adding and updating extensions and configuration without requiring user confirmation. Recommended option for CI/CD environments. In non-interactive environments, provide this flag, --allow-deletes, or --no-release.",
           "isOptional": true,
           "environmentValue": "SHOPIFY_FLAG_ALLOW_UPDATES"
         },
@@ -800,7 +800,7 @@
           "syntaxKind": "PropertySignature",
           "name": "--no-release",
           "value": "''",
-          "description": "Creates a version but doesn't release it - it's not made available to merchants. With this flag, a user confirmation is not required.",
+          "description": "Creates a version but doesn't release it - it's not made available to merchants. With this flag, a user confirmation is not required. In non-interactive environments, provide this flag, --allow-updates, or --allow-deletes.",
           "isOptional": true,
           "environmentValue": "SHOPIFY_FLAG_NO_RELEASE"
         },
@@ -859,7 +859,7 @@
           "environmentValue": "SHOPIFY_FLAG_APP_CONFIG"
         }
       ],
-      "value": "export interface appdeploy {\n  /**\n   * Allows removing extensions and configuration without requiring user confirmation. For CI/CD environments, the recommended flag is --allow-updates.\n   * @environment SHOPIFY_FLAG_ALLOW_DELETES\n   */\n  '--allow-deletes'?: ''\n\n  /**\n   * Allows adding and updating extensions and configuration without requiring user confirmation. Recommended option for CI/CD environments.\n   * @environment SHOPIFY_FLAG_ALLOW_UPDATES\n   */\n  '--allow-updates'?: ''\n\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--auth-alias <value>'?: string\n\n  /**\n   * The Client ID of your app.\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Optional message that will be associated with this version. This is for internal use only and won't be available externally.\n   * @environment SHOPIFY_FLAG_MESSAGE\n   */\n  '--message <value>'?: string\n\n  /**\n   * Use with caution: Skips building any elements of the app that require building. You should ensure your app has been prepared in advance, such as by running `shopify app build` or by caching build artifacts.\n   * @environment SHOPIFY_FLAG_NO_BUILD\n   */\n  '--no-build'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Creates a version but doesn't release it - it's not made available to merchants. With this flag, a user confirmation is not required.\n   * @environment SHOPIFY_FLAG_NO_RELEASE\n   */\n  '--no-release'?: ''\n\n  /**\n   * The path to your app directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Reset all your settings.\n   * @environment SHOPIFY_FLAG_RESET\n   */\n  '--reset'?: ''\n\n  /**\n   * URL associated with the new app version.\n   * @environment SHOPIFY_FLAG_SOURCE_CONTROL_URL\n   */\n  '--source-control-url <value>'?: string\n\n  /**\n   * Increase the verbosity of the output. May include sensitive data.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n\n  /**\n   * Optional version tag that will be associated with this app version. If not provided, an auto-generated identifier will be generated for this app version.\n   * @environment SHOPIFY_FLAG_VERSION\n   */\n  '--version <value>'?: string\n}"
+      "value": "export interface appdeploy {\n  /**\n   * Allows removing extensions and configuration without requiring user confirmation. For CI/CD environments, the recommended flag is --allow-updates. In non-interactive environments, provide this flag, --allow-updates, or --no-release.\n   * @environment SHOPIFY_FLAG_ALLOW_DELETES\n   */\n  '--allow-deletes'?: ''\n\n  /**\n   * Allows adding and updating extensions and configuration without requiring user confirmation. Recommended option for CI/CD environments. In non-interactive environments, provide this flag, --allow-deletes, or --no-release.\n   * @environment SHOPIFY_FLAG_ALLOW_UPDATES\n   */\n  '--allow-updates'?: ''\n\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--auth-alias <value>'?: string\n\n  /**\n   * The Client ID of your app.\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Optional message that will be associated with this version. This is for internal use only and won't be available externally.\n   * @environment SHOPIFY_FLAG_MESSAGE\n   */\n  '--message <value>'?: string\n\n  /**\n   * Use with caution: Skips building any elements of the app that require building. You should ensure your app has been prepared in advance, such as by running `shopify app build` or by caching build artifacts.\n   * @environment SHOPIFY_FLAG_NO_BUILD\n   */\n  '--no-build'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Creates a version but doesn't release it - it's not made available to merchants. With this flag, a user confirmation is not required. In non-interactive environments, provide this flag, --allow-updates, or --allow-deletes.\n   * @environment SHOPIFY_FLAG_NO_RELEASE\n   */\n  '--no-release'?: ''\n\n  /**\n   * The path to your app directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Reset all your settings.\n   * @environment SHOPIFY_FLAG_RESET\n   */\n  '--reset'?: ''\n\n  /**\n   * URL associated with the new app version.\n   * @environment SHOPIFY_FLAG_SOURCE_CONTROL_URL\n   */\n  '--source-control-url <value>'?: string\n\n  /**\n   * Increase the verbosity of the output. May include sensitive data.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n\n  /**\n   * Optional version tag that will be associated with this app version. If not provided, an auto-generated identifier will be generated for this app version.\n   * @environment SHOPIFY_FLAG_VERSION\n   */\n  '--version <value>'?: string\n}"
     }
   },
   "appdevclean": {
@@ -1671,7 +1671,7 @@
           "syntaxKind": "PropertySignature",
           "name": "-l, --log <value>",
           "value": "string",
-          "description": "Specifies a log identifier to replay instead of selecting from a list. The identifier is provided in the output of `shopify app dev` and is the suffix of the log file name.",
+          "description": "Specifies a log identifier to replay instead of selecting from a list. The identifier is provided in the output of `shopify app dev` and is the suffix of the log file name. Required if non interactive.",
           "isOptional": true,
           "environmentValue": "SHOPIFY_FLAG_LOG"
         },
@@ -1685,7 +1685,7 @@
           "environmentValue": "SHOPIFY_FLAG_WATCH"
         }
       ],
-      "value": "export interface appfunctionreplay {\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--auth-alias <value>'?: string\n\n  /**\n   * The Client ID of your app.\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Output the result as JSON. Automatically disables color output.\n   * @environment SHOPIFY_FLAG_JSON\n   */\n  '-j, --json'?: ''\n\n  /**\n   * Specifies a log identifier to replay instead of selecting from a list. The identifier is provided in the output of `shopify app dev` and is the suffix of the log file name.\n   * @environment SHOPIFY_FLAG_LOG\n   */\n  '-l, --log <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your function directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Reset all your settings.\n   * @environment SHOPIFY_FLAG_RESET\n   */\n  '--reset'?: ''\n\n  /**\n   * Increase the verbosity of the output. May include sensitive data.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n\n  /**\n   * Re-run the function when the source code changes.\n   * @environment SHOPIFY_FLAG_WATCH\n   */\n  '-w, --watch'?: ''\n}"
+      "value": "export interface appfunctionreplay {\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--auth-alias <value>'?: string\n\n  /**\n   * The Client ID of your app.\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Output the result as JSON. Automatically disables color output.\n   * @environment SHOPIFY_FLAG_JSON\n   */\n  '-j, --json'?: ''\n\n  /**\n   * Specifies a log identifier to replay instead of selecting from a list. The identifier is provided in the output of `shopify app dev` and is the suffix of the log file name. Required if non interactive.\n   * @environment SHOPIFY_FLAG_LOG\n   */\n  '-l, --log <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your function directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Reset all your settings.\n   * @environment SHOPIFY_FLAG_RESET\n   */\n  '--reset'?: ''\n\n  /**\n   * Increase the verbosity of the output. May include sensitive data.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n\n  /**\n   * Re-run the function when the source code changes.\n   * @environment SHOPIFY_FLAG_WATCH\n   */\n  '-w, --watch'?: ''\n}"
     }
   },
   "appfunctionrun": {
@@ -1985,7 +1985,7 @@
           "syntaxKind": "PropertySignature",
           "name": "--flavor <value>",
           "value": "string",
-          "description": "Choose a starting template for your extension, where applicable",
+          "description": "Choose a starting template for your extension, where applicable. Required if non interactive when the selected extension template supports multiple flavors.",
           "isOptional": true,
           "environmentValue": "SHOPIFY_FLAG_FLAVOR"
         },
@@ -2039,7 +2039,7 @@
           "syntaxKind": "PropertySignature",
           "name": "-n, --name <value>",
           "value": "string",
-          "description": "name of your Extension",
+          "description": "name of your Extension. Required if non interactive.",
           "isOptional": true,
           "environmentValue": "SHOPIFY_FLAG_NAME"
         },
@@ -2048,12 +2048,12 @@
           "syntaxKind": "PropertySignature",
           "name": "-t, --template <value>",
           "value": "string",
-          "description": "Extension template",
+          "description": "Extension template. Required if non interactive.",
           "isOptional": true,
           "environmentValue": "SHOPIFY_FLAG_EXTENSION_TEMPLATE"
         }
       ],
-      "value": "export interface appgenerateextension {\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--auth-alias <value>'?: string\n\n  /**\n   * The Client ID of your app.\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Choose a starting template for your extension, where applicable\n   * @environment SHOPIFY_FLAG_FLAVOR\n   */\n  '--flavor <value>'?: string\n\n  /**\n   * name of your Extension\n   * @environment SHOPIFY_FLAG_NAME\n   */\n  '-n, --name <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your app directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Reset all your settings.\n   * @environment SHOPIFY_FLAG_RESET\n   */\n  '--reset'?: ''\n\n  /**\n   * Extension template\n   * @environment SHOPIFY_FLAG_EXTENSION_TEMPLATE\n   */\n  '-t, --template <value>'?: string\n\n  /**\n   * Increase the verbosity of the output. May include sensitive data.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+      "value": "export interface appgenerateextension {\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--auth-alias <value>'?: string\n\n  /**\n   * The Client ID of your app.\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Choose a starting template for your extension, where applicable. Required if non interactive when the selected extension template supports multiple flavors.\n   * @environment SHOPIFY_FLAG_FLAVOR\n   */\n  '--flavor <value>'?: string\n\n  /**\n   * name of your Extension. Required if non interactive.\n   * @environment SHOPIFY_FLAG_NAME\n   */\n  '-n, --name <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your app directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Reset all your settings.\n   * @environment SHOPIFY_FLAG_RESET\n   */\n  '--reset'?: ''\n\n  /**\n   * Extension template. Required if non interactive.\n   * @environment SHOPIFY_FLAG_EXTENSION_TEMPLATE\n   */\n  '-t, --template <value>'?: string\n\n  /**\n   * Increase the verbosity of the output. May include sensitive data.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
     }
   },
   "appgraphiql": {
@@ -2445,7 +2445,7 @@
           "syntaxKind": "PropertySignature",
           "name": "--client-id <value>",
           "value": "string",
-          "description": "The Client ID of your app. Use this to automatically link your new project to an existing app. Using this flag avoids the app selection prompt.",
+          "description": "The Client ID of your app. Use this to automatically link your new project to an existing app. In non-interactive environments, provide this flag or both --name and --organization-id.",
           "isOptional": true,
           "environmentValue": "SHOPIFY_FLAG_CLIENT_ID"
         },
@@ -2454,7 +2454,7 @@
           "syntaxKind": "PropertySignature",
           "name": "--flavor <value>",
           "value": "string",
-          "description": "Which flavor of the given template to use.",
+          "description": "Which flavor of the given template to use. Required in non-interactive environments when the selected template offers multiple flavors.",
           "isOptional": true,
           "environmentValue": "SHOPIFY_FLAG_TEMPLATE_FLAVOR"
         },
@@ -2472,7 +2472,7 @@
           "syntaxKind": "PropertySignature",
           "name": "--organization-id <value>",
           "value": "string",
-          "description": "The organization ID. Your organization ID can be found in your Dev Dashboard URL: https://dev.shopify.com/dashboard/<organization-id>",
+          "description": "The organization ID. Your organization ID can be found in your Dev Dashboard URL: https://dev.shopify.com/dashboard/<organization-id>. Required in non-interactive environments unless --client-id is provided.",
           "isOptional": true,
           "environmentValue": "SHOPIFY_FLAG_ORGANIZATION_ID"
         },
@@ -2481,7 +2481,7 @@
           "syntaxKind": "PropertySignature",
           "name": "--template <value>",
           "value": "string",
-          "description": "The app template. Accepts one of the following:   - <reactRouter|none>\n  - Any GitHub repo with optional branch and subpath, e.g., https://github.com/Shopify/<repository>/[subpath]#[branch]",
+          "description": "The app template. Accepts one of the following:   - <reactRouter|none>\n  - Any GitHub repo with optional branch and subpath, e.g., https://github.com/Shopify/<repository>/[subpath]#[branch]. Required if non interactive.",
           "isOptional": true,
           "environmentValue": "SHOPIFY_FLAG_TEMPLATE"
         },
@@ -2508,7 +2508,7 @@
           "syntaxKind": "PropertySignature",
           "name": "-n, --name <value>",
           "value": "string",
-          "description": "The name for the new app. When provided, skips the app selection prompt and creates a new app with this name.",
+          "description": "The name for the new app. When provided, skips the app selection prompt and creates a new app with this name. Required in non-interactive environments unless --client-id is provided.",
           "isOptional": true,
           "environmentValue": "SHOPIFY_FLAG_NAME"
         },
@@ -2522,7 +2522,7 @@
           "environmentValue": "SHOPIFY_FLAG_PATH"
         }
       ],
-      "value": "export interface appinit {\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--auth-alias <value>'?: string\n\n  /**\n   * The Client ID of your app. Use this to automatically link your new project to an existing app. Using this flag avoids the app selection prompt.\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * Which flavor of the given template to use.\n   * @environment SHOPIFY_FLAG_TEMPLATE_FLAVOR\n   */\n  '--flavor <value>'?: string\n\n  /**\n   * The name for the new app. When provided, skips the app selection prompt and creates a new app with this name.\n   * @environment SHOPIFY_FLAG_NAME\n   */\n  '-n, --name <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The organization ID. Your organization ID can be found in your Dev Dashboard URL: https://dev.shopify.com/dashboard/<organization-id>\n   * @environment SHOPIFY_FLAG_ORGANIZATION_ID\n   */\n  '--organization-id <value>'?: string\n\n  /**\n   * \n   * @environment SHOPIFY_FLAG_PACKAGE_MANAGER\n   */\n  '-d, --package-manager <value>'?: string\n\n  /**\n   * \n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '-p, --path <value>'?: string\n\n  /**\n   * The app template. Accepts one of the following:\n       - <reactRouter|none>\n       - Any GitHub repo with optional branch and subpath, e.g., https://github.com/Shopify/<repository>/[subpath]#[branch]\n   * @environment SHOPIFY_FLAG_TEMPLATE\n   */\n  '--template <value>'?: string\n\n  /**\n   * Increase the verbosity of the output. May include sensitive data.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+      "value": "export interface appinit {\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--auth-alias <value>'?: string\n\n  /**\n   * The Client ID of your app. Use this to automatically link your new project to an existing app. In non-interactive environments, provide this flag or both --name and --organization-id.\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * Which flavor of the given template to use. Required in non-interactive environments when the selected template offers multiple flavors.\n   * @environment SHOPIFY_FLAG_TEMPLATE_FLAVOR\n   */\n  '--flavor <value>'?: string\n\n  /**\n   * The name for the new app. When provided, skips the app selection prompt and creates a new app with this name. Required in non-interactive environments unless --client-id is provided.\n   * @environment SHOPIFY_FLAG_NAME\n   */\n  '-n, --name <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The organization ID. Your organization ID can be found in your Dev Dashboard URL: https://dev.shopify.com/dashboard/<organization-id>. Required in non-interactive environments unless --client-id is provided.\n   * @environment SHOPIFY_FLAG_ORGANIZATION_ID\n   */\n  '--organization-id <value>'?: string\n\n  /**\n   * \n   * @environment SHOPIFY_FLAG_PACKAGE_MANAGER\n   */\n  '-d, --package-manager <value>'?: string\n\n  /**\n   * \n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '-p, --path <value>'?: string\n\n  /**\n   * The app template. Accepts one of the following:\n       - <reactRouter|none>\n       - Any GitHub repo with optional branch and subpath, e.g., https://github.com/Shopify/<repository>/[subpath]#[branch]. Required if non interactive.\n   * @environment SHOPIFY_FLAG_TEMPLATE\n   */\n  '--template <value>'?: string\n\n  /**\n   * Increase the verbosity of the output. May include sensitive data.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
     }
   },
   "applogssources": {
@@ -2721,7 +2721,7 @@
           "syntaxKind": "PropertySignature",
           "name": "--allow-deletes",
           "value": "''",
-          "description": "Allows removing extensions and configuration without requiring user confirmation. For CI/CD environments, the recommended flag is --allow-updates.",
+          "description": "Allows removing extensions and configuration without requiring user confirmation. For CI/CD environments, the recommended flag is --allow-updates. Required in non-interactive environments unless --allow-updates is provided.",
           "isOptional": true,
           "environmentValue": "SHOPIFY_FLAG_ALLOW_DELETES"
         },
@@ -2730,7 +2730,7 @@
           "syntaxKind": "PropertySignature",
           "name": "--allow-updates",
           "value": "''",
-          "description": "Allows adding and updating extensions and configuration without requiring user confirmation. Recommended option for CI/CD environments.",
+          "description": "Allows adding and updating extensions and configuration without requiring user confirmation. Recommended option for CI/CD environments. Required in non-interactive environments unless --allow-deletes is provided.",
           "isOptional": true,
           "environmentValue": "SHOPIFY_FLAG_ALLOW_UPDATES"
         },
@@ -2806,7 +2806,7 @@
           "environmentValue": "SHOPIFY_FLAG_APP_CONFIG"
         }
       ],
-      "value": "export interface apprelease {\n  /**\n   * Allows removing extensions and configuration without requiring user confirmation. For CI/CD environments, the recommended flag is --allow-updates.\n   * @environment SHOPIFY_FLAG_ALLOW_DELETES\n   */\n  '--allow-deletes'?: ''\n\n  /**\n   * Allows adding and updating extensions and configuration without requiring user confirmation. Recommended option for CI/CD environments.\n   * @environment SHOPIFY_FLAG_ALLOW_UPDATES\n   */\n  '--allow-updates'?: ''\n\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--auth-alias <value>'?: string\n\n  /**\n   * The Client ID of your app.\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your app directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Reset all your settings.\n   * @environment SHOPIFY_FLAG_RESET\n   */\n  '--reset'?: ''\n\n  /**\n   * Increase the verbosity of the output. May include sensitive data.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n\n  /**\n   * The name of the app version to release.\n   * @environment SHOPIFY_FLAG_VERSION\n   */\n  '--version <value>': string\n}"
+      "value": "export interface apprelease {\n  /**\n   * Allows removing extensions and configuration without requiring user confirmation. For CI/CD environments, the recommended flag is --allow-updates. Required in non-interactive environments unless --allow-updates is provided.\n   * @environment SHOPIFY_FLAG_ALLOW_DELETES\n   */\n  '--allow-deletes'?: ''\n\n  /**\n   * Allows adding and updating extensions and configuration without requiring user confirmation. Recommended option for CI/CD environments. Required in non-interactive environments unless --allow-deletes is provided.\n   * @environment SHOPIFY_FLAG_ALLOW_UPDATES\n   */\n  '--allow-updates'?: ''\n\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--auth-alias <value>'?: string\n\n  /**\n   * The Client ID of your app.\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The path to your app directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Reset all your settings.\n   * @environment SHOPIFY_FLAG_RESET\n   */\n  '--reset'?: ''\n\n  /**\n   * Increase the verbosity of the output. May include sensitive data.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n\n  /**\n   * The name of the app version to release.\n   * @environment SHOPIFY_FLAG_VERSION\n   */\n  '--version <value>': string\n}"
     }
   },
   "appversionslist": {
@@ -2904,7 +2904,7 @@
           "syntaxKind": "PropertySignature",
           "name": "--address <value>",
           "value": "string",
-          "description": "The URL where the webhook payload should be sent.                You will need a different address type for each delivery-method:\n                     · For remote HTTP testing, use a URL that starts with https://\n · For local HTTP testing, use http://localhost:{port}/{url-path}\n                     · For Google Pub/Sub, use pubsub://{project-id}:{topic-id}\n                     · For Amazon EventBridge, use an Amazon Resource Name (ARN) starting with arn:aws:events:",
+          "description": "The URL where the webhook payload should be sent.                You will need a different address type for each delivery-method:\n                     · For remote HTTP testing, use a URL that starts with https://\n · For local HTTP testing, use http://localhost:{port}/{url-path}\n                     · For Google Pub/Sub, use pubsub://{project-id}:{topic-id}\n                     · For Amazon EventBridge, use an Amazon Resource Name (ARN) starting with arn:aws:events:. Required if non interactive.",
           "isOptional": true,
           "environmentValue": "SHOPIFY_FLAG_ADDRESS"
         },
@@ -2913,7 +2913,7 @@
           "syntaxKind": "PropertySignature",
           "name": "--api-version <value>",
           "value": "string",
-          "description": "The API Version of the webhook topic.",
+          "description": "The API Version of the webhook topic. Required if non interactive.",
           "isOptional": true,
           "environmentValue": "SHOPIFY_FLAG_API_VERSION"
         },
@@ -2985,7 +2985,7 @@
           "syntaxKind": "PropertySignature",
           "name": "--topic <value>",
           "value": "string",
-          "description": "The requested webhook topic.",
+          "description": "The requested webhook topic. Required if non interactive.",
           "isOptional": true,
           "environmentValue": "SHOPIFY_FLAG_TOPIC"
         },
@@ -2999,7 +2999,7 @@
           "environmentValue": "SHOPIFY_FLAG_APP_CONFIG"
         }
       ],
-      "value": "export interface appwebhooktrigger {\n  /**\n   * The URL where the webhook payload should be sent.\n                    You will need a different address type for each delivery-method:\n                          · For remote HTTP testing, use a URL that starts with https://\n      · For local HTTP testing, use http://localhost:{port}/{url-path}\n                          · For Google Pub/Sub, use pubsub://{project-id}:{topic-id}\n                          · For Amazon EventBridge, use an Amazon Resource Name (ARN) starting with arn:aws:events:\n   * @environment SHOPIFY_FLAG_ADDRESS\n   */\n  '--address <value>'?: string\n\n  /**\n   * The API Version of the webhook topic.\n   * @environment SHOPIFY_FLAG_API_VERSION\n   */\n  '--api-version <value>'?: string\n\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--auth-alias <value>'?: string\n\n  /**\n   * The Client ID of your app.\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * Your app's client secret. This secret allows us to return the X-Shopify-Hmac-SHA256 header that lets you validate the origin of the response that you receive.\n   * @environment SHOPIFY_FLAG_CLIENT_SECRET\n   */\n  '--client-secret <value>'?: string\n\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Method chosen to deliver the topic payload. If not passed, it's inferred from the address.\n   * @environment SHOPIFY_FLAG_DELIVERY_METHOD\n   */\n  '--delivery-method <value>'?: string\n\n  /**\n   * This help. When you run the trigger command the CLI will prompt you for any information that isn't passed using flags.\n   * @environment SHOPIFY_FLAG_HELP\n   */\n  '--help'?: ''\n\n  /**\n   * The path to your app directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Reset all your settings.\n   * @environment SHOPIFY_FLAG_RESET\n   */\n  '--reset'?: ''\n\n  /**\n   * The requested webhook topic.\n   * @environment SHOPIFY_FLAG_TOPIC\n   */\n  '--topic <value>'?: string\n}"
+      "value": "export interface appwebhooktrigger {\n  /**\n   * The URL where the webhook payload should be sent.\n                    You will need a different address type for each delivery-method:\n                          · For remote HTTP testing, use a URL that starts with https://\n      · For local HTTP testing, use http://localhost:{port}/{url-path}\n                          · For Google Pub/Sub, use pubsub://{project-id}:{topic-id}\n                          · For Amazon EventBridge, use an Amazon Resource Name (ARN) starting with arn:aws:events:. Required if non interactive.\n   * @environment SHOPIFY_FLAG_ADDRESS\n   */\n  '--address <value>'?: string\n\n  /**\n   * The API Version of the webhook topic. Required if non interactive.\n   * @environment SHOPIFY_FLAG_API_VERSION\n   */\n  '--api-version <value>'?: string\n\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--auth-alias <value>'?: string\n\n  /**\n   * The Client ID of your app.\n   * @environment SHOPIFY_FLAG_CLIENT_ID\n   */\n  '--client-id <value>'?: string\n\n  /**\n   * Your app's client secret. This secret allows us to return the X-Shopify-Hmac-SHA256 header that lets you validate the origin of the response that you receive.\n   * @environment SHOPIFY_FLAG_CLIENT_SECRET\n   */\n  '--client-secret <value>'?: string\n\n  /**\n   * The name of the app configuration.\n   * @environment SHOPIFY_FLAG_APP_CONFIG\n   */\n  '-c, --config <value>'?: string\n\n  /**\n   * Method chosen to deliver the topic payload. If not passed, it's inferred from the address.\n   * @environment SHOPIFY_FLAG_DELIVERY_METHOD\n   */\n  '--delivery-method <value>'?: string\n\n  /**\n   * This help. When you run the trigger command the CLI will prompt you for any information that isn't passed using flags.\n   * @environment SHOPIFY_FLAG_HELP\n   */\n  '--help'?: ''\n\n  /**\n   * The path to your app directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Reset all your settings.\n   * @environment SHOPIFY_FLAG_RESET\n   */\n  '--reset'?: ''\n\n  /**\n   * The requested webhook topic. Required if non interactive.\n   * @environment SHOPIFY_FLAG_TOPIC\n   */\n  '--topic <value>'?: string\n}"
     }
   },
   "authlogin": {

--- a/packages/app/src/cli/commands/app/config/link.test.ts
+++ b/packages/app/src/cli/commands/app/config/link.test.ts
@@ -3,15 +3,18 @@ import link from '../../../services/app/config/link.js'
 import {linkedAppContext} from '../../../services/app-context.js'
 import {testAppLinked, testOrganizationApp} from '../../../models/app/app.test-data.js'
 import {inTemporaryDirectory} from '@shopify/cli-kit/node/fs'
+import {terminalSupportsPrompting} from '@shopify/cli-kit/node/system'
 import {beforeEach, describe, expect, test, vi} from 'vitest'
 
 vi.mock('../../../services/app/config/link.js')
 vi.mock('../../../services/app-context.js')
+vi.mock('@shopify/cli-kit/node/system')
 
 describe('app config link command', () => {
   beforeEach(() => {
     vi.mocked(link).mockReset()
     vi.mocked(linkedAppContext).mockReset()
+    vi.mocked(terminalSupportsPrompting).mockReturnValue(true)
   })
 
   test('accepts --client-id with --file-name to link a specific app to a specific config file', async () => {

--- a/packages/app/src/cli/commands/app/config/link.ts
+++ b/packages/app/src/cli/commands/app/config/link.ts
@@ -3,7 +3,7 @@ import {linkedAppContext} from '../../../services/app-context.js'
 import link, {LinkOptions} from '../../../services/app/config/link.js'
 import AppLinkedCommand, {AppLinkedCommandOutput} from '../../../utilities/app-linked-command.js'
 import {Flags} from '@oclif/core'
-import {globalFlags} from '@shopify/cli-kit/node/cli'
+import {globalFlags, requiredIfNonInteractive} from '@shopify/cli-kit/node/cli'
 
 export default class ConfigLink extends AppLinkedCommand {
   static summary = 'Fetch your app configuration from the Developer Dashboard.'
@@ -23,6 +23,7 @@ export default class ConfigLink extends AppLinkedCommand {
       env: 'SHOPIFY_FLAG_ORGANIZATION_ID',
       exclusive: ['client-id'],
     }),
+    'client-id': requiredIfNonInteractive(appFlags['client-id']),
     'file-name': Flags.string({
       hidden: false,
       description: 'The name of the app configuration file to create or overwrite.',

--- a/packages/app/src/cli/commands/app/deploy.ts
+++ b/packages/app/src/cli/commands/app/deploy.ts
@@ -8,6 +8,7 @@ import {linkedAppContext} from '../../services/app-context.js'
 import {Flags} from '@oclif/core'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
 import {addPublicMetadata} from '@shopify/cli-kit/node/metadata'
+import type {NonTTYFlagRequirement} from '@shopify/cli-kit/node/base-command'
 
 export default class Deploy extends AppLinkedCommand {
   static summary = 'Deploy your Shopify app.'
@@ -27,19 +28,19 @@ export default class Deploy extends AppLinkedCommand {
     'allow-updates': Flags.boolean({
       hidden: false,
       description:
-        'Allows adding and updating extensions and configuration without requiring user confirmation. Recommended option for CI/CD environments.',
+        'Allows adding and updating extensions and configuration without requiring user confirmation. Recommended option for CI/CD environments. In non-interactive environments, provide this flag, --allow-deletes, or --no-release.',
       env: 'SHOPIFY_FLAG_ALLOW_UPDATES',
     }),
     'allow-deletes': Flags.boolean({
       hidden: false,
       description:
-        'Allows removing extensions and configuration without requiring user confirmation. For CI/CD environments, the recommended flag is --allow-updates.',
+        'Allows removing extensions and configuration without requiring user confirmation. For CI/CD environments, the recommended flag is --allow-updates. In non-interactive environments, provide this flag, --allow-updates, or --no-release.',
       env: 'SHOPIFY_FLAG_ALLOW_DELETES',
     }),
     'no-release': Flags.boolean({
       hidden: false,
       description:
-        "Creates a version but doesn't release it - it's not made available to merchants. With this flag, a user confirmation is not required.",
+        "Creates a version but doesn't release it - it's not made available to merchants. With this flag, a user confirmation is not required. In non-interactive environments, provide this flag, --allow-updates, or --allow-deletes.",
       env: 'SHOPIFY_FLAG_NO_RELEASE',
       default: false,
       exclusive: ['allow-updates', 'allow-deletes'],
@@ -69,6 +70,10 @@ export default class Deploy extends AppLinkedCommand {
     }),
   }
 
+  static nonTTYFlagRequirements(): NonTTYFlagRequirement[] {
+    return [{flags: ['allow-updates', 'allow-deletes', 'no-release']}]
+  }
+
   async run(): Promise<AppLinkedCommandOutput> {
     const {flags} = await this.parse(Deploy)
 
@@ -86,14 +91,6 @@ export default class Deploy extends AppLinkedCommand {
     await addPublicMetadata(() => ({
       cmd_app_reset_used: flags.reset,
     }))
-
-    // When releasing, we require --no-release or --allow-updates or --allow-deletes for non-TTY.
-    const requiredNonTTYFlags: string[] = []
-    const hasAnyForceFlags = flags['no-release'] || flags['allow-updates'] || flags['allow-deletes']
-    if (!hasAnyForceFlags) {
-      requiredNonTTYFlags.push('allow-updates')
-    }
-    this.failMissingNonTTYFlags(flags, requiredNonTTYFlags)
 
     const {app, project, remoteApp, developerPlatformClient, organization} = await linkedAppContext({
       directory: flags.path,

--- a/packages/app/src/cli/commands/app/function/replay.ts
+++ b/packages/app/src/cli/commands/app/function/replay.ts
@@ -3,7 +3,7 @@ import {replay} from '../../../services/function/replay.js'
 import {appFlags} from '../../../flags.js'
 import AppLinkedCommand, {AppLinkedCommandOutput} from '../../../utilities/app-linked-command.js'
 import {linkedAppContext} from '../../../services/app-context.js'
-import {globalFlags, jsonFlag} from '@shopify/cli-kit/node/cli'
+import {globalFlags, jsonFlag, requiredIfNonInteractive} from '@shopify/cli-kit/node/cli'
 import {Flags} from '@oclif/core'
 
 export default class FunctionReplay extends AppLinkedCommand {
@@ -18,12 +18,14 @@ export default class FunctionReplay extends AppLinkedCommand {
     ...appFlags,
     ...functionFlags,
     ...jsonFlag,
-    log: Flags.string({
-      char: 'l',
-      description:
-        'Specifies a log identifier to replay instead of selecting from a list. The identifier is provided in the output of `shopify app dev` and is the suffix of the log file name.',
-      env: 'SHOPIFY_FLAG_LOG',
-    }),
+    log: requiredIfNonInteractive(
+      Flags.string({
+        char: 'l',
+        description:
+          'Specifies a log identifier to replay instead of selecting from a list. The identifier is provided in the output of `shopify app dev` and is the suffix of the log file name.',
+        env: 'SHOPIFY_FLAG_LOG',
+      }),
+    ),
     watch: Flags.boolean({
       char: 'w',
       hidden: false,

--- a/packages/app/src/cli/commands/app/generate/extension.ts
+++ b/packages/app/src/cli/commands/app/generate/extension.ts
@@ -5,7 +5,7 @@ import {checkFolderIsValidApp} from '../../../models/app/loader.js'
 import AppLinkedCommand, {AppLinkedCommandOutput} from '../../../utilities/app-linked-command.js'
 import {linkedAppContext} from '../../../services/app-context.js'
 import {Flags} from '@oclif/core'
-import {globalFlags} from '@shopify/cli-kit/node/cli'
+import {globalFlags, requiredIfNonInteractive} from '@shopify/cli-kit/node/cli'
 
 export default class AppGenerateExtension extends AppLinkedCommand {
   static summary = 'Generate a new app Extension.'
@@ -20,18 +20,22 @@ export default class AppGenerateExtension extends AppLinkedCommand {
   static flags = {
     ...globalFlags,
     ...appFlags,
-    template: Flags.string({
-      char: 't',
-      hidden: false,
-      description: `Extension template`,
-      env: 'SHOPIFY_FLAG_EXTENSION_TEMPLATE',
-    }),
-    name: Flags.string({
-      char: 'n',
-      hidden: false,
-      description: 'name of your Extension',
-      env: 'SHOPIFY_FLAG_NAME',
-    }),
+    template: requiredIfNonInteractive(
+      Flags.string({
+        char: 't',
+        hidden: false,
+        description: `Extension template`,
+        env: 'SHOPIFY_FLAG_EXTENSION_TEMPLATE',
+      }),
+    ),
+    name: requiredIfNonInteractive(
+      Flags.string({
+        char: 'n',
+        hidden: false,
+        description: 'name of your Extension',
+        env: 'SHOPIFY_FLAG_NAME',
+      }),
+    ),
     'clone-url': Flags.string({
       hidden: true,
       char: 'u',
@@ -41,7 +45,8 @@ export default class AppGenerateExtension extends AppLinkedCommand {
     }),
     flavor: Flags.string({
       hidden: false,
-      description: 'Choose a starting template for your extension, where applicable',
+      description:
+        'Choose a starting template for your extension, where applicable. Required if non interactive when the selected extension template supports multiple flavors.',
       options: ['vanilla-js', 'react', 'typescript', 'typescript-react', 'wasm', 'rust'],
       env: 'SHOPIFY_FLAG_FLAVOR',
     }),

--- a/packages/app/src/cli/commands/app/init.test.ts
+++ b/packages/app/src/cli/commands/app/init.test.ts
@@ -12,12 +12,15 @@ import {
   testOrganization,
   testOrganizationApp,
 } from '../../models/app/app.test-data.js'
-import {describe, expect, test, vi} from 'vitest'
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 import {mockAndCaptureOutput} from '@shopify/cli-kit/node/testing/output'
 import {inTemporaryDirectory} from '@shopify/cli-kit/node/fs'
 import {inferPackageManager} from '@shopify/cli-kit/node/node-package-manager'
 
-vi.mock('../../prompts/init/init.js')
+vi.mock('../../prompts/init/init.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../prompts/init/init.js')>()
+  return {...actual, default: vi.fn()}
+})
 vi.mock('../../services/init/init.js')
 vi.mock('../../utilities/developer-platform-client.js')
 vi.mock('../../services/context.js')
@@ -32,7 +35,59 @@ vi.mock('../../prompts/dev.js')
 vi.mock('../../services/init/validate.js')
 vi.mock('@shopify/cli-kit/node/node-package-manager')
 
+let originalStdinIsTTY: boolean | undefined
+let originalStdoutIsTTY: boolean | undefined
+
+beforeEach(() => {
+  originalStdinIsTTY = process.stdin.isTTY
+  originalStdoutIsTTY = process.stdout.isTTY
+  vi.unstubAllEnvs()
+  Object.defineProperty(process.stdin, 'isTTY', {value: true, configurable: true, writable: true})
+  Object.defineProperty(process.stdout, 'isTTY', {value: true, configurable: true, writable: true})
+  vi.stubEnv('CI', '')
+})
+
+afterEach(() => {
+  Object.defineProperty(process.stdin, 'isTTY', {value: originalStdinIsTTY, configurable: true, writable: true})
+  Object.defineProperty(process.stdout, 'isTTY', {value: originalStdoutIsTTY, configurable: true, writable: true})
+})
+
 describe('Init command', () => {
+  test('reports all unconditional requirements before running non-interactively', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      vi.stubEnv('CI', 'true')
+      const outputMock = mockAndCaptureOutput()
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      try {
+        await expect(Init.run(['--path', tmpDir])).rejects.toThrow('process.exit unexpectedly called with "1"')
+        expect(outputMock.error()).toContain('--template')
+        expect(outputMock.error()).toContain('--name or --client-id')
+        expect(outputMock.error()).toContain('--organization-id or --client-id')
+        expect(outputMock.error()).not.toContain('--flavor')
+      } finally {
+        consoleErrorSpy.mockRestore()
+      }
+    })
+  })
+
+  test('requires a flavor non-interactively when the selected template offers flavors', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      vi.stubEnv('CI', 'true')
+      const outputMock = mockAndCaptureOutput()
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      try {
+        await expect(
+          Init.run(['--path', tmpDir, '--template', 'reactRouter', '--name', 'my-app', '--organization-id', '1']),
+        ).rejects.toThrow('process.exit unexpectedly called with "1"')
+        expect(outputMock.error()).toContain('--flavor')
+      } finally {
+        consoleErrorSpy.mockRestore()
+      }
+    })
+  })
+
   test('runs init command with default flags', async () => {
     await inTemporaryDirectory(async (tmpDir) => {
       // Given
@@ -79,6 +134,7 @@ describe('Init command', () => {
   test('runs init command without prompts when organization-id, name, and template flags are provided', async () => {
     await inTemporaryDirectory(async (tmpDir) => {
       // Given
+      vi.stubEnv('CI', 'true')
       const mockOrganization = testOrganization()
       const mockDeveloperPlatformClient = testDeveloperPlatformClient()
       const mockApp = testAppLinked()
@@ -100,8 +156,8 @@ describe('Init command', () => {
       })
 
       vi.mocked(initPrompt).mockResolvedValue({
-        template: 'https://github.com/Shopify/shopify-app-template-remix',
-        templateType: 'remix',
+        template: 'https://github.com/Shopify/shopify-app-template-extension-only',
+        templateType: 'none',
         globalCLIResult: {install: false, alreadyInstalled: false},
       })
       vi.mocked(initService).mockResolvedValue({app: mockApp})
@@ -113,7 +169,7 @@ describe('Init command', () => {
         '--name',
         'my-app',
         '--template',
-        'remix',
+        'none',
         '--path',
         tmpDir,
       ])
@@ -130,7 +186,7 @@ describe('Init command', () => {
         expect.objectContaining({
           name: 'my-app',
           packageManager: 'npm',
-          template: 'https://github.com/Shopify/shopify-app-template-remix',
+          template: 'https://github.com/Shopify/shopify-app-template-extension-only',
         }),
       )
     })

--- a/packages/app/src/cli/commands/app/init.ts
+++ b/packages/app/src/cli/commands/app/init.ts
@@ -1,4 +1,4 @@
-import initPrompt, {visibleTemplates} from '../../prompts/init/init.js'
+import initPrompt, {templateRequiresFlavor, visibleTemplates} from '../../prompts/init/init.js'
 import initService from '../../services/init/init.js'
 import {defaultDeveloperPlatformClient, DeveloperPlatformClient} from '../../utilities/developer-platform-client.js'
 import {appFromIdentifiers, selectOrg} from '../../services/context.js'
@@ -10,7 +10,7 @@ import {appNamePrompt, createAsNewAppPrompt, selectAppPrompt} from '../../prompt
 import {searchForAppsByNameFactory} from '../../services/dev/prompt-helpers.js'
 import {isValidName} from '../../models/app/validation/common.js'
 import {Flags} from '@oclif/core'
-import {globalFlags} from '@shopify/cli-kit/node/cli'
+import {globalFlags, requiredIfNonInteractive} from '@shopify/cli-kit/node/cli'
 import {resolvePath, cwd} from '@shopify/cli-kit/node/path'
 import {addPublicMetadata} from '@shopify/cli-kit/node/metadata'
 
@@ -18,9 +18,15 @@ import {installGlobalShopifyCLI} from '@shopify/cli-kit/node/is-global'
 import {generateRandomNameForSubdirectory} from '@shopify/cli-kit/node/fs'
 import {inferPackageManager} from '@shopify/cli-kit/node/node-package-manager'
 import {AbortError} from '@shopify/cli-kit/node/error'
+import type {NonTTYFlagRequirement} from '@shopify/cli-kit/node/base-command'
 
 export default class Init extends AppLinkedCommand {
   static summary?: string | undefined = 'Create a new app project'
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %> --name my-app --organization-id 123 --template reactRouter --flavor typescript',
+    '<%= config.bin %> <%= command.id %> --client-id 123 --template none',
+  ]
 
   static flags = {
     ...globalFlags,
@@ -29,7 +35,7 @@ export default class Init extends AppLinkedCommand {
       env: 'SHOPIFY_FLAG_NAME',
       hidden: false,
       description:
-        'The name for the new app. When provided, skips the app selection prompt and creates a new app with this name.',
+        'The name for the new app. When provided, skips the app selection prompt and creates a new app with this name. Required in non-interactive environments unless --client-id is provided.',
     }),
     path: Flags.string({
       char: 'p',
@@ -38,14 +44,17 @@ export default class Init extends AppLinkedCommand {
       default: async () => cwd(),
       hidden: false,
     }),
-    template: Flags.string({
-      description: `The app template. Accepts one of the following:
+    template: requiredIfNonInteractive(
+      Flags.string({
+        description: `The app template. Accepts one of the following:
        - <${visibleTemplates.join('|')}>
        - Any GitHub repo with optional branch and subpath, e.g., https://github.com/Shopify/<repository>/[subpath]#[branch]`,
-      env: 'SHOPIFY_FLAG_TEMPLATE',
-    }),
+        env: 'SHOPIFY_FLAG_TEMPLATE',
+      }),
+    ),
     flavor: Flags.string({
-      description: 'Which flavor of the given template to use.',
+      description:
+        'Which flavor of the given template to use. Required in non-interactive environments when the selected template offers multiple flavors.',
       env: 'SHOPIFY_FLAG_TEMPLATE_FLAVOR',
     }),
     'package-manager': Flags.string({
@@ -63,17 +72,28 @@ export default class Init extends AppLinkedCommand {
     'client-id': Flags.string({
       hidden: false,
       description:
-        'The Client ID of your app. Use this to automatically link your new project to an existing app. Using this flag avoids the app selection prompt.',
+        'The Client ID of your app. Use this to automatically link your new project to an existing app. In non-interactive environments, provide this flag or both --name and --organization-id.',
       env: 'SHOPIFY_FLAG_CLIENT_ID',
       exclusive: ['config'],
     }),
     'organization-id': Flags.string({
       hidden: false,
       description:
-        'The organization ID. Your organization ID can be found in your Dev Dashboard URL: https://dev.shopify.com/dashboard/<organization-id>',
+        'The organization ID. Your organization ID can be found in your Dev Dashboard URL: https://dev.shopify.com/dashboard/<organization-id>. Required in non-interactive environments unless --client-id is provided.',
       env: 'SHOPIFY_FLAG_ORGANIZATION_ID',
       exclusive: ['client-id'],
     }),
+  }
+
+  static nonTTYFlagRequirements(): NonTTYFlagRequirement[] {
+    return [
+      {flags: ['name', 'client-id']},
+      {flags: ['organization-id', 'client-id']},
+      {
+        flags: ['flavor'],
+        when: (flags) => templateRequiresFlavor(flags.template as string | undefined),
+      },
+    ]
   }
 
   async run(): Promise<AppLinkedCommandOutput> {

--- a/packages/app/src/cli/commands/app/non-interactive-flags.test.ts
+++ b/packages/app/src/cli/commands/app/non-interactive-flags.test.ts
@@ -1,0 +1,36 @@
+import ConfigLink from './config/link.js'
+import Deploy from './deploy.js'
+import FunctionReplay from './function/replay.js'
+import AppGenerateExtension from './generate/extension.js'
+import Release from './release.js'
+import WebhookTrigger from './webhook/trigger.js'
+import {describe, expect, test} from 'vitest'
+
+describe('non-interactive app command flags', () => {
+  test.each([
+    {command: ConfigLink, flag: 'client-id'},
+    {command: FunctionReplay, flag: 'log'},
+    {command: AppGenerateExtension, flag: 'template'},
+    {command: AppGenerateExtension, flag: 'name'},
+    {command: WebhookTrigger, flag: 'api-version'},
+    {command: WebhookTrigger, flag: 'topic'},
+    {command: WebhookTrigger, flag: 'address'},
+  ])('$command.name documents --$flag as required', ({command, flag}) => {
+    const flags = command.flags as Record<string, {description?: string}>
+    expect(flags[flag]!.description).toMatch(/Required if non interactive\.$/)
+  })
+
+  test('app deploy accepts any flag that skips confirmation', () => {
+    expect(Deploy.nonTTYFlagRequirements()).toEqual([{flags: ['allow-updates', 'allow-deletes', 'no-release']}])
+  })
+
+  test('app generate extension documents its template-dependent flavor requirement', () => {
+    expect(AppGenerateExtension.flags.flavor.description).toMatch(
+      /Required if non interactive when the selected extension template supports multiple flavors\.$/,
+    )
+  })
+
+  test('app release accepts either flag that skips confirmation', () => {
+    expect(Release.nonTTYFlagRequirements()).toEqual([{flags: ['allow-updates', 'allow-deletes']}])
+  })
+})

--- a/packages/app/src/cli/commands/app/release.ts
+++ b/packages/app/src/cli/commands/app/release.ts
@@ -5,6 +5,7 @@ import {linkedAppContext} from '../../services/app-context.js'
 import {Flags} from '@oclif/core'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
 import {addPublicMetadata} from '@shopify/cli-kit/node/metadata'
+import type {NonTTYFlagRequirement} from '@shopify/cli-kit/node/base-command'
 
 export default class Release extends AppLinkedCommand {
   static summary = 'Release an app version.'
@@ -21,13 +22,13 @@ export default class Release extends AppLinkedCommand {
     'allow-updates': Flags.boolean({
       hidden: false,
       description:
-        'Allows adding and updating extensions and configuration without requiring user confirmation. Recommended option for CI/CD environments.',
+        'Allows adding and updating extensions and configuration without requiring user confirmation. Recommended option for CI/CD environments. Required in non-interactive environments unless --allow-deletes is provided.',
       env: 'SHOPIFY_FLAG_ALLOW_UPDATES',
     }),
     'allow-deletes': Flags.boolean({
       hidden: false,
       description:
-        'Allows removing extensions and configuration without requiring user confirmation. For CI/CD environments, the recommended flag is --allow-updates.',
+        'Allows removing extensions and configuration without requiring user confirmation. For CI/CD environments, the recommended flag is --allow-updates. Required in non-interactive environments unless --allow-updates is provided.',
       env: 'SHOPIFY_FLAG_ALLOW_DELETES',
     }),
     version: Flags.string({
@@ -36,6 +37,10 @@ export default class Release extends AppLinkedCommand {
       env: 'SHOPIFY_FLAG_VERSION',
       required: true,
     }),
+  }
+
+  static nonTTYFlagRequirements(): NonTTYFlagRequirement[] {
+    return [{flags: ['allow-updates', 'allow-deletes']}]
   }
 
   async run(): Promise<AppLinkedCommandOutput> {
@@ -51,13 +56,6 @@ export default class Release extends AppLinkedCommand {
     // `force` (skip confirmation prompt) is implied when both --allow-updates
     // and --allow-deletes are set.
     const force = Boolean(allowUpdates && allowDeletes)
-
-    // We require --allow-updates or --allow-deletes for non-TTY.
-    const requiredNonTTYFlags: string[] = []
-    if (!allowUpdates && !allowDeletes) {
-      requiredNonTTYFlags.push('allow-updates')
-    }
-    this.failMissingNonTTYFlags(flags, requiredNonTTYFlags)
 
     const {app, remoteApp, developerPlatformClient} = await linkedAppContext({
       directory: flags.path,

--- a/packages/app/src/cli/commands/app/webhook/trigger.ts
+++ b/packages/app/src/cli/commands/app/webhook/trigger.ts
@@ -5,6 +5,7 @@ import {appFlags} from '../../../flags.js'
 import AppLinkedCommand, {AppLinkedCommandOutput} from '../../../utilities/app-linked-command.js'
 import {linkedAppContext} from '../../../services/app-context.js'
 import {Flags} from '@oclif/core'
+import {requiredIfNonInteractive} from '@shopify/cli-kit/node/cli'
 
 export default class WebhookTrigger extends AppLinkedCommand {
   static summary = 'Trigger delivery of a sample webhook topic payload to a designated address.'
@@ -36,18 +37,22 @@ export default class WebhookTrigger extends AppLinkedCommand {
       env: 'SHOPIFY_FLAG_HELP',
       description: `This help. When you run the trigger command the CLI will prompt you for any information that isn't passed using flags.`,
     }),
-    topic: Flags.string({
-      required: false,
-      hidden: false,
-      env: 'SHOPIFY_FLAG_TOPIC',
-      description: 'The requested webhook topic.',
-    }),
-    'api-version': Flags.string({
-      required: false,
-      hidden: false,
-      env: 'SHOPIFY_FLAG_API_VERSION',
-      description: 'The API Version of the webhook topic.',
-    }),
+    topic: requiredIfNonInteractive(
+      Flags.string({
+        required: false,
+        hidden: false,
+        env: 'SHOPIFY_FLAG_TOPIC',
+        description: 'The requested webhook topic.',
+      }),
+    ),
+    'api-version': requiredIfNonInteractive(
+      Flags.string({
+        required: false,
+        hidden: false,
+        env: 'SHOPIFY_FLAG_API_VERSION',
+        description: 'The API Version of the webhook topic.',
+      }),
+    ),
     'delivery-method': Flags.string({
       required: false,
       hidden: false,
@@ -61,16 +66,18 @@ export default class WebhookTrigger extends AppLinkedCommand {
       env: 'SHOPIFY_FLAG_CLIENT_SECRET',
       description: `Your app's client secret. This secret allows us to return the X-Shopify-Hmac-SHA256 header that lets you validate the origin of the response that you receive.`,
     }),
-    address: Flags.string({
-      required: false,
-      hidden: false,
-      env: 'SHOPIFY_FLAG_ADDRESS',
-      description: `The URL where the webhook payload should be sent.
+    address: requiredIfNonInteractive(
+      Flags.string({
+        required: false,
+        hidden: false,
+        env: 'SHOPIFY_FLAG_ADDRESS',
+        description: `The URL where the webhook payload should be sent.
                     You will need a different address type for each delivery-method:
                     ${deliveryMethodInstructionsAsString(DELIVERY_METHOD.HTTP)}
                     ${deliveryMethodInstructionsAsString(DELIVERY_METHOD.PUBSUB)}
                     ${deliveryMethodInstructionsAsString(DELIVERY_METHOD.EVENTBRIDGE)}`,
-    }),
+      }),
+    ),
   }
 
   public async run(): Promise<AppLinkedCommandOutput> {

--- a/packages/app/src/cli/prompts/init/init.test.ts
+++ b/packages/app/src/cli/prompts/init/init.test.ts
@@ -1,4 +1,4 @@
-import init, {InitOptions, visibleTemplates} from './init.js'
+import init, {InitOptions, templateRequiresFlavor, visibleTemplates} from './init.js'
 import {describe, expect, vi, test, beforeEach} from 'vitest'
 import {renderSelectPrompt} from '@shopify/cli-kit/node/ui'
 import {installGlobalCLIPrompt} from '@shopify/cli-kit/node/is-global'
@@ -45,6 +45,16 @@ describe('init', () => {
     test('exposes only the templates that are still actively offered', () => {
       expect(visibleTemplates).toEqual(['reactRouter', 'none'])
     })
+  })
+
+  test.each<{template: string | undefined; expected: boolean}>([
+    {template: 'reactRouter', expected: true},
+    {template: 'remix', expected: true},
+    {template: 'none', expected: false},
+    {template: 'https://github.com/Shopify/custom-template', expected: false},
+    {template: undefined, expected: false},
+  ])('reports whether template $template requires a flavor', ({template, expected}) => {
+    expect(templateRequiresFlavor(template)).toBe(expected)
   })
 
   test('it renders branches for templates that have them', async () => {

--- a/packages/app/src/cli/prompts/init/init.ts
+++ b/packages/app/src/cli/prompts/init/init.ts
@@ -141,3 +141,7 @@ export default init
 export function isPredefinedTemplate(template: string): template is PredefinedTemplate {
   return allTemplates.includes(template as PredefinedTemplate)
 }
+
+export function templateRequiresFlavor(template: string | undefined): boolean {
+  return template !== undefined && isPredefinedTemplate(template) && templates[template].branches !== undefined
+}

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -384,7 +384,7 @@ FLAGS
       [env: SHOPIFY_FLAG_AUTH_ALIAS]
 
   --client-id=<value>
-      The Client ID of your app.
+      The Client ID of your app. Required if non interactive.
       [env: SHOPIFY_FLAG_CLIENT_ID]
 
   --file-name=<value>
@@ -577,12 +577,13 @@ FLAGS
 
   --allow-deletes
       Allows removing extensions and configuration without requiring user confirmation. For CI/CD environments, the
-      recommended flag is --allow-updates.
+      recommended flag is --allow-updates. In non-interactive environments, provide this flag, --allow-updates, or
+      --no-release.
       [env: SHOPIFY_FLAG_ALLOW_DELETES]
 
   --allow-updates
       Allows adding and updating extensions and configuration without requiring user confirmation. Recommended option for
-      CI/CD environments.
+      CI/CD environments. In non-interactive environments, provide this flag, --allow-deletes, or --no-release.
       [env: SHOPIFY_FLAG_ALLOW_UPDATES]
 
   --auth-alias=<value>
@@ -609,7 +610,7 @@ FLAGS
 
   --no-release
       Creates a version but doesn't release it - it's not made available to merchants. With this flag, a user confirmation
-      is not required.
+      is not required. In non-interactive environments, provide this flag, --allow-updates, or --allow-deletes.
       [env: SHOPIFY_FLAG_NO_RELEASE]
 
   --path=<value>
@@ -1090,7 +1091,7 @@ FLAGS
 
   -l, --log=<value>
       Specifies a log identifier to replay instead of selecting from a list. The identifier is provided in the output of
-      `shopify app dev` and is the suffix of the log file name.
+      `shopify app dev` and is the suffix of the log file name. Required if non interactive.
       [env: SHOPIFY_FLAG_LOG]
 
   -w, --[no-]watch
@@ -1304,11 +1305,11 @@ FLAGS
       [env: SHOPIFY_FLAG_APP_CONFIG]
 
   -n, --name=<value>
-      name of your Extension
+      name of your Extension. Required if non interactive.
       [env: SHOPIFY_FLAG_NAME]
 
   -t, --template=<value>
-      Extension template
+      Extension template. Required if non interactive.
       [env: SHOPIFY_FLAG_EXTENSION_TEMPLATE]
 
   --auth-alias=<value>
@@ -1320,7 +1321,8 @@ FLAGS
       [env: SHOPIFY_FLAG_CLIENT_ID]
 
   --flavor=<option>
-      Choose a starting template for your extension, where applicable
+      Choose a starting template for your extension, where applicable. Required if non interactive when the selected
+      extension template supports multiple flavors.
       [env: SHOPIFY_FLAG_FLAVOR]
       <options: vanilla-js|react|typescript|typescript-react|wasm|rust>
 
@@ -1590,6 +1592,7 @@ FLAGS
 
   -n, --name=<value>
       The name for the new app. When provided, skips the app selection prompt and creates a new app with this name.
+      Required in non-interactive environments unless --client-id is provided.
       [env: SHOPIFY_FLAG_NAME]
 
   -p, --path=<value>
@@ -1600,12 +1603,13 @@ FLAGS
       [env: SHOPIFY_FLAG_AUTH_ALIAS]
 
   --client-id=<value>
-      The Client ID of your app. Use this to automatically link your new project to an existing app. Using this flag
-      avoids the app selection prompt.
+      The Client ID of your app. Use this to automatically link your new project to an existing app. In non-interactive
+      environments, provide this flag or both --name and --organization-id.
       [env: SHOPIFY_FLAG_CLIENT_ID]
 
   --flavor=<value>
-      Which flavor of the given template to use.
+      Which flavor of the given template to use. Required in non-interactive environments when the selected template
+      offers multiple flavors.
       [env: SHOPIFY_FLAG_TEMPLATE_FLAVOR]
 
   --no-color
@@ -1614,18 +1618,25 @@ FLAGS
 
   --organization-id=<value>
       The organization ID. Your organization ID can be found in your Dev Dashboard URL:
-      https://dev.shopify.com/dashboard/<organization-id>
+      https://dev.shopify.com/dashboard/<organization-id>. Required in non-interactive environments unless --client-id is
+      provided.
       [env: SHOPIFY_FLAG_ORGANIZATION_ID]
 
   --template=<value>
       The app template. Accepts one of the following:
       - <reactRouter|none>
-      - Any GitHub repo with optional branch and subpath, e.g., https://github.com/Shopify/<repository>/[subpath]#[branch]
+      - Any GitHub repo with optional branch and subpath, e.g.,
+      https://github.com/Shopify/<repository>/[subpath]#[branch]. Required if non interactive.
       [env: SHOPIFY_FLAG_TEMPLATE]
 
   --verbose
       Increase the verbosity of the output. May include sensitive data.
       [env: SHOPIFY_FLAG_VERBOSE]
+
+EXAMPLES
+  $ shopify app init --name my-app --organization-id 123 --template reactRouter --flavor typescript
+
+  $ shopify app init --client-id 123 --template none
 ```
 
 ## `shopify app logs`
@@ -1756,12 +1767,12 @@ FLAGS
 
   --allow-deletes
       Allows removing extensions and configuration without requiring user confirmation. For CI/CD environments, the
-      recommended flag is --allow-updates.
+      recommended flag is --allow-updates. Required in non-interactive environments unless --allow-updates is provided.
       [env: SHOPIFY_FLAG_ALLOW_DELETES]
 
   --allow-updates
       Allows adding and updating extensions and configuration without requiring user confirmation. Recommended option for
-      CI/CD environments.
+      CI/CD environments. Required in non-interactive environments unless --allow-deletes is provided.
       [env: SHOPIFY_FLAG_ALLOW_UPDATES]
 
   --auth-alias=<value>
@@ -1867,11 +1878,12 @@ FLAGS
       · For remote HTTP testing, use a URL that starts with https://
       · For local HTTP testing, use http://localhost:{port}/{url-path}
       · For Google Pub/Sub, use pubsub://{project-id}:{topic-id}
-      · For Amazon EventBridge, use an Amazon Resource Name (ARN) starting with arn:aws:events:
+      · For Amazon EventBridge, use an Amazon Resource Name (ARN) starting with arn:aws:events:. Required if non
+      interactive.
       [env: SHOPIFY_FLAG_ADDRESS]
 
   --api-version=<value>
-      The API Version of the webhook topic.
+      The API Version of the webhook topic. Required if non interactive.
       [env: SHOPIFY_FLAG_API_VERSION]
 
   --auth-alias=<value>
@@ -1906,7 +1918,7 @@ FLAGS
       [env: SHOPIFY_FLAG_RESET]
 
   --topic=<value>
-      The requested webhook topic.
+      The requested webhook topic. Required if non interactive.
       [env: SHOPIFY_FLAG_TOPIC]
 
 DESCRIPTION

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -480,7 +480,7 @@
           "type": "option"
         },
         "client-id": {
-          "description": "The Client ID of your app.",
+          "description": "The Client ID of your app. Required if non interactive.",
           "env": "SHOPIFY_FLAG_CLIENT_ID",
           "exclusive": [
             "config"
@@ -855,7 +855,7 @@
       "flags": {
         "allow-deletes": {
           "allowNo": false,
-          "description": "Allows removing extensions and configuration without requiring user confirmation. For CI/CD environments, the recommended flag is --allow-updates.",
+          "description": "Allows removing extensions and configuration without requiring user confirmation. For CI/CD environments, the recommended flag is --allow-updates. In non-interactive environments, provide this flag, --allow-updates, or --no-release.",
           "env": "SHOPIFY_FLAG_ALLOW_DELETES",
           "hidden": false,
           "name": "allow-deletes",
@@ -863,7 +863,7 @@
         },
         "allow-updates": {
           "allowNo": false,
-          "description": "Allows adding and updating extensions and configuration without requiring user confirmation. Recommended option for CI/CD environments.",
+          "description": "Allows adding and updating extensions and configuration without requiring user confirmation. Recommended option for CI/CD environments. In non-interactive environments, provide this flag, --allow-deletes, or --no-release.",
           "env": "SHOPIFY_FLAG_ALLOW_UPDATES",
           "hidden": false,
           "name": "allow-updates",
@@ -925,7 +925,7 @@
         },
         "no-release": {
           "allowNo": false,
-          "description": "Creates a version but doesn't release it - it's not made available to merchants. With this flag, a user confirmation is not required.",
+          "description": "Creates a version but doesn't release it - it's not made available to merchants. With this flag, a user confirmation is not required. In non-interactive environments, provide this flag, --allow-updates, or --allow-deletes.",
           "env": "SHOPIFY_FLAG_NO_RELEASE",
           "exclusive": [
             "allow-updates",
@@ -1869,7 +1869,7 @@
         },
         "log": {
           "char": "l",
-          "description": "Specifies a log identifier to replay instead of selecting from a list. The identifier is provided in the output of `shopify app dev` and is the suffix of the log file name.",
+          "description": "Specifies a log identifier to replay instead of selecting from a list. The identifier is provided in the output of `shopify app dev` and is the suffix of the log file name. Required if non interactive.",
           "env": "SHOPIFY_FLAG_LOG",
           "hasDynamicHelp": false,
           "multiple": false,
@@ -2287,7 +2287,7 @@
           "type": "option"
         },
         "flavor": {
-          "description": "Choose a starting template for your extension, where applicable",
+          "description": "Choose a starting template for your extension, where applicable. Required if non interactive when the selected extension template supports multiple flavors.",
           "env": "SHOPIFY_FLAG_FLAVOR",
           "hasDynamicHelp": false,
           "hidden": false,
@@ -2305,7 +2305,7 @@
         },
         "name": {
           "char": "n",
-          "description": "name of your Extension",
+          "description": "name of your Extension. Required if non interactive.",
           "env": "SHOPIFY_FLAG_NAME",
           "hasDynamicHelp": false,
           "hidden": false,
@@ -2343,7 +2343,7 @@
         },
         "template": {
           "char": "t",
-          "description": "Extension template",
+          "description": "Extension template. Required if non interactive.",
           "env": "SHOPIFY_FLAG_EXTENSION_TEMPLATE",
           "hasDynamicHelp": false,
           "hidden": false,
@@ -2789,6 +2789,10 @@
       "args": {
       },
       "customPluginName": "@shopify/app",
+      "examples": [
+        "<%= config.bin %> <%= command.id %> --name my-app --organization-id 123 --template reactRouter --flavor typescript",
+        "<%= config.bin %> <%= command.id %> --client-id 123 --template none"
+      ],
       "flags": {
         "auth-alias": {
           "description": "Alias of the Shopify account to use for authentication.",
@@ -2799,7 +2803,7 @@
           "type": "option"
         },
         "client-id": {
-          "description": "The Client ID of your app. Use this to automatically link your new project to an existing app. Using this flag avoids the app selection prompt.",
+          "description": "The Client ID of your app. Use this to automatically link your new project to an existing app. In non-interactive environments, provide this flag or both --name and --organization-id.",
           "env": "SHOPIFY_FLAG_CLIENT_ID",
           "exclusive": [
             "config"
@@ -2811,7 +2815,7 @@
           "type": "option"
         },
         "flavor": {
-          "description": "Which flavor of the given template to use.",
+          "description": "Which flavor of the given template to use. Required in non-interactive environments when the selected template offers multiple flavors.",
           "env": "SHOPIFY_FLAG_TEMPLATE_FLAVOR",
           "hasDynamicHelp": false,
           "multiple": false,
@@ -2828,7 +2832,7 @@
         },
         "name": {
           "char": "n",
-          "description": "The name for the new app. When provided, skips the app selection prompt and creates a new app with this name.",
+          "description": "The name for the new app. When provided, skips the app selection prompt and creates a new app with this name. Required in non-interactive environments unless --client-id is provided.",
           "env": "SHOPIFY_FLAG_NAME",
           "hasDynamicHelp": false,
           "hidden": false,
@@ -2845,7 +2849,7 @@
           "type": "boolean"
         },
         "organization-id": {
-          "description": "The organization ID. Your organization ID can be found in your Dev Dashboard URL: https://dev.shopify.com/dashboard/<organization-id>",
+          "description": "The organization ID. Your organization ID can be found in your Dev Dashboard URL: https://dev.shopify.com/dashboard/<organization-id>. Required in non-interactive environments unless --client-id is provided.",
           "env": "SHOPIFY_FLAG_ORGANIZATION_ID",
           "exclusive": [
             "client-id"
@@ -2882,7 +2886,7 @@
           "type": "option"
         },
         "template": {
-          "description": "The app template. Accepts one of the following:\n       - <reactRouter|none>\n       - Any GitHub repo with optional branch and subpath, e.g., https://github.com/Shopify/<repository>/[subpath]#[branch]",
+          "description": "The app template. Accepts one of the following:\n       - <reactRouter|none>\n       - Any GitHub repo with optional branch and subpath, e.g., https://github.com/Shopify/<repository>/[subpath]#[branch]. Required if non interactive.",
           "env": "SHOPIFY_FLAG_TEMPLATE",
           "hasDynamicHelp": false,
           "multiple": false,
@@ -3129,7 +3133,7 @@
       "flags": {
         "allow-deletes": {
           "allowNo": false,
-          "description": "Allows removing extensions and configuration without requiring user confirmation. For CI/CD environments, the recommended flag is --allow-updates.",
+          "description": "Allows removing extensions and configuration without requiring user confirmation. For CI/CD environments, the recommended flag is --allow-updates. Required in non-interactive environments unless --allow-updates is provided.",
           "env": "SHOPIFY_FLAG_ALLOW_DELETES",
           "hidden": false,
           "name": "allow-deletes",
@@ -3137,7 +3141,7 @@
         },
         "allow-updates": {
           "allowNo": false,
-          "description": "Allows adding and updating extensions and configuration without requiring user confirmation. Recommended option for CI/CD environments.",
+          "description": "Allows adding and updating extensions and configuration without requiring user confirmation. Recommended option for CI/CD environments. Required in non-interactive environments unless --allow-deletes is provided.",
           "env": "SHOPIFY_FLAG_ALLOW_UPDATES",
           "hidden": false,
           "name": "allow-updates",
@@ -3336,7 +3340,7 @@
       "descriptionWithMarkdown": "\n  Triggers the delivery of a sample Admin API event topic payload to a designated address.\n\n  You should use this command to experiment with webhooks, to initially test your webhook configuration, or for unit testing. However, to test your webhook configuration from end to end, you should always trigger webhooks by performing the related action in Shopify.\n\n  Because most webhook deliveries use remote endpoints, you can trigger the command from any directory where you can use Shopify CLI, and send the webhook to any of the supported endpoint types. For example, you can run the command from your app's local directory, but send the webhook to a staging environment endpoint.\n\n  To learn more about using webhooks in a Shopify app, refer to [Webhooks overview](https://shopify.dev/docs/apps/webhooks).\n\n  ### Limitations\n\n  - Webhooks triggered using this method always have the same payload, so they can't be used to test scenarios that differ based on the payload contents.\n  - Webhooks triggered using this method aren't retried when they fail.\n  - Trigger requests are rate-limited using the [Partner API rate limit](https://shopify.dev/docs/api/partner#rate_limits).\n  - You can't use this method to validate your API webhook subscriptions.\n  ",
       "flags": {
         "address": {
-          "description": "The URL where the webhook payload should be sent.\n                    You will need a different address type for each delivery-method:\n                          · For remote HTTP testing, use a URL that starts with https://\n      · For local HTTP testing, use http://localhost:{port}/{url-path}\n                          · For Google Pub/Sub, use pubsub://{project-id}:{topic-id}\n                          · For Amazon EventBridge, use an Amazon Resource Name (ARN) starting with arn:aws:events:",
+          "description": "The URL where the webhook payload should be sent.\n                    You will need a different address type for each delivery-method:\n                          · For remote HTTP testing, use a URL that starts with https://\n      · For local HTTP testing, use http://localhost:{port}/{url-path}\n                          · For Google Pub/Sub, use pubsub://{project-id}:{topic-id}\n                          · For Amazon EventBridge, use an Amazon Resource Name (ARN) starting with arn:aws:events:. Required if non interactive.",
           "env": "SHOPIFY_FLAG_ADDRESS",
           "hasDynamicHelp": false,
           "hidden": false,
@@ -3346,7 +3350,7 @@
           "type": "option"
         },
         "api-version": {
-          "description": "The API Version of the webhook topic.",
+          "description": "The API Version of the webhook topic. Required if non interactive.",
           "env": "SHOPIFY_FLAG_API_VERSION",
           "hasDynamicHelp": false,
           "hidden": false,
@@ -3440,7 +3444,7 @@
           "type": "boolean"
         },
         "topic": {
-          "description": "The requested webhook topic.",
+          "description": "The requested webhook topic. Required if non interactive.",
           "env": "SHOPIFY_FLAG_TOPIC",
           "hasDynamicHelp": false,
           "hidden": false,

--- a/packages/create-app/oclif.manifest.json
+++ b/packages/create-app/oclif.manifest.json
@@ -5,6 +5,10 @@
       ],
       "args": {
       },
+      "examples": [
+        "<%= config.bin %> <%= command.id %> --name my-app --organization-id 123 --template reactRouter --flavor typescript",
+        "<%= config.bin %> <%= command.id %> --client-id 123 --template none"
+      ],
       "flags": {
         "auth-alias": {
           "description": "Alias of the Shopify account to use for authentication.",
@@ -15,7 +19,7 @@
           "type": "option"
         },
         "client-id": {
-          "description": "The Client ID of your app. Use this to automatically link your new project to an existing app. Using this flag avoids the app selection prompt.",
+          "description": "The Client ID of your app. Use this to automatically link your new project to an existing app. In non-interactive environments, provide this flag or both --name and --organization-id.",
           "env": "SHOPIFY_FLAG_CLIENT_ID",
           "exclusive": [
             "config"
@@ -27,7 +31,7 @@
           "type": "option"
         },
         "flavor": {
-          "description": "Which flavor of the given template to use.",
+          "description": "Which flavor of the given template to use. Required in non-interactive environments when the selected template offers multiple flavors.",
           "env": "SHOPIFY_FLAG_TEMPLATE_FLAVOR",
           "hasDynamicHelp": false,
           "multiple": false,
@@ -44,7 +48,7 @@
         },
         "name": {
           "char": "n",
-          "description": "The name for the new app. When provided, skips the app selection prompt and creates a new app with this name.",
+          "description": "The name for the new app. When provided, skips the app selection prompt and creates a new app with this name. Required in non-interactive environments unless --client-id is provided.",
           "env": "SHOPIFY_FLAG_NAME",
           "hasDynamicHelp": false,
           "hidden": false,
@@ -61,7 +65,7 @@
           "type": "boolean"
         },
         "organization-id": {
-          "description": "The organization ID. Your organization ID can be found in your Dev Dashboard URL: https://dev.shopify.com/dashboard/<organization-id>",
+          "description": "The organization ID. Your organization ID can be found in your Dev Dashboard URL: https://dev.shopify.com/dashboard/<organization-id>. Required in non-interactive environments unless --client-id is provided.",
           "env": "SHOPIFY_FLAG_ORGANIZATION_ID",
           "exclusive": [
             "client-id"
@@ -98,7 +102,7 @@
           "type": "option"
         },
         "template": {
-          "description": "The app template. Accepts one of the following:\n       - <reactRouter|none>\n       - Any GitHub repo with optional branch and subpath, e.g., https://github.com/Shopify/<repository>/[subpath]#[branch]",
+          "description": "The app template. Accepts one of the following:\n       - <reactRouter|none>\n       - Any GitHub repo with optional branch and subpath, e.g., https://github.com/Shopify/<repository>/[subpath]#[branch]. Required if non interactive.",
           "env": "SHOPIFY_FLAG_TEMPLATE",
           "hasDynamicHelp": false,
           "multiple": false,


### PR DESCRIPTION
Related: https://github.com/shop/issues-develop/issues/22928

## Summary

- Apply the new non-interactive requirement infrastructure to app commands.
- Cover `app init`, deploy/release alternatives, configuration linking, extension generation, function replay, and webhook triggering.
- Include conditional template-flavor validation, tests, and generated docs/manifests.

## Testing

See https://github.com/Shopify/cli/pull/8223