### PR TITLE
[Prototype] Add @shopify/dev-platform-auth package skeleton

### DIFF
--- a/.changeset/bright-auth-skeleton.md
+++ b/.changeset/bright-auth-skeleton.md
@@ -1,0 +1,5 @@
+---
+'@shopify/dev-platform-auth': minor
+---
+
+Add the `@shopify/dev-platform-auth` package skeleton.

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -12,7 +12,8 @@
     "@shopify/cli-kit",
     "@shopify/theme",
     "@shopify/plugin-cloudflare",
-    "@shopify/plugin-did-you-mean"
+    "@shopify/plugin-did-you-mean",
+    "@shopify/dev-platform-auth"
   ]],
   "access": "public",
   "baseBranch": "main",

--- a/package.json
+++ b/package.json
@@ -248,6 +248,17 @@
           ]
         }
       },
+      "packages/dev-platform-auth": {
+        "entry": [
+          "**/index.ts!"
+        ],
+        "project": "**/*.ts!",
+        "vite": {
+          "config": [
+            "vite.config.ts"
+          ]
+        }
+      },
       "packages/store": {
         "entry": [
           "**/{commands,hooks}/**/*.ts!",

--- a/packages/dev-platform-auth/README.md
+++ b/packages/dev-platform-auth/README.md
@@ -2,6 +2,6 @@
 
 `@shopify/dev-platform-auth` provides portable Shopify developer auth flows.
 
-This package is currently a contract prototype. It defines the shared protocol types and `AuthProtocolError`; Identity device flow, `client_credentials`, and Store PKCE runtime modules will arrive in subsequent pull requests.
+This package is currently a contract prototype. It defines separate Identity credential and application-access contracts plus `AuthProtocolError`; Identity device flow, `client_credentials`, and Store PKCE runtime modules will arrive in subsequent pull requests.
 
 The portability contract is ESM on Node.js >=20, with no Node built-ins in the `.` entry. Only `.` and `./testing` are exported.

--- a/packages/dev-platform-auth/README.md
+++ b/packages/dev-platform-auth/README.md
@@ -1,0 +1,7 @@
+# @shopify/dev-platform-auth
+
+`@shopify/dev-platform-auth` provides portable Shopify developer auth flows.
+
+This package is currently a skeleton. Identity device flow and `client_credentials` flow modules will arrive in subsequent pull requests.
+
+The portability contract is ESM on Node.js >=20, with no Node built-ins in the `.` entry. Only `.` and `./testing` are exported.

--- a/packages/dev-platform-auth/README.md
+++ b/packages/dev-platform-auth/README.md
@@ -2,6 +2,6 @@
 
 `@shopify/dev-platform-auth` provides portable Shopify developer auth flows.
 
-This package is currently a skeleton. Identity device flow and `client_credentials` flow modules will arrive in subsequent pull requests.
+This package is currently a contract prototype. It defines the shared protocol types and `AuthProtocolError`; Identity device flow, `client_credentials`, and Store PKCE runtime modules will arrive in subsequent pull requests.
 
 The portability contract is ESM on Node.js >=20, with no Node built-ins in the `.` entry. Only `.` and `./testing` are exported.

--- a/packages/dev-platform-auth/package.json
+++ b/packages/dev-platform-auth/package.json
@@ -1,0 +1,56 @@
+{
+  "name": "@shopify/dev-platform-auth",
+  "version": "4.6.0",
+  "packageManager": "pnpm@10.11.1",
+  "private": false,
+  "description": "Portable Shopify developer auth flows",
+  "homepage": "https://github.com/shopify/cli#readme",
+  "bugs": {
+    "url": "https://community.shopify.dev/c/shopify-cli-libraries/14"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Shopify/cli.git",
+    "directory": "packages/dev-platform-auth"
+  },
+  "license": "MIT",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "node": "./dist/index.js"
+    },
+    "./testing": {
+      "types": "./dist/testing/index.d.ts",
+      "import": "./dist/testing/index.js",
+      "node": "./dist/testing/index.js"
+    }
+  },
+  "files": ["dist"],
+  "scripts": {
+    "build": "nx build",
+    "clean": "nx clean",
+    "lint": "nx lint",
+    "lint:fix": "nx lint:fix",
+    "type-check": "nx type-check",
+    "vitest": "vitest"
+  },
+  "eslintConfig": {
+    "extends": ["../../.eslintrc.cjs"]
+  },
+  "devDependencies": {
+    "@types/node": "18.19.130",
+    "@vitest/coverage-istanbul": "^3.2.7",
+    "esbuild": "0.28.1"
+  },
+  "engines": {
+    "node": ">=20.10.0"
+  },
+  "publishConfig": {
+    "@shopify:registry": "https://registry.npmjs.org",
+    "access": "public"
+  },
+  "sideEffects": false,
+  "engine-strict": true
+}

--- a/packages/dev-platform-auth/project.json
+++ b/packages/dev-platform-auth/project.json
@@ -1,0 +1,46 @@
+{
+  "name": "dev-platform-auth",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/dev-platform-auth/src",
+  "projectType": "library",
+  "tags": ["scope:foundation"],
+  "targets": {
+    "clean": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm rimraf dist/",
+        "cwd": "packages/dev-platform-auth"
+      }
+    },
+    "build": {
+      "executor": "nx:run-commands",
+      "outputs": ["{workspaceRoot}/packages/dev-platform-auth/dist"],
+      "inputs": ["{projectRoot}/src/**/*", "{projectRoot}/package.json", "{projectRoot}/tsconfig.build.json"],
+      "options": {
+        "command": "pnpm tsc -b ./tsconfig.build.json",
+        "cwd": "packages/dev-platform-auth"
+      }
+    },
+    "lint": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm eslint src",
+        "cwd": "packages/dev-platform-auth"
+      }
+    },
+    "lint:fix": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm eslint src --fix",
+        "cwd": "packages/dev-platform-auth"
+      }
+    },
+    "type-check": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm tsc --noEmit",
+        "cwd": "packages/dev-platform-auth"
+      }
+    }
+  }
+}

--- a/packages/dev-platform-auth/src/index.ts
+++ b/packages/dev-platform-auth/src/index.ts
@@ -17,20 +17,20 @@ export interface ApplicationToken {
   storeFqdn?: string
 }
 
-export interface Session {
-  identity: IdentityToken
-  applications: Record<string, ApplicationToken>
-}
-
 export type ShopifyApplication = 'admin' | 'partners' | 'storefront-renderer' | 'business-platform' | 'app-management'
 
-export interface IdentityClientConfig {
+export interface AuthClientConfig {
   identityOrigin: string
   clientId: string
-  applicationIds: Record<ShopifyApplication, string>
   fetch?: AuthFetch
   clock?: Clock
   logger?: AuthLogger
+}
+
+export interface IdentityClientConfig extends AuthClientConfig {}
+
+export interface ApplicationAccessConfig extends AuthClientConfig {
+  applicationIds: Record<ShopifyApplication, string>
 }
 
 export interface AuthFetchResponse {
@@ -112,6 +112,9 @@ export interface IdentityClient {
   requestDeviceAuthorization(options: {scopes: string[]; signal?: AuthSignal}): Promise<DeviceAuthorization>
   exchangeDeviceCode(options: {deviceCode: string; signal?: AuthSignal}): Promise<DeviceCodeExchangeResult>
   refreshIdentityToken(options: {token: IdentityToken; signal?: AuthSignal}): Promise<IdentityToken>
+}
+
+export interface ApplicationAccessClient {
   exchangeApplicationToken(request: ApplicationTokenRequest): Promise<ApplicationToken>
 }
 

--- a/packages/dev-platform-auth/src/index.ts
+++ b/packages/dev-platform-auth/src/index.ts
@@ -1,3 +1,153 @@
 export const PACKAGE_NAME = '@shopify/dev-platform-auth'
 
-export type AuthFlowPlaceholder = 'skeleton'
+/** Epoch-millisecond credentials shared by auth adapters. */
+export interface IdentityToken {
+  accessToken: string
+  refreshToken: string
+  expiresAt: number
+  scopes: string[]
+  userId: string
+  alias?: string
+}
+
+export interface ApplicationToken {
+  accessToken: string
+  expiresAt: number
+  scopes: string[]
+  storeFqdn?: string
+}
+
+export interface Session {
+  identity: IdentityToken
+  applications: Record<string, ApplicationToken>
+}
+
+export type ShopifyApplication = 'admin' | 'partners' | 'storefront-renderer' | 'business-platform' | 'app-management'
+
+export interface IdentityClientConfig {
+  identityOrigin: string
+  clientId: string
+  applicationIds: Record<ShopifyApplication, string>
+  fetch?: AuthFetch
+  clock?: Clock
+  logger?: AuthLogger
+}
+
+export interface AuthFetchResponse {
+  ok: boolean
+  status: number
+  text(): Promise<string>
+}
+
+export interface AuthSignal {
+  readonly aborted: boolean
+  addEventListener(type: 'abort', listener: () => void, options?: {once?: boolean}): void
+  removeEventListener(type: 'abort', listener: () => void): void
+}
+
+export type AuthFetch = (
+  url: string,
+  init: {
+    method: string
+    headers: Record<string, string>
+    body?: string
+    signal?: AuthSignal
+  },
+) => Promise<AuthFetchResponse>
+
+export interface Clock {
+  now(): number
+  sleep?(milliseconds: number, signal?: AuthSignal): Promise<void>
+}
+
+export type AuthLogEvent =
+  | {
+      event: 'device_authorization_started' | 'device_authorization_completed'
+      application?: ShopifyApplication
+    }
+  | {
+      event: 'device_authorization_pending' | 'device_authorization_slow_down'
+      application?: ShopifyApplication
+    }
+  | {
+      event: 'auth_protocol_error'
+      code: AuthErrorCode
+      status?: number
+    }
+
+export interface AuthLogger {
+  debug(event: AuthLogEvent): void
+}
+
+export interface DeviceAuthorization {
+  userCode: string
+  verificationUri: string
+  verificationUriComplete?: string
+  expiresIn: number
+  interval?: number
+}
+
+export type DeviceCodeExchangeResult =
+  | {status: 'complete'; token: IdentityToken}
+  | {status: 'pending'}
+  | {status: 'slow_down'}
+
+export interface BaseApplicationTokenRequest {
+  identityToken: string
+  scopes: string[]
+  signal?: AuthSignal
+}
+
+export type ApplicationTokenRequest =
+  | (BaseApplicationTokenRequest & {
+      application: 'admin'
+      storeFqdn: string
+    })
+  | (BaseApplicationTokenRequest & {
+      application: Exclude<ShopifyApplication, 'admin'>
+      storeFqdn?: never
+    })
+
+export interface IdentityClient {
+  requestDeviceAuthorization(options: {scopes: string[]; signal?: AuthSignal}): Promise<DeviceAuthorization>
+  exchangeDeviceCode(options: {deviceCode: string; signal?: AuthSignal}): Promise<DeviceCodeExchangeResult>
+  refreshIdentityToken(options: {token: IdentityToken; signal?: AuthSignal}): Promise<IdentityToken>
+  exchangeApplicationToken(request: ApplicationTokenRequest): Promise<ApplicationToken>
+}
+
+export interface ClientCredentialsTokenRequest {
+  storeFqdn: string
+  clientId: string
+  clientSecret: string
+  signal?: AuthSignal
+}
+
+export interface ClientCredentialsClient {
+  requestToken(options: ClientCredentialsTokenRequest): Promise<ApplicationToken>
+}
+
+export type AuthErrorCode =
+  | 'invalid_grant'
+  | 'invalid_request'
+  | 'invalid_target'
+  | 'access_denied'
+  | 'expired_token'
+  | 'invalid_response'
+  | 'app_not_installed'
+  | 'unknown'
+
+export interface AuthProtocolErrorOptions {
+  status?: number
+}
+
+export class AuthProtocolError extends Error {
+  readonly code: AuthErrorCode
+  readonly status?: number
+
+  constructor(code: AuthErrorCode, options: AuthProtocolErrorOptions = {}) {
+    super(code)
+    this.name = 'AuthProtocolError'
+    this.code = code
+    this.status = options.status
+  }
+}

--- a/packages/dev-platform-auth/src/index.ts
+++ b/packages/dev-platform-auth/src/index.ts
@@ -1,0 +1,3 @@
+export const PACKAGE_NAME = '@shopify/dev-platform-auth'
+
+export type AuthFlowPlaceholder = 'skeleton'

--- a/packages/dev-platform-auth/src/portability.test.ts
+++ b/packages/dev-platform-auth/src/portability.test.ts
@@ -1,0 +1,38 @@
+/* eslint-disable no-restricted-imports, import-x/order */
+import {execFileSync} from 'node:child_process'
+import {readFileSync} from 'node:fs'
+import {resolve} from 'node:path'
+import {build} from 'esbuild'
+import {describe, expect, test} from 'vitest'
+
+const packageRoot = resolve(__dirname, '..')
+const entry = resolve(packageRoot, 'dist/index.js')
+
+function buildPackage() {
+  execFileSync('pnpm', ['exec', 'nx', 'build', 'dev-platform-auth'], {
+    cwd: resolve(packageRoot, '../..'),
+    stdio: 'ignore',
+  })
+}
+
+describe('package portability', () => {
+  test('can be consumed by plain JavaScript', () => {
+    buildPackage()
+    execFileSync(process.execPath, [resolve(packageRoot, 'tests/consumer.mjs')], {stdio: 'pipe'})
+  })
+
+  test('does not include Node built-ins or CommonJS in the portable entry', () => {
+    buildPackage()
+    const output = readFileSync(entry, 'utf8')
+    const nodeBuiltins =
+      /(?:node:)?(?:assert|buffer|child_process|cluster|crypto|dgram|dns|events|fs|http|https|module|net|os|path|perf_hooks|process|querystring|readline|stream|string_decoder|timers|tls|tty|url|util|v8|vm|worker_threads|zlib)/
+
+    expect(output).not.toMatch(nodeBuiltins)
+    expect(output).not.toContain('require(')
+  })
+
+  test('bundles for browsers without external dependencies', async () => {
+    buildPackage()
+    await expect(build({entryPoints: [entry], bundle: true, platform: 'browser', write: false})).resolves.toBeDefined()
+  })
+})

--- a/packages/dev-platform-auth/src/testing/index.ts
+++ b/packages/dev-platform-auth/src/testing/index.ts
@@ -1,0 +1,1 @@
+export const TESTING_PACKAGE_NAME = '@shopify/dev-platform-auth/testing'

--- a/packages/dev-platform-auth/tests/consumer.mjs
+++ b/packages/dev-platform-auth/tests/consumer.mjs
@@ -1,0 +1,5 @@
+import {PACKAGE_NAME} from '../dist/index.js'
+
+if (PACKAGE_NAME !== '@shopify/dev-platform-auth') {
+  throw new Error(`Unexpected package name: ${PACKAGE_NAME}`)
+}

--- a/packages/dev-platform-auth/tsconfig.build.json
+++ b/packages/dev-platform-auth/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["**/*.test.ts"]
+}

--- a/packages/dev-platform-auth/tsconfig.json
+++ b/packages/dev-platform-auth/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../configurations/tsconfig.json",
+  "include": ["./src/**/*.ts"],
+  "exclude": ["./dist"],
+  "compilerOptions": {
+    "lib": ["ES2022"],
+    "target": "ES2022",
+    "outDir": "dist",
+    "rootDir": "src",
+    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo",
+    "types": ["node", "vitest/importMeta"]
+  },
+  "references": []
+}

--- a/packages/dev-platform-auth/vite.config.ts
+++ b/packages/dev-platform-auth/vite.config.ts
@@ -1,0 +1,3 @@
+import config from '../../configurations/vite.config'
+
+export default config(__dirname)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -544,6 +544,18 @@ importers:
         specifier: ^2.1.1
         version: 2.1.1(esbuild@0.28.1)
 
+  packages/dev-platform-auth:
+    devDependencies:
+      '@types/node':
+        specifier: 18.19.130
+        version: 18.19.130
+      '@vitest/coverage-istanbul':
+        specifier: ^3.2.7
+        version: 3.2.7(vitest@4.1.10)
+      esbuild:
+        specifier: 0.28.1
+        version: 0.28.1
+
   packages/e2e:
     devDependencies:
       '@iarna/toml':


### PR DESCRIPTION
> [!NOTE]
> **Prototype.** This PR is design evidence for the portable Shopify auth effort. It is not a merge candidate until the extraction project and app-sdk PoC are approved.

### WHY are these changes introduced?

Define the consumer-neutral auth contract before moving protocol code. The shared package must support cli-kit and app-sdk without importing CLI storage, UI, environment, analytics, or app-sdk host code.

App-sdk is a co-evolving PoC. Its current facade is not a compatibility constraint, but Identity and Store PKCE behavior must remain compatible with the shared protocol fixtures.

### WHAT is this pull request doing?

- Adds epoch-millisecond identity and application-token types.
- Separates Identity credential operations from application-access operations and configuration.
- Defines structural transport, clock, optional cancellation, and safe logging ports.
- Defines device authorization and one-shot pending/slow-down/complete results without exposing `deviceCode`.
- Defines narrowed Admin/non-Admin application-token requests.
- Adds a secret-safe `AuthProtocolError` runtime class.
- Keeps the package free of network behavior, persistence, UI, environment reads, and runtime dependencies.

Store PKCE and runtime flow modules remain follow-up work.

### How to test your changes?

From the CLI repository:

```sh
pnpm --filter @shopify/dev-platform-auth type-check
pnpm --filter @shopify/dev-platform-auth lint
pnpm --filter @shopify/dev-platform-auth build
pnpm --filter @shopify/dev-platform-auth vitest run src/portability.test.ts
```

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible documentation changes; package README included
- [x] I've considered analytics changes; none apply
- [x] The package contract has no runtime dependencies or Node built-ins
