### PR TITLE
Run E2E app and store cleanup in parallel

### DIFF
--- a/.github/workflows/tests-pr.yml
+++ b/.github/workflows/tests-pr.yml
@@ -276,12 +276,16 @@ jobs:
           retention-days: 14
 
   e2e-cleanup:
-    name: 'Cleanup current-run E2E resources'
+    name: 'Cleanup current-run E2E ${{ matrix.resource }}'
     needs: e2e-tests
     if: ${{ always() && needs.e2e-tests.result != 'skipped' }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        resource: [ 'apps', 'stores' ]
     steps:
       - uses: actions/checkout@v6
         with:
@@ -305,7 +309,7 @@ jobs:
           E2E_ORG_ID: ${{ secrets.E2E_ORG_ID }}
           E2E_LOADTEST_HEADER: ${{ secrets.E2E_LOADTEST_HEADER }}
         run: pnpm --filter e2e exec tsx scripts/prime-browser-auth.ts
-      - name: Cleanup current-run E2E apps
+      - name: Cleanup current-run E2E ${{ matrix.resource }}
         if: ${{ always() }}
         continue-on-error: true
         env:
@@ -315,18 +319,7 @@ jobs:
           E2E_LOADTEST_HEADER: ${{ secrets.E2E_LOADTEST_HEADER }}
         run: |
           RUN_TOKEN=$(node -e "process.stdout.write(BigInt(process.env.GITHUB_RUN_ID).toString(36))")
-          pnpm --filter e2e exec tsx scripts/cleanup-apps.ts --pattern "r${RUN_TOKEN}"
-      - name: Cleanup current-run E2E stores
-        if: ${{ always() }}
-        continue-on-error: true
-        env:
-          E2E_ACCOUNT_EMAIL: ${{ secrets.E2E_ACCOUNT_EMAIL }}
-          E2E_ACCOUNT_PASSWORD: ${{ secrets.E2E_ACCOUNT_PASSWORD }}
-          E2E_ORG_ID: ${{ secrets.E2E_ORG_ID }}
-          E2E_LOADTEST_HEADER: ${{ secrets.E2E_LOADTEST_HEADER }}
-        run: |
-          RUN_TOKEN=$(node -e "process.stdout.write(BigInt(process.env.GITHUB_RUN_ID).toString(36))")
-          pnpm --filter e2e exec tsx scripts/cleanup-stores.ts --pattern "r${RUN_TOKEN}"
+          pnpm --filter e2e exec tsx scripts/cleanup-${{ matrix.resource }}.ts --pattern "r${RUN_TOKEN}"
 
   type-diff:
     if: github.event.pull_request.head.repo.full_name == github.repository


### PR DESCRIPTION
### WHY are these changes introduced?

The `e2e-cleanup` job ran app cleanup and store cleanup as sequential steps (up to 6m + 5.5m in recent runs), making it the longest chain in the PR workflow. A slow cleanup also widens the window where a new push's `cancel-in-progress` kills it midway and leaks E2E resources.

### WHAT is this pull request doing?

Splits `e2e-cleanup` into a two-leg matrix job (`apps`, `stores`) so both cleanups run in parallel. No script changes — each leg runs the same setup and one of the existing cleanup scripts.

The two cleanups already tolerate racing each other: apps cleanup previously ran *before* stores cleanup, so stores cleanup already handles apps that were just deleted.

### How to test your changes?

Check the PR run of this workflow: the two cleanup jobs run concurrently after the E2E shards (measured ~2m37s and ~1m42s vs up to 13m33s combined before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)