### PR TITLE
PoC: typed result contract for store:execute

### DIFF
--- a/.changeset/store-execute-result-contract.md
+++ b/.changeset/store-execute-result-contract.md
@@ -2,4 +2,4 @@
 '@shopify/store': patch
 ---
 
-Improve `store execute` structured output and report GraphQL user errors as unsuccessful results.
+Improve `store execute` structured output.

--- a/.changeset/store-execute-result-contract.md
+++ b/.changeset/store-execute-result-contract.md
@@ -1,0 +1,5 @@
+---
+'@shopify/store': patch
+---
+
+Improve `store execute` structured output and report GraphQL user errors as unsuccessful results.

--- a/packages/store/src/cli/services/store/execute/admin-transport.test.ts
+++ b/packages/store/src/cli/services/store/execute/admin-transport.test.ts
@@ -56,7 +56,7 @@ describe('runAdminStoreGraphQLOperation', () => {
   })
 
   test('executes the GraphQL request successfully', async () => {
-    vi.mocked(graphqlRequest).mockResolvedValue({data: {shop: {name: 'Test shop'}}})
+    vi.mocked(graphqlRequest).mockResolvedValue({shop: {name: 'Test shop'}})
     const request = await prepareStoreExecuteRequest({query: 'query { shop { name } }'})
 
     const result = await runAdminStoreGraphQLOperation({context, request})
@@ -141,6 +141,27 @@ describe('runAdminStoreGraphQLOperation', () => {
     const request = await prepareStoreExecuteRequest({query: 'query { nope }'})
 
     await expect(runAdminStoreGraphQLOperation({context, request})).rejects.toThrow('GraphQL operation failed.')
+  })
+
+  test('documents current behavior: read-only responses can be classified by nested userErrors', async () => {
+    vi.mocked(graphqlRequest).mockResolvedValue({shop: {userErrors: [{message: 'Upstream warning'}]}})
+    const request = await prepareStoreExecuteRequest({query: 'query { shop { userErrors { message } } }'})
+
+    await expect(runAdminStoreGraphQLOperation({context, request})).resolves.toEqual({
+      data: {shop: {userErrors: [{message: 'Upstream warning'}]}},
+      failure: {code: 'USER_ERRORS', details: [{message: 'Upstream warning'}]},
+    })
+  })
+
+  test('documents current behavior: HTTP-200 top-level GraphQL errors are discarded and partial data succeeds', async () => {
+    // cli-kit's graphqlRequest returns response.data, so top-level HTTP-200 errors are
+    // discarded before this adapter receives the payload.
+    vi.mocked(graphqlRequest).mockResolvedValue({shop: null})
+    const request = await prepareStoreExecuteRequest({query: 'query { shop { name } }'})
+
+    await expect(runAdminStoreGraphQLOperation({context, request})).resolves.toEqual({
+      data: {shop: null},
+    })
   })
 
   test('maps a 402 ClientError to a store-unavailable AbortError even when the response also carries `errors`', async () => {

--- a/packages/store/src/cli/services/store/execute/admin-transport.test.ts
+++ b/packages/store/src/cli/services/store/execute/admin-transport.test.ts
@@ -143,16 +143,6 @@ describe('runAdminStoreGraphQLOperation', () => {
     await expect(runAdminStoreGraphQLOperation({context, request})).rejects.toThrow('GraphQL operation failed.')
   })
 
-  test('documents current behavior: read-only responses can be classified by nested userErrors', async () => {
-    vi.mocked(graphqlRequest).mockResolvedValue({shop: {userErrors: [{message: 'Upstream warning'}]}})
-    const request = await prepareStoreExecuteRequest({query: 'query { shop { userErrors { message } } }'})
-
-    await expect(runAdminStoreGraphQLOperation({context, request})).resolves.toEqual({
-      data: {shop: {userErrors: [{message: 'Upstream warning'}]}},
-      failure: {code: 'USER_ERRORS', details: [{message: 'Upstream warning'}]},
-    })
-  })
-
   test('treats top-level GraphQL errors on an HTTP 200 as an execution-level failure', async () => {
     // graphql-request throws ClientError whenever the payload carries `errors` under the
     // default error policy, and cli-kit never overrides that policy. So a 200 response with

--- a/packages/store/src/cli/services/store/execute/admin-transport.test.ts
+++ b/packages/store/src/cli/services/store/execute/admin-transport.test.ts
@@ -153,15 +153,15 @@ describe('runAdminStoreGraphQLOperation', () => {
     })
   })
 
-  test('documents current behavior: HTTP-200 top-level GraphQL errors are discarded and partial data succeeds', async () => {
-    // cli-kit's graphqlRequest returns response.data, so top-level HTTP-200 errors are
-    // discarded before this adapter receives the payload.
-    vi.mocked(graphqlRequest).mockResolvedValue({shop: null})
+  test('treats top-level GraphQL errors on an HTTP 200 as an execution-level failure', async () => {
+    // graphql-request throws ClientError whenever the payload carries `errors` under the
+    // default error policy, and cli-kit never overrides that policy. So a 200 response with
+    // `errors` never reaches this adapter as data; it arrives as a rejection and belongs to
+    // the error boundary rather than to result-level failure classification.
+    vi.mocked(graphqlRequest).mockRejectedValue(makeClientErrorLike(200, 'Field does not exist'))
     const request = await prepareStoreExecuteRequest({query: 'query { shop { name } }'})
 
-    await expect(runAdminStoreGraphQLOperation({context, request})).resolves.toEqual({
-      data: {shop: null},
-    })
+    await expect(runAdminStoreGraphQLOperation({context, request})).rejects.toBeInstanceOf(AbortError)
   })
 
   test('maps a 402 ClientError to a store-unavailable AbortError even when the response also carries `errors`', async () => {

--- a/packages/store/src/cli/services/store/execute/admin-transport.ts
+++ b/packages/store/src/cli/services/store/execute/admin-transport.ts
@@ -13,6 +13,7 @@ import type {AdminSession} from '@shopify/cli-kit/node/session'
 import type {PreparedStoreExecuteRequest} from './request.js'
 import type {AdminStoreGraphQLContext} from './admin-context.js'
 import type {StoredStoreAppSession} from '@shopify/cli-kit/node/store-auth-session'
+import type {JsonValue, StoreExecuteResult} from './types.js'
 
 export {ABORTED_FETCH_MESSAGE_FRAGMENTS}
 
@@ -65,9 +66,9 @@ export async function fetchPublicApiVersions(input: {
 export async function runAdminStoreGraphQLOperation(input: {
   context: AdminStoreGraphQLContext
   request: PreparedStoreExecuteRequest
-}): Promise<unknown> {
+}): Promise<StoreExecuteResult> {
   try {
-    return await renderSingleTask({
+    const response = await renderSingleTask({
       title: outputContent`Executing GraphQL operation`,
       task: async () => {
         return graphqlRequest({
@@ -81,6 +82,7 @@ export async function runAdminStoreGraphQLOperation(input: {
       },
       renderOptions: {stdout: process.stderr},
     })
+    return storeExecuteResult(response)
   } catch (error) {
     throwIfStoredStoreAuthIsInvalid(error, input.context.session)
 
@@ -96,4 +98,21 @@ export async function runAdminStoreGraphQLOperation(input: {
 
     throw error
   }
+}
+
+function storeExecuteResult(response: unknown): StoreExecuteResult {
+  const data = response as JsonValue
+  const userErrors = findUserErrors(data)
+  return userErrors.length > 0 ? {data, failure: {code: 'USER_ERRORS', details: userErrors}} : {data}
+}
+
+function findUserErrors(value: JsonValue): JsonValue[] {
+  if (Array.isArray(value)) return value.flatMap(findUserErrors)
+  if (value === null || typeof value !== 'object') return []
+
+  const errors = 'userErrors' in value && Array.isArray(value.userErrors) ? value.userErrors : []
+  return [
+    ...errors,
+    ...Object.entries(value).flatMap(([key, child]) => (key === 'userErrors' ? [] : findUserErrors(child))),
+  ]
 }

--- a/packages/store/src/cli/services/store/execute/admin-transport.ts
+++ b/packages/store/src/cli/services/store/execute/admin-transport.ts
@@ -101,18 +101,5 @@ export async function runAdminStoreGraphQLOperation(input: {
 }
 
 function storeExecuteResult(response: unknown): StoreExecuteResult {
-  const data = response as JsonValue
-  const userErrors = findUserErrors(data)
-  return userErrors.length > 0 ? {data, failure: {code: 'USER_ERRORS', details: userErrors}} : {data}
-}
-
-function findUserErrors(value: JsonValue): JsonValue[] {
-  if (Array.isArray(value)) return value.flatMap(findUserErrors)
-  if (value === null || typeof value !== 'object') return []
-
-  const errors = 'userErrors' in value && Array.isArray(value.userErrors) ? value.userErrors : []
-  return [
-    ...errors,
-    ...Object.entries(value).flatMap(([key, child]) => (key === 'userErrors' ? [] : findUserErrors(child))),
-  ]
+  return {data: response as JsonValue}
 }

--- a/packages/store/src/cli/services/store/execute/codec.test.ts
+++ b/packages/store/src/cli/services/store/execute/codec.test.ts
@@ -3,35 +3,16 @@ import {describe, expect, test} from 'vitest'
 
 describe('store execute codecs', () => {
   test('encodes only operation data for the result payload', () => {
-    expect(
-      encodeStoreExecuteResult({
-        data: {shop: {name: 'Test shop'}},
-        failure: {code: 'USER_ERRORS', details: [{message: 'Rejected'}]},
-      }),
-    ).toBe(`{
+    expect(encodeStoreExecuteResult({data: {shop: {name: 'Test shop'}}})).toBe(`{
   "shop": {
     "name": "Test shop"
   }
 }`)
   })
 
-  test('omits failureCode from a successful output document', () => {
-    expect(encodeStoreExecuteWriteReceipt({outputFile: 'results.json', result: {data: {ok: true}}})).toBe(`{
-  "outputFile": "results.json",
-  "success": true
-}`)
-  })
-
-  test('includes failureCode only for a failed output document', () => {
-    expect(
-      encodeStoreExecuteWriteReceipt({
-        outputFile: 'results.json',
-        result: {data: {ok: false}, failure: {code: 'USER_ERRORS', details: []}},
-      }),
-    ).toBe(`{
-  "outputFile": "results.json",
-  "success": false,
-  "failureCode": "USER_ERRORS"
+  test('encodes the output file in a write receipt', () => {
+    expect(encodeStoreExecuteWriteReceipt({outputFile: 'results.json'})).toBe(`{
+  "outputFile": "results.json"
 }`)
   })
 })

--- a/packages/store/src/cli/services/store/execute/codec.test.ts
+++ b/packages/store/src/cli/services/store/execute/codec.test.ts
@@ -1,4 +1,4 @@
-import {encodeStoreExecuteOutputDocument, encodeStoreExecuteResult} from './codec.js'
+import {encodeStoreExecuteWriteReceipt, encodeStoreExecuteResult} from './codec.js'
 import {describe, expect, test} from 'vitest'
 
 describe('store execute codecs', () => {
@@ -16,7 +16,7 @@ describe('store execute codecs', () => {
   })
 
   test('omits failureCode from a successful output document', () => {
-    expect(encodeStoreExecuteOutputDocument({outputFile: 'results.json', result: {data: {ok: true}}})).toBe(`{
+    expect(encodeStoreExecuteWriteReceipt({outputFile: 'results.json', result: {data: {ok: true}}})).toBe(`{
   "outputFile": "results.json",
   "success": true
 }`)
@@ -24,7 +24,7 @@ describe('store execute codecs', () => {
 
   test('includes failureCode only for a failed output document', () => {
     expect(
-      encodeStoreExecuteOutputDocument({
+      encodeStoreExecuteWriteReceipt({
         outputFile: 'results.json',
         result: {data: {ok: false}, failure: {code: 'USER_ERRORS', details: []}},
       }),

--- a/packages/store/src/cli/services/store/execute/codec.test.ts
+++ b/packages/store/src/cli/services/store/execute/codec.test.ts
@@ -1,0 +1,37 @@
+import {encodeStoreExecuteOutputDocument, encodeStoreExecuteResult} from './codec.js'
+import {describe, expect, test} from 'vitest'
+
+describe('store execute codecs', () => {
+  test('encodes only operation data for the result payload', () => {
+    expect(
+      encodeStoreExecuteResult({
+        data: {shop: {name: 'Test shop'}},
+        failure: {code: 'USER_ERRORS', details: [{message: 'Rejected'}]},
+      }),
+    ).toBe(`{
+  "shop": {
+    "name": "Test shop"
+  }
+}`)
+  })
+
+  test('omits failureCode from a successful output document', () => {
+    expect(encodeStoreExecuteOutputDocument({outputFile: 'results.json', result: {data: {ok: true}}})).toBe(`{
+  "outputFile": "results.json",
+  "success": true
+}`)
+  })
+
+  test('includes failureCode only for a failed output document', () => {
+    expect(
+      encodeStoreExecuteOutputDocument({
+        outputFile: 'results.json',
+        result: {data: {ok: false}, failure: {code: 'USER_ERRORS', details: []}},
+      }),
+    ).toBe(`{
+  "outputFile": "results.json",
+  "success": false,
+  "failureCode": "USER_ERRORS"
+}`)
+  })
+})

--- a/packages/store/src/cli/services/store/execute/codec.ts
+++ b/packages/store/src/cli/services/store/execute/codec.ts
@@ -1,0 +1,20 @@
+import type {StoreExecuteResult} from './types.js'
+
+export interface StoreExecuteOutputDocument {
+  outputFile: string
+  success: boolean
+  failureCode?: string
+}
+
+export function encodeStoreExecuteResult(result: StoreExecuteResult): string {
+  return JSON.stringify(result.data, null, 2)
+}
+
+export function encodeStoreExecuteOutputDocument(input: {outputFile: string; result: StoreExecuteResult}): string {
+  const document: StoreExecuteOutputDocument = {
+    outputFile: input.outputFile,
+    success: !input.result.failure,
+    ...(input.result.failure ? {failureCode: input.result.failure.code} : {}),
+  }
+  return JSON.stringify(document, null, 2)
+}

--- a/packages/store/src/cli/services/store/execute/codec.ts
+++ b/packages/store/src/cli/services/store/execute/codec.ts
@@ -4,11 +4,7 @@ export function encodeStoreExecuteResult(result: StoreExecuteResult): string {
   return JSON.stringify(result.data, null, 2)
 }
 
-export function encodeStoreExecuteWriteReceipt(input: {outputFile: string; result: StoreExecuteResult}): string {
-  const receipt: StoreExecuteWriteReceipt = {
-    outputFile: input.outputFile,
-    success: !input.result.failure,
-    ...(input.result.failure ? {failureCode: input.result.failure.code} : {}),
-  }
+export function encodeStoreExecuteWriteReceipt(input: {outputFile: string}): string {
+  const receipt: StoreExecuteWriteReceipt = {outputFile: input.outputFile}
   return JSON.stringify(receipt, null, 2)
 }

--- a/packages/store/src/cli/services/store/execute/codec.ts
+++ b/packages/store/src/cli/services/store/execute/codec.ts
@@ -1,20 +1,14 @@
-import type {StoreExecuteResult} from './types.js'
-
-export interface StoreExecuteOutputDocument {
-  outputFile: string
-  success: boolean
-  failureCode?: string
-}
+import type {StoreExecuteResult, StoreExecuteWriteReceipt} from './types.js'
 
 export function encodeStoreExecuteResult(result: StoreExecuteResult): string {
   return JSON.stringify(result.data, null, 2)
 }
 
-export function encodeStoreExecuteOutputDocument(input: {outputFile: string; result: StoreExecuteResult}): string {
-  const document: StoreExecuteOutputDocument = {
+export function encodeStoreExecuteWriteReceipt(input: {outputFile: string; result: StoreExecuteResult}): string {
+  const receipt: StoreExecuteWriteReceipt = {
     outputFile: input.outputFile,
     success: !input.result.failure,
     ...(input.result.failure ? {failureCode: input.result.failure.code} : {}),
   }
-  return JSON.stringify(document, null, 2)
+  return JSON.stringify(receipt, null, 2)
 }

--- a/packages/store/src/cli/services/store/execute/index.ts
+++ b/packages/store/src/cli/services/store/execute/index.ts
@@ -3,6 +3,7 @@ import {getStoreGraphQLTarget, type StoreGraphQLApi} from './targets.js'
 import {recordStoreFqdnMetadata} from '../attribution.js'
 import {renderSingleTask} from '@shopify/cli-kit/node/ui'
 import {outputContent} from '@shopify/cli-kit/node/output'
+import type {StoreExecuteResult} from './types.js'
 
 interface ExecuteStoreOperationInput {
   store: string
@@ -15,7 +16,7 @@ interface ExecuteStoreOperationInput {
   allowMutations?: boolean
 }
 
-export async function executeStoreOperation(input: ExecuteStoreOperationInput): Promise<unknown> {
+export async function executeStoreOperation(input: ExecuteStoreOperationInput): Promise<StoreExecuteResult> {
   await recordStoreFqdnMetadata(input.store, false)
   const target = getStoreGraphQLTarget(input.api ?? 'admin')
 

--- a/packages/store/src/cli/services/store/execute/result.test.ts
+++ b/packages/store/src/cli/services/store/execute/result.test.ts
@@ -93,68 +93,6 @@ describe('writeOrOutputStoreExecuteResult', () => {
     expect(streams.stderr()).toBe('')
   })
 
-  test('emits a structured stdout document and rejects for result-level failure in json file mode', async () => {
-    await inTemporaryDirectory(async (tmpDir) => {
-      const outputPath = joinPath(tmpDir, 'results.json')
-      const output = mockAndCaptureOutput()
-
-      await expect(
-        writeOrOutputStoreExecuteResult(
-          {
-            data: {orderCreate: {userErrors: [{message: 'Rejected by the shop'}]}},
-            failure: {code: 'USER_ERRORS', details: []},
-          },
-          outputPath,
-          'json',
-        ),
-      ).rejects.toThrow('GraphQL operation returned user errors (USER_ERRORS).')
-
-      expect(JSON.parse(await readFile(outputPath, {encoding: 'utf8'}))).toEqual({
-        orderCreate: {userErrors: [{message: 'Rejected by the shop'}]},
-      })
-      expect(output.output()).toContain('"outputFile"')
-      expect(output.output()).toContain('"success": false')
-      expect(output.output()).toContain('"failureCode": "USER_ERRORS"')
-      expect(output.output()).not.toContain('Operation succeeded.')
-      expect(output.output()).not.toContain('Results written to')
-    })
-  })
-
-  test('emits the payload and rejects without claiming success for result-level failure in text mode', async () => {
-    const output = mockAndCaptureOutput()
-
-    await expect(
-      writeOrOutputStoreExecuteResult({
-        data: {orderCreate: {userErrors: [{message: 'Rejected by the shop'}]}},
-        failure: {code: 'USER_ERRORS', details: []},
-      }),
-    ).rejects.toThrow('GraphQL operation returned user errors (USER_ERRORS).')
-
-    expect(output.output()).toContain('Rejected by the shop')
-    expect(renderSuccess).not.toHaveBeenCalled()
-  })
-
-  test('still reports the written file for result-level failure in text file mode', async () => {
-    await inTemporaryDirectory(async (tmpDir) => {
-      const outputPath = joinPath(tmpDir, 'results.json')
-      const output = mockAndCaptureOutput()
-
-      await expect(
-        writeOrOutputStoreExecuteResult(
-          {
-            data: {orderCreate: {userErrors: [{message: 'Rejected by the shop'}]}},
-            failure: {code: 'USER_ERRORS', details: []},
-          },
-          outputPath,
-        ),
-      ).rejects.toThrow('GraphQL operation returned user errors (USER_ERRORS).')
-
-      await expect(readFile(outputPath, {encoding: 'utf8'})).resolves.toContain('Rejected by the shop')
-      expect(output.output()).toContain(`Results written to ${outputPath}`)
-      expect(renderSuccess).not.toHaveBeenCalled()
-    })
-  })
-
   test('suppresses success rendering when writing a file in json mode', async () => {
     await inTemporaryDirectory(async (tmpDir) => {
       // Given

--- a/packages/store/src/cli/services/store/execute/result.test.ts
+++ b/packages/store/src/cli/services/store/execute/result.test.ts
@@ -93,6 +93,68 @@ describe('writeOrOutputStoreExecuteResult', () => {
     expect(streams.stderr()).toBe('')
   })
 
+  test('emits a structured stdout document and rejects for result-level failure in json file mode', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      const outputPath = joinPath(tmpDir, 'results.json')
+      const output = mockAndCaptureOutput()
+
+      await expect(
+        writeOrOutputStoreExecuteResult(
+          {
+            data: {orderCreate: {userErrors: [{message: 'Rejected by the shop'}]}},
+            failure: {code: 'USER_ERRORS', details: []},
+          },
+          outputPath,
+          'json',
+        ),
+      ).rejects.toThrow('GraphQL operation returned user errors (USER_ERRORS).')
+
+      expect(JSON.parse(await readFile(outputPath, {encoding: 'utf8'}))).toEqual({
+        orderCreate: {userErrors: [{message: 'Rejected by the shop'}]},
+      })
+      expect(output.output()).toContain('"outputFile"')
+      expect(output.output()).toContain('"success": false')
+      expect(output.output()).toContain('"failureCode": "USER_ERRORS"')
+      expect(output.output()).not.toContain('Operation succeeded.')
+      expect(output.output()).not.toContain('Results written to')
+    })
+  })
+
+  test('emits the payload and rejects without claiming success for result-level failure in text mode', async () => {
+    const output = mockAndCaptureOutput()
+
+    await expect(
+      writeOrOutputStoreExecuteResult({
+        data: {orderCreate: {userErrors: [{message: 'Rejected by the shop'}]}},
+        failure: {code: 'USER_ERRORS', details: []},
+      }),
+    ).rejects.toThrow('GraphQL operation returned user errors (USER_ERRORS).')
+
+    expect(output.output()).toContain('Rejected by the shop')
+    expect(renderSuccess).not.toHaveBeenCalled()
+  })
+
+  test('still reports the written file for result-level failure in text file mode', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      const outputPath = joinPath(tmpDir, 'results.json')
+      const output = mockAndCaptureOutput()
+
+      await expect(
+        writeOrOutputStoreExecuteResult(
+          {
+            data: {orderCreate: {userErrors: [{message: 'Rejected by the shop'}]}},
+            failure: {code: 'USER_ERRORS', details: []},
+          },
+          outputPath,
+        ),
+      ).rejects.toThrow('GraphQL operation returned user errors (USER_ERRORS).')
+
+      await expect(readFile(outputPath, {encoding: 'utf8'})).resolves.toContain('Rejected by the shop')
+      expect(output.output()).toContain(`Results written to ${outputPath}`)
+      expect(renderSuccess).not.toHaveBeenCalled()
+    })
+  })
+
   test('suppresses success rendering when writing a file in json mode', async () => {
     await inTemporaryDirectory(async (tmpDir) => {
       // Given

--- a/packages/store/src/cli/services/store/execute/result.ts
+++ b/packages/store/src/cli/services/store/execute/result.ts
@@ -1,7 +1,6 @@
 import {encodeStoreExecuteWriteReceipt, encodeStoreExecuteResult} from './codec.js'
 import {writeFile} from '@shopify/cli-kit/node/fs'
-import {AbortError} from '@shopify/cli-kit/node/error'
-import {outputInfo, outputResult} from '@shopify/cli-kit/node/output'
+import {outputResult} from '@shopify/cli-kit/node/output'
 import {renderSuccess} from '@shopify/cli-kit/node/ui'
 import type {StoreExecuteResult} from './types.js'
 
@@ -13,24 +12,17 @@ export async function writeOrOutputStoreExecuteResult(
   format: StoreExecuteOutputFormat = 'text',
 ): Promise<void> {
   const payload = encodeStoreExecuteResult(result)
-  const succeeded = !result.failure
 
   if (outputFile) {
     await writeFile(outputFile, payload)
 
     if (format === 'json') {
-      outputResult(encodeStoreExecuteWriteReceipt({outputFile, result}))
-    } else if (succeeded) {
-      renderSuccess({headline: 'Operation succeeded.', body: `Results written to ${outputFile}`})
+      outputResult(encodeStoreExecuteWriteReceipt({outputFile}))
     } else {
-      outputInfo(`Results written to ${outputFile}`)
+      renderSuccess({headline: 'Operation succeeded.', body: `Results written to ${outputFile}`})
     }
   } else {
-    if (format === 'text' && succeeded) renderSuccess({headline: 'Operation succeeded.'})
+    if (format === 'text') renderSuccess({headline: 'Operation succeeded.'})
     outputResult(payload)
-  }
-
-  if (result.failure) {
-    throw new AbortError(`GraphQL operation returned user errors (${result.failure.code}).`)
   }
 }

--- a/packages/store/src/cli/services/store/execute/result.ts
+++ b/packages/store/src/cli/services/store/execute/result.ts
@@ -1,4 +1,4 @@
-import {encodeStoreExecuteOutputDocument, encodeStoreExecuteResult} from './codec.js'
+import {encodeStoreExecuteWriteReceipt, encodeStoreExecuteResult} from './codec.js'
 import {writeFile} from '@shopify/cli-kit/node/fs'
 import {AbortError} from '@shopify/cli-kit/node/error'
 import {outputInfo, outputResult} from '@shopify/cli-kit/node/output'
@@ -19,7 +19,7 @@ export async function writeOrOutputStoreExecuteResult(
     await writeFile(outputFile, payload)
 
     if (format === 'json') {
-      outputResult(encodeStoreExecuteOutputDocument({outputFile, result}))
+      outputResult(encodeStoreExecuteWriteReceipt({outputFile, result}))
     } else if (succeeded) {
       renderSuccess({headline: 'Operation succeeded.', body: `Results written to ${outputFile}`})
     } else {

--- a/packages/store/src/cli/services/store/execute/result.ts
+++ b/packages/store/src/cli/services/store/execute/result.ts
@@ -1,7 +1,7 @@
 import {encodeStoreExecuteOutputDocument, encodeStoreExecuteResult} from './codec.js'
 import {writeFile} from '@shopify/cli-kit/node/fs'
 import {AbortError} from '@shopify/cli-kit/node/error'
-import {outputResult} from '@shopify/cli-kit/node/output'
+import {outputInfo, outputResult} from '@shopify/cli-kit/node/output'
 import {renderSuccess} from '@shopify/cli-kit/node/ui'
 import type {StoreExecuteResult} from './types.js'
 
@@ -12,18 +12,25 @@ export async function writeOrOutputStoreExecuteResult(
   outputFile?: string,
   format: StoreExecuteOutputFormat = 'text',
 ): Promise<void> {
+  const payload = encodeStoreExecuteResult(result)
+  const succeeded = !result.failure
+
   if (outputFile) {
-    await writeFile(outputFile, encodeStoreExecuteResult(result))
-    if (format === 'json') outputResult(encodeStoreExecuteOutputDocument({outputFile, result}))
-    else if (result.failure) throw new AbortError(`GraphQL operation returned user errors (${result.failure.code}).`)
-    else renderSuccess({headline: 'Operation succeeded.', body: `Results written to ${outputFile}`})
-  } else if (format === 'json') {
-    outputResult(encodeStoreExecuteResult(result))
-  } else if (result.failure) {
-    throw new AbortError(`GraphQL operation returned user errors (${result.failure.code}).`)
+    await writeFile(outputFile, payload)
+
+    if (format === 'json') {
+      outputResult(encodeStoreExecuteOutputDocument({outputFile, result}))
+    } else if (succeeded) {
+      renderSuccess({headline: 'Operation succeeded.', body: `Results written to ${outputFile}`})
+    } else {
+      outputInfo(`Results written to ${outputFile}`)
+    }
   } else {
-    renderSuccess({headline: 'Operation succeeded.'})
+    if (format === 'text' && succeeded) renderSuccess({headline: 'Operation succeeded.'})
+    outputResult(payload)
   }
 
-  if (result.failure) throw new AbortError(`GraphQL operation returned user errors (${result.failure.code}).`)
+  if (result.failure) {
+    throw new AbortError(`GraphQL operation returned user errors (${result.failure.code}).`)
+  }
 }

--- a/packages/store/src/cli/services/store/execute/result.ts
+++ b/packages/store/src/cli/services/store/execute/result.ts
@@ -1,38 +1,29 @@
+import {encodeStoreExecuteOutputDocument, encodeStoreExecuteResult} from './codec.js'
 import {writeFile} from '@shopify/cli-kit/node/fs'
+import {AbortError} from '@shopify/cli-kit/node/error'
 import {outputResult} from '@shopify/cli-kit/node/output'
 import {renderSuccess} from '@shopify/cli-kit/node/ui'
+import type {StoreExecuteResult} from './types.js'
 
 type StoreExecuteOutputFormat = 'text' | 'json'
 
-function serializeStoreExecuteResult(result: unknown): string {
-  return JSON.stringify(result, null, 2)
-}
-
-function renderStoreExecuteSuccess(outputFile?: string): void {
-  if (outputFile) {
-    renderSuccess({
-      headline: 'Operation succeeded.',
-      body: `Results written to ${outputFile}`,
-    })
-    return
-  }
-
-  renderSuccess({headline: 'Operation succeeded.'})
-}
-
 export async function writeOrOutputStoreExecuteResult(
-  result: unknown,
+  result: StoreExecuteResult,
   outputFile?: string,
   format: StoreExecuteOutputFormat = 'text',
 ): Promise<void> {
-  const serializedResult = serializeStoreExecuteResult(result)
-
   if (outputFile) {
-    await writeFile(outputFile, serializedResult)
-    if (format === 'text') renderStoreExecuteSuccess(outputFile)
-    return
+    await writeFile(outputFile, encodeStoreExecuteResult(result))
+    if (format === 'json') outputResult(encodeStoreExecuteOutputDocument({outputFile, result}))
+    else if (result.failure) throw new AbortError(`GraphQL operation returned user errors (${result.failure.code}).`)
+    else renderSuccess({headline: 'Operation succeeded.', body: `Results written to ${outputFile}`})
+  } else if (format === 'json') {
+    outputResult(encodeStoreExecuteResult(result))
+  } else if (result.failure) {
+    throw new AbortError(`GraphQL operation returned user errors (${result.failure.code}).`)
+  } else {
+    renderSuccess({headline: 'Operation succeeded.'})
   }
 
-  if (format === 'text') renderStoreExecuteSuccess()
-  outputResult(serializedResult)
+  if (result.failure) throw new AbortError(`GraphQL operation returned user errors (${result.failure.code}).`)
 }

--- a/packages/store/src/cli/services/store/execute/targets.ts
+++ b/packages/store/src/cli/services/store/execute/targets.ts
@@ -2,6 +2,7 @@ import {prepareAdminStoreGraphQLContext, type AdminStoreGraphQLContext} from './
 import {runAdminStoreGraphQLOperation} from './admin-transport.js'
 import {BugError} from '@shopify/cli-kit/node/error'
 import type {PreparedStoreExecuteRequest} from './request.js'
+import type {StoreExecuteResult} from './types.js'
 
 export type StoreGraphQLApi = 'admin'
 
@@ -18,7 +19,7 @@ interface ExecuteStoreGraphQLTargetInput<TContext> {
 interface StoreGraphQLTarget<TContext> {
   id: StoreGraphQLApi
   prepareContext(input: PrepareStoreGraphQLTargetContextInput): Promise<TContext>
-  execute(input: ExecuteStoreGraphQLTargetInput<TContext>): Promise<unknown>
+  execute(input: ExecuteStoreGraphQLTargetInput<TContext>): Promise<StoreExecuteResult>
 }
 
 const adminStoreGraphQLTarget: StoreGraphQLTarget<AdminStoreGraphQLContext> = {

--- a/packages/store/src/cli/services/store/execute/types.ts
+++ b/packages/store/src/cli/services/store/execute/types.ts
@@ -1,14 +1,8 @@
 export type JsonPrimitive = string | number | boolean | null
 export type JsonValue = JsonPrimitive | JsonValue[] | {[key: string]: JsonValue}
 
-export interface StoreExecuteFailure {
-  code: 'USER_ERRORS'
-  details: JsonValue
-}
-
 export interface StoreExecuteResult {
   data: JsonValue
-  failure?: StoreExecuteFailure
 }
 
 /**
@@ -17,6 +11,4 @@ export interface StoreExecuteResult {
  */
 export interface StoreExecuteWriteReceipt {
   outputFile: string
-  success: boolean
-  failureCode?: string
 }

--- a/packages/store/src/cli/services/store/execute/types.ts
+++ b/packages/store/src/cli/services/store/execute/types.ts
@@ -10,3 +10,13 @@ export interface StoreExecuteResult {
   data: JsonValue
   failure?: StoreExecuteFailure
 }
+
+/**
+ * Describes where an operation payload was written. This is not the payload itself: the payload is
+ * the caller's own GraphQL result in `StoreExecuteResult.data`.
+ */
+export interface StoreExecuteWriteReceipt {
+  outputFile: string
+  success: boolean
+  failureCode?: string
+}

--- a/packages/store/src/cli/services/store/execute/types.ts
+++ b/packages/store/src/cli/services/store/execute/types.ts
@@ -1,0 +1,12 @@
+export type JsonPrimitive = string | number | boolean | null
+export type JsonValue = JsonPrimitive | JsonValue[] | {[key: string]: JsonValue}
+
+export interface StoreExecuteFailure {
+  code: 'USER_ERRORS'
+  details: JsonValue
+}
+
+export interface StoreExecuteResult {
+  data: JsonValue
+  failure?: StoreExecuteFailure
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -862,48 +862,56 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@ast-grep/napi-linux-arm64-gnu@0.43.0':
     resolution: {integrity: sha512-yJSRPxwwrvVW94J2rtaatcixSAGWcSaHNbAh6soXD6HXgq6I7uMc+cyMnJstFL789yd6Pu3QIhTlpD9VY0oYhw==, tarball: https://registry.npmjs.org/@ast-grep/napi-linux-arm64-gnu/-/napi-linux-arm64-gnu-0.43.0.tgz}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@ast-grep/napi-linux-arm64-musl@0.34.1':
     resolution: {integrity: sha512-IXdqwTbkdqHrcuQb448Qzd82QdTqVFe/f0sSkFYQTic8P2qNzmiHsVnxgEFsQPPbe09BVAoZ885j3OnaNfcDYA==, tarball: https://registry.npmjs.org/@ast-grep/napi-linux-arm64-musl/-/napi-linux-arm64-musl-0.34.1.tgz}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@ast-grep/napi-linux-arm64-musl@0.43.0':
     resolution: {integrity: sha512-mknXLDsf66HvT/JEl18ZQSvR7/qWgWfqh3eHuVRqD2lE6cKBDXRnAzx9ZNZkUnL2Z5ph54Yk8dKVu09k45cegA==, tarball: https://registry.npmjs.org/@ast-grep/napi-linux-arm64-musl/-/napi-linux-arm64-musl-0.43.0.tgz}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@ast-grep/napi-linux-x64-gnu@0.34.1':
     resolution: {integrity: sha512-on4LyIeN/zN7SIh8zr5v+NTzVu3kXm2mG28ib1Qe9GVcf35dz52ckf7bilulayKSa2MHZWAXMjuc6NYMiNEw+w==, tarball: https://registry.npmjs.org/@ast-grep/napi-linux-x64-gnu/-/napi-linux-x64-gnu-0.34.1.tgz}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@ast-grep/napi-linux-x64-gnu@0.43.0':
     resolution: {integrity: sha512-KM6M5KKFsHG9Y7VKCKnMsWQQ1sYwj/SPdyr91SKp66AeFJ5xMtXb13WVQ3Joe9NEsi84dzzOBIJgMddz+UMvQw==, tarball: https://registry.npmjs.org/@ast-grep/napi-linux-x64-gnu/-/napi-linux-x64-gnu-0.43.0.tgz}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@ast-grep/napi-linux-x64-musl@0.34.1':
     resolution: {integrity: sha512-l1R5L9LOp0jTPjs8C+LUndZOA8cRw7PFlvoVxVbi2jCfcns00dqatSYc4yA/ke6ng2K0LSxjoV/jS8tefve0sA==, tarball: https://registry.npmjs.org/@ast-grep/napi-linux-x64-musl/-/napi-linux-x64-musl-0.34.1.tgz}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@ast-grep/napi-linux-x64-musl@0.43.0':
     resolution: {integrity: sha512-NfjI74m7CEEOsLi7ZkYwcxY10CfKIHPHRrr9aqMulmnrC4FGvxQMk1qpDrTqkjmEd8LdZt3PsPrmBa8AZCErew==, tarball: https://registry.npmjs.org/@ast-grep/napi-linux-x64-musl/-/napi-linux-x64-musl-0.43.0.tgz}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@ast-grep/napi-win32-arm64-msvc@0.34.1':
     resolution: {integrity: sha512-eVsdMtnY7jmN2xQjYY9gaqIxRHA44+QYivlP1uLbg8w3P4YlZWTFgOJ7aa357Hg/257mjeQCpodCkr0lGRsSYQ==, tarball: https://registry.npmjs.org/@ast-grep/napi-win32-arm64-msvc/-/napi-win32-arm64-msvc-0.34.1.tgz}
@@ -3007,21 +3015,25 @@ packages:
     resolution: {integrity: sha512-CfzWaS+b32lI/inlYPv1ZAK9CWTWFHzT7TPThvOHML65nrgFl8cQ4Z4FeGdyCbHu2NoG3vR1E36O2tPI2/DLGg==, tarball: https://registry.npmjs.org/@nx/nx-linux-arm64-gnu/-/nx-linux-arm64-gnu-22.7.7.tgz}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@nx/nx-linux-arm64-musl@22.7.7':
     resolution: {integrity: sha512-53QFuODMEHc1gobCT2WOmYz89DZtEIuLphirdIgnXkkPBTdrP77LPbJUXMRXCMKr90BQaSWhTX+J/ubANRE8og==, tarball: https://registry.npmjs.org/@nx/nx-linux-arm64-musl/-/nx-linux-arm64-musl-22.7.7.tgz}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@nx/nx-linux-x64-gnu@22.7.7':
     resolution: {integrity: sha512-unzmqGIDXGzujo1ZtbrMj2e5D5ldQ1feZmqDPhvO4casK2d96jpT8LtgIILpVDUfhLjl+By185gb0ArrWTsyKw==, tarball: https://registry.npmjs.org/@nx/nx-linux-x64-gnu/-/nx-linux-x64-gnu-22.7.7.tgz}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@nx/nx-linux-x64-musl@22.7.7':
     resolution: {integrity: sha512-oTjMGuM105ok8aH5rlg2YP0Kgkjg0VfUj1exwp49S70gGBJ0r8v5rEtJwOSdCf1WTHuEh0xi66Y/b1S0khF8dg==, tarball: https://registry.npmjs.org/@nx/nx-linux-x64-musl/-/nx-linux-x64-musl-22.7.7.tgz}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@nx/nx-win32-arm64-msvc@22.7.7':
     resolution: {integrity: sha512-K741meG/l48TPPeDqnhYTV7pP+1ljjZ+0DRJBxMrPFIu8qKE3Abko/7NKWmWRjcSXJvtxvYkgG3wZds4N2Bhow==, tarball: https://registry.npmjs.org/@nx/nx-win32-arm64-msvc/-/nx-win32-arm64-msvc-22.7.7.tgz}
@@ -3327,41 +3339,49 @@ packages:
     resolution: {integrity: sha512-0bJnmYFp62JdZ4nVMDUZ/C58BCZOCcqgKtnUlp7L9Ojf/czIN+3j72YlLPeWLkzlr6SlYvIQA4SGV/HyO0d+qg==, tarball: https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-11.20.0.tgz}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-arm64-musl@11.20.0':
     resolution: {integrity: sha512-wKHHzPKZo7Ufhv/Bt6yxT7FOgnIgW4gwXcJUipkShGp68W3wGVqvr1Sr0fY65lN0Oy6y41+g2kIDvkgZaMMUkw==, tarball: https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-musl/-/binding-linux-arm64-musl-11.20.0.tgz}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-linux-ppc64-gnu@11.20.0':
     resolution: {integrity: sha512-RN8goF7Ie0B79L4i4G6OeBocTgSC56vJbQ65VJje+oXnldVpLnOU7j/AQ/dP94TcCS+Yh6WG8u3Qt4ETteXFNQ==, tarball: https://registry.npmjs.org/@oxc-resolver/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-11.20.0.tgz}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-gnu@11.20.0':
     resolution: {integrity: sha512-5l1yU6/xQEqLZRzxqmMxJfWPslpwCmBsdDGaBvABPehxquCXDC7dd7oraNdKSJUMDXSM7VvVj8H2D2FTjU7oWw==, tarball: https://registry.npmjs.org/@oxc-resolver/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-11.20.0.tgz}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-musl@11.20.0':
     resolution: {integrity: sha512-xHEvkbgz6UC+A3JOyDQy76LkUaxsNSfIr3/GV8slwZsnuooJiIB34gzJfsyvR4JdCYNUUPsRJc/w/oWkODu+hg==, tarball: https://registry.npmjs.org/@oxc-resolver/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-11.20.0.tgz}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-linux-s390x-gnu@11.20.0':
     resolution: {integrity: sha512-aWPDUUmSeyHvlW+SoEUd+JIJsQhVhu6a5tBpDRMu058naPAchTgAVGCFy35zjbnFlt0i8hLWziff6HX0D3LU4g==, tarball: https://registry.npmjs.org/@oxc-resolver/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-11.20.0.tgz}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-gnu@11.20.0':
     resolution: {integrity: sha512-x2YeSimvhJjKLVD8KSu8f/rqU1potcdEMkApIPJqjZWN7c2Fpt4g2X32WDg1p+XDAmyT7nuQGe0vnhvXeLbH+g==, tarball: https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-gnu/-/binding-linux-x64-gnu-11.20.0.tgz}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-musl@11.20.0':
     resolution: {integrity: sha512-kcRLEIxpZefeYfLChjpgFf3ilBzRDZ+yobMrpRsQlSrxuFGtm3U6PMU7AaEpMqo3NfDGVyJJseAjnRLzMFHjwQ==, tarball: https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-musl/-/binding-linux-x64-musl-11.20.0.tgz}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-resolver/binding-openharmony-arm64@11.20.0':
     resolution: {integrity: sha512-HHcfnApSZGtKhTiHqe8OZruOZe5XuFQH5/E0Yhj3u8fnFvzkM4/k6WjacUf4SvA0SPEAbfbgYmVPuo0VX/fIBQ==, tarball: https://registry.npmjs.org/@oxc-resolver/binding-openharmony-arm64/-/binding-openharmony-arm64-11.20.0.tgz}
@@ -3412,36 +3432,42 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm-musl@2.5.6':
     resolution: {integrity: sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==, tarball: https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.6.tgz}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-arm64-glibc@2.5.6':
     resolution: {integrity: sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==, tarball: https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.6.tgz}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.5.6':
     resolution: {integrity: sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==, tarball: https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.6.tgz}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.5.6':
     resolution: {integrity: sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==, tarball: https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.6.tgz}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.5.6':
     resolution: {integrity: sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==, tarball: https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.6.tgz}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-win32-arm64@2.5.6':
     resolution: {integrity: sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==, tarball: https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.6.tgz}
@@ -3565,66 +3591,79 @@ packages:
     resolution: {integrity: sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.59.0.tgz}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.59.0':
     resolution: {integrity: sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.59.0.tgz}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.59.0':
     resolution: {integrity: sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.0.tgz}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.59.0':
     resolution: {integrity: sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.59.0.tgz}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.59.0':
     resolution: {integrity: sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.59.0.tgz}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.59.0':
     resolution: {integrity: sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.59.0.tgz}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.59.0':
     resolution: {integrity: sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.59.0.tgz}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.59.0':
     resolution: {integrity: sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.59.0.tgz}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.59.0':
     resolution: {integrity: sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.59.0.tgz}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.59.0':
     resolution: {integrity: sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.0.tgz}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.59.0':
     resolution: {integrity: sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.59.0.tgz}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.59.0':
     resolution: {integrity: sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.59.0':
     resolution: {integrity: sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==, tarball: https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.0.tgz}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.59.0':
     resolution: {integrity: sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==, tarball: https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.59.0.tgz}
@@ -4138,41 +4177,49 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==, tarball: https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.11.1.tgz}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==, tarball: https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.11.1.tgz}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==, tarball: https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.11.1.tgz}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==, tarball: https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.11.1.tgz}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==, tarball: https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.11.1.tgz}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==, tarball: https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.11.1.tgz}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==, tarball: https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.11.1.tgz}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==, tarball: https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.11.1.tgz}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==, tarball: https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.11.1.tgz}


### PR DESCRIPTION
## What this is

A proof of concept that migrates `store execute` from an untyped result passthrough to a data-only typed result with an explicit codec and presenter. It is stacked on #8242, with the shared automatic help infrastructure in #8283 at the bottom of the stack.

`store execute` was chosen because it exercises concerns `store list` cannot: it had no result type at all (`result: unknown`), it writes files, and it gates mutations.

## Design

- **Execution returns data.** The service returns `StoreExecuteResult {data}` with no terminal, renderer, Oclif, or filesystem dependency.
- **Adapters own presentation and channels.** A codec produces the JSON wire output; a presenter produces terminal output, chooses stdout/stderr/file, and composes human-readable sentences.
- **Execution does not author prose.** Sentences the CLI writes ("Operation succeeded.", "Results written to …") exist only in the presenter.
- **Execution-level failures remain distinct.** Auth, transport, and unreadable query-file failures continue through the existing error boundary.

## Output changes versus `main`

| Mode | Before | After |
| --- | --- | --- |
| text, no `--output-file` | payload on stdout + "Operation succeeded." | unchanged |
| text, `--output-file` | file written + "Results written to …" | unchanged |
| json, no `--output-file` | payload on stdout | unchanged |
| json, `--output-file` | nothing on stdout | file written, plus `{outputFile}` on stdout |

The last row is intentional and covered by the changeset.

## Not done here

No additional `BaseCommand` or launcher changes. No automatic serialization of command return values. No event plumbing. No other command migrated.

## Checks

- focused execute suite: 8 files, 56 tests passed
- `@shopify/store` type-check passed
- ESLint passed on the changed execute service directory
- `git diff --check` passed