### PR TITLE
Document required non-interactive theme flags

### DIFF
--- a/docs-shopify.dev/generated/generated_docs_data_v2.json
+++ b/docs-shopify.dev/generated/generated_docs_data_v2.json
@@ -5684,7 +5684,7 @@
           "syntaxKind": "PropertySignature",
           "name": "-a, --show-all",
           "value": "''",
-          "description": "Include others development themes in theme list.",
+          "description": "Include other development themes in the theme list. Use --show-all, --development, or --theme in non-interactive environments.",
           "isOptional": true,
           "environmentValue": "SHOPIFY_FLAG_SHOW_ALL"
         },
@@ -5693,7 +5693,7 @@
           "syntaxKind": "PropertySignature",
           "name": "-d, --development",
           "value": "''",
-          "description": "Delete your development theme.",
+          "description": "Delete your development theme. Use --show-all, --development, or --theme in non-interactive environments.",
           "isOptional": true,
           "environmentValue": "SHOPIFY_FLAG_DEVELOPMENT"
         },
@@ -5711,7 +5711,7 @@
           "syntaxKind": "PropertySignature",
           "name": "-f, --force",
           "value": "''",
-          "description": "Skip confirmation.",
+          "description": "Skip confirmation. Required if non interactive.",
           "isOptional": true,
           "environmentValue": "SHOPIFY_FLAG_FORCE"
         },
@@ -5729,12 +5729,12 @@
           "syntaxKind": "PropertySignature",
           "name": "-t, --theme <value>",
           "value": "string",
-          "description": "Theme ID or name of the remote theme.",
+          "description": "Theme ID or name of the remote theme. Use --show-all, --development, or --theme in non-interactive environments.",
           "isOptional": true,
           "environmentValue": "SHOPIFY_FLAG_THEME_ID"
         }
       ],
-      "value": "export interface themedelete {\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--auth-alias <value>'?: string\n\n  /**\n   * Delete your development theme.\n   * @environment SHOPIFY_FLAG_DEVELOPMENT\n   */\n  '-d, --development'?: ''\n\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Skip confirmation.\n   * @environment SHOPIFY_FLAG_FORCE\n   */\n  '-f, --force'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Password generated from the Theme Access app or an Admin API token.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * The path where you want to run the command. Defaults to the current working directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Include others development themes in theme list.\n   * @environment SHOPIFY_FLAG_SHOW_ALL\n   */\n  '-a, --show-all'?: ''\n\n  /**\n   * Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Theme ID or name of the remote theme.\n   * @environment SHOPIFY_FLAG_THEME_ID\n   */\n  '-t, --theme <value>'?: string\n\n  /**\n   * Increase the verbosity of the output. May include sensitive data.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+      "value": "export interface themedelete {\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--auth-alias <value>'?: string\n\n  /**\n   * Delete your development theme. Use --show-all, --development, or --theme in non-interactive environments.\n   * @environment SHOPIFY_FLAG_DEVELOPMENT\n   */\n  '-d, --development'?: ''\n\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Skip confirmation. Required if non interactive.\n   * @environment SHOPIFY_FLAG_FORCE\n   */\n  '-f, --force'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Password generated from the Theme Access app or an Admin API token.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * The path where you want to run the command. Defaults to the current working directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Include other development themes in the theme list. Use --show-all, --development, or --theme in non-interactive environments.\n   * @environment SHOPIFY_FLAG_SHOW_ALL\n   */\n  '-a, --show-all'?: ''\n\n  /**\n   * Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Theme ID or name of the remote theme. Use --show-all, --development, or --theme in non-interactive environments.\n   * @environment SHOPIFY_FLAG_THEME_ID\n   */\n  '-t, --theme <value>'?: string\n\n  /**\n   * Increase the verbosity of the output. May include sensitive data.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
     }
   },
   "themedev": {
@@ -6012,7 +6012,7 @@
           "syntaxKind": "PropertySignature",
           "name": "-f, --force",
           "value": "''",
-          "description": "Force the duplicate operation to run without prompts or confirmations.",
+          "description": "Force the duplicate operation to run without prompts or confirmations. Required if non interactive outside CI.",
           "isOptional": true,
           "environmentValue": "SHOPIFY_FLAG_FORCE"
         },
@@ -6048,12 +6048,12 @@
           "syntaxKind": "PropertySignature",
           "name": "-t, --theme <value>",
           "value": "string",
-          "description": "Theme ID or name of the remote theme.",
+          "description": "Theme ID or name of the remote theme. Required if non interactive.",
           "isOptional": true,
           "environmentValue": "SHOPIFY_FLAG_THEME_ID"
         }
       ],
-      "value": "export interface themeduplicate {\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--auth-alias <value>'?: string\n\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Force the duplicate operation to run without prompts or confirmations.\n   * @environment SHOPIFY_FLAG_FORCE\n   */\n  '-f, --force'?: ''\n\n  /**\n   * Output the result as JSON. Automatically disables color output.\n   * @environment SHOPIFY_FLAG_JSON\n   */\n  '-j, --json'?: ''\n\n  /**\n   * Name of the newly duplicated theme.\n   * @environment SHOPIFY_FLAG_NAME\n   */\n  '-n, --name <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Password generated from the Theme Access app or an Admin API token.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Theme ID or name of the remote theme.\n   * @environment SHOPIFY_FLAG_THEME_ID\n   */\n  '-t, --theme <value>'?: string\n\n  /**\n   * Increase the verbosity of the output. May include sensitive data.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+      "value": "export interface themeduplicate {\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--auth-alias <value>'?: string\n\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Force the duplicate operation to run without prompts or confirmations. Required if non interactive outside CI.\n   * @environment SHOPIFY_FLAG_FORCE\n   */\n  '-f, --force'?: ''\n\n  /**\n   * Output the result as JSON. Automatically disables color output.\n   * @environment SHOPIFY_FLAG_JSON\n   */\n  '-j, --json'?: ''\n\n  /**\n   * Name of the newly duplicated theme.\n   * @environment SHOPIFY_FLAG_NAME\n   */\n  '-n, --name <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Password generated from the Theme Access app or an Admin API token.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Theme ID or name of the remote theme. Required if non interactive.\n   * @environment SHOPIFY_FLAG_THEME_ID\n   */\n  '-t, --theme <value>'?: string\n\n  /**\n   * Increase the verbosity of the output. May include sensitive data.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
     }
   },
   "themeinfo": {
@@ -6501,7 +6501,7 @@
           "syntaxKind": "PropertySignature",
           "name": "-d, --development",
           "value": "''",
-          "description": "Open your development theme.",
+          "description": "Open your development theme. Use --development, --live, or --theme in non-interactive environments.",
           "isOptional": true,
           "environmentValue": "SHOPIFY_FLAG_DEVELOPMENT"
         },
@@ -6528,7 +6528,7 @@
           "syntaxKind": "PropertySignature",
           "name": "-l, --live",
           "value": "''",
-          "description": "Open your live (published) theme.",
+          "description": "Open your live (published) theme. Use --development, --live, or --theme in non-interactive environments.",
           "isOptional": true,
           "environmentValue": "SHOPIFY_FLAG_LIVE"
         },
@@ -6546,12 +6546,12 @@
           "syntaxKind": "PropertySignature",
           "name": "-t, --theme <value>",
           "value": "string",
-          "description": "Theme ID or name of the remote theme.",
+          "description": "Theme ID or name of the remote theme. Use --development, --live, or --theme in non-interactive environments.",
           "isOptional": true,
           "environmentValue": "SHOPIFY_FLAG_THEME_ID"
         }
       ],
-      "value": "export interface themeopen {\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--auth-alias <value>'?: string\n\n  /**\n   * Open your development theme.\n   * @environment SHOPIFY_FLAG_DEVELOPMENT\n   */\n  '-d, --development'?: ''\n\n  /**\n   * Open the theme editor for the specified theme in the browser.\n   * @environment SHOPIFY_FLAG_EDITOR\n   */\n  '-E, --editor'?: ''\n\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Open your live (published) theme.\n   * @environment SHOPIFY_FLAG_LIVE\n   */\n  '-l, --live'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Password generated from the Theme Access app or an Admin API token.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * The path where you want to run the command. Defaults to the current working directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Theme ID or name of the remote theme.\n   * @environment SHOPIFY_FLAG_THEME_ID\n   */\n  '-t, --theme <value>'?: string\n\n  /**\n   * Increase the verbosity of the output. May include sensitive data.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+      "value": "export interface themeopen {\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--auth-alias <value>'?: string\n\n  /**\n   * Open your development theme. Use --development, --live, or --theme in non-interactive environments.\n   * @environment SHOPIFY_FLAG_DEVELOPMENT\n   */\n  '-d, --development'?: ''\n\n  /**\n   * Open the theme editor for the specified theme in the browser.\n   * @environment SHOPIFY_FLAG_EDITOR\n   */\n  '-E, --editor'?: ''\n\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Open your live (published) theme. Use --development, --live, or --theme in non-interactive environments.\n   * @environment SHOPIFY_FLAG_LIVE\n   */\n  '-l, --live'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Password generated from the Theme Access app or an Admin API token.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * The path where you want to run the command. Defaults to the current working directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Theme ID or name of the remote theme. Use --development, --live, or --theme in non-interactive environments.\n   * @environment SHOPIFY_FLAG_THEME_ID\n   */\n  '-t, --theme <value>'?: string\n\n  /**\n   * Increase the verbosity of the output. May include sensitive data.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
     }
   },
   "themepackage": {
@@ -6894,7 +6894,7 @@
           "syntaxKind": "PropertySignature",
           "name": "-f, --force",
           "value": "''",
-          "description": "Skip confirmation.",
+          "description": "Skip confirmation. Required if non interactive.",
           "isOptional": true,
           "environmentValue": "SHOPIFY_FLAG_FORCE"
         },
@@ -6912,12 +6912,12 @@
           "syntaxKind": "PropertySignature",
           "name": "-t, --theme <value>",
           "value": "string",
-          "description": "Theme ID or name of the remote theme.",
+          "description": "Theme ID or name of the remote theme. Required if non interactive.",
           "isOptional": true,
           "environmentValue": "SHOPIFY_FLAG_THEME_ID"
         }
       ],
-      "value": "export interface themepublish {\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--auth-alias <value>'?: string\n\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Skip confirmation.\n   * @environment SHOPIFY_FLAG_FORCE\n   */\n  '-f, --force'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Password generated from the Theme Access app or an Admin API token.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * The path where you want to run the command. Defaults to the current working directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Theme ID or name of the remote theme.\n   * @environment SHOPIFY_FLAG_THEME_ID\n   */\n  '-t, --theme <value>'?: string\n\n  /**\n   * Increase the verbosity of the output. May include sensitive data.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+      "value": "export interface themepublish {\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--auth-alias <value>'?: string\n\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Skip confirmation. Required if non interactive.\n   * @environment SHOPIFY_FLAG_FORCE\n   */\n  '-f, --force'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Password generated from the Theme Access app or an Admin API token.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * The path where you want to run the command. Defaults to the current working directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Theme ID or name of the remote theme. Required if non interactive.\n   * @environment SHOPIFY_FLAG_THEME_ID\n   */\n  '-t, --theme <value>'?: string\n\n  /**\n   * Increase the verbosity of the output. May include sensitive data.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
     }
   },
   "themepull": {
@@ -6977,7 +6977,7 @@
           "syntaxKind": "PropertySignature",
           "name": "-d, --development",
           "value": "''",
-          "description": "Pull theme files from your remote development theme.",
+          "description": "Pull theme files from your remote development theme. Use --development, --live, or --theme in non-interactive environments.",
           "isOptional": true,
           "environmentValue": "SHOPIFY_FLAG_DEVELOPMENT"
         },
@@ -6995,7 +6995,7 @@
           "syntaxKind": "PropertySignature",
           "name": "-l, --live",
           "value": "''",
-          "description": "Pull theme files from your remote live theme.",
+          "description": "Pull theme files from your remote live theme. Use --development, --live, or --theme in non-interactive environments.",
           "isOptional": true,
           "environmentValue": "SHOPIFY_FLAG_LIVE"
         },
@@ -7031,7 +7031,7 @@
           "syntaxKind": "PropertySignature",
           "name": "-t, --theme <value>",
           "value": "string",
-          "description": "Theme ID or name of the remote theme.",
+          "description": "Theme ID or name of the remote theme. Use --development, --live, or --theme in non-interactive environments.",
           "isOptional": true,
           "environmentValue": "SHOPIFY_FLAG_THEME_ID"
         },
@@ -7045,7 +7045,7 @@
           "environmentValue": "SHOPIFY_FLAG_IGNORE"
         }
       ],
-      "value": "export interface themepull {\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--auth-alias <value>'?: string\n\n  /**\n   * Pull theme files from your remote development theme.\n   * @environment SHOPIFY_FLAG_DEVELOPMENT\n   */\n  '-d, --development'?: ''\n\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Skip downloading the specified files (Multiple flags allowed). Wrap the value in double quotes if you're using wildcards.\n   * @environment SHOPIFY_FLAG_IGNORE\n   */\n  '-x, --ignore <value>'?: string\n\n  /**\n   * Pull theme files from your remote live theme.\n   * @environment SHOPIFY_FLAG_LIVE\n   */\n  '-l, --live'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Prevent deleting local files that don't exist remotely.\n   * @environment SHOPIFY_FLAG_NODELETE\n   */\n  '-n, --nodelete'?: ''\n\n  /**\n   * Download only the specified files (Multiple flags allowed). Wrap the value in double quotes if you're using wildcards.\n   * @environment SHOPIFY_FLAG_ONLY\n   */\n  '-o, --only <value>'?: string\n\n  /**\n   * Password generated from the Theme Access app or an Admin API token.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * The path where you want to run the command. Defaults to the current working directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Theme ID or name of the remote theme.\n   * @environment SHOPIFY_FLAG_THEME_ID\n   */\n  '-t, --theme <value>'?: string\n\n  /**\n   * Increase the verbosity of the output. May include sensitive data.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+      "value": "export interface themepull {\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--auth-alias <value>'?: string\n\n  /**\n   * Pull theme files from your remote development theme. Use --development, --live, or --theme in non-interactive environments.\n   * @environment SHOPIFY_FLAG_DEVELOPMENT\n   */\n  '-d, --development'?: ''\n\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Skip downloading the specified files (Multiple flags allowed). Wrap the value in double quotes if you're using wildcards.\n   * @environment SHOPIFY_FLAG_IGNORE\n   */\n  '-x, --ignore <value>'?: string\n\n  /**\n   * Pull theme files from your remote live theme. Use --development, --live, or --theme in non-interactive environments.\n   * @environment SHOPIFY_FLAG_LIVE\n   */\n  '-l, --live'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Prevent deleting local files that don't exist remotely.\n   * @environment SHOPIFY_FLAG_NODELETE\n   */\n  '-n, --nodelete'?: ''\n\n  /**\n   * Download only the specified files (Multiple flags allowed). Wrap the value in double quotes if you're using wildcards.\n   * @environment SHOPIFY_FLAG_ONLY\n   */\n  '-o, --only <value>'?: string\n\n  /**\n   * Password generated from the Theme Access app or an Admin API token.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * The path where you want to run the command. Defaults to the current working directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Theme ID or name of the remote theme. Use --development, --live, or --theme in non-interactive environments.\n   * @environment SHOPIFY_FLAG_THEME_ID\n   */\n  '-t, --theme <value>'?: string\n\n  /**\n   * Increase the verbosity of the output. May include sensitive data.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
     }
   },
   "themepush": {
@@ -7123,7 +7123,7 @@
           "syntaxKind": "PropertySignature",
           "name": "-a, --allow-live",
           "value": "''",
-          "description": "Allow push to a live theme.",
+          "description": "Allow push to a live theme. Required in non-interactive environments when targeting the live theme.",
           "isOptional": true,
           "environmentValue": "SHOPIFY_FLAG_ALLOW_LIVE"
         },
@@ -7141,7 +7141,7 @@
           "syntaxKind": "PropertySignature",
           "name": "-d, --development",
           "value": "''",
-          "description": "Push theme files from your remote development theme.",
+          "description": "Push theme files from your remote development theme. Use --development, --live, --theme, or --unpublished in non-interactive environments.",
           "isOptional": true,
           "environmentValue": "SHOPIFY_FLAG_DEVELOPMENT"
         },
@@ -7168,7 +7168,7 @@
           "syntaxKind": "PropertySignature",
           "name": "-l, --live",
           "value": "''",
-          "description": "Push theme files from your remote live theme.",
+          "description": "Push theme files from your remote live theme. Use --development, --live, --theme, or --unpublished in non-interactive environments.",
           "isOptional": true,
           "environmentValue": "SHOPIFY_FLAG_LIVE"
         },
@@ -7213,7 +7213,7 @@
           "syntaxKind": "PropertySignature",
           "name": "-t, --theme <value>",
           "value": "string",
-          "description": "Theme ID or name of the remote theme.",
+          "description": "Theme ID or name of the remote theme. Use --development, --live, --theme, or --unpublished in non-interactive environments. When using --unpublished without --development, use --theme to provide the new theme name.",
           "isOptional": true,
           "environmentValue": "SHOPIFY_FLAG_THEME_ID"
         },
@@ -7222,7 +7222,7 @@
           "syntaxKind": "PropertySignature",
           "name": "-u, --unpublished",
           "value": "''",
-          "description": "Create a new unpublished theme and push to it.",
+          "description": "Create a new unpublished theme and push to it. Use --development, --live, --theme, or --unpublished in non-interactive environments. When using --unpublished without --development, use --theme to provide the new theme name.",
           "isOptional": true,
           "environmentValue": "SHOPIFY_FLAG_UNPUBLISHED"
         },
@@ -7236,7 +7236,7 @@
           "environmentValue": "SHOPIFY_FLAG_IGNORE"
         }
       ],
-      "value": "export interface themepush {\n  /**\n   * Allow push to a live theme.\n   * @environment SHOPIFY_FLAG_ALLOW_LIVE\n   */\n  '-a, --allow-live'?: ''\n\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--auth-alias <value>'?: string\n\n  /**\n   * Push theme files from your remote development theme.\n   * @environment SHOPIFY_FLAG_DEVELOPMENT\n   */\n  '-d, --development'?: ''\n\n  /**\n   * Unique identifier for a development theme context (e.g., PR number, branch name). Reuses an existing development theme with this context name, or creates one if none exists.\n   * @environment SHOPIFY_FLAG_DEVELOPMENT_CONTEXT\n   */\n  '-c, --development-context <value>'?: string\n\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Skip uploading the specified files (Multiple flags allowed). Wrap the value in double quotes if you're using wildcards.\n   * @environment SHOPIFY_FLAG_IGNORE\n   */\n  '-x, --ignore <value>'?: string\n\n  /**\n   * Output the result as JSON. Automatically disables color output.\n   * @environment SHOPIFY_FLAG_JSON\n   */\n  '-j, --json'?: ''\n\n  /**\n   * The listing preset to use for multi-preset themes. Applies preset files from listings/[preset-name] directory.\n   * @environment SHOPIFY_FLAG_LISTING\n   */\n  '--listing <value>'?: string\n\n  /**\n   * Push theme files from your remote live theme.\n   * @environment SHOPIFY_FLAG_LIVE\n   */\n  '-l, --live'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Prevent deleting remote files that don't exist locally.\n   * @environment SHOPIFY_FLAG_NODELETE\n   */\n  '-n, --nodelete'?: ''\n\n  /**\n   * Upload only the specified files (Multiple flags allowed). Wrap the value in double quotes if you're using wildcards.\n   * @environment SHOPIFY_FLAG_ONLY\n   */\n  '-o, --only <value>'?: string\n\n  /**\n   * Password generated from the Theme Access app or an Admin API token.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * The path where you want to run the command. Defaults to the current working directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Publish as the live theme after uploading.\n   * @environment SHOPIFY_FLAG_PUBLISH\n   */\n  '-p, --publish'?: ''\n\n  /**\n   * Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Require theme check to pass without errors before pushing. Warnings are allowed.\n   * @environment SHOPIFY_FLAG_STRICT_PUSH\n   */\n  '--strict'?: ''\n\n  /**\n   * Theme ID or name of the remote theme.\n   * @environment SHOPIFY_FLAG_THEME_ID\n   */\n  '-t, --theme <value>'?: string\n\n  /**\n   * Create a new unpublished theme and push to it.\n   * @environment SHOPIFY_FLAG_UNPUBLISHED\n   */\n  '-u, --unpublished'?: ''\n\n  /**\n   * Increase the verbosity of the output. May include sensitive data.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+      "value": "export interface themepush {\n  /**\n   * Allow push to a live theme. Required in non-interactive environments when targeting the live theme.\n   * @environment SHOPIFY_FLAG_ALLOW_LIVE\n   */\n  '-a, --allow-live'?: ''\n\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--auth-alias <value>'?: string\n\n  /**\n   * Push theme files from your remote development theme. Use --development, --live, --theme, or --unpublished in non-interactive environments.\n   * @environment SHOPIFY_FLAG_DEVELOPMENT\n   */\n  '-d, --development'?: ''\n\n  /**\n   * Unique identifier for a development theme context (e.g., PR number, branch name). Reuses an existing development theme with this context name, or creates one if none exists.\n   * @environment SHOPIFY_FLAG_DEVELOPMENT_CONTEXT\n   */\n  '-c, --development-context <value>'?: string\n\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Skip uploading the specified files (Multiple flags allowed). Wrap the value in double quotes if you're using wildcards.\n   * @environment SHOPIFY_FLAG_IGNORE\n   */\n  '-x, --ignore <value>'?: string\n\n  /**\n   * Output the result as JSON. Automatically disables color output.\n   * @environment SHOPIFY_FLAG_JSON\n   */\n  '-j, --json'?: ''\n\n  /**\n   * The listing preset to use for multi-preset themes. Applies preset files from listings/[preset-name] directory.\n   * @environment SHOPIFY_FLAG_LISTING\n   */\n  '--listing <value>'?: string\n\n  /**\n   * Push theme files from your remote live theme. Use --development, --live, --theme, or --unpublished in non-interactive environments.\n   * @environment SHOPIFY_FLAG_LIVE\n   */\n  '-l, --live'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Prevent deleting remote files that don't exist locally.\n   * @environment SHOPIFY_FLAG_NODELETE\n   */\n  '-n, --nodelete'?: ''\n\n  /**\n   * Upload only the specified files (Multiple flags allowed). Wrap the value in double quotes if you're using wildcards.\n   * @environment SHOPIFY_FLAG_ONLY\n   */\n  '-o, --only <value>'?: string\n\n  /**\n   * Password generated from the Theme Access app or an Admin API token.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * The path where you want to run the command. Defaults to the current working directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Publish as the live theme after uploading.\n   * @environment SHOPIFY_FLAG_PUBLISH\n   */\n  '-p, --publish'?: ''\n\n  /**\n   * Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Require theme check to pass without errors before pushing. Warnings are allowed.\n   * @environment SHOPIFY_FLAG_STRICT_PUSH\n   */\n  '--strict'?: ''\n\n  /**\n   * Theme ID or name of the remote theme. Use --development, --live, --theme, or --unpublished in non-interactive environments. When using --unpublished without --development, use --theme to provide the new theme name.\n   * @environment SHOPIFY_FLAG_THEME_ID\n   */\n  '-t, --theme <value>'?: string\n\n  /**\n   * Create a new unpublished theme and push to it. Use --development, --live, --theme, or --unpublished in non-interactive environments. When using --unpublished without --development, use --theme to provide the new theme name.\n   * @environment SHOPIFY_FLAG_UNPUBLISHED\n   */\n  '-u, --unpublished'?: ''\n\n  /**\n   * Increase the verbosity of the output. May include sensitive data.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
     }
   },
   "themerename": {
@@ -7296,7 +7296,7 @@
           "syntaxKind": "PropertySignature",
           "name": "-d, --development",
           "value": "''",
-          "description": "Rename your development theme.",
+          "description": "Rename your development theme. Use --development, --live, or --theme in non-interactive environments.",
           "isOptional": true,
           "environmentValue": "SHOPIFY_FLAG_DEVELOPMENT"
         },
@@ -7314,7 +7314,7 @@
           "syntaxKind": "PropertySignature",
           "name": "-l, --live",
           "value": "''",
-          "description": "Rename your remote live theme.",
+          "description": "Rename your remote live theme. Use --development, --live, or --theme in non-interactive environments.",
           "isOptional": true,
           "environmentValue": "SHOPIFY_FLAG_LIVE"
         },
@@ -7323,7 +7323,7 @@
           "syntaxKind": "PropertySignature",
           "name": "-n, --name <value>",
           "value": "string",
-          "description": "The new name for the theme.",
+          "description": "The new name for the theme. Required if non interactive.",
           "isOptional": true,
           "environmentValue": "SHOPIFY_FLAG_NEW_NAME"
         },
@@ -7341,12 +7341,12 @@
           "syntaxKind": "PropertySignature",
           "name": "-t, --theme <value>",
           "value": "string",
-          "description": "Theme ID or name of the remote theme.",
+          "description": "Theme ID or name of the remote theme. Use --development, --live, or --theme in non-interactive environments.",
           "isOptional": true,
           "environmentValue": "SHOPIFY_FLAG_THEME_ID"
         }
       ],
-      "value": "export interface themerename {\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--auth-alias <value>'?: string\n\n  /**\n   * Rename your development theme.\n   * @environment SHOPIFY_FLAG_DEVELOPMENT\n   */\n  '-d, --development'?: ''\n\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Rename your remote live theme.\n   * @environment SHOPIFY_FLAG_LIVE\n   */\n  '-l, --live'?: ''\n\n  /**\n   * The new name for the theme.\n   * @environment SHOPIFY_FLAG_NEW_NAME\n   */\n  '-n, --name <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Password generated from the Theme Access app or an Admin API token.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * The path where you want to run the command. Defaults to the current working directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Theme ID or name of the remote theme.\n   * @environment SHOPIFY_FLAG_THEME_ID\n   */\n  '-t, --theme <value>'?: string\n\n  /**\n   * Increase the verbosity of the output. May include sensitive data.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+      "value": "export interface themerename {\n  /**\n   * Alias of the Shopify account to use for authentication.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--auth-alias <value>'?: string\n\n  /**\n   * Rename your development theme. Use --development, --live, or --theme in non-interactive environments.\n   * @environment SHOPIFY_FLAG_DEVELOPMENT\n   */\n  '-d, --development'?: ''\n\n  /**\n   * The environment to apply to the current command.\n   * @environment SHOPIFY_FLAG_ENVIRONMENT\n   */\n  '-e, --environment <value>'?: string\n\n  /**\n   * Rename your remote live theme. Use --development, --live, or --theme in non-interactive environments.\n   * @environment SHOPIFY_FLAG_LIVE\n   */\n  '-l, --live'?: ''\n\n  /**\n   * The new name for the theme. Required if non interactive.\n   * @environment SHOPIFY_FLAG_NEW_NAME\n   */\n  '-n, --name <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Password generated from the Theme Access app or an Admin API token.\n   * @environment SHOPIFY_CLI_THEME_TOKEN\n   */\n  '--password <value>'?: string\n\n  /**\n   * The path where you want to run the command. Defaults to the current working directory.\n   * @environment SHOPIFY_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * Store URL. It can be the store prefix (example) or the full myshopify.com URL (example.myshopify.com, https://example.myshopify.com).\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>'?: string\n\n  /**\n   * Theme ID or name of the remote theme. Use --development, --live, or --theme in non-interactive environments.\n   * @environment SHOPIFY_FLAG_THEME_ID\n   */\n  '-t, --theme <value>'?: string\n\n  /**\n   * Increase the verbosity of the output. May include sensitive data.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
     }
   },
   "themeshare": {

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -4078,11 +4078,12 @@ USAGE
 
 FLAGS
   -a, --show-all
-      Include others development themes in theme list.
+      Include other development themes in the theme list. Use --show-all, --development, or --theme in non-interactive
+      environments.
       [env: SHOPIFY_FLAG_SHOW_ALL]
 
   -d, --development
-      Delete your development theme.
+      Delete your development theme. Use --show-all, --development, or --theme in non-interactive environments.
       [env: SHOPIFY_FLAG_DEVELOPMENT]
 
   -e, --environment=<value>...
@@ -4090,7 +4091,7 @@ FLAGS
       [env: SHOPIFY_FLAG_ENVIRONMENT]
 
   -f, --force
-      Skip confirmation.
+      Skip confirmation. Required if non interactive.
       [env: SHOPIFY_FLAG_FORCE]
 
   -s, --store=<value>
@@ -4099,7 +4100,7 @@ FLAGS
       [env: SHOPIFY_FLAG_STORE]
 
   -t, --theme=<value>...
-      Theme ID or name of the remote theme.
+      Theme ID or name of the remote theme. Use --show-all, --development, or --theme in non-interactive environments.
       [env: SHOPIFY_FLAG_THEME_ID]
 
   --auth-alias=<value>
@@ -4302,7 +4303,7 @@ FLAGS
       [env: SHOPIFY_FLAG_ENVIRONMENT]
 
   -f, --force
-      Force the duplicate operation to run without prompts or confirmations.
+      Force the duplicate operation to run without prompts or confirmations. Required if non interactive outside CI.
       [env: SHOPIFY_FLAG_FORCE]
 
   -j, --json
@@ -4319,7 +4320,7 @@ FLAGS
       [env: SHOPIFY_FLAG_STORE]
 
   -t, --theme=<value>
-      Theme ID or name of the remote theme.
+      Theme ID or name of the remote theme. Required if non interactive.
       [env: SHOPIFY_FLAG_THEME_ID]
 
   --auth-alias=<value>
@@ -4632,7 +4633,7 @@ FLAGS
       [env: SHOPIFY_FLAG_EDITOR]
 
   -d, --development
-      Open your development theme.
+      Open your development theme. Use --development, --live, or --theme in non-interactive environments.
       [env: SHOPIFY_FLAG_DEVELOPMENT]
 
   -e, --environment=<value>...
@@ -4640,7 +4641,7 @@ FLAGS
       [env: SHOPIFY_FLAG_ENVIRONMENT]
 
   -l, --live
-      Open your live (published) theme.
+      Open your live (published) theme. Use --development, --live, or --theme in non-interactive environments.
       [env: SHOPIFY_FLAG_LIVE]
 
   -s, --store=<value>
@@ -4649,7 +4650,7 @@ FLAGS
       [env: SHOPIFY_FLAG_STORE]
 
   -t, --theme=<value>
-      Theme ID or name of the remote theme.
+      Theme ID or name of the remote theme. Use --development, --live, or --theme in non-interactive environments.
       [env: SHOPIFY_FLAG_THEME_ID]
 
   --auth-alias=<value>
@@ -4874,7 +4875,7 @@ FLAGS
       [env: SHOPIFY_FLAG_ENVIRONMENT]
 
   -f, --force
-      Skip confirmation.
+      Skip confirmation. Required if non interactive.
       [env: SHOPIFY_FLAG_FORCE]
 
   -s, --store=<value>
@@ -4883,7 +4884,7 @@ FLAGS
       [env: SHOPIFY_FLAG_STORE]
 
   -t, --theme=<value>
-      Theme ID or name of the remote theme.
+      Theme ID or name of the remote theme. Required if non interactive.
       [env: SHOPIFY_FLAG_THEME_ID]
 
   --auth-alias=<value>
@@ -4932,7 +4933,8 @@ USAGE
 
 FLAGS
   -d, --development
-      Pull theme files from your remote development theme.
+      Pull theme files from your remote development theme. Use --development, --live, or --theme in non-interactive
+      environments.
       [env: SHOPIFY_FLAG_DEVELOPMENT]
 
   -e, --environment=<value>...
@@ -4940,7 +4942,7 @@ FLAGS
       [env: SHOPIFY_FLAG_ENVIRONMENT]
 
   -l, --live
-      Pull theme files from your remote live theme.
+      Pull theme files from your remote live theme. Use --development, --live, or --theme in non-interactive environments.
       [env: SHOPIFY_FLAG_LIVE]
 
   -n, --nodelete
@@ -4958,7 +4960,7 @@ FLAGS
       [env: SHOPIFY_FLAG_STORE]
 
   -t, --theme=<value>
-      Theme ID or name of the remote theme.
+      Theme ID or name of the remote theme. Use --development, --live, or --theme in non-interactive environments.
       [env: SHOPIFY_FLAG_THEME_ID]
 
   -x, --ignore=<value>...
@@ -5005,7 +5007,7 @@ USAGE
 
 FLAGS
   -a, --allow-live
-      Allow push to a live theme.
+      Allow push to a live theme. Required in non-interactive environments when targeting the live theme.
       [env: SHOPIFY_FLAG_ALLOW_LIVE]
 
   -c, --development-context=<value>
@@ -5014,7 +5016,8 @@ FLAGS
       [env: SHOPIFY_FLAG_DEVELOPMENT_CONTEXT]
 
   -d, --development
-      Push theme files from your remote development theme.
+      Push theme files from your remote development theme. Use --development, --live, --theme, or --unpublished in
+      non-interactive environments.
       [env: SHOPIFY_FLAG_DEVELOPMENT]
 
   -e, --environment=<value>...
@@ -5026,7 +5029,8 @@ FLAGS
       [env: SHOPIFY_FLAG_JSON]
 
   -l, --live
-      Push theme files from your remote live theme.
+      Push theme files from your remote live theme. Use --development, --live, --theme, or --unpublished in
+      non-interactive environments.
       [env: SHOPIFY_FLAG_LIVE]
 
   -n, --nodelete
@@ -5047,11 +5051,14 @@ FLAGS
       [env: SHOPIFY_FLAG_STORE]
 
   -t, --theme=<value>
-      Theme ID or name of the remote theme.
+      Theme ID or name of the remote theme. Use --development, --live, --theme, or --unpublished in non-interactive
+      environments. When using --unpublished without --development, use --theme to provide the new theme name.
       [env: SHOPIFY_FLAG_THEME_ID]
 
   -u, --unpublished
-      Create a new unpublished theme and push to it.
+      Create a new unpublished theme and push to it. Use --development, --live, --theme, or --unpublished in
+      non-interactive environments. When using --unpublished without --development, use --theme to provide the new theme
+      name.
       [env: SHOPIFY_FLAG_UNPUBLISHED]
 
   -x, --ignore=<value>...
@@ -5135,7 +5142,7 @@ USAGE
 
 FLAGS
   -d, --development
-      Rename your development theme.
+      Rename your development theme. Use --development, --live, or --theme in non-interactive environments.
       [env: SHOPIFY_FLAG_DEVELOPMENT]
 
   -e, --environment=<value>...
@@ -5143,11 +5150,11 @@ FLAGS
       [env: SHOPIFY_FLAG_ENVIRONMENT]
 
   -l, --live
-      Rename your remote live theme.
+      Rename your remote live theme. Use --development, --live, or --theme in non-interactive environments.
       [env: SHOPIFY_FLAG_LIVE]
 
   -n, --name=<value>
-      The new name for the theme.
+      The new name for the theme. Required if non interactive.
       [env: SHOPIFY_FLAG_NEW_NAME]
 
   -s, --store=<value>
@@ -5156,7 +5163,7 @@ FLAGS
       [env: SHOPIFY_FLAG_STORE]
 
   -t, --theme=<value>
-      Theme ID or name of the remote theme.
+      Theme ID or name of the remote theme. Use --development, --live, or --theme in non-interactive environments.
       [env: SHOPIFY_FLAG_THEME_ID]
 
   --auth-alias=<value>

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -7646,7 +7646,7 @@
         "development": {
           "allowNo": false,
           "char": "d",
-          "description": "Delete your development theme.",
+          "description": "Delete your development theme. Use --show-all, --development, or --theme in non-interactive environments.",
           "env": "SHOPIFY_FLAG_DEVELOPMENT",
           "name": "development",
           "type": "boolean"
@@ -7663,7 +7663,7 @@
         "force": {
           "allowNo": false,
           "char": "f",
-          "description": "Skip confirmation.",
+          "description": "Skip confirmation. Required if non interactive.",
           "env": "SHOPIFY_FLAG_FORCE",
           "name": "force",
           "type": "boolean"
@@ -7696,7 +7696,7 @@
         "show-all": {
           "allowNo": false,
           "char": "a",
-          "description": "Include others development themes in theme list.",
+          "description": "Include other development themes in the theme list. Use --show-all, --development, or --theme in non-interactive environments.",
           "env": "SHOPIFY_FLAG_SHOW_ALL",
           "name": "show-all",
           "type": "boolean"
@@ -7712,7 +7712,7 @@
         },
         "theme": {
           "char": "t",
-          "description": "Theme ID or name of the remote theme.",
+          "description": "Theme ID or name of the remote theme. Use --show-all, --development, or --theme in non-interactive environments.",
           "env": "SHOPIFY_FLAG_THEME_ID",
           "hasDynamicHelp": false,
           "multiple": true,
@@ -7737,7 +7737,8 @@
         "password",
         [
           "development",
-          "theme"
+          "theme",
+          "show-all"
         ]
       ],
       "pluginAlias": "@shopify/cli",
@@ -8021,7 +8022,7 @@
         "force": {
           "allowNo": false,
           "char": "f",
-          "description": "Force the duplicate operation to run without prompts or confirmations.",
+          "description": "Force the duplicate operation to run without prompts or confirmations. Required if non interactive outside CI.",
           "env": "SHOPIFY_FLAG_FORCE",
           "name": "force",
           "type": "boolean"
@@ -8071,7 +8072,7 @@
         },
         "theme": {
           "char": "t",
-          "description": "Theme ID or name of the remote theme.",
+          "description": "Theme ID or name of the remote theme. Required if non interactive.",
           "env": "SHOPIFY_FLAG_THEME_ID",
           "hasDynamicHelp": false,
           "multiple": false,
@@ -8565,7 +8566,7 @@
         "development": {
           "allowNo": false,
           "char": "d",
-          "description": "Open your development theme.",
+          "description": "Open your development theme. Use --development, --live, or --theme in non-interactive environments.",
           "env": "SHOPIFY_FLAG_DEVELOPMENT",
           "name": "development",
           "type": "boolean"
@@ -8590,7 +8591,7 @@
         "live": {
           "allowNo": false,
           "char": "l",
-          "description": "Open your live (published) theme.",
+          "description": "Open your live (published) theme. Use --development, --live, or --theme in non-interactive environments.",
           "env": "SHOPIFY_FLAG_LIVE",
           "name": "live",
           "type": "boolean"
@@ -8631,7 +8632,7 @@
         },
         "theme": {
           "char": "t",
-          "description": "Theme ID or name of the remote theme.",
+          "description": "Theme ID or name of the remote theme. Use --development, --live, or --theme in non-interactive environments.",
           "env": "SHOPIFY_FLAG_THEME_ID",
           "hasDynamicHelp": false,
           "multiple": false,
@@ -8985,7 +8986,7 @@
         "force": {
           "allowNo": false,
           "char": "f",
-          "description": "Skip confirmation.",
+          "description": "Skip confirmation. Required if non interactive.",
           "env": "SHOPIFY_FLAG_FORCE",
           "name": "force",
           "type": "boolean"
@@ -9026,7 +9027,7 @@
         },
         "theme": {
           "char": "t",
-          "description": "Theme ID or name of the remote theme.",
+          "description": "Theme ID or name of the remote theme. Required if non interactive.",
           "env": "SHOPIFY_FLAG_THEME_ID",
           "hasDynamicHelp": false,
           "multiple": false,
@@ -9078,7 +9079,7 @@
         "development": {
           "allowNo": false,
           "char": "d",
-          "description": "Pull theme files from your remote development theme.",
+          "description": "Pull theme files from your remote development theme. Use --development, --live, or --theme in non-interactive environments.",
           "env": "SHOPIFY_FLAG_DEVELOPMENT",
           "name": "development",
           "type": "boolean"
@@ -9113,7 +9114,7 @@
         "live": {
           "allowNo": false,
           "char": "l",
-          "description": "Pull theme files from your remote live theme.",
+          "description": "Pull theme files from your remote live theme. Use --development, --live, or --theme in non-interactive environments.",
           "env": "SHOPIFY_FLAG_LIVE",
           "name": "live",
           "type": "boolean"
@@ -9171,7 +9172,7 @@
         },
         "theme": {
           "char": "t",
-          "description": "Theme ID or name of the remote theme.",
+          "description": "Theme ID or name of the remote theme. Use --development, --live, or --theme in non-interactive environments.",
           "env": "SHOPIFY_FLAG_THEME_ID",
           "hasDynamicHelp": false,
           "multiple": false,
@@ -9220,7 +9221,7 @@
         "allow-live": {
           "allowNo": false,
           "char": "a",
-          "description": "Allow push to a live theme.",
+          "description": "Allow push to a live theme. Required in non-interactive environments when targeting the live theme.",
           "env": "SHOPIFY_FLAG_ALLOW_LIVE",
           "name": "allow-live",
           "type": "boolean"
@@ -9236,7 +9237,7 @@
         "development": {
           "allowNo": false,
           "char": "d",
-          "description": "Push theme files from your remote development theme.",
+          "description": "Push theme files from your remote development theme. Use --development, --live, --theme, or --unpublished in non-interactive environments.",
           "env": "SHOPIFY_FLAG_DEVELOPMENT",
           "name": "development",
           "type": "boolean"
@@ -9303,7 +9304,7 @@
         "live": {
           "allowNo": false,
           "char": "l",
-          "description": "Push theme files from your remote live theme.",
+          "description": "Push theme files from your remote live theme. Use --development, --live, --theme, or --unpublished in non-interactive environments.",
           "env": "SHOPIFY_FLAG_LIVE",
           "name": "live",
           "type": "boolean"
@@ -9376,7 +9377,7 @@
         },
         "theme": {
           "char": "t",
-          "description": "Theme ID or name of the remote theme.",
+          "description": "Theme ID or name of the remote theme. Use --development, --live, --theme, or --unpublished in non-interactive environments. When using --unpublished without --development, use --theme to provide the new theme name.",
           "env": "SHOPIFY_FLAG_THEME_ID",
           "hasDynamicHelp": false,
           "multiple": false,
@@ -9386,7 +9387,7 @@
         "unpublished": {
           "allowNo": false,
           "char": "u",
-          "description": "Create a new unpublished theme and push to it.",
+          "description": "Create a new unpublished theme and push to it. Use --development, --live, --theme, or --unpublished in non-interactive environments. When using --unpublished without --development, use --theme to provide the new theme name.",
           "env": "SHOPIFY_FLAG_UNPUBLISHED",
           "name": "unpublished",
           "type": "boolean"
@@ -9445,7 +9446,7 @@
         "development": {
           "allowNo": false,
           "char": "d",
-          "description": "Rename your development theme.",
+          "description": "Rename your development theme. Use --development, --live, or --theme in non-interactive environments.",
           "env": "SHOPIFY_FLAG_DEVELOPMENT",
           "name": "development",
           "type": "boolean"
@@ -9462,14 +9463,14 @@
         "live": {
           "allowNo": false,
           "char": "l",
-          "description": "Rename your remote live theme.",
+          "description": "Rename your remote live theme. Use --development, --live, or --theme in non-interactive environments.",
           "env": "SHOPIFY_FLAG_LIVE",
           "name": "live",
           "type": "boolean"
         },
         "name": {
           "char": "n",
-          "description": "The new name for the theme.",
+          "description": "The new name for the theme. Required if non interactive.",
           "env": "SHOPIFY_FLAG_NEW_NAME",
           "hasDynamicHelp": false,
           "multiple": false,
@@ -9513,7 +9514,7 @@
         },
         "theme": {
           "char": "t",
-          "description": "Theme ID or name of the remote theme.",
+          "description": "Theme ID or name of the remote theme. Use --development, --live, or --theme in non-interactive environments.",
           "env": "SHOPIFY_FLAG_THEME_ID",
           "hasDynamicHelp": false,
           "multiple": false,

--- a/packages/theme/src/cli/commands/theme/delete.ts
+++ b/packages/theme/src/cli/commands/theme/delete.ts
@@ -2,9 +2,10 @@ import {themesDelete} from '../../services/delete.js'
 import {themeFlags} from '../../flags.js'
 import ThemeCommand from '../../utilities/theme-command.js'
 import {Flags} from '@oclif/core'
-import {globalFlags} from '@shopify/cli-kit/node/cli'
+import {globalFlags, requiredIfNonInteractive} from '@shopify/cli-kit/node/cli'
 import {OutputFlags} from '@oclif/core/interfaces'
 import {AdminSession} from '@shopify/cli-kit/node/session'
+import type {NonTTYFlagRequirement} from '@shopify/cli-kit/node/base-command'
 
 type DeleteFlags = OutputFlags<typeof Delete.flags>
 export default class Delete extends ThemeCommand {
@@ -23,28 +24,37 @@ export default class Delete extends ThemeCommand {
     ...themeFlags,
     development: Flags.boolean({
       char: 'd',
-      description: 'Delete your development theme.',
+      description:
+        'Delete your development theme. Use --show-all, --development, or --theme in non-interactive environments.',
       env: 'SHOPIFY_FLAG_DEVELOPMENT',
     }),
     'show-all': Flags.boolean({
       char: 'a',
-      description: 'Include others development themes in theme list.',
+      description:
+        'Include other development themes in the theme list. Use --show-all, --development, or --theme in non-interactive environments.',
       env: 'SHOPIFY_FLAG_SHOW_ALL',
     }),
-    force: Flags.boolean({
-      char: 'f',
-      description: 'Skip confirmation.',
-      env: 'SHOPIFY_FLAG_FORCE',
-    }),
+    force: requiredIfNonInteractive(
+      Flags.boolean({
+        char: 'f',
+        description: 'Skip confirmation.',
+        env: 'SHOPIFY_FLAG_FORCE',
+      }),
+    ),
     theme: Flags.string({
       char: 't',
-      description: 'Theme ID or name of the remote theme.',
+      description:
+        'Theme ID or name of the remote theme. Use --show-all, --development, or --theme in non-interactive environments.',
       env: 'SHOPIFY_FLAG_THEME_ID',
       multiple: true,
     }),
   }
 
-  static multiEnvironmentsFlags = ['store', 'password', ['development', 'theme']]
+  static multiEnvironmentsFlags = ['store', 'password', ['development', 'theme', 'show-all']]
+
+  static nonTTYFlagRequirements(): NonTTYFlagRequirement[] {
+    return [{flags: ['theme', 'development', 'show-all']}]
+  }
 
   async command(flags: DeleteFlags, adminSession: AdminSession, multiEnvironment: boolean) {
     const {environment, development, force, theme} = flags

--- a/packages/theme/src/cli/commands/theme/duplicate.ts
+++ b/packages/theme/src/cli/commands/theme/duplicate.ts
@@ -3,8 +3,10 @@ import {themeFlags} from '../../flags.js'
 import ThemeCommand from '../../utilities/theme-command.js'
 import {duplicate} from '../../services/duplicate.js'
 import {Flags} from '@oclif/core'
-import {globalFlags, jsonFlag} from '@shopify/cli-kit/node/cli'
+import {globalFlags, jsonFlag, requiredIfNonInteractive} from '@shopify/cli-kit/node/cli'
 import {ensureAuthenticatedThemes} from '@shopify/cli-kit/node/session'
+import {isCI} from '@shopify/cli-kit/node/system'
+import type {NonTTYFlagRequirement} from '@shopify/cli-kit/node/base-command'
 
 export default class Duplicate extends ThemeCommand {
   static summary = 'Duplicates a theme from your theme library.'
@@ -48,11 +50,13 @@ Sample JSON output:
     ...globalFlags,
     ...jsonFlag,
     password: themeFlags.password,
-    theme: Flags.string({
-      char: 't',
-      description: 'Theme ID or name of the remote theme.',
-      env: 'SHOPIFY_FLAG_THEME_ID',
-    }),
+    theme: requiredIfNonInteractive(
+      Flags.string({
+        char: 't',
+        description: 'Theme ID or name of the remote theme.',
+        env: 'SHOPIFY_FLAG_THEME_ID',
+      }),
+    ),
     name: Flags.string({
       char: 'n',
       description: 'Name of the newly duplicated theme.',
@@ -62,9 +66,14 @@ Sample JSON output:
     environment: themeFlags.environment,
     force: Flags.boolean({
       char: 'f',
-      description: 'Force the duplicate operation to run without prompts or confirmations.',
+      description:
+        'Force the duplicate operation to run without prompts or confirmations. Required if non interactive outside CI.',
       env: 'SHOPIFY_FLAG_FORCE',
     }),
+  }
+
+  static nonTTYFlagRequirements(): NonTTYFlagRequirement[] {
+    return [{flags: ['force'], when: () => !isCI()}]
   }
 
   async run(): Promise<void> {

--- a/packages/theme/src/cli/commands/theme/non-interactive-flags.test.ts
+++ b/packages/theme/src/cli/commands/theme/non-interactive-flags.test.ts
@@ -1,0 +1,86 @@
+import Delete from './delete.js'
+import Duplicate from './duplicate.js'
+import Open from './open.js'
+import Publish from './publish.js'
+import Pull from './pull.js'
+import Push from './push.js'
+import Rename from './rename.js'
+import {describe, expect, test} from 'vitest'
+
+describe('non-interactive theme command flags', () => {
+  test.each([
+    {command: Delete, flag: 'force'},
+    {command: Duplicate, flag: 'theme'},
+    {command: Publish, flag: 'force'},
+    {command: Publish, flag: 'theme'},
+    {command: Rename, flag: 'name'},
+  ])('$command.name documents --$flag as required', ({command, flag}) => {
+    const flags = command.flags as Record<string, {description?: string}>
+    expect(flags[flag]!.description).toMatch(/Required if non interactive\.$/)
+  })
+
+  test.each([
+    {command: Delete, requirements: [{flags: ['theme', 'development', 'show-all']}]},
+    {command: Open, requirements: [{flags: ['theme', 'development', 'live']}]},
+    {command: Pull, requirements: [{flags: ['theme', 'development', 'live']}]},
+    {command: Rename, requirements: [{flags: ['theme', 'development', 'live']}]},
+  ])('$command.name accepts any theme selector', ({command, requirements}) => {
+    expect(command.nonTTYFlagRequirements()).toEqual(requirements)
+  })
+
+  test.each([
+    {
+      command: Delete,
+      selectors: ['show-all', 'development', 'theme'],
+      guidance: 'Use --show-all, --development, or --theme in non-interactive environments.',
+    },
+    {
+      command: Open,
+      selectors: ['development', 'live', 'theme'],
+      guidance: 'Use --development, --live, or --theme in non-interactive environments.',
+    },
+    {
+      command: Pull,
+      selectors: ['development', 'live', 'theme'],
+      guidance: 'Use --development, --live, or --theme in non-interactive environments.',
+    },
+    {
+      command: Push,
+      selectors: ['development', 'live', 'theme', 'unpublished'],
+      guidance: 'Use --development, --live, --theme, or --unpublished in non-interactive environments.',
+    },
+    {
+      command: Rename,
+      selectors: ['development', 'live', 'theme'],
+      guidance: 'Use --development, --live, or --theme in non-interactive environments.',
+    },
+  ])('$command.name consistently documents its theme selectors', ({command, selectors, guidance}) => {
+    const flags = command.flags as Record<string, {description?: string}>
+    selectors.forEach((selector) => expect(flags[selector]!.description).toContain(guidance))
+  })
+
+  test('theme duplicate requires confirmation bypass outside CI', () => {
+    expect(Duplicate.nonTTYFlagRequirements()).toEqual([{flags: ['force'], when: expect.any(Function)}])
+    expect(Duplicate.flags.force.description).toMatch(/Required if non interactive outside CI\.$/)
+  })
+
+  test('theme push requires a destination', () => {
+    expect(Push.nonTTYFlagRequirements()).toEqual([
+      {flags: ['theme', 'development', 'live', 'unpublished']},
+      {flags: ['theme'], when: expect.any(Function)},
+      {flags: ['allow-live'], when: expect.any(Function)},
+    ])
+  })
+
+  test('theme push requires a name for a new unpublished theme', () => {
+    const requirements = Push.nonTTYFlagRequirements()
+    expect(requirements[1]!.when!({unpublished: true})).toBe(true)
+    expect(requirements[1]!.when!({unpublished: true, development: true})).toBe(false)
+  })
+
+  test('theme push requires explicit permission for the live theme', () => {
+    const requirements = Push.nonTTYFlagRequirements()
+    expect(requirements[2]!.when!({live: true})).toBe(true)
+    expect(requirements[2]!.when!({live: false})).toBe(false)
+  })
+})

--- a/packages/theme/src/cli/commands/theme/open.ts
+++ b/packages/theme/src/cli/commands/theme/open.ts
@@ -5,6 +5,7 @@ import {Flags} from '@oclif/core'
 import {globalFlags} from '@shopify/cli-kit/node/cli'
 import {AdminSession} from '@shopify/cli-kit/node/session'
 import {InferredFlags} from '@oclif/core/interfaces'
+import type {NonTTYFlagRequirement} from '@shopify/cli-kit/node/base-command'
 
 type OpenFlags = InferredFlags<typeof Open.flags>
 export default class Open extends ThemeCommand {
@@ -24,7 +25,8 @@ export default class Open extends ThemeCommand {
     ...themeFlags,
     development: Flags.boolean({
       char: 'd',
-      description: 'Open your development theme.',
+      description:
+        'Open your development theme. Use --development, --live, or --theme in non-interactive environments.',
       env: 'SHOPIFY_FLAG_DEVELOPMENT',
     }),
     editor: Flags.boolean({
@@ -34,17 +36,23 @@ export default class Open extends ThemeCommand {
     }),
     live: Flags.boolean({
       char: 'l',
-      description: 'Open your live (published) theme.',
+      description:
+        'Open your live (published) theme. Use --development, --live, or --theme in non-interactive environments.',
       env: 'SHOPIFY_FLAG_LIVE',
     }),
     theme: Flags.string({
       char: 't',
-      description: 'Theme ID or name of the remote theme.',
+      description:
+        'Theme ID or name of the remote theme. Use --development, --live, or --theme in non-interactive environments.',
       env: 'SHOPIFY_FLAG_THEME_ID',
     }),
   }
 
   static multiEnvironmentsFlags: RequiredFlags = null
+
+  static nonTTYFlagRequirements(): NonTTYFlagRequirement[] {
+    return [{flags: ['theme', 'development', 'live']}]
+  }
 
   async command(flags: OpenFlags, adminSession: AdminSession) {
     await open(adminSession, flags)

--- a/packages/theme/src/cli/commands/theme/publish.ts
+++ b/packages/theme/src/cli/commands/theme/publish.ts
@@ -2,7 +2,7 @@ import {publish} from '../../services/publish.js'
 import {themeFlags} from '../../flags.js'
 import ThemeCommand from '../../utilities/theme-command.js'
 import {Flags} from '@oclif/core'
-import {globalFlags} from '@shopify/cli-kit/node/cli'
+import {globalFlags, requiredIfNonInteractive} from '@shopify/cli-kit/node/cli'
 import {OutputFlags} from '@oclif/core/interfaces'
 import {AdminSession} from '@shopify/cli-kit/node/session'
 
@@ -24,16 +24,20 @@ If you want to publish your local theme, then you need to run \`shopify theme pu
   static flags = {
     ...globalFlags,
     ...themeFlags,
-    force: Flags.boolean({
-      char: 'f',
-      description: 'Skip confirmation.',
-      env: 'SHOPIFY_FLAG_FORCE',
-    }),
-    theme: Flags.string({
-      char: 't',
-      description: 'Theme ID or name of the remote theme.',
-      env: 'SHOPIFY_FLAG_THEME_ID',
-    }),
+    force: requiredIfNonInteractive(
+      Flags.boolean({
+        char: 'f',
+        description: 'Skip confirmation.',
+        env: 'SHOPIFY_FLAG_FORCE',
+      }),
+    ),
+    theme: requiredIfNonInteractive(
+      Flags.string({
+        char: 't',
+        description: 'Theme ID or name of the remote theme.',
+        env: 'SHOPIFY_FLAG_THEME_ID',
+      }),
+    ),
   }
 
   static multiEnvironmentsFlags = ['store', 'password', 'theme']

--- a/packages/theme/src/cli/commands/theme/pull.ts
+++ b/packages/theme/src/cli/commands/theme/pull.ts
@@ -7,8 +7,8 @@ import {recordTiming} from '@shopify/cli-kit/node/analytics'
 import {InferredFlags} from '@oclif/core/interfaces'
 import {AdminSession} from '@shopify/cli-kit/node/session'
 import {ArgOutput} from '@shopify/cli-kit/node/base-command'
-
 import {Writable} from 'stream'
+import type {NonTTYFlagRequirement} from '@shopify/cli-kit/node/base-command'
 
 type PullFlags = InferredFlags<typeof Pull.flags>
 export default class Pull extends ThemeCommand {
@@ -26,17 +26,20 @@ If no theme is specified, then you're prompted to select the theme to pull from 
     ...globFlags('download'),
     theme: Flags.string({
       char: 't',
-      description: 'Theme ID or name of the remote theme.',
+      description:
+        'Theme ID or name of the remote theme. Use --development, --live, or --theme in non-interactive environments.',
       env: 'SHOPIFY_FLAG_THEME_ID',
     }),
     development: Flags.boolean({
       char: 'd',
-      description: 'Pull theme files from your remote development theme.',
+      description:
+        'Pull theme files from your remote development theme. Use --development, --live, or --theme in non-interactive environments.',
       env: 'SHOPIFY_FLAG_DEVELOPMENT',
     }),
     live: Flags.boolean({
       char: 'l',
-      description: 'Pull theme files from your remote live theme.',
+      description:
+        'Pull theme files from your remote live theme. Use --development, --live, or --theme in non-interactive environments.',
       env: 'SHOPIFY_FLAG_LIVE',
     }),
     nodelete: Flags.boolean({
@@ -53,6 +56,10 @@ If no theme is specified, then you're prompted to select the theme to pull from 
   }
 
   static multiEnvironmentsFlags: RequiredFlags = ['store', 'password', 'path', ['live', 'development', 'theme']]
+
+  static nonTTYFlagRequirements(): NonTTYFlagRequirement[] {
+    return [{flags: ['theme', 'development', 'live']}]
+  }
 
   async command(
     flags: PullFlags,

--- a/packages/theme/src/cli/commands/theme/push.ts
+++ b/packages/theme/src/cli/commands/theme/push.ts
@@ -7,8 +7,8 @@ import {recordTiming} from '@shopify/cli-kit/node/analytics'
 import {AdminSession} from '@shopify/cli-kit/node/session'
 import {InferredFlags} from '@oclif/core/interfaces'
 import {ArgOutput} from '@shopify/cli-kit/node/base-command'
-
 import {Writable} from 'stream'
+import type {NonTTYFlagRequirement} from '@shopify/cli-kit/node/base-command'
 
 type PushFlags = InferredFlags<typeof Push.flags>
 
@@ -55,12 +55,14 @@ export default class Push extends ThemeCommand {
     ...jsonFlag,
     theme: Flags.string({
       char: 't',
-      description: 'Theme ID or name of the remote theme.',
+      description:
+        'Theme ID or name of the remote theme. Use --development, --live, --theme, or --unpublished in non-interactive environments. When using --unpublished without --development, use --theme to provide the new theme name.',
       env: 'SHOPIFY_FLAG_THEME_ID',
     }),
     development: Flags.boolean({
       char: 'd',
-      description: 'Push theme files from your remote development theme.',
+      description:
+        'Push theme files from your remote development theme. Use --development, --live, --theme, or --unpublished in non-interactive environments.',
       env: 'SHOPIFY_FLAG_DEVELOPMENT',
     }),
     'development-context': Flags.string({
@@ -73,12 +75,14 @@ export default class Push extends ThemeCommand {
     }),
     live: Flags.boolean({
       char: 'l',
-      description: 'Push theme files from your remote live theme.',
+      description:
+        'Push theme files from your remote live theme. Use --development, --live, --theme, or --unpublished in non-interactive environments.',
       env: 'SHOPIFY_FLAG_LIVE',
     }),
     unpublished: Flags.boolean({
       char: 'u',
-      description: 'Create a new unpublished theme and push to it.',
+      description:
+        'Create a new unpublished theme and push to it. Use --development, --live, --theme, or --unpublished in non-interactive environments. When using --unpublished without --development, use --theme to provide the new theme name.',
       env: 'SHOPIFY_FLAG_UNPUBLISHED',
     }),
     nodelete: Flags.boolean({
@@ -88,7 +92,8 @@ export default class Push extends ThemeCommand {
     }),
     'allow-live': Flags.boolean({
       char: 'a',
-      description: 'Allow push to a live theme.',
+      description:
+        'Allow push to a live theme. Required in non-interactive environments when targeting the live theme.',
       env: 'SHOPIFY_FLAG_ALLOW_LIVE',
     }),
     publish: Flags.boolean({
@@ -115,6 +120,14 @@ export default class Push extends ThemeCommand {
   }
 
   static multiEnvironmentsFlags = ['store', 'password', 'path', ['live', 'development', 'theme']]
+
+  static nonTTYFlagRequirements(): NonTTYFlagRequirement[] {
+    return [
+      {flags: ['theme', 'development', 'live', 'unpublished']},
+      {flags: ['theme'], when: (parsedFlags) => Boolean(parsedFlags.unpublished && !parsedFlags.development)},
+      {flags: ['allow-live'], when: (parsedFlags) => Boolean(parsedFlags.live)},
+    ]
+  }
 
   async command(
     flags: PushFlags,

--- a/packages/theme/src/cli/commands/theme/rename.ts
+++ b/packages/theme/src/cli/commands/theme/rename.ts
@@ -2,8 +2,9 @@ import ThemeCommand, {RequiredFlags} from '../../utilities/theme-command.js'
 import {themeFlags} from '../../flags.js'
 import {RenameOptions, renameTheme} from '../../services/rename.js'
 import {Flags} from '@oclif/core'
-import {globalFlags} from '@shopify/cli-kit/node/cli'
+import {globalFlags, requiredIfNonInteractive} from '@shopify/cli-kit/node/cli'
 import {AdminSession} from '@shopify/cli-kit/node/session'
+import type {NonTTYFlagRequirement} from '@shopify/cli-kit/node/base-command'
 
 export default class Rename extends ThemeCommand {
   static summary = 'Renames an existing theme.'
@@ -18,30 +19,39 @@ export default class Rename extends ThemeCommand {
   static flags = {
     ...globalFlags,
     ...themeFlags,
-    name: Flags.string({
-      char: 'n',
-      description: 'The new name for the theme.',
-      env: 'SHOPIFY_FLAG_NEW_NAME',
-      required: false,
-    }),
+    name: requiredIfNonInteractive(
+      Flags.string({
+        char: 'n',
+        description: 'The new name for the theme.',
+        env: 'SHOPIFY_FLAG_NEW_NAME',
+        required: false,
+      }),
+    ),
     development: Flags.boolean({
       char: 'd',
-      description: 'Rename your development theme.',
+      description:
+        'Rename your development theme. Use --development, --live, or --theme in non-interactive environments.',
       env: 'SHOPIFY_FLAG_DEVELOPMENT',
     }),
     theme: Flags.string({
       char: 't',
-      description: 'Theme ID or name of the remote theme.',
+      description:
+        'Theme ID or name of the remote theme. Use --development, --live, or --theme in non-interactive environments.',
       env: 'SHOPIFY_FLAG_THEME_ID',
     }),
     live: Flags.boolean({
       char: 'l',
-      description: 'Rename your remote live theme.',
+      description:
+        'Rename your remote live theme. Use --development, --live, or --theme in non-interactive environments.',
       env: 'SHOPIFY_FLAG_LIVE',
     }),
   }
 
   static multiEnvironmentsFlags: RequiredFlags = ['store', 'password', 'name', ['live', 'development', 'theme']]
+
+  static nonTTYFlagRequirements(): NonTTYFlagRequirement[] {
+    return [{flags: ['theme', 'development', 'live']}]
+  }
 
   async command(flags: RenameOptions, adminSession: AdminSession) {
     await renameTheme(flags, adminSession)


### PR DESCRIPTION
Related: https://github.com/shop/issues-develop/issues/22928

## Summary

- Apply non-interactive flag requirements to theme selection, confirmation, naming, and live-theme safety flows.
- Cover delete, duplicate, open, publish, pull, push, and rename commands.
- Include alternative and conditional requirements, tests,

## Testing

See https://github.com/Shopify/cli/pull/8223