### PR TITLE
Fix development store command help text

### DIFF
--- a/.changeset/quiet-dev-store-help.md
+++ b/.changeset/quiet-dev-store-help.md
@@ -1,0 +1,5 @@
+---
+'@shopify/store': patch
+---
+
+Correct development store command help text.

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -6697,8 +6697,8 @@
       "args": {
       },
       "customPluginName": "@shopify/store",
-      "description": "Creates a new app development store in your organization.",
-      "descriptionWithMarkdown": "Creates a new app development store in your organization.",
+      "description": "Creates a new development store in your organization.",
+      "descriptionWithMarkdown": "Creates a new development store in your organization.",
       "enableJsonFlag": false,
       "flags": {
         "country": {

--- a/packages/store/src/cli/commands/store/create/dev.ts
+++ b/packages/store/src/cli/commands/store/create/dev.ts
@@ -14,7 +14,7 @@ export default class StoreCreateDev extends Command {
 
   static summary = 'Create a new development store.'
 
-  static descriptionWithMarkdown = 'Creates a new app development store in your organization.'
+  static descriptionWithMarkdown = 'Creates a new development store in your organization.'
 
   static description = this.descriptionWithoutMarkdown()
 


### PR DESCRIPTION
### WHY are these changes introduced?

`shopify store create dev` help incorrectly calls a development store an "app development store."

Context: https://shopify.slack.com/archives/C0BNPM9FTPF/p1787607546461019

### WHAT is this pull request doing?

Correct the command help text and regenerate the OCLIF manifest.

### How to test your changes?

Run `pnpm shopify store create dev --help` and confirm it says `Creates a new development store in your organization.`

### Post-release steps

None.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [x] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`
