### PR TITLE
[Refactor] Use startsWith in platformAndArch

### DIFF
--- a/packages/cli-kit/src/public/node/os.ts
+++ b/packages/cli-kit/src/public/node/os.ts
@@ -64,7 +64,7 @@ export function platformAndArch(
   arch: PlatformArch
 } {
   const archString = ARCH_MAP[arch] ?? (arch as PlatformArch)
-  const platformString = (platform.match(/^win.+/) ? 'windows' : platform) as PlatformStrings
+  const platformString = (platform.startsWith('win') ? 'windows' : platform) as PlatformStrings
   return {platform: platformString, arch: archString}
 }
 


### PR DESCRIPTION
### WHY are these changes introduced?
Replaces regular expression matching `platform.match(/^win.+/)` with the standard `platform.startsWith('win')` method in `platformAndArch`.

### WHAT is this pull request doing?
- Simplifies string inspection logic in `platformAndArch` (`packages/cli-kit/src/public/node/os.ts`).
- Preserves all existing observable behavior and type definitions.

### How to test your changes?
CI


---
*PR created automatically by Jules for task [14961170502515935592](https://jules.google.com/task/14961170502515935592) started by @gonzaloriestra*