### PR TITLE
Fix Shopify Function GraphQL scalar types

### DIFF
--- a/.changeset/curvy-carrots-typegen.md
+++ b/.changeset/curvy-carrots-typegen.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Generate concrete GraphQL scalar types for JavaScript and TypeScript Shopify Functions

--- a/packages/app/src/cli/services/function/build.test.ts
+++ b/packages/app/src/cli/services/function/build.test.ts
@@ -24,7 +24,7 @@ import {beforeEach, describe, expect, test, vi} from 'vitest'
 import {exec} from '@shopify/cli-kit/node/system'
 import {packageManagerBinaryCommandForDirectory} from '@shopify/cli-kit/node/node-package-manager'
 import {dirname, joinPath} from '@shopify/cli-kit/node/path'
-import {inTemporaryDirectory, mkdir, writeFile, removeFile} from '@shopify/cli-kit/node/fs'
+import {inTemporaryDirectory, mkdir, readFile, writeFile, removeFile} from '@shopify/cli-kit/node/fs'
 import {build as esBuild} from 'esbuild'
 
 vi.mock('@shopify/cli-kit/node/system')
@@ -92,24 +92,24 @@ beforeEach(async () => {
   stderr = {write: vi.fn()}
   stdout = {write: vi.fn()}
   signal = vi.fn()
-  vi.mocked(packageManagerBinaryCommandForDirectory).mockResolvedValue({
-    command: 'npm',
-    args: ['exec', '--', 'graphql-code-generator', '--config', 'package.json'],
-  })
+  vi.mocked(packageManagerBinaryCommandForDirectory).mockImplementation(
+    async (_directory, binary, ...binaryArguments) => ({
+      command: 'npm',
+      args: ['exec', '--', binary, ...binaryArguments],
+    }),
+  )
 })
 
 describe('buildGraphqlTypes', () => {
-  test('generate types', {timeout: 20000}, async () => {
+  test('uses the default config path when package.json is missing', async () => {
     await inTemporaryDirectory(async (tmpDir) => {
       // Given
       const ourFunction = await testFunctionExtension({dir: tmpDir, entryPath: 'src/index.js'})
 
       // When
-      const got = buildGraphqlTypes(ourFunction, {stdout, stderr, signal, app})
+      await buildGraphqlTypes(ourFunction, {stdout, stderr, signal, app})
 
       // Then
-      await expect(got).resolves.toBeUndefined()
-      expect(packageManagerBinaryCommandForDirectory).toHaveBeenCalledTimes(1)
       expect(packageManagerBinaryCommandForDirectory).toHaveBeenCalledWith(
         ourFunction.directory,
         'graphql-code-generator',
@@ -124,13 +124,20 @@ describe('buildGraphqlTypes', () => {
     })
   })
 
-  test('generate types executes the command returned by the shared helper', {timeout: 20000}, async () => {
+  test('generate types', {timeout: 20000}, async () => {
     await inTemporaryDirectory(async (tmpDir) => {
       // Given
       const ourFunction = await testFunctionExtension({dir: tmpDir, entryPath: 'src/index.js'})
-      vi.mocked(packageManagerBinaryCommandForDirectory).mockResolvedValue({
-        command: 'pnpm',
-        args: ['exec', 'graphql-code-generator', '--config', 'package.json'],
+      const codegen = {
+        schema: 'schema.graphql',
+        documents: 'src/*.graphql',
+        generates: {'generated/api.ts': {plugins: ['typescript', 'typescript-operations']}},
+        config: {omitOperationSuffix: true},
+      }
+      await writeFile(joinPath(tmpDir, 'package.json'), JSON.stringify({codegen}))
+      let generatedCodegenConfig: unknown
+      vi.mocked(exec).mockImplementation(async (_command, args) => {
+        generatedCodegenConfig = JSON.parse(await readFile(args.at(-1)!))
       })
 
       // When
@@ -138,7 +145,125 @@ describe('buildGraphqlTypes', () => {
 
       // Then
       await expect(got).resolves.toBeUndefined()
-      expect(exec).toHaveBeenCalledWith('pnpm', ['exec', 'graphql-code-generator', '--config', 'package.json'], {
+      expect(packageManagerBinaryCommandForDirectory).toHaveBeenCalledTimes(1)
+      const codegenConfigPath = vi.mocked(packageManagerBinaryCommandForDirectory).mock.calls[0]![3]!
+      expect(packageManagerBinaryCommandForDirectory).toHaveBeenCalledWith(
+        ourFunction.directory,
+        'graphql-code-generator',
+        '--config',
+        codegenConfigPath,
+      )
+      expect(exec).toHaveBeenCalledWith(
+        'npm',
+        ['exec', '--', 'graphql-code-generator', '--config', codegenConfigPath],
+        {
+          cwd: ourFunction.directory,
+          stderr,
+          signal,
+        },
+      )
+      expect(generatedCodegenConfig).toEqual({
+        ...codegen,
+        config: {
+          defaultScalarType: 'unknown',
+          omitOperationSuffix: true,
+          scalars: {
+            Date: 'string',
+            DateTime: 'string',
+            DateTimeWithoutTimezone: 'string',
+            Decimal: 'string',
+            Handle: 'string',
+            ID: 'string',
+            JSON: 'unknown',
+            TimeWithoutTimezone: 'string',
+            URL: 'string',
+            Void: 'null',
+          },
+        },
+      })
+    })
+  })
+
+  test('preserves user-defined scalar mappings and fallback type', {timeout: 20000}, async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      const ourFunction = await testFunctionExtension({dir: tmpDir, entryPath: 'src/index.js'})
+      await writeFile(
+        joinPath(tmpDir, 'package.json'),
+        JSON.stringify({
+          codegen: {
+            schema: 'schema.graphql',
+            config: {defaultScalarType: 'any', scalars: {Decimal: 'number', JSON: 'JsonValue'}},
+          },
+        }),
+      )
+      let generatedCodegenConfig: {config: {scalars: Record<string, string>}} | undefined
+      vi.mocked(exec).mockImplementation(async (_command, args) => {
+        generatedCodegenConfig = JSON.parse(await readFile(args.at(-1)!))
+      })
+
+      // When
+      await buildGraphqlTypes(ourFunction, {stdout, stderr, signal, app})
+
+      // Then
+      expect(generatedCodegenConfig?.config).toMatchObject({
+        defaultScalarType: 'any',
+        scalars: {
+          Date: 'string',
+          DateTime: 'string',
+          DateTimeWithoutTimezone: 'string',
+          Decimal: 'number',
+          Handle: 'string',
+          ID: 'string',
+          JSON: 'JsonValue',
+          TimeWithoutTimezone: 'string',
+          URL: 'string',
+          Void: 'null',
+        },
+      })
+    })
+  })
+
+  test.each([
+    {name: 'config', config: null},
+    {name: 'scalar mapping', config: {scalars: null}},
+  ])('handles a null $name', async ({config}) => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      const ourFunction = await testFunctionExtension({dir: tmpDir, entryPath: 'src/index.js'})
+      await writeFile(joinPath(tmpDir, 'package.json'), JSON.stringify({codegen: {schema: 'schema.graphql', config}}))
+      let generatedCodegenConfig: {config: {defaultScalarType: string; scalars: Record<string, string>}} | undefined
+      vi.mocked(exec).mockImplementation(async (_command, args) => {
+        generatedCodegenConfig = JSON.parse(await readFile(args.at(-1)!))
+      })
+
+      // When
+      await buildGraphqlTypes(ourFunction, {stdout, stderr, signal, app})
+
+      // Then
+      expect(generatedCodegenConfig?.config).toMatchObject({
+        defaultScalarType: 'unknown',
+        scalars: {Decimal: 'string'},
+      })
+    })
+  })
+
+  test('generate types executes the command returned by the shared helper', {timeout: 20000}, async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      const ourFunction = await testFunctionExtension({dir: tmpDir, entryPath: 'src/index.js'})
+      await writeFile(joinPath(tmpDir, 'package.json'), JSON.stringify({codegen: {schema: 'schema.graphql'}}))
+      vi.mocked(packageManagerBinaryCommandForDirectory).mockResolvedValue({
+        command: 'pnpm',
+        args: ['exec', 'graphql-code-generator'],
+      })
+
+      // When
+      const got = buildGraphqlTypes(ourFunction, {stdout, stderr, signal, app})
+
+      // Then
+      await expect(got).resolves.toBeUndefined()
+      expect(exec).toHaveBeenCalledWith('pnpm', ['exec', 'graphql-code-generator'], {
         cwd: ourFunction.directory,
         stderr,
         signal,

--- a/packages/app/src/cli/services/function/build.ts
+++ b/packages/app/src/cli/services/function/build.ts
@@ -19,16 +19,47 @@ import {outputContent, outputDebug, outputToken} from '@shopify/cli-kit/node/out
 import {exec} from '@shopify/cli-kit/node/system'
 import {dirname, joinPath} from '@shopify/cli-kit/node/path'
 import {build as esBuild, BuildResult} from 'esbuild'
-import {findPathUp, inTemporaryDirectory, readFile, readFileSync, writeFile} from '@shopify/cli-kit/node/fs'
+import {fileExists, findPathUp, inTemporaryDirectory, readFile, readFileSync, writeFile} from '@shopify/cli-kit/node/fs'
 import {AbortSignal} from '@shopify/cli-kit/node/abort'
 import {renderTasks} from '@shopify/cli-kit/node/ui'
 import {pickBy} from '@shopify/cli-kit/common/object'
 import {runWithTimer} from '@shopify/cli-kit/node/metadata'
 import {AbortError} from '@shopify/cli-kit/node/error'
-import {packageManagerBinaryCommandForDirectory} from '@shopify/cli-kit/node/node-package-manager'
+import {
+  packageManagerBinaryCommandForDirectory,
+  readAndParsePackageJson,
+} from '@shopify/cli-kit/node/node-package-manager'
 import {Writable} from 'stream'
 
 export const PREFERRED_FUNCTION_NPM_PACKAGE_MAJOR_VERSION = '2'
+
+interface FunctionCodegenConfig {
+  config?: {
+    scalars?: Record<string, unknown> | null
+    [key: string]: unknown
+  } | null
+  [key: string]: unknown
+}
+
+interface FunctionPackageJson {
+  codegen?: FunctionCodegenConfig
+}
+
+const shopifyFunctionCodegenDefaults = {
+  defaultScalarType: 'unknown',
+  scalars: {
+    Date: 'string',
+    DateTime: 'string',
+    DateTimeWithoutTimezone: 'string',
+    Decimal: 'string',
+    Handle: 'string',
+    ID: 'string',
+    JSON: 'unknown',
+    TimeWithoutTimezone: 'string',
+    URL: 'string',
+    Void: 'null',
+  },
+} as const
 
 class InvalidShopifyFunctionPackageError extends AbortError {
   constructor(message: string) {
@@ -145,11 +176,41 @@ export async function buildGraphqlTypes(
     )
   }
 
+  const packageJsonPath = joinPath(fun.directory, 'package.json')
+  if (!(await fileExists(packageJsonPath))) {
+    return runGraphqlCodegen(fun, options, 'package.json')
+  }
+
+  const packageJson = (await readAndParsePackageJson(packageJsonPath)) as FunctionPackageJson
+  if (!packageJson.codegen) {
+    return runGraphqlCodegen(fun, options, 'package.json')
+  }
+
+  const codegenConfig = {
+    ...packageJson.codegen,
+    config: {
+      ...shopifyFunctionCodegenDefaults,
+      ...(packageJson.codegen.config ?? {}),
+      scalars: {
+        ...shopifyFunctionCodegenDefaults.scalars,
+        ...(packageJson.codegen.config?.scalars ?? {}),
+      },
+    },
+  }
+
+  return inTemporaryDirectory(async (temporaryDirectory) => {
+    const codegenConfigPath = joinPath(temporaryDirectory, 'codegen.json')
+    await writeFile(codegenConfigPath, JSON.stringify(codegenConfig))
+    return runGraphqlCodegen(fun, options, codegenConfigPath)
+  })
+}
+
+async function runGraphqlCodegen(fun: {directory: string}, options: JSFunctionBuildOptions, codegenConfigPath: string) {
   const command = await packageManagerBinaryCommandForDirectory(
     fun.directory,
     'graphql-code-generator',
     '--config',
-    'package.json',
+    codegenConfigPath,
   )
 
   return runWithTimer('cmd_all_timing_network_ms')(async () => {


### PR DESCRIPTION
### WHY are these changes introduced?

Shopify Function type generation leaves custom GraphQL scalars as `any`, which removes useful type safety from generated JavaScript and TypeScript APIs.

### WHAT is this pull request doing?

Adds default TypeScript mappings for every custom scalar currently used by Shopify Function schemas. Unknown future scalars fall back to `unknown` instead of `any`, while mappings configured by the app developer continue to take precedence.

The generated codegen configuration is temporary and does not modify the function project.

### How to test your changes?

- `pnpm --filter @shopify/app vitest run src/cli/services/function/build.test.ts`
- `pnpm --filter @shopify/app type-check`
- `pnpm --filter @shopify/app lint -- --no-cache`

### Checklist

- [x] I have considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I have considered possible documentation changes
- [x] I have considered analytics changes to measure impact
- [x] The change is user-facing and includes a patch changeset