### PR TITLE
[Tests] Cover TomlFile decode fallback error path

### DIFF
--- a/packages/cli-kit/src/public/node/toml/toml-file.test.ts
+++ b/packages/cli-kit/src/public/node/toml/toml-file.test.ts
@@ -1,8 +1,17 @@
 import {TomlFile, TomlFileError} from './toml-file.js'
+import {decodeToml} from './codec.js'
 import {shouldReportErrorAsUnexpected} from '../error.js'
 import {writeFile, readFile, inTemporaryDirectory} from '../fs.js'
 import {joinPath} from '../path.js'
-import {describe, expect, test} from 'vitest'
+import {describe, expect, test, vi} from 'vitest'
+
+vi.mock('./codec.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./codec.js')>()
+  return {
+    ...actual,
+    decodeToml: vi.fn(actual.decodeToml),
+  }
+})
 
 describe('TomlFile', () => {
   describe('read', () => {
@@ -53,6 +62,19 @@ describe('TomlFile', () => {
 
     test('throws TomlFileError if file does not exist', async () => {
       await expect(TomlFile.read('/nonexistent/path/test.toml')).rejects.toThrow(TomlFileError)
+    })
+
+    test('throws the original error when decoding fails with an error that lacks row/col information', async () => {
+      await inTemporaryDirectory(async (dir) => {
+        const path = joinPath(dir, 'test.toml')
+        await writeFile(path, 'name = "app"\n')
+
+        vi.mocked(decodeToml).mockImplementationOnce(() => {
+          throw new Error('Some internal decode error')
+        })
+
+        await expect(TomlFile.read(path)).rejects.toThrow('Some internal decode error')
+      })
     })
   })
 


### PR DESCRIPTION
### WHY are these changes introduced?

There was a coverage gap on the TOML decoding error fallback path in `toml-file.ts` (specifically line 149), where decoding errors that do not contain `.line` or `.col` were not covered by tests.

### WHAT is this pull request doing?

This pull request introduces a unit test in `packages/cli-kit/src/public/node/toml/toml-file.test.ts` to cover this exact fallback branch. It mocks `decodeToml` to throw a generic error during `TomlFile.read`, ensuring that the original error is propagated and raising `toml-file.ts` coverage to 100%.

### How to test your changes?

CI

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [602823037343178907](https://jules.google.com/task/602823037343178907) started by @gonzaloriestra*