### PR TITLE
Encode device authorization request parameters

### DIFF
--- a/.changeset/encode-device-authorization-request.md
+++ b/.changeset/encode-device-authorization-request.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': patch
+---
+
+Encode device authorization request parameters safely.

--- a/packages/cli-kit/src/private/node/session/device-authorization.test.ts
+++ b/packages/cli-kit/src/private/node/session/device-authorization.test.ts
@@ -74,17 +74,15 @@ describe('requestDeviceAuthorization', () => {
     vi.mocked(shopifyFetch).mockResolvedValue(response)
     vi.mocked(identityFqdn).mockResolvedValue('fqdn.com')
     vi.mocked(clientId).mockReturnValue('clientId')
-    const scopes = ['scope&name', 'scope=value', 'scope%value']
 
     // When
-    await requestDeviceAuthorization(scopes)
+    await requestDeviceAuthorization(['scope&=%'])
 
     // Then
-    expect(shopifyFetch).toHaveBeenCalledWith('https://fqdn.com/oauth/device_authorization', {
-      method: 'POST',
-      headers: {'Content-type': 'application/x-www-form-urlencoded'},
-      body: 'client_id=clientId&scope=scope%26name+scope%3Dvalue+scope%25value',
-    })
+    expect(shopifyFetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({body: 'client_id=clientId&scope=scope%26%3D%25'}),
+    )
   })
 
   test('omits empty authorization scope values', async () => {

--- a/packages/cli-kit/src/private/node/session/device-authorization.test.ts
+++ b/packages/cli-kit/src/private/node/session/device-authorization.test.ts
@@ -63,9 +63,46 @@ describe('requestDeviceAuthorization', () => {
     expect(shopifyFetch).toBeCalledWith('https://fqdn.com/oauth/device_authorization', {
       method: 'POST',
       headers: {'Content-type': 'application/x-www-form-urlencoded'},
-      body: 'client_id=clientId&scope=scope1 scope2',
+      body: new URLSearchParams({client_id: 'clientId', scope: 'scope1 scope2'}).toString(),
     })
     expect(got).toEqual(dataExpected)
+  })
+
+  test('encodes special characters in authorization scopes', async () => {
+    // Given
+    const response = new Response(JSON.stringify(data))
+    vi.mocked(shopifyFetch).mockResolvedValue(response)
+    vi.mocked(identityFqdn).mockResolvedValue('fqdn.com')
+    vi.mocked(clientId).mockReturnValue('clientId')
+    const scopes = ['scope&name', 'scope=value', 'scope%value']
+
+    // When
+    await requestDeviceAuthorization(scopes)
+
+    // Then
+    expect(shopifyFetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        body: new URLSearchParams({client_id: 'clientId', scope: scopes.join(' ')}).toString(),
+      }),
+    )
+  })
+
+  test('omits empty authorization scope values', async () => {
+    // Given
+    const response = new Response(JSON.stringify(data))
+    vi.mocked(shopifyFetch).mockResolvedValue(response)
+    vi.mocked(identityFqdn).mockResolvedValue('fqdn.com')
+    vi.mocked(clientId).mockReturnValue('clientId')
+
+    // When
+    await requestDeviceAuthorization([])
+
+    // Then
+    expect(shopifyFetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({body: new URLSearchParams({client_id: 'clientId'}).toString()}),
+    )
   })
 
   test('opens the browser directly in an interactive terminal', async () => {

--- a/packages/cli-kit/src/private/node/session/device-authorization.test.ts
+++ b/packages/cli-kit/src/private/node/session/device-authorization.test.ts
@@ -63,7 +63,7 @@ describe('requestDeviceAuthorization', () => {
     expect(shopifyFetch).toBeCalledWith('https://fqdn.com/oauth/device_authorization', {
       method: 'POST',
       headers: {'Content-type': 'application/x-www-form-urlencoded'},
-      body: new URLSearchParams({client_id: 'clientId', scope: 'scope1 scope2'}).toString(),
+      body: 'client_id=clientId&scope=scope1+scope2',
     })
     expect(got).toEqual(dataExpected)
   })

--- a/packages/cli-kit/src/private/node/session/device-authorization.test.ts
+++ b/packages/cli-kit/src/private/node/session/device-authorization.test.ts
@@ -80,12 +80,11 @@ describe('requestDeviceAuthorization', () => {
     await requestDeviceAuthorization(scopes)
 
     // Then
-    expect(shopifyFetch).toHaveBeenCalledWith(
-      expect.any(String),
-      expect.objectContaining({
-        body: new URLSearchParams({client_id: 'clientId', scope: scopes.join(' ')}).toString(),
-      }),
-    )
+    expect(shopifyFetch).toHaveBeenCalledWith('https://fqdn.com/oauth/device_authorization', {
+      method: 'POST',
+      headers: {'Content-type': 'application/x-www-form-urlencoded'},
+      body: 'client_id=clientId&scope=scope%26name+scope%3Dvalue+scope%25value',
+    })
   })
 
   test('omits empty authorization scope values', async () => {
@@ -99,10 +98,11 @@ describe('requestDeviceAuthorization', () => {
     await requestDeviceAuthorization([])
 
     // Then
-    expect(shopifyFetch).toHaveBeenCalledWith(
-      expect.any(String),
-      expect.objectContaining({body: new URLSearchParams({client_id: 'clientId'}).toString()}),
-    )
+    expect(shopifyFetch).toHaveBeenCalledWith('https://fqdn.com/oauth/device_authorization', {
+      method: 'POST',
+      headers: {'Content-type': 'application/x-www-form-urlencoded'},
+      body: 'client_id=clientId',
+    })
   })
 
   test('opens the browser directly in an interactive terminal', async () => {

--- a/packages/cli-kit/src/private/node/session/device-authorization.ts
+++ b/packages/cli-kit/src/private/node/session/device-authorization.ts
@@ -152,10 +152,7 @@ export async function pollForDeviceAuthorization(code: string, interval = 5): Pr
 }
 
 function convertRequestToParams(queryParams: {client_id: string; scope: string}): string {
-  return Object.entries(queryParams)
-    .map(([key, value]) => value && `${key}=${value}`)
-    .filter((hasValue) => Boolean(hasValue))
-    .join('&')
+  return new URLSearchParams(Object.entries(queryParams).filter(([, value]) => Boolean(value))).toString()
 }
 
 /**

--- a/packages/cli-kit/src/private/node/session/device-authorization.ts
+++ b/packages/cli-kit/src/private/node/session/device-authorization.ts
@@ -152,6 +152,7 @@ export async function pollForDeviceAuthorization(code: string, interval = 5): Pr
 }
 
 function convertRequestToParams(queryParams: {client_id: string; scope: string}): string {
+  // URLSearchParams applies form encoding so scope values cannot change the request structure.
   return new URLSearchParams(Object.entries(queryParams).filter(([, value]) => Boolean(value))).toString()
 }
 

--- a/packages/cli-kit/src/private/node/session/device-authorization.ts
+++ b/packages/cli-kit/src/private/node/session/device-authorization.ts
@@ -152,7 +152,6 @@ export async function pollForDeviceAuthorization(code: string, interval = 5): Pr
 }
 
 function convertRequestToParams(queryParams: {client_id: string; scope: string}): string {
-  // URLSearchParams applies form encoding so scope values cannot change the request structure.
   return new URLSearchParams(Object.entries(queryParams).filter(([, value]) => Boolean(value))).toString()
 }
 


### PR DESCRIPTION
### WHY are these changes introduced?

The device authorization request built its `application/x-www-form-urlencoded` body by string concatenation without encoding. Scopes are joined with spaces, so the body carried literal spaces, and any `&`, `=`, or `%` in a value could change the request structure. It works today only because the server is lenient. The token endpoint in `exchange.ts` already uses `URLSearchParams` for the same reason.

### WHAT is this pull request doing?

- Build the device authorization body with `URLSearchParams`, matching the existing token-request precedent.
- Preserve the current behavior of omitting empty values (an empty scope string stays out of the body).
- Pin the request in tests: exact URL, method, `Content-Type`, and a hand-written encoded body (spaces as `+`, `%26`/`%3D`/`%25` for reserved characters), so the expectation does not depend on `URLSearchParams` itself.

One pre-existing assertion changes from the unencoded body to the encoded form — that wire change is the fix. No change to prompts, returned data, or requested scopes.

### How to test your changes?

Run `shopify auth logout`, then any authenticated command (for example `shopify theme list`). Device login completes as before; the request body is now correctly encoded.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [x] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`