### PR TITLE
[Tests] Cover deprecations postrun hook

### DIFF
--- a/packages/cli-kit/src/public/node/hooks/deprecations.test.ts
+++ b/packages/cli-kit/src/public/node/hooks/deprecations.test.ts
@@ -1,0 +1,94 @@
+import {postrun} from './deprecations.js'
+import {getNextDeprecationDate} from '../../../private/node/context/deprecations-store.js'
+import {renderWarning} from '../ui.js'
+import {Command} from '@oclif/core'
+import {describe, expect, test, vi, beforeEach} from 'vitest'
+
+vi.mock('../../../private/node/context/deprecations-store.js')
+vi.mock('../ui.js')
+
+describe('postrun', () => {
+  beforeEach(() => {
+    vi.mocked(getNextDeprecationDate).mockReturnValue(undefined)
+    vi.mocked(renderWarning).mockClear()
+  })
+
+  test('does nothing if getNextDeprecationDate returns undefined', () => {
+    // Given
+    const mockCommand = {
+      id: 'app:dev',
+    } as Command.Class
+
+    // When
+    postrun(mockCommand)
+
+    // Then
+    expect(renderWarning).not.toHaveBeenCalled()
+  })
+
+  test('renders upgrade warning for non-theme command', () => {
+    // Given
+    const deprecationDate = new Date('2025-12-31T00:00:00Z')
+    vi.mocked(getNextDeprecationDate).mockReturnValue(deprecationDate)
+    const mockCommand = {
+      id: 'app:dev',
+    } as Command.Class
+
+    // When
+    postrun(mockCommand)
+
+    // Then
+    expect(renderWarning).toHaveBeenCalledWith(
+      expect.objectContaining({
+        headline: expect.stringContaining('December 31, 2025'),
+        body: 'This command requires an upgrade to continue working as intended.',
+        nextSteps: [
+          [
+            'Run',
+            {command: 'upgrade'},
+            'to',
+            {
+              link: {
+                label: 'upgrade Shopify CLI',
+                url: 'https://shopify.dev/docs/apps/tools/cli#upgrade-shopify-cli',
+              },
+            },
+          ],
+        ],
+      }),
+    )
+  })
+
+  test('renders upgrade warning for theme command', () => {
+    // Given
+    const deprecationDate = new Date('2025-12-31T00:00:00Z')
+    vi.mocked(getNextDeprecationDate).mockReturnValue(deprecationDate)
+    const mockCommand = {
+      id: 'theme:dev',
+    } as Command.Class
+
+    // When
+    postrun(mockCommand)
+
+    // Then
+    expect(renderWarning).toHaveBeenCalledWith(
+      expect.objectContaining({
+        headline: expect.stringContaining('December 31, 2025'),
+        body: 'This command requires an upgrade to continue working as intended.',
+        nextSteps: [
+          [
+            'Run',
+            {command: 'upgrade'},
+            'to',
+            {
+              link: {
+                label: 'upgrade Shopify CLI',
+                url: 'https://shopify.dev/docs/themes/tools/cli#upgrade-shopify-cli',
+              },
+            },
+          ],
+        ],
+      }),
+    )
+  })
+})


### PR DESCRIPTION
Add complete unit test coverage for `packages/cli-kit/src/public/node/hooks/deprecations.ts` under multiple conditional paths (non-theme commands vs theme commands, and when getNextDeprecationDate returns undefined).

---
*PR created automatically by Jules for task [1053317445426373045](https://jules.google.com/task/1053317445426373045) started by @gonzaloriestra*