### PR TITLE
[Tests] Add unit tests for global-context module

### DIFF
--- a/packages/cli-kit/src/public/node/global-context.test.ts
+++ b/packages/cli-kit/src/public/node/global-context.test.ts
@@ -1,0 +1,17 @@
+import {getCurrentCommandId, setCurrentCommandId} from './global-context.js'
+import {afterEach, describe, expect, test} from 'vitest'
+
+describe('global-context', () => {
+  afterEach(() => {
+    setCurrentCommandId('')
+  })
+
+  test('returns empty string as default command ID', () => {
+    expect(getCurrentCommandId()).toBe('')
+  })
+
+  test('sets and gets current command ID', () => {
+    setCurrentCommandId('test-command-123')
+    expect(getCurrentCommandId()).toBe('test-command-123')
+  })
+})


### PR DESCRIPTION
### WHAT is this pull request doing?

Adds unit tests for `global-context.ts` in `packages/cli-kit/src/public/node/global-context.test.ts` to test `getCurrentCommandId` and `setCurrentCommandId`.

### How to test your changes?

CI


---
*PR created automatically by Jules for task [3610602918756598759](https://jules.google.com/task/3610602918756598759) started by @gonzaloriestra*