### PR TITLE
Fix reauthentication after a preview store is claimed

### DIFF
--- a/.changeset/claimed-preview-store-auth-recovery.md
+++ b/.changeset/claimed-preview-store-auth-recovery.md
@@ -1,0 +1,5 @@
+---
+'@shopify/store': patch
+---
+
+Allow store auth recovery after a preview store is claimed.

--- a/packages/store/src/cli/services/store/admin-errors.ts
+++ b/packages/store/src/cli/services/store/admin-errors.ts
@@ -59,12 +59,7 @@ export function throwIfStoredStoreAuthIsInvalid(error: unknown, session: StoredS
   const status = graphQLClientErrorStatus(error)
   if (status !== 401 && status !== 404) return
 
-  // Preview-store sessions are left uncleared: `store auth` overwrites the bucket's
-  // `currentUserId` regardless, and clearing here would make a follow-up `store info` run
-  // fall through to a full interactive login instead of repeating this same actionable message.
-  if (session.kind !== 'preview') {
-    clearStoredStoreAppSession(session.store, session.userId)
-  }
+  clearStoredStoreAppSession(session.store, session.userId)
 
   throwStoredAuthInvalidError(session)
 }

--- a/packages/store/src/cli/services/store/auth/preview-claim-recovery.test.ts
+++ b/packages/store/src/cli/services/store/auth/preview-claim-recovery.test.ts
@@ -1,0 +1,63 @@
+import {authenticateStoreWithApp} from './index.js'
+import {STORE_AUTH_APP_CLIENT_ID} from './config.js'
+import {
+  clearStoredStoreAppSession,
+  getCurrentStoredStoreAppSession,
+  setStoredStoreAppSession,
+  type StoredStoreAppSession,
+} from '@shopify/cli-kit/node/store-auth-session'
+import {inTemporaryDirectory} from '@shopify/cli-kit/node/fs'
+import {LocalStorage} from '@shopify/cli-kit/node/local-storage'
+import {AbortError} from '@shopify/cli-kit/node/error'
+import {describe, expect, test, vi} from 'vitest'
+
+vi.mock('../attribution.js')
+
+const SHOP = 'shop.myshopify.com'
+const SCOPE_RESOLUTION_REACHED = 'Scope resolution reached, so the preview-store guard did not fire.'
+
+type StoreAuthStorage = NonNullable<Parameters<typeof getCurrentStoredStoreAppSession>[1]>
+
+function createStoreAuthStorage(cwd: string): StoreAuthStorage {
+  return new LocalStorage({cwd})
+}
+
+function previewSession(): StoredStoreAppSession {
+  return {
+    store: SHOP,
+    clientId: STORE_AUTH_APP_CLIENT_ID,
+    userId: 'preview:placeholder-uuid',
+    accessToken: 'shpat_preview_token',
+    scopes: ['read_themes', 'write_themes'],
+    acquiredAt: '2026-06-08T12:00:00.000Z',
+    kind: 'preview',
+    preview: {shopId: '123', name: 'Lavender Candles', createdAt: '2026-06-08T12:00:00.000Z'},
+  }
+}
+
+function runStoreAuth(storage: StoreAuthStorage): Promise<unknown> {
+  return authenticateStoreWithApp(
+    {store: SHOP, scopes: 'read_products'},
+    {
+      getCurrentStoredStoreAppSession: (store) => getCurrentStoredStoreAppSession(store, storage),
+      resolveExistingScopes: () => Promise.reject(new AbortError(SCOPE_RESOLUTION_REACHED)),
+    },
+  )
+}
+
+describe('recovering from a claimed preview store', () => {
+  test('clearing the invalid preview session unblocks the suggested `store auth` run', async () => {
+    await inTemporaryDirectory(async (cwd) => {
+      const storage = createStoreAuthStorage(cwd)
+      const session = previewSession()
+      setStoredStoreAppSession(session, storage)
+
+      await expect(runStoreAuth(storage)).rejects.toThrow('`store auth` is unavailable for preview stores.')
+
+      clearStoredStoreAppSession(session.store, session.userId, storage)
+      expect(getCurrentStoredStoreAppSession(SHOP, storage)).toBeUndefined()
+
+      await expect(runStoreAuth(storage)).rejects.toThrow(SCOPE_RESOLUTION_REACHED)
+    })
+  })
+})

--- a/packages/store/src/cli/services/store/execute/admin-transport.test.ts
+++ b/packages/store/src/cli/services/store/execute/admin-transport.test.ts
@@ -110,7 +110,7 @@ describe('runAdminStoreGraphQLOperation', () => {
     expect(clearStoredStoreAppSession).toHaveBeenCalledWith(store, '42')
   })
 
-  test('flags a likely claim and does not re-list scopes when a lingering preview session 401s', async () => {
+  test('clears a likely claimed preview session and does not re-list scopes when it 401s', async () => {
     vi.mocked(graphqlRequest).mockRejectedValue({response: {status: 401}})
     const request = await prepareStoreExecuteRequest({query: 'query { shop { name } }'})
     const previewContext = {
@@ -133,7 +133,7 @@ describe('runAdminStoreGraphQLOperation', () => {
         ],
       ],
     })
-    expect(clearStoredStoreAppSession).not.toHaveBeenCalled()
+    expect(clearStoredStoreAppSession).toHaveBeenCalledWith(store, 'preview:placeholder-uuid')
   })
 
   test('throws a GraphQL operation error when errors are returned', async () => {
@@ -273,7 +273,7 @@ describe('fetchPublicApiVersions', () => {
     expect(clearStoredStoreAppSession).toHaveBeenCalledWith(store, '42')
   })
 
-  test('flags a likely claim and does not re-list scopes when a lingering preview session 401s', async () => {
+  test('clears a likely claimed preview session and does not re-list scopes when it 401s', async () => {
     vi.mocked(graphqlRequest).mockRejectedValue(makeClientErrorLike(401, 'Unauthorized'))
     const previewSession = {
       ...session,
@@ -292,7 +292,7 @@ describe('fetchPublicApiVersions', () => {
         ],
       ],
     })
-    expect(clearStoredStoreAppSession).not.toHaveBeenCalled()
+    expect(clearStoredStoreAppSession).toHaveBeenCalledWith(store, 'preview:placeholder-uuid')
   })
 
   test('maps 402 Unavailable Shop to an AbortError without clearing stored auth', async () => {

--- a/packages/store/src/cli/services/store/info/index.test.ts
+++ b/packages/store/src/cli/services/store/info/index.test.ts
@@ -197,7 +197,7 @@ describe('getStoreInfo', () => {
   })
 
   test.each([401, 404])(
-    'prompts re-auth without clearing the stale preview session when the preview store lookup returns %s',
+    'clears the stale preview session and prompts re-auth when the preview store lookup returns %s',
     async (status) => {
       vi.mocked(getCurrentStoredStoreAppSession).mockReturnValueOnce({
         store: SHOP,
@@ -231,7 +231,7 @@ describe('getStoreInfo', () => {
           ],
         ],
       })
-      expect(clearStoredStoreAppSession).not.toHaveBeenCalled()
+      expect(clearStoredStoreAppSession).toHaveBeenCalledWith(SHOP, 'placeholder-uuid')
     },
   )
 
@@ -564,7 +564,7 @@ The CLI is currently unable to prompt for reauthentication.`)
     expect(clearStoredStoreAppSession).toHaveBeenCalledWith(SHOP, '42')
   })
 
-  test('flags a likely claim (not a generic invalid-auth error) for a lingering preview session that 401s against Admin', async () => {
+  test('clears a likely claimed preview session that 401s against Admin', async () => {
     mockStoreAuthFallback()
     vi.mocked(loadStoredStoreSession).mockResolvedValue({
       ...STORED_SESSION,
@@ -584,7 +584,7 @@ The CLI is currently unable to prompt for reauthentication.`)
         ],
       ],
     })
-    expect(clearStoredStoreAppSession).not.toHaveBeenCalled()
+    expect(clearStoredStoreAppSession).toHaveBeenCalledWith(SHOP, 'placeholder-uuid')
   })
 
   test('also treats Admin 404 as a stored-auth-no-longer-valid signal', async () => {

--- a/packages/store/src/cli/services/store/info/index.ts
+++ b/packages/store/src/cli/services/store/info/index.ts
@@ -7,7 +7,7 @@ import {getPreviewStore, PreviewStoreRequestError} from '../create/preview/clien
 import {storeTypeHandle} from '../store-type.js'
 import {StoreLookupStoreNotFoundError, fetchDestinationsContext} from '../../../utilities/store-lookup/destinations.js'
 import {fetchOrganizationShop} from '../../../utilities/store-lookup/organization-shop.js'
-import {getCurrentStoredStoreAppSession} from '@shopify/cli-kit/node/store-auth-session'
+import {clearStoredStoreAppSession, getCurrentStoredStoreAppSession} from '@shopify/cli-kit/node/store-auth-session'
 import {AbortError} from '@shopify/cli-kit/node/error'
 import {adminUrl} from '@shopify/cli-kit/node/api/admin'
 import {graphqlRequest} from '@shopify/cli-kit/node/api/graphql'
@@ -161,10 +161,10 @@ async function fetchPreviewStoreUrls(previewSession: PreviewStoreSession): Promi
     }
   } catch (error) {
     // The CLI has no local signal for when a preview store gets claimed via the browser; a
-    // 401/404 here is the first indication. The stored session is left uncleared on purpose: it
-    // isn't needed for `store auth` to take over, and keeping it means every `store info` run
-    // keeps producing this same actionable message instead of falling through to a full login.
+    // 401/404 here is the first indication. Remove the stale preview session so the `store auth`
+    // command in the recovery error is not blocked by the preview-store guard.
     if (error instanceof PreviewStoreRequestError && (error.status === 401 || error.status === 404)) {
+      clearStoredStoreAppSession(previewSession.store, previewSession.userId)
       throwStoredAuthInvalidError(previewSession)
     }
 

--- a/packages/store/src/cli/services/store/info/index.ts
+++ b/packages/store/src/cli/services/store/info/index.ts
@@ -160,9 +160,8 @@ async function fetchPreviewStoreUrls(previewSession: PreviewStoreSession): Promi
       ...(previewStore.claimUrl ? {saveUrl: previewStore.claimUrl} : {}),
     }
   } catch (error) {
-    // The CLI has no local signal for when a preview store gets claimed via the browser; a
-    // 401/404 here is the first indication. Remove the stale preview session so the `store auth`
-    // command in the recovery error is not blocked by the preview-store guard.
+    // The CLI does not receive a claim event. A 401/404 is the first signal that the preview
+    // credential is invalid. Clear the session so the `store auth` command can run.
     if (error instanceof PreviewStoreRequestError && (error.status === 401 || error.status === 404)) {
       clearStoredStoreAppSession(previewSession.store, previewSession.userId)
       throwStoredAuthInvalidError(previewSession)


### PR DESCRIPTION
### WHY are these changes introduced?

[#7986](https://github.com/Shopify/cli/pull/7986) detects a claimed preview store and tells the user to run `shopify store auth`. It retains the stale `kind: 'preview'` session, but `store auth` stops in `throwIfPreviewStore` before it can replace that session. The recovery command therefore cannot run.

The old behavior retained the session so later `store info` calls repeated the claimed-preview error instead of starting normal login. After claim, normal OAuth is the required recovery. This change clears a session only after 401/404 proves that its preview credential is invalid.

This is intentionally split from [#8190](https://github.com/Shopify/cli/pull/8190). This PR repairs the existing `store` recovery contract. The follow-up PR will handle theme commands and its required shared transport/recovery changes.

### WHAT is this pull request doing?

Clear a preview session after a 401/404 proves that its token is no longer valid, then keep the existing claimed-preview reauthentication error and scope placeholder. The change covers both Preview Stores lookup and Admin API paths used by `store info` and `store execute`.

A real-local-storage regression test proves that the suggested `store auth` command gets past the preview-store guard after recovery.

### Manual testing

Use a throwaway preview store. Claiming revokes its preview credential. Use the same local CLI profile for all steps.

This snapshot tests `store info` and `store execute`. Theme-command recovery is separate.

(Pre-PR behavior)

1. Create a preview store:

   ```sh
   shopify store create preview
   ```

2. Get and open its claim URL:

   ```sh
   shopify store info --store <preview-store>.myshopify.com --json
   ```

   Open `saveUrl` from the JSON output. Complete the browser claim as the new store owner.

3. With the released CLI still installed, reproduce the bug:

   ```sh
   shopify store info --store <claimed-store>.myshopify.com

   shopify store auth \
     --store <claimed-store>.myshopify.com \
     --scopes read_products
   ```

   The first command reports a likely claim. The second command fails with ``store auth` is unavailable for preview stores` because the stale preview session blocks recovery.


(Post-PR behavior)

1. Install the snapshot and confirm the executable version:

   ```sh
   pnpm i -g --@shopify:registry=https://registry.npmjs.org \
     @shopify/cli@0.0.0-snapshot-20260819161547

   shopify version
   ```

   Expect `0.0.0-snapshot-20260819161547`. If the version differs, run `which shopify` to find the executable in use.

2. Trigger recovery again, then authenticate:

   ```sh
   shopify store info --store <claimed-store>.myshopify.com

   shopify store auth \
     --store <claimed-store>.myshopify.com \
     --scopes read_products
   ```

   The first command gives the same claimed-preview recovery message and clears the stale session. The second command gets past the preview guard and starts browser OAuth. Complete OAuth as the claimed store owner or another authorized user.

3. Verify the new stored session:

   ```sh
   shopify store execute \
     --store <claimed-store>.myshopify.com \
     --query 'query { shop { name } }'
   ```

   Expect the claimed store name.

To test the `store execute` invalidation path directly, repeat the flow with a new preview store. Use the `store execute` command above instead of `store info` in steps 3 and 5. The next `store auth` command must start OAuth rather than fail because the store is still classified as a preview store.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [x] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`
