### PR TITLE
Update Javy and function-runner

### DIFF
--- a/.changeset/update-javy-function-runner.md
+++ b/.changeset/update-javy-function-runner.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Update the Javy and function-runner binaries to fix issue with larger QuickJS bytecode.

--- a/packages/app/src/cli/services/function/binaries.ts
+++ b/packages/app/src/cli/services/function/binaries.ts
@@ -11,10 +11,10 @@ import fs from 'node:fs'
 import * as gzip from 'node:zlib'
 import {fileURLToPath} from 'node:url'
 
-export const PREFERRED_FUNCTION_RUNNER_VERSION = '9.2.1'
+export const PREFERRED_FUNCTION_RUNNER_VERSION = '9.2.2'
 
 // Javy dependencies.
-export const PREFERRED_JAVY_VERSION = '9.0.0'
+export const PREFERRED_JAVY_VERSION = '9.1.0'
 // The Javy plugin version should match the plugin version used in the
 // function-runner version specified above.
 export const PREFERRED_JAVY_PLUGIN_VERSION = '4'


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it's a work in progress
-->

### WHY are these changes introduced?

Related to https://github.com/Shopify/shopify-function-javascript/issues/127.

This ships a new version of function-runner that includes an up-to-date version of the v4 Shopify Functions Javy plugin. I've also updated the Javy CLI because while I'm in here.

### WHAT is this pull request doing?

Updates the versions of function-runner and the Javy CLI.

### How to test your changes?

`pnpm shopify app function run --input <input_for_the_function> --path <path_to_a_function>`. You can use `{}` for the input to confirm the function-runner binary is invoked and fails complaining about the input being invalid.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [x] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`
