### PR TITLE
[Tests] Add unit test coverage for systemTempDir

### DIFF
--- a/packages/cli-kit/src/private/node/temp-dir.test.ts
+++ b/packages/cli-kit/src/private/node/temp-dir.test.ts
@@ -1,0 +1,13 @@
+import {systemTempDir} from './temp-dir.js'
+import {describe, test, expect} from 'vitest'
+import {stat} from 'fs/promises'
+
+describe('systemTempDir', () => {
+  test('is exported as a non-empty string pointing to an existing directory', async () => {
+    expect(typeof systemTempDir).toBe('string')
+    expect(systemTempDir.length).toBeGreaterThan(0)
+
+    const stats = await stat(systemTempDir)
+    expect(stats.isDirectory()).toBe(true)
+  })
+})


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #0000

The `temp-dir.ts` module in `@shopify/cli-kit` lacked unit test coverage to ensure `systemTempDir` is properly exported and points to a valid, existing system directory.

### WHAT is this pull request doing?

Adds unit test coverage in `packages/cli-kit/src/private/node/temp-dir.test.ts` to verify that `systemTempDir` is exported as a non-empty string and resolves to an existing directory on the filesystem.

### How to test your changes?

CI

### Post-release steps

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [13153742942320172031](https://jules.google.com/task/13153742942320172031) started by @gonzaloriestra*