### PR TITLE
[Refactor] Simplify environment extraction in loadEnvironment

### DIFF
--- a/packages/cli-kit/src/public/node/environments.ts
+++ b/packages/cli-kit/src/public/node/environments.ts
@@ -39,8 +39,7 @@ export async function loadEnvironment(
     return undefined
   }
   const file = await TomlFile.read(filePath)
-  const environmentsJson = file.content as Environments
-  const environments = environmentsJson.environments
+  const environments = (file.content as Environments).environments
   if (!environments) {
     renderWarningIfNeeded(
       {


### PR DESCRIPTION
### WHAT
Simplify `loadEnvironment` in `packages/cli-kit/src/public/node/environments.ts` by inlining the redundant intermediate variable `environmentsJson`.

### WHY
This reduces unnecessary variable declarations and simplifies the reading flow when extracting the environment dictionary from parsed TOML files.

### How to test your changes?
CI

---
*PR created automatically by Jules for task [2782637259354096951](https://jules.google.com/task/2782637259354096951) started by @gonzaloriestra*