### PR TITLE
Document other required non-interactive flags

### DIFF
--- a/docs-shopify.dev/generated/generated_docs_data_v2.json
+++ b/docs-shopify.dev/generated/generated_docs_data_v2.json
@@ -3014,12 +3014,12 @@
           "syntaxKind": "PropertySignature",
           "name": "--alias <value>",
           "value": "string",
-          "description": "Alias of the session you want to login to.",
+          "description": "Alias of an existing session you want to use. Required if non interactive.",
           "isOptional": true,
           "environmentValue": "SHOPIFY_FLAG_AUTH_ALIAS"
         }
       ],
-      "value": "export interface authlogin {\n  /**\n   * Alias of the session you want to login to.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--alias <value>'?: string\n}"
+      "value": "export interface authlogin {\n  /**\n   * Alias of an existing session you want to use. Required if non interactive.\n   * @environment SHOPIFY_FLAG_AUTH_ALIAS\n   */\n  '--alias <value>'?: string\n}"
     }
   },
   "authlogout": {

--- a/packages/app/src/cli/commands/app/non-interactive-flags.test.ts
+++ b/packages/app/src/cli/commands/app/non-interactive-flags.test.ts
@@ -2,6 +2,7 @@ import ConfigLink from './config/link.js'
 import Deploy from './deploy.js'
 import FunctionReplay from './function/replay.js'
 import AppGenerateExtension from './generate/extension.js'
+import Init from './init.js'
 import Release from './release.js'
 import WebhookTrigger from './webhook/trigger.js'
 import {describe, expect, test} from 'vitest'
@@ -12,11 +13,13 @@ describe('non-interactive app command flags', () => {
     {command: FunctionReplay, flag: 'log'},
     {command: AppGenerateExtension, flag: 'template'},
     {command: AppGenerateExtension, flag: 'name'},
+    {command: Init, flag: 'template'},
     {command: WebhookTrigger, flag: 'api-version'},
     {command: WebhookTrigger, flag: 'topic'},
     {command: WebhookTrigger, flag: 'address'},
-  ])('$command.name documents --$flag as required', ({command, flag}) => {
-    const flags = command.flags as Record<string, {description?: string}>
+  ])('$command.name marks --$flag as required', ({command, flag}) => {
+    const flags = command.flags as Record<string, {description?: string; requiredIfNonInteractive?: boolean}>
+    expect(flags[flag]!.requiredIfNonInteractive).toBe(true)
     expect(flags[flag]!.description).toMatch(/Required if non interactive\.$/)
   })
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1958,7 +1958,7 @@ USAGE
 
 FLAGS
   --alias=<value>
-      Alias of the session you want to login to.
+      Alias of an existing session you want to use. Required if non interactive.
       [env: SHOPIFY_FLAG_AUTH_ALIAS]
 
 DESCRIPTION

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -3473,7 +3473,7 @@
       "enableJsonFlag": false,
       "flags": {
         "alias": {
-          "description": "Alias of the session you want to login to.",
+          "description": "Alias of an existing session you want to use. Required if non interactive.",
           "env": "SHOPIFY_FLAG_AUTH_ALIAS",
           "hasDynamicHelp": false,
           "multiple": false,

--- a/packages/cli/src/cli/commands/auth/login.test.ts
+++ b/packages/cli/src/cli/commands/auth/login.test.ts
@@ -2,13 +2,16 @@ import Login from './login.js'
 import {describe, expect, vi, test} from 'vitest'
 import {promptSessionSelect} from '@shopify/cli-kit/node/session-prompt'
 import {mockAndCaptureOutput} from '@shopify/cli-kit/node/testing/output'
+import {terminalSupportsPrompting} from '@shopify/cli-kit/node/system'
 
 vi.mock('@shopify/cli-kit/node/session-prompt')
+vi.mock('@shopify/cli-kit/node/system')
 
 describe('Login command', () => {
   test('runs login without alias flag', async () => {
     // Given
     const outputMock = mockAndCaptureOutput()
+    vi.mocked(terminalSupportsPrompting).mockReturnValue(true)
     vi.mocked(promptSessionSelect).mockResolvedValue('test-account')
 
     // When
@@ -22,6 +25,7 @@ describe('Login command', () => {
   test('runs login with alias flag', async () => {
     // Given
     const outputMock = mockAndCaptureOutput()
+    vi.mocked(terminalSupportsPrompting).mockReturnValue(true)
     vi.mocked(promptSessionSelect).mockResolvedValue('test-account')
 
     // When
@@ -38,7 +42,8 @@ describe('Login command', () => {
 
     // Then
     expect(flags.alias).toBeDefined()
-    expect(flags.alias.description).toBe('Alias of the session you want to login to.')
+    expect(flags.alias).toMatchObject({requiredIfNonInteractive: true})
+    expect(flags.alias.description).toBe('Alias of an existing session you want to use. Required if non interactive.')
     expect(flags.alias.env).toBe('SHOPIFY_FLAG_AUTH_ALIAS')
   })
 })

--- a/packages/cli/src/cli/commands/auth/login.ts
+++ b/packages/cli/src/cli/commands/auth/login.ts
@@ -1,5 +1,6 @@
 import Command from '@shopify/cli-kit/node/base-command'
 import {promptSessionSelect} from '@shopify/cli-kit/node/session-prompt'
+import {requiredIfNonInteractive} from '@shopify/cli-kit/node/cli'
 import {Flags} from '@oclif/core'
 import {outputCompleted} from '@shopify/cli-kit/node/output'
 
@@ -7,10 +8,12 @@ export default class Login extends Command {
   static description = 'Logs you in to your Shopify account.'
 
   static flags = {
-    alias: Flags.string({
-      description: 'Alias of the session you want to login to.',
-      env: 'SHOPIFY_FLAG_AUTH_ALIAS',
-    }),
+    alias: requiredIfNonInteractive(
+      Flags.string({
+        description: 'Alias of an existing session you want to use.',
+        env: 'SHOPIFY_FLAG_AUTH_ALIAS',
+      }),
+    ),
   }
 
   async run(): Promise<void> {

--- a/packages/store/src/cli/commands/store/non-interactive-flags.test.ts
+++ b/packages/store/src/cli/commands/store/non-interactive-flags.test.ts
@@ -8,10 +8,14 @@ describe('non-interactive store command flags', () => {
     {command: StoreCreateDev, flag: 'name'},
     {command: StoreCreateDev, flag: 'organization-id'},
     {command: StoreCreateDev, flag: 'plan'},
-    {command: StoreDelete, flag: 'force'},
-  ])('$command.name documents --$flag as required', ({command, flag}) => {
-    const flags = command.flags as Record<string, {description?: string}>
+  ])('$command.name marks --$flag as required', ({command, flag}) => {
+    const flags = command.flags as Record<string, {description?: string; requiredIfNonInteractive?: boolean}>
+    expect(flags[flag]!.requiredIfNonInteractive).toBe(true)
     expect(flags[flag]!.description).toMatch(/Required if non interactive\.$/)
+  })
+
+  test('store delete documents its custom non-interactive JSON error requirement', () => {
+    expect(StoreDelete.flags.force.description).toMatch(/Required if non interactive\.$/)
   })
 
   test('store list documents its runtime-dependent organization requirement', () => {

--- a/packages/theme/src/cli/commands/theme/non-interactive-flags.test.ts
+++ b/packages/theme/src/cli/commands/theme/non-interactive-flags.test.ts
@@ -14,8 +14,9 @@ describe('non-interactive theme command flags', () => {
     {command: Publish, flag: 'force'},
     {command: Publish, flag: 'theme'},
     {command: Rename, flag: 'name'},
-  ])('$command.name documents --$flag as required', ({command, flag}) => {
-    const flags = command.flags as Record<string, {description?: string}>
+  ])('$command.name marks --$flag as required', ({command, flag}) => {
+    const flags = command.flags as Record<string, {description?: string; requiredIfNonInteractive?: boolean}>
+    expect(flags[flag]!.requiredIfNonInteractive).toBe(true)
     expect(flags[flag]!.description).toMatch(/Required if non interactive\.$/)
   })
 


### PR DESCRIPTION
Related: https://github.com/shop/issues-develop/issues/22928

## Summary

- Document that `auth login --alias` is required non-interactively whenever at least one stored session is available.
- Clarify that the alias must match an existing session; otherwise the command still opens the account picker.

A fresh login remains possible when no sessions exist, although the authentication flow can still request an alias if one cannot be derived. Hydrogen commands are supplied by the external `@shopify/cli-hydrogen` plugin and are outside this repository-owned command layer. Hidden notification and kitchen-sink prompt commands are developer utilities.

## Testing

- `pnpm i -g --@shopify:registry=https://registry.npmjs.org @shopify/cli@0.0.0-snapshot-20260731142924`
- Run any command with missing flags and `CI=1,`it should raise an error showing a list with the required flags
- Run any command with `--help` to check it explains which flags are required

<img width="1705" height="818" alt="31-29-imnhn-pqkwy" src="https://github.com/user-attachments/assets/a9a69a8e-f4ec-4a2c-9bb4-132adf4b255d" />