### PR TITLE
[Performance] Optimize intermediate array operations in fetchOptionalOrganizationShop

### DIFF
--- a/packages/store/src/cli/utilities/store-lookup/organization-shop.ts
+++ b/packages/store/src/cli/utilities/store-lookup/organization-shop.ts
@@ -46,7 +46,7 @@ export async function fetchOptionalOrganizationShop(
 
   const edges = response.organization?.accessibleShops?.edges ?? []
   const lowerStore = options.store.toLowerCase()
-  const matched = edges.map((edge) => edge.node).find((node) => extractHost(node.primaryDomain) === lowerStore)
+  const matched = edges.find((edge) => extractHost(edge.node.primaryDomain) === lowerStore)?.node
 
   if (!matched) return undefined
 


### PR DESCRIPTION
Optimizes `fetchOptionalOrganizationShop` by replacing `edges.map(...).find(...)` with `edges.find(...)?.node`. This avoids allocating an intermediate array and enables lazy-evaluation (early exit) during store search operations.

---
*PR created automatically by Jules for task [6385341017887946003](https://jules.google.com/task/6385341017887946003) started by @gonzaloriestra*