### PR TITLE
[Refactor] Simplify control flow in globalCLIVersion

### DIFF
--- a/packages/cli-kit/src/public/node/version.ts
+++ b/packages/cli-kit/src/public/node/version.ts
@@ -27,15 +27,17 @@ export async function globalCLIVersion(): Promise<string | undefined> {
     const env = {...process.env, SHOPIFY_CLI_NO_ANALYTICS: '1'}
     // Both execa and which find the project dependency. We need to exclude it.
     const shopifyBinaries = which.sync('shopify', {all: true}).filter((path) => !path.includes('node_modules'))
-    if (!shopifyBinaries[0]) return undefined
-    const output = await captureOutput(shopifyBinaries[0], [], {env})
-    const versionMatch = output.match(/@shopify\/cli\/([^\s]+)/)
-    if (versionMatch && versionMatch[1]) {
-      const version = versionMatch[1]
-      if (satisfies(version, `>=3.59.0`) || isPreReleaseVersion(version)) {
-        return version
-      }
+    const globalBinary = shopifyBinaries[0]
+    if (!globalBinary) return undefined
+
+    const output = await captureOutput(globalBinary, [], {env})
+    const version = output.match(/@shopify\/cli\/([^\s]+)/)?.[1]
+    if (!version) return undefined
+
+    if (satisfies(version, `>=3.59.0`) || isPreReleaseVersion(version)) {
+      return version
     }
+
     return undefined
     // eslint-disable-next-line no-catch-all/no-catch-all
   } catch {


### PR DESCRIPTION
### WHY are these changes introduced?

Refactor `globalCLIVersion` in `packages/cli-kit/src/public/node/version.ts` to improve code readability and maintainability.

### WHAT is this pull request doing?

- Replaces nested `if` statements in `globalCLIVersion` with early exit guard clauses and optional chaining (`?.[1]`).
- Assigns `shopifyBinaries[0]` to `globalBinary` for clarity.
- Preserves identical observable behavior and public API.

### How to test your changes?

CI

### Post-release steps

N/A

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [1493009398738821081](https://jules.google.com/task/1493009398738821081) started by @gonzaloriestra*