### PR TITLE
[Refactor] Simplify control flow in abortSignalFromRequestBehaviour

### DIFF
--- a/packages/cli-kit/src/public/node/http.ts
+++ b/packages/cli-kit/src/public/node/http.ts
@@ -106,15 +106,16 @@ interface FetchOptions {
  * @returns An AbortSignal.
  */
 export function abortSignalFromRequestBehaviour(behaviour: RequestBehaviour): AbortSignal {
-  let signal: AbortSignal
   if (behaviour.useAbortSignal === true) {
-    signal = AbortSignal.timeout(behaviour.timeoutMs)
-  } else if (behaviour.useAbortSignal && typeof behaviour.useAbortSignal === 'function') {
-    signal = behaviour.useAbortSignal()
-  } else if (behaviour.useAbortSignal) {
-    signal = behaviour.useAbortSignal
+    return AbortSignal.timeout(behaviour.timeoutMs)
   }
-  return signal
+  if (typeof behaviour.useAbortSignal === 'function') {
+    return behaviour.useAbortSignal()
+  }
+  if (behaviour.useAbortSignal) {
+    return behaviour.useAbortSignal
+  }
+  return undefined
 }
 
 async function innerFetch({url, behaviour, init, logRequest, useHttpsAgent}: FetchOptions): Promise<Response> {


### PR DESCRIPTION
### What changed?
Refactored `abortSignalFromRequestBehaviour` in `packages/cli-kit/src/public/node/http.ts` to replace mutable local variable assignment (`let signal`) and nested `if / else if` statements with linear guard clauses and early returns.

### Why?
Simplifies control flow, improves code readability, and eliminates unnecessary variable reassignments without changing observable behavior.

### How to test your changes?
CI

---
*PR created automatically by Jules for task [741939202906716487](https://jules.google.com/task/741939202906716487) started by @gonzaloriestra*