### PR TITLE
[Refactor] Refactor resolveFramework to use declarative .some() and .every()

### DIFF
--- a/packages/cli-kit/src/public/node/framework.test.ts
+++ b/packages/cli-kit/src/public/node/framework.test.ts
@@ -1,4 +1,4 @@
-import {resolveFramework} from './framework.js'
+import {resolveFramework, _frameworks} from './framework.js'
 import {inTemporaryDirectory, writeFile} from './fs.js'
 import {joinPath} from './path.js'
 import {describe, expect, test} from 'vitest'
@@ -129,6 +129,38 @@ describe('frontFrameworkUsed', () => {
 
       // Then
       expect(got).toEqual('unknown')
+    })
+  })
+
+  test('matches a custom framework if any detector in some matches and all in every match', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      _frameworks.push({
+        name: 'custom-framework',
+        detectors: {
+          some: [
+            {path: 'package.json', matchContent: '"custom-dep-1"'},
+            {path: 'package.json', matchContent: '"custom-dep-2"'},
+          ],
+          every: [{path: 'package.json', matchContent: '"framework-core"'}],
+        },
+      })
+
+      try {
+        const packageJsonPath = joinPath(tmpDir, 'package.json')
+        const packageJson = {
+          dependencies: {'framework-core': '1.0.0', 'custom-dep-2': '1.0.0'},
+        }
+        await writeFile(packageJsonPath, JSON.stringify(packageJson))
+
+        // When
+        const got = await resolveFramework(tmpDir)
+
+        // Then
+        expect(got).toEqual('custom-framework')
+      } finally {
+        _frameworks.pop()
+      }
     })
   })
 })

--- a/packages/cli-kit/src/public/node/framework.ts
+++ b/packages/cli-kit/src/public/node/framework.ts
@@ -151,23 +151,21 @@ const frameworks: Framework[] = [
 export async function resolveFramework(rootDirectory: string): Promise<string> {
   const fwConfigFiles: Record<string, string | undefined> = {}
 
-  const matchedFramework = frameworks.find(
-    (framework) =>
-      (!framework.detectors.some ||
-        framework.detectors.some.reduce(
-          (_previousDetectorsMatch: boolean, detector) =>
-            matchDetector(detector, loadFwConfigFile(rootDirectory, detector.path, fwConfigFiles)),
-          false,
-        )) &&
-      (!framework.detectors.every ||
-        framework.detectors.every.reduce(
-          (previousDetectorsMatch: boolean, detector) =>
-            previousDetectorsMatch
-              ? matchDetector(detector, loadFwConfigFile(rootDirectory, detector.path, fwConfigFiles))
-              : false,
-          true,
-        )),
-  )
+  const matchedFramework = frameworks.find((framework) => {
+    const matchesSome =
+      !framework.detectors.some ||
+      framework.detectors.some.some((detector) =>
+        matchDetector(detector, loadFwConfigFile(rootDirectory, detector.path, fwConfigFiles)),
+      )
+
+    const matchesEvery =
+      !framework.detectors.every ||
+      framework.detectors.every.every((detector) =>
+        matchDetector(detector, loadFwConfigFile(rootDirectory, detector.path, fwConfigFiles)),
+      )
+
+    return matchesSome && matchesEvery
+  })
 
   return matchedFramework ? matchedFramework.name : 'unknown'
 }
@@ -197,3 +195,5 @@ function loadFwConfigFile(
   fwConfigFiles[fwConfigFileName] = rawContent
   return fwConfigFiles
 }
+
+export const _frameworks = frameworks


### PR DESCRIPTION
Refactored resolveFramework in packages/cli-kit/src/public/node/framework.ts to use standard .some() and .every() array helper methods instead of .reduce(). This fixes a bug in the old reduce implementation where the accumulator was not correctly passed on the `some` detectors and enables early exit short-circuiting. Added unit tests for these behaviors in framework.test.ts.

---
*PR created automatically by Jules for task [23259390411241093](https://jules.google.com/task/23259390411241093) started by @gonzaloriestra*