### PR TITLE
[Refactor] Use lookup map for global CLI install command

### DIFF
--- a/packages/cli-kit/src/public/node/upgrade.ts
+++ b/packages/cli-kit/src/public/node/upgrade.ts
@@ -21,6 +21,14 @@ import {CLI_KIT_VERSION} from '../common/version.js'
 
 export {getAutoUpgradeEnabled, setAutoUpgradeEnabled}
 
+const CLI_INSTALL_COMMANDS: Partial<Record<string, string>> = {
+  homebrew: 'brew upgrade shopify-cli',
+  yarn: 'yarn global add @shopify/cli@latest',
+  pnpm: 'pnpm add -g @shopify/cli@latest',
+  npm: 'npm install -g @shopify/cli@latest',
+  bun: 'bun install -g @shopify/cli@latest',
+}
+
 /**
  * Utility function for generating an install command for the user to run
  * to install an updated version of Shopify CLI.
@@ -29,16 +37,7 @@ export {getAutoUpgradeEnabled, setAutoUpgradeEnabled}
  */
 export function cliInstallCommand(): string | undefined {
   const packageManager = inferPackageManagerForGlobalCLI()
-  if (!packageManager || packageManager === 'unknown') return undefined
-
-  if (packageManager === 'homebrew') {
-    return 'brew upgrade shopify-cli'
-  } else if (packageManager === 'yarn') {
-    return `${packageManager} global add @shopify/cli@latest`
-  } else {
-    const verb = packageManager === 'pnpm' ? 'add' : 'install'
-    return `${packageManager} ${verb} -g @shopify/cli@latest`
-  }
+  return CLI_INSTALL_COMMANDS[packageManager]
 }
 
 /**


### PR DESCRIPTION
### What this PR does

Refactors `cliInstallCommand` in `packages/cli-kit/src/public/node/upgrade.ts` to replace the `if/else` conditional chain with a declarative lookup table map (`CLI_INSTALL_COMMANDS`).

### How to test your changes?

CI

### Checklist

- [ ] I have generated a changeset if this PR changes a package's surface area.
- [ ] I have added/updated tests for my changes.
- [ ] I have tested my changes locally.


---
*PR created automatically by Jules for task [9607277180850261613](https://jules.google.com/task/9607277180850261613) started by @gonzaloriestra*