### PR TITLE
Allow packed agent metadata in analytics

### DIFF
--- a/packages/cli-kit/src/private/node/analytics.ts
+++ b/packages/cli-kit/src/private/node/analytics.ts
@@ -75,6 +75,8 @@ interface EnvironmentData {
 const allowedShopifyEnvironmentVariableNames = new Set([
   'SHOPIFY_INVOKED_BY',
   'SHOPIFY_CLI_AGENT',
+  'SHOPIFY_CLI_AGENT_INFO',
+  'SHOPIFY_CLI_AGENT_IDS',
   'SHOPIFY_CLI_AGENT_VERSION',
   'SHOPIFY_CLI_AGENT_RUN_ID',
   'SHOPIFY_CLI_AGENT_SESSION_ID',

--- a/packages/cli-kit/src/public/node/analytics.test.ts
+++ b/packages/cli-kit/src/public/node/analytics.test.ts
@@ -254,9 +254,13 @@ describe('event tracking', () => {
   test('sends only allowlisted Shopify environment variables in sensitive payload', async () => {
     const originalShopifyInvokedBy = process.env.SHOPIFY_INVOKED_BY
     const originalShopifyCliAgent = process.env.SHOPIFY_CLI_AGENT
+    const originalShopifyCliAgentInfo = process.env.SHOPIFY_CLI_AGENT_INFO
+    const originalShopifyCliAgentIds = process.env.SHOPIFY_CLI_AGENT_IDS
     const originalShopifySomethingKey = process.env.SHOPIFY_SOMETHING_KEY
     process.env.SHOPIFY_INVOKED_BY = 'shopify-function-test-helpers'
     process.env.SHOPIFY_CLI_AGENT = 'test-agent'
+    process.env.SHOPIFY_CLI_AGENT_INFO = 'n:test-agent|v:1.0.0|p:test-provider|m:test-model'
+    process.env.SHOPIFY_CLI_AGENT_IDS = 's:session-id|r:run-id|i:instance-id'
     process.env.SHOPIFY_SOMETHING_KEY = '123'
 
     try {
@@ -280,11 +284,18 @@ describe('event tracking', () => {
         const shopifyVars = JSON.parse(sensitivePayload.env_shopify_variables as string)
         expect(shopifyVars).toHaveProperty('SHOPIFY_INVOKED_BY', 'shopify-function-test-helpers')
         expect(shopifyVars).toHaveProperty('SHOPIFY_CLI_AGENT', 'test-agent')
+        expect(shopifyVars).toHaveProperty(
+          'SHOPIFY_CLI_AGENT_INFO',
+          'n:test-agent|v:1.0.0|p:test-provider|m:test-model',
+        )
+        expect(shopifyVars).toHaveProperty('SHOPIFY_CLI_AGENT_IDS', 's:session-id|r:run-id|i:instance-id')
         expect(shopifyVars).not.toHaveProperty('SHOPIFY_SOMETHING_KEY')
       })
     } finally {
       restoreEnvVariable('SHOPIFY_INVOKED_BY', originalShopifyInvokedBy)
       restoreEnvVariable('SHOPIFY_CLI_AGENT', originalShopifyCliAgent)
+      restoreEnvVariable('SHOPIFY_CLI_AGENT_INFO', originalShopifyCliAgentInfo)
+      restoreEnvVariable('SHOPIFY_CLI_AGENT_IDS', originalShopifyCliAgentIds)
       restoreEnvVariable('SHOPIFY_SOMETHING_KEY', originalShopifySomethingKey)
     }
   })


### PR DESCRIPTION
## Why

AI Toolkit sends packed CLI attribution through `SHOPIFY_CLI_AGENT_INFO` and `SHOPIFY_CLI_AGENT_IDS`. The analytics allowlist currently drops both variables, while the data-warehouse model already reads them as fallbacks.

## What

- Add both packed agent variables to `getShopifyEnvironmentVariables()`.
- Extend the allowlist regression test and keep unknown `SHOPIFY_*` variables excluded.

## Testing

- `pnpm vitest run packages/cli-kit/src/public/node/analytics.test.ts`
- `pnpm eslint packages/cli-kit/src/private/node/analytics.ts packages/cli-kit/src/public/node/analytics.test.ts`
- `pnpm nx bundle cli --skip-nx-cache`
- Verified both packed variables in real verbose CLI output while `SHOPIFY_SOMETHING_KEY=123` remained excluded.
- `git diff --check`

No changeset: this only restores internal analytics collection.