### PR TITLE
Avoid bundling TypeScript in the production CLI

### DIFF
--- a/packages/cli/bin/bundle.js
+++ b/packages/cli/bin/bundle.js
@@ -19,6 +19,8 @@ const external = [
   'react-devtools-core',
   // esbuild can't be bundled per design
   'esbuild',
+  // Oclif only uses TypeScript to load source plugins during development
+  'typescript',
   'lightningcss',
   // These two are binary dependencies from Hydrogen that can't be bundled
   '@ast-grep/napi',

--- a/packages/create-app/bin/bundle.js
+++ b/packages/create-app/bin/bundle.js
@@ -14,6 +14,8 @@ const external = [
   'react-devtools-core',
   // esbuild can't be bundled per design
   'esbuild',
+  // Oclif only uses TypeScript to load source plugins during development
+  'typescript',
   'lightningcss',
 ]
 


### PR DESCRIPTION
## Why

Oclif has an optional TypeScript loader for development and linked source plugins. Esbuild follows that reference and adds the TypeScript compiler to both production bundles, although production commands use compiled JavaScript and skip the loader.

## What

Keep TypeScript external to the Shopify CLI and create-app bundles. Development can resolve the repository dev dependency. Packaged CLIs without TypeScript use the Oclif compiled-source fallback.

This reduces the Shopify CLI static bootstrap JavaScript from about 4.0 MB to 391 KB. It also reduces the create-app JavaScript bundle from 33.42 MB to 24.36 MB.

## Validation

- pnpm nx bundle cli --skip-nx-cache
- pnpm nx bundle create-app --skip-nx-cache
- Prettier checks for both bundle files
- Development-mode help and version commands
- Production-style packages without TypeScript: Shopify CLI version, help, and app dev help; create-app help