### PR TITLE
[Tests] Add unit tests for deepStrict schema utility

### DIFF
--- a/packages/cli-kit/src/public/node/schema.test.ts
+++ b/packages/cli-kit/src/public/node/schema.test.ts
@@ -37,6 +37,59 @@ describe('deepStrict', () => {
     // Then
     expect(result.success).toBeTruthy()
   })
+
+  test('validates non-optional object schemas as strict', async () => {
+    // Given
+    const schema = z.object({
+      name: z.string(),
+    })
+    const validContent = {name: 'app'}
+    const invalidContent = {name: 'app', extra: 'field'}
+
+    // When
+    const strictSchema = deepStrict(schema)
+
+    // Then
+    expect(strictSchema.safeParse(validContent).success).toBe(true)
+    expect(strictSchema.safeParse(invalidContent).success).toBe(false)
+  })
+
+  test('validates deeply nested object structures as strict', async () => {
+    // Given
+    const schema = z.object({
+      level1: z.object({
+        level2: z.object({
+          key: z.string(),
+        }),
+      }),
+    })
+    const invalidContent = {
+      level1: {
+        level2: {
+          key: 'value',
+          unwanted: true,
+        },
+      },
+    }
+
+    // When
+    const strictSchema = deepStrict(schema)
+
+    // Then
+    expect(strictSchema.safeParse(invalidContent).success).toBe(false)
+  })
+
+  test('returns non-object schemas unchanged', async () => {
+    // Given
+    const stringSchema = z.string()
+
+    // When
+    const resultSchema = deepStrict(stringSchema)
+
+    // Then
+    expect(resultSchema.safeParse('hello').success).toBe(true)
+    expect(resultSchema.safeParse(123).success).toBe(false)
+  })
 })
 
 describe('errorsToString', () => {


### PR DESCRIPTION
### Summary

Added unit tests for `deepStrict` in `packages/cli-kit/src/public/node/schema.test.ts` to improve coverage for schema utilities.

### What was tested?

- Non-optional object schema strict validation rejecting extra keys
- Deeply nested object structure strict validation
- Non-object primitive schemas returned unchanged

### How to test your changes?

CI

---
*PR created automatically by Jules for task [1040419481797455426](https://jules.google.com/task/1040419481797455426) started by @gonzaloriestra*