### PR TITLE
Read single-subscription events modules back into the TOML subscription list

### DIFF
--- a/.changeset/events-single-subscription-readback.md
+++ b/.changeset/events-single-subscription-readback.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Read events modules stored as one module per subscription back into the TOML subscription list

--- a/packages/app/src/cli/models/extensions/specifications/transform/app_config_events.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/transform/app_config_events.test.ts
@@ -1,4 +1,5 @@
 import {transformToEventsConfig, transformFromEventsConfig} from './app_config_events.js'
+import {deepMergeObjects} from '@shopify/cli-kit/common/object'
 import {describe, expect, test} from 'vitest'
 
 describe('transformFromEventsConfig', () => {
@@ -189,6 +190,81 @@ describe('transformToEventsConfig', () => {
       events: {
         api_version: '2024-01',
         subscription: undefined,
+      },
+    })
+  })
+
+  test('wraps a single-subscription object into a one-element subscription list and strips identifier', () => {
+    const remoteContent = {
+      events: {
+        api_version: '2024-01',
+        subscription: {
+          topic: 'Product',
+          actions: ['update'],
+          uri: 'https://example.com/webhook',
+          handle: 'product-updates',
+          identifier: 'id-1',
+        },
+      },
+    }
+
+    const result = transformToEventsConfig(remoteContent)
+
+    expect(result).toEqual({
+      events: {
+        api_version: '2024-01',
+        subscription: [
+          {
+            topic: 'Product',
+            actions: ['update'],
+            uri: 'https://example.com/webhook',
+            handle: 'product-updates',
+          },
+        ],
+      },
+    })
+  })
+
+  test('multiple single-subscription modules deep-merge into one subscription list', () => {
+    const moduleConfigs = [
+      {
+        events: {
+          api_version: '2024-01',
+          subscription: {
+            topic: 'Product',
+            actions: ['update'],
+            uri: 'https://example.com/a',
+            handle: 'a',
+            identifier: 'id-a',
+          },
+        },
+      },
+      {
+        events: {
+          api_version: '2024-01',
+          subscription: {
+            topic: 'Order',
+            actions: ['create'],
+            uri: 'https://example.com/b',
+            handle: 'b',
+            identifier: 'id-b',
+          },
+        },
+      },
+    ]
+
+    const merged = moduleConfigs.reduce(
+      (accumulator, moduleConfig) => deepMergeObjects(accumulator, transformToEventsConfig(moduleConfig)),
+      {},
+    )
+
+    expect(merged).toEqual({
+      events: {
+        api_version: '2024-01',
+        subscription: [
+          {topic: 'Product', actions: ['update'], uri: 'https://example.com/a', handle: 'a'},
+          {topic: 'Order', actions: ['create'], uri: 'https://example.com/b', handle: 'b'},
+        ],
       },
     })
   })

--- a/packages/app/src/cli/models/extensions/specifications/transform/app_config_events.ts
+++ b/packages/app/src/cli/models/extensions/specifications/transform/app_config_events.ts
@@ -42,11 +42,20 @@ export function transformFromEventsConfig(content: object, appConfiguration?: ob
 /**
  * Transforms the events config from remote to local format.
  * Strips the server-managed 'identifier' field from subscriptions.
+ *
+ * The server stores events modules in two shapes: a legacy aggregate module
+ * whose subscription is a list, and one module per subscription whose
+ * subscription is a single object. Both are normalized to a list here so that
+ * multiple single-subscription modules deep-merge back into the TOML
+ * subscription array.
  */
 export function transformToEventsConfig(content: object) {
-  const eventsConfig = getPathValue(content, 'events') as {api_version: string; subscription: object[]}
+  const eventsConfig = getPathValue(content, 'events') as {
+    api_version: string
+    subscription: object[] | object
+  }
   const apiVersion = getPathValue(eventsConfig, 'api_version')
-  const subscription = getPathValue(eventsConfig, 'subscription') as {identifier: string}[]
+  const subscription = normalizeSubscriptions(getPathValue(eventsConfig, 'subscription'))
 
   // Server always includes identifier - strip it for local TOML
   const cleanedSubscriptions = subscription?.map((sub) => {
@@ -58,4 +67,10 @@ export function transformToEventsConfig(content: object) {
     (apiVersion ?? cleanedSubscriptions) ? {api_version: apiVersion, subscription: cleanedSubscriptions} : {}
 
   return {events}
+}
+
+function normalizeSubscriptions(subscription: unknown): {identifier?: string}[] | undefined {
+  if (subscription === undefined) return undefined
+  if (Array.isArray(subscription)) return subscription as {identifier?: string}[]
+  return [subscription as {identifier?: string}]
 }


### PR DESCRIPTION
## WHY are these changes introduced?

Core is migrating `events` app modules to a one-module-per-subscription structure ([dual contract](https://github.com/shop/world/pull/998781)): each module's config carries `events.subscription` as a **single object** instead of a list, with the module uid derived from the subscription handle.

`transformToEventsConfig` assumes `subscription` is always a list and calls `.map` on it, so reading remote configuration (`app config link`, deploy config diffing) throws a TypeError once an app's stored modules use the new shape.

## WHAT is this pull request doing?

- Normalizes the remote `events.subscription` value to a list (object → one-element list) before stripping the server-managed `identifier`.
- Multiple single-subscription modules then deep-merge back into one TOML `[[events.subscription]]` array through the existing `remoteAppConfigurationExtensionContent` union-array merge — the same mechanism `webhook_subscription` modules use today.
- Legacy aggregate (list-shape) modules are unaffected; the TOML format does not change.

Known follow-up (out of scope): subscription ordering after merging N remote modules follows server module order, which may produce cosmetic diff noise in `app config link` output. Webhooks solves this with sort-on-parse (`mergeAllWebhooks`); events can adopt the same if it becomes a problem.

## How to test your changes?

- `pnpm vitest run packages/app/src/cli/models/extensions/specifications/transform/app_config_events.test.ts` (12 tests, includes single-object wrap + N-module merge)
- Against a top-hat app whose events modules are stored single-shape (see Core PR): `shopify app config link` round-trips the TOML unchanged.

## Measuring impact

- [x] n/a — bugfix/forward-compat for internal storage migration

## Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible documentation changes
