### PR TITLE
[Refactor] Simplify isTruthy utility

### DIFF
--- a/packages/cli-kit/src/public/node/context/utilities.test.ts
+++ b/packages/cli-kit/src/public/node/context/utilities.test.ts
@@ -22,6 +22,12 @@ describe('isTruthy', () => {
     expect(isTruthy('YES')).toBe(true)
   })
 
+  test('returns true for mixed case truthy values', () => {
+    expect(isTruthy('tRuE')).toBe(true)
+    expect(isTruthy('YEs')).toBe(true)
+    expect(isTruthy('True')).toBe(true)
+  })
+
   test('returns false for "0"', () => {
     expect(isTruthy('0')).toBe(false)
   })

--- a/packages/cli-kit/src/public/node/context/utilities.ts
+++ b/packages/cli-kit/src/public/node/context/utilities.ts
@@ -8,5 +8,5 @@ export function isTruthy(variable: string | undefined): boolean {
   if (!variable) {
     return false
   }
-  return ['1', 'true', 'TRUE', 'yes', 'YES'].includes(variable)
+  return ['1', 'true', 'yes'].includes(variable.toLowerCase())
 }


### PR DESCRIPTION
### WHY are these changes introduced?

The current `isTruthy` helper checks for uppercase/lowercase configurations explicitly by including duplicates like `'TRUE'` and `'YES'` in an array, which is redundant and doesn't handle all other case variations (e.g., `'True'`, `'Yes'`, `'tRuE'`).

### WHAT is this pull request doing?

Refactors `isTruthy` to normalize the input string to lowercase via `.toLowerCase()` and matches against `['1', 'true', 'yes']`. This eliminates redundant list items and makes truthiness checking case-insensitive. Also added mixed-case unit test assertions.

### How to test your changes?

CI

### Post-release steps

None.

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [6676906449923356672](https://jules.google.com/task/6676906449923356672) started by @gonzaloriestra*