### PR TITLE
[Refactor] Use early returns in sniffForPath

### DIFF
--- a/packages/cli-kit/src/public/node/path.ts
+++ b/packages/cli-kit/src/public/node/path.ts
@@ -187,13 +187,17 @@ export function cwd(): string {
  */
 export function sniffForPath(argv = process.argv): string | undefined {
   const pathFlagIndex = argv.indexOf('--path')
-  if (pathFlagIndex === -1) {
-    const pathArg = argv.find((arg) => arg.startsWith('--path='))
-    return pathArg?.split('=')[1]
+
+  if (pathFlagIndex !== -1) {
+    const pathFlag = argv[pathFlagIndex + 1]
+    if (pathFlag && !pathFlag.startsWith('-')) {
+      return pathFlag
+    }
+    return undefined
   }
-  const pathFlag = argv[pathFlagIndex + 1]
-  if (!pathFlag || pathFlag.startsWith('-')) return
-  return pathFlag
+
+  const pathArg = argv.find((arg) => arg.startsWith('--path='))
+  return pathArg?.split('=')[1]
 }
 
 /**


### PR DESCRIPTION
### WHY are these changes introduced?

This is a clean refactoring of `sniffForPath` to replace nested `if` statements with flat early returns and guard clauses, improving the code readability and maintainability of path utility functions.

### WHAT is this pull request doing?

Refactors `sniffForPath` in `packages/cli-kit/src/public/node/path.ts` to use early returns/guard clauses rather than checking the negative condition (`pathFlagIndex === -1`) to handle the `--path=` fallback.

### How to test your changes?

CI

### Post-release steps

N/A

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [15343219626415874416](https://jules.google.com/task/15343219626415874416) started by @gonzaloriestra*