### PR TITLE
Report store lifecycle command telemetry

### DIFF
--- a/packages/store/src/cli/commands/store/create/dev.test.ts
+++ b/packages/store/src/cli/commands/store/create/dev.test.ts
@@ -6,7 +6,7 @@ import {reportAnalyticsEvent} from '@shopify/cli-kit/node/analytics'
 import {AbortError} from '@shopify/cli-kit/node/error'
 import {outputResult} from '@shopify/cli-kit/node/output'
 import {terminalSupportsPrompting} from '@shopify/cli-kit/node/system'
-import {describe, expect, test, vi, beforeEach} from 'vitest'
+import {beforeEach, describe, expect, test, vi} from 'vitest'
 
 vi.mock('../../../services/store/create/dev.js')
 vi.mock('../../../prompts/store.js')
@@ -232,44 +232,18 @@ describe('store create dev command', () => {
     mockExit.mockRestore()
   })
 
-  test('outputs structured JSON error when --json is active and organization selection throws AbortError', async () => {
+  test('leaves organization selection errors to global handling when --json is active', async () => {
     vi.mocked(selectOrg).mockRejectedValueOnce(new AbortError('Could not select organization'))
-    const mockExit = vi.spyOn(process, 'exit').mockImplementation((() => {
-      throw new Error('process.exit')
-    }) as never)
-    const mockCommandCatch = vi.spyOn(StoreCreateDev.prototype, 'catch').mockImplementation(async (error) => {
+    vi.spyOn(StoreCreateDev.prototype, 'catch').mockImplementation(async (error) => {
       throw error
     })
 
     await expect(
       StoreCreateDev.run(['--name', 'my-test-store', '--plan', 'plus', '--organization-id', '12345', '--json']),
-    ).rejects.toThrow('process.exit')
+    ).rejects.toThrow('Could not select organization')
 
-    expect(outputResult).toHaveBeenCalledTimes(1)
-    expect(outputResult).toHaveBeenCalledWith(
-      JSON.stringify(
-        {
-          error: true,
-          message: 'Could not select organization',
-          nextSteps: [],
-          exitCode: 1,
-        },
-        null,
-        2,
-      ),
-    )
-    expect(createDevStore).not.toHaveBeenCalled()
-    expect(mockExit).toHaveBeenCalledTimes(1)
-    expect(mockExit).toHaveBeenCalledWith(1)
-    expect(reportAnalyticsEvent).toHaveBeenCalledTimes(1)
-    expect(reportAnalyticsEvent).toHaveBeenCalledWith({
-      config: expect.anything(),
-      errorMessage: 'Could not select organization',
-      exitMode: 'expected_error',
-    })
-
-    mockCommandCatch.mockRestore()
-    mockExit.mockRestore()
+    expect(outputResult).not.toHaveBeenCalled()
+    expect(reportAnalyticsEvent).not.toHaveBeenCalled()
   })
 
   test('does not output JSON for non-AbortError even when --json is active', async () => {

--- a/packages/store/src/cli/commands/store/create/dev.test.ts
+++ b/packages/store/src/cli/commands/store/create/dev.test.ts
@@ -2,6 +2,7 @@ import StoreCreateDev from './dev.js'
 import {createDevStore} from '../../../services/store/create/dev.js'
 import {storeNamePrompt, storePlanPrompt} from '../../../prompts/store.js'
 import {selectOrg} from '@shopify/organizations'
+import {reportAnalyticsEvent} from '@shopify/cli-kit/node/analytics'
 import {AbortError} from '@shopify/cli-kit/node/error'
 import {outputResult} from '@shopify/cli-kit/node/output'
 import {terminalSupportsPrompting} from '@shopify/cli-kit/node/system'
@@ -10,6 +11,9 @@ import {describe, expect, test, vi, beforeEach} from 'vitest'
 vi.mock('../../../services/store/create/dev.js')
 vi.mock('../../../prompts/store.js')
 vi.mock('@shopify/cli-kit/node/system')
+vi.mock('@shopify/cli-kit/node/analytics', () => ({
+  reportAnalyticsEvent: vi.fn(),
+}))
 
 vi.mock('@shopify/organizations', () => ({
   selectOrg: vi.fn(),
@@ -31,6 +35,10 @@ beforeEach(() => {
 })
 
 describe('store create dev command', () => {
+  test('requires synchronous analytics', () => {
+    expect(StoreCreateDev.requiresSyncAnalytics).toBe(true)
+  })
+
   test('resolves the organization and passes parsed flags through to the service', async () => {
     await StoreCreateDev.run(['--name', 'my-test-store', '--plan', 'plus', '--organization-id', '12345'])
 
@@ -190,21 +198,77 @@ describe('store create dev command', () => {
     const mockExit = vi.spyOn(process, 'exit').mockImplementation((() => {
       throw new Error('process.exit')
     }) as never)
+    const mockCommandCatch = vi.spyOn(StoreCreateDev.prototype, 'catch').mockImplementation(async (error) => {
+      throw error
+    })
 
     await expect(
       StoreCreateDev.run(['--name', 'my-test-store', '--plan', 'plus', '--organization-id', '12345', '--json']),
     ).rejects.toThrow('process.exit')
 
-    const call = vi.mocked(outputResult).mock.calls[0]![0] as string
-    const parsed = JSON.parse(call)
-    expect(parsed).toEqual({
-      error: true,
-      message: 'Something went wrong',
-      nextSteps: [],
-      exitCode: 1,
-    })
+    expect(outputResult).toHaveBeenCalledTimes(1)
+    expect(outputResult).toHaveBeenCalledWith(
+      JSON.stringify(
+        {
+          error: true,
+          message: 'Something went wrong',
+          nextSteps: [],
+          exitCode: 1,
+        },
+        null,
+        2,
+      ),
+    )
+    expect(mockExit).toHaveBeenCalledTimes(1)
     expect(mockExit).toHaveBeenCalledWith(1)
+    expect(reportAnalyticsEvent).toHaveBeenCalledTimes(1)
+    expect(reportAnalyticsEvent).toHaveBeenCalledWith({
+      config: expect.anything(),
+      errorMessage: 'Something went wrong',
+      exitMode: 'expected_error',
+    })
 
+    mockCommandCatch.mockRestore()
+    mockExit.mockRestore()
+  })
+
+  test('outputs structured JSON error when --json is active and organization selection throws AbortError', async () => {
+    vi.mocked(selectOrg).mockRejectedValueOnce(new AbortError('Could not select organization'))
+    const mockExit = vi.spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('process.exit')
+    }) as never)
+    const mockCommandCatch = vi.spyOn(StoreCreateDev.prototype, 'catch').mockImplementation(async (error) => {
+      throw error
+    })
+
+    await expect(
+      StoreCreateDev.run(['--name', 'my-test-store', '--plan', 'plus', '--organization-id', '12345', '--json']),
+    ).rejects.toThrow('process.exit')
+
+    expect(outputResult).toHaveBeenCalledTimes(1)
+    expect(outputResult).toHaveBeenCalledWith(
+      JSON.stringify(
+        {
+          error: true,
+          message: 'Could not select organization',
+          nextSteps: [],
+          exitCode: 1,
+        },
+        null,
+        2,
+      ),
+    )
+    expect(createDevStore).not.toHaveBeenCalled()
+    expect(mockExit).toHaveBeenCalledTimes(1)
+    expect(mockExit).toHaveBeenCalledWith(1)
+    expect(reportAnalyticsEvent).toHaveBeenCalledTimes(1)
+    expect(reportAnalyticsEvent).toHaveBeenCalledWith({
+      config: expect.anything(),
+      errorMessage: 'Could not select organization',
+      exitMode: 'expected_error',
+    })
+
+    mockCommandCatch.mockRestore()
     mockExit.mockRestore()
   })
 

--- a/packages/store/src/cli/commands/store/create/dev.ts
+++ b/packages/store/src/cli/commands/store/create/dev.ts
@@ -5,12 +5,17 @@ import {countryFlag, storeFlags} from '../../../flags.js'
 import {selectOrg} from '@shopify/organizations'
 import Command from '@shopify/cli-kit/node/base-command'
 import {globalFlags, jsonFlag, requiredIfNonInteractive} from '@shopify/cli-kit/node/cli'
+import {reportAnalyticsEvent} from '@shopify/cli-kit/node/analytics'
 import {AbortError} from '@shopify/cli-kit/node/error'
 import {outputResult} from '@shopify/cli-kit/node/output'
 import {Flags} from '@oclif/core'
 
 export default class StoreCreateDev extends Command {
   static hidden = true
+
+  public static get requiresSyncAnalytics(): boolean {
+    return true
+  }
 
   static summary = 'Create a new development store.'
 
@@ -50,11 +55,11 @@ export default class StoreCreateDev extends Command {
   async run(): Promise<void> {
     const {flags} = await this.parse(StoreCreateDev)
 
-    const organization = await selectOrg(flags['organization-id']?.toString())
-    const name = flags.name ?? (await storeNamePrompt())
-    const plan = (flags.plan as DevStorePlan | undefined) ?? (await storePlanPrompt())
-
     try {
+      const organization = await selectOrg(flags['organization-id']?.toString())
+      const name = flags.name ?? (await storeNamePrompt())
+      const plan = (flags.plan as DevStorePlan | undefined) ?? (await storePlanPrompt())
+
       await createDevStore({
         name,
         organization,
@@ -66,6 +71,7 @@ export default class StoreCreateDev extends Command {
       })
     } catch (error) {
       if (flags.json && error instanceof AbortError) {
+        await reportAnalyticsEvent({config: this.config, errorMessage: error.message, exitMode: 'expected_error'})
         outputResult(
           JSON.stringify(
             {

--- a/packages/store/src/cli/commands/store/create/dev.ts
+++ b/packages/store/src/cli/commands/store/create/dev.ts
@@ -55,11 +55,11 @@ export default class StoreCreateDev extends Command {
   async run(): Promise<void> {
     const {flags} = await this.parse(StoreCreateDev)
 
-    try {
-      const organization = await selectOrg(flags['organization-id']?.toString())
-      const name = flags.name ?? (await storeNamePrompt())
-      const plan = (flags.plan as DevStorePlan | undefined) ?? (await storePlanPrompt())
+    const organization = await selectOrg(flags['organization-id']?.toString())
+    const name = flags.name ?? (await storeNamePrompt())
+    const plan = (flags.plan as DevStorePlan | undefined) ?? (await storePlanPrompt())
 
+    try {
       await createDevStore({
         name,
         organization,

--- a/packages/store/src/cli/commands/store/delete.test.ts
+++ b/packages/store/src/cli/commands/store/delete.test.ts
@@ -6,7 +6,7 @@ import {reportAnalyticsEvent} from '@shopify/cli-kit/node/analytics'
 import {AbortError} from '@shopify/cli-kit/node/error'
 import {outputResult} from '@shopify/cli-kit/node/output'
 import {isTTY, renderDangerousConfirmationPrompt} from '@shopify/cli-kit/node/ui'
-import {describe, expect, test, vi, beforeEach} from 'vitest'
+import {beforeEach, describe, expect, test, vi} from 'vitest'
 
 vi.mock('../../services/store/delete/dev.js')
 vi.mock('../../services/store/attribution.js')

--- a/packages/store/src/cli/commands/store/delete.test.ts
+++ b/packages/store/src/cli/commands/store/delete.test.ts
@@ -1,13 +1,19 @@
 import StoreDelete from './delete.js'
 import {deleteDevStore} from '../../services/store/delete/dev.js'
 import {resolveOrganizationForStore} from '../../utilities/store-lookup/organization.js'
+import {recordStoreFqdnMetadata} from '../../services/store/attribution.js'
+import {reportAnalyticsEvent} from '@shopify/cli-kit/node/analytics'
 import {AbortError} from '@shopify/cli-kit/node/error'
 import {outputResult} from '@shopify/cli-kit/node/output'
 import {isTTY, renderDangerousConfirmationPrompt} from '@shopify/cli-kit/node/ui'
 import {describe, expect, test, vi, beforeEach} from 'vitest'
 
 vi.mock('../../services/store/delete/dev.js')
+vi.mock('../../services/store/attribution.js')
 vi.mock('../../utilities/store-lookup/organization.js')
+vi.mock('@shopify/cli-kit/node/analytics', () => ({
+  reportAnalyticsEvent: vi.fn(),
+}))
 
 vi.mock('@shopify/cli-kit/node/output', async (importOriginal) => {
   const actual: Record<string, unknown> = await importOriginal()
@@ -35,6 +41,10 @@ beforeEach(() => {
 })
 
 describe('store delete command', () => {
+  test('requires synchronous analytics', () => {
+    expect(StoreDelete.requiresSyncAnalytics).toBe(true)
+  })
+
   test('resolves the organization and passes parsed flags through to the service', async () => {
     await StoreDelete.run(['--store', 'my-store.myshopify.com', '--organization-id', '12345'])
 
@@ -91,6 +101,7 @@ describe('store delete command', () => {
 
     await expect(StoreDelete.run(['--store', 'my-store.myshopify.com', '--organization-id', '12345'])).rejects.toThrow()
     expect(deleteDevStore).not.toHaveBeenCalled()
+    expect(reportAnalyticsEvent).not.toHaveBeenCalled()
   })
 
   test('skips the confirmation prompt when --force is passed', async () => {
@@ -123,22 +134,39 @@ describe('store delete command', () => {
     const mockExit = vi.spyOn(process, 'exit').mockImplementation((() => {
       throw new Error('process.exit')
     }) as never)
+    const mockCommandCatch = vi.spyOn(StoreDelete.prototype, 'catch').mockImplementation(async (error) => {
+      throw error
+    })
 
     await expect(
       StoreDelete.run(['--store', 'my-store.myshopify.com', '--organization-id', '12345', '--json']),
     ).rejects.toThrow('process.exit')
 
-    const call = vi.mocked(outputResult).mock.calls[0]![0] as string
-    const parsed = JSON.parse(call)
-    expect(parsed).toEqual({
-      error: true,
-      message: 'Deleting the development store my-store.myshopify.com requires confirmation.',
-      nextSteps: ['Use the `--force` flag to skip confirmation when running non-interactively.'],
-      exitCode: 1,
-    })
+    expect(outputResult).toHaveBeenCalledTimes(1)
+    expect(outputResult).toHaveBeenCalledWith(
+      JSON.stringify(
+        {
+          error: true,
+          message: 'Deleting the development store my-store.myshopify.com requires confirmation.',
+          nextSteps: ['Use the `--force` flag to skip confirmation when running non-interactively.'],
+          exitCode: 1,
+        },
+        null,
+        2,
+      ),
+    )
     expect(deleteDevStore).not.toHaveBeenCalled()
+    expect(mockExit).toHaveBeenCalledTimes(1)
     expect(mockExit).toHaveBeenCalledWith(1)
+    expect(recordStoreFqdnMetadata).toHaveBeenCalledWith('my-store.myshopify.com', false)
+    expect(reportAnalyticsEvent).toHaveBeenCalledTimes(1)
+    expect(reportAnalyticsEvent).toHaveBeenCalledWith({
+      config: expect.anything(),
+      errorMessage: 'Deleting the development store my-store.myshopify.com requires confirmation.',
+      exitMode: 'expected_error',
+    })
 
+    mockCommandCatch.mockRestore()
     mockExit.mockRestore()
   })
 
@@ -147,21 +175,38 @@ describe('store delete command', () => {
     const mockExit = vi.spyOn(process, 'exit').mockImplementation((() => {
       throw new Error('process.exit')
     }) as never)
+    const mockCommandCatch = vi.spyOn(StoreDelete.prototype, 'catch').mockImplementation(async (error) => {
+      throw error
+    })
 
     await expect(
       StoreDelete.run(['--store', 'my-store.myshopify.com', '--organization-id', '12345', '--json']),
     ).rejects.toThrow('process.exit')
 
-    const call = vi.mocked(outputResult).mock.calls[0]![0] as string
-    const parsed = JSON.parse(call)
-    expect(parsed).toEqual({
-      error: true,
-      message: 'Something went wrong',
-      nextSteps: [],
-      exitCode: 1,
-    })
+    expect(outputResult).toHaveBeenCalledTimes(1)
+    expect(outputResult).toHaveBeenCalledWith(
+      JSON.stringify(
+        {
+          error: true,
+          message: 'Something went wrong',
+          nextSteps: [],
+          exitCode: 1,
+        },
+        null,
+        2,
+      ),
+    )
+    expect(mockExit).toHaveBeenCalledTimes(1)
     expect(mockExit).toHaveBeenCalledWith(1)
+    expect(recordStoreFqdnMetadata).toHaveBeenCalledWith('my-store.myshopify.com', false)
+    expect(reportAnalyticsEvent).toHaveBeenCalledTimes(1)
+    expect(reportAnalyticsEvent).toHaveBeenCalledWith({
+      config: expect.anything(),
+      errorMessage: 'Something went wrong',
+      exitMode: 'expected_error',
+    })
 
+    mockCommandCatch.mockRestore()
     mockExit.mockRestore()
   })
 
@@ -170,20 +215,37 @@ describe('store delete command', () => {
     const mockExit = vi.spyOn(process, 'exit').mockImplementation((() => {
       throw new Error('process.exit')
     }) as never)
+    const mockCommandCatch = vi.spyOn(StoreDelete.prototype, 'catch').mockImplementation(async (error) => {
+      throw error
+    })
 
     await expect(StoreDelete.run(['--store', 'my-store.myshopify.com', '--json'])).rejects.toThrow('process.exit')
 
-    const call = vi.mocked(outputResult).mock.calls[0]![0] as string
-    const parsed = JSON.parse(call)
-    expect(parsed).toEqual({
-      error: true,
-      message: 'Could not resolve organization',
-      nextSteps: [],
-      exitCode: 1,
-    })
+    expect(outputResult).toHaveBeenCalledTimes(1)
+    expect(outputResult).toHaveBeenCalledWith(
+      JSON.stringify(
+        {
+          error: true,
+          message: 'Could not resolve organization',
+          nextSteps: [],
+          exitCode: 1,
+        },
+        null,
+        2,
+      ),
+    )
     expect(deleteDevStore).not.toHaveBeenCalled()
+    expect(mockExit).toHaveBeenCalledTimes(1)
     expect(mockExit).toHaveBeenCalledWith(1)
+    expect(recordStoreFqdnMetadata).toHaveBeenCalledWith('my-store.myshopify.com', false)
+    expect(reportAnalyticsEvent).toHaveBeenCalledTimes(1)
+    expect(reportAnalyticsEvent).toHaveBeenCalledWith({
+      config: expect.anything(),
+      errorMessage: 'Could not resolve organization',
+      exitMode: 'expected_error',
+    })
 
+    mockCommandCatch.mockRestore()
     mockExit.mockRestore()
   })
 

--- a/packages/store/src/cli/commands/store/delete.ts
+++ b/packages/store/src/cli/commands/store/delete.ts
@@ -1,8 +1,10 @@
 import {deleteDevStore} from '../../services/store/delete/dev.js'
 import {storeFlags} from '../../flags.js'
 import {resolveOrganizationForStore} from '../../utilities/store-lookup/organization.js'
+import {recordStoreFqdnMetadata} from '../../services/store/attribution.js'
 import Command from '@shopify/cli-kit/node/base-command'
 import {globalFlags, jsonFlag} from '@shopify/cli-kit/node/cli'
+import {reportAnalyticsEvent} from '@shopify/cli-kit/node/analytics'
 import {AbortError, AbortSilentError} from '@shopify/cli-kit/node/error'
 import {outputResult} from '@shopify/cli-kit/node/output'
 import {isTTY, renderDangerousConfirmationPrompt} from '@shopify/cli-kit/node/ui'
@@ -10,6 +12,10 @@ import {Flags} from '@oclif/core'
 
 export default class StoreDelete extends Command {
   static hidden = true
+
+  public static get requiresSyncAnalytics(): boolean {
+    return true
+  }
 
   static summary = 'Delete a development store.'
 
@@ -38,6 +44,7 @@ export default class StoreDelete extends Command {
 
   async run(): Promise<void> {
     const {flags} = await this.parse(StoreDelete)
+    await recordStoreFqdnMetadata(flags.store, false)
 
     try {
       // Deleting a store is irreversible: in non-interactive runs (CI, agents, piped
@@ -67,6 +74,7 @@ export default class StoreDelete extends Command {
       // Only expected failures (AbortError) are rendered as JSON. Unexpected errors rethrow to the
       // global error handler so they keep their stack traces and get reported as CLI bugs.
       if (flags.json && error instanceof AbortError) {
+        await reportAnalyticsEvent({config: this.config, errorMessage: error.message, exitMode: 'expected_error'})
         outputResult(
           JSON.stringify(
             {

--- a/packages/store/src/cli/services/store/create/dev.test.ts
+++ b/packages/store/src/cli/services/store/create/dev.test.ts
@@ -1,4 +1,5 @@
 import {createDevStore} from './dev.js'
+import {recordStoreFqdnMetadata} from '../attribution.js'
 import {describe, expect, test, vi, beforeEach} from 'vitest'
 
 import {businessPlatformOrganizationsRequestDoc} from '@shopify/cli-kit/node/api/business-platform'
@@ -31,6 +32,8 @@ vi.mock('@shopify/cli-kit/node/output', async (importOriginal) => {
 vi.mock('@shopify/cli-kit/node/system', () => ({
   sleep: vi.fn(),
 }))
+
+vi.mock('../attribution.js')
 
 const defaultOrg = {id: '123', businessName: 'Test Org'}
 const defaultMutationResult = {
@@ -253,6 +256,32 @@ describe('createDevStore', () => {
     expect(renderSuccess).not.toHaveBeenCalled()
   })
 
+  test('records the created store domain before a later polling failure', async () => {
+    vi.mocked(businessPlatformOrganizationsRequestDoc)
+      .mockResolvedValueOnce(defaultMutationResult)
+      .mockResolvedValueOnce({
+        organization: {id: '123', storeCreation: {status: 'FAILED'}},
+      })
+
+    await expect(
+      createDevStore({name: 'test-store', organization: defaultOrg, plan: 'plus', json: false}),
+    ).rejects.toThrow('Store creation failed with status: FAILED')
+
+    expect(recordStoreFqdnMetadata).toHaveBeenCalledWith('test-store.myshopify.com', true)
+  })
+
+  test('does not record store attribution for mutation failures before a domain is returned', async () => {
+    vi.mocked(businessPlatformOrganizationsRequestDoc).mockResolvedValueOnce({
+      createAppDevelopmentStore: null,
+    })
+
+    await expect(
+      createDevStore({name: 'test-store', organization: defaultOrg, plan: 'plus', json: false}),
+    ).rejects.toThrow('unexpected empty response')
+
+    expect(recordStoreFqdnMetadata).not.toHaveBeenCalled()
+  })
+
   test('throws AbortError when mutation returns null createAppDevelopmentStore', async () => {
     vi.mocked(businessPlatformOrganizationsRequestDoc).mockResolvedValueOnce({
       createAppDevelopmentStore: null,
@@ -275,6 +304,7 @@ describe('createDevStore', () => {
     await expect(
       createDevStore({name: 'test-store', organization: defaultOrg, plan: 'plus', json: false}),
     ).rejects.toThrow('Name is taken')
+    expect(recordStoreFqdnMetadata).not.toHaveBeenCalled()
   })
 
   test('throws AbortError when mutation returns no shopDomain', async () => {
@@ -289,6 +319,7 @@ describe('createDevStore', () => {
     await expect(
       createDevStore({name: 'test-store', organization: defaultOrg, plan: 'plus', json: false}),
     ).rejects.toThrow('no shop domain was returned')
+    expect(recordStoreFqdnMetadata).not.toHaveBeenCalled()
   })
 
   test('throws AbortError when polling returns FAILED status', async () => {

--- a/packages/store/src/cli/services/store/create/dev.ts
+++ b/packages/store/src/cli/services/store/create/dev.ts
@@ -1,4 +1,5 @@
 import {businessPlatformTokenRefreshHandler} from '../business-platform.js'
+import {recordStoreFqdnMetadata} from '../attribution.js'
 import {DEV_STORE_PLANS, DevStorePlan} from '../constants.js'
 import {CreateAppDevelopmentStore} from '../../../api/graphql/business-platform-organizations/generated/create_app_development_store.js'
 import {
@@ -84,6 +85,8 @@ export async function createDevStore(options: CreateDevStoreOptions): Promise<vo
   if (!shopDomain) {
     throw new AbortError('Store creation succeeded but no shop domain was returned.')
   }
+
+  await recordStoreFqdnMetadata(shopDomain, true)
 
   await renderSingleTask({
     title: outputContent`Waiting for store to be ready`,

--- a/packages/store/src/cli/services/store/delete/dev.test.ts
+++ b/packages/store/src/cli/services/store/delete/dev.test.ts
@@ -1,4 +1,5 @@
 import {deleteDevStore, toOrganizationsShopifyShopId} from './dev.js'
+import {recordStoreFqdnMetadata} from '../attribution.js'
 import {businessPlatformOrganizationsRequestDoc} from '@shopify/cli-kit/node/api/business-platform'
 import {ensureAuthenticatedBusinessPlatform} from '@shopify/cli-kit/node/session'
 import {renderSingleTask, renderSuccess, renderWarning} from '@shopify/cli-kit/node/ui'
@@ -31,6 +32,8 @@ vi.mock('@shopify/cli-kit/node/output', async (importOriginal) => {
 vi.mock('@shopify/cli-kit/node/system', () => ({
   sleep: vi.fn(),
 }))
+
+vi.mock('../attribution.js')
 
 const defaultOrg = {id: '123', businessName: 'Test Org'}
 const defaultOptions = {store: 'test-store.myshopify.com', organization: defaultOrg, json: false}
@@ -109,6 +112,28 @@ describe('deleteDevStore', () => {
       }),
     )
     expect(renderWarning).not.toHaveBeenCalled()
+    expect(recordStoreFqdnMetadata).toHaveBeenCalledWith('test-store.myshopify.com', true, '72193245184')
+  })
+
+  test('records matching-store attribution again when a second lookup supplies the ID', async () => {
+    mockBusinessPlatformRequests({
+      lookupResults: [shopLookupResult(), defaultShopLookupResult],
+    })
+
+    await deleteDevStore(defaultOptions)
+
+    expect(recordStoreFqdnMetadata).toHaveBeenNthCalledWith(1, 'test-store.myshopify.com', true, undefined)
+    expect(recordStoreFqdnMetadata).toHaveBeenNthCalledWith(2, 'test-store.myshopify.com', true, '72193245184')
+  })
+
+  test('does not record validated attribution when the shop lookup has no match', async () => {
+    const noShopMatch = {organization: {accessibleShops: {edges: []}}}
+    mockBusinessPlatformRequests({lookupResults: [noShopMatch, noShopMatch]})
+
+    await deleteDevStore(defaultOptions)
+
+    expect(recordStoreFqdnMetadata).not.toHaveBeenCalled()
+    expect(renderWarning).toHaveBeenCalled()
   })
 
   test('outputs JSON when --json flag is set', async () => {
@@ -249,16 +274,22 @@ describe('deleteDevStore', () => {
   })
 })
 
-function mockBusinessPlatformRequests(options: {mutationResult?: unknown; pollShops?: PollShop[]} = {}) {
+function mockBusinessPlatformRequests(
+  options: {mutationResult?: unknown; pollShops?: PollShop[]; lookupResults?: unknown[]} = {},
+) {
   const mutationResult = options.mutationResult ?? defaultMutationResult
   const pollShops = options.pollShops ?? [pollShop({planName: 'cancelled'})]
+  const lookupResults = options.lookupResults ?? [defaultShopLookupResult]
+  let lookupIndex = 0
   let pollIndex = 0
 
   vi.mocked(businessPlatformOrganizationsRequestDoc).mockImplementation(async (request) => {
     const variables = request.variables as Record<string, unknown>
 
     if ('search' in variables) {
-      return defaultShopLookupResult as never
+      const lookupResult = lookupResults[Math.min(lookupIndex, lookupResults.length - 1)]
+      lookupIndex++
+      return lookupResult as never
     }
 
     if ('storeFqdn' in variables) {
@@ -273,6 +304,23 @@ function mockBusinessPlatformRequests(options: {mutationResult?: unknown; pollSh
 
     throw new Error(`Unexpected request variables: ${JSON.stringify(variables)}`)
   })
+}
+
+function shopLookupResult(shopifyShopId?: string) {
+  return {
+    organization: {
+      accessibleShops: {
+        edges: [
+          {
+            node: {
+              ...defaultShopLookupResult.organization.accessibleShops.edges[0]!.node,
+              shopifyShopId,
+            },
+          },
+        ],
+      },
+    },
+  }
 }
 
 function pollShop(overrides: NonNullable<PollShop> = {}): NonNullable<PollShop> {

--- a/packages/store/src/cli/services/store/delete/dev.ts
+++ b/packages/store/src/cli/services/store/delete/dev.ts
@@ -1,4 +1,5 @@
 import {businessPlatformTokenRefreshHandler} from '../business-platform.js'
+import {recordStoreFqdnMetadata} from '../attribution.js'
 import {fetchOptionalOrganizationShop} from '../../../utilities/store-lookup/organization-shop.js'
 import {DeleteAppDevelopmentStore} from '../../../api/graphql/business-platform-organizations/generated/delete_app_development_store.js'
 import {
@@ -95,6 +96,9 @@ async function fetchShopifyShopId(options: {
   token: string
 }): Promise<string | undefined> {
   const shop = await fetchOptionalOrganizationShop(options)
+  if (shop) {
+    await recordStoreFqdnMetadata(options.store, true, shop.shopifyShopId)
+  }
   return shop?.shopifyShopId
 }
 


### PR DESCRIPTION
### WHY are these changes introduced?

Context: https://github.com/shop/issues-develop/issues/22725

`store create dev` and `store delete` print exact JSON for expected errors and exit directly. This path skipped the async command analytics report, so JSON expected failures were invisible in `app_cli3_command`. Command analytics also had no store attribution for these lifecycle commands.

### WHAT is this pull request doing?

Existing command analytics now covers JSON expected failures and gains known store attribution. No new events, no schema changes, and no telemetry-only network requests.

- Both commands set `requiresSyncAnalytics` and await expected-error reporting for their JSON `AbortError` paths before the exact JSON output and direct exit.
- `store delete` records the parsed store FQDN as unvalidated; the existing accessible-shop lookup upgrades it to validated with the shop ID when available.
- `store create dev` records the returned domain as validated before polling.
- Interactive delete decline stays unreported.

### How to test your changes?

No behavior or output change is intended. Run `store create dev --json` or `store delete --json` with an expected failure (for example, an inaccessible store) and confirm the JSON error output and exit code are unchanged.

**Smoke test:** Compared the PR head with the base using a non-interactive `store delete --json` expected failure and disabled analytics delivery. Both returned byte-identical JSON and exit code 1. Only the PR head built the awaited `expected_error` payload before exit, including the unvalidated store domain and matching hash. No analytics event was sent and no real store was created or deleted. The `store create dev` error path was verified through focused command tests because a live create would mutate state.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

No changeset: internal telemetry only, no user-visible behavior or output change.
