### PR TITLE
Fix `app dev --use-localhost` aborting instead of prompting to generate the localhost certificate

### DIFF
--- a/.changeset/prompt-for-localhost-certificate.md
+++ b/.changeset/prompt-for-localhost-certificate.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Prompt to generate the localhost certificate again instead of aborting on `app dev --use-localhost`

--- a/packages/app/src/cli/commands/app/dev.test.ts
+++ b/packages/app/src/cli/commands/app/dev.test.ts
@@ -33,22 +33,27 @@ describe('app dev command', () => {
     vi.mocked(addPublicMetadata).mockReset()
   })
 
+  function mockAppAndStore(directory: string) {
+    const appContextResult = {
+      app: testAppLinked({directory}),
+      remoteApp: testOrganizationApp(),
+      organization: testOrganization(),
+      project: testProject(),
+      activeConfig: {} as never,
+      specifications: [],
+      developerPlatformClient: testDeveloperPlatformClient(),
+    } as Awaited<ReturnType<typeof linkedAppContext>>
+    const store = testOrganizationStore({shopDomain: 'dev-store.myshopify.com'})
+
+    vi.mocked(linkedAppContext).mockResolvedValue(appContextResult)
+    vi.mocked(storeContext).mockResolvedValue(store)
+
+    return {store}
+  }
+
   test('does not require --use-localhost when --install-mkcert is not passed', async () => {
     await inTemporaryDirectory(async (tmp) => {
-      const app = testAppLinked({directory: tmp})
-      const appContextResult = {
-        app,
-        remoteApp: testOrganizationApp(),
-        organization: testOrganization(),
-        project: testProject(),
-        activeConfig: {} as never,
-        specifications: [],
-        developerPlatformClient: testDeveloperPlatformClient(),
-      } as Awaited<ReturnType<typeof linkedAppContext>>
-      const store = testOrganizationStore({shopDomain: 'dev-store.myshopify.com'})
-
-      vi.mocked(linkedAppContext).mockResolvedValue(appContextResult)
-      vi.mocked(storeContext).mockResolvedValue(store)
+      const {store} = mockAppAndStore(tmp)
       vi.mocked(getTunnelMode).mockResolvedValue({mode: 'auto'})
 
       await Dev.run(['--path', tmp, '--store', store.shopDomain], import.meta.url)
@@ -58,7 +63,34 @@ describe('app dev command', () => {
         tunnelUrl: undefined,
         localhostPort: undefined,
       })
-      expect(dev).toHaveBeenCalledWith(expect.objectContaining({installMkcert: false, tunnel: {mode: 'auto'}}))
+      expect(dev).toHaveBeenCalledWith(expect.objectContaining({installMkcert: undefined, tunnel: {mode: 'auto'}}))
+    })
+  })
+
+  // `generateCertificate()` only shows the "generate it now?" prompt when `installMkcert` is nullish, so an
+  // omitted --install-mkcert must stay undefined rather than being collapsed into an explicit `false`.
+  test('leaves installMkcert undefined with --use-localhost so the certificate prompt is reached', async () => {
+    await inTemporaryDirectory(async (tmp) => {
+      const {store} = mockAppAndStore(tmp)
+      vi.mocked(getTunnelMode).mockResolvedValue({mode: 'use-localhost', requestedPort: 3458, actualPort: 3458})
+
+      await Dev.run(['--path', tmp, '--store', store.shopDomain, '--use-localhost'], import.meta.url)
+
+      expect(dev).toHaveBeenCalledWith(expect.objectContaining({installMkcert: undefined}))
+    })
+  })
+
+  test('sets installMkcert to true when --install-mkcert is passed', async () => {
+    await inTemporaryDirectory(async (tmp) => {
+      const {store} = mockAppAndStore(tmp)
+      vi.mocked(getTunnelMode).mockResolvedValue({mode: 'use-localhost', requestedPort: 3458, actualPort: 3458})
+
+      await Dev.run(
+        ['--path', tmp, '--store', store.shopDomain, '--use-localhost', '--install-mkcert'],
+        import.meta.url,
+      )
+
+      expect(dev).toHaveBeenCalledWith(expect.objectContaining({installMkcert: true}))
     })
   })
 

--- a/packages/app/src/cli/commands/app/dev.ts
+++ b/packages/app/src/cli/commands/app/dev.ts
@@ -151,7 +151,8 @@ export default class Dev extends AppLinkedCommand {
       notify: flags.notify,
       graphiqlPort: flags['graphiql-port'],
       graphiqlKey: flags['graphiql-key'],
-      installMkcert: flags['install-mkcert'] ?? false,
+      // Must stay undefined when the flag is absent: generateCertificate() only prompts when this is nullish.
+      installMkcert: flags['install-mkcert'],
       tunnel: tunnelMode,
     }
 


### PR DESCRIPTION
### WHY are these changes introduced?

`shopify app dev --use-localhost` aborts immediately on any app that doesn't already have a localhost certificate:

```
error ───────────────────────────────────────────────────────────────
  Localhost certificate and key are required at .shopify/localhost.pem and .shopify/localhost-key.pem
```

The `--use-localhost` requires a certificate for `localhost`. Generate it now? prompt is never shown, so there's no way to get the certificate generated without also passing `--install-mkcert`. Reproduces on a brand new `shopify app init` app.

Regression: last good is **4.5.2**, first broken is **4.6.0**, still broken on `main`.

`generateCertificate()` treats `forceInstall` as tri-state and only falls through to the prompt when it's nullish — [`utilities/mkcert.ts`](https://github.com/Shopify/cli/blob/main/packages/app/src/cli/utilities/mkcert.ts#L160):

```ts
const shouldGenerate = forceInstall ?? (await generateCertificatePrompt())

if (!shouldGenerate) {
  throw new AbortError(`Localhost certificate and key are required at ...`)
}
```

But the command collapsed "flag not passed" into an explicit `false` — [`commands/app/dev.ts`](https://github.com/Shopify/cli/blob/main/packages/app/src/cli/commands/app/dev.ts#L154):

```ts
installMkcert: flags['install-mkcert'] ?? false,
```

`false` isn't nullish, so `??` never evaluated the prompt and the abort was thrown on every run where the certificate didn't already exist. The flag has no `allowNo`, so `false` could only ever come from that default.

Both halves came in with #7632: `forceInstall ?? prompt()` in ea162428d, and the `?? false` in the follow-up fb770af84 — that commit correctly dropped `default: false` from the flag (it was making `dependsOn: ['use-localhost']` fire on every invocation) but re-added the same collapse at the call site. First released in 4.6.0.

### WHAT is this pull request doing?

Lets the flag stay `undefined` when it isn't passed, so `generateCertificate()` reaches the prompt again:

```diff
-      installMkcert: flags['install-mkcert'] ?? false,
+      installMkcert: flags['install-mkcert'],
```

`DevOptions.installMkcert` is already `boolean | undefined`, so nothing else in the chain (`commands/app/dev.ts` → `services/dev.ts` → `setupNetworkingOptions` → `generateCertificate`) needs to change. A comment at the call site records why there's no default, since the collapse has been reintroduced once already.

Tests: the existing expectation encoded the broken value (`installMkcert: false`) and now asserts `undefined`; two tests are added for the `--use-localhost` paths with and without `--install-mkcert`. Both new assertions fail against `main` and pass with the fix.

Behaviour that is deliberately unchanged:

- `--install-mkcert` / `SHOPIFY_FLAG_INSTALL_MKCERT=1` still skips the prompt and installs.
- `SHOPIFY_FLAG_INSTALL_MKCERT=0` still resolves to a real `false` through oclif's `isTruthy`, so a non-interactive *decline* remains possible without adding `allowNo`.
- In CI without either, the prompt raises the usual `Failed to prompt` error from `throwInNonTTY`, which names the flag to pass.
- `dependsOn: ['use-localhost']` is untouched — the `??` was applied after parsing and never affected oclif validation.

No flag definitions or command signatures changed, so no manifest, README, or docs regeneration is needed.

### How to test your changes?

```
shopify app init            # any template, new app
cd <app>
rm -f .shopify/localhost.pem .shopify/localhost-key.pem
shopify app dev --use-localhost
```

Before: aborts with `Localhost certificate and key are required at ...`.
After: prompts `--use-localhost requires a certificate for localhost. Generate it now?`, and generating produces `.shopify/localhost.pem`. Declining still aborts with the same message.

Workaround for anyone hitting this on 4.6.0–4.7.0: `shopify app dev --use-localhost --install-mkcert` once, then plain `--use-localhost` works.

Locally: full `type-check` and `lint` pass across all packages; `dev.test.ts` and `mkcert.test.ts` pass. The pre-existing `init.test.ts` / `config/link.test.ts` / `config/validate.test.ts` failures on this branch reproduce unchanged on `main` and are unrelated.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [x] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
