### PR TITLE
[Refactor] Extract parseGraphQLDocument helper in bulk operation helpers

### DIFF
--- a/packages/cli-kit/src/public/node/api/bulk-operations/helpers.ts
+++ b/packages/cli-kit/src/public/node/api/bulk-operations/helpers.ts
@@ -36,6 +36,17 @@ export function extractBulkOperationId(gid: string): string {
   return match?.[1] ?? gid
 }
 
+function parseGraphQLDocument(graphqlOperation: string) {
+  try {
+    return parse(graphqlOperation)
+  } catch (error) {
+    if (error instanceof Error) {
+      throw new AbortError(`Invalid GraphQL syntax: ${error.message}`)
+    }
+    throw error
+  }
+}
+
 /**
  * Validates that a GraphQL document contains exactly one operation definition.
  *
@@ -43,15 +54,7 @@ export function extractBulkOperationId(gid: string): string {
  * @throws AbortError if the document doesn't contain exactly one operation or has syntax errors.
  */
 export function validateSingleOperation(graphqlOperation: string): void {
-  let document
-  try {
-    document = parse(graphqlOperation)
-  } catch (error) {
-    if (error instanceof Error) {
-      throw new AbortError(`Invalid GraphQL syntax: ${error.message}`)
-    }
-    throw error
-  }
+  const document = parseGraphQLDocument(graphqlOperation)
 
   const operationDefinitions = document.definitions.filter((def) => def.kind === 'OperationDefinition')
 
@@ -70,15 +73,7 @@ export function validateSingleOperation(graphqlOperation: string): void {
  * @throws AbortError if the operation has invalid GraphQL syntax.
  */
 export function isMutation(graphqlOperation: string): boolean {
-  let document
-  try {
-    document = parse(graphqlOperation)
-  } catch (error) {
-    if (error instanceof Error) {
-      throw new AbortError(`Invalid GraphQL syntax: ${error.message}`)
-    }
-    throw error
-  }
+  const document = parseGraphQLDocument(graphqlOperation)
 
   const operationDefinition = document.definitions.find((def) => def.kind === 'OperationDefinition')
 


### PR DESCRIPTION
### WHAT is this pull request doing?

Extracts duplicated GraphQL document parsing and syntax error handling from `validateSingleOperation` and `isMutation` in `packages/cli-kit/src/public/node/api/bulk-operations/helpers.ts` into a private `parseGraphQLDocument` helper function.

### How to test your changes?

CI

### Checklist

- [ ] I have evaluated the [impact of my change](https://github.com/Shopify/cli/blob/main/docs/dev/scaling-cli/impact-assessment.md)
- [ ] I have added a [changeset](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#changesets) if this PR contains user-facing changes

---
*PR created automatically by Jules for task [2009343155212158420](https://jules.google.com/task/2009343155212158420) started by @gonzaloriestra*