### PR TITLE
[Tests] Add comprehensive unit tests for doctor reporter module

### DIFF
--- a/packages/cli-kit/src/public/node/doctor/reporter.test.ts
+++ b/packages/cli-kit/src/public/node/doctor/reporter.test.ts
@@ -1,0 +1,137 @@
+import {initReporter, reportSuiteStart, reportTestStart, reportTestResult, reportSummary} from './reporter.js'
+import {outputInfo} from '../output.js'
+import {describe, expect, test, vi} from 'vitest'
+
+vi.mock('../output.js', () => ({
+  outputInfo: vi.fn(),
+}))
+
+vi.mock('../colors.js', () => ({
+  default: {
+    bold: (x: string) => x,
+    cyan: (x: string) => x,
+    dim: (x: string) => x,
+    blue: (x: string) => x,
+    green: (x: string) => x,
+    red: (x: string) => x,
+    yellow: (x: string) => x,
+  },
+}))
+
+describe('reporter', () => {
+  test('reportSuiteStart outputs suite name and description', () => {
+    reportSuiteStart('My Suite', 'Description of My Suite')
+
+    expect(outputInfo).toHaveBeenCalledWith('')
+    expect(outputInfo).toHaveBeenCalledWith('Suite: My Suite')
+    expect(outputInfo).toHaveBeenCalledWith('Description of My Suite')
+  })
+
+  test('reportTestStart outputs test name', () => {
+    reportTestStart('My Test')
+
+    expect(outputInfo).toHaveBeenCalledWith('Running: My Test')
+  })
+
+  test('reportTestResult outputs passed result with assertions', () => {
+    const result = {
+      name: 'Successful Test',
+      status: 'passed' as const,
+      duration: 1250,
+      assertions: [
+        {passed: true, description: 'Assert 1'},
+        {passed: true, description: 'Assert 2'},
+      ],
+    }
+
+    reportTestResult(result)
+
+    expect(outputInfo).toHaveBeenCalledWith('PASSED: Successful Test (1.25s)')
+    expect(outputInfo).toHaveBeenCalledWith('  [OK] Assert 1')
+    expect(outputInfo).toHaveBeenCalledWith('  [OK] Assert 2')
+  })
+
+  test('reportTestResult outputs failed result without base path', () => {
+    // empty/falsy base path
+    initReporter('')
+
+    const result = {
+      name: 'Failing Test No Base Path',
+      status: 'failed' as const,
+      duration: 500,
+      assertions: [],
+      error: new Error('File exists: /workspace/project/src/file.ts'),
+    }
+
+    reportTestResult(result)
+
+    expect(outputInfo).toHaveBeenCalledWith('FAILED: Failing Test No Base Path (0.50s)')
+    expect(outputInfo).toHaveBeenCalledWith('  Error: File exists: /workspace/project/src/file.ts')
+  })
+
+  test('reportTestResult outputs failed result with assertions and truncated paths in error message', () => {
+    initReporter('/workspace/project')
+
+    const result = {
+      name: 'Failing Test',
+      status: 'failed' as const,
+      duration: 500,
+      assertions: [
+        {passed: true, description: 'Assert 1'},
+        {passed: false, description: 'Assert 2', expected: 'foo', actual: 'bar'},
+      ],
+      error: new Error('File exists: /workspace/project/src/file.ts'),
+    }
+
+    reportTestResult(result)
+
+    expect(outputInfo).toHaveBeenCalledWith('FAILED: Failing Test (0.50s)')
+    expect(outputInfo).toHaveBeenCalledWith('  [OK] Assert 1')
+    expect(outputInfo).toHaveBeenCalledWith('  [FAIL] Assert 2 (expected: foo, actual: bar)')
+    expect(outputInfo).toHaveBeenCalledWith('  Error: File exists: src/file.ts')
+  })
+
+  test('reportTestResult outputs skipped status', () => {
+    const result = {
+      name: 'Skipped Test',
+      status: 'skipped' as const,
+      duration: 0,
+      assertions: [],
+    }
+
+    reportTestResult(result)
+
+    expect(outputInfo).toHaveBeenCalledWith('SKIPPED: Skipped Test')
+  })
+
+  test('reportSummary outputs correct counts and duration when all pass', () => {
+    const results = [
+      {name: 'T1', status: 'passed' as const, duration: 100, assertions: []},
+      {name: 'T2', status: 'passed' as const, duration: 200, assertions: []},
+    ]
+
+    reportSummary(results)
+
+    expect(outputInfo).toHaveBeenCalledWith('Doctor Complete: 2/2 tests passed')
+    expect(outputInfo).toHaveBeenCalledWith('  Passed: 2')
+    expect(outputInfo).toHaveBeenCalledWith('  Failed: 0')
+    expect(outputInfo).toHaveBeenCalledWith('  Total time: 0.30s')
+  })
+
+  test('reportSummary outputs correct counts and duration when some fail and some are skipped', () => {
+    const results = [
+      {name: 'T1', status: 'passed' as const, duration: 100, assertions: []},
+      {name: 'T2', status: 'failed' as const, duration: 200, assertions: []},
+      {name: 'T3', status: 'skipped' as const, duration: 0, assertions: []},
+    ]
+
+    reportSummary(results)
+
+    expect(outputInfo).toHaveBeenCalledWith('Doctor Complete: 1/3 tests failed')
+    expect(outputInfo).toHaveBeenCalledWith('  Passed: 1')
+    expect(outputInfo).toHaveBeenCalledWith('  Failed: 1')
+    expect(outputInfo).not.toHaveBeenCalledWith('  Skipped: 3')
+    expect(outputInfo).toHaveBeenCalledWith('  Skipped: 1')
+    expect(outputInfo).toHaveBeenCalledWith('  Total time: 0.30s')
+  })
+})


### PR DESCRIPTION
### WHY are these changes introduced?

To improve testing coverage of the `cli-kit` workspace project by adding unit tests for the previously untested `packages/cli-kit/src/public/node/doctor/reporter.ts` module, making subsequent refactoring and changes safer.

### WHAT is this pull request doing?

This pull request introduces a comprehensive unit test suite in `packages/cli-kit/src/public/node/doctor/reporter.test.ts` to test the public contract of the `doctor/reporter` module, fully covering `initReporter`, `reportSuiteStart`, `reportTestStart`, `reportTestResult`, and `reportSummary` functions, including handling both defined and undefined base paths for absolute path relativization.

### How to test your changes?

CI

### Post-release steps

N/A

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [12861941159566517781](https://jules.google.com/task/12861941159566517781) started by @gonzaloriestra*