### PR TITLE
hydrogen/Bump cli-hydrogen to 13.0.4

### DIFF
--- a/.changeset/update-cli-hydrogen-13-0-4.md
+++ b/.changeset/update-cli-hydrogen-13-0-4.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli': patch
+---
+
+Update cli-hydrogen to 13.0.4

--- a/docs-shopify.dev/generated/generated_docs_data_v2.json
+++ b/docs-shopify.dev/generated/generated_docs_data_v2.json
@@ -3450,6 +3450,14 @@
         {
           "filePath": "docs-shopify.dev/commands/interfaces/hydrogen-customer-account-push.interface.ts",
           "syntaxKind": "PropertySignature",
+          "name": "--javascript-origin <value>",
+          "value": "string",
+          "description": "The origin to register as the allowed JavaScript origin for the Customer Account API OAuth flow. Defaults to --dev-origin. Must not include a port (Shopify rejects origins with ports); use this to register a portless origin while keeping a portful --dev-origin.",
+          "isOptional": true
+        },
+        {
+          "filePath": "docs-shopify.dev/commands/interfaces/hydrogen-customer-account-push.interface.ts",
+          "syntaxKind": "PropertySignature",
           "name": "--path <value>",
           "value": "string",
           "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
@@ -3481,7 +3489,7 @@
           "isOptional": true
         }
       ],
-      "value": "export interface hydrogencustomeraccountpush {\n  /**\n   * The development domain of your application.\n   *\n   */\n  '--dev-origin <value>': string\n\n  /**\n   * The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.\n   * @environment SHOPIFY_HYDROGEN_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * The relative url of allowed url that will be redirected to post-logout for Customer Account API OAuth flow. Default to nothing.\n   *\n   */\n  '--relative-logout-uri <value>'?: string\n\n  /**\n   * The relative url of allowed callback url for Customer Account API OAuth flow. Default is '/account/authorize'\n   *\n   */\n  '--relative-redirect-uri <value>'?: string\n\n  /**\n   * The id of the storefront the configuration should be pushed to. Must start with 'gid://shopify/HydrogenStorefront/'\n   *\n   */\n  '--storefront-id <value>'?: string\n}"
+      "value": "export interface hydrogencustomeraccountpush {\n  /**\n   * The development domain of your application.\n   *\n   */\n  '--dev-origin <value>': string\n\n  /**\n   * The origin to register as the allowed JavaScript origin for the Customer Account API OAuth flow. Defaults to --dev-origin. Must not include a port (Shopify rejects origins with ports); use this to register a portless origin while keeping a portful --dev-origin.\n   *\n   */\n  '--javascript-origin <value>'?: string\n\n  /**\n   * The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.\n   * @environment SHOPIFY_HYDROGEN_FLAG_PATH\n   */\n  '--path <value>'?: string\n\n  /**\n   * The relative url of allowed url that will be redirected to post-logout for Customer Account API OAuth flow. Default to nothing.\n   *\n   */\n  '--relative-logout-uri <value>'?: string\n\n  /**\n   * The relative url of allowed callback url for Customer Account API OAuth flow. Default is '/account/authorize'\n   *\n   */\n  '--relative-redirect-uri <value>'?: string\n\n  /**\n   * The id of the storefront the configuration should be pushed to. Must start with 'gid://shopify/HydrogenStorefront/'\n   *\n   */\n  '--storefront-id <value>'?: string\n}"
     }
   },
   "hydrogendebugcpu": {

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -2318,12 +2318,17 @@ Push project configuration to admin
 
 ```
 USAGE
-  $ shopify hydrogen customer-account-push --dev-origin <value> [--path <value>] [--relative-logout-uri <value>]
-    [--relative-redirect-uri <value>] [--storefront-id <value>]
+  $ shopify hydrogen customer-account-push --dev-origin <value> [--javascript-origin <value>] [--path <value>]
+    [--relative-logout-uri <value>] [--relative-redirect-uri <value>] [--storefront-id <value>]
 
 FLAGS
   --dev-origin=<value>
       (required) The development domain of your application.
+
+  --javascript-origin=<value>
+      The origin to register as the allowed JavaScript origin for the Customer Account API OAuth flow. Defaults to
+      --dev-origin. Must not include a port (Shopify rejects origins with ports); use this to register a portless origin
+      while keeping a portful --dev-origin.
 
   --path=<value>
       The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -4306,6 +4306,13 @@
           "required": true,
           "type": "option"
         },
+        "javascript-origin": {
+          "description": "The origin to register as the allowed JavaScript origin for the Customer Account API OAuth flow. Defaults to --dev-origin. Must not include a port (Shopify rejects origins with ports); use this to register a portless origin while keeping a portful --dev-origin.",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "javascript-origin",
+          "type": "option"
+        },
         "path": {
           "description": "The path to the directory of the Hydrogen storefront. Defaults to the current directory where the command is run.",
           "env": "SHOPIFY_HYDROGEN_FLAG_PATH",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -66,7 +66,7 @@
     "@shopify/plugin-cloudflare": "4.6.1",
     "@shopify/plugin-did-you-mean": "4.6.1",
     "@shopify/theme": "4.6.1",
-    "@shopify/cli-hydrogen": "13.0.3",
+    "@shopify/cli-hydrogen": "13.0.4",
     "@types/global-agent": "3.0.0",
     "@vitest/coverage-istanbul": "^3.2.7",
     "esbuild-plugin-copy": "^2.1.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -275,8 +275,8 @@ importers:
         specifier: 4.6.1
         version: link:../app
       '@shopify/cli-hydrogen':
-        specifier: 13.0.3
-        version: 13.0.3(@graphql-codegen/cli@6.3.1(@parcel/watcher@2.5.6)(@types/node@18.19.130)(crossws@0.3.5)(graphql@16.14.2)(typescript@5.9.3))(graphql-config@5.1.6(@types/node@26.1.1)(crossws@0.3.5)(graphql@16.14.2)(typescript@5.9.3))(graphql@16.14.2)(react-dom@19.2.4(react@18.3.1))(react@18.3.1)(vite@6.4.3(@types/node@26.1.1)(jiti@2.6.1)(sass@1.100.0)(tsx@4.23.1)(yaml@2.9.0))
+        specifier: 13.0.4
+        version: 13.0.4(@graphql-codegen/cli@6.3.1(@parcel/watcher@2.5.6)(@types/node@18.19.130)(crossws@0.3.5)(graphql@16.14.2)(typescript@5.9.3))(graphql-config@5.1.6(@types/node@26.1.1)(crossws@0.3.5)(graphql@16.14.2)(typescript@5.9.3))(graphql@16.14.2)(react-dom@19.2.4(react@18.3.1))(react@18.3.1)(vite@6.4.3(@types/node@26.1.1)(jiti@2.6.1)(sass@1.100.0)(tsx@4.23.1)(yaml@2.9.0))
       '@shopify/cli-kit':
         specifier: 4.6.1
         version: link:../cli-kit
@@ -3671,15 +3671,15 @@ packages:
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==, tarball: https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz}
 
-  '@shopify/cli-hydrogen@13.0.3':
-    resolution: {integrity: sha512-H9chTIgF0eCrObIv/MFZBxf/4WRpJ7bwQo9ihd4VDVabh7e6UcIMm3kQ5/et+bKgbXbJKbhkT6jTD9Bblmy9ag==, tarball: https://registry.npmjs.org/@shopify/cli-hydrogen/-/cli-hydrogen-13.0.3.tgz}
+  '@shopify/cli-hydrogen@13.0.4':
+    resolution: {integrity: sha512-uYeFV0MdVQV/zaoWCYLnYsq5ggcRAADJ8nAaX56ovGkADYxFMlwMPloVf0k2ziV/xSP4t5N32O27/kz6GiKZcg==, tarball: https://registry.npmjs.org/@shopify/cli-hydrogen/-/cli-hydrogen-13.0.4.tgz}
     engines: {node: ^22 || ^24}
     hasBin: true
     peerDependencies:
       '@graphql-codegen/cli': ^5.0.2
       '@react-router/dev': ~7.16.0
       '@shopify/hydrogen-codegen': 0.3.3
-      '@shopify/mini-oxygen': 4.2.1
+      '@shopify/mini-oxygen': 4.2.2
       graphql-config: ^5.0.3
       vite: 6.4.3
     peerDependenciesMeta:
@@ -12395,7 +12395,7 @@ snapshots:
 
   '@shikijs/vscode-textmate@10.0.2': {}
 
-  '@shopify/cli-hydrogen@13.0.3(@graphql-codegen/cli@6.3.1(@parcel/watcher@2.5.6)(@types/node@18.19.130)(crossws@0.3.5)(graphql@16.14.2)(typescript@5.9.3))(graphql-config@5.1.6(@types/node@26.1.1)(crossws@0.3.5)(graphql@16.14.2)(typescript@5.9.3))(graphql@16.14.2)(react-dom@19.2.4(react@18.3.1))(react@18.3.1)(vite@6.4.3(@types/node@26.1.1)(jiti@2.6.1)(sass@1.100.0)(tsx@4.23.1)(yaml@2.9.0))':
+  '@shopify/cli-hydrogen@13.0.4(@graphql-codegen/cli@6.3.1(@parcel/watcher@2.5.6)(@types/node@18.19.130)(crossws@0.3.5)(graphql@16.14.2)(typescript@5.9.3))(graphql-config@5.1.6(@types/node@26.1.1)(crossws@0.3.5)(graphql@16.14.2)(typescript@5.9.3))(graphql@16.14.2)(react-dom@19.2.4(react@18.3.1))(react@18.3.1)(vite@6.4.3(@types/node@26.1.1)(jiti@2.6.1)(sass@1.100.0)(tsx@4.23.1)(yaml@2.9.0))':
     dependencies:
       '@ast-grep/napi': 0.34.1
       '@oclif/core': 3.26.5


### PR DESCRIPTION
## What changed

- Bump `@shopify/cli-hydrogen` from `13.0.3` to `13.0.4`
- Refresh generated command manifests and docs
- Add the stable-branch patch changeset

## Release notes

- Add `--javascript-origin` to `hydrogen customer-account-push`
- Fix local Hydrogen CLI discovery for `customer-account-push`
- Recommend the Shopify AI Toolkit in newly scaffolded storefronts

Full release: https://github.com/Shopify/hydrogen/releases/tag/%40shopify/cli-hydrogen%4013.0.4

## Verification

- CLI tests: 42 passed
- CLI type-check passed
- Frozen lockfile install passed
