### PR TITLE
[Tests] Add unit tests for deprecations store

### DIFF
--- a/packages/cli-kit/src/private/node/context/deprecations-store.test.ts
+++ b/packages/cli-kit/src/private/node/context/deprecations-store.test.ts
@@ -1,0 +1,48 @@
+import {getNextDeprecationDate, setNextDeprecationDate} from './deprecations-store.js'
+import {describe, test, expect} from 'vitest'
+
+describe('deprecations-store', () => {
+  test('getNextDeprecationDate returns undefined by default', () => {
+    expect(getNextDeprecationDate()).toBeUndefined()
+  })
+
+  test('setNextDeprecationDate does not update store when given empty dates list', () => {
+    setNextDeprecationDate([])
+    expect(getNextDeprecationDate()).toBeUndefined()
+  })
+
+  test('setNextDeprecationDate does not update store when dates are in the past', () => {
+    const pastDate = new Date(Date.now() - 100000)
+    setNextDeprecationDate([pastDate])
+    expect(getNextDeprecationDate()).toBeUndefined()
+  })
+
+  test('setNextDeprecationDate sets earliest future deprecation date', () => {
+    const futureDate1 = new Date(Date.now() + 100000)
+    const futureDate2 = new Date(Date.now() + 200000)
+
+    setNextDeprecationDate([futureDate2, futureDate1])
+
+    expect(getNextDeprecationDate()).toEqual(futureDate1)
+  })
+
+  test('setNextDeprecationDate updates store if a newer date is earlier than existing nextDeprecationDate', () => {
+    const initialFutureDate = new Date(Date.now() + 100000)
+    setNextDeprecationDate([initialFutureDate])
+
+    const earlierFutureDate = new Date(Date.now() + 50000)
+    setNextDeprecationDate([earlierFutureDate])
+
+    expect(getNextDeprecationDate()).toEqual(earlierFutureDate)
+  })
+
+  test('setNextDeprecationDate keeps existing date if new future dates are later', () => {
+    const initialFutureDate = new Date(Date.now() + 50000)
+    setNextDeprecationDate([initialFutureDate])
+
+    const laterFutureDate = new Date(Date.now() + 300000)
+    setNextDeprecationDate([laterFutureDate])
+
+    expect(getNextDeprecationDate()).toEqual(initialFutureDate)
+  })
+})

--- a/packages/cli-kit/src/private/node/context/deprecations-store.test.ts
+++ b/packages/cli-kit/src/private/node/context/deprecations-store.test.ts
@@ -18,8 +18,8 @@ describe('deprecations-store', () => {
   })
 
   test('setNextDeprecationDate sets earliest future deprecation date', () => {
-    const futureDate1 = new Date(Date.now() + 100000)
-    const futureDate2 = new Date(Date.now() + 200000)
+    const futureDate1 = new Date(Date.now() + 500000)
+    const futureDate2 = new Date(Date.now() + 600000)
 
     setNextDeprecationDate([futureDate2, futureDate1])
 
@@ -27,20 +27,20 @@ describe('deprecations-store', () => {
   })
 
   test('setNextDeprecationDate updates store if a newer date is earlier than existing nextDeprecationDate', () => {
-    const initialFutureDate = new Date(Date.now() + 100000)
+    const initialFutureDate = new Date(Date.now() + 400000)
     setNextDeprecationDate([initialFutureDate])
 
-    const earlierFutureDate = new Date(Date.now() + 50000)
+    const earlierFutureDate = new Date(Date.now() + 300000)
     setNextDeprecationDate([earlierFutureDate])
 
     expect(getNextDeprecationDate()).toEqual(earlierFutureDate)
   })
 
   test('setNextDeprecationDate keeps existing date if new future dates are later', () => {
-    const initialFutureDate = new Date(Date.now() + 50000)
+    const initialFutureDate = new Date(Date.now() + 100000)
     setNextDeprecationDate([initialFutureDate])
 
-    const laterFutureDate = new Date(Date.now() + 300000)
+    const laterFutureDate = new Date(Date.now() + 200000)
     setNextDeprecationDate([laterFutureDate])
 
     expect(getNextDeprecationDate()).toEqual(initialFutureDate)


### PR DESCRIPTION
### WHY are these changes introduced?

`deprecations-store.ts` in `@shopify/cli-kit` manages state for the earliest upcoming deprecation date across CLI calls, but previously lacked unit tests.

### WHAT is this pull request doing?

Adds unit tests in `packages/cli-kit/src/private/node/context/deprecations-store.test.ts` covering `getNextDeprecationDate` and `setNextDeprecationDate`:
- Verifies default `undefined` state
- Handles empty date arrays and past dates
- Sets the earliest future deprecation date when provided multiple dates
- Updates stored date when a newer date is earlier, and preserves existing date when new dates are later

### How to test your changes?

CI

### Post-release steps

N/A

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [2854649748783195092](https://jules.google.com/task/2854649748783195092) started by @gonzaloriestra*