### PR TITLE
[Tests] Add unit tests for developerDashboardFqdn and storeAdminUrl

### DIFF
--- a/packages/cli-kit/src/public/node/context/fqdn.test.ts
+++ b/packages/cli-kit/src/public/node/context/fqdn.test.ts
@@ -1,11 +1,13 @@
 import {
   partnersFqdn,
   appManagementFqdn,
+  developerDashboardFqdn,
   identityFqdn,
   normalizeStoreFqdn,
   businessPlatformFqdn,
   appDevFqdn,
   adminFqdn,
+  storeAdminUrl,
 } from './fqdn.js'
 import {Environment, serviceEnvironment} from '../../../private/node/context/service.js'
 import {expect, describe, test, vi} from 'vitest'
@@ -171,6 +173,68 @@ describe('adminFqdn', () => {
 
     // Then
     expect(got).toEqual('admin.shopify.com')
+  })
+})
+
+describe('developerDashboardFqdn', () => {
+  test('returns the local fqdn when the environment is local', async () => {
+    // Given
+    vi.mocked(serviceEnvironment).mockReturnValue(Environment.Local)
+
+    // When
+    const got = await developerDashboardFqdn()
+
+    // Then
+    expect(got).toEqual('dev.myshopify.io')
+  })
+
+  test('returns the production fqdn when the environment is production', async () => {
+    // Given
+    vi.mocked(serviceEnvironment).mockReturnValue(Environment.Production)
+
+    // When
+    const got = await developerDashboardFqdn()
+
+    // Then
+    expect(got).toEqual('dev.shopify.com')
+  })
+})
+
+describe('storeAdminUrl', () => {
+  test('transforms store fqdn ending in .my.shop.dev when environment is local', () => {
+    // Given
+    vi.mocked(serviceEnvironment).mockReturnValue(Environment.Local)
+    const storeFqdn = 'my-store.my.shop.dev'
+
+    // When
+    const got = storeAdminUrl(storeFqdn)
+
+    // Then
+    expect(got).toEqual('admin.shop.dev/store/my-store')
+  })
+
+  test('returns unchanged store fqdn when environment is local but domain does not end in .my.shop.dev', () => {
+    // Given
+    vi.mocked(serviceEnvironment).mockReturnValue(Environment.Local)
+    const storeFqdn = 'my-store.myshopify.com'
+
+    // When
+    const got = storeAdminUrl(storeFqdn)
+
+    // Then
+    expect(got).toEqual('my-store.myshopify.com')
+  })
+
+  test('returns unchanged store fqdn when environment is production', () => {
+    // Given
+    vi.mocked(serviceEnvironment).mockReturnValue(Environment.Production)
+    const storeFqdn = 'my-store.my.shop.dev'
+
+    // When
+    const got = storeAdminUrl(storeFqdn)
+
+    // Then
+    expect(got).toEqual('my-store.my.shop.dev')
   })
 })
 


### PR DESCRIPTION
### WHY are these changes introduced?

`developerDashboardFqdn` and `storeAdminUrl` in `packages/cli-kit/src/public/node/context/fqdn.ts` were missing unit tests.

### WHAT is this pull request doing?

Adds unit test coverage for `developerDashboardFqdn` and `storeAdminUrl` in `packages/cli-kit/src/public/node/context/fqdn.test.ts` to verify domain formatting and environment-based (local vs. production) domain resolution.

### How to test your changes?

CI

### Post-release steps

N/A

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [6691744448840272138](https://jules.google.com/task/6691744448840272138) started by @gonzaloriestra*