### PR TITLE
Lazy-load app context in the public_command_metadata analytics hook

### DIFF
--- a/packages/app/src/cli/constants.ts
+++ b/packages/app/src/cli/constants.ts
@@ -8,6 +8,9 @@ export const environmentVariableNames = {
   disableMinificationOnDev: 'SHOPIFY_CLI_DISABLE_MINIFICATION_ON_DEV',
 }
 
+// Matches the default config file (shopify.app.toml) and named configs (shopify.app.<name>.toml)
+export const appConfigurationFileGlob = 'shopify.app*.toml'
+
 export const configurationFileNames = {
   app: 'shopify.app.toml',
   web: 'shopify.web.toml',

--- a/packages/app/src/cli/hooks/public_metadata.test.ts
+++ b/packages/app/src/cli/hooks/public_metadata.test.ts
@@ -2,51 +2,85 @@ import gatherPublicMetadata from './public_metadata.js'
 import {localAppContext} from '../services/app-context.js'
 import metadata from '../metadata.js'
 import {describe, expect, test, vi, beforeEach} from 'vitest'
-import {cwd} from '@shopify/cli-kit/node/path'
+import {cwd, joinPath} from '@shopify/cli-kit/node/path'
+import {inTemporaryDirectory, writeFile} from '@shopify/cli-kit/node/fs'
 
 vi.mock('../services/app-context.js')
-vi.mock('@shopify/cli-kit/node/path')
+vi.mock('@shopify/cli-kit/node/path', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@shopify/cli-kit/node/path')>()
+  return {...actual, cwd: vi.fn()}
+})
+
+async function inTemporaryAppProject(runTest: (appDirectory: string) => Promise<void>): Promise<void> {
+  await inTemporaryDirectory(async (tmpDir) => {
+    await writeFile(joinPath(tmpDir, 'shopify.app.toml'), '')
+    await runTest(tmpDir)
+  })
+}
 
 describe('gatherPublicMetadata', () => {
   beforeEach(() => {
-    vi.mocked(cwd).mockReturnValue('/some/app/dir')
     vi.mocked(localAppContext).mockResolvedValue({} as Awaited<ReturnType<typeof localAppContext>>)
   })
 
   test('opportunistically enriches metadata from the current directory and returns the public metadata', async () => {
-    // Given
-    vi.spyOn(metadata, 'getAllPublicMetadata').mockReturnValueOnce({}).mockReturnValue({api_key: 'from-loader'})
+    await inTemporaryAppProject(async (appDirectory) => {
+      // Given
+      vi.mocked(cwd).mockReturnValue(appDirectory)
+      vi.spyOn(metadata, 'getAllPublicMetadata').mockReturnValueOnce({}).mockReturnValue({api_key: 'from-loader'})
 
-    // When
-    const result = await (gatherPublicMetadata as () => Promise<unknown>)()
+      // When
+      const result = await (gatherPublicMetadata as () => Promise<unknown>)()
 
-    // Then
-    expect(localAppContext).toHaveBeenCalledWith({directory: '/some/app/dir', skipPrompts: true})
-    expect(result).toEqual(metadata.getAllPublicMetadata())
+      // Then
+      expect(localAppContext).toHaveBeenCalledWith({directory: appDirectory, skipPrompts: true})
+      expect(result).toEqual(metadata.getAllPublicMetadata())
+    })
   })
 
   test('skips local app loading when api_key is already set', async () => {
-    // Given
-    vi.spyOn(metadata, 'getAllPublicMetadata').mockReturnValue({api_key: 'already-set'})
+    await inTemporaryAppProject(async (appDirectory) => {
+      // Given
+      vi.mocked(cwd).mockReturnValue(appDirectory)
+      vi.spyOn(metadata, 'getAllPublicMetadata').mockReturnValue({api_key: 'already-set'})
 
-    // When
-    const result = await (gatherPublicMetadata as () => Promise<unknown>)()
+      // When
+      const result = await (gatherPublicMetadata as () => Promise<unknown>)()
 
-    // Then
-    expect(localAppContext).not.toHaveBeenCalled()
-    expect(result).toEqual(metadata.getAllPublicMetadata())
+      // Then
+      expect(localAppContext).not.toHaveBeenCalled()
+      expect(result).toEqual(metadata.getAllPublicMetadata())
+    })
+  })
+
+  test('skips local app loading when the directory is not inside an app project', async () => {
+    await inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      vi.mocked(cwd).mockReturnValue(tmpDir)
+      vi.spyOn(metadata, 'getAllPublicMetadata').mockReturnValue({})
+
+      // When
+      const result = await (gatherPublicMetadata as () => Promise<unknown>)()
+
+      // Then
+      expect(localAppContext).not.toHaveBeenCalled()
+      expect(result).toEqual(metadata.getAllPublicMetadata())
+    })
   })
 
   test('still returns metadata when best-effort app loading fails', async () => {
-    // Given
-    vi.spyOn(metadata, 'getAllPublicMetadata').mockReturnValue({})
-    vi.mocked(localAppContext).mockRejectedValue(new Error('not an app'))
+    await inTemporaryAppProject(async (appDirectory) => {
+      // Given
+      vi.mocked(cwd).mockReturnValue(appDirectory)
+      vi.spyOn(metadata, 'getAllPublicMetadata').mockReturnValue({})
+      vi.mocked(localAppContext).mockRejectedValue(new Error('not an app'))
 
-    // When
-    const result = await (gatherPublicMetadata as () => Promise<unknown>)()
+      // When
+      const result = await (gatherPublicMetadata as () => Promise<unknown>)()
 
-    // Then
-    expect(localAppContext).toHaveBeenCalledOnce()
-    expect(result).toEqual(metadata.getAllPublicMetadata())
+      // Then
+      expect(localAppContext).toHaveBeenCalledOnce()
+      expect(result).toEqual(metadata.getAllPublicMetadata())
+    })
   })
 })

--- a/packages/app/src/cli/hooks/public_metadata.ts
+++ b/packages/app/src/cli/hooks/public_metadata.ts
@@ -1,15 +1,31 @@
 import metadata from '../metadata.js'
-import {localAppContext} from '../services/app-context.js'
+import {appConfigurationFileGlob} from '../constants.js'
 import {FanoutHookFunction} from '@shopify/cli-kit/node/plugins'
-import {cwd} from '@shopify/cli-kit/node/path'
+import {cwd, joinPath} from '@shopify/cli-kit/node/path'
+import {findPathUp, glob} from '@shopify/cli-kit/node/fs'
 
 const APP_CONTEXT_METADATA_TIMEOUT_MS = 3000
+
+async function insideAppProject(directory: string): Promise<boolean> {
+  const found = await findPathUp(
+    async (candidateDirectory) => {
+      const matches = await glob(joinPath(candidateDirectory, appConfigurationFileGlob))
+      if (matches.length > 0) return candidateDirectory
+    },
+    {cwd: directory, type: 'directory'},
+  )
+  return found !== undefined
+}
 
 async function logAppContextMetadata(directory: string): Promise<void> {
   let timer: ReturnType<typeof setTimeout> | undefined
   try {
     if (metadata.getAllPublicMetadata().api_key !== undefined) return
+    if (!(await insideAppProject(directory))) return
 
+    // Loading the app context pulls in a large module graph, so only import it
+    // once we know the command ran inside an app project.
+    const {localAppContext} = await import('../services/app-context.js')
     await Promise.race([
       localAppContext({directory, skipPrompts: true}),
       new Promise<void>((resolve) => {

--- a/packages/app/src/cli/models/project/project.ts
+++ b/packages/app/src/cli/models/project/project.ts
@@ -1,4 +1,4 @@
-import {configurationFileNames} from '../../constants.js'
+import {appConfigurationFileGlob, configurationFileNames} from '../../constants.js'
 import {TomlFile, TomlFileError} from '@shopify/cli-kit/node/toml/toml-file'
 import {readAndParseDotEnv, DotEnvFile} from '@shopify/cli-kit/node/dot-env'
 import {fileExists, glob, findPathUp, readFile} from '@shopify/cli-kit/node/fs'
@@ -12,7 +12,7 @@ import {joinPath, basename} from '@shopify/cli-kit/node/path'
 import {AbortError} from '@shopify/cli-kit/node/error'
 import {JsonMapType} from '@shopify/cli-kit/node/toml'
 
-const APP_CONFIG_GLOB = 'shopify.app*.toml'
+const APP_CONFIG_GLOB = appConfigurationFileGlob
 const APP_CONFIG_REGEX = /^shopify\.app(\.[-\w]+)?\.toml$/
 const EXTENSION_TOML = '*.extension.toml'
 const WEB_TOML = 'shopify.web.toml'

--- a/packages/cli-kit/src/private/node/otel-metrics.test.ts
+++ b/packages/cli-kit/src/private/node/otel-metrics.test.ts
@@ -26,11 +26,13 @@ describe('otel-metrics', () => {
 
   test('logs metrics when activated', async () => {
     const mockOtelRecorder = vi.fn()
+    const mockForceFlush = vi.fn().mockResolvedValue(undefined)
     const mockOtelCreator = vi.fn()
     mockOtelCreator.mockReturnValue({
       type: 'otel',
       otel: {
         record: mockOtelRecorder,
+        getMeterProvider: () => ({forceFlush: mockForceFlush}),
       },
     })
 
@@ -52,5 +54,42 @@ describe('otel-metrics', () => {
 
     expect(mockOtelCreator).toHaveBeenCalledOnce()
     expect(mockOtelRecorder.mock.calls).toMatchSnapshot()
+    expect(mockForceFlush).toHaveBeenCalledOnce()
+  })
+
+  test('waits for metrics to flush', async () => {
+    let resolveFlush: () => void = () => {}
+    const flush = new Promise<void>((resolve) => {
+      resolveFlush = resolve
+    })
+    const recorderFactory = vi.fn().mockReturnValue({
+      type: 'otel',
+      otel: {
+        record: vi.fn(),
+        getMeterProvider: () => ({forceFlush: () => flush}),
+      },
+    })
+
+    let metricsRecorded = false
+    const recording = recordMetrics(
+      {
+        skipMetricAnalytics: false,
+        cliVersion: '4.6.0',
+        owningPlugin: '@shopify/app',
+        command: 'app dev',
+        exitMode: 'ok',
+      },
+      {active: 10, network: 20, prompt: 30},
+      recorderFactory,
+    ).then(() => {
+      metricsRecorded = true
+    })
+
+    await vi.waitFor(() => expect(recorderFactory).toHaveBeenCalledOnce())
+    expect(metricsRecorded).toBe(false)
+
+    resolveFlush()
+    await recording
+    expect(metricsRecorded).toBe(true)
   })
 })

--- a/packages/cli-kit/src/private/node/otel-metrics.ts
+++ b/packages/cli-kit/src/private/node/otel-metrics.ts
@@ -11,7 +11,7 @@ type MetricRecorder =
   | 'console'
   | {
       type: 'otel'
-      otel: Pick<OtelService, 'record'>
+      otel: Pick<OtelService, 'getMeterProvider' | 'record'>
     }
 
 // this should be type, not interface
@@ -80,6 +80,9 @@ export async function recordMetrics(
 
   recordCommandCounter(recorder, labels)
   recordCommandTiming(recorder, labels, timing)
+  if (recorder !== 'console') {
+    await recorder.otel.getMeterProvider().forceFlush({})
+  }
 }
 
 const COMMAND_DURATION_BOUNDARIES_MS = [

--- a/packages/cli-kit/src/public/node/analytics.test.ts
+++ b/packages/cli-kit/src/public/node/analytics.test.ts
@@ -1,4 +1,11 @@
-import {reportAnalyticsEvent, recordTiming, recordError, recordRetry, recordEvent} from './analytics.js'
+import {
+  reportAnalyticsEvent,
+  sendAnalyticsEventFromStdin,
+  recordTiming,
+  recordError,
+  recordRetry,
+  recordEvent,
+} from './analytics.js'
 import * as os from './os.js'
 import {
   analyticsDisabled,
@@ -16,11 +23,11 @@ import {mockAndCaptureOutput} from './testing/output.js'
 import {addPublicMetadata, addSensitiveMetadata} from './metadata.js'
 import {sendErrorToBugsnag} from './error-handler.js'
 import {hashString} from './crypto.js'
+import {exec, readStdinString} from './system.js'
 import * as store from '../../private/node/analytics/storage.js'
 import {startAnalytics} from '../../private/node/analytics.js'
 import {CLI_KIT_VERSION} from '../common/version.js'
 import {setLastSeenAuthMethod, setLastSeenUserIdAfterAuth} from '../../private/node/session.js'
-
 import {test, expect, describe, vi, beforeEach, afterEach, MockedFunction} from 'vitest'
 
 vi.mock('./context/local.js')
@@ -32,6 +39,7 @@ vi.mock('../../version.js')
 vi.mock('./monorail.js')
 vi.mock('./cli.js')
 vi.mock('./error-handler.js')
+vi.mock('./system.js')
 
 function restoreEnvVariable(key: string, value: string | undefined): void {
   if (value === undefined) {
@@ -44,19 +52,21 @@ function restoreEnvVariable(key: string, value: string | undefined): void {
 describe('event tracking', () => {
   const currentDate = new Date(Date.UTC(2022, 1, 1, 10, 0, 0))
   let publishEventMock: MockedFunction<typeof publishMonorailEvent>
+  let execMock: MockedFunction<typeof exec>
 
   beforeEach(() => {
     vi.setSystemTime(currentDate)
     vi.mocked(isShopify).mockResolvedValue(false)
     vi.mocked(isDevelopment).mockReturnValue(false)
     vi.mocked(analyticsDisabled).mockReturnValue(false)
-    vi.mocked(ciPlatform).mockReturnValue({isCI: true, name: 'vitest', metadata: {}})
+    vi.mocked(ciPlatform).mockReturnValue({isCI: false})
     vi.mocked(macAddress).mockResolvedValue('macAddress')
     vi.mocked(hashString).mockReturnValue('hashed-macaddress')
     vi.mocked(isUnitTest).mockReturnValue(true)
     vi.mocked(cloudEnvironment).mockReturnValue({platform: 'localhost', editor: false})
     vi.mocked(os.platformAndArch).mockReturnValue({platform: 'darwin', arch: 'arm64'})
     publishEventMock = vi.mocked(publishMonorailEvent).mockReturnValue(Promise.resolve({type: 'ok'}))
+    execMock = vi.mocked(exec).mockResolvedValue(undefined)
   })
 
   afterEach(() => {
@@ -71,6 +81,163 @@ describe('event tracking', () => {
       await execute(['--path', tmpDir])
     })
   }
+
+  async function sendReportedAnalyticsPayload(): Promise<void> {
+    expect(execMock).toHaveBeenCalledOnce()
+    expect(execMock.mock.calls[0]![0]).toBe(process.execPath)
+    const execArgs = execMock.mock.calls[0]![1]
+    expect(execArgs.slice(1)).toEqual(['send-analytics'])
+
+    const payloadInput = execMock.mock.calls[0]![2]?.input
+    if (payloadInput === undefined) throw new Error('Expected send-analytics to receive stdin input')
+
+    vi.mocked(readStdinString).mockResolvedValueOnce(payloadInput)
+    await sendAnalyticsEventFromStdin()
+  }
+
+  test('waits for the analytics process on Windows', async () => {
+    await inProjectWithFile('package.json', async (args) => {
+      // Given
+      const commandContent = {command: 'info', topic: 'app'}
+      await startAnalytics({commandContent, args, currentTime: currentDate.getTime() - 100})
+      vi.mocked(os.platformAndArch).mockReturnValue({platform: 'windows', arch: 'arm64'})
+
+      let resolveAnalyticsProcess: () => void = () => {}
+      const analyticsProcess = new Promise<void>((resolve) => {
+        resolveAnalyticsProcess = resolve
+      })
+      execMock.mockReturnValueOnce(analyticsProcess)
+
+      const config = {
+        runHook: vi.fn().mockResolvedValue({successes: [], failures: []}),
+        plugins: [],
+      } as any
+
+      // When
+      let reportCompleted = false
+      const report = reportAnalyticsEvent({config, exitMode: 'expected_error'}).then(() => {
+        reportCompleted = true
+      })
+      await vi.waitFor(() => expect(execMock).toHaveBeenCalledOnce())
+
+      // Then
+      expect(reportCompleted).toBe(false)
+      expect(execMock).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.objectContaining({background: false}),
+      )
+      resolveAnalyticsProcess()
+      await report
+      expect(reportCompleted).toBe(true)
+      await sendReportedAnalyticsPayload()
+    })
+  })
+
+  test('does not wait for the analytics process on non-Windows platforms', async () => {
+    await inProjectWithFile('package.json', async (args) => {
+      // Given
+      const commandContent = {command: 'info', topic: 'app'}
+      await startAnalytics({commandContent, args, currentTime: currentDate.getTime() - 100})
+
+      let resolveAnalyticsProcess: () => void = () => {}
+      const analyticsProcess = new Promise<void>((resolve) => {
+        resolveAnalyticsProcess = resolve
+      })
+      execMock.mockReturnValueOnce(analyticsProcess)
+
+      const config = {
+        runHook: vi.fn().mockResolvedValue({successes: [], failures: []}),
+        plugins: [],
+      } as any
+
+      // When
+      await reportAnalyticsEvent({config, exitMode: 'expected_error'})
+
+      // Then
+      expect(execMock).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.objectContaining({background: true, input: expect.any(String)}),
+      )
+      resolveAnalyticsProcess()
+      await sendReportedAnalyticsPayload()
+    })
+  })
+
+  test('waits for the analytics process in CI', async () => {
+    await inProjectWithFile('package.json', async (args) => {
+      // Given
+      const commandContent = {command: 'info', topic: 'app'}
+      await startAnalytics({commandContent, args, currentTime: currentDate.getTime() - 100})
+      vi.mocked(ciPlatform).mockReturnValue({isCI: true, name: 'github', metadata: {}})
+
+      let resolveAnalyticsProcess: () => void = () => {}
+      const analyticsProcess = new Promise<void>((resolve) => {
+        resolveAnalyticsProcess = resolve
+      })
+      execMock.mockReturnValueOnce(analyticsProcess)
+
+      const config = {
+        runHook: vi.fn().mockResolvedValue({successes: [], failures: []}),
+        plugins: [],
+      } as any
+
+      // When
+      let reportCompleted = false
+      const report = reportAnalyticsEvent({config, exitMode: 'ok'}).then(() => {
+        reportCompleted = true
+      })
+      await vi.waitFor(() => expect(execMock).toHaveBeenCalledOnce())
+
+      // Then
+      expect(reportCompleted).toBe(false)
+      expect(execMock).toHaveBeenCalledWith(
+        process.execPath,
+        expect.anything(),
+        expect.objectContaining({background: false}),
+      )
+      resolveAnalyticsProcess()
+      await report
+      expect(reportCompleted).toBe(true)
+      await sendReportedAnalyticsPayload()
+    })
+  })
+
+  test('sends analytics synchronously for create-app', async () => {
+    await inProjectWithFile('package.json', async (args) => {
+      // Given
+      const commandContent = {command: 'init'}
+      await startAnalytics({commandContent, args, currentTime: currentDate.getTime() - 100})
+      const config = {
+        bin: 'create-app',
+        runHook: vi.fn().mockResolvedValue({successes: [], failures: []}),
+        plugins: [],
+      } as any
+
+      // When
+      await reportAnalyticsEvent({config, exitMode: 'ok'})
+
+      // Then
+      expect(execMock).not.toHaveBeenCalled()
+      expect(publishEventMock).toHaveBeenCalledOnce()
+    })
+  })
+
+  test('reports invalid analytics JSON received from stdin', async () => {
+    // Given
+    vi.mocked(readStdinString).mockResolvedValueOnce('{invalid')
+    const outputMock = mockAndCaptureOutput()
+
+    // When
+    await sendAnalyticsEventFromStdin()
+
+    // Then
+    expect(outputMock.debug()).toContain('Failed to send analytics in background')
+    expect(publishEventMock).not.toHaveBeenCalled()
+    expect(sendErrorToBugsnag).toHaveBeenCalledOnce()
+    expect(sendErrorToBugsnag).toHaveBeenCalledWith(expect.any(Error), 'expected_error')
+  })
 
   test('sends the expected data to Monorail with cached app info', async () => {
     await inProjectWithFile('package.json', async (args) => {
@@ -95,6 +262,7 @@ describe('event tracking', () => {
         plugins: pluginsMap,
       } as any
       await reportAnalyticsEvent({config, exitMode: 'ok'})
+      await sendReportedAnalyticsPayload()
       // Then
       const version = CLI_KIT_VERSION
       const expectedPayloadPublic = {
@@ -155,6 +323,7 @@ describe('event tracking', () => {
         plugins: [],
       } as any
       await reportAnalyticsEvent({config, exitMode: 'ok'})
+      await sendReportedAnalyticsPayload()
 
       // Then
       expect(publishEventMock).toHaveBeenCalledOnce()
@@ -179,6 +348,7 @@ describe('event tracking', () => {
         plugins: [],
       } as any
       await reportAnalyticsEvent({config, errorMessage: 'Permission denied', exitMode: 'unexpected_error'})
+      await sendReportedAnalyticsPayload()
 
       // Then
       const version = CLI_KIT_VERSION
@@ -219,6 +389,7 @@ describe('event tracking', () => {
         plugins: [],
       } as any
       await reportAnalyticsEvent({config, exitMode: 'ok'})
+      await sendReportedAnalyticsPayload()
 
       // Then
       const expectedPayloadSensitive = {
@@ -243,6 +414,7 @@ describe('event tracking', () => {
         plugins: [],
       } as any
       await reportAnalyticsEvent({config, exitMode: 'ok'})
+      await sendReportedAnalyticsPayload()
 
       expect(publishEventMock).toHaveBeenCalledOnce()
       expect(publishEventMock.mock.calls[0]![2]).toMatchObject({
@@ -274,6 +446,7 @@ describe('event tracking', () => {
           plugins: [],
         } as any
         await reportAnalyticsEvent({config, exitMode: 'ok'})
+        await sendReportedAnalyticsPayload()
 
         // Then
         const sensitivePayload = publishEventMock.mock.calls[0]![2]

--- a/packages/cli-kit/src/public/node/analytics.ts
+++ b/packages/cli-kit/src/public/node/analytics.ts
@@ -1,6 +1,6 @@
-import {alwaysLogAnalytics, alwaysLogMetrics, analyticsDisabled, isShopify} from './context/local.js'
+import {alwaysLogAnalytics, alwaysLogMetrics, analyticsDisabled, ciPlatform, isShopify} from './context/local.js'
 import * as metadata from './metadata.js'
-import {publishMonorailEvent, MONORAIL_COMMAND_TOPIC} from './monorail.js'
+import {publishMonorailEvent, MONORAIL_COMMAND_TOPIC, type Schemas} from './monorail.js'
 import {fanoutHooks} from './plugins.js'
 import {sendErrorToBugsnag} from './error-handler.js'
 import {outputContent, outputDebug, outputToken} from './output.js'
@@ -36,6 +36,70 @@ interface ReportAnalyticsEventOptions {
   exitMode: CommandExitMode
 }
 
+type MonorailCommandPayload = Schemas[typeof MONORAIL_COMMAND_TOPIC]
+interface AnalyticsPayload {
+  public: MonorailCommandPayload['public'] & {cmd_all_exit: CommandExitMode}
+  sensitive: MonorailCommandPayload['sensitive']
+}
+
+async function sendAnalyticsEvent(
+  payload: AnalyticsPayload,
+  skipMonorailAnalytics: boolean,
+  skipMetricAnalytics: boolean,
+): Promise<void> {
+  const doMonorail = async () => {
+    if (skipMonorailAnalytics) return
+    const response = await publishMonorailEvent(MONORAIL_COMMAND_TOPIC, payload.public, payload.sensitive)
+    if (response.type === 'error') {
+      outputDebug(response.message)
+    }
+  }
+
+  const doOpenTelemetry = async () => {
+    const active = payload.public.cmd_all_timing_active_ms ?? 0
+    const network = payload.public.cmd_all_timing_network_ms ?? 0
+    const prompt = payload.public.cmd_all_timing_prompts_ms ?? 0
+
+    return recordMetrics(
+      {
+        skipMetricAnalytics,
+        cliVersion: payload.public.cli_version,
+        owningPlugin: payload.public.cmd_all_plugin ?? '@shopify/cli',
+        command: payload.public.command,
+        exitMode: payload.public.cmd_all_exit,
+      },
+      {
+        active,
+        network,
+        prompt,
+      },
+    )
+  }
+
+  await Promise.all([doMonorail(), doOpenTelemetry()])
+}
+
+export async function sendAnalyticsEventFromStdin(): Promise<void> {
+  try {
+    const {readStdinString} = await import('./system.js')
+    const payloadStr = await readStdinString()
+    if (payloadStr === undefined) throw new Error('No analytics payload received from stdin')
+
+    const {payload, skipMonorailAnalytics, skipMetricAnalytics} = JSON.parse(payloadStr) as {
+      payload: AnalyticsPayload
+      skipMonorailAnalytics: boolean
+      skipMetricAnalytics: boolean
+    }
+
+    await sendAnalyticsEvent(payload, skipMonorailAnalytics, skipMetricAnalytics)
+    // eslint-disable-next-line no-catch-all/no-catch-all
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    outputDebug(`Failed to send analytics in background: ${message}`)
+    await sendErrorToBugsnag(error, 'expected_error')
+  }
+}
+
 /**
  * Report an analytics event, sending it off to Monorail -- Shopify's internal analytics service.
  *
@@ -45,8 +109,7 @@ interface ReportAnalyticsEventOptions {
 export async function reportAnalyticsEvent(options: ReportAnalyticsEventOptions): Promise<void> {
   try {
     const payload = await buildPayload(options)
-    if (payload === undefined) {
-      // Nothing to log
+    if (payload === undefined || payload.public.command === 'send-analytics') {
       return
     }
 
@@ -65,40 +128,43 @@ export async function reportAnalyticsEvent(options: ReportAnalyticsEventOptions)
 
     const skipMonorailAnalytics = !alwaysLogAnalytics() && analyticsDisabled()
     const skipMetricAnalytics = !alwaysLogMetrics() && analyticsDisabled()
-    if (skipMonorailAnalytics || skipMetricAnalytics) {
+    if (skipMonorailAnalytics && skipMetricAnalytics) {
       outputDebug(outputContent`Skipping command analytics, payload: ${outputToken.json(payload)}`)
+      return
     }
 
-    const doMonorail = async () => {
-      if (skipMonorailAnalytics) {
-        return
-      }
-      const response = await publishMonorailEvent(MONORAIL_COMMAND_TOPIC, payload.public, payload.sensitive)
-      if (response.type === 'error') {
-        outputDebug(response.message)
-      }
-    }
-    const doOpenTelemetry = async () => {
-      const active = payload.public.cmd_all_timing_active_ms ?? 0
-      const network = payload.public.cmd_all_timing_network_ms ?? 0
-      const prompt = payload.public.cmd_all_timing_prompts_ms ?? 0
+    const {platformAndArch} = await import('./os.js')
+    const sendSynchronously = options.config.bin === 'create-app'
+    const sendInBackground = !sendSynchronously && platformAndArch().platform !== 'windows' && !ciPlatform().isCI
+    const deliveryDescription = sendInBackground ? ' in background' : ''
+    outputDebug(outputContent`Sending command analytics${deliveryDescription}, payload: ${outputToken.json(payload)}`)
 
-      return recordMetrics(
-        {
-          skipMetricAnalytics,
-          cliVersion: payload.public.cli_version,
-          owningPlugin: payload.public.cmd_all_plugin ?? '@shopify/cli',
-          command: payload.public.command,
-          exitMode: options.exitMode,
-        },
-        {
-          active,
-          network,
-          prompt,
-        },
-      )
+    if (sendSynchronously) {
+      await sendAnalyticsEvent(payload, skipMonorailAnalytics, skipMetricAnalytics)
+      return
     }
-    await Promise.all([doMonorail(), doOpenTelemetry()])
+
+    const {exec} = await import('./system.js')
+    const argv = process.argv
+    if (!argv[1]) return
+    const nodeBinary = process.execPath
+    const shopifyBinary = argv[1]
+    const args = [shopifyBinary, 'send-analytics']
+
+    const analyticsProcess = exec(nodeBinary, args, {
+      background: sendInBackground,
+      env: {...process.env, SHOPIFY_CLI_NO_ANALYTICS: '1'},
+      input: JSON.stringify({payload, skipMonorailAnalytics, skipMetricAnalytics}),
+      externalErrorHandler: async (error: unknown) => {
+        outputDebug(`Failed to send analytics in background: ${(error as Error).message}`)
+      },
+    })
+    if (sendInBackground) {
+      // eslint-disable-next-line no-void
+      void analyticsProcess
+    } else {
+      await analyticsProcess
+    }
 
     // eslint-disable-next-line no-catch-all/no-catch-all
   } catch (error) {
@@ -111,7 +177,11 @@ export async function reportAnalyticsEvent(options: ReportAnalyticsEventOptions)
   }
 }
 
-async function buildPayload({config, errorMessage, exitMode}: ReportAnalyticsEventOptions) {
+async function buildPayload({
+  config,
+  errorMessage,
+  exitMode,
+}: ReportAnalyticsEventOptions): Promise<AnalyticsPayload | undefined> {
   const {commandStartOptions, environmentFlags, ...sensitiveMetadata} = metadata.getAllSensitiveMetadata()
   if (commandStartOptions === undefined) {
     outputDebug('Unable to log analytics event - no information on executed command')

--- a/packages/cli-kit/src/public/node/fs.ts
+++ b/packages/cli-kit/src/public/node/fs.ts
@@ -211,6 +211,8 @@ export function appendFileSync(path: string, data: string): void {
 
 export interface WriteOptions {
   encoding: BufferEncoding
+  mode?: number
+  flag?: string
 }
 
 /**

--- a/packages/cli-kit/src/public/node/hooks/postrun.ts
+++ b/packages/cli-kit/src/public/node/hooks/postrun.ts
@@ -74,11 +74,11 @@ export const hook: Hook.Postrun = async ({config, Command}) => {
   const command = Command.id.replace(/:/g, ' ')
   outputDebug(`Completed command ${command}`)
 
-  if (!command.includes('notifications') && !command.includes('upgrade')) await autoUpgradeIfNeeded()
+  if (!command.includes('notifications') && !command.includes('upgrade') && !command.includes('send-analytics'))
+    await autoUpgradeIfNeeded()
 
   const {reportAnalyticsEvent} = await import('../analytics.js')
   await reportAnalyticsEvent({config, exitMode: 'ok'})
-
   postRunHookCompleted = true
 }
 

--- a/packages/cli-kit/src/public/node/notifications-system.test.ts
+++ b/packages/cli-kit/src/public/node/notifications-system.test.ts
@@ -442,7 +442,7 @@ describe('fetchNotificationsInBackground', () => {
     expect(exec).not.toHaveBeenCalled()
   })
 
-  test('calls the expected Shopify binary', async () => {
+  test('calls the current Shopify entry point with the canonical Node executable', async () => {
     // Given / When
     fetchNotificationsInBackground('theme:list', ['/path/to/node', '/path/to/shopify', 'theme', 'list'], {
       SHOPIFY_UNIT_TEST: 'false',
@@ -450,7 +450,7 @@ describe('fetchNotificationsInBackground', () => {
 
     // Then
     expect(exec).toHaveBeenCalledWith(
-      '/path/to/node',
+      process.execPath,
       ['/path/to/shopify', 'notifications', 'list', '--ignore-errors'],
       expect.anything(),
     )

--- a/packages/cli-kit/src/public/node/notifications-system.ts
+++ b/packages/cli-kit/src/public/node/notifications-system.ts
@@ -21,6 +21,7 @@ const COMMANDS_TO_SKIP = [
   'theme:init',
   'hydrogen:init',
   'cache:clear',
+  'send-analytics',
 ]
 
 function url(): string {
@@ -179,10 +180,10 @@ export function fetchNotificationsInBackground(
   environment: NodeJS.ProcessEnv = process.env,
 ): void {
   if (skipNotifications(currentCommand, environment)) return
-  if (!argv[0] || !argv[1]) return
+  if (!argv[1]) return
 
   // Run the Shopify command the same way as the current execution
-  const nodeBinary = argv[0]
+  const nodeBinary = process.execPath
   const shopifyBinary = argv[1]
   const args = [shopifyBinary, 'notifications', 'list', '--ignore-errors']
 

--- a/packages/cli-kit/src/public/node/system.test.ts
+++ b/packages/cli-kit/src/public/node/system.test.ts
@@ -276,6 +276,28 @@ describe('execCommand', () => {
     expect(execa).toHaveBeenCalledWith('cat', [], expect.objectContaining({stdin: 'inherit'}))
   })
 
+  test.skipIf(process.platform === 'win32')(
+    'pipes input to a background process while ignoring its output',
+    async () => {
+      // Given
+      vi.mocked(which.sync).mockReturnValueOnce('/system/cat')
+      const unref = vi.fn()
+      const childProcess = Object.assign(Promise.resolve({}), {unref})
+      vi.mocked(execa).mockReturnValueOnce(childProcess as any)
+
+      // When
+      await system.exec('cat', [], {background: true, input: 'payload'})
+
+      // Then
+      expect(execa).toHaveBeenCalledWith(
+        'cat',
+        [],
+        expect.objectContaining({input: 'payload', stdio: ['pipe', 'ignore', 'ignore']}),
+      )
+      expect(unref).toHaveBeenCalledOnce()
+    },
+  )
+
   test('raises an error if the command to run is found in the current directory', async () => {
     // Given
     vi.mocked(which.sync).mockReturnValueOnce('/currentDirectory/command')
@@ -308,7 +330,11 @@ describe('execCommand', () => {
 describe('isStdinPiped', () => {
   test('returns true when stdin is a FIFO (pipe)', () => {
     // Given
-    vi.mocked(fs.fstatSync).mockReturnValue({isFIFO: () => true, isFile: () => false} as fs.Stats)
+    vi.mocked(fs.fstatSync).mockReturnValue({
+      isFIFO: () => true,
+      isFile: () => false,
+      isSocket: () => false,
+    } as fs.Stats)
 
     // When
     const got = system.isStdinPiped()
@@ -319,7 +345,26 @@ describe('isStdinPiped', () => {
 
   test('returns true when stdin is a file redirect', () => {
     // Given
-    vi.mocked(fs.fstatSync).mockReturnValue({isFIFO: () => false, isFile: () => true} as fs.Stats)
+    vi.mocked(fs.fstatSync).mockReturnValue({
+      isFIFO: () => false,
+      isFile: () => true,
+      isSocket: () => false,
+    } as fs.Stats)
+
+    // When
+    const got = system.isStdinPiped()
+
+    // Then
+    expect(got).toBe(true)
+  })
+
+  test('returns true when stdin is a child-process pipe represented as a socket', () => {
+    // Given
+    vi.mocked(fs.fstatSync).mockReturnValue({
+      isFIFO: () => false,
+      isFile: () => false,
+      isSocket: () => true,
+    } as fs.Stats)
 
     // When
     const got = system.isStdinPiped()
@@ -330,7 +375,11 @@ describe('isStdinPiped', () => {
 
   test('returns false when stdin is a TTY (interactive)', () => {
     // Given
-    vi.mocked(fs.fstatSync).mockReturnValue({isFIFO: () => false, isFile: () => false} as fs.Stats)
+    vi.mocked(fs.fstatSync).mockReturnValue({
+      isFIFO: () => false,
+      isFile: () => false,
+      isSocket: () => false,
+    } as fs.Stats)
 
     // When
     const got = system.isStdinPiped()

--- a/packages/cli-kit/src/public/node/system.ts
+++ b/packages/cli-kit/src/public/node/system.ts
@@ -277,11 +277,12 @@ function buildExec(
   }
   const executionCwd = options?.cwd ?? cwd()
   checkCommandSafety(command, {cwd: executionCwd})
+  const backgroundStdio = options?.input === undefined ? 'ignore' : (['pipe', 'ignore', 'ignore'] as const)
   const commandProcess = execa(command, args, {
     env,
     cwd: executionCwd,
     input: options?.input,
-    stdio: options?.background ? 'ignore' : options?.stdio,
+    stdio: options?.background ? backgroundStdio : options?.stdio,
     stdin: options?.stdin,
     stdout: options?.stdout === 'inherit' ? 'inherit' : undefined,
     stderr: options?.stderr === 'inherit' ? 'inherit' : undefined,
@@ -373,7 +374,7 @@ export async function isWsl(): Promise<boolean> {
 export function isStdinPiped(): boolean {
   try {
     const stats = fstatSync(0)
-    return stats.isFIFO() || stats.isFile()
+    return stats.isFIFO() || stats.isFile() || stats.isSocket()
     // eslint-disable-next-line no-catch-all/no-catch-all
   } catch {
     return false

--- a/packages/cli-kit/src/public/node/vendor/otel-js/service/types.ts
+++ b/packages/cli-kit/src/public/node/vendor/otel-js/service/types.ts
@@ -1,12 +1,11 @@
 import type {
   Counter,
   Histogram,
-  MeterProvider,
   MetricAttributes,
   MetricOptions,
   UpDownCounter,
 } from '@opentelemetry/api'
-import type {ViewOptions} from '@opentelemetry/sdk-metrics'
+import type {MeterProvider, ViewOptions} from '@opentelemetry/sdk-metrics'
 
 export type CustomMetricLabels<
   TLabels extends Record<TKeys, MetricAttributes>,

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -6314,6 +6314,24 @@
       "strict": true,
       "usage": "search [query]"
     },
+    "send-analytics": {
+      "aliases": [
+      ],
+      "args": {
+      },
+      "enableJsonFlag": false,
+      "flags": {
+      },
+      "hasDynamicHelp": false,
+      "hidden": true,
+      "hiddenAliases": [
+      ],
+      "id": "send-analytics",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true
+    },
     "store:auth": {
       "aliases": [
       ],

--- a/packages/cli/src/cli/commands/send-analytics.ts
+++ b/packages/cli/src/cli/commands/send-analytics.ts
@@ -1,0 +1,10 @@
+import Command from '@shopify/cli-kit/node/base-command'
+import {sendAnalyticsEventFromStdin} from '@shopify/cli-kit/node/analytics'
+
+export default class SendAnalytics extends Command {
+  static hidden = true
+
+  async run(): Promise<void> {
+    await sendAnalyticsEventFromStdin()
+  }
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,6 +1,7 @@
 import VersionCommand from './cli/commands/version.js'
 import Search from './cli/commands/search.js'
 import Upgrade from './cli/commands/upgrade.js'
+import SendAnalytics from './cli/commands/send-analytics.js'
 import Logout from './cli/commands/auth/logout.js'
 import Login from './cli/commands/auth/login.js'
 import CommandFlags from './cli/commands/debug/command-flags.js'
@@ -149,6 +150,7 @@ export const COMMANDS: any = {
   search: Search,
   upgrade: Upgrade,
   version: VersionCommand,
+  'send-analytics': SendAnalytics,
   help: HelpCommand,
   'auth:logout': Logout,
   'auth:login': Login,


### PR DESCRIPTION
### WHY are these changes introduced?

Building the analytics payload after every command takes ~150–190ms, roughly as long as the Monorail HTTP send itself. Almost all of that time is oclif dynamically importing the `public_command_metadata` hook module: the hook eagerly imported `services/app-context.js`, which pulls in a large chunk of the `@shopify/app` module graph — even for commands like `shopify version` run outside any app project.

This is stacked on https://github.com/Shopify/cli/pull/7615: that PR moves analytics *delivery* out of the critical path, but the payload is still built in the main process, so the hook-import cost remains in the foreground.

### WHAT is this pull request doing?

- The hook now defers `import('../services/app-context.js')` until it is actually needed: `api_key` not already set in metadata, and a `shopify.app*.toml` found by walking up from the current directory.
- The `shopify.app*.toml` glob moves to the import-free `constants.ts` and is shared with `models/project/project.ts` instead of being duplicated.
- Hook tests use real temporary directories instead of a mocked `cwd`, with a new test covering the not-in-an-app-project skip.

Behavior is unchanged inside app projects: the hook still loads the app context there, and real app commands stay free because the modules are already loaded and `api_key` is already set.

### Benchmarks

`shopify version` (production bundle, non-app directory, macOS, avg of 3 runs):

| | Wall clock | User CPU |
| --- | ---:| ---:|
| `main` | 1.50s | 0.49s |
| #7615 alone | 0.40s | 0.48s |
| #7615 + this PR | 0.23s | 0.22s |

Isolated effect of this change (measured against `main` before stacking): `buildPayload` drops from ~190ms to ~14ms. With #7615 the payload build is the bulk of what's left in the foreground, so this PR removes ~40% of the remaining time — and halves the CPU spent parsing/evaluating modules that were never used.

### How to test your changes?

- `pnpm nx bundle cli`
- Outside an app project: `time node packages/cli/bin/run.js version` — compare against `main`
- Inside an app project: `shopify version --verbose` and check the analytics payload still includes app metadata (`api_key`, etc.)

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)
