### PR TITLE
[Tests] Add unit tests for logs.ts utility

### DIFF
--- a/packages/cli-kit/src/public/node/logs.test.ts
+++ b/packages/cli-kit/src/public/node/logs.test.ts
@@ -1,0 +1,48 @@
+import {getLogsDir, createLogsDir, writeLog} from './logs.js'
+import {inTemporaryDirectory, fileExists, readFile} from './fs.js'
+import {joinPath} from './path.js'
+import {logsFolder} from '../../private/node/constants.js'
+import {describe, expect, test, vi} from 'vitest'
+
+vi.mock('../../private/node/constants.js', async (importOriginal) => {
+  const original = await importOriginal<typeof import('../../private/node/constants.js')>()
+  return {
+    ...original,
+    logsFolder: vi.fn(),
+  }
+})
+
+describe('getLogsDir', () => {
+  test('returns the path to the logs directory', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      vi.mocked(logsFolder).mockReturnValue(tmpDir)
+      expect(getLogsDir()).toBe(tmpDir)
+    })
+  })
+})
+
+describe('createLogsDir', () => {
+  test('creates a subdirectory in the logs directory', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      vi.mocked(logsFolder).mockReturnValue(tmpDir)
+      const subpath = 'custom-subdir'
+      await createLogsDir(subpath)
+      const expectedPath = joinPath(tmpDir, subpath)
+      await expect(fileExists(expectedPath)).resolves.toBe(true)
+    })
+  })
+})
+
+describe('writeLog', () => {
+  test('writes log content to the specified file in the logs directory', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      vi.mocked(logsFolder).mockReturnValue(tmpDir)
+      const logFilename = 'app-log.txt'
+      const logData = 'Hello world log content'
+      await writeLog(logFilename, logData)
+      const expectedFilePath = joinPath(tmpDir, logFilename)
+      await expect(fileExists(expectedFilePath)).resolves.toBe(true)
+      await expect(readFile(expectedFilePath)).resolves.toBe(logData)
+    })
+  })
+})


### PR DESCRIPTION
### WHY are these changes introduced?

To improve the testing coverage and verify the behavior of the `logs` module under `@shopify/cli-kit`.

### WHAT is this pull request doing?

This pull request introduces comprehensive unit tests for `packages/cli-kit/src/public/node/logs.ts`, covering:
- `getLogsDir`
- `createLogsDir`
- `writeLog`

These tests use real files and directories inside an isolated temporary directory via `inTemporaryDirectory`.

### How to test your changes?

CI

### Post-release steps

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [931035401241244560](https://jules.google.com/task/931035401241244560) started by @gonzaloriestra*