### PR TITLE
[Tests] Add unit tests for hrtime utility

### DIFF
--- a/packages/cli-kit/src/public/node/hrtime.test.ts
+++ b/packages/cli-kit/src/public/node/hrtime.test.ts
@@ -1,0 +1,37 @@
+import {startHRTime, endHRTimeInMs} from './hrtime.js'
+import {describe, expect, test, vi} from 'vitest'
+
+describe('startHRTime', () => {
+  test('returns the correct start time array', () => {
+    const mockHrtime: [number, number] = [12345, 67890]
+    const spy = vi.spyOn(process, 'hrtime').mockReturnValue(mockHrtime)
+
+    const result = startHRTime()
+
+    expect(spy).toHaveBeenCalledOnce()
+    expect(result).toEqual(mockHrtime)
+  })
+})
+
+describe('endHRTimeInMs', () => {
+  test('returns the elapsed time in milliseconds as a string with two decimal places', () => {
+    const startTime: [number, number] = [1000, 2000]
+    const mockElapsed: [number, number] = [2, 500000]
+    const spy = vi.spyOn(process, 'hrtime').mockReturnValue(mockElapsed)
+
+    const result = endHRTimeInMs(startTime)
+
+    expect(spy).toHaveBeenCalledWith(startTime)
+    expect(result).toBe('2000.50')
+  })
+
+  test('formats integer elapsed milliseconds correctly', () => {
+    const startTime: [number, number] = [1000, 2000]
+    const mockElapsed: [number, number] = [1, 0]
+    vi.spyOn(process, 'hrtime').mockReturnValue(mockElapsed)
+
+    const result = endHRTimeInMs(startTime)
+
+    expect(result).toBe('1000.00')
+  })
+})


### PR DESCRIPTION
### WHY are these changes introduced?

To improve testing coverage and ensure high-resolution time calculation utilities in `packages/cli-kit` are robustly tested.

### WHAT is this pull request doing?

This pull request introduces a comprehensive unit test suite in `packages/cli-kit/src/public/node/hrtime.test.ts` to cover `startHRTime` and `endHRTimeInMs`.

### How to test your changes?

CI

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [17514253540239281474](https://jules.google.com/task/17514253540239281474) started by @gonzaloriestra*