### PR TITLE
[Tests] Add unit tests for isValidMetricName validator

### DIFF
--- a/packages/cli-kit/src/public/node/vendor/otel-js/utils/validators.test.ts
+++ b/packages/cli-kit/src/public/node/vendor/otel-js/utils/validators.test.ts
@@ -1,0 +1,24 @@
+import {isValidMetricName} from './validators.js'
+import {diag} from '@opentelemetry/api'
+import {describe, expect, test, vi} from 'vitest'
+
+describe('isValidMetricName', () => {
+  test('returns true for valid metric names', () => {
+    expect(isValidMetricName('valid_metric_name')).toBe(true)
+    expect(isValidMetricName('metric')).toBe(true)
+    expect(isValidMetricName('_metric')).toBe(true)
+    expect(isValidMetricName('METRIC_NAME')).toBe(true)
+  })
+
+  test('returns false and logs warning for invalid metric names', () => {
+    const diagSpy = vi.spyOn(diag, 'warn').mockImplementation(() => {})
+
+    expect(isValidMetricName('invalid-metric')).toBe(false)
+    expect(isValidMetricName('123metric')).toBe(false)
+    expect(isValidMetricName('metric.name')).toBe(false)
+    expect(isValidMetricName('metric@name')).toBe(false)
+    expect(isValidMetricName('metric name')).toBe(false)
+
+    expect(diagSpy).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
### What page / article is this about?

This PR adds unit tests for `isValidMetricName` in `@shopify/cli-kit`.

### What changed?

- Added unit test file `packages/cli-kit/src/public/node/vendor/otel-js/utils/validators.test.ts`.
- Tested `isValidMetricName` with valid metric names (`valid_metric_name`, `metric`, `_metric`, `METRIC_NAME`) returning `true`.
- Tested `isValidMetricName` with invalid metric names (`invalid-metric`, `123metric`, `metric.name`, `metric@name`, `metric name`) returning `false` and triggering a diagnostic warning via `diag.warn`.

### How to test your changes?

CI

### Checklist

- [ ] I have read the [Contributing Guidelines](https://github.com/Shopify/cli/blob/main/.github/CONTRIBUTING.md).
- [ ] I have signed the [Contributor License Agreement](https://cla.shopify.com/).
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.


---
*PR created automatically by Jules for task [15547795319124221370](https://jules.google.com/task/15547795319124221370) started by @gonzaloriestra*