### PR TITLE
Report extension compressed bundle size using Brotli

### DIFF
--- a/.changeset/brotli-bundle-size-report.md
+++ b/.changeset/brotli-bundle-size-report.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Report extension compressed bundle size using Brotli

--- a/packages/app/src/cli/services/build/bundle-size.test.ts
+++ b/packages/app/src/cli/services/build/bundle-size.test.ts
@@ -2,10 +2,19 @@ import {getBundleSize, formatBundleSize} from './bundle-size.js'
 import {describe, expect, test} from 'vitest'
 import {inTemporaryDirectory, writeFile} from '@shopify/cli-kit/node/fs'
 import {joinPath} from '@shopify/cli-kit/node/path'
-import {deflate} from 'node:zlib'
+import {brotliCompress, constants as zlibConstants} from 'node:zlib'
 import {promisify} from 'node:util'
 
-const deflateAsync = promisify(deflate)
+const brotliCompressAsync = promisify(brotliCompress)
+
+async function brotliSize(content: string) {
+  const compressed = await brotliCompressAsync(Buffer.from(content), {
+    params: {
+      [zlibConstants.BROTLI_PARAM_QUALITY]: 11,
+    },
+  })
+  return compressed.byteLength
+}
 
 describe('getBundleSize', () => {
   test('returns raw and compressed sizes', async () => {
@@ -20,12 +29,12 @@ describe('getBundleSize', () => {
 
       // Then
       expect(result.rawBytes).toBe(10000)
-      expect(result.compressedBytes).toBe((await deflateAsync(Buffer.from(content))).byteLength)
+      expect(result.compressedBytes).toBe(await brotliSize(content))
       expect(result.compressedBytes).toBeLessThan(result.rawBytes)
     })
   })
 
-  test('compressed size uses deflate to match the backend (Ruby Zlib::Deflate.deflate)', async () => {
+  test('compressed size uses Brotli to match the backend size gate (Ruby Brotli.deflate)', async () => {
     await inTemporaryDirectory(async (tmpDir) => {
       // Given
       const content = JSON.stringify({key: 'value', nested: {array: [1, 2, 3]}})
@@ -36,8 +45,7 @@ describe('getBundleSize', () => {
       const result = await getBundleSize(filePath)
 
       // Then
-      const expectedCompressed = (await deflateAsync(Buffer.from(content))).byteLength
-      expect(result.compressedBytes).toBe(expectedCompressed)
+      expect(result.compressedBytes).toBe(await brotliSize(content))
     })
   })
 })
@@ -49,7 +57,7 @@ describe('formatBundleSize', () => {
       const content = 'x'.repeat(50000)
       const filePath = joinPath(tmpDir, 'bundle.js')
       await writeFile(filePath, content)
-      const compressedSize = (await deflateAsync(Buffer.from(content))).byteLength
+      const compressedSize = await brotliSize(content)
 
       // When
       const result = await formatBundleSize(filePath)
@@ -67,7 +75,7 @@ describe('formatBundleSize', () => {
       const content = 'a'.repeat(2 * 1024 * 1024)
       const filePath = joinPath(tmpDir, 'bundle.js')
       await writeFile(filePath, content)
-      const compressedSize = (await deflateAsync(Buffer.from(content))).byteLength
+      const compressedSize = await brotliSize(content)
 
       // When
       const result = await formatBundleSize(filePath)

--- a/packages/app/src/cli/services/build/bundle-size.ts
+++ b/packages/app/src/cli/services/build/bundle-size.ts
@@ -1,18 +1,22 @@
 import {readFile} from '@shopify/cli-kit/node/fs'
 import {outputDebug} from '@shopify/cli-kit/node/output'
-import {deflate} from 'node:zlib'
+import {brotliCompress, constants as zlibConstants} from 'node:zlib'
 import {promisify} from 'node:util'
 
-const deflateAsync = promisify(deflate)
+const brotliCompressAsync = promisify(brotliCompress)
 
 /**
- * Computes the raw and compressed (deflate) size of a file.
- * Uses the same compression algorithm as the Shopify backend (Zlib::Deflate.deflate).
+ * Computes the raw and compressed (Brotli) size of a file.
+ * Uses the same compression algorithm as the Shopify backend (Ruby Brotli.deflate).
  */
 export async function getBundleSize(filePath: string) {
   const content = await readFile(filePath)
   const rawBytes = Buffer.byteLength(content)
-  const compressed = await deflateAsync(Buffer.from(content))
+  const compressed = await brotliCompressAsync(Buffer.from(content), {
+    params: {
+      [zlibConstants.BROTLI_PARAM_QUALITY]: 11,
+    },
+  })
   const compressedBytes = compressed.byteLength
 
   return {path: filePath, rawBytes, compressedBytes}


### PR DESCRIPTION
### Why?

The build output prints a compressed size estimate (`... built in 123ms (215.4 KB original, ~48.1 KB compressed)`) so developers can stay under the platform's compressed-size limit for remote-DOM extensions (64 KB for checkout). The platform now measures that limit with Brotli instead of deflate, so the CLI's deflate-based estimate overestimates and no longer matches what's enforced.

### What?

Compress with Brotli using the same settings as the platform: quality 11.

Trade-off: brotli-11 costs ~1ms/KB per rebuild (incl. `app dev` watch loop) — ≤ ~0.3s for realistic bundles, acceptable for a number that matches the enforced limit exactly.

### Testing

1. Run `app build` (or `app dev`) on an app with a checkout UI extension.
2. Check the `~Y KB compressed` suffix matches `zlib.brotliCompressSync` at quality 11 on the built JS.