### PR TITLE
Document required non-interactive store flags

### DIFF
--- a/docs-shopify.dev/generated/generated_docs_data_v2.json
+++ b/docs-shopify.dev/generated/generated_docs_data_v2.json
@@ -5344,7 +5344,7 @@
           "syntaxKind": "PropertySignature",
           "name": "--organization-id <value>",
           "value": "string",
-          "description": "The numeric organization ID. Auto-selects if you belong to a single organization.",
+          "description": "The numeric organization ID. Auto-selects if you belong to a single organization. Required if non interactive when more than one organization is available.",
           "isOptional": true,
           "environmentValue": "SHOPIFY_FLAG_ORGANIZATION_ID"
         },
@@ -5367,7 +5367,7 @@
           "environmentValue": "SHOPIFY_FLAG_JSON"
         }
       ],
-      "value": "export interface storelist {\n  /**\n   * Output the result as JSON. Automatically disables color output.\n   * @environment SHOPIFY_FLAG_JSON\n   */\n  '-j, --json'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The numeric organization ID. Auto-selects if you belong to a single organization.\n   * @environment SHOPIFY_FLAG_ORGANIZATION_ID\n   */\n  '--organization-id <value>'?: string\n\n  /**\n   * Increase the verbosity of the output. May include sensitive data.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+      "value": "export interface storelist {\n  /**\n   * Output the result as JSON. Automatically disables color output.\n   * @environment SHOPIFY_FLAG_JSON\n   */\n  '-j, --json'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The numeric organization ID. Auto-selects if you belong to a single organization. Required if non interactive when more than one organization is available.\n   * @environment SHOPIFY_FLAG_ORGANIZATION_ID\n   */\n  '--organization-id <value>'?: string\n\n  /**\n   * Increase the verbosity of the output. May include sensitive data.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
     }
   },
   "storeopen": {

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -3879,7 +3879,8 @@ FLAGS
       [env: SHOPIFY_FLAG_NO_COLOR]
 
   --organization-id=<value>
-      The numeric organization ID. Auto-selects if you belong to a single organization.
+      The numeric organization ID. Auto-selects if you belong to a single organization. Required if non interactive when
+      more than one organization is available.
       [env: SHOPIFY_FLAG_ORGANIZATION_ID]
 
   --verbose
@@ -3892,8 +3893,7 @@ DESCRIPTION
   Lists stores in a Shopify organization available to the current CLI account.
 
   When more than one organization is available, the command prompts you to pick one unless you provide
-  `--organization-id`.
-  In non-interactive environments, `--organization-id` is required.
+  `--organization-id`. In that case, `--organization-id` is required in non-interactive environments.
 
   Run `shopify organization list` to find organization IDs.
 

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -6710,7 +6710,7 @@
           "type": "boolean"
         },
         "name": {
-          "description": "Name for the new development store.",
+          "description": "Name for the new development store. Required if non interactive.",
           "env": "SHOPIFY_FLAG_STORE_NAME",
           "hasDynamicHelp": false,
           "multiple": false,
@@ -6726,7 +6726,7 @@
           "type": "boolean"
         },
         "organization-id": {
-          "description": "The numeric organization ID. Auto-selects if you belong to a single organization.",
+          "description": "The numeric organization ID. Auto-selects if you belong to a single organization. Required if non interactive.",
           "env": "SHOPIFY_FLAG_ORGANIZATION_ID",
           "hasDynamicHelp": false,
           "multiple": false,
@@ -6734,7 +6734,7 @@
           "type": "option"
         },
         "plan": {
-          "description": "The Shopify plan to use for the new development store.",
+          "description": "The Shopify plan to use for the new development store. Required if non interactive.",
           "env": "SHOPIFY_FLAG_STORE_PLAN",
           "hasDynamicHelp": false,
           "multiple": false,
@@ -6860,7 +6860,7 @@
         "force": {
           "allowNo": false,
           "char": "f",
-          "description": "Skip confirmation.",
+          "description": "Skip confirmation. Required if non interactive.",
           "env": "SHOPIFY_FLAG_FORCE",
           "name": "force",
           "type": "boolean"
@@ -7193,8 +7193,8 @@
       "args": {
       },
       "customPluginName": "@shopify/store",
-      "description": "Lists stores in a Shopify organization available to the current CLI account.\n\nWhen more than one organization is available, the command prompts you to pick one unless you provide `--organization-id`.\nIn non-interactive environments, `--organization-id` is required.\n\nRun `<%= config.bin %> organization list` to find organization IDs.",
-      "descriptionWithMarkdown": "Lists stores in a Shopify organization available to the current CLI account.\n\nWhen more than one organization is available, the command prompts you to pick one unless you provide `--organization-id`.\nIn non-interactive environments, `--organization-id` is required.\n\nRun `<%= config.bin %> organization list` to find organization IDs.",
+      "description": "Lists stores in a Shopify organization available to the current CLI account.\n\nWhen more than one organization is available, the command prompts you to pick one unless you provide `--organization-id`. In that case, `--organization-id` is required in non-interactive environments.\n\nRun `<%= config.bin %> organization list` to find organization IDs.",
+      "descriptionWithMarkdown": "Lists stores in a Shopify organization available to the current CLI account.\n\nWhen more than one organization is available, the command prompts you to pick one unless you provide `--organization-id`. In that case, `--organization-id` is required in non-interactive environments.\n\nRun `<%= config.bin %> organization list` to find organization IDs.",
       "examples": [
         "<%= config.bin %> <%= command.id %>",
         "<%= config.bin %> <%= command.id %> --organization-id 1234567",
@@ -7219,7 +7219,7 @@
           "type": "boolean"
         },
         "organization-id": {
-          "description": "The numeric organization ID. Auto-selects if you belong to a single organization.",
+          "description": "The numeric organization ID. Auto-selects if you belong to a single organization. Required if non interactive when more than one organization is available.",
           "env": "SHOPIFY_FLAG_ORGANIZATION_ID",
           "hasDynamicHelp": false,
           "multiple": false,

--- a/packages/store/src/cli/commands/store/create/dev.ts
+++ b/packages/store/src/cli/commands/store/create/dev.ts
@@ -4,7 +4,7 @@ import {storeNamePrompt, storePlanPrompt} from '../../../prompts/store.js'
 import {countryFlag, storeFlags} from '../../../flags.js'
 import {selectOrg} from '@shopify/organizations'
 import Command from '@shopify/cli-kit/node/base-command'
-import {globalFlags, jsonFlag} from '@shopify/cli-kit/node/cli'
+import {globalFlags, jsonFlag, requiredIfNonInteractive} from '@shopify/cli-kit/node/cli'
 import {AbortError} from '@shopify/cli-kit/node/error'
 import {outputResult} from '@shopify/cli-kit/node/output'
 import {Flags} from '@oclif/core'
@@ -21,16 +21,20 @@ export default class StoreCreateDev extends Command {
   static flags = {
     ...globalFlags,
     ...jsonFlag,
-    name: Flags.string({
-      description: 'Name for the new development store.',
-      env: 'SHOPIFY_FLAG_STORE_NAME',
-    }),
-    'organization-id': storeFlags['organization-id'],
-    plan: Flags.string({
-      description: 'The Shopify plan to use for the new development store.',
-      options: devStorePlanHandles,
-      env: 'SHOPIFY_FLAG_STORE_PLAN',
-    }),
+    name: requiredIfNonInteractive(
+      Flags.string({
+        description: 'Name for the new development store.',
+        env: 'SHOPIFY_FLAG_STORE_NAME',
+      }),
+    ),
+    'organization-id': requiredIfNonInteractive(storeFlags['organization-id']),
+    plan: requiredIfNonInteractive(
+      Flags.string({
+        description: 'The Shopify plan to use for the new development store.',
+        options: devStorePlanHandles,
+        env: 'SHOPIFY_FLAG_STORE_PLAN',
+      }),
+    ),
     'feature-preview': Flags.string({
       description: 'The handle of a feature preview to enable on the new development store.',
       env: 'SHOPIFY_FLAG_STORE_FEATURE_PREVIEW',
@@ -45,7 +49,6 @@ export default class StoreCreateDev extends Command {
 
   async run(): Promise<void> {
     const {flags} = await this.parse(StoreCreateDev)
-    this.failMissingNonTTYFlags(flags, ['name', 'organization-id', 'plan'])
 
     const organization = await selectOrg(flags['organization-id']?.toString())
     const name = flags.name ?? (await storeNamePrompt())

--- a/packages/store/src/cli/commands/store/delete.ts
+++ b/packages/store/src/cli/commands/store/delete.ts
@@ -30,7 +30,7 @@ export default class StoreDelete extends Command {
     'organization-id': storeFlags['organization-id'],
     force: Flags.boolean({
       char: 'f',
-      description: 'Skip confirmation.',
+      description: 'Skip confirmation. Required if non interactive.',
       env: 'SHOPIFY_FLAG_FORCE',
       default: false,
     }),

--- a/packages/store/src/cli/commands/store/list.ts
+++ b/packages/store/src/cli/commands/store/list.ts
@@ -3,14 +3,14 @@ import {writeStoreListResult} from '../../services/store/list/result.js'
 import {storeFlags} from '../../flags.js'
 import StoreCommand from '../../utilities/store-command.js'
 import {globalFlags, jsonFlag} from '@shopify/cli-kit/node/cli'
+import {Flags} from '@oclif/core'
 
 export default class StoreList extends StoreCommand {
   static summary = 'List stores in a Shopify organization.'
 
   static descriptionWithMarkdown = `Lists stores in a Shopify organization available to the current CLI account.
 
-When more than one organization is available, the command prompts you to pick one unless you provide \`--organization-id\`.
-In non-interactive environments, \`--organization-id\` is required.
+When more than one organization is available, the command prompts you to pick one unless you provide \`--organization-id\`. In that case, \`--organization-id\` is required in non-interactive environments.
 
 Run \`<%= config.bin %> organization list\` to find organization IDs.`
 
@@ -25,7 +25,10 @@ Run \`<%= config.bin %> organization list\` to find organization IDs.`
   static flags = {
     ...globalFlags,
     ...jsonFlag,
-    'organization-id': storeFlags['organization-id'],
+    'organization-id': Flags.integer({
+      description: `${storeFlags['organization-id'].description} Required if non interactive when more than one organization is available.`,
+      env: 'SHOPIFY_FLAG_ORGANIZATION_ID',
+    }),
   }
 
   public async run(): Promise<void> {

--- a/packages/store/src/cli/commands/store/non-interactive-flags.test.ts
+++ b/packages/store/src/cli/commands/store/non-interactive-flags.test.ts
@@ -1,0 +1,22 @@
+import StoreCreateDev from './create/dev.js'
+import StoreDelete from './delete.js'
+import StoreList from './list.js'
+import {describe, expect, test} from 'vitest'
+
+describe('non-interactive store command flags', () => {
+  test.each([
+    {command: StoreCreateDev, flag: 'name'},
+    {command: StoreCreateDev, flag: 'organization-id'},
+    {command: StoreCreateDev, flag: 'plan'},
+    {command: StoreDelete, flag: 'force'},
+  ])('$command.name documents --$flag as required', ({command, flag}) => {
+    const flags = command.flags as Record<string, {description?: string}>
+    expect(flags[flag]!.description).toMatch(/Required if non interactive\.$/)
+  })
+
+  test('store list documents its runtime-dependent organization requirement', () => {
+    expect(StoreList.flags['organization-id'].description).toMatch(
+      /Required if non interactive when more than one organization is available\.$/,
+    )
+  })
+})


### PR DESCRIPTION
Related: https://github.com/shop/issues-develop/issues/22928

## Summary

- Apply non-interactive flag requirements to development-store creation.
- Document `store delete --force` while preserving its structured JSON error behavior.
- Document the runtime-dependent `store list --organization-id` requirement without changing single-organization behavior.
- Include tests and generated docs/manifests.

## Testing

See https://github.com/Shopify/cli/pull/8223