### PR TITLE
Allow http notifications URLs on loopback hosts

### DIFF
--- a/packages/cli-kit/src/public/node/notifications-system.test.ts
+++ b/packages/cli-kit/src/public/node/notifications-system.test.ts
@@ -461,9 +461,17 @@ describe('fetchNotificationsInBackground', () => {
 })
 
 describe('fetchNotifications', () => {
-  test('uses the default URL when SHOPIFY_CLI_NOTIFICATIONS_URL is not secure', async () => {
+  const defaultUrl = 'https://cdn.shopify.com/static/cli/notifications.json'
+
+  test.each([
+    'https://my-secure-repo.com/notifications.json',
+    // Loopback hosts are allowed over plain http so notifications can be tested locally.
+    'http://127.0.0.1:8082/notifications.json',
+    'http://localhost:8082/notifications.json',
+    'http://[::1]:8082/notifications.json',
+  ])('uses the provided URL when SHOPIFY_CLI_NOTIFICATIONS_URL is %s', async (allowedUrl) => {
     // Given
-    vi.stubEnv('SHOPIFY_CLI_NOTIFICATIONS_URL', 'http://malicious.com/notifications.json')
+    vi.stubEnv('SHOPIFY_CLI_NOTIFICATIONS_URL', allowedUrl)
     vi.mocked(fetch).mockResolvedValue({
       status: 200,
       text: () => Promise.resolve(JSON.stringify({notifications: []})),
@@ -473,18 +481,21 @@ describe('fetchNotifications', () => {
     await fetchNotifications()
 
     // Then
-    expect(fetch).toHaveBeenCalledWith(
-      'https://cdn.shopify.com/static/cli/notifications.json',
-      undefined,
-      expect.anything(),
-    )
+    expect(fetch).toHaveBeenCalledWith(allowedUrl, undefined, expect.anything())
     vi.unstubAllEnvs()
   })
 
-  test('uses the provided URL when SHOPIFY_CLI_NOTIFICATIONS_URL is secure', async () => {
+  test.each([
+    'http://malicious.com/notifications.json',
+    // Lookalike hosts must not be mistaken for loopback ones.
+    'http://127.0.0.1.malicious.com/notifications.json',
+    'http://localhost.malicious.com/notifications.json',
+    'http://malicious.com/#@127.0.0.1/notifications.json',
+    'ftp://127.0.0.1/notifications.json',
+    'not-a-url',
+  ])('uses the default URL when SHOPIFY_CLI_NOTIFICATIONS_URL is %s', async (rejectedUrl) => {
     // Given
-    const secureUrl = 'https://my-secure-repo.com/notifications.json'
-    vi.stubEnv('SHOPIFY_CLI_NOTIFICATIONS_URL', secureUrl)
+    vi.stubEnv('SHOPIFY_CLI_NOTIFICATIONS_URL', rejectedUrl)
     vi.mocked(fetch).mockResolvedValue({
       status: 200,
       text: () => Promise.resolve(JSON.stringify({notifications: []})),
@@ -494,7 +505,7 @@ describe('fetchNotifications', () => {
     await fetchNotifications()
 
     // Then
-    expect(fetch).toHaveBeenCalledWith(secureUrl, undefined, expect.anything())
+    expect(fetch).toHaveBeenCalledWith(defaultUrl, undefined, expect.anything())
     vi.unstubAllEnvs()
   })
 })

--- a/packages/cli-kit/src/public/node/notifications-system.ts
+++ b/packages/cli-kit/src/public/node/notifications-system.ts
@@ -25,7 +25,7 @@ const COMMANDS_TO_SKIP = [
 ]
 
 // Hostnames whose traffic never leaves the machine, so it can't be intercepted or tampered with.
-const LOOPBACK_HOSTNAMES = ['127.0.0.1', 'localhost', '[::1]']
+const LOOPBACK_HOSTNAMES = ['127.0.0.1', 'localhost', '::1', '[::1]']
 
 function url(): string {
   const envUrl = process.env.SHOPIFY_CLI_NOTIFICATIONS_URL

--- a/packages/cli-kit/src/public/node/notifications-system.ts
+++ b/packages/cli-kit/src/public/node/notifications-system.ts
@@ -24,17 +24,22 @@ const COMMANDS_TO_SKIP = [
   'send-analytics',
 ]
 
+// Hostnames whose traffic never leaves the machine, so it can't be intercepted or tampered with.
+const LOOPBACK_HOSTNAMES = ['127.0.0.1', 'localhost', '[::1]']
+
 function url(): string {
   const envUrl = process.env.SHOPIFY_CLI_NOTIFICATIONS_URL
   if (envUrl) {
     try {
       const parsedUrl = new globalThis.URL(envUrl)
-      // We only allow https for notifications to prevent loading malicious content from insecure sources.
-      if (parsedUrl.protocol === 'https:') {
+      // We only allow https for notifications to prevent loading malicious content from insecure
+      // sources. Plain http is allowed for loopback hosts so that notifications can be tested
+      // against a local server, where there is no network for an attacker to sit on.
+      if (isAllowedNotificationsUrl(parsedUrl)) {
         return envUrl
       }
       outputDebug(
-        `The notifications URL provided via SHOPIFY_CLI_NOTIFICATIONS_URL (${envUrl}) is not secure (https). Falling back to default.`,
+        `The notifications URL provided via SHOPIFY_CLI_NOTIFICATIONS_URL (${envUrl}) must use https, or http with a loopback host. Falling back to default.`,
       )
       // eslint-disable-next-line no-catch-all/no-catch-all
     } catch {
@@ -44,6 +49,18 @@ function url(): string {
     }
   }
   return URL
+}
+
+/**
+ * Checks whether a notifications URL is safe to load from.
+ *
+ * @param parsedUrl - The parsed notifications URL.
+ * @returns - A boolean indicating whether the URL may be used.
+ */
+function isAllowedNotificationsUrl(parsedUrl: globalThis.URL): boolean {
+  if (parsedUrl.protocol === 'https:') return true
+  // `hostname` is the parsed authority, so lookalikes such as `127.0.0.1.example.com` don't match.
+  return parsedUrl.protocol === 'http:' && LOOPBACK_HOSTNAMES.includes(parsedUrl.hostname)
 }
 
 const NotificationSchema = zod.object({


### PR DESCRIPTION
### WHY are these changes introduced?

`SHOPIFY_CLI_NOTIFICATIONS_URL` lets you point the CLI at an alternative notifications feed, which is the natural way to check how a notification will actually render before it ships. But `url()` only accepted `https:`, so a local server was silently discarded and the CLI went to the production CDN instead — with the only clue being a `--verbose` debug line:

```
The notifications URL provided via SHOPIFY_CLI_NOTIFICATIONS_URL
  (http://127.0.0.1:8082/...) is not secure (https). Falling back to default.
Request to https://cdn.shopify.com/static/cli/notifications.json completed in 1634 ms
```

The https restriction exists to stop the CLI loading content that an attacker could inject over the wire. That reasoning doesn't apply to loopback: the traffic never leaves the machine, so there's no network position to attack from. Serving the fixture over https just to satisfy the check means standing up a TLS cert or a tunnel for a purely local test.

### WHAT is this pull request doing?

`http:` is now accepted when the host is a loopback host (`127.0.0.1`, `localhost`, `[::1]`). Everything else is unchanged: remote `http:`, other protocols, and unparseable values still fall back to the CDN.

The check matches on `URL.hostname` — the parsed authority — so the near-miss cases don't slip through:

| URL | hostname | Allowed |
|---|---|---|
| `http://127.0.0.1:8082/n.json` | `127.0.0.1` | yes |
| `http://127.1:8082/n.json` | `127.0.0.1` | yes (normalizes to loopback) |
| `http://127.0.0.1.example.com/n.json` | `127.0.0.1.example.com` | no |
| `http://example.com/#@127.0.0.1/` | `example.com` | no |

The debug message now names the actual rule instead of just saying "not secure".

Only the three canonical loopback hosts are allowed, not all of `127.0.0.0/8` — happy to widen it if anyone is binding a fixture server to something like `127.0.0.2`.

### How to test your changes?

```bash
mkdir -p /tmp/notif/static-24h/cli
cat > /tmp/notif/static-24h/cli/notifications.json <<'JSON'
{"notifications":[{"id":"test-loopback","type":"info","title":"Release notes for 4.7.0",
"frequency":"once","message":"Release highlights","minVersion":"4.7.0","maxVersion":"4.7.0",
"ownerChannel":"#devtools-dev-experience"}]}
JSON
(cd /tmp/notif && python3 -m http.server 8083 --bind 127.0.0.1 &)

export SHOPIFY_CLI_NOTIFICATIONS_URL=http://127.0.0.1:8083/static-24h/cli/notifications.json
pnpm shopify notifications list   # fetches + caches from loopback
pnpm shopify version              # renders the notification
```

`version` reads notifications from the cache and never fetches — the fetch happens in a detached background process from the prerun hook — so `notifications list` has to run first to populate it. Note that `shopify cache clear` wipes that cache, so clearing before every attempt guarantees you see nothing. `frequency: once` also means only the first `version` after a clear renders it.

On `main`, step two prints nothing and `--verbose` shows the fallback to the CDN.

### Post-release steps

None.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows) — pure `URL` parsing, no platform-specific behavior
- [x] I've considered possible [documentation](https://shopify.dev) changes — `SHOPIFY_CLI_NOTIFICATIONS_URL` isn't documented on shopify.dev or anywhere in this repo outside the source and its tests, so there's nothing to update
- [x] I've considered analytics changes to measure impact — none needed
- [ ] The change is user-facing — no changeset: this only affects an undocumented env var used for local testing of notifications, with no change to default behavior. Happy to add a `patch` if you'd rather it appear in the changelog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)