### PR TITLE
[Refactor] Extract adminUrl helper in themes/urls.ts

### DIFF
--- a/packages/cli-kit/src/public/node/themes/urls.ts
+++ b/packages/cli-kit/src/public/node/themes/urls.ts
@@ -11,20 +11,21 @@ export function themePreviewUrl(theme: Theme, session: AdminSession) {
 }
 
 export function themeEditorUrl(theme: Theme, session: AdminSession) {
-  const store = session.storeFqdn
-  return `https://${store}/admin/themes/${theme.id}/editor`
+  return adminUrl(session.storeFqdn, `/themes/${theme.id}/editor`)
 }
 
 export function codeEditorUrl(theme: Theme, session: AdminSession) {
-  const store = session.storeFqdn
-  return `https://${store}/admin/themes/${theme.id}`
+  return adminUrl(session.storeFqdn, `/themes/${theme.id}`)
 }
 
 export function storeAdminUrl(session: AdminSession) {
-  const store = session.storeFqdn
-  return `https://${store}/admin`
+  return adminUrl(session.storeFqdn)
 }
 
 export function storePasswordPage(store: AdminSession['storeFqdn']) {
-  return `https://${store}/admin/online_store/preferences`
+  return adminUrl(store, '/online_store/preferences')
+}
+
+function adminUrl(store: string, path = ''): string {
+  return `https://${store}/admin${path}`
 }


### PR DESCRIPTION
### WHY are these changes introduced?

The URL construction functions in `packages/cli-kit/src/public/node/themes/urls.ts` repeated the string interpolation logic for constructing store admin URLs (`https://${store}/admin...`).

This PR refactors them by introducing a private helper function `adminUrl` to centralize this formatting logic, improving maintainability and reducing code duplication.

### WHAT is this pull request doing?

- Extracts `adminUrl(store: string, path = ''): string` helper function.
- Updates `themeEditorUrl`, `codeEditorUrl`, `storeAdminUrl`, and `storePasswordPage` to delegate URL generation to `adminUrl`.

### How to test your changes?

CI

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [11628264692596972264](https://jules.google.com/task/11628264692596972264) started by @gonzaloriestra*