### PR TITLE
[Refactor] Replace deprecated .substr with .slice in base command

### DIFF
--- a/packages/cli-kit/src/public/node/base-command.ts
+++ b/packages/cli-kit/src/public/node/base-command.ts
@@ -296,7 +296,7 @@ function reportEnvironmentApplication<
     const userSpecifiedThisFlag = Object.prototype.hasOwnProperty.call(noDefaultsFlags, name)
     const environmentContainsFlag = Object.prototype.hasOwnProperty.call(environment, name)
     if (!userSpecifiedThisFlag && environmentContainsFlag) {
-      const valueToReport = name === 'password' ? `********${value.substr(-4)}` : value
+      const valueToReport = name === 'password' && typeof value === 'string' ? `********${value.slice(-4)}` : value
       changes[name] = valueToReport
     }
   }


### PR DESCRIPTION
### Why is this change needed?
In `packages/cli-kit/src/public/node/base-command.ts`, `value.substr(-4)` is used to format and mask the password flag before logging. `String.prototype.substr()` is deprecated in modern ECMAScript/TypeScript, and using `.slice()` is the recommended standard. Furthermore, since `value` is of type `any` / `unknown`, this PR adds `typeof value === 'string'` check for strict type-safety to prevent potential runtime type-error crashes.

### How to test your changes?
CI

### Checklist
- [ ] My build is green
- [ ] My tests are green

---
*PR created automatically by Jules for task [4830717441821901444](https://jules.google.com/task/4830717441821901444) started by @gonzaloriestra*