### PR TITLE
Add tak instruction-count benchmarks for CLI startup

### DIFF
--- a/.github/actions/setup-tak/action.yml
+++ b/.github/actions/setup-tak/action.yml
@@ -1,0 +1,62 @@
+name: 'Setup tak'
+description: 'Installs valgrind and a pinned tak release, then derives the runner class'
+inputs:
+  node-version:
+    required: true
+    description: 'Node version the measurement will be taken with. Encoded into the runner class.'
+runs:
+  using: 'composite'
+  steps:
+    # cachegrind is what makes any of this worth doing: it counts retired
+    # instructions, which reproduce to ~0.0003% run to run where wall clock on
+    # a hosted runner moves by double digits. Without it tak still records
+    # timing, but the series stops being precise enough to gate on.
+    - name: Install valgrind
+      shell: bash
+      run: |
+        command -v valgrind || {
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends valgrind
+        }
+        valgrind --version
+
+    # tak is pinned by version AND by checksum, for two separate reasons.
+    #
+    # Supply chain: this downloads a binary from a third-party release and runs
+    # it in CI, so the bytes are verified rather than trusted.
+    #
+    # Measurement: the instrument is part of the experiment. Changing tak can
+    # put a step in the series that looks like a change in the CLI, so it moves
+    # deliberately, in a commit that changes nothing else.
+    #
+    # Checksum from https://github.com/jdx/tak/releases/download/v0.0.5/SHA256SUMS
+    - name: Install tak
+      shell: bash
+      env:
+        TAK_VERSION: '0.0.5'
+        TAK_SHA256: '1430efa4e44f58921e27db931820187bbac297b33c0dd7c11ae5e382fa11b93e'
+      run: |
+        set -euo pipefail
+        asset="tak-x86_64-unknown-linux-gnu.tar.gz"
+        curl --fail --silent --show-error --location --retry 3 \
+          --output "/tmp/$asset" \
+          "https://github.com/jdx/tak/releases/download/v${TAK_VERSION}/${asset}"
+        echo "${TAK_SHA256}  /tmp/${asset}" | sha256sum --check --strict
+        mkdir -p /tmp/tak-bin
+        tar -xzf "/tmp/$asset" -C /tmp/tak-bin
+        echo "/tmp/tak-bin" >> "$GITHUB_PATH"
+
+    # Series are partitioned on the runner class, and must be: absolute
+    # instruction counts shift between machine and toolchain classes by more
+    # than a real regression does. Encoding the Node version means a Node bump
+    # starts a fresh series instead of landing in the old one as a step change
+    # that reads like a regression.
+    - name: Derive the runner class
+      shell: bash
+      env:
+        NODE_VERSION: ${{ inputs.node-version }}
+      run: echo "TAK_RUNNER=gha-ubuntu-24.04-x64-node${NODE_VERSION}" >> "$GITHUB_ENV"
+
+    - name: Report what is available
+      shell: bash
+      run: tak doctor

--- a/.github/workflows/perf-pr.yml
+++ b/.github/workflows/perf-pr.yml
@@ -1,0 +1,233 @@
+name: Perf (PR)
+
+# Measures this pull request and compares it against the commit it branched
+# from, then says so in a sticky comment.
+#
+# Nothing here writes to refs/notes/tak. A pull request's measurements are
+# recorded locally, used for the comparison, and thrown away with the runner.
+# Only main contributes to the history: a branch's numbers are not the trunk's,
+# and a series that mixes them cannot be read.
+#
+# ---------------------------------------------------------------------------
+# The gate is off until main has history. See TAK_GATE below.
+# ---------------------------------------------------------------------------
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    # Cheap changes should not pay ten minutes of valgrind. Note that if this
+    # workflow is ever made a required check, this list needs the usual
+    # required-check-with-path-filters workaround, or doc-only PRs will hang
+    # waiting for a job that never runs.
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'docs-shopify.dev/**'
+      - '.changeset/**'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  PNPM_VERSION: '10.11.1'
+  DEFAULT_NODE_VERSION: '26.1.0'
+  # Set to '1' to make an instruction-count regression fail this workflow.
+  #
+  # Off for now, on the tool's own advice: a gate needs a baseline series to
+  # compare against, and perf.yml has to run on main for a while before there
+  # is one. Until then every comparison would come back empty, and an empty
+  # comparison is not a pass — it means the base was never recorded. The
+  # comment and the job summary are posted either way, so the numbers are
+  # visible from day one.
+  #
+  # Turn it on once main has a few weeks of points and the series looks flat.
+  TAK_GATE: '0'
+
+jobs:
+  measure:
+    name: Compare instruction counts
+    # Same class as perf.yml. tak refuses to compare across runner classes, so a
+    # mismatch here produces "nothing was compared" rather than a wrong answer.
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    permissions:
+      # Read only. This job builds and runs code from the pull request, so it
+      # must not hold a token that can write anything. The comment is posted by
+      # the `report` job below, which runs none of it.
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # Deliberately the base repository, not the head repository the test
+          # workflows check out: the base branch and refs/notes/tak only exist
+          # here, and a fork's copy of either would be stale or absent. A fork
+          # PR's head commit is still reachable from the base repo.
+          #
+          # The branch commit, not the synthetic merge commit actions/checkout
+          # defaults to for a pull_request event. That merge commit exists only
+          # for the run and changes whenever main advances, so a measurement of
+          # it belongs to a commit nobody can check out.
+          ref: ${{ github.event.pull_request.head.sha }}
+          # Needed to find the merge base.
+          fetch-depth: 0
+          # Kept only for the trusted fetch in the next step, which runs before
+          # any code from the pull request does.
+          persist-credentials: true
+
+      - name: Fetch the comparison inputs
+        id: base
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          set -euo pipefail
+          git fetch --quiet origin "+$BASE_REF:refs/remotes/origin/$BASE_REF"
+          git fetch --quiet --depth 1 origin '+refs/notes/tak:refs/notes/tak' || \
+            echo "no notes ref yet — the comparison will be empty until perf.yml has run on main"
+          # The merge base, not the branch tip: comparing against a moving
+          # target attributes other people's commits to this pull request.
+          base=$(git merge-base "origin/$BASE_REF" HEAD)
+          echo "sha=$base" >> "$GITHUB_OUTPUT"
+          echo "comparing against $base on $BASE_REF"
+
+      # Drop the checkout token before any action reads pull-request-controlled
+      # files or any project code runs.
+      - name: Remove checkout credentials
+        run: git config --local --unset-all http.https://github.com/.extraheader
+
+      - name: Setup deps
+        uses: ./.github/actions/setup-cli-deps
+        with:
+          node-version: ${{ env.DEFAULT_NODE_VERSION }}
+
+      - name: Setup tak
+        uses: ./.github/actions/setup-tak
+        with:
+          node-version: ${{ env.DEFAULT_NODE_VERSION }}
+
+      # The same command perf.yml and a developer's laptop run. `--record`
+      # writes a git note locally and nothing more: there is no `tak push` in
+      # this workflow and there should never be one.
+      - name: Measure this pull request
+        run: pnpm perf:record
+
+      # Not `continue-on-error`: that would hide a comparison that died for an
+      # unrelated reason behind a green check. The exit code is captured, the
+      # comment is posted either way, and the `report` job decides what to do
+      # with it.
+      - name: Compare against the base
+        env:
+          BASE_SHA: ${{ steps.base.outputs.sha }}
+        run: |
+          set +e
+          tak compare "$BASE_SHA" > /tmp/tak-report.md
+          echo $? > /tmp/tak-gate-status
+          set -e
+          cat /tmp/tak-report.md
+          cat /tmp/tak-report.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Package the report
+        if: always()
+        env:
+          BASE_SHA: ${{ steps.base.outputs.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          mkdir -p /tmp/tak-out
+          # A missing report means an earlier step died. Say so, rather than
+          # letting the reporting job find nothing and infer a pass.
+          if [ -f /tmp/tak-report.md ]; then
+            cp /tmp/tak-report.md /tmp/tak-out/report.md
+          else
+            echo "The comparison never ran — an earlier step failed." > /tmp/tak-out/report.md
+          fi
+          # 2, not 1: a missing status means the comparison never ran, which is
+          # a different failure from a regression and must not be reported as
+          # one.
+          cp /tmp/tak-gate-status /tmp/tak-out/status 2>/dev/null || echo 2 > /tmp/tak-out/status
+          printf '%s %s\n' "${HEAD_SHA:0:12}" "${BASE_SHA:0:12}" > /tmp/tak-out/shas
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: tak-report
+          path: /tmp/tak-out
+          retention-days: 1
+          if-no-files-found: error
+
+  # A separate job so the write token is never in scope while pull-request code
+  # is executing. This one checks out nothing and runs no project code: it reads
+  # an artifact and talks to the API.
+  report:
+    name: Report
+    needs: measure
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      pull-requests: write # the sticky comment, and nothing else
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: tak-report
+          path: /tmp/tak-out
+
+      # Skipped for pull requests from forks, which get a read-only token. The
+      # comparison still runs there; only the comment is missing.
+      - name: Comment on the pull request
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          marker='<!-- shopify-cli-perf -->'
+          read -r head_sha base_sha < /tmp/tak-out/shas
+          {
+            printf '%s\n' "$marker"
+            printf '### Instruction counts\n\n'
+            cat /tmp/tak-out/report.md
+            printf '\n<sub>`%s` vs `%s` · measured on the runner, not pushed to the history.</sub>\n' \
+              "$head_sha" "$base_sha"
+          } > /tmp/tak-comment.md
+
+          # One comment per pull request, edited in place. A new comment on
+          # every push buries the conversation under numbers.
+          existing="$(gh api "repos/$REPOSITORY/issues/$PR_NUMBER/comments" --paginate \
+            --jq ".[] | select(.body | contains(\"$marker\")) | .id" | tail -n1)"
+          if [ -n "$existing" ]; then
+            gh api --method PATCH "repos/$REPOSITORY/issues/comments/$existing" \
+              --field body="$(cat /tmp/tak-comment.md)"
+          else
+            gh api --method POST "repos/$REPOSITORY/issues/$PR_NUMBER/comments" \
+              --field body="$(cat /tmp/tak-comment.md)"
+          fi
+
+      # `always()` on both this step and the job: a failed step stops the ones
+      # after it, and a `gh api` hiccup must not skip the gate once it is on.
+      - name: Fail on a regression
+        if: always()
+        run: |
+          status=$(cat /tmp/tak-out/status)
+          if [ "${TAK_GATE}" != '1' ]; then
+            echo "::notice::gate is off (TAK_GATE=${TAK_GATE}); compare exited ${status}"
+            exit 0
+          fi
+          if grep -Fq '**Nothing was compared' /tmp/tak-out/report.md; then
+            echo "::error::no comparable baseline was found — the base commit was never recorded, or the runner classes differ"
+            exit 1
+          fi
+          case "$status" in
+            0) ;;
+            2)
+              echo "::error::the comparison never ran — an earlier step failed, so nothing was gated"
+              exit 1
+              ;;
+            *)
+              echo "::error::an instruction count rose beyond the gate — see the comment or the job summary"
+              exit "$status"
+              ;;
+          esac

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -1,0 +1,92 @@
+name: Perf (main)
+
+# Records the CLI's startup cost for every commit that lands on main, into the
+# git-notes ref `refs/notes/tak`. The history lives in this repository: there is
+# no dashboard, service or account behind it, and
+# `git fetch origin refs/notes/tak:refs/notes/tak` gets you all of it.
+#
+# This workflow owns the baseline. perf-pr.yml reads it and never writes to it.
+#
+# See tak.toml for what is measured and why, and docs/cli/performance.md for how
+# to run the same measurement locally.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions: {}
+
+# Never two at once. Concurrent runs race the notes push; tak retries with a
+# cat_sort_uniq merge so nothing is lost, but serialising avoids the churn.
+# cancel-in-progress is off deliberately: a cancelled run is a hole in the
+# series, and a push that contains several commits only records its tip.
+concurrency:
+  group: perf
+  cancel-in-progress: false
+
+# Deliberately NOT setting DEBUG, SHOPIFY_CLI_ENV or SHOPIFY_CONFIG the way the
+# test workflows do: each changes what the CLI does, so a measurement taken with
+# them set is not comparable with one taken without. tak.toml strips them from
+# the measured command anyway, as a second line of defence.
+env:
+  PNPM_VERSION: '10.11.1'
+  DEFAULT_NODE_VERSION: '26.1.0'
+
+jobs:
+  measure:
+    name: Measure and record
+    # Pinned rather than ubuntu-latest on purpose. When the latest label moves
+    # to a new image the glibc and kernel underneath change, which shifts
+    # absolute instruction counts. A series that wanders between images is
+    # unreadable.
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    permissions:
+      contents: write # pushing refs/notes/tak is a write to this repository
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # Needed for the git-notes history tak reads and appends to.
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup deps
+        uses: ./.github/actions/setup-cli-deps
+        with:
+          node-version: ${{ env.DEFAULT_NODE_VERSION }}
+
+      - name: Setup tak
+        uses: ./.github/actions/setup-tak
+        with:
+          node-version: ${{ env.DEFAULT_NODE_VERSION }}
+
+      # The same command a developer runs locally, so the two cannot drift. It
+      # bundles the CLI first — the bundle is what ships to npm and what users
+      # start, and it costs about a third fewer instructions than the tsc
+      # output, so measuring the wrong one measures the wrong CLI.
+      #
+      # `--record` writes a git note locally. Nothing leaves the machine until
+      # `tak push` below.
+      - name: Measure and record
+        run: pnpm perf:record
+
+      # persist-credentials: false above means the push needs its own auth.
+      # Re-pointing origin rather than pushing to a one-shot URL gives tak's
+      # retry path a remote to fetch from when it loses a race.
+      #
+      # Only main publishes: workflow_dispatch can be pointed at any branch, and
+      # refs/notes/tak should hold main's history and nothing else. Gating the
+      # push rather than the whole job means a dispatch elsewhere still measures
+      # and still prints its numbers, it just keeps them local.
+      - name: Push measurements
+        if: github.ref == 'refs/heads/main'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${REPOSITORY}.git"
+          tak push
+
+      - name: Summary
+        run: tak history >> "$GITHUB_STEP_SUMMARY"

--- a/docs/cli/performance.md
+++ b/docs/cli/performance.md
@@ -2,6 +2,43 @@
 
 Good performance significantly contributes to a good CLI experience; therefore, we should be mindful of it when contributing code to the project. This page documents how to benchmark the CLI using built-in Node functionality and provides principles to ensure we release functionality with sensible performance numbers.
 
+## Tracking startup cost over time
+
+Profiling tells you where the time goes today. It doesn't tell you that a dependency added last Tuesday made every invocation 4% slower. That is what [tak](https://tak.jdx.dev) is for: it measures the CLI's startup cost on every commit that lands on `main` and keeps the history in this repository, under the git-notes ref `refs/notes/tak`. There is no dashboard, service or account behind it.
+
+```bash
+git fetch origin refs/notes/tak:refs/notes/tak
+tak history
+```
+
+### Why instruction counts
+
+tak measures **retired instruction counts** with valgrind's cachegrind, not wall time. Wall clock on a shared CI runner moves by double-digit percentages between runs, which is far larger than most regressions worth catching; a threshold tight enough to catch one would fire constantly. Instruction counts on the same commit reproduce to about 0.0003%, so a 1% change is unambiguous. tak records wall time too, but never gates on it.
+
+This only holds because the benchmarks run Node with `--predictable`. V8 randomises its string hash seed per process, tiers functions up on a time-based budget, and marks the heap on background threads, all of which move the instruction count of a plain `node` run by around 0.2%. `--predictable` removes all three. Don't drop that flag from `tak.toml`.
+
+### Running it locally
+
+Requires Linux and valgrind (`apt-get install valgrind`); instruction counting is unavailable on Apple Silicon and Windows, where tak records timing only. Install the same tak version [`.github/actions/setup-tak/action.yml`](../../.github/actions/setup-tak/action.yml) pins, then:
+
+```bash
+pnpm perf           # bundle the CLI and print the numbers
+pnpm perf:record    # the same, appended to your local refs/notes/tak
+```
+
+Nothing leaves your machine unless you run `tak push`, which only CI should do.
+
+### Adding or changing a benchmark
+
+The benchmarks are declared in [`tak.toml`](../../tak.toml), which explains what each one measures and why. Two rules matter when adding one:
+
+- **It must be hermetic.** No network, no clock, no mutable machine state. Verify it rather than assuming it: run the command with no network (`unshare -rn`) and confirm the instruction count is unchanged. `shopify commands` failed exactly this test and was rejected.
+- **It must measure the bundle.** `pnpm nx bundle cli` produces what ships to npm; the `tsc` output costs about a third more instructions for the same command, so measuring it measures a CLI nobody runs.
+
+### What CI does with it
+
+[`perf.yml`](../../.github/workflows/perf.yml) records the tip of every push to `main` and is the only thing that writes to the shared history. [`perf-pr.yml`](../../.github/workflows/perf-pr.yml) measures a pull request, compares it against its merge base, and posts the numbers as a sticky comment. It does not fail on a regression yet: a gate needs a baseline series, and `main` has to accumulate one first. Flip `TAK_GATE` to `'1'` in that workflow when it has.
+
 ## How to benchmark the CLI performance
 
 Node can profile and output the time the runtime expects in various tasks (e.g., loading modules or running a function).

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
     "lint:fix:affected": "nx affected --target=lint:fix",
     "lint:fix": "nx run-many --target=lint:fix --all --skip-nx-cache",
     "lint": "nx run-many --target=lint --all --skip-nx-cache",
+    "perf": "pnpm nx bundle cli --output-style=stream && CI=1 SHOPIFY_CLI_NO_ANALYTICS=1 tak run",
+    "perf:record": "pnpm nx bundle cli --output-style=stream && CI=1 SHOPIFY_CLI_NO_ANALYTICS=1 tak run --record",
     "create-homebrew-pr": "bin/create-homebrew-pr.js",
     "refresh-code-documentation": "nx run-many --target=refresh-code-documentation --all --skip-nx-cache",
     "refresh-manifests": "nx run-many --target=refresh-manifests --all --skip-nx-cache && bin/prettify-manifests.js && pnpm refresh-readme",

--- a/tak.toml
+++ b/tak.toml
@@ -1,0 +1,116 @@
+# Instruction-counted benchmarks for the Shopify CLI, measured by tak
+# (https://tak.jdx.dev).
+#
+# Why instruction counts and not wall time: the CLI's startup cost is the thing
+# users feel first, and it is also the thing a shared CI runner is worst at
+# measuring. Wall clock on a GitHub-hosted runner moves by double-digit
+# percentages between runs, which is larger than almost any regression worth
+# catching. Retired instruction counts, read out of cachegrind, do not move.
+# tak therefore gates on instruction counts and reports wall time without
+# gating on it.
+#
+# ---------------------------------------------------------------------------
+# `node --predictable` is load-bearing. Do not remove it.
+# ---------------------------------------------------------------------------
+#
+# V8 randomises its string hash seed per process, tiers functions up on a
+# time-based budget, and marks the heap on background threads. All three make
+# the instruction count of a plain `node` invocation move far too much to gate
+# on. `--predictable` fixes the seed, makes optimisation decisions
+# deterministic, and runs V8 single-threaded.
+#
+# Measured on `shopify --version` (three cachegrind runs each):
+#
+#   plain node           2,242,137,664 / 2,246,359,516 / 2,245,626,358  → 0.188% spread
+#   node --predictable   2,344,654,834 / 2,344,659,033 / 2,344,651,185  → 0.00033% spread
+#
+# 570x tighter, which is what turns a 1% gate from "fires on noise" into
+# "fires on a real change". The absolute numbers shift under `--predictable`,
+# but a benchmark series only has to be comparable with itself.
+#
+# ---------------------------------------------------------------------------
+# Warmup is load-bearing too.
+# ---------------------------------------------------------------------------
+#
+# `packages/cli/bin/run.js` calls `module.enableCompileCache()`, so the first
+# invocation after a rebuild pays full parse and compile cost and every later
+# one does not: 2,499,297,579 instructions cold against 1,543,554,209 warm, a
+# 62% difference. tak's default of three warmup runs covers this. If you lower
+# `warmup` anywhere in this file, you will be measuring the cache, not the code.
+#
+# ---------------------------------------------------------------------------
+# Hermeticity
+# ---------------------------------------------------------------------------
+#
+# Every benchmark below was verified by running it inside a network namespace
+# with no network at all, not by assuming it. Each produced the same
+# instruction count it produces with a working network:
+#
+#   bench          with network      no network        delta
+#   version        1,543,545,676     1,543,559,947     0.0009%
+#   help           1,606,628,841     1,606,569,920     0.0037%
+#   app-dev-help   1,637,259,977     1,637,265,138     0.0003%
+#
+# `shopify commands` was measured and rejected: 12,027,416,226 instructions
+# with a network and 11,570,376,673 without, a 3.9% swing. It is the widest
+# manifest walk in the CLI and would have made a good benchmark, but something
+# on that path reaches the network, so its number depends on conditions that
+# have nothing to do with the code under test.
+#
+# The benchmarks measure the **bundled** CLI (`pnpm nx bundle cli`), not the
+# `tsc` output, because the bundle is what ships to npm and what users actually
+# start. The two differ by roughly a third: 1.54B instructions bundled against
+# 2.34B unbundled for the same command.
+
+[gate]
+# tak's default. Roughly thirty times the worst spread observed above, which
+# leaves room for the small movement a Node or dependency bump produces without
+# turning the gate into noise. Worth tightening once main has enough history to
+# show what the series actually does.
+pct = 1.0
+
+[env]
+# Replaces tak's default deny list rather than adding to it, so the two
+# defaults are repeated here.
+#
+# The Shopify entries matter locally more than in CI: `dev.yml` exports
+# SHOPIFY_CLI_ENV and SHOPIFY_SERVICE_ENV into every dev shell, and the repo's
+# own CI workflows set DEBUG=1 and SHOPIFY_CONFIG=debug. Any of them changes
+# what the CLI does, so a measurement taken with them set is not comparable
+# with one taken without.
+deny = [
+  "GITHUB_TOKEN",
+  "GH_TOKEN",
+  "DEBUG",
+  "SHOPIFY_CLI_ENV",
+  "SHOPIFY_SERVICE_ENV",
+  "SHOPIFY_CONFIG",
+  "SHOPIFY_CLI_PARTNERS_TOKEN",
+  "SHOPIFY_CLI_THEME_TOKEN",
+  "SHOPIFY_FLAG_STORE",
+  "NODE_OPTIONS",
+  "NODE_COMPILE_CACHE",
+]
+
+# The runner class is set by the workflows in .github/workflows/perf*.yml, not
+# here, because it has to encode the Node version the measurement was taken
+# with. Series are partitioned on it: a Node bump starts a fresh series rather
+# than showing up as a step change that looks like a regression.
+
+# The control. Process start, the bootstrap module, oclif init, and nothing
+# else — no command resolution, no manifest walk. Reading the other two against
+# this separates "the CLI got slower to start" from "this path got slower".
+[bench.version]
+cmd = ["node", "--predictable", "packages/cli/bin/run.js", "--version"]
+
+# Root help: loads the oclif manifest and renders the topic tree. 4% above the
+# control, and the cheapest command that touches the plugin machinery.
+[bench.help]
+cmd = ["node", "--predictable", "packages/cli/bin/run.js", "--help"]
+
+# A leaf command's help, which is the cheapest hermetic way to make oclif load
+# an actual command class rather than just its manifest entry. `app dev` is the
+# most-run command in the CLI, so its module graph is the one worth watching.
+# 6% above the control; the 2% gap over root help is the command class itself.
+[bench.app-dev-help]
+cmd = ["node", "--predictable", "packages/cli/bin/run.js", "app", "dev", "--help"]


### PR DESCRIPTION
### WHY are these changes introduced?

Startup cost is the first thing a CLI user feels, and it is the thing this repo has the least visibility into over time. `docs/cli/performance.md` explains how to profile a single invocation, but nothing tells us that a dependency added last Tuesday made every invocation 4% slower.

The usual reason that gap stays open is that wall-clock benchmarking on a shared CI runner has roughly the same noise floor as the regressions worth catching, so any threshold either cries wolf or catches nothing. [tak](https://tak.jdx.dev) takes a different measurement: retired instruction counts, read out of valgrind's cachegrind, which are deterministic. The history lives in this repository as git notes under `refs/notes/tak` — no dashboard, no service, no account.

### WHAT is this pull request doing?

- **`tak.toml`** declares three benchmarks against the **bundled** CLI (`pnpm nx bundle cli`), which is what ships to npm: `version` (the startup control), `help` (manifest load and render), and `app-dev-help` (loads an actual command class). Each is commented with what it measures and why.
- **`.github/actions/setup-tak`** installs valgrind and tak, pinned by version *and* sha256. The instrument is part of the experiment: changing tak can put a step in the series that looks like a change in the CLI.
- **`.github/workflows/perf.yml`** measures the tip of every push to `main` and appends it to `refs/notes/tak`. It is the only thing that writes to the shared history.
- **`.github/workflows/perf-pr.yml`** measures a PR, compares against the merge base, and posts a sticky comment. Measurement and reporting are split into two jobs so the write token is never in scope while PR code runs.
- **`pnpm perf` / `pnpm perf:record`** so local and CI runs invoke the same command.
- **`docs/cli/performance.md`** gains a section on running and extending it.

#### Two decisions worth reviewing

**Every benchmark runs `node --predictable`, and that is load-bearing.** V8 randomises its string hash seed per process, tiers functions up on a time-based budget, and marks the heap on background threads. Measured here on `shopify --version`:

| | run 1 | run 2 | run 3 | spread |
|---|---|---|---|---|
| plain `node` | 2,242,137,664 | 2,246,359,516 | 2,245,626,358 | 0.188% |
| `node --predictable` | 2,344,654,834 | 2,344,659,033 | 2,344,651,185 | **0.00033%** |

570x tighter, which is the difference between a 1% gate that fires on noise and one that fires on a change. The tradeoff is that this is not the V8 configuration a user runs: the numbers are a relative signal, valid against themselves, and work V8 would do on a background thread is counted on the main thread. An optimization that moves work *off* the main thread is a real win that would read as flat here.

**The PR gate is off (`TAK_GATE: '0'`).** A gate needs a baseline series, and `main` has to accumulate one first; until then every comparison comes back empty, and an empty comparison is not a pass. The comment and job summary are posted from day one, so the numbers are visible immediately. Flip it to `'1'` once `main` has a few weeks of points and the series looks flat.

#### Hermeticity was verified, not assumed

Each benchmark was run inside a network namespace with no network at all and produced the same instruction count:

| bench | with network | no network | delta |
|---|---|---|---|
| `version` | 1,543,545,676 | 1,543,559,947 | 0.0009% |
| `help` | 1,606,628,841 | 1,606,569,920 | 0.0037% |
| `app-dev-help` | 1,637,259,977 | 1,637,265,138 | 0.0003% |

`shopify commands` was measured and **rejected**: 12,027,416,226 instructions with a network against 11,570,376,673 without, a 3.9% swing. It would have been the widest manifest walk available, but something on that path reaches the network.

One more thing the measurements turned up: `bin/run.js` calls `module.enableCompileCache()`, so the first invocation after a rebuild costs 2,499,297,579 instructions against 1,543,554,209 warm — a 62% difference. tak's default of three warmup runs covers it, but nothing should lower `warmup` in `tak.toml`.

> [!NOTE]
> tak is explicitly pre-v1 and its author labels the docs as unreviewed. Its CLI, config format and storage format may change incompatibly. That is the main argument against adopting it now; the counter-argument is that everything it produces is JSON lines in a git ref this repo owns, so the data survives the tool.

### How to test your changes?

Requires Linux and valgrind — instruction counting is unavailable on Apple Silicon and Windows.

```bash
sudo apt-get install -y valgrind
# install tak 0.0.5, pinned in .github/actions/setup-tak/action.yml
pnpm perf
```

Expect roughly:

```
  app-dev-help  node --predictable packages/cli/bin/run.js app dev --help
  instructions         1637126823
  help          node --predictable packages/cli/bin/run.js --help
  instructions         1606763914
  version       node --predictable packages/cli/bin/run.js --version
  instructions         1543544937
```

Absolute numbers will differ on your machine; the run-to-run spread should not exceed ~0.03%.

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---

Requested by Isaac Roldan <isaac.roldan@shopify.com>
Slack thread: https://shopify.slack.com/archives/C0AG0L37Q4C/p1785681072538939
AI Confidence Score: 85% — every claim in this description is a measurement taken in a sandbox with the CLI built from this commit, and `pnpm perf` was run end to end. The workflows themselves are unrun: they follow the patterns in `tests-pr.yml` and tak's own docs, and their YAML parses, but GitHub Actions is not exercised until this branch runs.
