### PR TITLE
[Tests] Add unit test coverage for version and constants

### DIFF
--- a/packages/cli-kit/src/public/common/version.test.ts
+++ b/packages/cli-kit/src/public/common/version.test.ts
@@ -1,0 +1,9 @@
+import {CLI_KIT_VERSION} from './version.js'
+import {describe, expect, test} from 'vitest'
+
+describe('CLI_KIT_VERSION', () => {
+  test('exports a valid semver version string', () => {
+    expect(typeof CLI_KIT_VERSION).toBe('string')
+    expect(CLI_KIT_VERSION).toMatch(/^\d+\.\d+\.\d+/)
+  })
+})

--- a/packages/cli-kit/src/public/node/constants.test.ts
+++ b/packages/cli-kit/src/public/node/constants.test.ts
@@ -1,0 +1,9 @@
+import {STORE_AUTH_APP_CLIENT_ID} from './constants.js'
+import {describe, expect, test} from 'vitest'
+
+describe('STORE_AUTH_APP_CLIENT_ID', () => {
+  test('exports a non-empty string client ID', () => {
+    expect(typeof STORE_AUTH_APP_CLIENT_ID).toBe('string')
+    expect(STORE_AUTH_APP_CLIENT_ID.length).toBeGreaterThan(0)
+  })
+})


### PR DESCRIPTION
### WHY are these changes introduced?

To improve test coverage for exported constants and version definitions in `@shopify/cli-kit` (`CLI_KIT_VERSION` and `STORE_AUTH_APP_CLIENT_ID`).

### WHAT is this pull request doing?

- Adds `packages/cli-kit/src/public/common/version.test.ts` to assert that `CLI_KIT_VERSION` is exported as a valid semver string.
- Adds `packages/cli-kit/src/public/node/constants.test.ts` to assert that `STORE_AUTH_APP_CLIENT_ID` is exported as a non-empty string.

### How to test your changes?

CI

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [8617214505178974847](https://jules.google.com/task/8617214505178974847) started by @gonzaloriestra*