### PR TITLE
[Security] Prevent option injection in checkIfIgnoredInGitRepository

### DIFF
--- a/packages/cli-kit/src/public/node/git.test.ts
+++ b/packages/cli-kit/src/public/node/git.test.ts
@@ -538,3 +538,34 @@ describe('removeGitRemote()', () => {
     expect(mockedExeca).not.toHaveBeenCalledWith('git', ['remote', 'remove', remoteName], {cwd: directory})
   })
 })
+
+describe('checkIfIgnoredInGitRepository()', () => {
+  test('returns empty array without calling git if files array is empty', async () => {
+    const directory = '/test/directory'
+
+    const result = await git.checkIfIgnoredInGitRepository(directory, [])
+
+    expect(result).toEqual([])
+    expect(mockedExeca).not.toHaveBeenCalled()
+  })
+
+  test('passes -- before file paths to prevent option injection', async () => {
+    const directory = '/test/directory'
+    mockGitCommand('file1.txt\n')
+
+    const result = await git.checkIfIgnoredInGitRepository(directory, ['file1.txt', '-v'])
+
+    expect(mockedExeca).toHaveBeenCalledWith('git', ['check-ignore', '--', 'file1.txt', '-v'], {cwd: directory})
+    expect(result).toEqual(['file1.txt'])
+  })
+
+  test('returns empty array when git check-ignore exits with code 1', async () => {
+    const directory = '/test/directory'
+    const error = Object.assign(new Error('no files ignored'), {exitCode: 1})
+    mockedExeca.mockRejectedValue(error)
+
+    const result = await git.checkIfIgnoredInGitRepository(directory, ['file1.txt'])
+
+    expect(result).toEqual([])
+  })
+})

--- a/packages/cli-kit/src/public/node/git.ts
+++ b/packages/cli-kit/src/public/node/git.ts
@@ -73,8 +73,10 @@ export async function initializeGitRepository(directory: string, initialBranch =
  * @returns Files ignored by the lockfile.
  */
 export async function checkIfIgnoredInGitRepository(directory: string, files: string[]): Promise<string[]> {
+  if (files.length === 0) return []
   try {
-    const stdout = await gitCommand(['check-ignore', ...files], directory)
+    // Pass '--' to separate git check-ignore options from file paths and prevent option injection
+    const stdout = await gitCommand(['check-ignore', '--', ...files], directory)
     return stdout.split('\n').filter(Boolean)
   } catch (error) {
     // git check-ignore exits with code 1 when no files are ignored


### PR DESCRIPTION
### WHY are these changes introduced?

Hardens file path checking against option injection vulnerabilities in Git commands.

### WHAT is this pull request doing?

Passes `--` prior to file paths in `git check-ignore` command execution to ensure trailing options or file names starting with hyphens are treated as literal paths rather than command flags. Short-circuits empty file list checks.

### How to test your changes?

CI

### Post-release steps

N/A

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [3028190617833342616](https://jules.google.com/task/3028190617833342616) started by @gonzaloriestra*