### PR TITLE
Remove .changeset/serve-ui-extension-source-maps-in-dev.md

### DIFF
--- a/.changeset/serve-ui-extension-source-maps-in-dev.md
+++ b/.changeset/serve-ui-extension-source-maps-in-dev.md
@@ -1,5 +1,0 @@
----
-'@shopify/app': patch
----
-
-Serve UI extension source maps during `app dev`


### PR DESCRIPTION
The source-maps fix shipped in **4.6.1** via `stable/4.6` (#8260, released in #8264). Per the release runbook, a cherry-picked changeset should only live on the stable branch — removing it from `main` so the 4.7.0 changelog doesn't list the entry twice.

Same cleanup as e20949f101 after the 4.5.x patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)