### PR TITLE
Add a create store option to the app dev store picker

### DIFF
--- a/.changeset/app-dev-store-picker-create-option.md
+++ b/.changeset/app-dev-store-picker-create-option.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': minor
+---
+
+Add a "Create a new dev store" option to the store picker in `app dev`.

--- a/packages/app/src/cli/commands/app/dev.test.ts
+++ b/packages/app/src/cli/commands/app/dev.test.ts
@@ -63,7 +63,7 @@ describe('app dev command', () => {
         tunnelUrl: undefined,
         localhostPort: undefined,
       })
-      expect(storeContext).toHaveBeenCalledWith(expect.objectContaining({storeCreationMode: 'when-empty'}))
+      expect(storeContext).toHaveBeenCalledWith(expect.objectContaining({storeCreationMode: 'selection-option'}))
       expect(dev).toHaveBeenCalledWith(expect.objectContaining({installMkcert: undefined, tunnel: {mode: 'auto'}}))
     })
   })

--- a/packages/app/src/cli/commands/app/dev.ts
+++ b/packages/app/src/cli/commands/app/dev.ts
@@ -134,7 +134,7 @@ export default class Dev extends AppLinkedCommand {
       appContextResult,
       storeFqdn: flags.store,
       forceReselectStore: flags.reset,
-      storeCreationMode: 'when-empty',
+      storeCreationMode: 'selection-option',
     })
 
     const devOptions: DevOptions = {

--- a/packages/app/src/cli/prompts/dev.test.ts
+++ b/packages/app/src/cli/prompts/dev.test.ts
@@ -143,7 +143,7 @@ describe('selectStore', () => {
     expect(outputMock.output()).toMatch('Using your default dev store, store1, to preview your project')
   })
 
-  test('creates directly when the list is empty and a creation handler is provided', async () => {
+  test('creates directly when the list is empty and a zero-store creation handler is provided', async () => {
     const onCreateStoreWhenEmpty = vi.fn().mockResolvedValue(STORE1)
 
     const got = await selectStorePrompt({
@@ -157,7 +157,7 @@ describe('selectStore', () => {
     expect(renderAutocompletePrompt).not.toHaveBeenCalled()
   })
 
-  test('returns the only store without creating when a creation handler is provided', async () => {
+  test('returns the only store without creating when a zero-store creation handler is provided', async () => {
     const onCreateStoreWhenEmpty = vi.fn().mockResolvedValue(STORE2)
     const outputMock = mockAndCaptureOutput()
 
@@ -171,6 +171,71 @@ describe('selectStore', () => {
     expect(onCreateStoreWhenEmpty).not.toHaveBeenCalled()
     expect(renderAutocompletePrompt).not.toBeCalled()
     expect(outputMock.output()).toMatch('Using your default dev store, store1, to preview your project')
+  })
+
+  test('offers a create choice instead of auto-selecting the only store when a picker creation handler is provided', async () => {
+    const createdStore = {...STORE2, shopId: 'created'}
+    const onCreateStore = vi.fn().mockResolvedValue(createdStore)
+    vi.mocked(renderAutocompletePrompt).mockResolvedValue('__create_new_dev_store__')
+
+    const got = await selectStorePrompt({
+      stores: [STORE1],
+      showDomainOnPrompt: defaultShowDomainOnPrompt,
+      onCreateStore,
+    })
+
+    expect(got).toEqual(createdStore)
+    expect(onCreateStore).toHaveBeenCalledOnce()
+    expect(renderAutocompletePrompt).toHaveBeenCalledWith({
+      message: 'Which store would you like to use to view your project?',
+      choices: [
+        {label: 'store1', value: '1'},
+        {label: 'Create a new dev store', value: '__create_new_dev_store__'},
+      ],
+      hasMorePages: false,
+    })
+  })
+
+  test('returns the selected store when the create choice is offered with multiple stores', async () => {
+    const onCreateStore = vi.fn().mockResolvedValue(STORE3)
+    vi.mocked(renderAutocompletePrompt).mockResolvedValue('2')
+
+    const got = await selectStorePrompt({
+      stores: [STORE1, STORE2],
+      showDomainOnPrompt: defaultShowDomainOnPrompt,
+      onCreateStore,
+    })
+
+    expect(got).toEqual(STORE2)
+    expect(onCreateStore).not.toHaveBeenCalled()
+    expect(renderAutocompletePrompt).toHaveBeenCalledWith({
+      message: 'Which store would you like to use to view your project?',
+      choices: [
+        {label: 'store1', value: '1'},
+        {label: 'store2', value: '2'},
+        {label: 'Create a new dev store', value: '__create_new_dev_store__'},
+      ],
+      hasMorePages: false,
+    })
+  })
+
+  test('keeps the create choice when the store list is searched', async () => {
+    const onCreateStore = vi.fn().mockResolvedValue(STORE3)
+    vi.mocked(renderAutocompletePrompt).mockImplementation(async ({search}) => {
+      const searchResults = await search!('new')
+      expect(searchResults.data).toContainEqual({label: 'Create a new dev store', value: '__create_new_dev_store__'})
+      return '__create_new_dev_store__'
+    })
+
+    const got = await selectStorePrompt({
+      stores: [STORE1],
+      showDomainOnPrompt: defaultShowDomainOnPrompt,
+      onCreateStore,
+      onSearchForStoresByName: (_term: string) => Promise.resolve({stores: [STORE3], hasMorePages: false}),
+    })
+
+    expect(got).toEqual(STORE3)
+    expect(onCreateStore).toHaveBeenCalledOnce()
   })
 
   test('returns store if user selects one', async () => {

--- a/packages/app/src/cli/prompts/dev.test.ts
+++ b/packages/app/src/cli/prompts/dev.test.ts
@@ -143,6 +143,24 @@ describe('selectStore', () => {
     expect(outputMock.output()).toMatch('Using your default dev store, store1, to preview your project')
   })
 
+  test('prompts when only one store is loaded but more pages are available', async () => {
+    const stores: OrganizationStore[] = [STORE1]
+    vi.mocked(renderAutocompletePrompt).mockResolvedValue(STORE1.shopId)
+
+    const got = await selectStorePrompt({
+      stores,
+      hasMorePages: true,
+      showDomainOnPrompt: defaultShowDomainOnPrompt,
+    })
+
+    expect(got).toEqual(STORE1)
+    expect(renderAutocompletePrompt).toHaveBeenCalledWith({
+      message: 'Which store would you like to use to view your project?',
+      choices: [{label: 'store1', value: '1'}],
+      hasMorePages: true,
+    })
+  })
+
   test('creates directly when the list is empty and a zero-store creation handler is provided', async () => {
     const onCreateStoreWhenEmpty = vi.fn().mockResolvedValue(STORE1)
 

--- a/packages/app/src/cli/prompts/dev.test.ts
+++ b/packages/app/src/cli/prompts/dev.test.ts
@@ -238,6 +238,26 @@ describe('selectStore', () => {
     expect(onCreateStore).toHaveBeenCalledOnce()
   })
 
+  test('returns a searched store without creating when the create choice is offered', async () => {
+    const onCreateStore = vi.fn().mockResolvedValue(STORE2)
+    vi.mocked(renderAutocompletePrompt).mockImplementation(async ({search}) => {
+      const searchResults = await search!('new')
+      expect(searchResults.data).toContainEqual({label: 'store3', value: '3'})
+      expect(searchResults.data).toContainEqual({label: 'Create a new dev store', value: '__create_new_dev_store__'})
+      return '3'
+    })
+
+    const got = await selectStorePrompt({
+      stores: [STORE1],
+      showDomainOnPrompt: defaultShowDomainOnPrompt,
+      onCreateStore,
+      onSearchForStoresByName: (_term: string) => Promise.resolve({stores: [STORE3], hasMorePages: false}),
+    })
+
+    expect(got).toEqual(STORE3)
+    expect(onCreateStore).not.toHaveBeenCalled()
+  })
+
   test('returns store if user selects one', async () => {
     // Given
     const stores: OrganizationStore[] = [STORE1, STORE2]

--- a/packages/app/src/cli/prompts/dev.ts
+++ b/packages/app/src/cli/prompts/dev.ts
@@ -70,6 +70,7 @@ interface SelectStorePromptOptions {
   hasMorePages?: boolean
   showDomainOnPrompt: boolean
   onCreateStoreWhenEmpty?: () => Promise<OrganizationStore | undefined>
+  onCreateStore?: () => Promise<OrganizationStore | undefined>
 }
 
 interface ExtraAutoCompletePropsForStoreSelect {
@@ -82,9 +83,10 @@ export async function selectStorePrompt({
   onSearchForStoresByName,
   showDomainOnPrompt = true,
   onCreateStoreWhenEmpty,
+  onCreateStore,
 }: SelectStorePromptOptions): Promise<OrganizationStore | undefined> {
   if (stores.length === 0) return onCreateStoreWhenEmpty?.()
-  if (stores.length === 1) {
+  if (stores.length === 1 && !onCreateStore) {
     outputCompleted(`Using your default dev store, ${stores[0]!.shopName}, to preview your project.`)
     return stores[0]
   }
@@ -99,6 +101,11 @@ export async function selectStorePrompt({
 
   let currentStores = stores
   const storesById = new Map(stores.map((store) => [store.shopId, store]))
+  const createStoreChoice = '__create_new_dev_store__'
+  const choices = () => [
+    ...currentStores.map(storeToChoice),
+    ...(onCreateStore ? [{label: 'Create a new dev store', value: createStoreChoice}] : []),
+  ]
 
   const extraAutocompletePromptProps: ExtraAutoCompletePropsForStoreSelect = {}
   if (onSearchForStoresByName) {
@@ -110,7 +117,7 @@ export async function selectStorePrompt({
       }
 
       return {
-        data: currentStores.map(storeToChoice),
+        data: choices(),
         meta: {
           hasNextPage: result.hasMorePages,
         },
@@ -120,10 +127,11 @@ export async function selectStorePrompt({
 
   const id = await renderAutocompletePrompt({
     message: 'Which store would you like to use to view your project?',
-    choices: currentStores.map(storeToChoice),
+    choices: choices(),
     hasMorePages,
     ...extraAutocompletePromptProps,
   })
+  if (id === createStoreChoice) return onCreateStore?.()
   return storesById.get(id)
 }
 

--- a/packages/app/src/cli/prompts/dev.ts
+++ b/packages/app/src/cli/prompts/dev.ts
@@ -86,7 +86,7 @@ export async function selectStorePrompt({
   onCreateStore,
 }: SelectStorePromptOptions): Promise<OrganizationStore | undefined> {
   if (stores.length === 0) return onCreateStoreWhenEmpty?.()
-  if (stores.length === 1 && !onCreateStore) {
+  if (stores.length === 1 && !hasMorePages && !onCreateStore) {
     outputCompleted(`Using your default dev store, ${stores[0]!.shopName}, to preview your project.`)
     return stores[0]
   }

--- a/packages/app/src/cli/services/dev/select-store.test.ts
+++ b/packages/app/src/cli/services/dev/select-store.test.ts
@@ -115,7 +115,7 @@ describe('selectStore', async () => {
     ).resolves.toEqual(STORE1)
     expect(devStoreCapReached).not.toHaveBeenCalled()
     expect(createDevStore).not.toHaveBeenCalled()
-    expect(vi.mocked(selectStorePrompt).mock.calls[0]?.[0]).not.toHaveProperty('onCreateStoreWhenEmpty')
+    expect(vi.mocked(selectStorePrompt).mock.calls[0]?.[0]).not.toHaveProperty('onCreateStore')
   })
 
   test('auto-selects the only Partners store in a non-interactive environment when store creation is enabled', async () => {
@@ -131,7 +131,7 @@ describe('selectStore', async () => {
       ),
     ).resolves.toEqual(STORE1)
     expect(devStoreCapReached).not.toHaveBeenCalled()
-    expect(vi.mocked(selectStorePrompt).mock.calls[0]?.[0]).not.toHaveProperty('onCreateStoreWhenEmpty')
+    expect(vi.mocked(selectStorePrompt).mock.calls[0]?.[0]).not.toHaveProperty('onCreateStore')
   })
 
   test('keeps prompting in a non-interactive environment when store creation is disabled', async () => {
@@ -225,7 +225,7 @@ describe('selectStore', async () => {
       selectStore({stores: [STORE1, STORE2], hasMorePages: false}, ORG1, developerPlatformClient, 'when-empty'),
     ).resolves.toEqual(STORE1)
     expect(devStoreCapReached).not.toHaveBeenCalled()
-    expect(vi.mocked(selectStorePrompt).mock.calls[0]?.[0]).not.toHaveProperty('onCreateStoreWhenEmpty')
+    expect(vi.mocked(selectStorePrompt).mock.calls[0]?.[0]).not.toHaveProperty('onCreateStore')
   })
 
   test('does not offer creation when store creation is disabled', async () => {
@@ -236,7 +236,123 @@ describe('selectStore', async () => {
       STORE1,
     )
     expect(devStoreCapReached).not.toHaveBeenCalled()
-    expect(vi.mocked(selectStorePrompt).mock.calls[0]?.[0]).not.toHaveProperty('onCreateStoreWhenEmpty')
+    expect(vi.mocked(selectStorePrompt).mock.calls[0]?.[0]).not.toHaveProperty('onCreateStore')
+  })
+
+  test('offers creation with existing stores when the selection-option app-management organization is not capped', async () => {
+    const developerPlatformClient = testDeveloperPlatformClient({clientName: ClientName.AppManagement})
+    vi.mocked(devStoreCapReached).mockResolvedValue(false)
+    vi.mocked(selectStorePrompt).mockResolvedValueOnce(STORE1)
+
+    await expect(
+      selectStore({stores: [STORE1, STORE2], hasMorePages: false}, ORG1, developerPlatformClient, 'selection-option'),
+    ).resolves.toEqual(STORE1)
+    expect(devStoreCapReached).toHaveBeenCalledWith(ORG1.id, developerPlatformClient)
+    expect(vi.mocked(selectStorePrompt).mock.calls[0]?.[0]).toHaveProperty('onCreateStore')
+  })
+
+  test('hides creation but keeps store selection when the selection-option app-management organization is capped', async () => {
+    const developerPlatformClient = testDeveloperPlatformClient({clientName: ClientName.AppManagement})
+    vi.mocked(devStoreCapReached).mockResolvedValue(true)
+    vi.mocked(selectStorePrompt).mockResolvedValueOnce(STORE1)
+
+    await expect(
+      selectStore({stores: [STORE1, STORE2], hasMorePages: false}, ORG1, developerPlatformClient, 'selection-option'),
+    ).resolves.toEqual(STORE1)
+    expect(devStoreCapReached).toHaveBeenCalledWith(ORG1.id, developerPlatformClient)
+    expect(vi.mocked(selectStorePrompt).mock.calls[0]?.[0]).not.toHaveProperty('onCreateStore')
+    expect(createDevStore).not.toHaveBeenCalled()
+  })
+
+  test('keeps the dashboard fallback when the capped selection-option app-management store prompt is cancelled', async () => {
+    const developerPlatformClient = testDeveloperPlatformClient({clientName: ClientName.AppManagement})
+    vi.mocked(devStoreCapReached).mockResolvedValue(true)
+    vi.mocked(selectStorePrompt).mockResolvedValueOnce(undefined)
+    vi.mocked(reloadStoreListPrompt).mockResolvedValue(false)
+
+    await expect(
+      selectStore({stores: [STORE1], hasMorePages: false}, ORG1, developerPlatformClient, 'selection-option'),
+    ).rejects.toBeInstanceOf(CancelExecution)
+    expect(developerPlatformClient.getCreateDevStoreLink).toHaveBeenCalledWith(ORG1)
+    expect(sleep).toHaveBeenCalledWith(5)
+    expect(reloadStoreListPrompt).toHaveBeenCalledWith(ORG1)
+    expect(createDevStore).not.toHaveBeenCalled()
+  })
+
+  test('does not query the cap or offer creation for Partners with the selection-option mode', async () => {
+    const developerPlatformClient = testDeveloperPlatformClient({clientName: ClientName.Partners})
+    vi.mocked(selectStorePrompt).mockResolvedValueOnce(STORE1)
+
+    await expect(
+      selectStore({stores: [STORE1, STORE2], hasMorePages: false}, ORG1, developerPlatformClient, 'selection-option'),
+    ).resolves.toEqual(STORE1)
+    expect(devStoreCapReached).not.toHaveBeenCalled()
+    expect(vi.mocked(selectStorePrompt).mock.calls[0]?.[0]).not.toHaveProperty('onCreateStore')
+  })
+
+  test('fails before the prompt in a non-interactive environment when the selection-option app-management organization has no stores', async () => {
+    vi.mocked(isTTY).mockReturnValue(false)
+
+    await expect(
+      selectStore(
+        {stores: [], hasMorePages: false},
+        ORG1,
+        testDeveloperPlatformClient({clientName: ClientName.AppManagement}),
+        'selection-option',
+      ),
+    ).rejects.toMatchObject({
+      message: 'No development store was specified.',
+      tryMessage: 'Create a development store in Dev Dashboard, then run `app dev` again.',
+    })
+    expect(selectStorePrompt).not.toHaveBeenCalled()
+    expect(devStoreCapReached).not.toHaveBeenCalled()
+    expect(createDevStore).not.toHaveBeenCalled()
+  })
+
+  test('auto-selects the only app-management store in a non-interactive environment with the selection-option mode', async () => {
+    vi.mocked(isTTY).mockReturnValue(false)
+    vi.mocked(selectStorePrompt).mockResolvedValueOnce(STORE1)
+
+    await expect(
+      selectStore(
+        {stores: [STORE1], hasMorePages: false},
+        ORG1,
+        testDeveloperPlatformClient({clientName: ClientName.AppManagement}),
+        'selection-option',
+      ),
+    ).resolves.toEqual(STORE1)
+    expect(devStoreCapReached).not.toHaveBeenCalled()
+    expect(createDevStore).not.toHaveBeenCalled()
+    expect(vi.mocked(selectStorePrompt).mock.calls[0]?.[0]).not.toHaveProperty('onCreateStore')
+  })
+
+  test('creates and refetches an app-management store selected from a non-empty list', async () => {
+    const developerPlatformClient = testDeveloperPlatformClient({clientName: ClientName.AppManagement})
+    vi.mocked(devStoreCapReached).mockResolvedValue(false)
+    vi.mocked(devStoreNamePrompt).mockResolvedValue('created-store')
+    vi.mocked(devStorePlanPrompt).mockResolvedValue('grow')
+    vi.mocked(createDevStore).mockResolvedValue('created-store.myshopify.com')
+    vi.mocked(fetchStore).mockResolvedValueOnce(STORE1)
+    vi.mocked(renderTasks).mockImplementation(async (tasks: Task[]) => {
+      for (const task of tasks) {
+        // eslint-disable-next-line no-await-in-loop
+        await task.task({}, task)
+      }
+      return {}
+    })
+    vi.mocked(selectStorePrompt).mockImplementation(async ({onCreateStore}) => onCreateStore!())
+
+    await expect(
+      selectStore({stores: [STORE2], hasMorePages: false}, ORG1, developerPlatformClient, 'selection-option'),
+    ).resolves.toEqual(STORE1)
+    expect(createDevStore).toHaveBeenCalledWith({
+      name: 'created-store',
+      plan: 'grow',
+      organization: ORG1,
+      json: false,
+      summary: false,
+    })
+    expect(renderSuccess).toHaveBeenCalledWith({headline: 'Development store "store1" created successfully.'})
   })
 
   test('keeps the dashboard fallback when the app-management store prompt is cancelled', async () => {

--- a/packages/app/src/cli/services/dev/select-store.test.ts
+++ b/packages/app/src/cli/services/dev/select-store.test.ts
@@ -302,7 +302,46 @@ describe('selectStore', async () => {
       ),
     ).rejects.toMatchObject({
       message: 'No development store was specified.',
-      tryMessage: 'Create a development store in Dev Dashboard, then run `app dev` again.',
+      tryMessage:
+        'Create a development store with `shopify store create dev --organization-id 1 --name <store-name> --plan <plan>`, then run `shopify app dev --store <store-domain>`.',
+    })
+    expect(selectStorePrompt).not.toHaveBeenCalled()
+    expect(devStoreCapReached).toHaveBeenCalled()
+    expect(createDevStore).not.toHaveBeenCalled()
+  })
+
+  test('fails before the prompt in a non-interactive environment when selection-option requires choosing between stores', async () => {
+    vi.mocked(isTTY).mockReturnValue(false)
+
+    await expect(
+      selectStore(
+        {stores: [STORE1, STORE2], hasMorePages: false},
+        ORG1,
+        testDeveloperPlatformClient({clientName: ClientName.AppManagement}),
+        'selection-option',
+      ),
+    ).rejects.toMatchObject({
+      message: 'No development store was specified.',
+      tryMessage: 'Run `app dev --store <store-domain>` to select a development store.',
+    })
+    expect(selectStorePrompt).not.toHaveBeenCalled()
+    expect(devStoreCapReached).not.toHaveBeenCalled()
+    expect(createDevStore).not.toHaveBeenCalled()
+  })
+
+  test('fails before the prompt in a non-interactive environment when selection-option has more stores to load', async () => {
+    vi.mocked(isTTY).mockReturnValue(false)
+
+    await expect(
+      selectStore(
+        {stores: [STORE1], hasMorePages: true},
+        ORG1,
+        testDeveloperPlatformClient({clientName: ClientName.AppManagement}),
+        'selection-option',
+      ),
+    ).rejects.toMatchObject({
+      message: 'No development store was specified.',
+      tryMessage: 'Run `app dev --store <store-domain>` to select a development store.',
     })
     expect(selectStorePrompt).not.toHaveBeenCalled()
     expect(devStoreCapReached).not.toHaveBeenCalled()
@@ -345,6 +384,7 @@ describe('selectStore', async () => {
     await expect(
       selectStore({stores: [STORE2], hasMorePages: false}, ORG1, developerPlatformClient, 'selection-option'),
     ).resolves.toEqual(STORE1)
+    expect(devStoreCapReached).toHaveBeenCalledTimes(2)
     expect(createDevStore).toHaveBeenCalledWith({
       name: 'created-store',
       plan: 'grow',

--- a/packages/app/src/cli/services/dev/select-store.test.ts
+++ b/packages/app/src/cli/services/dev/select-store.test.ts
@@ -251,13 +251,13 @@ describe('selectStore', async () => {
     expect(vi.mocked(selectStorePrompt).mock.calls[0]?.[0]).toHaveProperty('onCreateStore')
   })
 
-  test('hides creation but keeps store selection when the selection-option app-management organization is capped', async () => {
+  test('hides creation but keeps paginated store selection when the selection-option organization is capped', async () => {
     const developerPlatformClient = testDeveloperPlatformClient({clientName: ClientName.AppManagement})
     vi.mocked(devStoreCapReached).mockResolvedValue(true)
     vi.mocked(selectStorePrompt).mockResolvedValueOnce(STORE1)
 
     await expect(
-      selectStore({stores: [STORE1, STORE2], hasMorePages: false}, ORG1, developerPlatformClient, 'selection-option'),
+      selectStore({stores: [STORE1], hasMorePages: true}, ORG1, developerPlatformClient, 'selection-option'),
     ).resolves.toEqual(STORE1)
     expect(devStoreCapReached).toHaveBeenCalledWith(ORG1.id, developerPlatformClient)
     expect(vi.mocked(selectStorePrompt).mock.calls[0]?.[0]).not.toHaveProperty('onCreateStore')
@@ -271,7 +271,7 @@ describe('selectStore', async () => {
     vi.mocked(reloadStoreListPrompt).mockResolvedValue(false)
 
     await expect(
-      selectStore({stores: [STORE1], hasMorePages: false}, ORG1, developerPlatformClient, 'selection-option'),
+      selectStore({stores: [STORE1, STORE2], hasMorePages: false}, ORG1, developerPlatformClient, 'selection-option'),
     ).rejects.toBeInstanceOf(CancelExecution)
     expect(developerPlatformClient.getCreateDevStoreLink).toHaveBeenCalledWith(ORG1)
     expect(sleep).toHaveBeenCalledWith(5)

--- a/packages/app/src/cli/services/dev/select-store.test.ts
+++ b/packages/app/src/cli/services/dev/select-store.test.ts
@@ -115,6 +115,7 @@ describe('selectStore', async () => {
     ).resolves.toEqual(STORE1)
     expect(devStoreCapReached).not.toHaveBeenCalled()
     expect(createDevStore).not.toHaveBeenCalled()
+    expect(vi.mocked(selectStorePrompt).mock.calls[0]?.[0]).not.toHaveProperty('onCreateStoreWhenEmpty')
     expect(vi.mocked(selectStorePrompt).mock.calls[0]?.[0]).not.toHaveProperty('onCreateStore')
   })
 
@@ -131,6 +132,7 @@ describe('selectStore', async () => {
       ),
     ).resolves.toEqual(STORE1)
     expect(devStoreCapReached).not.toHaveBeenCalled()
+    expect(vi.mocked(selectStorePrompt).mock.calls[0]?.[0]).not.toHaveProperty('onCreateStoreWhenEmpty')
     expect(vi.mocked(selectStorePrompt).mock.calls[0]?.[0]).not.toHaveProperty('onCreateStore')
   })
 
@@ -225,6 +227,7 @@ describe('selectStore', async () => {
       selectStore({stores: [STORE1, STORE2], hasMorePages: false}, ORG1, developerPlatformClient, 'when-empty'),
     ).resolves.toEqual(STORE1)
     expect(devStoreCapReached).not.toHaveBeenCalled()
+    expect(vi.mocked(selectStorePrompt).mock.calls[0]?.[0]).not.toHaveProperty('onCreateStoreWhenEmpty')
     expect(vi.mocked(selectStorePrompt).mock.calls[0]?.[0]).not.toHaveProperty('onCreateStore')
   })
 
@@ -236,6 +239,7 @@ describe('selectStore', async () => {
       STORE1,
     )
     expect(devStoreCapReached).not.toHaveBeenCalled()
+    expect(vi.mocked(selectStorePrompt).mock.calls[0]?.[0]).not.toHaveProperty('onCreateStoreWhenEmpty')
     expect(vi.mocked(selectStorePrompt).mock.calls[0]?.[0]).not.toHaveProperty('onCreateStore')
   })
 

--- a/packages/app/src/cli/services/dev/select-store.test.ts
+++ b/packages/app/src/cli/services/dev/select-store.test.ts
@@ -322,7 +322,7 @@ describe('selectStore', async () => {
       ),
     ).rejects.toMatchObject({
       message: 'No development store was specified.',
-      tryMessage: 'Run `app dev --store <store-domain>` to select a development store.',
+      tryMessage: 'Run `shopify app dev --store <store-domain>` to select a development store.',
     })
     expect(selectStorePrompt).not.toHaveBeenCalled()
     expect(devStoreCapReached).not.toHaveBeenCalled()
@@ -341,7 +341,7 @@ describe('selectStore', async () => {
       ),
     ).rejects.toMatchObject({
       message: 'No development store was specified.',
-      tryMessage: 'Run `app dev --store <store-domain>` to select a development store.',
+      tryMessage: 'Run `shopify app dev --store <store-domain>` to select a development store.',
     })
     expect(selectStorePrompt).not.toHaveBeenCalled()
     expect(devStoreCapReached).not.toHaveBeenCalled()

--- a/packages/app/src/cli/services/dev/select-store.ts
+++ b/packages/app/src/cli/services/dev/select-store.ts
@@ -47,9 +47,16 @@ export async function selectStore(
       throw new AbortError('No development store was specified.', createDevStoreTryMessage(org.id))
     }
     onCreateStoreWhenEmpty = createStoreInline
-  } else if (storeCreationEnabled && storeCreationMode === 'selection-option' && isTTY()) {
+  } else if (storeCreationEnabled && storeCreationMode === 'selection-option') {
+    if (isTTY() === false && (storesSearch.stores.length > 1 || storesSearch.hasMorePages)) {
+      throw new AbortError(
+        'No development store was specified.',
+        'Run `app dev --store <store-domain>` to select a development store.',
+      )
+    }
+
     // A capped organization keeps normal store selection without the create choice.
-    if (!(await devStoreCapReached(org.id, developerPlatformClient))) {
+    if (isTTY() && !(await devStoreCapReached(org.id, developerPlatformClient))) {
       onCreateStore = createStoreInline
     }
   }

--- a/packages/app/src/cli/services/dev/select-store.ts
+++ b/packages/app/src/cli/services/dev/select-store.ts
@@ -9,9 +9,9 @@ import {AbortError, CancelExecution} from '@shopify/cli-kit/node/error'
 import {createDevStore} from '@shopify/organizations'
 
 /** Store creation from store selection is an explicit command opt-in. */
-export type StoreCreationMode = 'disabled' | 'when-empty'
+export type StoreCreationMode = 'disabled' | 'when-empty' | 'selection-option'
 
-/** Selects an eligible development store, or creates one when creation is enabled and the organization has none. */
+/** Selects an eligible development store, or creates one when store creation is enabled. */
 export async function selectStore(
   storesSearch: Paginateable<{stores: OrganizationStore[]}>,
   org: Organization,
@@ -21,9 +21,23 @@ export async function selectStore(
   const showDomainOnPrompt = developerPlatformClient.clientName === ClientName.AppManagement
   const onSearchForStoresByName = async (term: string) => developerPlatformClient.devStoresForOrg(org.id, term)
   const storeCreationEnabled =
-    storeCreationMode === 'when-empty' && developerPlatformClient.clientName === ClientName.AppManagement
+    storeCreationMode !== 'disabled' && developerPlatformClient.clientName === ClientName.AppManagement
+
+  const createStoreInline = async () => {
+    if (await devStoreCapReached(org.id, developerPlatformClient)) {
+      throw new AbortError(devStoreCapReachedMessage, devStoreCapReachedTryMessage(org.id))
+    }
+
+    const name = await devStoreNamePrompt()
+    const plan = await devStorePlanPrompt()
+    const domain = await createDevStore({name, plan, organization: org, json: false, summary: false})
+    const createdStore = await waitForCreatedStoreByDomain(org, domain, developerPlatformClient)
+    renderSuccess({headline: `Development store "${createdStore.shopName}" created successfully.`})
+    return createdStore
+  }
 
   let onCreateStoreWhenEmpty: (() => Promise<OrganizationStore>) | undefined
+  let onCreateStore: (() => Promise<OrganizationStore>) | undefined
   if (storeCreationEnabled && storesSearch.stores.length === 0) {
     if (await devStoreCapReached(org.id, developerPlatformClient)) {
       throw new AbortError(devStoreCapReachedMessage, devStoreCapReachedTryMessage(org.id))
@@ -32,17 +46,11 @@ export async function selectStore(
     if (isTTY() === false) {
       throw new AbortError('No development store was specified.', createDevStoreTryMessage(org.id))
     }
-    onCreateStoreWhenEmpty = async () => {
-      if (await devStoreCapReached(org.id, developerPlatformClient)) {
-        throw new AbortError(devStoreCapReachedMessage, devStoreCapReachedTryMessage(org.id))
-      }
-
-      const name = await devStoreNamePrompt()
-      const plan = await devStorePlanPrompt()
-      const domain = await createDevStore({name, plan, organization: org, json: false, summary: false})
-      const createdStore = await waitForCreatedStoreByDomain(org, domain, developerPlatformClient)
-      renderSuccess({headline: `Development store "${createdStore.shopName}" created successfully.`})
-      return createdStore
+    onCreateStoreWhenEmpty = createStoreInline
+  } else if (storeCreationEnabled && storeCreationMode === 'selection-option' && isTTY()) {
+    // A capped organization keeps normal store selection without the create choice.
+    if (!(await devStoreCapReached(org.id, developerPlatformClient))) {
+      onCreateStore = createStoreInline
     }
   }
 
@@ -53,6 +61,7 @@ export async function selectStore(
     ...storesSearch,
     showDomainOnPrompt,
     ...(onCreateStoreWhenEmpty ? {onCreateStoreWhenEmpty} : {}),
+    ...(onCreateStore ? {onCreateStore} : {}),
   })
   if (!store) {
     if (onCreateStoreWhenEmpty) {

--- a/packages/app/src/cli/services/dev/select-store.ts
+++ b/packages/app/src/cli/services/dev/select-store.ts
@@ -51,7 +51,7 @@ export async function selectStore(
     if (isTTY() === false && (storesSearch.stores.length > 1 || storesSearch.hasMorePages)) {
       throw new AbortError(
         'No development store was specified.',
-        'Run `app dev --store <store-domain>` to select a development store.',
+        'Run `shopify app dev --store <store-domain>` to select a development store.',
       )
     }
 

--- a/packages/app/src/cli/services/store-context.test.ts
+++ b/packages/app/src/cli/services/store-context.test.ts
@@ -49,7 +49,7 @@ describe('storeContext', () => {
     activeConfig: {isLinked: true, hiddenConfig: {}} as unknown as ActiveConfig,
   }
 
-  test('uses explicitly provided storeFqdn', async () => {
+  test('uses an explicitly provided store before selection-option store selection', async () => {
     await inTemporaryDirectory(async (dir) => {
       vi.mocked(fetchStore).mockResolvedValue(mockStore)
       await prepareAppFolder(mockApp, dir)
@@ -58,6 +58,7 @@ describe('storeContext', () => {
         appContextResult,
         storeFqdn: 'explicit-store.myshopify.com',
         forceReselectStore: false,
+        storeCreationMode: 'selection-option',
       })
 
       expect(fetchStore).toHaveBeenCalledWith(
@@ -66,12 +67,14 @@ describe('storeContext', () => {
         mockDeveloperPlatformClient,
         ['APP_DEVELOPMENT'],
       )
+      expect(mockDeveloperPlatformClient.devStoresForOrg).not.toHaveBeenCalled()
+      expect(selectStore).not.toHaveBeenCalled()
       expect(ensureTransferDisabledStore).toHaveBeenCalledWith(mockStore)
       expect(result).toEqual(mockStore)
     })
   })
 
-  test('uses cached dev_store_url when no explicit storeFqdn is provided', async () => {
+  test('uses the cached dev_store_url before selection-option store selection', async () => {
     await inTemporaryDirectory(async (dir) => {
       vi.mocked(fetchStore).mockResolvedValue(mockStore)
       await prepareAppFolder(mockApp, dir)
@@ -79,6 +82,7 @@ describe('storeContext', () => {
       const result = await storeContext({
         appContextResult,
         forceReselectStore: false,
+        storeCreationMode: 'selection-option',
       })
 
       expect(fetchStore).toHaveBeenCalledWith(
@@ -87,6 +91,8 @@ describe('storeContext', () => {
         mockDeveloperPlatformClient,
         ['APP_DEVELOPMENT'],
       )
+      expect(mockDeveloperPlatformClient.devStoresForOrg).not.toHaveBeenCalled()
+      expect(selectStore).not.toHaveBeenCalled()
       expect(result).toEqual(mockStore)
     })
   })

--- a/packages/cli-kit/src/private/node/ui/components/AutocompletePrompt.test.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/AutocompletePrompt.test.tsx
@@ -128,6 +128,34 @@ describe('AutocompletePrompt', async () => {
     expect(onEnter).toHaveBeenCalledWith(items[1]!.value)
   })
 
+  test('searches and selects later-page items from a short paginated list', async () => {
+    const onSubmit = vi.fn()
+    const search = vi.fn(async (term: string) => ({
+      data: term === 'l' ? [{label: 'later-page-store', value: 'later-page-store'}] : [],
+    }))
+
+    const renderInstance = render(
+      <AutocompletePrompt
+        message="Select a store"
+        choices={[{label: 'first-page-store', value: 'first-page-store'}]}
+        onSubmit={onSubmit}
+        hasMorePages
+        search={search}
+        searchDebounceMs={0}
+      />,
+    )
+
+    expect(renderInstance.lastFrame()).toContain('ype to search...')
+
+    await waitForInputsToBeReady()
+    await sendInputAndWaitForContent(renderInstance, 'ater-page-store', 'l')
+    await sendInputAndWait(renderInstance, 10, ARROW_DOWN)
+    await sendInputAndWaitForChange(renderInstance, ENTER)
+
+    expect(search).toHaveBeenCalledWith('l')
+    expect(onSubmit).toHaveBeenCalledWith('later-page-store')
+  })
+
   test('renders groups', async () => {
     const items = [
       {label: 'first', value: 'first', group: 'Automations'},

--- a/packages/cli-kit/src/private/node/ui/components/AutocompletePrompt.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/AutocompletePrompt.tsx
@@ -55,7 +55,7 @@ function AutocompletePrompt<T>({
   const complete = useComplete()
   const [searchTerm, setSearchTerm] = useState('')
   const [searchResults, setSearchResults] = useState<SelectItem<T>[]>(choices)
-  const canSearch = choices.length > MIN_NUMBER_OF_ITEMS_FOR_SEARCH
+  const canSearch = initialHasMorePages || choices.length > MIN_NUMBER_OF_ITEMS_FOR_SEARCH
   const [hasMorePages, setHasMorePages] = useState(initialHasMorePages)
   const {promptState, setPromptState, answer, setAnswer} = usePrompt<SelectItem<T> | undefined>({
     initialAnswer: undefined,


### PR DESCRIPTION
> [!IMPORTANT]
> **Stacked PR.** Base is `dlm-app-dev-inline-store-creation` (#8323), not `main`. This PR only shows the store-picker option on top of the inline creation flow that #8323 adds. Do not merge before #8323.

### WHY are these changes introduced?

Closes shop/issues-develop#23597

#8323 lets `app dev` create a dev store inline, but only when the organization has zero stores. Developers with existing stores still have to leave the CLI to create a new one. Per the [command-scope decision](https://github.com/shop/issues-develop/issues/23597#issuecomment-5413800138), the store picker in `app dev` should also offer a "create store" option.

### WHAT is this pull request doing?

Adds a `Create a new dev store` choice to the `app dev` store picker for App Management organizations that already have stores. Selecting it runs the same name/plan/create/poll flow that #8323 added for the zero-store case.

- New `StoreCreationMode` value `'selection-option'`; only `app dev` opts in. All other callers keep the default `'disabled'`, and `'when-empty'` behavior is unchanged.
- With one or more returned stores, the picker shows those stores plus the create choice. Search finds other stores. One store no longer auto-selects when the create choice is available. The choice persists through search, and an initial store remains selectable after the search input is cleared.
- Zero stores still create directly (no picker), as in #8323.
- Cap handling: with existing stores, a capped organization keeps normal store selection and cancellation; the create choice is hidden. A partial one-store page opens a searchable picker. The flow checks the cap again before it asks for the store name or plan. With zero usable stores, a capped organization must first make a slot available in Dev Dashboard, then use the finite creation sequence from #8323. The cap query still fails open and never runs for Partners or disabled callers.
- Non-interactive runs never prompt or create. With zero stores, the CLI directs the developer to run `shopify store create dev` with the required flags, then `shopify app dev --store <store-domain>`. Multiple returned stores or a partial page uses explicit `shopify app dev --store <store-domain>` guidance. One confirmed store still auto-selects, and explicit or cached selection still bypasses the picker.
- Partners keeps the dashboard link/reload flow.
- This PR does not define JSON output, NDJSON, an event stream, or a prompt protocol for `app dev`. The [CLI JSON outputs design](https://docs.google.com/document/d/1M2YZHKJFFgZo0O8TvBG0NMJGDaiDu98xWOeUxW2QMFM/edit?tab=t.0#heading=h.ixauxxv1jr68) defers long-lived commands such as `app dev` and their prompt protocol.

### How to test your changes?

1. Link an app in an App Management organization that has at least one dev store.
2. Run `shopify app dev --reset`. The store picker lists your stores plus `Create a new dev store`.
3. Pick an existing store: dev starts as before.
4. Run `shopify app dev --reset` again and pick `Create a new dev store`: enter a name, pick a plan, and dev continues on the new store after the success banner.

Manual tophat: this picker-entry behavior was tophatted before the stack split, on the pre-split equivalent SHA `4e85e16c` (multi-store list with create choice, name/basic plan, single success banner, preview ready, explicit `--store` and cached-store bypass, store list stays dev-type, standalone `store create dev --json` unaffected, cleanup). The current child SHA has not been live-tophatted yet.

![tophat screenshot](https://github.com/user-attachments/assets/4ac3c271-f42e-4185-a401-68da06504224)

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [x] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`



