### PR TITLE
[Performance] Optimize rejectGeneratedStaticAssets filtering

### DIFF
--- a/packages/theme/src/cli/utilities/asset-checksum.ts
+++ b/packages/theme/src/cli/utilities/asset-checksum.ts
@@ -85,9 +85,12 @@ function md5(content: string | Buffer) {
  * as these are not needed for theme comparison.
  */
 export function rejectGeneratedStaticAssets(themeChecksums: Checksum[]) {
-  const liquidAssetKeys = new Set(
-    themeChecksums.filter(({key}) => key.startsWith('assets/') && key.endsWith('.liquid')).map(({key}) => key),
-  )
+  const liquidAssetKeys = new Set<string>()
+  for (const {key} of themeChecksums) {
+    if (key.startsWith('assets/') && key.endsWith('.liquid')) {
+      liquidAssetKeys.add(key)
+    }
+  }
 
   return themeChecksums.filter(({key}) => {
     const isStaticAsset = key.startsWith('assets/')


### PR DESCRIPTION
### Why is this change necessary?
In `packages/theme/src/cli/utilities/asset-checksum.ts`, `rejectGeneratedStaticAssets` constructed `liquidAssetKeys` using chained `.filter(...)` and `.map(...)` array operations. This created two temporary intermediate arrays and traversed the theme checksum array twice.

### How was it resolved?
Replaced the `.filter(...).map(...)` chaining with a single `for...of` loop that directly inserts matching Liquid asset keys into the `Set`. This avoids extra array allocations and reduces iteration overhead when processing large theme checksum sets during theme operations (e.g., `theme pull` or `theme push`).

### How to test your changes?
`shopify theme pull` or `shopify theme push`

---
*PR created automatically by Jules for task [8883107987903545011](https://jules.google.com/task/8883107987903545011) started by @gonzaloriestra*