### PR TITLE
Fix app deploy including stale dist files in the extension bundle

### DIFF
--- a/.changeset/fix-stale-dist-files-in-deploy-bundle.md
+++ b/.changeset/fix-stale-dist-files-in-deploy-bundle.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Fix `app deploy` including stale files from the extension's dist directory in the uploaded bundle

--- a/packages/app/src/cli/services/build/steps/bundle-ui-step.test.ts
+++ b/packages/app/src/cli/services/build/steps/bundle-ui-step.test.ts
@@ -3,6 +3,7 @@ import * as generateManifest from './include-assets/generate-manifest.js'
 import * as buildExtension from '../extension.js'
 import {BundleUIStep, BuildContext} from '../client-steps.js'
 import {ExtensionInstance} from '../../../models/extensions/extension-instance.js'
+import {AssetIdentifier} from '../../../models/extensions/specification.js'
 import {describe, expect, test, vi, beforeEach} from 'vitest'
 import {inTemporaryDirectory, mkdir, writeFile, fileExists} from '@shopify/cli-kit/node/fs'
 import {joinPath} from '@shopify/cli-kit/node/path'
@@ -19,7 +20,8 @@ describe('executeBundleUIStep', () => {
         directory: '/test/extension',
         outputPath: '/test/extension/dist/handle.js',
         configuration: {},
-      } as ExtensionInstance,
+        getBundleExtensionStdinContent: () => ({main: "import './src/index.js';"}),
+      } as unknown as ExtensionInstance,
       options: {
         stdout: {write: vi.fn()} as any,
         stderr: {write: vi.fn()} as any,
@@ -57,6 +59,60 @@ describe('executeBundleUIStep', () => {
 
       // Then
       await expect(fileExists(joinPath(bundleOutputDir, 'handle.js'))).resolves.toBe(true)
+    })
+  })
+
+  test('copies only the built artifacts, excluding stale files in the local output directory', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      const extensionDir = joinPath(tmpDir, 'extension')
+      const localOutputDir = joinPath(extensionDir, 'dist')
+      const bundleOutputDir = joinPath(tmpDir, 'bundle', 'handle')
+
+      await mkdir(localOutputDir)
+      await writeFile(joinPath(localOutputDir, 'handle.js'), 'console.log("fresh")')
+      await writeFile(joinPath(localOutputDir, 'handle.js.map'), '{}')
+      await writeFile(joinPath(localOutputDir, 'old-handle.js'), 'console.log("stale")')
+
+      mockContext.extension.directory = extensionDir
+      mockContext.extension.outputPath = joinPath(bundleOutputDir, 'handle.js')
+      vi.mocked(buildExtension.buildUIExtension).mockResolvedValue(joinPath(localOutputDir, 'handle.js'))
+
+      // When
+      await executeBundleUIStep(step, mockContext)
+
+      // Then
+      await expect(fileExists(joinPath(bundleOutputDir, 'handle.js'))).resolves.toBe(true)
+      await expect(fileExists(joinPath(bundleOutputDir, 'handle.js.map'))).resolves.toBe(true)
+      await expect(fileExists(joinPath(bundleOutputDir, 'old-handle.js'))).resolves.toBe(false)
+    })
+  })
+
+  test('copies extra built assets alongside the main output', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      const extensionDir = joinPath(tmpDir, 'extension')
+      const localOutputDir = joinPath(extensionDir, 'dist')
+      const bundleOutputDir = joinPath(tmpDir, 'bundle', 'handle')
+
+      await mkdir(localOutputDir)
+      await writeFile(joinPath(localOutputDir, 'handle.js'), 'console.log("main")')
+      await writeFile(joinPath(localOutputDir, 'handle-conditions.js'), 'console.log("conditions")')
+
+      mockContext.extension.directory = extensionDir
+      mockContext.extension.outputPath = joinPath(bundleOutputDir, 'handle.js')
+      mockContext.extension.getBundleExtensionStdinContent = () => ({
+        main: "import './src/index.js';",
+        assets: [{identifier: AssetIdentifier.ShouldRender, outputFileName: 'handle-conditions.js', content: ''}],
+      })
+      vi.mocked(buildExtension.buildUIExtension).mockResolvedValue(joinPath(localOutputDir, 'handle.js'))
+
+      // When
+      await executeBundleUIStep(step, mockContext)
+
+      // Then
+      await expect(fileExists(joinPath(bundleOutputDir, 'handle.js'))).resolves.toBe(true)
+      await expect(fileExists(joinPath(bundleOutputDir, 'handle-conditions.js'))).resolves.toBe(true)
     })
   })
 

--- a/packages/app/src/cli/services/build/steps/bundle-ui-step.ts
+++ b/packages/app/src/cli/services/build/steps/bundle-ui-step.ts
@@ -1,8 +1,8 @@
 import {createOrUpdateManifestFile} from './include-assets/generate-manifest.js'
 import {buildUIExtension} from '../extension.js'
 import {BuildManifest} from '../../../models/extensions/specifications/ui_extension.js'
-import {copyFile} from '@shopify/cli-kit/node/fs'
-import {dirname, joinPath, resolvePath} from '@shopify/cli-kit/node/path'
+import {copyFile, glob} from '@shopify/cli-kit/node/fs'
+import {dirname, joinPath, parsePath, resolvePath} from '@shopify/cli-kit/node/path'
 import type {BundleUIStep, BuildContext} from '../client-steps.js'
 
 interface ExtensionPointWithBuildManifest {
@@ -30,7 +30,7 @@ export async function executeBundleUIStep(step: BundleUIStep, context: BuildCont
   // If the final output path is the same as the local one: don't copy the results and don't generate manifests.
   if (resolvePath(localOutputDir) === resolvePath(bundleOutputDir)) return
 
-  await copyFile(localOutputDir, bundleOutputDir)
+  await copyBuiltArtifacts(context, localOutputPath, bundleOutputDir)
 
   if (!step.config?.generatesAssetsManifest) return
 
@@ -44,6 +44,32 @@ export async function executeBundleUIStep(step: BundleUIStep, context: BuildCont
   if (Object.keys(entries).length > 0) {
     await createOrUpdateManifestFile(context, entries)
   }
+}
+
+/**
+ * Copies only the artifacts produced by the build (the main output and any extra
+ * assets, plus their sourcemaps and metafiles) into the bundle directory.
+ *
+ * The local output directory can contain stale files from previous builds (for
+ * example a script built under an old extension handle). Copying the whole
+ * directory would ship those files inside the module, which breaks extensions
+ * that only accept a single script, like web pixels.
+ */
+async function copyBuiltArtifacts(
+  context: BuildContext,
+  localOutputPath: string,
+  bundleOutputDir: string,
+): Promise<void> {
+  const localOutputDir = dirname(localOutputPath)
+  const {assets = []} = context.extension.getBundleExtensionStdinContent()
+  const builtOutputNames = [localOutputPath, ...assets.map((asset) => asset.outputFileName)]
+  const builtFiles = await glob(
+    builtOutputNames.map((outputName) => `${parsePath(outputName).name}.*`),
+    {cwd: localOutputDir},
+  )
+  await Promise.all(
+    builtFiles.map((fileName) => copyFile(joinPath(localOutputDir, fileName), joinPath(bundleOutputDir, fileName))),
+  )
 }
 
 /**


### PR DESCRIPTION
### WHY are these changes introduced?

Related to #6069.

Since 3.94.0 (0986095dfb), `executeBundleUIStep` builds the UI extension into the extension's local `dist/` directory and then copies the **whole directory** into the deploy bundle. Any stale file sitting in `dist/` (a script built under an old handle, a dev's own bundler output, old sourcemaps/metafiles) ships inside the module.

For web pixel extensions this is fatal: core's `FetchScriptContent` rejects modules whose uploaded files contain more than one `.js`, so `appVersionCreate` fails with a generic "Version couldn't be created" even though every prior step (build, GCS upload) succeeds. `dist/` is gitignored, so reverting source changes doesn't clear it — which is why "the same source deployed fine before and now fails".

Root cause analysis in [this Slack thread](https://shopify.slack.com/archives/C07UJ7UNMTK/p1785155330271909). Server-side error message improvement in https://github.com/shop/world/pull/967972.

### WHAT is this pull request doing?

- `bundle-ui-step.ts`: instead of copying the entire local output directory, copy only the artifacts produced by the build — `<output-name>.*` for the main entry and each extra asset (which also covers their sourcemaps and `.metafile.json`). Stale files next to the built ones no longer ship.
- Adds two tests: a stale `.js` in the local `dist/` is excluded from the bundle; extra built assets (e.g. `-conditions.js`) are still copied.

### How to test your changes?

1. Create an app with a web pixel extension and deploy it once.
2. Rename the extension handle in `shopify.extension.toml` (leaving the old `extensions/<pixel>/dist/<old-handle>.js` in place) and run `shopify app deploy`.
3. Without this fix, `appVersionCreate` fails ("Version couldn't be created"); with it, only the freshly built script is included and the deploy succeeds.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [x] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

