### PR TITLE
Add shopify feedback command, bumping app_cli3_command to 1.29

### DIFF
--- a/.changeset/feedback-command.md
+++ b/.changeset/feedback-command.md
@@ -1,0 +1,6 @@
+---
+'@shopify/cli-kit': minor
+'@shopify/cli': minor
+---
+
+Add `shopify feedback` command for sending feedback about the CLI to Shopify

--- a/packages/cli-kit/src/public/node/metadata.ts
+++ b/packages/cli-kit/src/public/node/metadata.ts
@@ -176,11 +176,12 @@ export function createRuntimeMetadataContainer<
 }
 
 // We want to track anything that ends up getting sent to monorail as `cmd_all_*`,
-// `cmd_app_*`, `cmd_theme_*`, `store_*`, and `env_auto_upgrade_*`
+// `cmd_app_*`, `cmd_theme_*`, `store_*`, `env_auto_upgrade_*`, and `cmd_feedback_*`
 type CmdFieldsFromMonorail = PickByPrefix<MonorailEventPublic, 'cmd_all_'> &
   PickByPrefix<MonorailEventPublic, 'cmd_app_'> &
   PickByPrefix<MonorailEventPublic, 'cmd_create_app_'> &
   PickByPrefix<MonorailEventPublic, 'cmd_theme_'> &
+  PickByPrefix<MonorailEventPublic, 'cmd_feedback_'> &
   PickByPrefix<MonorailEventPublic, 'store_'> &
   PickByPrefix<MonorailEventPublic, 'env_auto_upgrade_'>
 
@@ -195,7 +196,12 @@ const coreData = createRuntimeMetadataContainer<
       startArgs: string[]
       requiresSyncAnalytics?: boolean
     }
-  } & {environmentFlags: string} & PickByPrefix<MonorailEventSensitive, 'store_'>
+  } & {
+    environmentFlags: string
+    // The `shopify feedback` message is user-authored free text that may contain PII, so it travels
+    // inside the sensitive `metadata` field of the Monorail event rather than as a public field.
+    cmd_feedback_message: string
+  } & PickByPrefix<MonorailEventSensitive, 'store_'>
 >({cmd_all_timing_network_ms: 0, cmd_all_timing_prompts_ms: 0})
 
 export const {getAllPublicMetadata, getAllSensitiveMetadata, addPublicMetadata, addSensitiveMetadata, runWithTimer} =

--- a/packages/cli-kit/src/public/node/monorail.ts
+++ b/packages/cli-kit/src/public/node/monorail.ts
@@ -10,7 +10,7 @@ const url = 'https://monorail-edge.shopifysvc.com/v1/produce'
 type Optional<T> = T | null
 
 // This is the topic name of the main event we log to Monorail, the command tracker
-export const MONORAIL_COMMAND_TOPIC = 'app_cli3_command/1.28'
+export const MONORAIL_COMMAND_TOPIC = 'app_cli3_command/1.29'
 
 export interface Schemas {
   [MONORAIL_COMMAND_TOPIC]: {
@@ -134,6 +134,14 @@ export interface Schemas {
 
       // Release related commands
       cmd_release_confirm_cancelled?: Optional<boolean>
+
+      // Feedback command. The message itself is user-authored free text, so it travels in the
+      // sensitive `metadata` field rather than as a public field.
+      cmd_feedback_sentiment?: Optional<string>
+      cmd_feedback_category?: Optional<string>
+      cmd_feedback_message_length?: Optional<number>
+      cmd_feedback_message_truncated?: Optional<boolean>
+      cmd_feedback_source?: Optional<string>
 
       // App setup
       app_extensions_any?: Optional<boolean>

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -42,6 +42,7 @@
 * [`shopify config autoupgrade status`](#shopify-config-autoupgrade-status)
 * [`shopify doc fetch`](#shopify-doc-fetch)
 * [`shopify doc search`](#shopify-doc-search)
+* [`shopify feedback`](#shopify-feedback)
 * [`shopify help [command] [flags]`](#shopify-help-command-flags)
 * [`shopify hydrogen build`](#shopify-hydrogen-build)
 * [`shopify hydrogen check RESOURCE`](#shopify-hydrogen-check-resource)
@@ -2210,6 +2211,59 @@ EXAMPLES
       shopify doc search --query "subscribe to webhooks"
       # narrow the search to a specific API and version
       shopify doc search --query "create a product" --api-name admin --api-version latest
+```
+
+## `shopify feedback`
+
+Send feedback about Shopify CLI.
+
+```
+USAGE
+  $ shopify feedback -m <value> [--category
+    wrong_guidance|missing_capability|confusing_docs|tool_failure|slow|other] [-j] [--no-color] [--sentiment
+    frustrated|blocked|confused|praise] [--verbose]
+
+FLAGS
+  -j, --json
+      Output the result as JSON. Automatically disables color output.
+      [env: SHOPIFY_FLAG_JSON]
+
+  -m, --message=<value>
+      (required) The feedback message. Pass - to read the message from stdin. Messages longer than 2000 characters are
+      truncated.
+      [env: SHOPIFY_FLAG_MESSAGE]
+
+  --category=<option>
+      What the feedback is about.
+      [env: SHOPIFY_FLAG_CATEGORY]
+      <options: wrong_guidance|missing_capability|confusing_docs|tool_failure|slow|other>
+
+  --no-color
+      Disable color output.
+      [env: SHOPIFY_FLAG_NO_COLOR]
+
+  --sentiment=<option>
+      How the experience felt.
+      [env: SHOPIFY_FLAG_SENTIMENT]
+      <options: frustrated|blocked|confused|praise>
+
+  --verbose
+      Increase the verbosity of the output. May include sensitive data.
+      [env: SHOPIFY_FLAG_VERBOSE]
+
+DESCRIPTION
+  Send feedback about Shopify CLI.
+
+  Sends feedback about Shopify CLI to the team that builds it. The feedback travels on the usage analytics the CLI
+  already reports, so it makes no separate network request and respects the analytics opt-out. It never prompts, so both
+  humans and AI agents can run it.
+
+EXAMPLES
+  $ shopify feedback --message "The deploy command told me to use a flag that does not exist"
+
+  $ shopify feedback --message "dev keeps disconnecting from my store" --sentiment frustrated --category tool_failure
+
+  echo "Docs and CLI disagree about theme push" | shopify feedback --message -
 ```
 
 ## `shopify help [command] [flags]`

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -4086,6 +4086,96 @@
       "pluginType": "core",
       "strict": true
     },
+    "feedback": {
+      "aliases": [
+      ],
+      "args": {
+      },
+      "description": "Sends feedback about Shopify CLI to the team that builds it. The feedback travels on the usage analytics the CLI already reports, so it makes no separate network request and respects the analytics opt-out. It never prompts, so both humans and AI agents can run it.",
+      "descriptionWithMarkdown": "Sends feedback about Shopify CLI to the team that builds it. The feedback travels on the usage analytics the CLI already reports, so it makes no separate network request and respects the analytics opt-out. It never prompts, so both humans and AI agents can run it.",
+      "enableJsonFlag": false,
+      "examples": [
+        "<%= config.bin %> <%= command.id %> --message \"The deploy command told me to use a flag that does not exist\"",
+        "<%= config.bin %> <%= command.id %> --message \"dev keeps disconnecting from my store\" --sentiment frustrated --category tool_failure",
+        "echo \"Docs and CLI disagree about theme push\" | <%= config.bin %> <%= command.id %> --message -"
+      ],
+      "flags": {
+        "category": {
+          "description": "What the feedback is about.",
+          "env": "SHOPIFY_FLAG_CATEGORY",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "category",
+          "options": [
+            "wrong_guidance",
+            "missing_capability",
+            "confusing_docs",
+            "tool_failure",
+            "slow",
+            "other"
+          ],
+          "type": "option"
+        },
+        "json": {
+          "allowNo": false,
+          "char": "j",
+          "description": "Output the result as JSON. Automatically disables color output.",
+          "env": "SHOPIFY_FLAG_JSON",
+          "hidden": false,
+          "name": "json",
+          "type": "boolean"
+        },
+        "message": {
+          "char": "m",
+          "description": "The feedback message. Pass - to read the message from stdin. Messages longer than 2000 characters are truncated.",
+          "env": "SHOPIFY_FLAG_MESSAGE",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "message",
+          "required": true,
+          "type": "option"
+        },
+        "no-color": {
+          "allowNo": false,
+          "description": "Disable color output.",
+          "env": "SHOPIFY_FLAG_NO_COLOR",
+          "hidden": false,
+          "name": "no-color",
+          "type": "boolean"
+        },
+        "sentiment": {
+          "description": "How the experience felt.",
+          "env": "SHOPIFY_FLAG_SENTIMENT",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "sentiment",
+          "options": [
+            "frustrated",
+            "blocked",
+            "confused",
+            "praise"
+          ],
+          "type": "option"
+        },
+        "verbose": {
+          "allowNo": false,
+          "description": "Increase the verbosity of the output. May include sensitive data.",
+          "env": "SHOPIFY_FLAG_VERBOSE",
+          "hidden": false,
+          "name": "verbose",
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [
+      ],
+      "id": "feedback",
+      "pluginAlias": "@shopify/cli",
+      "pluginName": "@shopify/cli",
+      "pluginType": "core",
+      "strict": true,
+      "summary": "Send feedback about Shopify CLI."
+    },
     "help": {
       "aliases": [
       ],

--- a/packages/cli/src/cli/commands/feedback.test.ts
+++ b/packages/cli/src/cli/commands/feedback.test.ts
@@ -1,0 +1,55 @@
+import Feedback from './feedback.js'
+import {feedbackService} from '../services/commands/feedback.js'
+import {describe, expect, test, vi} from 'vitest'
+
+// Only mock the service function itself: the command imports MAX_FEEDBACK_MESSAGE_LENGTH from the
+// same module, and that must stay real for the flag descriptions.
+vi.mock('../services/commands/feedback.js', async (importOriginal) => {
+  const original = await importOriginal<typeof import('../services/commands/feedback.js')>()
+  return {...original, feedbackService: vi.fn()}
+})
+
+describe('feedback command', () => {
+  test('delegates to the feedback service with the parsed flags', async () => {
+    await Feedback.run(
+      ['--message', 'The docs were wrong', '--sentiment', 'confused', '--category', 'confusing_docs'],
+      import.meta.url,
+    )
+
+    expect(feedbackService).toHaveBeenCalledWith({
+      message: 'The docs were wrong',
+      sentiment: 'confused',
+      category: 'confusing_docs',
+      json: false,
+    })
+  })
+
+  test('passes --json through to the service', async () => {
+    await Feedback.run(['--message', 'It worked!', '--json'], import.meta.url)
+
+    expect(feedbackService).toHaveBeenCalledWith({
+      message: 'It worked!',
+      sentiment: undefined,
+      category: undefined,
+      json: true,
+    })
+  })
+
+  test('fails when --message is missing', async () => {
+    await expect(Feedback.run([], import.meta.url)).rejects.toThrow()
+
+    expect(feedbackService).not.toHaveBeenCalled()
+  })
+
+  test('rejects a sentiment outside the closed set', async () => {
+    await expect(Feedback.run(['--message', 'hi', '--sentiment', 'angry'], import.meta.url)).rejects.toThrow()
+
+    expect(feedbackService).not.toHaveBeenCalled()
+  })
+
+  test('rejects a category outside the closed set', async () => {
+    await expect(Feedback.run(['--message', 'hi', '--category', 'bad_vibes'], import.meta.url)).rejects.toThrow()
+
+    expect(feedbackService).not.toHaveBeenCalled()
+  })
+})

--- a/packages/cli/src/cli/commands/feedback.ts
+++ b/packages/cli/src/cli/commands/feedback.ts
@@ -1,0 +1,55 @@
+import {feedbackService, MAX_FEEDBACK_MESSAGE_LENGTH} from '../services/commands/feedback.js'
+import Command from '@shopify/cli-kit/node/base-command'
+import {globalFlags, jsonFlag} from '@shopify/cli-kit/node/cli'
+import {Flags} from '@oclif/core'
+
+export default class Feedback extends Command {
+  // The analytics event carrying the feedback is the whole point of this command, so wait for the
+  // delivery attempt instead of detaching it to a background process that might not outlive us.
+  public static get requiresSyncAnalytics(): boolean {
+    return true
+  }
+
+  static summary = 'Send feedback about Shopify CLI.'
+
+  static descriptionWithMarkdown = `Sends feedback about Shopify CLI to the team that builds it. The feedback travels on the usage analytics the CLI already reports, so it makes no separate network request and respects the analytics opt-out. It never prompts, so both humans and AI agents can run it.`
+
+  static description = this.descriptionWithoutMarkdown()
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %> --message "The deploy command told me to use a flag that does not exist"',
+    '<%= config.bin %> <%= command.id %> --message "dev keeps disconnecting from my store" --sentiment frustrated --category tool_failure',
+    'echo "Docs and CLI disagree about theme push" | <%= config.bin %> <%= command.id %> --message -',
+  ]
+
+  static flags = {
+    ...globalFlags,
+    ...jsonFlag,
+    message: Flags.string({
+      char: 'm',
+      description: `The feedback message. Pass - to read the message from stdin. Messages longer than ${MAX_FEEDBACK_MESSAGE_LENGTH} characters are truncated.`,
+      required: true,
+      env: 'SHOPIFY_FLAG_MESSAGE',
+    }),
+    sentiment: Flags.string({
+      description: 'How the experience felt.',
+      options: ['frustrated', 'blocked', 'confused', 'praise'],
+      env: 'SHOPIFY_FLAG_SENTIMENT',
+    }),
+    category: Flags.string({
+      description: 'What the feedback is about.',
+      options: ['wrong_guidance', 'missing_capability', 'confusing_docs', 'tool_failure', 'slow', 'other'],
+      env: 'SHOPIFY_FLAG_CATEGORY',
+    }),
+  }
+
+  async run(): Promise<void> {
+    const {flags} = await this.parse(Feedback)
+    await feedbackService({
+      message: flags.message,
+      sentiment: flags.sentiment,
+      category: flags.category,
+      json: flags.json,
+    })
+  }
+}

--- a/packages/cli/src/cli/services/commands/feedback.test.ts
+++ b/packages/cli/src/cli/services/commands/feedback.test.ts
@@ -1,0 +1,173 @@
+import {feedbackService, MAX_FEEDBACK_MESSAGE_LENGTH} from './feedback.js'
+import {alwaysLogAnalytics, analyticsDisabled} from '@shopify/cli-kit/node/context/local'
+import {AbortError, AbortSilentError} from '@shopify/cli-kit/node/error'
+import {addPublicMetadata, addSensitiveMetadata} from '@shopify/cli-kit/node/metadata'
+import {outputResult} from '@shopify/cli-kit/node/output'
+import {readStdinString} from '@shopify/cli-kit/node/system'
+import {renderSuccess, renderWarning} from '@shopify/cli-kit/node/ui'
+import {afterEach, describe, expect, test, vi} from 'vitest'
+
+vi.mock('@shopify/cli-kit/node/context/local')
+vi.mock('@shopify/cli-kit/node/metadata')
+vi.mock('@shopify/cli-kit/node/output')
+vi.mock('@shopify/cli-kit/node/system')
+vi.mock('@shopify/cli-kit/node/ui')
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
+
+// The test process itself can run under an AI agent that sets SHOPIFY_CLI_AGENT*, which would flip
+// the detected source, so tests that expect 'human' clear those variables first.
+function clearAgentEnvironmentVariables() {
+  Object.keys(process.env)
+    .filter((variableName) => variableName.startsWith('SHOPIFY_CLI_AGENT'))
+    .forEach((variableName) => vi.stubEnv(variableName, undefined))
+}
+
+// The metadata functions receive a callback that produces the data, so we run the callback the
+// service passed in to see what it would record.
+async function recordedPublicMetadata() {
+  return vi.mocked(addPublicMetadata).mock.calls[0]![0]()
+}
+
+async function recordedSensitiveMetadata() {
+  return vi.mocked(addSensitiveMetadata).mock.calls[0]![0]()
+}
+
+describe('feedbackService', () => {
+  test('records the dimensions as public metadata and the message as sensitive metadata', async () => {
+    clearAgentEnvironmentVariables()
+
+    await feedbackService({message: 'It worked!', sentiment: 'praise', category: 'other', json: false})
+
+    await expect(recordedPublicMetadata()).resolves.toEqual({
+      cmd_feedback_sentiment: 'praise',
+      cmd_feedback_category: 'other',
+      cmd_feedback_message_length: 10,
+      cmd_feedback_message_truncated: false,
+      cmd_feedback_source: 'human',
+    })
+    await expect(recordedSensitiveMetadata()).resolves.toEqual({cmd_feedback_message: 'It worked!'})
+    expect(renderSuccess).toHaveBeenCalledWith({headline: 'Thanks for your feedback.'})
+  })
+
+  test('truncates the message at the cap but reports the original length', async () => {
+    const longMessage = 'a'.repeat(MAX_FEEDBACK_MESSAGE_LENGTH + 500)
+
+    await feedbackService({message: longMessage, json: false})
+
+    await expect(recordedPublicMetadata()).resolves.toMatchObject({
+      cmd_feedback_message_length: MAX_FEEDBACK_MESSAGE_LENGTH + 500,
+      cmd_feedback_message_truncated: true,
+    })
+    await expect(recordedSensitiveMetadata()).resolves.toEqual({
+      cmd_feedback_message: 'a'.repeat(MAX_FEEDBACK_MESSAGE_LENGTH),
+    })
+    expect(renderSuccess).toHaveBeenCalledWith({
+      headline: 'Thanks for your feedback.',
+      body: expect.stringContaining('truncated'),
+    })
+  })
+
+  test('does not leave half a surrogate pair when truncation lands inside an emoji', async () => {
+    // The emoji is two UTF-16 code units, so the cap cuts straight through it.
+    const messageEndingInEmoji = `${'a'.repeat(MAX_FEEDBACK_MESSAGE_LENGTH - 1)}😀`
+
+    await feedbackService({message: messageEndingInEmoji, json: false})
+
+    await expect(recordedSensitiveMetadata()).resolves.toEqual({
+      cmd_feedback_message: 'a'.repeat(MAX_FEEDBACK_MESSAGE_LENGTH - 1),
+    })
+  })
+
+  test('reads the message from stdin when --message - is passed', async () => {
+    vi.mocked(readStdinString).mockResolvedValue('piped feedback')
+
+    await feedbackService({message: '-', json: false})
+
+    await expect(recordedSensitiveMetadata()).resolves.toEqual({cmd_feedback_message: 'piped feedback'})
+  })
+
+  test('throws when --message - is passed but nothing is piped to stdin', async () => {
+    vi.mocked(readStdinString).mockResolvedValue(undefined)
+
+    await expect(feedbackService({message: '-', json: false})).rejects.toThrow(AbortError)
+    expect(addPublicMetadata).not.toHaveBeenCalled()
+  })
+
+  test('reports the missing stdin message as JSON when --json is passed', async () => {
+    vi.mocked(readStdinString).mockResolvedValue(undefined)
+
+    await expect(feedbackService({message: '-', json: true})).rejects.toThrow(AbortSilentError)
+    expect(outputResult).toHaveBeenCalledWith(JSON.stringify({sent: false, reason: 'no_stdin_message'}, null, 2))
+  })
+
+  test('throws when the message is only whitespace', async () => {
+    await expect(feedbackService({message: '   ', json: false})).rejects.toThrow(AbortError)
+    expect(addPublicMetadata).not.toHaveBeenCalled()
+  })
+
+  test('reports the empty message as JSON when --json is passed', async () => {
+    await expect(feedbackService({message: '   ', json: true})).rejects.toThrow(AbortSilentError)
+    expect(outputResult).toHaveBeenCalledWith(JSON.stringify({sent: false, reason: 'empty_message'}, null, 2))
+  })
+
+  test('marks the source as agent when a SHOPIFY_CLI_AGENT variable is present', async () => {
+    vi.stubEnv('SHOPIFY_CLI_AGENT', 'claude-code')
+
+    await feedbackService({message: 'sent for the user', json: false})
+
+    await expect(recordedPublicMetadata()).resolves.toMatchObject({cmd_feedback_source: 'agent'})
+  })
+
+  test('does not treat SHOPIFY_INVOKED_BY as an agent', async () => {
+    clearAgentEnvironmentVariables()
+    vi.stubEnv('SHOPIFY_INVOKED_BY', 'some-wrapper')
+
+    await feedbackService({message: 'typed by hand', json: false})
+
+    await expect(recordedPublicMetadata()).resolves.toMatchObject({cmd_feedback_source: 'human'})
+  })
+
+  test('outputs a JSON result when --json is passed', async () => {
+    await feedbackService({message: 'It worked!', json: true})
+
+    expect(outputResult).toHaveBeenCalledWith(
+      JSON.stringify({sent: true, messageLength: 10, truncated: false}, null, 2),
+    )
+    expect(renderSuccess).not.toHaveBeenCalled()
+  })
+
+  test('warns instead of confirming when analytics are disabled', async () => {
+    vi.mocked(analyticsDisabled).mockReturnValue(true)
+
+    await feedbackService({message: 'It worked!', json: false})
+
+    expect(renderWarning).toHaveBeenCalledWith({
+      headline: "Feedback can't be sent because analytics are disabled.",
+      body: expect.stringContaining('analytics'),
+    })
+    expect(renderSuccess).not.toHaveBeenCalled()
+  })
+
+  test('reports sent: false in JSON when analytics are disabled', async () => {
+    vi.mocked(analyticsDisabled).mockReturnValue(true)
+
+    await feedbackService({message: 'It worked!', json: true})
+
+    expect(outputResult).toHaveBeenCalledWith(
+      JSON.stringify({sent: false, reason: 'analytics_disabled', messageLength: 10, truncated: false}, null, 2),
+    )
+  })
+
+  test('confirms the send when the always-log-analytics override outweighs the opt-out', async () => {
+    vi.mocked(analyticsDisabled).mockReturnValue(true)
+    vi.mocked(alwaysLogAnalytics).mockReturnValue(true)
+
+    await feedbackService({message: 'It worked!', json: false})
+
+    expect(renderSuccess).toHaveBeenCalledWith({headline: 'Thanks for your feedback.'})
+    expect(renderWarning).not.toHaveBeenCalled()
+  })
+})

--- a/packages/cli/src/cli/services/commands/feedback.ts
+++ b/packages/cli/src/cli/services/commands/feedback.ts
@@ -1,0 +1,104 @@
+import {alwaysLogAnalytics, analyticsDisabled} from '@shopify/cli-kit/node/context/local'
+import {AbortError, AbortSilentError} from '@shopify/cli-kit/node/error'
+import {addPublicMetadata, addSensitiveMetadata} from '@shopify/cli-kit/node/metadata'
+import {outputResult} from '@shopify/cli-kit/node/output'
+import {readStdinString} from '@shopify/cli-kit/node/system'
+import {renderSuccess, renderWarning} from '@shopify/cli-kit/node/ui'
+
+export const MAX_FEEDBACK_MESSAGE_LENGTH = 2000
+
+interface FeedbackServiceOptions {
+  message: string
+  sentiment?: string
+  category?: string
+  json: boolean
+}
+
+export async function feedbackService(options: FeedbackServiceOptions): Promise<void> {
+  const message = (options.message === '-' ? await readMessageFromStdin(options.json) : options.message).trim()
+  if (message.length === 0) {
+    // In --json mode machine consumers need a parseable failure, so print one and abort silently.
+    if (options.json) {
+      outputResult(JSON.stringify({sent: false, reason: 'empty_message'}, null, 2))
+      throw new AbortSilentError()
+    }
+    throw new AbortError("The feedback message can't be empty.")
+  }
+
+  const truncated = message.length > MAX_FEEDBACK_MESSAGE_LENGTH
+  // Truncating can cut a surrogate pair (like an emoji) in half; drop a trailing lone high
+  // surrogate so the delivered message stays valid Unicode.
+  const deliveredMessage = truncated
+    ? message.slice(0, MAX_FEEDBACK_MESSAGE_LENGTH).replace(/[\uD800-\uDBFF]$/, '')
+    : message
+
+  await addPublicMetadata(() => ({
+    cmd_feedback_sentiment: options.sentiment,
+    cmd_feedback_category: options.category,
+    cmd_feedback_message_length: message.length,
+    cmd_feedback_message_truncated: truncated,
+    cmd_feedback_source: feedbackSource(),
+  }))
+  await addSensitiveMetadata(() => ({cmd_feedback_message: deliveredMessage}))
+
+  // Mirrors the condition under which reportAnalyticsEvent skips the Monorail event, so the user
+  // isn't told their feedback was sent when the opt-out will drop it. Best-effort: other silent
+  // drops (like the daily analytics rate limit) can't be detected from here.
+  const suppressedByOptOut = analyticsDisabled() && !alwaysLogAnalytics()
+
+  if (options.json) {
+    outputResult(
+      JSON.stringify(
+        {
+          sent: !suppressedByOptOut,
+          ...(suppressedByOptOut ? {reason: 'analytics_disabled'} : {}),
+          messageLength: message.length,
+          truncated,
+        },
+        null,
+        2,
+      ),
+    )
+    return
+  }
+
+  if (suppressedByOptOut) {
+    renderWarning({
+      headline: "Feedback can't be sent because analytics are disabled.",
+      body:
+        'Feedback is delivered through the usage analytics the CLI reports. Remove the analytics ' +
+        'opt-out (for example, unset SHOPIFY_CLI_NO_ANALYTICS or OPT_OUT_INSTRUMENTATION) and try again.',
+    })
+    return
+  }
+
+  renderSuccess({
+    headline: 'Thanks for your feedback.',
+    ...(truncated
+      ? {body: `The message was longer than ${MAX_FEEDBACK_MESSAGE_LENGTH} characters, so it was truncated.`}
+      : {}),
+  })
+}
+
+async function readMessageFromStdin(json: boolean): Promise<string> {
+  const stdinMessage = await readStdinString()
+  if (stdinMessage === undefined) {
+    // In --json mode machine consumers need a parseable failure, so print one and abort silently.
+    if (json) {
+      outputResult(JSON.stringify({sent: false, reason: 'no_stdin_message'}, null, 2))
+      throw new AbortSilentError()
+    }
+    throw new AbortError(
+      'No feedback message was piped to stdin.',
+      'Pipe the message when using --message -, for example: echo "It worked!" | shopify feedback --message -',
+    )
+  }
+  return stdinMessage
+}
+
+function feedbackSource(): string {
+  // The SHOPIFY_CLI_AGENT* variables mark an AI agent driving the CLI. SHOPIFY_INVOKED_BY marks
+  // wrapper tooling rather than an agent, so it deliberately doesn't count here.
+  const invokedByAgent = Object.keys(process.env).some((variableName) => variableName.startsWith('SHOPIFY_CLI_AGENT'))
+  return invokedByAgent ? 'agent' : 'human'
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,5 +1,6 @@
 import VersionCommand from './cli/commands/version.js'
 import Search from './cli/commands/search.js'
+import Feedback from './cli/commands/feedback.js'
 import Upgrade from './cli/commands/upgrade.js'
 import SendAnalytics from './cli/commands/send-analytics.js'
 import Logout from './cli/commands/auth/logout.js'
@@ -148,6 +149,7 @@ export const COMMANDS: any = {
   ...HydrogenCommands,
   ...StoreCommands,
   search: Search,
+  feedback: Feedback,
   upgrade: Upgrade,
   version: VersionCommand,
   'send-analytics': SendAnalytics,


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it's a work in progress
-->

### WHY are these changes introduced?

Fixes #0000 <!-- link to issue if one exists -->

<!--
  Context about the problem that's being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes.
-->

### How to test your changes?

<!--
  Please, provide steps for the reviewer to test your changes locally.
  You can post a comment with `/snapit` to generate a snapshot of the changes to be tested.
-->

### Post-release steps

<!--
  If changes require post-release steps, for example merging and publishing some documentation changes,
  specify it in this section and add the label "includes-post-release-steps".
  If it doesn't, feel free to remove this section.
-->

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`
