### PR TITLE
[Tests] Add comprehensive unit tests for os username utility

### DIFF
--- a/packages/cli-kit/src/public/node/os.test.ts
+++ b/packages/cli-kit/src/public/node/os.test.ts
@@ -1,7 +1,17 @@
-import {platformAndArch} from './os.js'
-import {describe, test, expect, vi} from 'vitest'
+import {platformAndArch, username} from './os.js'
+import {execa} from 'execa'
+import {describe, test, expect, vi, beforeEach, afterEach} from 'vitest'
+import {userInfo} from 'os'
 
 vi.mock('node:process')
+vi.mock('execa')
+vi.mock('os', async (importOriginal) => {
+  const original = await importOriginal<typeof import('os')>()
+  return {
+    ...original,
+    userInfo: vi.fn(),
+  }
+})
 
 describe('platformAndArch', () => {
   test("returns the right architecture when it's x64", () => {
@@ -38,5 +48,111 @@ describe('platformAndArch', () => {
     // Got
     expect(got.platform).toEqual('windows')
     expect(got.arch).toEqual('arm64')
+  })
+})
+
+describe('username', () => {
+  const originalEnv = {...process.env}
+
+  beforeEach(() => {
+    // Clear environment variables that might interfere
+    delete process.env.SUDO_USER
+    delete process.env.C9_USER
+    delete process.env.LOGNAME
+    delete process.env.USER
+    delete process.env.LNAME
+    delete process.env.USERNAME
+  })
+
+  afterEach(() => {
+    process.env = {...originalEnv}
+  })
+
+  test('returns the username from environment variables (e.g. SUDO_USER)', async () => {
+    // Given
+    process.env.SUDO_USER = 'sudo_user'
+
+    // When
+    const got = await username()
+
+    // Then
+    expect(got).toEqual('sudo_user')
+  })
+
+  test('falls back to getUsernameFromOsUserInfo when environment variables are not set', async () => {
+    // Given
+    vi.mocked(userInfo).mockReturnValue({username: 'os_user'} as any)
+
+    // When
+    const got = await username()
+
+    // Then
+    expect(got).toEqual('os_user')
+  })
+
+  test('falls back to win32 command whoami when env vars and userInfo are empty or failing', async () => {
+    // Given
+    vi.mocked(userInfo).mockImplementation(() => {
+      throw new Error('userInfo failed')
+    })
+    vi.mocked(execa).mockResolvedValue({stdout: 'domain\\win_user'} as any)
+
+    // When
+    const got = await username('win32')
+
+    // Then
+    expect(got).toEqual('win_user')
+    expect(execa).toHaveBeenCalledWith('whoami')
+  })
+
+  test('falls back to Unix command id when env vars and userInfo are empty or failing', async () => {
+    // Given
+    vi.mocked(userInfo).mockImplementation(() => {
+      throw new Error('userInfo failed')
+    })
+    // First call to id -u returns 1001, second call to id -un 1001 returns unix_user
+    vi.mocked(execa)
+      .mockResolvedValueOnce({stdout: '1001'} as any)
+      .mockResolvedValueOnce({stdout: 'unix_user'} as any)
+
+    // When
+    const got = await username('darwin')
+
+    // Then
+    expect(got).toEqual('unix_user')
+    expect(execa).toHaveBeenNthCalledWith(1, 'id', ['-u'])
+    expect(execa).toHaveBeenNthCalledWith(2, 'id', ['-un', '1001'])
+  })
+
+  test('falls back to no-username-ID if Unix lookup fails on name resolution', async () => {
+    // Given
+    vi.mocked(userInfo).mockImplementation(() => {
+      throw new Error('userInfo failed')
+    })
+    vi.mocked(execa)
+      .mockResolvedValueOnce({stdout: '1002'} as any)
+      .mockRejectedValueOnce(new Error('id -un failed'))
+
+    // When
+    const got = await username('linux')
+
+    // Then
+    expect(got).toEqual('no-username-1002')
+    expect(execa).toHaveBeenNthCalledWith(1, 'id', ['-u'])
+    expect(execa).toHaveBeenNthCalledWith(2, 'id', ['-un', '1002'])
+  })
+
+  test('returns null when all lookups fail', async () => {
+    // Given
+    vi.mocked(userInfo).mockImplementation(() => {
+      throw new Error('userInfo failed')
+    })
+    vi.mocked(execa).mockRejectedValue(new Error('execa failed'))
+
+    // When
+    const got = await username('darwin')
+
+    // Then
+    expect(got).toBeNull()
   })
 })


### PR DESCRIPTION
### WHY are these changes introduced?

The `username` utility in `packages/cli-kit/src/public/node/os.ts` lacked complete test coverage for its various fallback paths (including environment variables, `os.userInfo` fallbacks, platform-specific command executions via `execa`, and multiple branch scenarios).

### WHAT is this pull request doing?

This PR introduces comprehensive unit tests for the `username` utility in `packages/cli-kit/src/public/node/os.test.ts`, covering:
- Correct username resolution when environment variables are present.
- Resolution via `os.userInfo()` when environment variables are omitted.
- Windows-specific fallback utilizing the `whoami` command.
- Unix/POSIX fallback using the `id -u` and `id -un` commands.
- Handling of name lookup failures and command execution failures.

### How to test your changes?

CI

### Post-release steps

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [16685993225714546115](https://jules.google.com/task/16685993225714546115) started by @gonzaloriestra*