### PR TITLE
Prototype store info diagnostic event sink

### DIFF
--- a/packages/cli-kit/src/public/node/output.test.ts
+++ b/packages/cli-kit/src/public/node/output.test.ts
@@ -2,6 +2,7 @@ import {
   collectedLogs,
   clearCollectedLogs,
   LogLevel,
+  debugMessageSink,
   outputDebug,
   outputWhereAppropriate,
   outputToken,
@@ -31,6 +32,15 @@ beforeEach(() => {
 })
 
 describe('Output helpers', () => {
+  test('delegates debug events only to outputDebug', () => {
+    isUnitTestMock.mockReturnValue(true)
+
+    debugMessageSink({level: 'debug', message: 'debug'})
+    debugMessageSink({level: 'info', message: 'info'})
+    debugMessageSink({level: 'warning', message: 'warning'})
+
+    expect(collectedLogs.debug).toEqual(['debug'])
+  })
   test('can format dependency manager commands with flags', () => {
     expect(outputToken.packagejsonScript('yarn', 'dev', '--reset').value).toEqual('yarn dev --reset')
     expect(outputToken.packagejsonScript('npm', 'dev', '--reset').value).toEqual('npm run dev -- --reset')

--- a/packages/cli-kit/src/public/node/output.ts
+++ b/packages/cli-kit/src/public/node/output.ts
@@ -37,6 +37,20 @@ export class TokenizedString {
 
 export type OutputMessage = string | TokenizedString
 
+interface DiagnosticEvent {
+  level: 'debug' | 'info' | 'warning'
+  message: string
+}
+
+/**
+ * Adapts diagnostic data to the CLI's existing debug output behavior.
+ *
+ * @param event - Diagnostic event to adapt.
+ */
+export function debugMessageSink(event: DiagnosticEvent): void {
+  if (event.level === 'debug') outputDebug(event.message)
+}
+
 export const outputToken = {
   raw(value: string): RawContentToken {
     return new RawContentToken(value)

--- a/packages/cli-kit/src/public/node/output.ts
+++ b/packages/cli-kit/src/public/node/output.ts
@@ -43,7 +43,7 @@ interface DiagnosticEvent {
 }
 
 /**
- * Adapts diagnostic data to the CLI's existing debug output behavior.
+ * Adapts a debug-level diagnostic event to the CLI's existing debug output behavior.
  *
  * @param event - Diagnostic event to adapt.
  */

--- a/packages/cli-kit/tsconfig.json
+++ b/packages/cli-kit/tsconfig.json
@@ -7,5 +7,4 @@
     "rootDir": "src",
     "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo"
   },
-  "references": []
 }

--- a/packages/diagnostics/package.json
+++ b/packages/diagnostics/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@shopify/diagnostics",
+  "version": "4.5.0",
+  "packageManager": "pnpm@10.11.1",
+  "private": true,
+  "description": "Dependency-free synchronous diagnostic primitives",
+  "license": "MIT",
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": ["/dist"],
+  "scripts": {
+    "build": "nx build",
+    "clean": "nx clean",
+    "lint": "nx lint",
+    "lint:fix": "nx lint:fix",
+    "vitest": "vitest",
+    "type-check": "nx type-check"
+  },
+  "eslintConfig": {
+    "extends": [
+      "../../.eslintrc.cjs"
+    ]
+  },
+  "devDependencies": {
+    "@vitest/coverage-istanbul": "^3.2.7"
+  },
+  "engines": {
+    "node": ">=22.12.0"
+  },
+  "os": [
+    "darwin",
+    "linux",
+    "win32"
+  ]
+}

--- a/packages/diagnostics/project.json
+++ b/packages/diagnostics/project.json
@@ -1,0 +1,46 @@
+{
+  "name": "@shopify/diagnostics",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/diagnostics/src",
+  "projectType": "library",
+  "tags": ["npm:private"],
+  "targets": {
+    "clean": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm rimraf dist/",
+        "cwd": "packages/diagnostics"
+      }
+    },
+    "build": {
+      "executor": "nx:run-commands",
+      "outputs": ["{projectRoot}/dist"],
+      "inputs": ["{projectRoot}/src/**/*", "{projectRoot}/package.json"],
+      "options": {
+        "command": "pnpm tsc -b ./tsconfig.build.json",
+        "cwd": "packages/diagnostics"
+      }
+    },
+    "lint": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm eslint 'src/**/*.ts'",
+        "cwd": "packages/diagnostics"
+      }
+    },
+    "lint:fix": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm eslint 'src/**/*.ts' --fix",
+        "cwd": "packages/diagnostics"
+      }
+    },
+    "type-check": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm tsc --noEmit",
+        "cwd": "packages/diagnostics"
+      }
+    }
+  }
+}

--- a/packages/diagnostics/src/index.test.ts
+++ b/packages/diagnostics/src/index.test.ts
@@ -1,0 +1,19 @@
+import {createSyncDiagnosticChannel} from './index.js'
+import {describe, expect, test} from 'vitest'
+
+describe('createSyncDiagnosticChannel', () => {
+  test('delivers synchronously in registration order and isolates observer failures', () => {
+    const calls: string[] = []
+    const channel = createSyncDiagnosticChannel<{level: 'debug'; message: string; value: string}>(
+      () => {
+        calls.push('first')
+        throw new Error('failure')
+      },
+      () => calls.push('second'),
+    )
+
+    channel.emit({level: 'debug', message: 'message', value: 'value'})
+
+    expect(calls).toEqual(['first', 'second'])
+  })
+})

--- a/packages/diagnostics/src/index.ts
+++ b/packages/diagnostics/src/index.ts
@@ -1,0 +1,56 @@
+/* eslint-disable no-catch-all/no-catch-all */
+
+/**
+ * Data-only, synchronous diagnostic primitives for the event-sink PoC.
+ *
+ * This module intentionally has no imports. Domain packages can depend on this leaf without
+ * introducing terminal, renderer, or domain dependencies.
+ */
+export type DiagnosticLevel = 'debug' | 'info' | 'warning'
+
+/**
+ * Data emitted by command execution to describe a diagnostic.
+ *
+ * Domain-specific events can extend this shape with a discriminant and structured fields. The
+ * event carries no terminal or renderer objects, so adapters can render, suppress, record, or
+ * route it without changing the execution code.
+ */
+export interface DiagnosticEvent {
+  readonly level: DiagnosticLevel
+  readonly message: string
+}
+
+/** Receives one diagnostic from an execution channel. */
+export type DiagnosticObserver<TEvent extends DiagnosticEvent = DiagnosticEvent> = (event: TEvent) => void
+
+/**
+ * Delivers diagnostics from execution to one or more observers.
+ *
+ * This PoC delivers events synchronously. Async delivery can remain a compatible future extension
+ * without making execution depend on an async channel API today.
+ */
+export interface SyncDiagnosticChannel<TEvent extends DiagnosticEvent = DiagnosticEvent> {
+  emit(event: TEvent): void
+}
+
+/**
+ * Creates a synchronous channel that calls observers in registration order.
+ *
+ * Diagnostic observers are advisory. A failing observer is isolated so it cannot change the
+ * command result or prevent later observers from receiving the event.
+ */
+export function createSyncDiagnosticChannel<TEvent extends DiagnosticEvent = DiagnosticEvent>(
+  ...observers: DiagnosticObserver<TEvent>[]
+): SyncDiagnosticChannel<TEvent> {
+  return {
+    emit(event) {
+      for (const observer of observers) {
+        try {
+          observer(event)
+        } catch {
+          // Optional diagnostic observers must not change the command result.
+        }
+      }
+    },
+  }
+}

--- a/packages/diagnostics/tsconfig.build.json
+++ b/packages/diagnostics/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["**/*.test.ts"]
+}

--- a/packages/diagnostics/tsconfig.json
+++ b/packages/diagnostics/tsconfig.json
@@ -7,9 +7,5 @@
     "rootDir": "src",
     "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo"
   },
-  "references": [
-    {"path": "../cli-kit"},
-    {"path": "../diagnostics"},
-    {"path": "../organizations"}
-  ]
+  "references": []
 }

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -42,6 +42,7 @@
     "@graphql-typed-document-node/core": "3.2.0",
     "@oclif/core": "4.8.3",
     "@shopify/cli-kit": "4.5.0",
+    "@shopify/diagnostics": "4.5.0",
     "@shopify/organizations": "4.5.0"
   },
   "devDependencies": {

--- a/packages/store/src/cli/commands/store/info.test.ts
+++ b/packages/store/src/cli/commands/store/info.test.ts
@@ -20,6 +20,7 @@ describe('store info command', () => {
 
     expect(getStoreInfo).toHaveBeenCalledWith({
       store: 'shop.myshopify.com',
+      context: expect.any(Object),
     })
     expect(renderStoreInfoResult).toHaveBeenCalledWith(
       expect.objectContaining({subdomain: 'shop.myshopify.com'}),

--- a/packages/store/src/cli/commands/store/info.test.ts
+++ b/packages/store/src/cli/commands/store/info.test.ts
@@ -20,7 +20,6 @@ describe('store info command', () => {
 
     expect(getStoreInfo).toHaveBeenCalledWith({
       store: 'shop.myshopify.com',
-      context: expect.any(Object),
     })
     expect(renderStoreInfoResult).toHaveBeenCalledWith(
       expect.objectContaining({subdomain: 'shop.myshopify.com'}),

--- a/packages/store/src/cli/commands/store/info.ts
+++ b/packages/store/src/cli/commands/store/info.ts
@@ -2,7 +2,9 @@ import {getStoreInfo} from '../../services/store/info/index.js'
 import {renderStoreInfoResult} from '../../services/store/info/result.js'
 import StoreCommand from '../../utilities/store-command.js'
 import {storeFlags} from '../../flags.js'
+import {createSyncDiagnosticChannel} from '@shopify/diagnostics'
 import {globalFlags, jsonFlag} from '@shopify/cli-kit/node/cli'
+import {debugMessageSink} from '@shopify/cli-kit/node/output'
 
 export default class StoreInfo extends StoreCommand {
   static summary = 'Surface metadata about a Shopify store.'
@@ -29,7 +31,10 @@ Use \`--json\` for machine-readable output.`
   public async run(): Promise<void> {
     const {flags} = await this.parse(StoreInfo)
 
-    const result = await getStoreInfo({store: flags.store})
+    const result = await getStoreInfo({
+      store: flags.store,
+      context: {diagnostics: createSyncDiagnosticChannel(debugMessageSink)},
+    })
 
     renderStoreInfoResult(result, flags.json ? 'json' : 'text')
   }

--- a/packages/store/src/cli/services/store/info/context.ts
+++ b/packages/store/src/cli/services/store/info/context.ts
@@ -1,8 +1,0 @@
-import type {StoreInfoExecutionContext} from './types.js'
-import type {SyncDiagnosticChannel} from '@shopify/diagnostics'
-
-const noopSyncDiagnosticChannel: SyncDiagnosticChannel = {emit: () => {}}
-
-export const defaultStoreInfoExecutionContext: StoreInfoExecutionContext = {
-  diagnostics: noopSyncDiagnosticChannel,
-}

--- a/packages/store/src/cli/services/store/info/context.ts
+++ b/packages/store/src/cli/services/store/info/context.ts
@@ -1,0 +1,8 @@
+import type {StoreInfoExecutionContext} from './types.js'
+import type {SyncDiagnosticChannel} from '@shopify/diagnostics'
+
+const noopSyncDiagnosticChannel: SyncDiagnosticChannel = {emit: () => {}}
+
+export const defaultStoreInfoExecutionContext: StoreInfoExecutionContext = {
+  diagnostics: noopSyncDiagnosticChannel,
+}

--- a/packages/store/src/cli/services/store/info/index.test.ts
+++ b/packages/store/src/cli/services/store/info/index.test.ts
@@ -5,6 +5,7 @@ import {STORE_AUTH_APP_CLIENT_ID} from '../auth/config.js'
 import {loadStoredStoreSession} from '../auth/session-lifecycle.js'
 import {recordStoreFqdnMetadata} from '../attribution.js'
 import {getPreviewStore, PreviewStoreRequestError} from '../create/preview/client.js'
+import {createSyncDiagnosticChannel} from '@shopify/diagnostics'
 import {clearStoredStoreAppSession, getCurrentStoredStoreAppSession} from '@shopify/cli-kit/node/store-auth-session'
 import {AbortError, BugError} from '@shopify/cli-kit/node/error'
 import {adminUrl} from '@shopify/cli-kit/node/api/admin'
@@ -129,7 +130,11 @@ describe('getStoreInfo', () => {
   })
 
   test('uses BP destinations and org-shop when there is no stored store auth session', async () => {
-    const result = await getStoreInfo({store: SHOP})
+    const events: unknown[] = []
+    const result = await getStoreInfo({
+      store: SHOP,
+      context: {diagnostics: createSyncDiagnosticChannel((event) => events.push(event))},
+    })
 
     expect(getCurrentStoredStoreAppSession).toHaveBeenCalledWith(SHOP)
     expect(fetchDestinationsContext).toHaveBeenCalledWith({store: SHOP, noPrompt: false})
@@ -149,6 +154,7 @@ describe('getStoreInfo', () => {
       featurePreview: 'extended_variants',
       adminUrl: 'https://admin.shopify.com/store/shop',
     })
+    expect(events).toEqual([])
   })
 
   test('returns fresh access and save URLs for locally stored preview stores', async () => {
@@ -346,10 +352,14 @@ describe('getStoreInfo', () => {
     expect(getPreviewStore).not.toHaveBeenCalled()
   })
 
-  test('falls back to stored store auth when BP cannot resolve a store-auth store', async () => {
+  test('falls back to stored store auth and emits a diagnostic when BP cannot resolve a store-auth store', async () => {
     mockStoreAuthFallback()
+    const events: unknown[] = []
 
-    const result = await getStoreInfo({store: SHOP})
+    const result = await getStoreInfo({
+      store: SHOP,
+      context: {diagnostics: createSyncDiagnosticChannel((event) => events.push(event))},
+    })
 
     expect(fetchDestinationsContext).toHaveBeenCalledWith({store: SHOP, noPrompt: true})
     expect(fetchOrganizationShop).not.toHaveBeenCalled()
@@ -372,6 +382,20 @@ describe('getStoreInfo', () => {
       plan: 'Grow',
       adminUrl: 'https://admin.shopify.com/store/shop',
     })
+    expect(events).toEqual([
+      {
+        type: 'business-platform-fallback',
+        level: 'debug',
+        message: `BP store info lookup failed; falling back to stored store auth: Couldn't find a store with domain ${SHOP} for the current account.`,
+        error: {
+          message: `Couldn't find a store with domain ${SHOP} for the current account.`,
+          name: 'Error',
+        },
+      },
+    ])
+    expect(events[0]).not.toBeInstanceOf(Error)
+    expect((events[0] as {error: unknown}).error).not.toBeInstanceOf(Error)
+    expect(events[0]).not.toHaveProperty('stack')
   })
 
   test('falls back to stored store auth when BP auth would need to prompt', async () => {
@@ -519,22 +543,37 @@ The CLI is currently unable to prompt for reauthentication.`)
     expect(result.storeOwner).toBeUndefined()
   })
 
-  test('omits org-sourced fields when the owning org is unknown in the BP path', async () => {
+  test('omits org-sourced fields and emits a diagnostic when the owning org is unknown in the BP path', async () => {
     vi.mocked(fetchDestinationsContext).mockResolvedValue({})
+    const events: unknown[] = []
 
-    const result = await getStoreInfo({store: SHOP})
+    const result = await getStoreInfo({
+      store: SHOP,
+      context: {diagnostics: createSyncDiagnosticChannel((event) => events.push(event))},
+    })
 
     expect(fetchOrganizationShop).not.toHaveBeenCalled()
     expect(result).toEqual({
       subdomain: SHOP,
       adminUrl: 'https://admin.shopify.com/store/shop',
     })
+    expect(events).toEqual([
+      {
+        type: 'organization-shop-lookup-skipped',
+        level: 'debug',
+        message: 'Owning organization id is unknown; skipping BP Organizations shop lookup.',
+      },
+    ])
   })
 
-  test('omits org-sourced fields without throwing when the BP org-shop lookup fails', async () => {
+  test('omits org-sourced fields and emits a diagnostic when the BP org-shop lookup fails', async () => {
     vi.mocked(fetchOrganizationShop).mockRejectedValue(new Error('5xx'))
+    const events: unknown[] = []
 
-    const result = await getStoreInfo({store: SHOP})
+    const result = await getStoreInfo({
+      store: SHOP,
+      context: {diagnostics: createSyncDiagnosticChannel((event) => events.push(event))},
+    })
 
     expect(result).toEqual({
       subdomain: SHOP,
@@ -542,6 +581,17 @@ The CLI is currently unable to prompt for reauthentication.`)
       organizationName: 'Acme Holdings',
       adminUrl: 'https://admin.shopify.com/store/shop',
     })
+    expect(events).toEqual([
+      {
+        type: 'organization-shop-lookup-failed',
+        level: 'debug',
+        message: 'BP Organizations shop lookup failed: 5xx',
+        error: {message: '5xx', name: 'Error'},
+      },
+    ])
+    expect(events[0]).not.toBeInstanceOf(Error)
+    expect((events[0] as {error: unknown}).error).not.toBeInstanceOf(Error)
+    expect(events[0]).not.toHaveProperty('stack')
   })
 
   test('throws when Shopify does not return Admin shop info', async () => {

--- a/packages/store/src/cli/services/store/info/index.test.ts
+++ b/packages/store/src/cli/services/store/info/index.test.ts
@@ -594,6 +594,66 @@ The CLI is currently unable to prompt for reauthentication.`)
     expect(events[0]).not.toHaveProperty('stack')
   })
 
+  test.each<[string, unknown, string]>([
+    ['a string', '5xx', '5xx'],
+    ['null', null, 'null'],
+    ['an object', {message: '5xx'}, 'Unknown error'],
+    [
+      'an object with a throwing toString',
+      {
+        toString: () => {
+          throw new Error('toString failed')
+        },
+      },
+      'Unknown error',
+    ],
+  ])('projects %s rejected values without changing the result', async (_label, error, expectedMessage) => {
+    vi.mocked(fetchOrganizationShop).mockRejectedValue(error as never)
+    const events: unknown[] = []
+
+    const result = await getStoreInfo({
+      store: SHOP,
+      context: {diagnostics: createSyncDiagnosticChannel((event) => events.push(event))},
+    })
+
+    expect(result).toMatchObject({
+      subdomain: SHOP,
+      organizationId: '149572536',
+      organizationName: 'Acme Holdings',
+    })
+    expect(events).toEqual([
+      expect.objectContaining({
+        type: 'organization-shop-lookup-failed',
+        error: expect.objectContaining({message: expectedMessage}),
+      }),
+    ])
+  })
+
+  test('protects the diagnostic projection from throwing Error accessors', async () => {
+    const error = new Error('ignored')
+    Object.defineProperty(error, 'message', {
+      configurable: true,
+      get: () => {
+        throw new Error('message failed')
+      },
+    })
+    Object.defineProperty(error, 'code', {
+      configurable: true,
+      get: () => {
+        throw new Error('code failed')
+      },
+    })
+    vi.mocked(fetchOrganizationShop).mockRejectedValue(error)
+    const events: unknown[] = []
+
+    await getStoreInfo({
+      store: SHOP,
+      context: {diagnostics: createSyncDiagnosticChannel((event) => events.push(event))},
+    })
+
+    expect((events[0] as {error: unknown}).error).toEqual({message: 'Unknown error', name: 'Error'})
+  })
+
   test('throws when Shopify does not return Admin shop info', async () => {
     mockStoreAuthFallback()
     vi.mocked(graphqlRequest).mockResolvedValue({shop: undefined})

--- a/packages/store/src/cli/services/store/info/index.ts
+++ b/packages/store/src/cli/services/store/info/index.ts
@@ -1,5 +1,4 @@
 import {mapPlanToPublicHandle} from './plan.js'
-import {defaultStoreInfoExecutionContext} from './context.js'
 import {classifyAdminApiError, throwIfStoredStoreAuthIsInvalid} from '../admin-errors.js'
 import {recordStoreFqdnMetadata} from '../attribution.js'
 import {throwStoredAuthInvalidError} from '../auth/recovery.js'
@@ -23,6 +22,12 @@ import type {
   StoreInfoStoreOwner,
 } from './types.js'
 import type {StoredStoreAppSession} from '@shopify/cli-kit/node/store-auth-session'
+
+const noopSyncDiagnosticChannel: StoreInfoExecutionContext['diagnostics'] = {emit: () => {}}
+
+const defaultStoreInfoExecutionContext: StoreInfoExecutionContext = {
+  diagnostics: noopSyncDiagnosticChannel,
+}
 
 interface GetStoreInfoOptions {
   store?: string
@@ -113,8 +118,8 @@ async function getAdminStoreInfo(store: string): Promise<StoreInfoResult> {
 
 async function getBusinessPlatformStoreInfo(
   store: string,
-  options: {noPrompt?: boolean} = {},
-  context: StoreInfoExecutionContext = defaultStoreInfoExecutionContext,
+  options: {noPrompt?: boolean},
+  context: StoreInfoExecutionContext,
 ): Promise<StoreInfoResult> {
   const destinationsCtx = await fetchDestinationsContext({store, noPrompt: options.noPrompt})
   const orgShop = await safeFetchOrganizationShop(destinationsCtx, store, {noPrompt: options.noPrompt}, context)
@@ -189,8 +194,8 @@ async function fetchPreviewStoreUrls(previewSession: PreviewStoreSession): Promi
 async function safeFetchOrganizationShop(
   ctx: DestinationsContext,
   store: string,
-  options: {noPrompt?: boolean} = {},
-  context: StoreInfoExecutionContext = defaultStoreInfoExecutionContext,
+  options: {noPrompt?: boolean},
+  context: StoreInfoExecutionContext,
 ): Promise<OrganizationShopFields | undefined> {
   if (!ctx.owningOrg?.id) {
     // Without an org id we can't address the BP Organizations API, so the shop-level fields

--- a/packages/store/src/cli/services/store/info/index.ts
+++ b/packages/store/src/cli/services/store/info/index.ts
@@ -227,16 +227,36 @@ function isNoPromptAuthenticationError(error: unknown): boolean {
 }
 
 function toSafeDiagnosticError(error: unknown): StoreInfoDiagnosticError {
-  if (error instanceof Error) {
-    const code = 'code' in error && typeof error.code === 'string' ? error.code : undefined
-    return {
-      message: error.message,
-      ...(error.name ? {name: error.name} : {}),
-      ...(code ? {code} : {}),
+  try {
+    if (error instanceof Error) {
+      const message = readSafeDiagnosticField(error, 'message') ?? 'Unknown error'
+      const name = readSafeDiagnosticField(error, 'name')
+      const code = readSafeDiagnosticField(error, 'code')
+      return {
+        message,
+        ...(name ? {name} : {}),
+        ...(code ? {code} : {}),
+      }
     }
-  }
 
-  return {message: String(error)}
+    if (error === null) return {message: 'null'}
+    if (typeof error === 'object' || typeof error === 'function') return {message: 'Unknown error'}
+
+    return {message: String(error)}
+    // eslint-disable-next-line no-catch-all/no-catch-all
+  } catch {
+    return {message: 'Unknown error'}
+  }
+}
+
+function readSafeDiagnosticField(error: Error, field: 'message' | 'name' | 'code'): string | undefined {
+  try {
+    const value = (error as unknown as Record<string, unknown>)[field]
+    return typeof value === 'string' ? value : undefined
+    // eslint-disable-next-line no-catch-all/no-catch-all
+  } catch {
+    return undefined
+  }
 }
 
 interface BuildAdminResultArgs {

--- a/packages/store/src/cli/services/store/info/index.ts
+++ b/packages/store/src/cli/services/store/info/index.ts
@@ -1,4 +1,5 @@
 import {mapPlanToPublicHandle} from './plan.js'
+import {defaultStoreInfoExecutionContext} from './context.js'
 import {classifyAdminApiError, throwIfStoredStoreAuthIsInvalid} from '../admin-errors.js'
 import {recordStoreFqdnMetadata} from '../attribution.js'
 import {throwStoredAuthInvalidError} from '../auth/recovery.js'
@@ -14,13 +15,18 @@ import {graphqlRequest} from '@shopify/cli-kit/node/api/graphql'
 import {compact} from '@shopify/cli-kit/common/object'
 import {extractMyshopifyHandle} from '@shopify/cli-kit/common/url'
 import {setLastSeenUserId} from '@shopify/cli-kit/node/session'
-import {outputDebug} from '@shopify/cli-kit/node/output'
 import type {DestinationsContext, OrganizationShopFields} from '../../../utilities/store-lookup/types.js'
-import type {StoreInfoResult, StoreInfoStoreOwner} from './types.js'
+import type {
+  StoreInfoDiagnosticError,
+  StoreInfoExecutionContext,
+  StoreInfoResult,
+  StoreInfoStoreOwner,
+} from './types.js'
 import type {StoredStoreAppSession} from '@shopify/cli-kit/node/store-auth-session'
 
 interface GetStoreInfoOptions {
   store?: string
+  context?: StoreInfoExecutionContext
 }
 
 interface AdminStoreInfoResponse {
@@ -55,6 +61,7 @@ const StoreInfoAdminShopQuery = `#graphql
 
 export async function getStoreInfo(options: GetStoreInfoOptions): Promise<StoreInfoResult> {
   const store = options.store
+  const context = options.context ?? defaultStoreInfoExecutionContext
   if (!store) {
     throw new AbortError(
       'No store specified.',
@@ -78,13 +85,19 @@ export async function getStoreInfo(options: GetStoreInfoOptions): Promise<StoreI
   const hasStoredStoreAuth = Boolean(storedSession)
 
   try {
-    return await getBusinessPlatformStoreInfo(store, {noPrompt: hasStoredStoreAuth})
+    return await getBusinessPlatformStoreInfo(store, {noPrompt: hasStoredStoreAuth}, context)
   } catch (error) {
     if (!hasStoredStoreAuth || !isBusinessPlatformFallbackError(error)) {
       throw error
     }
 
-    outputDebug(`BP store info lookup failed; falling back to stored store auth: ${errorMessage(error)}`)
+    const diagnosticError = toSafeDiagnosticError(error)
+    context.diagnostics.emit({
+      type: 'business-platform-fallback',
+      level: 'debug',
+      message: `BP store info lookup failed; falling back to stored store auth: ${diagnosticError.message}`,
+      error: diagnosticError,
+    })
     return getAdminStoreInfo(store)
   }
 }
@@ -101,9 +114,10 @@ async function getAdminStoreInfo(store: string): Promise<StoreInfoResult> {
 async function getBusinessPlatformStoreInfo(
   store: string,
   options: {noPrompt?: boolean} = {},
+  context: StoreInfoExecutionContext = defaultStoreInfoExecutionContext,
 ): Promise<StoreInfoResult> {
   const destinationsCtx = await fetchDestinationsContext({store, noPrompt: options.noPrompt})
-  const orgShop = await safeFetchOrganizationShop(destinationsCtx, store, {noPrompt: options.noPrompt})
+  const orgShop = await safeFetchOrganizationShop(destinationsCtx, store, {noPrompt: options.noPrompt}, context)
 
   return buildBusinessPlatformResult({store, destinationsCtx, orgShop})
 }
@@ -176,19 +190,30 @@ async function safeFetchOrganizationShop(
   ctx: DestinationsContext,
   store: string,
   options: {noPrompt?: boolean} = {},
+  context: StoreInfoExecutionContext = defaultStoreInfoExecutionContext,
 ): Promise<OrganizationShopFields | undefined> {
   if (!ctx.owningOrg?.id) {
     // Without an org id we can't address the BP Organizations API, so the shop-level fields
     // (id, owner, type, feature preview) are unavailable. The destination already gives us a
     // usable baseline (display name, admin URL).
-    outputDebug('Owning organization id is unknown; skipping BP Organizations shop lookup.')
+    context.diagnostics.emit({
+      type: 'organization-shop-lookup-skipped',
+      level: 'debug',
+      message: 'Owning organization id is unknown; skipping BP Organizations shop lookup.',
+    })
     return undefined
   }
   try {
     return await fetchOrganizationShop({store, organizationId: ctx.owningOrg.id, noPrompt: options.noPrompt})
     // eslint-disable-next-line no-catch-all/no-catch-all
   } catch (error) {
-    outputDebug(`BP Organizations shop lookup failed: ${error instanceof Error ? error.message : String(error)}`)
+    const diagnosticError = toSafeDiagnosticError(error)
+    context.diagnostics.emit({
+      type: 'organization-shop-lookup-failed',
+      level: 'debug',
+      message: `BP Organizations shop lookup failed: ${diagnosticError.message}`,
+      error: diagnosticError,
+    })
     return undefined
   }
 }
@@ -201,9 +226,17 @@ function isNoPromptAuthenticationError(error: unknown): boolean {
   return error instanceof AbortError && error.message.includes('unable to prompt for reauthentication')
 }
 
-function errorMessage(error: unknown): string {
-  if (error instanceof Error) return error.message
-  return String(error)
+function toSafeDiagnosticError(error: unknown): StoreInfoDiagnosticError {
+  if (error instanceof Error) {
+    const code = 'code' in error && typeof error.code === 'string' ? error.code : undefined
+    return {
+      message: error.message,
+      ...(error.name ? {name: error.name} : {}),
+      ...(code ? {code} : {}),
+    }
+  }
+
+  return {message: String(error)}
 }
 
 interface BuildAdminResultArgs {

--- a/packages/store/src/cli/services/store/info/types.ts
+++ b/packages/store/src/cli/services/store/info/types.ts
@@ -1,3 +1,29 @@
+import type {DiagnosticEvent, SyncDiagnosticChannel} from '@shopify/diagnostics'
+
+export interface StoreInfoDiagnosticError {
+  message: string
+  name?: string
+  code?: string
+}
+
+/** Store-info events stay domain-owned while extending the generic, data-only event shape. */
+export type StoreInfoDiagnosticEvent =
+  | (DiagnosticEvent & {
+      type: 'business-platform-fallback'
+      level: 'debug'
+      error: StoreInfoDiagnosticError
+    })
+  | (DiagnosticEvent & {type: 'organization-shop-lookup-skipped'; level: 'debug'})
+  | (DiagnosticEvent & {
+      type: 'organization-shop-lookup-failed'
+      level: 'debug'
+      error: StoreInfoDiagnosticError
+    })
+
+export interface StoreInfoExecutionContext {
+  diagnostics: SyncDiagnosticChannel<StoreInfoDiagnosticEvent>
+}
+
 export interface StoreInfoStoreOwner {
   name?: string
   email?: string

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -544,6 +544,12 @@ importers:
         specifier: ^2.1.1
         version: 2.1.1(esbuild@0.28.1)
 
+  packages/diagnostics:
+    devDependencies:
+      '@vitest/coverage-istanbul':
+        specifier: ^3.2.7
+        version: 3.2.7(vitest@4.1.10)
+
   packages/e2e:
     devDependencies:
       '@iarna/toml':
@@ -676,6 +682,9 @@ importers:
       '@shopify/cli-kit':
         specifier: 4.5.0
         version: link:../cli-kit
+      '@shopify/diagnostics':
+        specifier: 4.5.0
+        version: link:../diagnostics
       '@shopify/organizations':
         specifier: 4.5.0
         version: link:../organizations
@@ -862,48 +871,56 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@ast-grep/napi-linux-arm64-gnu@0.43.0':
     resolution: {integrity: sha512-yJSRPxwwrvVW94J2rtaatcixSAGWcSaHNbAh6soXD6HXgq6I7uMc+cyMnJstFL789yd6Pu3QIhTlpD9VY0oYhw==, tarball: https://registry.npmjs.org/@ast-grep/napi-linux-arm64-gnu/-/napi-linux-arm64-gnu-0.43.0.tgz}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@ast-grep/napi-linux-arm64-musl@0.34.1':
     resolution: {integrity: sha512-IXdqwTbkdqHrcuQb448Qzd82QdTqVFe/f0sSkFYQTic8P2qNzmiHsVnxgEFsQPPbe09BVAoZ885j3OnaNfcDYA==, tarball: https://registry.npmjs.org/@ast-grep/napi-linux-arm64-musl/-/napi-linux-arm64-musl-0.34.1.tgz}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@ast-grep/napi-linux-arm64-musl@0.43.0':
     resolution: {integrity: sha512-mknXLDsf66HvT/JEl18ZQSvR7/qWgWfqh3eHuVRqD2lE6cKBDXRnAzx9ZNZkUnL2Z5ph54Yk8dKVu09k45cegA==, tarball: https://registry.npmjs.org/@ast-grep/napi-linux-arm64-musl/-/napi-linux-arm64-musl-0.43.0.tgz}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@ast-grep/napi-linux-x64-gnu@0.34.1':
     resolution: {integrity: sha512-on4LyIeN/zN7SIh8zr5v+NTzVu3kXm2mG28ib1Qe9GVcf35dz52ckf7bilulayKSa2MHZWAXMjuc6NYMiNEw+w==, tarball: https://registry.npmjs.org/@ast-grep/napi-linux-x64-gnu/-/napi-linux-x64-gnu-0.34.1.tgz}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@ast-grep/napi-linux-x64-gnu@0.43.0':
     resolution: {integrity: sha512-KM6M5KKFsHG9Y7VKCKnMsWQQ1sYwj/SPdyr91SKp66AeFJ5xMtXb13WVQ3Joe9NEsi84dzzOBIJgMddz+UMvQw==, tarball: https://registry.npmjs.org/@ast-grep/napi-linux-x64-gnu/-/napi-linux-x64-gnu-0.43.0.tgz}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@ast-grep/napi-linux-x64-musl@0.34.1':
     resolution: {integrity: sha512-l1R5L9LOp0jTPjs8C+LUndZOA8cRw7PFlvoVxVbi2jCfcns00dqatSYc4yA/ke6ng2K0LSxjoV/jS8tefve0sA==, tarball: https://registry.npmjs.org/@ast-grep/napi-linux-x64-musl/-/napi-linux-x64-musl-0.34.1.tgz}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@ast-grep/napi-linux-x64-musl@0.43.0':
     resolution: {integrity: sha512-NfjI74m7CEEOsLi7ZkYwcxY10CfKIHPHRrr9aqMulmnrC4FGvxQMk1qpDrTqkjmEd8LdZt3PsPrmBa8AZCErew==, tarball: https://registry.npmjs.org/@ast-grep/napi-linux-x64-musl/-/napi-linux-x64-musl-0.43.0.tgz}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@ast-grep/napi-win32-arm64-msvc@0.34.1':
     resolution: {integrity: sha512-eVsdMtnY7jmN2xQjYY9gaqIxRHA44+QYivlP1uLbg8w3P4YlZWTFgOJ7aa357Hg/257mjeQCpodCkr0lGRsSYQ==, tarball: https://registry.npmjs.org/@ast-grep/napi-win32-arm64-msvc/-/napi-win32-arm64-msvc-0.34.1.tgz}
@@ -3007,21 +3024,25 @@ packages:
     resolution: {integrity: sha512-CfzWaS+b32lI/inlYPv1ZAK9CWTWFHzT7TPThvOHML65nrgFl8cQ4Z4FeGdyCbHu2NoG3vR1E36O2tPI2/DLGg==, tarball: https://registry.npmjs.org/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-22.7.7.tgz}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@nx/nx-linux-arm64-musl@22.7.7':
     resolution: {integrity: sha512-53QFuODMEHc1gobCT2WOmYz89DZtEIuLphirdIgnXkkPBTdrP77LPbJUXMRXCMKr90BQaSWhTX+J/ubANRE8og==, tarball: https://registry.npmjs.org/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-22.7.7.tgz}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@nx/nx-linux-x64-gnu@22.7.7':
     resolution: {integrity: sha512-unzmqGIDXGzujo1ZtbrMj2e5D5ldQ1feZmqDPhvO4casK2d96jpT8LtgIILpVDUfhLjl+By185gb0ArrWTsyKw==, tarball: https://registry.npmjs.org/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-22.7.7.tgz}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@nx/nx-linux-x64-musl@22.7.7':
     resolution: {integrity: sha512-oTjMGuM105ok8aH5rlg2YP0Kgkjg0VfUj1exwp49S70gGBJ0r8v5rEtJwOSdCf1WTHuEh0xi66Y/b1S0khF8dg==, tarball: https://registry.npmjs.org/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-22.7.7.tgz}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@nx/nx-win32-arm64-msvc@22.7.7':
     resolution: {integrity: sha512-K741meG/l48TPPeDqnhYTV7pP+1ljjZ+0DRJBxMrPFIu8qKE3Abko/7NKWmWRjcSXJvtxvYkgG3wZds4N2Bhow==, tarball: https://registry.npmjs.org/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-22.7.7.tgz}
@@ -3327,41 +3348,49 @@ packages:
     resolution: {integrity: sha512-0bJnmYFp62JdZ4nVMDUZ/C58BCZOCcqgKtnUlp7L9Ojf/czIN+3j72YlLPeWLkzlr6SlYvIQA4SGV/HyO0d+qg==, tarball: https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-11.20.0.tgz}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-arm64-musl@11.20.0':
     resolution: {integrity: sha512-wKHHzPKZo7Ufhv/Bt6yxT7FOgnIgW4gwXcJUipkShGp68W3wGVqvr1Sr0fY65lN0Oy6y41+g2kIDvkgZaMMUkw==, tarball: https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-musl/-/binding-linux-arm64-musl-11.20.0.tgz}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-linux-ppc64-gnu@11.20.0':
     resolution: {integrity: sha512-RN8goF7Ie0B79L4i4G6OeBocTgSC56vJbQ65VJje+oXnldVpLnOU7j/AQ/dP94TcCS+Yh6WG8u3Qt4ETteXFNQ==, tarball: https://registry.npmjs.org/@oxc-resolver/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-11.20.0.tgz}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-gnu@11.20.0':
     resolution: {integrity: sha512-5l1yU6/xQEqLZRzxqmMxJfWPslpwCmBsdDGaBvABPehxquCXDC7dd7oraNdKSJUMDXSM7VvVj8H2D2FTjU7oWw==, tarball: https://registry.npmjs.org/@oxc-resolver/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-11.20.0.tgz}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-musl@11.20.0':
     resolution: {integrity: sha512-xHEvkbgz6UC+A3JOyDQy76LkUaxsNSfIr3/GV8slwZsnuooJiIB34gzJfsyvR4JdCYNUUPsRJc/w/oWkODu+hg==, tarball: https://registry.npmjs.org/@oxc-resolver/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-11.20.0.tgz}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-linux-s390x-gnu@11.20.0':
     resolution: {integrity: sha512-aWPDUUmSeyHvlW+SoEUd+JIJsQhVhu6a5tBpDRMu058naPAchTgAVGCFy35zjbnFlt0i8hLWziff6HX0D3LU4g==, tarball: https://registry.npmjs.org/@oxc-resolver/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-11.20.0.tgz}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-gnu@11.20.0':
     resolution: {integrity: sha512-x2YeSimvhJjKLVD8KSu8f/rqU1potcdEMkApIPJqjZWN7c2Fpt4g2X32WDg1p+XDAmyT7nuQGe0vnhvXeLbH+g==, tarball: https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-gnu/-/binding-linux-x64-gnu-11.20.0.tgz}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-musl@11.20.0':
     resolution: {integrity: sha512-kcRLEIxpZefeYfLChjpgFf3ilBzRDZ+yobMrpRsQlSrxuFGtm3U6PMU7AaEpMqo3NfDGVyJJseAjnRLzMFHjwQ==, tarball: https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-musl/-/binding-linux-x64-musl-11.20.0.tgz}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-openharmony-arm64@11.20.0':
     resolution: {integrity: sha512-HHcfnApSZGtKhTiHqe8OZruOZe5XuFQH5/E0Yhj3u8fnFvzkM4/k6WjacUf4SvA0SPEAbfbgYmVPuo0VX/fIBQ==, tarball: https://registry.npmjs.org/@oxc-resolver/binding-openharmony-arm64/-/binding-openharmony-arm64-11.20.0.tgz}
@@ -3412,36 +3441,42 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm-musl@2.5.6':
     resolution: {integrity: sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==, tarball: https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.6.tgz}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-arm64-glibc@2.5.6':
     resolution: {integrity: sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==, tarball: https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.6.tgz}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.5.6':
     resolution: {integrity: sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==, tarball: https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.6.tgz}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.5.6':
     resolution: {integrity: sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==, tarball: https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.6.tgz}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.5.6':
     resolution: {integrity: sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==, tarball: https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.6.tgz}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-win32-arm64@2.5.6':
     resolution: {integrity: sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==, tarball: https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.6.tgz}
@@ -3565,66 +3600,79 @@ packages:
     resolution: {integrity: sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.59.0.tgz}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.59.0':
     resolution: {integrity: sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.59.0.tgz}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.59.0':
     resolution: {integrity: sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.0.tgz}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.59.0':
     resolution: {integrity: sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.59.0.tgz}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.59.0':
     resolution: {integrity: sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.59.0.tgz}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.59.0':
     resolution: {integrity: sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.59.0.tgz}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.59.0':
     resolution: {integrity: sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.59.0.tgz}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.59.0':
     resolution: {integrity: sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.59.0.tgz}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.59.0':
     resolution: {integrity: sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.59.0.tgz}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.59.0':
     resolution: {integrity: sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.0.tgz}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.59.0':
     resolution: {integrity: sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.59.0.tgz}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.59.0':
     resolution: {integrity: sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.59.0':
     resolution: {integrity: sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.0.tgz}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.59.0':
     resolution: {integrity: sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==, tarball: https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.59.0.tgz}
@@ -4138,41 +4186,49 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==, tarball: https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.11.1.tgz}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==, tarball: https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.11.1.tgz}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==, tarball: https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.11.1.tgz}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==, tarball: https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.11.1.tgz}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==, tarball: https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.11.1.tgz}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==, tarball: https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.11.1.tgz}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==, tarball: https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.11.1.tgz}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==, tarball: https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.11.1.tgz}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==, tarball: https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.11.1.tgz}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -871,56 +871,48 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@ast-grep/napi-linux-arm64-gnu@0.43.0':
     resolution: {integrity: sha512-yJSRPxwwrvVW94J2rtaatcixSAGWcSaHNbAh6soXD6HXgq6I7uMc+cyMnJstFL789yd6Pu3QIhTlpD9VY0oYhw==, tarball: https://registry.npmjs.org/@ast-grep/napi-linux-arm64-gnu/-/napi-linux-arm64-gnu-0.43.0.tgz}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@ast-grep/napi-linux-arm64-musl@0.34.1':
     resolution: {integrity: sha512-IXdqwTbkdqHrcuQb448Qzd82QdTqVFe/f0sSkFYQTic8P2qNzmiHsVnxgEFsQPPbe09BVAoZ885j3OnaNfcDYA==, tarball: https://registry.npmjs.org/@ast-grep/napi-linux-arm64-musl/-/napi-linux-arm64-musl-0.34.1.tgz}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@ast-grep/napi-linux-arm64-musl@0.43.0':
     resolution: {integrity: sha512-mknXLDsf66HvT/JEl18ZQSvR7/qWgWfqh3eHuVRqD2lE6cKBDXRnAzx9ZNZkUnL2Z5ph54Yk8dKVu09k45cegA==, tarball: https://registry.npmjs.org/@ast-grep/napi-linux-arm64-musl/-/napi-linux-arm64-musl-0.43.0.tgz}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@ast-grep/napi-linux-x64-gnu@0.34.1':
     resolution: {integrity: sha512-on4LyIeN/zN7SIh8zr5v+NTzVu3kXm2mG28ib1Qe9GVcf35dz52ckf7bilulayKSa2MHZWAXMjuc6NYMiNEw+w==, tarball: https://registry.npmjs.org/@ast-grep/napi-linux-x64-gnu/-/napi-linux-x64-gnu-0.34.1.tgz}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@ast-grep/napi-linux-x64-gnu@0.43.0':
     resolution: {integrity: sha512-KM6M5KKFsHG9Y7VKCKnMsWQQ1sYwj/SPdyr91SKp66AeFJ5xMtXb13WVQ3Joe9NEsi84dzzOBIJgMddz+UMvQw==, tarball: https://registry.npmjs.org/@ast-grep/napi-linux-x64-gnu/-/napi-linux-x64-gnu-0.43.0.tgz}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@ast-grep/napi-linux-x64-musl@0.34.1':
     resolution: {integrity: sha512-l1R5L9LOp0jTPjs8C+LUndZOA8cRw7PFlvoVxVbi2jCfcns00dqatSYc4yA/ke6ng2K0LSxjoV/jS8tefve0sA==, tarball: https://registry.npmjs.org/@ast-grep/napi-linux-x64-musl/-/napi-linux-x64-musl-0.34.1.tgz}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@ast-grep/napi-linux-x64-musl@0.43.0':
     resolution: {integrity: sha512-NfjI74m7CEEOsLi7ZkYwcxY10CfKIHPHRrr9aqMulmnrC4FGvxQMk1qpDrTqkjmEd8LdZt3PsPrmBa8AZCErew==, tarball: https://registry.npmjs.org/@ast-grep/napi-linux-x64-musl/-/napi-linux-x64-musl-0.43.0.tgz}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@ast-grep/napi-win32-arm64-msvc@0.34.1':
     resolution: {integrity: sha512-eVsdMtnY7jmN2xQjYY9gaqIxRHA44+QYivlP1uLbg8w3P4YlZWTFgOJ7aa357Hg/257mjeQCpodCkr0lGRsSYQ==, tarball: https://registry.npmjs.org/@ast-grep/napi-win32-arm64-msvc/-/napi-win32-arm64-msvc-0.34.1.tgz}
@@ -3024,25 +3016,21 @@ packages:
     resolution: {integrity: sha512-CfzWaS+b32lI/inlYPv1ZAK9CWTWFHzT7TPThvOHML65nrgFl8cQ4Z4FeGdyCbHu2NoG3vR1E36O2tPI2/DLGg==, tarball: https://registry.npmjs.org/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-22.7.7.tgz}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@nx/nx-linux-arm64-musl@22.7.7':
     resolution: {integrity: sha512-53QFuODMEHc1gobCT2WOmYz89DZtEIuLphirdIgnXkkPBTdrP77LPbJUXMRXCMKr90BQaSWhTX+J/ubANRE8og==, tarball: https://registry.npmjs.org/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-22.7.7.tgz}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@nx/nx-linux-x64-gnu@22.7.7':
     resolution: {integrity: sha512-unzmqGIDXGzujo1ZtbrMj2e5D5ldQ1feZmqDPhvO4casK2d96jpT8LtgIILpVDUfhLjl+By185gb0ArrWTsyKw==, tarball: https://registry.npmjs.org/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-22.7.7.tgz}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@nx/nx-linux-x64-musl@22.7.7':
     resolution: {integrity: sha512-oTjMGuM105ok8aH5rlg2YP0Kgkjg0VfUj1exwp49S70gGBJ0r8v5rEtJwOSdCf1WTHuEh0xi66Y/b1S0khF8dg==, tarball: https://registry.npmjs.org/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-22.7.7.tgz}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@nx/nx-win32-arm64-msvc@22.7.7':
     resolution: {integrity: sha512-K741meG/l48TPPeDqnhYTV7pP+1ljjZ+0DRJBxMrPFIu8qKE3Abko/7NKWmWRjcSXJvtxvYkgG3wZds4N2Bhow==, tarball: https://registry.npmjs.org/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-22.7.7.tgz}
@@ -3348,49 +3336,41 @@ packages:
     resolution: {integrity: sha512-0bJnmYFp62JdZ4nVMDUZ/C58BCZOCcqgKtnUlp7L9Ojf/czIN+3j72YlLPeWLkzlr6SlYvIQA4SGV/HyO0d+qg==, tarball: https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-11.20.0.tgz}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-arm64-musl@11.20.0':
     resolution: {integrity: sha512-wKHHzPKZo7Ufhv/Bt6yxT7FOgnIgW4gwXcJUipkShGp68W3wGVqvr1Sr0fY65lN0Oy6y41+g2kIDvkgZaMMUkw==, tarball: https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-musl/-/binding-linux-arm64-musl-11.20.0.tgz}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-resolver/binding-linux-ppc64-gnu@11.20.0':
     resolution: {integrity: sha512-RN8goF7Ie0B79L4i4G6OeBocTgSC56vJbQ65VJje+oXnldVpLnOU7j/AQ/dP94TcCS+Yh6WG8u3Qt4ETteXFNQ==, tarball: https://registry.npmjs.org/@oxc-resolver/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-11.20.0.tgz}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-gnu@11.20.0':
     resolution: {integrity: sha512-5l1yU6/xQEqLZRzxqmMxJfWPslpwCmBsdDGaBvABPehxquCXDC7dd7oraNdKSJUMDXSM7VvVj8H2D2FTjU7oWw==, tarball: https://registry.npmjs.org/@oxc-resolver/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-11.20.0.tgz}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-musl@11.20.0':
     resolution: {integrity: sha512-xHEvkbgz6UC+A3JOyDQy76LkUaxsNSfIr3/GV8slwZsnuooJiIB34gzJfsyvR4JdCYNUUPsRJc/w/oWkODu+hg==, tarball: https://registry.npmjs.org/@oxc-resolver/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-11.20.0.tgz}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-resolver/binding-linux-s390x-gnu@11.20.0':
     resolution: {integrity: sha512-aWPDUUmSeyHvlW+SoEUd+JIJsQhVhu6a5tBpDRMu058naPAchTgAVGCFy35zjbnFlt0i8hLWziff6HX0D3LU4g==, tarball: https://registry.npmjs.org/@oxc-resolver/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-11.20.0.tgz}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-gnu@11.20.0':
     resolution: {integrity: sha512-x2YeSimvhJjKLVD8KSu8f/rqU1potcdEMkApIPJqjZWN7c2Fpt4g2X32WDg1p+XDAmyT7nuQGe0vnhvXeLbH+g==, tarball: https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-gnu/-/binding-linux-x64-gnu-11.20.0.tgz}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-musl@11.20.0':
     resolution: {integrity: sha512-kcRLEIxpZefeYfLChjpgFf3ilBzRDZ+yobMrpRsQlSrxuFGtm3U6PMU7AaEpMqo3NfDGVyJJseAjnRLzMFHjwQ==, tarball: https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-musl/-/binding-linux-x64-musl-11.20.0.tgz}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-resolver/binding-openharmony-arm64@11.20.0':
     resolution: {integrity: sha512-HHcfnApSZGtKhTiHqe8OZruOZe5XuFQH5/E0Yhj3u8fnFvzkM4/k6WjacUf4SvA0SPEAbfbgYmVPuo0VX/fIBQ==, tarball: https://registry.npmjs.org/@oxc-resolver/binding-openharmony-arm64/-/binding-openharmony-arm64-11.20.0.tgz}
@@ -3441,42 +3421,36 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-arm-musl@2.5.6':
     resolution: {integrity: sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==, tarball: https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.6.tgz}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-linux-arm64-glibc@2.5.6':
     resolution: {integrity: sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==, tarball: https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.6.tgz}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.5.6':
     resolution: {integrity: sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==, tarball: https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.6.tgz}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.5.6':
     resolution: {integrity: sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==, tarball: https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.6.tgz}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.5.6':
     resolution: {integrity: sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==, tarball: https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.6.tgz}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-win32-arm64@2.5.6':
     resolution: {integrity: sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==, tarball: https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.6.tgz}
@@ -3600,79 +3574,66 @@ packages:
     resolution: {integrity: sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.59.0.tgz}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.59.0':
     resolution: {integrity: sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.59.0.tgz}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.59.0':
     resolution: {integrity: sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.0.tgz}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.59.0':
     resolution: {integrity: sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.59.0.tgz}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.59.0':
     resolution: {integrity: sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.59.0.tgz}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.59.0':
     resolution: {integrity: sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.59.0.tgz}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.59.0':
     resolution: {integrity: sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.59.0.tgz}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.59.0':
     resolution: {integrity: sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.59.0.tgz}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.59.0':
     resolution: {integrity: sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.59.0.tgz}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.59.0':
     resolution: {integrity: sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.0.tgz}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.59.0':
     resolution: {integrity: sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.59.0.tgz}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.59.0':
     resolution: {integrity: sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.59.0':
     resolution: {integrity: sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.0.tgz}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.59.0':
     resolution: {integrity: sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==, tarball: https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.59.0.tgz}
@@ -4186,49 +4147,41 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==, tarball: https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.11.1.tgz}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==, tarball: https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.11.1.tgz}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==, tarball: https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.11.1.tgz}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==, tarball: https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.11.1.tgz}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==, tarball: https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.11.1.tgz}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==, tarball: https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.11.1.tgz}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==, tarball: https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.11.1.tgz}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==, tarball: https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.11.1.tgz}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==, tarball: https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.11.1.tgz}


### PR DESCRIPTION
## What

Add a private, dependency-free `@shopify/diagnostics` leaf and a typed synchronous diagnostic side channel to `store:info`. The CLI adapter connects those events to the existing `debugMessageSink`, so current output and result behavior remain unchanged.

## Why

Shopify CLI is moving toward data-only finite execution contracts that can serve CLI, SDK, MCP, and other adapters without depending on terminal rendering. This proof of concept demonstrates the compatibility seam between renderer-first execution and future explicit result/event adapters without claiming a universal event framework.

## How

- Keep diagnostics data-only and synchronous; observers run in registration order and observer failures do not affect command results.
- Keep domain events owned by `store:info`, with typed variants and safe error projections.
- Preserve the existing JSON wire shape, stdout/stderr separation, debug filtering, timestamps, color handling, test log collection, fallback/result/error behavior, and non-interactive behavior through the existing CLI output adapter.

Async delivery, stream/progress protocols, universal result/error/event envelopes, launcher or `BaseCommand` changes, infrastructure logging, and broader command migration are out of scope.

## Verification and limitations

- 55 focused tests pass.
- `@shopify/diagnostics` build, type-check, and lint pass.
- cli-kit type-check, changed-file ESLint, and `git diff --check` pass.
- Full `store` type-check remains blocked by the pre-existing missing `@shopify/organizations` declarations; no errors were reported in the changed diagnostics or store-info code.

Post-release steps: None.
