### PR TITLE
Use a secret for the E2E loadtest header

### DIFF
--- a/.github/workflows/tests-pr.yml
+++ b/.github/workflows/tests-pr.yml
@@ -253,20 +253,26 @@ jobs:
           E2E_ACCOUNT_PASSWORD: ${{ secrets.E2E_ACCOUNT_PASSWORD }}
           E2E_STORE_FQDN: ${{ secrets.E2E_STORE_FQDN }}
           E2E_ORG_ID: ${{ secrets.E2E_ORG_ID }}
+          E2E_LOADTEST_HEADER: ${{ secrets.E2E_LOADTEST_HEADER }}
         run: pnpm exec playwright test --shard ${{ matrix.shard }}
       - name: Upload Playwright report
         uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}
         with:
           name: playwright-report-${{ strategy.job-index }}
-          path: packages/e2e/playwright-report/
+          # Playwright traces contain request headers and must not expose E2E_LOADTEST_HEADER.
+          path: |
+            packages/e2e/playwright-report/
+            !packages/e2e/playwright-report/**/*.zip
           retention-days: 14
       - name: Upload test results
         uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}
         with:
           name: playwright-results-${{ strategy.job-index }}
-          path: packages/e2e/test-results/
+          path: |
+            packages/e2e/test-results/
+            !packages/e2e/test-results/**/trace.zip
           retention-days: 14
 
   e2e-cleanup:
@@ -297,6 +303,7 @@ jobs:
           E2E_ACCOUNT_EMAIL: ${{ secrets.E2E_ACCOUNT_EMAIL }}
           E2E_ACCOUNT_PASSWORD: ${{ secrets.E2E_ACCOUNT_PASSWORD }}
           E2E_ORG_ID: ${{ secrets.E2E_ORG_ID }}
+          E2E_LOADTEST_HEADER: ${{ secrets.E2E_LOADTEST_HEADER }}
         run: pnpm --filter e2e exec tsx scripts/prime-browser-auth.ts
       - name: Cleanup current-run E2E apps
         if: ${{ always() }}
@@ -305,6 +312,7 @@ jobs:
           E2E_ACCOUNT_EMAIL: ${{ secrets.E2E_ACCOUNT_EMAIL }}
           E2E_ACCOUNT_PASSWORD: ${{ secrets.E2E_ACCOUNT_PASSWORD }}
           E2E_ORG_ID: ${{ secrets.E2E_ORG_ID }}
+          E2E_LOADTEST_HEADER: ${{ secrets.E2E_LOADTEST_HEADER }}
         run: |
           RUN_TOKEN=$(node -e "process.stdout.write(BigInt(process.env.GITHUB_RUN_ID).toString(36))")
           pnpm --filter e2e exec tsx scripts/cleanup-apps.ts --pattern "r${RUN_TOKEN}"
@@ -315,6 +323,7 @@ jobs:
           E2E_ACCOUNT_EMAIL: ${{ secrets.E2E_ACCOUNT_EMAIL }}
           E2E_ACCOUNT_PASSWORD: ${{ secrets.E2E_ACCOUNT_PASSWORD }}
           E2E_ORG_ID: ${{ secrets.E2E_ORG_ID }}
+          E2E_LOADTEST_HEADER: ${{ secrets.E2E_LOADTEST_HEADER }}
         run: |
           RUN_TOKEN=$(node -e "process.stdout.write(BigInt(process.env.GITHUB_RUN_ID).toString(36))")
           pnpm --filter e2e exec tsx scripts/cleanup-stores.ts --pattern "r${RUN_TOKEN}"

--- a/packages/e2e/.env.example
+++ b/packages/e2e/.env.example
@@ -9,3 +9,7 @@ E2E_ACCOUNT_PASSWORD=
 # Required: dedicated e2e org ID
 # CI secret: E2E_ORG_ID
 E2E_ORG_ID=
+
+# Required: full X-Shopify-Loadtest-<UUID> header name
+# CI secret: E2E_LOADTEST_HEADER
+E2E_LOADTEST_HEADER=

--- a/packages/e2e/helpers/loadtest-header.ts
+++ b/packages/e2e/helpers/loadtest-header.ts
@@ -1,0 +1,33 @@
+import type {BrowserContext} from '@playwright/test'
+
+const LOADTEST_HEADER_PATTERN = /^X-Shopify-Loadtest-[\da-f]{8}(?:-[\da-f]{4}){3}-[\da-f]{12}$/i
+const SHOPIFY_APEX_DOMAINS = [
+  'shopify.com',
+  'myshopify.com',
+  'shopifysvc.com',
+  'shopifycdn.com',
+  'shopifyapps.com',
+  'shopifycloud.com',
+]
+
+export async function addLoadtestHeader(context: BrowserContext): Promise<void> {
+  const loadtestHeader = process.env.E2E_LOADTEST_HEADER?.trim()
+
+  if (!loadtestHeader) {
+    throw new Error('E2E_LOADTEST_HEADER is required')
+  }
+
+  if (!LOADTEST_HEADER_PATTERN.test(loadtestHeader)) {
+    throw new Error('E2E_LOADTEST_HEADER must contain a full X-Shopify-Loadtest-<UUID> header name')
+  }
+
+  await context.route(
+    (requestUrl) =>
+      SHOPIFY_APEX_DOMAINS.some(
+        (apexDomain) => requestUrl.hostname === apexDomain || requestUrl.hostname.endsWith(`.${apexDomain}`),
+      ),
+    async (route, request) => {
+      await route.continue({headers: {...request.headers(), [loadtestHeader]: 'true'}})
+    },
+  )
+}

--- a/packages/e2e/helpers/loadtest-header.ts
+++ b/packages/e2e/helpers/loadtest-header.ts
@@ -1,14 +1,7 @@
 import type {BrowserContext} from '@playwright/test'
 
 const LOADTEST_HEADER_PATTERN = /^X-Shopify-Loadtest-[\da-f]{8}(?:-[\da-f]{4}){3}-[\da-f]{12}$/i
-const SHOPIFY_APEX_DOMAINS = [
-  'shopify.com',
-  'myshopify.com',
-  'shopifysvc.com',
-  'shopifycdn.com',
-  'shopifyapps.com',
-  'shopifycloud.com',
-]
+const LOADTEST_HEADER_DOMAINS = ['shopify.com', 'myshopify.com']
 
 export async function addLoadtestHeader(context: BrowserContext): Promise<void> {
   const loadtestHeader = process.env.E2E_LOADTEST_HEADER?.trim()
@@ -23,7 +16,7 @@ export async function addLoadtestHeader(context: BrowserContext): Promise<void> 
 
   await context.route(
     (requestUrl) =>
-      SHOPIFY_APEX_DOMAINS.some(
+      LOADTEST_HEADER_DOMAINS.some(
         (apexDomain) => requestUrl.hostname === apexDomain || requestUrl.hostname.endsWith(`.${apexDomain}`),
       ),
     async (route, request) => {

--- a/packages/e2e/scripts/cleanup-apps.ts
+++ b/packages/e2e/scripts/cleanup-apps.ts
@@ -18,6 +18,7 @@
  *   E2E_ACCOUNT_EMAIL    — Shopify account email for login
  *   E2E_ACCOUNT_PASSWORD — Shopify account password
  *   E2E_ORG_ID           — Organization ID to scan for apps
+ *   E2E_LOADTEST_HEADER  — Load-test bypass header name
  */
 
 import {config} from 'dotenv'
@@ -30,11 +31,17 @@ import {getLastPageStatus, navigateToDashboard, refreshIfPageError, trackMainFra
 import {deleteAppFromDevDashboard} from '../setup/app.js'
 import {uninstallAppFromStore} from '../setup/store.js'
 import {completeLogin} from '../helpers/browser-login.js'
+import {addLoadtestHeader} from '../helpers/loadtest-header.js'
 import type {Page} from '@playwright/test'
 
 // Load .env from packages/e2e/ (not cwd) only if not already configured
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
-if (!process.env.E2E_ACCOUNT_EMAIL || !process.env.E2E_ACCOUNT_PASSWORD || !process.env.E2E_ORG_ID) {
+if (
+  !process.env.E2E_ACCOUNT_EMAIL ||
+  !process.env.E2E_ACCOUNT_PASSWORD ||
+  !process.env.E2E_ORG_ID ||
+  !process.env.E2E_LOADTEST_HEADER
+) {
   config({path: path.resolve(__dirname, '../.env')})
 }
 
@@ -131,11 +138,9 @@ export async function cleanupAllApps(opts: CleanupOptions = {}): Promise<void> {
 
   const browser = await chromium.launch({headless: !opts.headed})
   const context = await browser.newContext({
-    extraHTTPHeaders: {
-      'X-Shopify-Loadtest-Bf8d22e7-120e-4b5b-906c-39ca9d5499a9': 'true',
-    },
     ...(storageStatePath ? {storageState: storageStatePath} : {}),
   })
+  await addLoadtestHeader(context)
   context.setDefaultTimeout(BROWSER_TIMEOUT.max)
   context.setDefaultNavigationTimeout(BROWSER_TIMEOUT.max)
   const page = await context.newPage()

--- a/packages/e2e/scripts/cleanup-stores.ts
+++ b/packages/e2e/scripts/cleanup-stores.ts
@@ -17,6 +17,7 @@
  *   E2E_ACCOUNT_EMAIL    — Shopify account email for login
  *   E2E_ACCOUNT_PASSWORD — Shopify account password
  *   E2E_ORG_ID           — Organization ID to scan for stores
+ *   E2E_LOADTEST_HEADER  — Load-test bypass header name
  */
 
 import {config} from 'dotenv'
@@ -28,6 +29,7 @@ import {BROWSER_TIMEOUT} from '../setup/constants.js'
 import {deleteStore, dismissDevConsole, isStoreAppsEmpty} from '../setup/store.js'
 import {refreshIfPageError, trackMainFrameStatus} from '../setup/browser.js'
 import {completeLogin} from '../helpers/browser-login.js'
+import {addLoadtestHeader} from '../helpers/loadtest-header.js'
 import {
   ListAppDevStores,
   type ListAppDevStoresQuery,
@@ -39,7 +41,12 @@ import type {Page} from '@playwright/test'
 
 // Load .env from packages/e2e/ (not cwd) only if not already configured
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
-if (!process.env.E2E_ACCOUNT_EMAIL || !process.env.E2E_ACCOUNT_PASSWORD || !process.env.E2E_ORG_ID) {
+if (
+  !process.env.E2E_ACCOUNT_EMAIL ||
+  !process.env.E2E_ACCOUNT_PASSWORD ||
+  !process.env.E2E_ORG_ID ||
+  !process.env.E2E_LOADTEST_HEADER
+) {
   config({path: path.resolve(__dirname, '../.env')})
 }
 
@@ -113,11 +120,9 @@ export async function cleanupStores(opts: CleanupStoresOptions = {}): Promise<vo
 
   const browser = await chromium.launch({headless: !opts.headed})
   const context = await browser.newContext({
-    extraHTTPHeaders: {
-      'X-Shopify-Loadtest-Bf8d22e7-120e-4b5b-906c-39ca9d5499a9': 'true',
-    },
     ...(storageStatePath ? {storageState: storageStatePath} : {}),
   })
+  await addLoadtestHeader(context)
   context.setDefaultTimeout(BROWSER_TIMEOUT.max)
   context.setDefaultNavigationTimeout(BROWSER_TIMEOUT.max)
   const page = await context.newPage()

--- a/packages/e2e/scripts/prime-browser-auth.ts
+++ b/packages/e2e/scripts/prime-browser-auth.ts
@@ -18,6 +18,7 @@ import {BROWSER_TIMEOUT, CLI_TIMEOUT} from '../setup/constants.js'
 import {executables} from '../setup/env.js'
 import {isVisibleWithin} from '../setup/browser.js'
 import {completeLogin} from '../helpers/browser-login.js'
+import {addLoadtestHeader} from '../helpers/loadtest-header.js'
 import {stripAnsi} from '../helpers/strip-ansi.js'
 import {waitForText} from '../helpers/wait-for-text.js'
 import {execa} from 'execa'
@@ -25,7 +26,12 @@ import type {Page} from '@playwright/test'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
-if (!process.env.E2E_ACCOUNT_EMAIL || !process.env.E2E_ACCOUNT_PASSWORD || !process.env.E2E_ORG_ID) {
+if (
+  !process.env.E2E_ACCOUNT_EMAIL ||
+  !process.env.E2E_ACCOUNT_PASSWORD ||
+  !process.env.E2E_ORG_ID ||
+  !process.env.E2E_LOADTEST_HEADER
+) {
   config({path: path.resolve(__dirname, '../.env')})
 }
 
@@ -37,8 +43,6 @@ interface PrimeBrowserAuthOptions {
   /** Organization ID (default: from E2E_ORG_ID env) */
   orgId?: string
 }
-
-const LOADTEST_HEADER = 'X-Shopify-Loadtest-Bf8d22e7-120e-4b5b-906c-39ca9d5499a9'
 
 function isAccountsShopifyUrl(rawUrl: string): boolean {
   try {
@@ -111,11 +115,8 @@ export async function primeBrowserAuthStorage(opts: PrimeBrowserAuthOptions = {}
 
   const browser = await chromium.launch({headless: !opts.headed})
   try {
-    const context = await browser.newContext({
-      extraHTTPHeaders: {
-        [LOADTEST_HEADER]: 'true',
-      },
-    })
+    const context = await browser.newContext()
+    await addLoadtestHeader(context)
     context.setDefaultTimeout(BROWSER_TIMEOUT.max)
     context.setDefaultNavigationTimeout(BROWSER_TIMEOUT.max)
     const page = await context.newPage()

--- a/packages/e2e/setup/browser.ts
+++ b/packages/e2e/setup/browser.ts
@@ -1,5 +1,6 @@
 import {cliFixture} from './cli.js'
 import {BROWSER_TIMEOUT} from './constants.js'
+import {addLoadtestHeader} from '../helpers/loadtest-header.js'
 import {chromium, type Locator, type Page} from '@playwright/test'
 import * as fs from 'fs'
 
@@ -59,11 +60,9 @@ export const browserFixture = cliFixture.extend<{}, {browserPage: Page}>({
       const storageStatePath = process.env.E2E_BROWSER_STATE_PATH
       const hasValidStorageState = storageStatePath && fs.existsSync(storageStatePath)
       const context = await browser.newContext({
-        extraHTTPHeaders: {
-          'X-Shopify-Loadtest-Bf8d22e7-120e-4b5b-906c-39ca9d5499a9': 'true',
-        },
         ...(hasValidStorageState ? {storageState: storageStatePath} : {}),
       })
+      await addLoadtestHeader(context)
       context.setDefaultTimeout(BROWSER_TIMEOUT.max)
       context.setDefaultNavigationTimeout(BROWSER_TIMEOUT.max)
       const page = await context.newPage()

--- a/packages/e2e/setup/global-auth.ts
+++ b/packages/e2e/setup/global-auth.ts
@@ -12,6 +12,7 @@ import {CLI_TIMEOUT, BROWSER_TIMEOUT} from './constants.js'
 import {stripAnsi} from '../helpers/strip-ansi.js'
 import {waitForText} from '../helpers/wait-for-text.js'
 import {completeLogin} from '../helpers/browser-login.js'
+import {addLoadtestHeader} from '../helpers/loadtest-header.js'
 import {execa} from 'execa'
 import {chromium, type Page} from '@playwright/test'
 import * as path from 'path'
@@ -103,11 +104,8 @@ export default async function globalSetup() {
     // Complete login in a headless browser
     const browser = await chromium.launch({headless: !process.env.E2E_HEADED})
     try {
-      const context = await browser.newContext({
-        extraHTTPHeaders: {
-          'X-Shopify-Loadtest-Bf8d22e7-120e-4b5b-906c-39ca9d5499a9': 'true',
-        },
-      })
+      const context = await browser.newContext()
+      await addLoadtestHeader(context)
       context.setDefaultTimeout(BROWSER_TIMEOUT.max)
       context.setDefaultNavigationTimeout(BROWSER_TIMEOUT.max)
       const page = await context.newPage()


### PR DESCRIPTION
### WHY are these changes introduced?

The legacy loadtest header was retired. Its replacement is a shared secret and must not be committed to the public repository.

### WHAT is this pull request doing?

- Reads the header name from the `E2E_LOADTEST_HEADER` repository secret.
- Injects it only into requests to Shopify-owned domains.
- Excludes Playwright trace archives that record request headers from uploaded artifacts.

The repository secret has already been configured. No changeset is needed because this only changes internal E2E infrastructure.

### How to test your changes?

- `NX_DAEMON=false pnpm nx run e2e:type-check --skip-nx-cache`
- `NX_DAEMON=false pnpm nx run e2e:lint --skip-nx-cache`
- `yamllint -d "{extends: relaxed, rules: {line-length: disable}}" .github/workflows/tests-pr.yml`