### PR TITLE
Fix CORS credentials on app-dev reverse-proxy preflight

### DIFF
--- a/.changeset/cors-proxy-credentials.md
+++ b/.changeset/cors-proxy-credentials.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Include Access-Control-Allow-Credentials on app-dev reverse-proxy CORS preflights so credentialed cross-origin fetches succeed.

--- a/.changeset/cors-proxy-credentials.md
+++ b/.changeset/cors-proxy-credentials.md
@@ -2,4 +2,4 @@
 '@shopify/app': patch
 ---
 
-Include Access-Control-Allow-Credentials on app-dev reverse-proxy CORS preflights so credentialed cross-origin fetches succeed.
+Forward app-dev preflight requests so target servers can safely authorize credentialed cross-origin fetches.

--- a/packages/app/src/cli/utilities/app/http-reverse-proxy.test.ts
+++ b/packages/app/src/cli/utilities/app/http-reverse-proxy.test.ts
@@ -70,6 +70,7 @@ describe.sequential.each(each)('http-reverse-proxy for %s', (protocol) => {
     expect(response.headers.get('access-control-allow-methods')).toBe('GET')
     expect(response.headers.get('access-control-allow-headers')).toBe('Authorization')
     expect(response.headers.get('access-control-max-age')).toBe('86400')
+    expect(response.headers.get('access-control-allow-credentials')).toBe('true')
   })
 
   test('responds to CORS preflight OPTIONS with defaults when no request headers', {retry: 2}, async ({setup}) => {
@@ -81,6 +82,7 @@ describe.sequential.each(each)('http-reverse-proxy for %s', (protocol) => {
     expect(response.headers.get('access-control-allow-origin')).toBe('*')
     expect(response.headers.get('access-control-allow-methods')).toBe('GET, POST, PUT, DELETE, PATCH, OPTIONS')
     expect(response.headers.get('access-control-allow-headers')).toBe('Content-Type, Authorization')
+    expect(response.headers.get('access-control-allow-credentials')).toBeNull()
   })
 
   test('closes the server when aborted', async ({setup}) => {

--- a/packages/app/src/cli/utilities/app/http-reverse-proxy.test.ts
+++ b/packages/app/src/cli/utilities/app/http-reverse-proxy.test.ts
@@ -8,6 +8,7 @@ import https from 'https'
 import net from 'net'
 
 const each = ['http', 'https'] as const
+const authorizedOrigin = 'https://extensions.shopifycdn.com'
 
 describe.sequential.each(each)('http-reverse-proxy for %s', (protocol) => {
   const test = getTestReverseProxy(protocol)
@@ -55,34 +56,58 @@ describe.sequential.each(each)('http-reverse-proxy for %s', (protocol) => {
     })
   })
 
-  test('responds to CORS preflight OPTIONS with default headers', {retry: 2}, async ({setup}) => {
+  test('forwards an authorized credentialed CORS preflight to the target', {retry: 2}, async ({setup}) => {
     const response = await fetch(`${protocol}://localhost:${setup.proxyPort}/path1/test`, {
       method: 'OPTIONS',
       headers: {
-        Origin: 'https://extensions.shopifycdn.com',
-        'Access-Control-Request-Method': 'GET',
-        'Access-Control-Request-Headers': 'Authorization',
+        Origin: authorizedOrigin,
+        'Access-Control-Request-Method': 'POST',
+        'Access-Control-Request-Headers': 'Content-Type',
       },
       agent,
     })
     expect(response.status).toBe(204)
-    expect(response.headers.get('access-control-allow-origin')).toBe('https://extensions.shopifycdn.com')
-    expect(response.headers.get('access-control-allow-methods')).toBe('GET')
-    expect(response.headers.get('access-control-allow-headers')).toBe('Authorization')
-    expect(response.headers.get('access-control-max-age')).toBe('86400')
+    expect(response.headers.get('x-preflight-handled-by')).toBe('target')
+    expect(response.headers.get('access-control-allow-origin')).toBe(authorizedOrigin)
+    expect(response.headers.get('access-control-allow-methods')).toBe('POST')
+    expect(response.headers.get('access-control-allow-headers')).toBe('Content-Type')
     expect(response.headers.get('access-control-allow-credentials')).toBe('true')
   })
 
-  test('responds to CORS preflight OPTIONS with defaults when no request headers', {retry: 2}, async ({setup}) => {
-    const response = await fetch(`${protocol}://localhost:${setup.proxyPort}/path1/test`, {
-      method: 'OPTIONS',
-      agent,
-    })
+  test('does not authorize credentials for untrusted origins', {retry: 2}, async ({setup}) => {
+    const untrustedOrigins = [
+      'https://evil.example',
+      'null',
+      'not a valid origin',
+      'http://extensions.shopifycdn.com',
+      'https://extensions.shopifycdn.com:3000',
+    ]
+
+    await Promise.all(
+      untrustedOrigins.map(async (origin) => {
+        const response = await fetch(`${protocol}://localhost:${setup.proxyPort}/path1/test`, {
+          method: 'OPTIONS',
+          headers: {
+            Origin: origin,
+            'Access-Control-Request-Method': 'POST',
+            'Access-Control-Request-Headers': 'Content-Type',
+          },
+          agent,
+        })
+        expect(response.status).toBe(204)
+        expect(response.headers.get('access-control-allow-origin')).toBeNull()
+        expect(response.headers.get('access-control-allow-credentials')).toBeNull()
+        expect(response.headers.get('x-preflight-handled-by')).toBe('target')
+      }),
+    )
+  })
+
+  test('forwards OPTIONS without an Origin without authorizing credentials', {retry: 2}, async ({setup}) => {
+    const response = await fetch(`${protocol}://localhost:${setup.proxyPort}/path1/test`, {method: 'OPTIONS', agent})
     expect(response.status).toBe(204)
-    expect(response.headers.get('access-control-allow-origin')).toBe('*')
-    expect(response.headers.get('access-control-allow-methods')).toBe('GET, POST, PUT, DELETE, PATCH, OPTIONS')
-    expect(response.headers.get('access-control-allow-headers')).toBe('Content-Type, Authorization')
+    expect(response.headers.get('access-control-allow-origin')).toBeNull()
     expect(response.headers.get('access-control-allow-credentials')).toBeNull()
+    expect(response.headers.get('x-preflight-handled-by')).toBe('target')
   })
 
   test('closes the server when aborted', async ({setup}) => {
@@ -115,6 +140,21 @@ function getTestReverseProxy(protocol: 'http' | 'https') {
     // eslint-disable-next-line no-empty-pattern
     setup: async ({}, use) => {
       const targetServer1 = http.createServer((req, res) => {
+        if (req.method === 'OPTIONS') {
+          const origin = req.headers.origin
+          res.writeHead(204, {
+            'X-Preflight-Handled-By': 'target',
+            ...(origin === authorizedOrigin
+              ? {
+                  'Access-Control-Allow-Origin': origin,
+                  'Access-Control-Allow-Credentials': 'true',
+                  'Access-Control-Allow-Methods': req.headers['access-control-request-method'] ?? '',
+                  'Access-Control-Allow-Headers': req.headers['access-control-request-headers'] ?? '',
+                }
+              : {}),
+          })
+          return res.end()
+        }
         res.writeHead(200, {'Content-Type': 'text/plain'})
         res.end('Response from target server 1')
       })

--- a/packages/app/src/cli/utilities/app/http-reverse-proxy.ts
+++ b/packages/app/src/cli/utilities/app/http-reverse-proxy.ts
@@ -74,13 +74,15 @@ function getProxyServerRequestListener(
       // The proxy does not forward OPTIONS reliably, so we respond here
       // using the headers requested by the client.
       if (req.method === 'OPTIONS') {
+        const origin = req.headers.origin
         res.writeHead(204, {
-          'Access-Control-Allow-Origin': req.headers.origin ?? '*',
+          'Access-Control-Allow-Origin': origin ?? '*',
           'Access-Control-Allow-Methods':
             req.headers['access-control-request-method'] ?? 'GET, POST, PUT, DELETE, PATCH, OPTIONS',
           'Access-Control-Allow-Headers':
             req.headers['access-control-request-headers'] ?? 'Content-Type, Authorization',
           'Access-Control-Max-Age': '86400',
+          ...(origin ? {'Access-Control-Allow-Credentials': 'true'} : {}),
         })
         return res.end()
       }

--- a/packages/app/src/cli/utilities/app/http-reverse-proxy.ts
+++ b/packages/app/src/cli/utilities/app/http-reverse-proxy.ts
@@ -70,22 +70,6 @@ function getProxyServerRequestListener(
   return function (req, res) {
     const target = match(rules, req)
     if (target) {
-      // Handle CORS preflight requests directly
-      // The proxy does not forward OPTIONS reliably, so we respond here
-      // using the headers requested by the client.
-      if (req.method === 'OPTIONS') {
-        const origin = req.headers.origin
-        res.writeHead(204, {
-          'Access-Control-Allow-Origin': origin ?? '*',
-          'Access-Control-Allow-Methods':
-            req.headers['access-control-request-method'] ?? 'GET, POST, PUT, DELETE, PATCH, OPTIONS',
-          'Access-Control-Allow-Headers':
-            req.headers['access-control-request-headers'] ?? 'Content-Type, Authorization',
-          'Access-Control-Max-Age': '86400',
-          ...(origin ? {'Access-Control-Allow-Credentials': 'true'} : {}),
-        })
-        return res.end()
-      }
       return proxy.web(req, res, {target}, (err) => {
         useConcurrentOutputContext({outputPrefix: 'proxy', stripAnsi: false}, () => {
           const lastError = isAggregateError(err) ? err.errors[err.errors.length - 1] : undefined


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #8259

After #7164, the app-dev reverse proxy began answering CORS `OPTIONS` itself instead of forwarding them to the backend. That synthetic 204 included `Access-Control-Allow-Origin` / methods / headers, but not `Access-Control-Allow-Credentials`. Credentialed cross-origin requests that require preflight therefore fail before reaching the backend.

### WHAT is this pull request doing?

When the preflight request has an `Origin`, include `Access-Control-Allow-Credentials: true` on the proxy's OPTIONS response (still reflecting the concrete origin, never pairing credentials with `*`).

- Unit coverage for Origin + credentials and no-Origin (credentials absent)
- Patch changeset for `@shopify/app`

### How to test your changes?

```bash
pnpm --filter @shopify/app exec vitest run src/cli/utilities/app/http-reverse-proxy.test.ts
```

Expect 12/12. The OPTIONS cases assert:
- with `Origin` → `Access-Control-Allow-Credentials: true`
- without `Origin` → credentials header absent

Optional manual check: run `shopify app dev` with a frontend request that actually triggers preflight (e.g. `POST` + `Content-Type: application/json` + `credentials: include`). On main the OPTIONS preflight fails CORS; on this branch it succeeds (backend must still send credentials CORS on the actual response).

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [x] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`