### PR TITLE
theme: overlap checksum fetch with file system setup

### DIFF
--- a/packages/theme/src/cli/services/push.test.ts
+++ b/packages/theme/src/cli/services/push.test.ts
@@ -2,13 +2,14 @@ import {setDevelopmentTheme} from './local-storage.js'
 import {PullFlags} from './pull.js'
 import {createOrSelectTheme, push, PushFlags} from './push.js'
 import {mountThemeFileSystem} from '../utilities/theme-fs.js'
+import {fakeThemeFileSystem} from '../utilities/theme-fs/theme-fs-mock-factory.js'
 import {runThemeCheck} from '../commands/theme/check.js'
 import {findOrSelectTheme} from '../utilities/theme-selector.js'
 import {ensureThemeStore} from '../utilities/theme-store.js'
 import {uploadTheme} from '../utilities/theme-uploader.js'
 import {buildTheme} from '@shopify/cli-kit/node/themes/factories'
 import {test, describe, vi, expect, beforeEach} from 'vitest'
-import {themeCreate, fetchTheme, themePublish} from '@shopify/cli-kit/node/themes/api'
+import {themeCreate, fetchTheme, themePublish, fetchChecksums} from '@shopify/cli-kit/node/themes/api'
 import {ensureAuthenticatedThemes} from '@shopify/cli-kit/node/session'
 import {
   DEVELOPMENT_THEME_ROLE,
@@ -55,6 +56,8 @@ describe('push', () => {
     })
     vi.mocked(ensureThemeStore).mockReturnValue('example.myshopify.com')
     vi.mocked(ensureAuthenticatedThemes).mockResolvedValue(adminSession)
+    vi.mocked(mountThemeFileSystem).mockReturnValue(fakeThemeFileSystem(path, new Map()))
+    vi.mocked(fetchChecksums).mockResolvedValue([])
     vi.mocked(outputResult).mockReturnValue()
   })
 

--- a/packages/theme/src/cli/services/push.ts
+++ b/packages/theme/src/cli/services/push.ts
@@ -223,11 +223,11 @@ async function executePush(
   context?: {stdout?: Writable; stderr?: Writable},
 ) {
   recordTiming('theme-service:push:file-system')
-  const themeChecksums = await fetchChecksums(theme.id, session)
   const themeFileSystem = mountThemeFileSystem(options.path, {
     filters: options,
     listing: options.listing,
   })
+  const [themeChecksums] = await Promise.all([fetchChecksums(theme.id, session), themeFileSystem.ready()])
   recordTiming('theme-service:push:file-system')
 
   const {uploadResults, renderThemeSyncProgress} = uploadTheme(


### PR DESCRIPTION
## Summary

Start mounting the local theme file system before fetching remote checksums during `theme push`, then wait for both operations together.

This matches the existing pattern used by `theme pull` and allows the two independent operations to overlap while preserving the existing behavior.

## Testing

- Updated unit tests (only if needed)
- Relevant tests pass
- Lint passes
- Typecheck passes