### PR TITLE
Retry E2E tests once in CI and report flaky results

### DIFF
--- a/.github/workflows/tests-pr.yml
+++ b/.github/workflows/tests-pr.yml
@@ -260,6 +260,10 @@ jobs:
           E2E_ORG_ID: ${{ secrets.E2E_ORG_ID }}
           E2E_LOADTEST_HEADER: ${{ secrets.E2E_LOADTEST_HEADER }}
         run: pnpm exec playwright test --shard ${{ matrix.shard }}
+      - name: Report flaky tests
+        if: ${{ !cancelled() }}
+        working-directory: packages/e2e
+        run: node scripts/report-flaky.js
       - name: Upload Playwright report
         uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}

--- a/packages/e2e/playwright.config.ts
+++ b/packages/e2e/playwright.config.ts
@@ -12,10 +12,12 @@ export default defineConfig({
   testDir: './tests',
   fullyParallel: true,
   forbidOnly: isCI,
-  retries: 0,
+  retries: isCI ? 1 : 0, // One retry in CI; flaky-on-retry is reported, not ignored (scripts/report-flaky.js)
   workers: 10,
-  maxFailures: isCI ? 3 : 0, // Stop early in CI after 3 failures
-  reporter: isCI ? [['html', {open: 'never'}], ['list']] : [['list']],
+  maxFailures: isCI ? 5 : 0, // Stop early in CI; first attempts of flaky tests count, so leave room for retries
+  reporter: isCI
+    ? [['html', {open: 'never'}], ['list'], ['json', {outputFile: 'test-results/results.json'}]]
+    : [['list']],
   timeout: TEST_TIMEOUT.default, // Heavy tests override via test.setTimeout()
   globalTimeout: 20 * 60 * 1000,
 

--- a/packages/e2e/scripts/report-flaky.js
+++ b/packages/e2e/scripts/report-flaky.js
@@ -1,0 +1,57 @@
+/* eslint-disable no-console */
+
+// Surfaces tests that failed and then passed on retry ("flaky" in Playwright's
+// JSON report). Retries keep flake from failing the shard; this keeps it from
+// disappearing. Each flaky test is printed as a grep-able `FLAKY:` log line
+// and listed in the GitHub job summary.
+
+import {appendFileSync, existsSync, readFileSync} from 'node:fs'
+import * as path from 'node:path'
+import {fileURLToPath} from 'node:url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const resultsPath = path.join(__dirname, '../test-results/results.json')
+
+if (!existsSync(resultsPath)) {
+  console.log('no results.json found, skipping flaky report')
+  process.exit(0)
+}
+
+const report = JSON.parse(readFileSync(resultsPath, 'utf8'))
+
+const flakyTests = []
+function walkSuite(suite, titlePath) {
+  for (const spec of suite.specs ?? []) {
+    for (const test of spec.tests ?? []) {
+      if (test.status === 'flaky') {
+        flakyTests.push({title: [...titlePath, spec.title].join(' › '), file: spec.file})
+      }
+    }
+  }
+  for (const child of suite.suites ?? []) {
+    walkSuite(child, [...titlePath, child.title])
+  }
+}
+for (const suite of report.suites ?? []) {
+  // Root suites are titled with the file name, which spec.file already carries.
+  walkSuite(suite, [])
+}
+
+if (flakyTests.length === 0) {
+  console.log('no flaky tests in this shard')
+  process.exit(0)
+}
+
+for (const test of flakyTests) {
+  console.log(`FLAKY: ${test.file} › ${test.title}`)
+}
+
+if (process.env.GITHUB_STEP_SUMMARY) {
+  const summary = [
+    '## Flaky tests (failed, then passed on retry)',
+    '',
+    ...flakyTests.map((test) => `- \`${test.file}\` › ${test.title}`),
+    '',
+  ].join('\n')
+  appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${summary}\n`)
+}


### PR DESCRIPTION
### WHY are these changes introduced?

The E2E suite runs with `retries: 0`, so one flaky interaction fails the entire shard. Retrying alone would just hide the flake, so this pairs the retry with reporting.

### WHAT is this pull request doing?

- `retries: isCI ? 1 : 0` — a test that fails once and passes on retry keeps the shard green. Local runs keep zero retries so flake fails fast during development.
- `maxFailures: 3 → 5` in CI — first attempts of flaky tests count toward the early-stop limit, so the old value could kill a shard before retries got to prove tests flaky rather than broken.
- JSON reporter in CI + `scripts/report-flaky.js` — every failed-then-passed test is printed as a grep-able `FLAKY:` log line and listed in the GitHub job summary, so the nightly failure counter (and humans) can track flake instead of losing it to green shards.

### Interaction with the cli-kit throttle retry (#8317)

Layered deliberately: the CLI-level retry absorbs short throttle bursts inside a command; the Playwright retry covers everything else. Worst-case per-test wall clock grows — if shards start brushing the 20-minute job timeout, that's the knob to revisit.

### How to test your changes?

```
cd packages/e2e
mkdir -p test-results && echo '{"suites":[{"title":"x.spec.ts","suites":[{"title":"S","specs":[{"title":"t","file":"x.spec.ts","tests":[{"status":"flaky"}]}]}]}]}' > test-results/results.json
node scripts/report-flaky.js   # prints FLAKY: x.spec.ts › S › t
```

### Measuring impact

- [x] n/a — CI/test-infra only, no user-facing impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)