### PR TITLE
Revert "Avoid bundling TypeScript in the production CLI"

### DIFF
--- a/packages/cli/bin/bundle.js
+++ b/packages/cli/bin/bundle.js
@@ -19,8 +19,6 @@ const external = [
   'react-devtools-core',
   // esbuild can't be bundled per design
   'esbuild',
-  // Oclif only uses TypeScript to load source plugins during development
-  'typescript',
   'lightningcss',
   // These two are binary dependencies from Hydrogen that can't be bundled
   '@ast-grep/napi',

--- a/packages/create-app/bin/bundle.js
+++ b/packages/create-app/bin/bundle.js
@@ -14,8 +14,6 @@ const external = [
   'react-devtools-core',
   // esbuild can't be bundled per design
   'esbuild',
-  // Oclif only uses TypeScript to load source plugins during development
-  'typescript',
   'lightningcss',
 ]
 


### PR DESCRIPTION
Reverts Shopify/cli#8248

Using [this snapshot](https://github.com/Shopify/cli/pull/8248#issuecomment-5178033802):

```
❯ shopify app dev
╭─ error ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│                                                                                                                                                           │
│  Cannot find package 'typescript' imported from                                                                                                           │
│  /Users/gonzalo/Library/pnpm/global/5/.pnpm/@shopify+cli@0.0.0-snapshot-20260804105319/node_modules/@shopify/cli/dist/chunk-73JGNLLL.js                   │
│                                                                                                                                                           │
│  To investigate the issue, examine this stack trace:                                                                                                      │
│    at 0-snapshot-20260804105319/node_modules/                                                                                                             │
│    at getPackageJSONURL (node:internal/modules/package_json_reader:301)                                                                                   │
│    at packageResolve (node:internal/modules/esm/resolve:764)                                                                                              │
│    at moduleResolve (node:internal/modules/esm/resolve:855)                                                                                               │
│    at defaultResolve (node:internal/modules/esm/resolve:988)                                                                                              │
│    at #cachedDefaultResolve (node:internal/modules/esm/loader:697)                                                                                        │
│    at #resolveAndMaybeBlockOnLoaderThread (node:internal/modules/esm/loader:714)                                                                          │
│    at resolveSync (node:internal/modules/esm/loader:746)                                                                                                  │
│    at #resolve (node:internal/modules/esm/loader:679)                                                                                                     │
│    at getOrCreateModuleJob (node:internal/modules/esm/loader:599)                                                                                         │
│    at (node:internal/modules/esm/loader:628)                                                                                                              │
│                                                                                                                                                           │
╰───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```