### PR TITLE
Support the bundle_size_exception capability

### DIFF
--- a/.changeset/spicy-crabs-bundle.md
+++ b/.changeset/spicy-crabs-bundle.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': minor
+---
+
+Support the bundle_size_exception extension capability

--- a/packages/app/src/cli/models/extensions/schemas.ts
+++ b/packages/app/src/cli/models/extensions/schemas.ts
@@ -26,6 +26,7 @@ const CapabilitiesSchema = zod.object({
   api_access: zod.boolean().optional(),
   collect_buyer_consent: CollectBuyerConsentCapabilitySchema.optional(),
   iframe: IframeCapabilitySchema.optional(),
+  bundle_size_exception: zod.boolean().optional(),
 })
 
 const SupportedFeaturesSchema = zod.object({

--- a/packages/app/src/cli/models/extensions/specifications/ui_extension.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/ui_extension.test.ts
@@ -942,6 +942,53 @@ Please check the configuration in ${uiExtension.configurationPath}`),
       })
     })
 
+    test('includes the bundle_size_exception capability in the deploy config', async () => {
+      await inTemporaryDirectory(async (tmpDir) => {
+        // Given
+        vi.spyOn(loadLocales, 'loadLocalesConfig').mockResolvedValue({})
+        const configurationPath = joinPath(tmpDir, 'shopify.extension.toml')
+        const allSpecs = await loadLocalExtensionsSpecifications()
+        const specification = allSpecs.find((spec) => spec.identifier === 'ui_extension')!
+        const parsed = specification.parseConfigurationObject({
+          targeting: [
+            {
+              target: 'EXTENSION::POINT::A',
+              module: './src/ExtensionPointA.js',
+            },
+          ],
+          api_version: '2025-10' as const,
+          name: 'UI Extension',
+          type: 'ui_extension',
+          handle: 'test-ui-extension',
+          capabilities: {
+            bundle_size_exception: true,
+          },
+          settings: {},
+        })
+        if (parsed.state !== 'ok') {
+          throw new Error("Couldn't parse configuration")
+        }
+        const uiExtension = new ExtensionInstance({
+          configuration: parsed.data,
+          directory: tmpDir,
+          specification,
+          configurationPath,
+          entryPath: '',
+        })
+
+        // When
+        const deployConfig = await uiExtension.deployConfig({
+          apiKey: 'apiKey',
+          appConfiguration: placeholderAppConfiguration,
+        })
+
+        // Then
+        expect(deployConfig?.capabilities).toStrictEqual({
+          bundle_size_exception: true,
+        })
+      })
+    })
+
     test('returns supported_features with runs_offline true when configured', async () => {
       await inTemporaryDirectory(async (tmpDir) => {
         // Given


### PR DESCRIPTION
### Why

Shopify can grant specific apps an exception to the UI extension bundle size limit, applied per extension through the `bundle_size_exception` capability in `shopify.extension.toml`. The capabilities schema strips unknown keys, so without this change the capability never reaches the extension configuration deployed to Shopify and the exception can't take effect. Enforcement is entirely server-side; the exception is granted by Shopify directly to the affected apps.

### What

- Adds `bundle_size_exception` as an optional boolean to `CapabilitiesSchema`.

### Testing

1. In a UI extension's `shopify.extension.toml`, add:
   ```toml
   [extensions.capabilities]
   bundle_size_exception = true
   ```
2. Run `shopify app deploy` (or inspect the module config sent to App Management) and verify the capability is present in the extension's configuration instead of being stripped.
3. Unit: `pnpm vitest run src/cli/models/extensions/specifications/ui_extension.test.ts` in `packages/app`.