### PR TITLE
Shard macOS unit tests and split E2E tests into three shards

### DIFF
--- a/.github/workflows/tests-pr.yml
+++ b/.github/workflows/tests-pr.yml
@@ -160,7 +160,7 @@ jobs:
         node: [ '22.12.0', '24.1.0', '26.1.0' ]
         shard: [ '' ]
         include:
-          # Add sharding for Windows jobs to reduce wall-clock time
+          # Add sharding for Windows and macOS jobs to reduce wall-clock time
           - os: windows-latest
             node: '22.12.0'
             shard: '1/2'
@@ -177,10 +177,28 @@ jobs:
             node: '26.1.0'
             shard: '1/2'
           - os: windows-latest
+            node: '26.1.0'
+            shard: '2/2'
+          - os: macos-latest
+            node: '22.12.0'
+            shard: '1/2'
+          - os: macos-latest
+            node: '22.12.0'
+            shard: '2/2'
+          - os: macos-latest
+            node: '24.1.0'
+            shard: '1/2'
+          - os: macos-latest
+            node: '24.1.0'
+            shard: '2/2'
+          - os: macos-latest
+            node: '26.1.0'
+            shard: '1/2'
+          - os: macos-latest
             node: '26.1.0'
             shard: '2/2'
         exclude:
-          # Exclude the non-sharded Windows entries (replaced by sharded ones above)
+          # Exclude the non-sharded Windows and macOS entries (replaced by sharded ones above)
           - os: windows-latest
             node: '22.12.0'
             shard: ''
@@ -188,6 +206,15 @@ jobs:
             node: '24.1.0'
             shard: ''
           - os: windows-latest
+            node: '26.1.0'
+            shard: ''
+          - os: macos-latest
+            node: '22.12.0'
+            shard: ''
+          - os: macos-latest
+            node: '24.1.0'
+            shard: ''
+          - os: macos-latest
             node: '26.1.0'
             shard: ''
     steps:

--- a/.github/workflows/tests-pr.yml
+++ b/.github/workflows/tests-pr.yml
@@ -255,7 +255,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: ['1/2', '2/2']
+        shard: ['1/3', '2/3', '3/3']
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
### WHY are these changes introduced?

Two hotspots from analyzing recent CI runs:

- macOS is the slowest and most variable unit-test runner (4m38s–15m34s for the same suite) and it gates the required "Unit tests" check.
- The two Playwright E2E shards are unbalanced: shard 1 consistently takes 1.5–2.5× as long as shard 2 (6.5–12m vs 4–5m).

### WHAT is this pull request doing?

- Shards macOS unit tests 2×, mirroring the existing Windows sharding.
- Splits the E2E tests into three Playwright shards instead of two.

### How to test your changes?

Check this PR's workflow run: all macOS unit shards finish in under ~5 minutes and the three E2E shards land within ~1 minute of each other (two attempts measured: 7m06s and 8m30s total, vs a 9–23m baseline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)