### PR TITLE
[Refactor] Use Array.prototype.some in sniffForJson

### DIFF
--- a/packages/cli-kit/src/public/node/path.ts
+++ b/packages/cli-kit/src/public/node/path.ts
@@ -203,7 +203,7 @@ export function sniffForPath(argv = process.argv): string | undefined {
  * @returns Whether the `--json` or `-j` flag is present in the arguments.
  */
 export function sniffForJson(argv = process.argv): boolean {
-  return argv.includes('--json') || argv.includes('-j')
+  return argv.some((arg) => arg === '--json' || arg === '-j')
 }
 
 /**


### PR DESCRIPTION
Refactored `sniffForJson` in `packages/cli-kit/src/public/node/path.ts` to use `Array.prototype.some` for single-pass array checking, avoiding multiple traversals of the argument list.

---
*PR created automatically by Jules for task [6808978738318766704](https://jules.google.com/task/6808978738318766704) started by @gonzaloriestra*