### PR TITLE
[Tests] Add coverage for theme configuration helpers

### DIFF
--- a/packages/cli-kit/src/public/node/themes/conf.test.ts
+++ b/packages/cli-kit/src/public/node/themes/conf.test.ts
@@ -1,0 +1,52 @@
+import {getHostTheme, setHostTheme, removeHostTheme, hostThemeLocalStorage} from './conf.js'
+import {describe, test, expect, vi, beforeEach} from 'vitest'
+
+vi.mock('../local-storage.js', () => {
+  return {
+    LocalStorage: class {
+      get = vi.fn()
+      set = vi.fn()
+      delete = vi.fn()
+    },
+  }
+})
+
+describe('conf', () => {
+  beforeEach(() => {
+    const storage = hostThemeLocalStorage()
+    vi.mocked(storage.get).mockReset()
+    vi.mocked(storage.set).mockReset()
+    vi.mocked(storage.delete).mockReset()
+  })
+
+  test('getHostTheme gets theme from local storage', () => {
+    const storage = hostThemeLocalStorage()
+    vi.mocked(storage.get).mockReturnValue('12345')
+
+    const got = getHostTheme('example.myshopify.com')
+
+    expect(got).toBe('12345')
+    expect(storage.get).toHaveBeenCalledWith('example.myshopify.com')
+  })
+
+  test('setHostTheme sets theme in local storage', () => {
+    const storage = hostThemeLocalStorage()
+
+    setHostTheme('example.myshopify.com', '12345')
+
+    expect(storage.set).toHaveBeenCalledWith('example.myshopify.com', '12345')
+  })
+
+  test('removeHostTheme deletes theme from local storage', () => {
+    const storage = hostThemeLocalStorage()
+
+    removeHostTheme('example.myshopify.com')
+
+    expect(storage.delete).toHaveBeenCalledWith('example.myshopify.com')
+  })
+
+  test('hostThemeLocalStorage returns LocalStorage instance', () => {
+    const storage = hostThemeLocalStorage()
+    expect(storage).toBeDefined()
+  })
+})


### PR DESCRIPTION
### WHY are these changes introduced?

To increase test coverage and ensure reliability of the theme configuration helper functions.

### WHAT is this pull request doing?

It implements comprehensive unit tests for `getHostTheme`, `setHostTheme`, `removeHostTheme`, and `hostThemeLocalStorage` in `packages/cli-kit/src/public/node/themes/conf.test.ts`.

### How to test your changes?

CI

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [10172262455545163376](https://jules.google.com/task/10172262455545163376) started by @gonzaloriestra*