### PR TITLE
Fix apps failing validation when a configuration module contract requires its own section

### DIFF
--- a/.changeset/config-contract-root-required.md
+++ b/.changeset/config-contract-root-required.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli': patch
+---
+
+Fix "[events]: Required" validation errors for apps whose configuration has no [events] section

--- a/packages/app/src/cli/models/extensions/specifications/transform/app_config_events.test.ts
+++ b/packages/app/src/cli/models/extensions/specifications/transform/app_config_events.test.ts
@@ -192,4 +192,9 @@ describe('transformToEventsConfig', () => {
       },
     })
   })
+
+  test('omits the events section when there is no events config', () => {
+    expect(transformToEventsConfig({})).toEqual({})
+    expect(transformToEventsConfig({events: {}})).toEqual({})
+  })
 })

--- a/packages/app/src/cli/models/extensions/specifications/transform/app_config_events.ts
+++ b/packages/app/src/cli/models/extensions/specifications/transform/app_config_events.ts
@@ -54,8 +54,11 @@ export function transformToEventsConfig(content: object) {
     return rest
   })
 
-  const events =
-    (apiVersion ?? cleanedSubscriptions) ? {api_version: apiVersion, subscription: cleanedSubscriptions} : {}
+  // Omit the section entirely when there is no events config, so an empty `events` object
+  // isn't injected into linked configurations or deploy diffs
+  if (apiVersion === undefined && cleanedSubscriptions === undefined) {
+    return {}
+  }
 
-  return {events}
+  return {events: {api_version: apiVersion, subscription: cleanedSubscriptions}}
 }

--- a/packages/app/src/cli/services/generate/fetch-extension-specifications.test.ts
+++ b/packages/app/src/cli/services/generate/fetch-extension-specifications.test.ts
@@ -106,4 +106,33 @@ describe('fetchExtensionSpecifications', () => {
     expect(withoutLocalization?.appModuleFeatures()).toEqual([])
     expect(withLocalization?.appModuleFeatures()).toEqual(['localization'])
   })
+
+  test('configuration-experience specs do not require their section to be present in the app config', async () => {
+    // Given - a configuration-style spec whose remote contract has a root-level required property
+    const got = await fetchSpecifications({
+      developerPlatformClient: testDeveloperPlatformClient(),
+      app: testOrganizationApp(),
+    })
+    const configStyleSpec = got.find((spec) => spec.identifier === 'remote_only_extension_schema_config_style')
+
+    // When - parsing an app config that doesn't include the spec's section
+    const resultWithoutSection = configStyleSpec?.parseConfigurationObject({name: 'my app'})
+
+    // Then - the root-level required property is not enforced
+    expect(resultWithoutSection).toEqual({
+      state: 'ok',
+      data: {name: 'my app'},
+      errors: undefined,
+    })
+
+    // When - parsing an app config where the section has the wrong type
+    const resultWithInvalidSection = configStyleSpec?.parseConfigurationObject({name: 'my app', pattern: 123})
+
+    // Then - the rest of the contract is still enforced
+    expect(resultWithInvalidSection?.state).toBe('error')
+    expect(resultWithInvalidSection?.errors).toContainEqual({
+      path: ['pattern'],
+      message: 'Expected string, received number',
+    })
+  })
 })

--- a/packages/app/src/cli/utilities/json-schema.test.ts
+++ b/packages/app/src/cli/utilities/json-schema.test.ts
@@ -152,6 +152,72 @@ describe('unifiedConfigurationParserFactory', () => {
     expect(priceError).toBeDefined()
   })
 
+  test('ignores root-level required properties for configuration-experience specs', async () => {
+    // Given
+    const merged = {
+      identifier: randomUUID(),
+      experience: 'configuration',
+      parseConfigurationObject: mockParseConfigurationObject,
+      validationSchema: {
+        jsonSchema:
+          '{"type":"object","properties":{"events":{"type":"object","properties":{"api_version":{"type":"string"}},"required":["api_version"]}},"required":["events"]}',
+      },
+    }
+
+    // When
+    const parser = await unifiedConfigurationParserFactory(merged as any, merged.validationSchema)
+    const result = parser({name: 'my app'})
+
+    // Then - the absent section must not be required, and non-contract keys are stripped
+    expect(result).toEqual({
+      state: 'ok',
+      data: {},
+      errors: undefined,
+    })
+  })
+
+  test('still enforces nested required properties for configuration-experience specs when the section is present', async () => {
+    // Given
+    const merged = {
+      identifier: randomUUID(),
+      experience: 'configuration',
+      parseConfigurationObject: mockParseConfigurationObject,
+      validationSchema: {
+        jsonSchema:
+          '{"type":"object","properties":{"events":{"type":"object","properties":{"api_version":{"type":"string"}},"required":["api_version"]}},"required":["events"]}',
+      },
+    }
+
+    // When
+    const parser = await unifiedConfigurationParserFactory(merged as any, merged.validationSchema)
+    const result = parser({name: 'my app', events: {}})
+
+    // Then
+    expect(result.state).toBe('error')
+    expect(result.errors).toContainEqual({path: ['events', 'api_version'], message: 'Required'})
+    expect(result.errors).not.toContainEqual({path: ['events'], message: 'Required'})
+  })
+
+  test('still enforces root-level required properties for extension-experience specs', async () => {
+    // Given
+    const merged = {
+      identifier: randomUUID(),
+      experience: 'extension',
+      parseConfigurationObject: mockParseConfigurationObject,
+      validationSchema: {
+        jsonSchema: '{"type":"object","properties":{"type":{"type":"string"}},"required":["price"]}',
+      },
+    }
+
+    // When
+    const parser = await unifiedConfigurationParserFactory(merged as any, merged.validationSchema)
+    const result = parser({type: 'product_subscription'})
+
+    // Then
+    expect(result.state).toBe('error')
+    expect(result.errors).toContainEqual({path: ['price'], message: 'Required'})
+  })
+
   test('adds base properties to the JSON schema', async () => {
     // Given
     const merged = {

--- a/packages/app/src/cli/utilities/json-schema.ts
+++ b/packages/app/src/cli/utilities/json-schema.ts
@@ -41,6 +41,12 @@ export async function unifiedConfigurationParserFactory(
   }
   const contract = await normaliseJsonSchema(contractJsonSchema)
   contract.properties = {...JsonSchemaBaseProperties, ...contract.properties}
+  // Configuration-experience specs validate the entire app config; an absent section means "no module for this
+  // spec" (decided by the loader), so a root-level `required` from the contract must not force the section into
+  // existence. Nested `required` properties still apply once the section is present.
+  if (merged.experience === 'configuration') {
+    delete contract.required
+  }
   const extensionIdentifier = merged.identifier
 
   const parseConfigurationObject = (config: object): ParseConfigurationResult<BaseConfigType> => {


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #8386

Since 2026-08-24, `shopify app deploy`, `shopify app dev`, and `shopify app config validate` fail with `[events]: Required` for apps whose `shopify.app.toml` has never had an `[events]` section. Adding the section only produces a contradictory pair of errors (`[events.subscription]: Required` + `Unsupported section(s) in app configuration: events`), so no toml content can pass. The failure reproduces identically on CLI 3.94.3 through 4.7.0, which points at the remote specification contracts rather than any single release.

Root cause: `unifiedConfigurationParserFactory` validates the **whole app config object** against every configuration-experience spec's remote JSON-schema contract, even when that spec's section is absent from the toml. The platform's `events` spec contract now ships a root-level `"required": ["events"]`, so every app without an `[events]` section fails validation before the loader's existing "empty config → no module for this spec" short-circuit (`createConfigExtensionInstances`) can run. Any configuration spec shipping a root-level `required` for its own section would break all apps the same way.

### WHAT is this pull request doing?

- `packages/app/src/cli/utilities/json-schema.ts`: for configuration-experience specs, drop the contract's **root-level** `required` before compiling the AJV validator. Whether a config module exists is decided by the presence of its section in the toml (the loader's model), so the contract must not force the section into existence. Nested `required` properties (e.g. `events.api_version`, `events.subscription`) are still fully enforced once the section is present, and extension-experience specs — where the toml *is* the module config — are untouched.
- `packages/app/src/cli/models/extensions/specifications/transform/app_config_events.ts`: the events reverse transform returned `{events: {}}` when there is no events config, instead of omitting the section like every other config transform (e.g. `transformToWebhookConfig`). That empty object leaked into linked configurations and deploy diffs. It now returns `{}`.
- Tests for both changes, including an end-to-end one through `fetchSpecifications` using the existing `remote_only_extension_schema_config_style` fixture (configuration experience + root-level `required`).
- Changeset (`@shopify/cli`, patch).

### How to test your changes?

1. `pnpm vitest run packages/app/src/cli/utilities/json-schema.test.ts packages/app/src/cli/models/extensions/specifications/transform/app_config_events.test.ts packages/app/src/cli/services/generate/fetch-extension-specifications.test.ts`
2. To reproduce the incident end-to-end: with a development store app whose `shopify.app.toml` has no `[events]` section, run `shopify app config validate` on `main` (fails with `[events]: Required` while the platform serves the current events contract) and again with this branch (passes).
3. Regression check: an app **with** an `[events]` section still gets nested contract validation (`[events.api_version]: Required` etc.).

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [x] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`
