### PR TITLE
[Refactor] Refactor setMimeTypes in mimes.ts to be declarative

### DIFF
--- a/packages/cli-kit/src/public/node/mimes.ts
+++ b/packages/cli-kit/src/public/node/mimes.ts
@@ -17,7 +17,5 @@ export function lookupMimeType(fileName: string): string {
  * @param newTypes - Object of key-values where key is extension and value is mime type.
  */
 export function setMimeTypes(newTypes: Record<string, string>): void {
-  Object.entries(newTypes).forEach(([extension, mimeType]) => {
-    mimes[extension] = mimeType
-  })
+  Object.assign(mimes, newTypes)
 }


### PR DESCRIPTION
### WHY are these changes introduced?

The imperative `Object.entries(newTypes).forEach(([extension, mimeType]) => { mimes[extension] = mimeType })` loop is verbose and can be replaced with a much cleaner, declarative and standard JS built-in mechanism.

### WHAT is this pull request doing?

Refactors `setMimeTypes` in `packages/cli-kit/src/public/node/mimes.ts` to use `Object.assign(mimes, newTypes)`.

### How to test your changes?

CI

### Post-release steps

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [6836511310053491875](https://jules.google.com/task/6836511310053491875) started by @gonzaloriestra*