### PR TITLE
[Tests] Add test for existing hidden folder missing gitignore

### DIFF
--- a/packages/cli-kit/src/public/node/hidden-folder.test.ts
+++ b/packages/cli-kit/src/public/node/hidden-folder.test.ts
@@ -47,4 +47,21 @@ describe('getOrCreateHiddenShopifyFolder', () => {
       expect(writeFileSpy).not.toHaveBeenCalled()
     })
   })
+
+  test('creates .gitignore when hidden folder exists but .gitignore does not', async () => {
+    await fs.inTemporaryDirectory(async (tmpDir) => {
+      // Given
+      const hiddenFolder = joinPath(tmpDir, '.shopify')
+      await fs.mkdir(hiddenFolder)
+      const gitignorePath = joinPath(hiddenFolder, '.gitignore')
+
+      // When
+      await getOrCreateHiddenShopifyFolder(tmpDir)
+
+      // Then
+      await expect(fs.fileExists(gitignorePath)).resolves.toBe(true)
+      const gitignoreContent = await fs.readFile(gitignorePath)
+      expect(gitignoreContent).toContain('# Ignore the entire .shopify directory')
+    })
+  })
 })


### PR DESCRIPTION
### WHY are these changes introduced?

Improves test coverage for `getOrCreateHiddenShopifyFolder` in `@shopify/cli-kit`.

### WHAT is this pull request doing?

Adds a unit test to `packages/cli-kit/src/public/node/hidden-folder.test.ts` verifying that when the `.shopify` hidden directory already exists but `.gitignore` inside it does not, `getOrCreateHiddenShopifyFolder` creates the `.gitignore` file.

### How to test your changes?

CI

### Post-release steps

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [12665915907185140325](https://jules.google.com/task/12665915907185140325) started by @gonzaloriestra*