### PR TITLE
[Security] Harden removeGitRemote against option injection

### DIFF
--- a/packages/cli-kit/src/public/node/git.test.ts
+++ b/packages/cli-kit/src/public/node/git.test.ts
@@ -537,4 +537,13 @@ describe('removeGitRemote()', () => {
     expect(mockedExeca).toHaveBeenCalledWith('git', ['remote'], {cwd: directory})
     expect(mockedExeca).not.toHaveBeenCalledWith('git', ['remote', 'remove', remoteName], {cwd: directory})
   })
+
+  test('throws an error if remote name starts with a hyphen', async () => {
+    const directory = '/test/directory'
+
+    await expect(git.removeGitRemote(directory, '-invalid-remote')).rejects.toThrowError(
+      /Invalid remote name: -invalid-remote. Remote names can't start with a hyphen./,
+    )
+    expect(mockedExeca).not.toHaveBeenCalled()
+  })
 })

--- a/packages/cli-kit/src/public/node/git.ts
+++ b/packages/cli-kit/src/public/node/git.ts
@@ -431,6 +431,11 @@ export async function getLatestTag(directory?: string): Promise<string | undefin
  * @returns A promise that resolves when the remote is removed.
  */
 export async function removeGitRemote(directory: string, remoteName = 'origin'): Promise<void> {
+  // Guard against command/argument injection attacks if remoteName starts with '-'
+  if (remoteName.startsWith('-')) {
+    throw new AbortError(`Invalid remote name: ${remoteName}. Remote names can't start with a hyphen.`)
+  }
+
   outputDebug(outputContent`Removing git remote ${remoteName} from ${outputToken.path(directory)}...`)
   await ensureGitIsPresentOrAbort()
 


### PR DESCRIPTION
### WHY are these changes introduced?

Hardens `removeGitRemote` in `@shopify/cli-kit` against argument/option injection attacks.

### WHAT is this pull request doing?

Validates that the `remoteName` argument passed to `removeGitRemote` does not start with a hyphen (`-`), throwing an `AbortError` if it does.

### How to test your changes?

CI

### Post-release steps

N/A

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [2187496675414287180](https://jules.google.com/task/2187496675414287180) started by @gonzaloriestra*