### PR TITLE
Allowlist Shopify environment variables in analytics

### DIFF
--- a/packages/cli-kit/src/private/node/analytics.ts
+++ b/packages/cli-kit/src/private/node/analytics.ts
@@ -72,6 +72,15 @@ interface EnvironmentData {
   env_auto_upgrade_enabled: boolean | null
 }
 
+const allowedShopifyEnvironmentVariableNames = new Set([
+  'SHOPIFY_INVOKED_BY',
+  'SHOPIFY_CLI_AGENT',
+  'SHOPIFY_CLI_AGENT_VERSION',
+  'SHOPIFY_CLI_AGENT_RUN_ID',
+  'SHOPIFY_CLI_AGENT_SESSION_ID',
+  'SHOPIFY_CLI_AGENT_PROVIDER',
+])
+
 export async function getEnvironmentData(config: Interfaces.Config): Promise<EnvironmentData> {
   const ciplatform = ciPlatform()
 
@@ -108,13 +117,9 @@ export async function getSensitiveEnvironmentData(config: Interfaces.Config) {
 }
 
 function getShopifyEnvironmentVariables() {
-  // Agent callers can identify themselves today via SHOPIFY_* environment
-  // variables. The current contract is intentionally lightweight and is kept in
-  // the sensitive payload until we prove which dimensions deserve first-class
-  // Monorail fields, e.g. SHOPIFY_CLI_AGENT, SHOPIFY_CLI_AGENT_VERSION,
-  // SHOPIFY_CLI_AGENT_RUN_ID, SHOPIFY_CLI_AGENT_SESSION_ID, and
-  // SHOPIFY_CLI_AGENT_PROVIDER.
-  return Object.fromEntries(Object.entries(process.env).filter(([key]) => key.startsWith('SHOPIFY_')))
+  return Object.fromEntries(
+    Object.entries(process.env).filter(([key]) => allowedShopifyEnvironmentVariableNames.has(key)),
+  )
 }
 
 function getPluginNames(config: Interfaces.Config) {

--- a/packages/cli-kit/src/public/node/analytics.test.ts
+++ b/packages/cli-kit/src/public/node/analytics.test.ts
@@ -251,15 +251,13 @@ describe('event tracking', () => {
     })
   })
 
-  test('sends SHOPIFY_ environment variables in sensitive payload', async () => {
-    const originalShopifyTestVar = process.env.SHOPIFY_TEST_VAR
-    const originalShopifyAnotherVar = process.env.SHOPIFY_ANOTHER_VAR
-    const originalShopifyFlagStorePassword = process.env.SHOPIFY_FLAG_STORE_PASSWORD
-    const originalNotShopifyVar = process.env.NOT_SHOPIFY_VAR
-    process.env.SHOPIFY_TEST_VAR = 'test_value'
-    process.env.SHOPIFY_ANOTHER_VAR = 'another_value'
-    process.env.SHOPIFY_FLAG_STORE_PASSWORD = 'store-secret'
-    process.env.NOT_SHOPIFY_VAR = 'should_not_appear'
+  test('sends only allowlisted Shopify environment variables in sensitive payload', async () => {
+    const originalShopifyInvokedBy = process.env.SHOPIFY_INVOKED_BY
+    const originalShopifyCliAgent = process.env.SHOPIFY_CLI_AGENT
+    const originalShopifySomethingKey = process.env.SHOPIFY_SOMETHING_KEY
+    process.env.SHOPIFY_INVOKED_BY = 'shopify-function-test-helpers'
+    process.env.SHOPIFY_CLI_AGENT = 'test-agent'
+    process.env.SHOPIFY_SOMETHING_KEY = '123'
 
     try {
       await inProjectWithFile('package.json', async (args) => {
@@ -280,16 +278,14 @@ describe('event tracking', () => {
         expect(sensitivePayload.env_shopify_variables).toBeDefined()
 
         const shopifyVars = JSON.parse(sensitivePayload.env_shopify_variables as string)
-        expect(shopifyVars).toHaveProperty('SHOPIFY_TEST_VAR', 'test_value')
-        expect(shopifyVars).toHaveProperty('SHOPIFY_ANOTHER_VAR', 'another_value')
-        expect(shopifyVars).toHaveProperty('SHOPIFY_FLAG_STORE_PASSWORD', '*****')
-        expect(shopifyVars).not.toHaveProperty('NOT_SHOPIFY_VAR')
+        expect(shopifyVars).toHaveProperty('SHOPIFY_INVOKED_BY', 'shopify-function-test-helpers')
+        expect(shopifyVars).toHaveProperty('SHOPIFY_CLI_AGENT', 'test-agent')
+        expect(shopifyVars).not.toHaveProperty('SHOPIFY_SOMETHING_KEY')
       })
     } finally {
-      restoreEnvVariable('SHOPIFY_TEST_VAR', originalShopifyTestVar)
-      restoreEnvVariable('SHOPIFY_ANOTHER_VAR', originalShopifyAnotherVar)
-      restoreEnvVariable('SHOPIFY_FLAG_STORE_PASSWORD', originalShopifyFlagStorePassword)
-      restoreEnvVariable('NOT_SHOPIFY_VAR', originalNotShopifyVar)
+      restoreEnvVariable('SHOPIFY_INVOKED_BY', originalShopifyInvokedBy)
+      restoreEnvVariable('SHOPIFY_CLI_AGENT', originalShopifyCliAgent)
+      restoreEnvVariable('SHOPIFY_SOMETHING_KEY', originalShopifySomethingKey)
     }
   })
 


### PR DESCRIPTION
## Why

`getShopifyEnvironmentVariables()` collected every `SHOPIFY_*` variable. This could send arbitrary credentials to Monorail and show them in verbose output.

The collector was originally added to track `shopify-function-test-helpers` through `SHOPIFY_INVOKED_BY`.

## What

- Collect `SHOPIFY_INVOKED_BY` and the five `SHOPIFY_CLI_AGENT*` telemetry variables.
- Exclude all other `SHOPIFY_*` variables.
- Keep the existing sensitive analytics payload in verbose output for debugging.

## Testing

- `pnpm vitest run packages/cli-kit/src/public/node/analytics.test.ts`
- `pnpm eslint packages/cli-kit/src/private/node/analytics.ts packages/cli-kit/src/public/node/analytics.test.ts`
- `pnpm nx bundle cli --skip-nx-cache`
- Verified that verbose output includes sensitive arguments, `SHOPIFY_INVOKED_BY`, and the allowlisted agent variable, but excludes `SHOPIFY_SOMETHING_KEY=123`.
- `git diff --check`