### PR TITLE
Report missing Theme Check config files as expected errors

### DIFF
--- a/.changeset/calm-themes-check.md
+++ b/.changeset/calm-themes-check.md
@@ -1,0 +1,5 @@
+---
+'@shopify/theme': patch
+---
+
+Report missing Theme Check config files as expected user errors.

--- a/packages/theme/src/cli/commands/theme/check.test.ts
+++ b/packages/theme/src/cli/commands/theme/check.test.ts
@@ -1,7 +1,8 @@
-import Check from './check.js'
+import Check, {runThemeCheck} from './check.js'
 import {describe, vi, expect, test, beforeEach} from 'vitest'
 import {Config} from '@oclif/core'
 import {themeCheckRun, Theme, Config as ThemeConfig, Offense} from '@shopify/theme-check-node'
+import {AbortError} from '@shopify/cli-kit/node/error'
 
 vi.mock('@shopify/theme-check-node')
 const CommandConfig = new Config({root: __dirname})
@@ -77,6 +78,49 @@ describe('Check', () => {
       })
 
       await run([`--config=${expectedConfig}`])
+    })
+
+    test('reports a missing explicitly configured file as an expected error', async () => {
+      const config = './.theme-check.yml'
+      const missingConfigError = Object.assign(new Error(`ENOENT: no such file or directory, open '${config}'`), {
+        code: 'ENOENT',
+        path: config,
+      })
+      vi.mocked(themeCheckRun).mockRejectedValue(missingConfigError)
+
+      const result = runThemeCheck(path, 'text', config)
+
+      await expect(result).rejects.toBeInstanceOf(AbortError)
+      await expect(result).rejects.toThrowError(`Theme Check config file not found: ${config}`)
+    })
+
+    test('does not treat a missing extended config as a missing explicitly configured file', async () => {
+      const config = '/my-theme/.theme-check.yml'
+      const missingExtendedConfigError = Object.assign(new Error('ENOENT'), {
+        code: 'ENOENT',
+        path: '/my-theme/missing-extended.yml',
+      })
+      vi.mocked(themeCheckRun).mockRejectedValue(missingExtendedConfigError)
+
+      await expect(runThemeCheck(path, 'text', config)).rejects.toBe(missingExtendedConfigError)
+    })
+
+    test('does not treat other config failures as a missing explicitly configured file', async () => {
+      const config = '/my-theme/.theme-check.yml'
+      const permissionError = Object.assign(new Error('EACCES'), {code: 'EACCES', path: config})
+      vi.mocked(themeCheckRun).mockRejectedValue(permissionError)
+
+      await expect(runThemeCheck(path, 'text', config)).rejects.toBe(permissionError)
+    })
+
+    test('does not treat missing files as config errors when no config was explicitly provided', async () => {
+      const missingThemeFileError = Object.assign(new Error('ENOENT'), {
+        code: 'ENOENT',
+        path: '/my-theme/templates/index.liquid',
+      })
+      vi.mocked(themeCheckRun).mockRejectedValue(missingThemeFileError)
+
+      await expect(runThemeCheck(path, 'text')).rejects.toBe(missingThemeFileError)
     })
   })
 })

--- a/packages/theme/src/cli/commands/theme/check.ts
+++ b/packages/theme/src/cli/commands/theme/check.ts
@@ -10,6 +10,7 @@ import {
   sortOffenses,
   isExtendedWriteStream,
   handleExit,
+  withThemeCheckConfigErrorHandling,
   type FailLevel,
 } from '../../services/check.js'
 import {themeFlags} from '../../flags.js'
@@ -151,11 +152,13 @@ export default class Check extends ThemeCommand {
 }
 
 export async function runThemeCheck(path: string, outputFormat: string, config?: string, environment?: string) {
-  const {offenses, theme} = await themeCheckRun(path, config, (message) => {
-    if (process.env.SHOPIFY_TMP_FLAG_DEBUG) {
-      outputDebug(message)
-    }
-  })
+  const {offenses, theme} = await withThemeCheckConfigErrorHandling(config, () =>
+    themeCheckRun(path, config, (message) => {
+      if (process.env.SHOPIFY_TMP_FLAG_DEBUG) {
+        outputDebug(message)
+      }
+    }),
+  )
 
   const offensesByFile = sortOffenses(offenses)
 

--- a/packages/theme/src/cli/services/check.test.ts
+++ b/packages/theme/src/cli/services/check.test.ts
@@ -4,10 +4,13 @@ import {
   formatSummary,
   handleExit,
   initConfig,
+  outputActiveChecks,
+  outputActiveConfig,
   renderOffensesText,
   sortOffenses,
 } from './check.js'
 import {fileExists, writeFile} from '@shopify/cli-kit/node/fs'
+import {AbortError} from '@shopify/cli-kit/node/error'
 import {outputInfo, outputSuccess} from '@shopify/cli-kit/node/output'
 import {renderInfo} from '@shopify/cli-kit/node/ui'
 import {
@@ -25,10 +28,14 @@ vi.mock('@shopify/cli-kit/node/fs', async () => ({
   writeFile: vi.fn(),
 }))
 
-vi.mock('@shopify/cli-kit/node/output', async () => ({
-  outputInfo: vi.fn(),
-  outputSuccess: vi.fn(),
-}))
+vi.mock('@shopify/cli-kit/node/output', async () => {
+  const actual = await vi.importActual('@shopify/cli-kit/node/output')
+  return {
+    ...actual,
+    outputInfo: vi.fn(),
+    outputSuccess: vi.fn(),
+  }
+})
 
 vi.mock('@shopify/theme-check-node', async () => {
   const actual: any = await vi.importActual('@shopify/theme-check-node')
@@ -425,5 +432,37 @@ describe('initConfig', () => {
     expect(loadConfig).toHaveBeenCalledWith(undefined, '/path/to/root')
     expect(writeFile).toHaveBeenCalledWith('/path/to/root/.theme-check.yml', expect.any(String))
     expect(outputSuccess).toHaveBeenCalledWith('Created .theme-check.yml at /path/to/root')
+  })
+})
+
+describe('outputActiveConfig', () => {
+  test('reports a missing explicitly configured file as an expected error', async () => {
+    const configPath = './.theme-check.yml'
+    const missingConfigError = Object.assign(new Error(`ENOENT: no such file or directory, open '${configPath}'`), {
+      code: 'ENOENT',
+      path: configPath,
+    })
+    vi.mocked(loadConfig).mockRejectedValue(missingConfigError)
+
+    const result = outputActiveConfig('/my-theme', configPath)
+
+    await expect(result).rejects.toBeInstanceOf(AbortError)
+    await expect(result).rejects.toThrowError(`Theme Check config file not found: ${configPath}`)
+  })
+})
+
+describe('outputActiveChecks', () => {
+  test('reports a missing explicitly configured file as an expected error', async () => {
+    const configPath = './.theme-check.yml'
+    const missingConfigError = Object.assign(new Error(`ENOENT: no such file or directory, open '${configPath}'`), {
+      code: 'ENOENT',
+      path: configPath,
+    })
+    vi.mocked(loadConfig).mockRejectedValue(missingConfigError)
+
+    const result = outputActiveChecks('/my-theme', configPath)
+
+    await expect(result).rejects.toBeInstanceOf(AbortError)
+    await expect(result).rejects.toThrowError(`Theme Check config file not found: ${configPath}`)
   })
 })

--- a/packages/theme/src/cli/services/check.ts
+++ b/packages/theme/src/cli/services/check.ts
@@ -1,8 +1,9 @@
 import {fileExists, writeFile} from '@shopify/cli-kit/node/fs'
 import {outputResult, outputInfo, outputSuccess} from '@shopify/cli-kit/node/output'
-import {joinPath} from '@shopify/cli-kit/node/path'
+import {joinPath, resolvePath} from '@shopify/cli-kit/node/path'
 import {renderInfo} from '@shopify/cli-kit/node/ui'
 import {uniq} from '@shopify/cli-kit/common/array'
+import {AbortError} from '@shopify/cli-kit/node/error'
 import {
   Severity,
   applyFixToString,
@@ -45,6 +46,31 @@ type SeverityCounts = Partial<{
 }>
 
 export type FailLevel = 'error' | 'suggestion' | 'style' | 'warning' | 'info' | 'crash'
+
+function isMissingThemeCheckConfigFile(error: unknown, configPath: string) {
+  return (
+    error instanceof Error &&
+    'code' in error &&
+    error.code === 'ENOENT' &&
+    'path' in error &&
+    typeof error.path === 'string' &&
+    resolvePath(error.path) === resolvePath(configPath)
+  )
+}
+
+export async function withThemeCheckConfigErrorHandling<T>(
+  configPath: string | undefined,
+  operation: () => Promise<T>,
+): Promise<T> {
+  try {
+    return await operation()
+  } catch (error) {
+    if (configPath !== undefined && isMissingThemeCheckConfigFile(error, configPath)) {
+      throw new AbortError(`Theme Check config file not found: ${configPath}`)
+    }
+    throw error
+  }
+}
 
 function failLevelToSeverity(failLevel: FailLevel): Severity | undefined {
   switch (failLevel) {
@@ -308,7 +334,9 @@ export async function performAutoFixes(sourceCodes: Theme, offenses: Offense[]) 
 }
 
 export async function outputActiveConfig(themeRoot: string, configPath?: string, environment?: string) {
-  const {ignore, settings, rootUri} = await loadConfig(configPath, themeRoot)
+  const {ignore, settings, rootUri} = await withThemeCheckConfigErrorHandling(configPath, () =>
+    loadConfig(configPath, themeRoot),
+  )
 
   const config = {
     // loadConfig flattens all configs, it doesn't extend anything
@@ -328,7 +356,9 @@ export async function outputActiveConfig(themeRoot: string, configPath?: string,
 }
 
 export async function outputActiveChecks(root: string, configPath?: string, environment?: string) {
-  const {settings, ignore, checks} = await loadConfig(configPath, root)
+  const {settings, ignore, checks} = await withThemeCheckConfigErrorHandling(configPath, () =>
+    loadConfig(configPath, root),
+  )
   // Depending on how the configs were merged during loadConfig, there may be
   // duplicate patterns to ignore. We can clean them before outputting.
   const ignorePatterns = uniq(ignore ?? [])


### PR DESCRIPTION
# TL;DR

Report an explicitly selected but missing Theme Check configuration file as an expected CLI error instead of sending an unhandled filesystem error to Bugsnag and Observe.

# Context

Observe error group [1547901448068571580](https://observe.shopify.io/a/observe/errors/1547901448068571580) recorded 11 events over the inspected 30-day window, affecting 11 stable sessions. The error was consistently `ENOENT: no such file or directory, open '<path>/.theme-check.yml'` from `@shopify/theme-check-node` after the user supplied `--config=./.theme-check.yml`. The issue snapshot recorded 7 events affecting 7 users over seven days.

The Theme Check library correctly raises `ENOENT` when an explicit root config does not exist, but Shopify CLI treated that raw Node error as an unexpected bug. The command should still exit unsuccessfully and explain the missing file; it should not report expected invalid input as a product defect.

Closes https://github.com/shop/issues/issues/71880

# Changes

- Translate `ENOENT` into `AbortError` only when the missing path matches the explicitly selected root configuration file.
- Apply the same behavior to normal checks, `--print`, and `--list`.
- Preserve unexpected reporting for missing nested `extends` files, unrelated missing files, permission errors, and all other I/O failures.
- Add command- and service-level regression coverage.
- Add a patch changeset for `@shopify/theme`.

# Tophatting

- `pnpm exec vitest run packages/theme/src/cli/services/check.test.ts packages/theme/src/cli/commands/theme/check.test.ts` — 24 tests passed after rebasing onto current `main`.
- Full `@shopify/theme` test suite — 576 tests passed.
- `dev check` — type-check and lint passed.
- `pnpm nx build cli` — passed.
- Manually ran `theme check`, `theme check --print`, and `theme check --list` with a missing explicit config; each printed `Theme Check config file not found: <path>`, omitted a stack trace, and exited with status 1.
- Local Binks review: no comments.

---
_Generated with Pi. Vetted by Me._

---
_Generated with Pi. Vetted by Me._
<!-- github-gate:footer -->
<!-- github-gate:idempotency=issue-71880-theme-check-missing-config-pr -->