### PR TITLE
[Security] Prevent argument injection in git repository initialization

### DIFF
--- a/packages/cli-kit/src/public/node/git.test.ts
+++ b/packages/cli-kit/src/public/node/git.test.ts
@@ -184,6 +184,15 @@ describe('initializeRepository()', () => {
     expect(mockedExeca).toHaveBeenCalledWith('git', ['init'], {cwd: directory})
     expect(mockedExeca).toHaveBeenCalledWith('git', ['checkout', '-b', 'my-branch'], {cwd: directory})
   })
+
+  test('throws an error if the initial branch starts with a hyphen', async () => {
+    const directory = '/tmp/git-repo'
+
+    await expect(git.initializeGitRepository(directory, '-invalid-branch')).rejects.toThrowError(
+      /Invalid initial branch name: -invalid-branch. Branch names can't start with a hyphen./,
+    )
+    expect(mockedExeca).not.toHaveBeenCalled()
+  })
 })
 
 describe('createGitIgnore()', () => {

--- a/packages/cli-kit/src/public/node/git.ts
+++ b/packages/cli-kit/src/public/node/git.ts
@@ -51,6 +51,11 @@ async function gitCommand(args: string[], directory?: string): Promise<string> {
  * @param initialBranch - The name of the initial branch.
  */
 export async function initializeGitRepository(directory: string, initialBranch = 'main'): Promise<void> {
+  // Guard against command/argument injection attacks if initialBranch starts with '-'
+  if (initialBranch.startsWith('-')) {
+    throw new AbortError(`Invalid initial branch name: ${initialBranch}. Branch names can't start with a hyphen.`)
+  }
+
   outputDebug(outputContent`Initializing git repository at ${outputToken.path(directory)}...`)
   await ensureGitIsPresentOrAbort()
   // We use init and checkout instead of `init --initial-branch` because the latter is only supported in git 2.28+


### PR DESCRIPTION
This pull request hardens git repository initialization against argument and option injection by verifying that the initial branch name does not start with a hyphen (`-`). Corresponding unit tests are added in `git.test.ts` to ensure this behavior.

---
*PR created automatically by Jules for task [10018993654953565653](https://jules.google.com/task/10018993654953565653) started by @gonzaloriestra*