### PR TITLE
[Refactor] Use declarative .find() in import-extractor resolution helpers

### DIFF
--- a/packages/cli-kit/src/public/node/import-extractor.ts
+++ b/packages/cli-kit/src/public/node/import-extractor.ts
@@ -1,5 +1,5 @@
 import {fileExistsSync, isDirectorySync} from './fs.js'
-import {dirname, joinPath} from './path.js'
+import {dirname, extname, joinPath} from './path.js'
 import {uniq} from '../common/array.js'
 import {openSync, readSync, closeSync} from 'fs'
 
@@ -69,7 +69,7 @@ export function extractImportPaths(filePath: string): string[] {
   if (cached) return cached
 
   const content = readFileContent(filePath)
-  const ext = filePath.substring(filePath.lastIndexOf('.'))
+  const ext = extname(filePath)
 
   let result: string[]
   switch (ext) {
@@ -231,12 +231,7 @@ function resolveJSImport(importPath: string, fromFile: string): string | null {
       joinPath(resolvedPath, 'index.jsx'),
     ]
 
-    for (const indexPath of indexPaths) {
-      if (cachedFileExists(indexPath) && !cachedIsDir(indexPath)) {
-        return indexPath
-      }
-    }
-    return null
+    return indexPaths.find((indexPath) => cachedFileExists(indexPath) && !cachedIsDir(indexPath)) ?? null
   }
 
   const possiblePaths = [
@@ -247,24 +242,12 @@ function resolveJSImport(importPath: string, fromFile: string): string | null {
     `${resolvedPath}.jsx`,
   ]
 
-  for (const path of possiblePaths) {
-    if (cachedFileExists(path) && !cachedIsDir(path)) {
-      return path
-    }
-  }
-
-  return null
+  return possiblePaths.find((path) => cachedFileExists(path) && !cachedIsDir(path)) ?? null
 }
 
 function resolveRustModule(modName: string, fromFile: string): string | null {
   const basePath = dirname(fromFile)
   const possiblePaths = [joinPath(basePath, `${modName}.rs`), joinPath(basePath, modName, 'mod.rs')]
 
-  for (const path of possiblePaths) {
-    if (cachedFileExists(path)) {
-      return path
-    }
-  }
-
-  return null
+  return possiblePaths.find((path) => cachedFileExists(path)) ?? null
 }


### PR DESCRIPTION
### What this PR does / why we need it

Refactors `resolveJSImport` and `resolveRustModule` in `packages/cli-kit/src/public/node/import-extractor.ts` by replacing imperative `for...of` loops with declarative `Array.prototype.find()` calls. Also replaces manual string slicing for extension extraction with `extname` from `./path.js`.

### How to test your changes?

CI

### Checklist

- [ ] I have executed `pnpm suppress-warnings` from the root of the repository to record any new compiler warnings introduced by this PR.
- [ ] I have updated the documentation in `/docs` to reflect any user-facing changes in this PR.
- [ ] I have created a changeset using `pnpm changeset` if this PR contains user-facing changes or changes that should be published.
- [ ] I have added tests to cover my changes.
- [ ] I have run `pnpm run lint` and fixed any linting errors.
- [ ] I have verified that all tests pass locally.

---
*PR created automatically by Jules for task [11092848067801520960](https://jules.google.com/task/11092848067801520960) started by @gonzaloriestra*