### PR TITLE
Fan out one events module per subscription behind an organization flag or environment opt-in

### DIFF
--- a/.changeset/events-subscription-fanout.md
+++ b/.changeset/events-subscription-fanout.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Fan out one events module per subscription, gated by an organization flag or SHOPIFY_CLI_EVENTS_SUBSCRIPTION_FANOUT

--- a/packages/app/src/cli/models/app/loader.test.ts
+++ b/packages/app/src/cli/models/app/loader.test.ts
@@ -2174,6 +2174,217 @@ describe('load', () => {
     ])
   })
 
+  test('fans out one events module per subscription when the fan-out is enabled', async () => {
+    // Given
+    const appConfigurationWithEvents = `
+    name = "for-testing-events"
+    client_id = "1234567890"
+    application_url = "https://example.com/lala"
+    embedded = true
+
+    [build]
+    include_config_on_deploy = true
+
+    [webhooks]
+    api_version = "2024-01"
+
+    [auth]
+    redirect_urls = [ "https://example.com/api/auth" ]
+
+    [events]
+    api_version = "2024-01"
+
+    [[events.subscription]]
+      topic = "orders/create"
+      actions = ["create"]
+      handle = "order-notifier"
+      uri = "https://example.com/events/orders"
+
+    [[events.subscription]]
+      topic = "products/update"
+      actions = ["update"]
+      handle = "product-sync"
+      uri = "https://example.com/events/products"
+    `
+    await writeConfig(appConfigurationWithEvents)
+    process.env.SHOPIFY_CLI_EVENTS_SUBSCRIPTION_FANOUT = '1'
+
+    try {
+      // When
+      const app = await loadTestingApp({remoteFlags: []})
+
+      // Then
+      const eventsExtensions = app.allExtensions.filter((ext) => ext.specification.identifier === 'events')
+      expect(eventsExtensions).toHaveLength(2)
+      expect(eventsExtensions.map((ext) => ext.configuration)).toEqual([
+        {
+          events: {
+            api_version: '2024-01',
+            subscription: {
+              topic: 'orders/create',
+              actions: ['create'],
+              handle: 'order-notifier',
+              uri: 'https://example.com/events/orders',
+            },
+          },
+        },
+        {
+          events: {
+            api_version: '2024-01',
+            subscription: {
+              topic: 'products/update',
+              actions: ['update'],
+              handle: 'product-sync',
+              uri: 'https://example.com/events/products',
+            },
+          },
+        },
+      ])
+      expect(eventsExtensions.map((ext) => ext.handle)).toEqual(['order-notifier', 'product-sync'])
+      expect(eventsExtensions.map((ext) => ext.uid)).toEqual(['order-notifier', 'product-sync'])
+    } finally {
+      delete process.env.SHOPIFY_CLI_EVENTS_SUBSCRIPTION_FANOUT
+    }
+  })
+
+  test('fans out events modules when the remote flag is enabled without the environment opt-in', async () => {
+    // Given
+    const appConfigurationWithEvents = `
+    name = "for-testing-events"
+    client_id = "1234567890"
+    application_url = "https://example.com/lala"
+    embedded = true
+
+    [webhooks]
+    api_version = "2024-01"
+
+    [auth]
+    redirect_urls = [ "https://example.com/api/auth" ]
+
+    [events]
+    api_version = "2024-01"
+
+    [[events.subscription]]
+      topic = "orders/create"
+      actions = ["create"]
+      handle = "order-notifier"
+      uri = "https://example.com/events/orders"
+    `
+    await writeConfig(appConfigurationWithEvents)
+
+    // When
+    const app = await loadTestingApp({remoteFlags: [Flag.SingleSubscriptionEventsModules]})
+
+    // Then
+    const eventsExtensions = app.allExtensions.filter((ext) => ext.specification.identifier === 'events')
+    expect(eventsExtensions).toHaveLength(1)
+    expect(eventsExtensions[0]!.configuration).toEqual({
+      events: {
+        api_version: '2024-01',
+        subscription: {
+          topic: 'orders/create',
+          actions: ['create'],
+          handle: 'order-notifier',
+          uri: 'https://example.com/events/orders',
+        },
+      },
+    })
+    expect(eventsExtensions[0]!.handle).toEqual('order-notifier')
+  })
+
+  test('loads a single events module with the subscription list when the fan-out is disabled', async () => {
+    // Given
+    const appConfigurationWithEvents = `
+    name = "for-testing-events"
+    client_id = "1234567890"
+    application_url = "https://example.com/lala"
+    embedded = true
+
+    [webhooks]
+    api_version = "2024-01"
+
+    [auth]
+    redirect_urls = [ "https://example.com/api/auth" ]
+
+    [events]
+    api_version = "2024-01"
+
+    [[events.subscription]]
+      topic = "orders/create"
+      actions = ["create"]
+      handle = "order-notifier"
+      uri = "https://example.com/events/orders"
+    `
+    await writeConfig(appConfigurationWithEvents)
+
+    // When
+    const app = await loadTestingApp({remoteFlags: []})
+
+    // Then
+    const eventsExtensions = app.allExtensions.filter((ext) => ext.specification.identifier === 'events')
+    expect(eventsExtensions).toHaveLength(1)
+    expect(eventsExtensions[0]!.configuration).toMatchObject({
+      events: {
+        api_version: '2024-01',
+        subscription: [
+          {
+            topic: 'orders/create',
+            actions: ['create'],
+            handle: 'order-notifier',
+            uri: 'https://example.com/events/orders',
+          },
+        ],
+      },
+    })
+  })
+
+  test('rejects duplicate event subscription handles when the fan-out is enabled', async () => {
+    // Given
+    const appConfigurationWithEvents = `
+    name = "for-testing-events"
+    client_id = "1234567890"
+    application_url = "https://example.com/lala"
+    embedded = true
+
+    [webhooks]
+    api_version = "2024-01"
+
+    [auth]
+    redirect_urls = [ "https://example.com/api/auth" ]
+
+    [events]
+    api_version = "2024-01"
+
+    [[events.subscription]]
+      topic = "orders/create"
+      actions = ["create"]
+      handle = "order-notifier"
+      uri = "https://example.com/events/orders"
+
+    [[events.subscription]]
+      topic = "products/update"
+      actions = ["update"]
+      handle = "order-notifier"
+      uri = "https://example.com/events/products"
+    `
+    await writeConfig(appConfigurationWithEvents)
+    process.env.SHOPIFY_CLI_EVENTS_SUBSCRIPTION_FANOUT = '1'
+
+    try {
+      // When
+      const app = await loadTestingApp({remoteFlags: []})
+
+      // Then
+      const errorMessages = app.errors
+        .getErrors()
+        .map((error) => error.message)
+        .join('\n')
+      expect(errorMessages).toContain('Duplicated handle "order-notifier"')
+    } finally {
+      delete process.env.SHOPIFY_CLI_EVENTS_SUBSCRIPTION_FANOUT
+    }
+  })
+
   test('loads the app with several functions that have valid configurations', async () => {
     // Given
     await writeConfig(appConfiguration)

--- a/packages/app/src/cli/models/app/loader.ts
+++ b/packages/app/src/cli/models/app/loader.ts
@@ -26,6 +26,7 @@ import {ExtensionSpecification, isAppConfigSpecification} from '../extensions/sp
 import {CreateAppOptions, Flag} from '../../utilities/developer-platform-client.js'
 import {findConfigFiles} from '../../prompts/config.js'
 import {WebhookSubscriptionSpecIdentifier} from '../extensions/specifications/app_config_webhook_subscription.js'
+import {EventsSpecIdentifier} from '../extensions/specifications/app_config_events.js'
 import {WebhooksSchema} from '../extensions/specifications/app_config_webhook_schemas/webhooks_schema.js'
 import {ApplicationURLs, generateApplicationURLs} from '../../services/dev/urls.js'
 import {Project} from '../project/project.js'
@@ -49,6 +50,8 @@ import {AbortError} from '@shopify/cli-kit/node/error'
 import {outputContent, outputDebug, outputToken, stringifyMessage} from '@shopify/cli-kit/node/output'
 import {joinWithAnd} from '@shopify/cli-kit/common/string'
 import {getArrayRejectingUndefined} from '@shopify/cli-kit/common/array'
+import {getPathValue} from '@shopify/cli-kit/common/object'
+import {isTruthy} from '@shopify/cli-kit/node/context/utilities'
 import {showNotificationsIfNeeded} from '@shopify/cli-kit/node/notifications-system'
 import ignore from 'ignore'
 import type {ActiveConfig} from '../project/active-config.js'
@@ -787,11 +790,21 @@ class AppLoader<TConfig extends CurrentAppConfiguration, TModuleSpec extends Ext
           const specResult = parseConfigurationObjectAgainstSpecification(specification, configPath, appConfiguration)
           if (specResult.errors) {
             this.errors.addErrors(specResult.errors)
-            return [null, [] as string[]] as const
+            return [[], [] as string[]] as const
           }
           const specConfiguration = specResult.data
 
-          if (Object.keys(specConfiguration).length === 0) return [null, Object.keys(specConfiguration)] as const
+          if (Object.keys(specConfiguration).length === 0) return [[], Object.keys(specConfiguration)] as const
+
+          const eventSubscriptionInstances = await this.createEventSubscriptionInstances(
+            specification,
+            specConfiguration,
+            configPath,
+            directory,
+          )
+          if (eventSubscriptionInstances) {
+            return [eventSubscriptionInstances, Object.keys(specConfiguration)] as const
+          }
 
           const instance = await this.createExtensionInstance(
             specification.identifier,
@@ -805,7 +818,7 @@ class AppLoader<TConfig extends CurrentAppConfiguration, TModuleSpec extends Ext
               extensionInstance,
             ),
           )
-          return [instance, Object.keys(specConfiguration)] as const
+          return [[instance], Object.keys(specConfiguration)] as const
         }),
     )
 
@@ -824,9 +837,39 @@ class AppLoader<TConfig extends CurrentAppConfiguration, TModuleSpec extends Ext
         message: `Unsupported section(s) in app configuration: ${unusedKeys.sort().join(', ')}`,
       })
     }
-    return extensionInstancesWithKeys
-      .filter(([instance]) => instance)
-      .map(([instance]) => instance as ExtensionInstance)
+    return getArrayRejectingUndefined(extensionInstancesWithKeys.flatMap(([instances]) => instances))
+  }
+
+  private async createEventSubscriptionInstances(
+    specification: ExtensionSpecification,
+    specConfiguration: object,
+    configPath: string,
+    directory: string,
+  ): Promise<ExtensionInstance[] | undefined> {
+    if (specification.identifier !== EventsSpecIdentifier) return undefined
+    const fanoutEnabled =
+      this.remoteFlags.includes(Flag.SingleSubscriptionEventsModules) ||
+      isTruthy(process.env.SHOPIFY_CLI_EVENTS_SUBSCRIPTION_FANOUT)
+    if (!fanoutEnabled) return undefined
+
+    const events = getPathValue<{api_version?: string; subscription?: {[key: string]: unknown}[]}>(
+      specConfiguration,
+      'events',
+    )
+    const subscriptions = events?.subscription
+    if (!Array.isArray(subscriptions) || subscriptions.length === 0) return undefined
+
+    const instances = await Promise.all(
+      subscriptions.map(async (subscription) =>
+        this.createExtensionInstance(
+          specification.identifier,
+          {events: {api_version: events?.api_version, subscription}},
+          configPath,
+          directory,
+        ),
+      ),
+    )
+    return getArrayRejectingUndefined(instances)
   }
 
   private async validateConfigurationExtensionInstance(

--- a/packages/app/src/cli/models/extensions/extension-instance.ts
+++ b/packages/app/src/cli/models/extensions/extension-instance.ts
@@ -522,7 +522,17 @@ export class ExtensionInstance<TConfiguration extends BaseConfigType = BaseConfi
     }
   }
 
+  private singleEventSubscriptionHandle(): string | undefined {
+    if (this.specification.identifier !== 'events') return undefined
+    const subscription = getPathValue(this.configuration, 'events.subscription')
+    if (!subscription || Array.isArray(subscription)) return undefined
+    return getPathValue(subscription, 'handle')
+  }
+
   private buildHandle() {
+    const eventSubscriptionHandle = this.singleEventSubscriptionHandle()
+    if (eventSubscriptionHandle) return eventSubscriptionHandle
+
     switch (this.specification.uidStrategy) {
       case 'single':
         return this.specification.identifier
@@ -541,6 +551,9 @@ export class ExtensionInstance<TConfiguration extends BaseConfigType = BaseConfi
   }
 
   private buildUIDFromStrategy() {
+    const eventSubscriptionHandle = this.singleEventSubscriptionHandle()
+    if (eventSubscriptionHandle) return eventSubscriptionHandle
+
     switch (this.specification.uidStrategy) {
       case 'single':
         return this.specification.identifier

--- a/packages/app/src/cli/utilities/developer-platform-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client.ts
@@ -141,7 +141,9 @@ export type AssetUrlSchema = WithUserErrors<{
   assetUrl?: string | null
 }>
 
-export enum Flag {}
+export enum Flag {
+  SingleSubscriptionEventsModules = 'single_subscription_events_modules',
+}
 
 const FlagMap: {[key: string]: Flag} = {}
 

--- a/packages/app/src/cli/utilities/developer-platform-client/app-management-client.test.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/app-management-client.test.ts
@@ -9,6 +9,7 @@ import {
   versionDeepLink,
 } from './app-management-client.js'
 import {OrganizationBetaFlagsQuerySchema} from './app-management-client/graphql/organization_beta_flags.js'
+import {Flag} from '../developer-platform-client.js'
 import {OrganizationExpFlagsQuery} from '../../api/graphql/business-platform-organizations/generated/organization_exp_flags.js'
 import {
   testUIExtension,
@@ -1229,6 +1230,80 @@ describe('deploy', () => {
     expect(result.appDeploy.userErrors).toHaveLength(1)
     expect(result.appDeploy.userErrors[0]?.message).toBe('Invalid version')
     expect(result.appDeploy.userErrors[0]?.details).toHaveLength(0)
+  })
+
+  describe('appFromIdentifiers', () => {
+    function mockedActiveAppReleaseResponse() {
+      return {
+        app: {
+          id: 'gid://shopify/App/123',
+          key: 'api-key',
+          organizationId: 'gid://shopify/Organization/123',
+          activeRoot: {
+            grantedShopifyApprovalScopes: [],
+            clientCredentials: {secrets: [{key: 'secret'}]},
+          },
+          activeRelease: {
+            id: 'gid://shopify/Release/1',
+            version: {
+              name: 'app-name',
+              appModules: [],
+            },
+          },
+        },
+      }
+    }
+
+    test('includes the single-subscription events flag when the organization exp flag is enabled', async () => {
+      // Given
+      const client = AppManagementClient.getInstance()
+      client.token = () => Promise.resolve('token')
+      client.businessPlatformToken = () => Promise.resolve('business-platform-token')
+      vi.mocked(appManagementRequestDoc).mockResolvedValueOnce(mockedActiveAppReleaseResponse())
+      const mockedExpFlagsResponse: OrganizationExpFlagsQuery = {
+        organization: {id: 'gid://organization/Organization/123', enabledFlags: [true]},
+      }
+      vi.mocked(businessPlatformOrganizationsRequestDoc).mockResolvedValueOnce(mockedExpFlagsResponse)
+
+      // When
+      const app = await client.appFromIdentifiers('api-key')
+
+      // Then
+      expect(app?.flags).toEqual([Flag.SingleSubscriptionEventsModules])
+    })
+
+    test('returns no flags when the organization exp flag is disabled', async () => {
+      // Given
+      const client = AppManagementClient.getInstance()
+      client.token = () => Promise.resolve('token')
+      client.businessPlatformToken = () => Promise.resolve('business-platform-token')
+      vi.mocked(appManagementRequestDoc).mockResolvedValueOnce(mockedActiveAppReleaseResponse())
+      const mockedExpFlagsResponse: OrganizationExpFlagsQuery = {
+        organization: {id: 'gid://organization/Organization/123', enabledFlags: [false]},
+      }
+      vi.mocked(businessPlatformOrganizationsRequestDoc).mockResolvedValueOnce(mockedExpFlagsResponse)
+
+      // When
+      const app = await client.appFromIdentifiers('api-key')
+
+      // Then
+      expect(app?.flags).toEqual([])
+    })
+
+    test('returns no flags when the exp flag lookup fails', async () => {
+      // Given
+      const client = AppManagementClient.getInstance()
+      client.token = () => Promise.resolve('token')
+      client.businessPlatformToken = () => Promise.resolve('business-platform-token')
+      vi.mocked(appManagementRequestDoc).mockResolvedValueOnce(mockedActiveAppReleaseResponse())
+      vi.mocked(businessPlatformOrganizationsRequestDoc).mockRejectedValueOnce(new Error('boom'))
+
+      // When
+      const app = await client.appFromIdentifiers('api-key')
+
+      // Then
+      expect(app?.flags).toEqual([])
+    })
   })
 
   test('queries for versions list', async () => {

--- a/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
+++ b/packages/app/src/cli/utilities/developer-platform-client/app-management-client.ts
@@ -20,6 +20,7 @@ import {
   AssetUrlSchema,
   AppVersionIdentifiers,
   filterDisabledFlags,
+  Flag,
   ClientName,
   AppModuleVersion,
   CreateAppOptions,
@@ -158,6 +159,7 @@ import {webhooksRequestDoc, WebhooksRequestOptions} from '@shopify/cli-kit/node/
 import {randomUUID} from 'crypto'
 
 const TEMPLATE_JSON_URL = 'https://cdn.shopify.com/static/cli/extensions/templates.json'
+const SINGLE_SUBSCRIPTION_EVENTS_MODULES_EXP_FLAG = 'f_single_subscription_events_modules_cli'
 const commandRunId = randomUUID()
 
 type OrgType = NonNullable<ListAppDevStoresQuery['organization']>
@@ -341,16 +343,17 @@ export class AppManagementClient implements DeveloperPlatformClient {
     const {name, appModules} = app.activeRelease.version
     const appHomeModule = appModules.find((mod) => mod.specification.externalIdentifier === 'app_home')
     const apiSecretKeys = app.activeRoot.clientCredentials.secrets.map((secret) => ({secret: secret.key}))
+    const organizationId = String(numberFromGid(app.organizationId))
     return {
       id: app.id,
       title: name,
       apiKey: app.key,
       apiSecretKeys,
-      organizationId: String(numberFromGid(app.organizationId)),
+      organizationId,
       grantedScopes: app.activeRoot.grantedShopifyApprovalScopes,
       applicationUrl: appHomeModule?.config?.app_url as string | undefined,
       embedded: appHomeModule?.config?.embedded as boolean | undefined,
-      flags: [],
+      flags: await this.remoteFlagsForOrganization(organizationId),
       developerPlatformClient: this,
     }
   }
@@ -1049,6 +1052,18 @@ export class AppManagementClient implements DeveloperPlatformClient {
 
   private async activeAppVersionRawResult(apiKey: string): Promise<ActiveAppReleaseQuery> {
     return this.appManagementRequest({query: ActiveAppReleaseFromApiKey, variables: {apiKey}})
+  }
+
+  private async remoteFlagsForOrganization(organizationId: string): Promise<Flag[]> {
+    try {
+      const enabledFlags = await this.organizationExpFlags(organizationId, [
+        SINGLE_SUBSCRIPTION_EVENTS_MODULES_EXP_FLAG,
+      ])
+      return enabledFlags[SINGLE_SUBSCRIPTION_EVENTS_MODULES_EXP_FLAG] ? [Flag.SingleSubscriptionEventsModules] : []
+      // eslint-disable-next-line no-catch-all/no-catch-all
+    } catch {
+      return []
+    }
   }
 
   private async organizationBetaFlags(


### PR DESCRIPTION
### WHY are these changes introduced?

Stacked on #8425.

Shopify Core is migrating `events` app modules from one list-shaped module (`subscription: [...]`, uid `"events"`) to one single-subscription module per subscription (`subscription: {...}`, uid = subscription handle). The Core contract, uid derivation, and validation already support both shapes; this PR makes the CLI deploy the new shape.

### WHAT is this pull request doing?

- **Loader fan-out** (`loader.ts`): when enabled, each `[[events.subscription]]` entry in the TOML becomes its own `events` module instance with `{events: {api_version, subscription: <object>}}` — the single shape Core recognizes. The fan-out runs inside `createConfigExtensionInstances` so the `events` key is still claimed (no "Unsupported section(s)" false positive). The tuple shape changed from `[instance, keys]` to `[instances[], keys]`.
- **Identity** (`extension-instance.ts`): for a single-shape events config, `buildHandle`/`buildUIDFromStrategy` return the subscription handle — shape-driven and strategy-agnostic, mirroring Core's uid derivation (uid = subscription handle). Duplicate subscription handles are rejected by the loader's existing global duplicate-handle check.
- **Gating**: fan-out is enabled by either
  - the org-scoped exp flag `f_single_subscription_events_modules_cli`, fetched in `appFromIdentifiers` via the existing `organizationExpFlags` Business Platform query and surfaced through the previously-empty `Flag` enum / `remoteFlags` pipe (`Flag.SingleSubscriptionEventsModules`), best-effort with a catch-all so a failed lookup never breaks a command; or
  - the `SHOPIFY_CLI_EVENTS_SUBSCRIPTION_FANOUT` env var as a local opt-in/escape hatch.

Core's per-app Verdict flag remains the authoritative server-side gate: a fanned-out deploy for an app that isn't allowed the single shape fails loudly at Core validation.

### How to test your changes?

- `pnpm vitest run src/cli/models/app/loader.test.ts src/cli/utilities/developer-platform-client/app-management-client.test.ts src/cli/models/extensions/extension-instance.test.ts` (new tests: fan-out shapes/handles/uids via env var, fan-out via remote flag, disabled path unchanged, duplicate-handle rejection, exp-flag enabled/disabled/failure in `appFromIdentifiers`).
- Manually: set `SHOPIFY_CLI_EVENTS_SUBSCRIPTION_FANOUT=1`, add two `[[events.subscription]]` entries with handles, run `app deploy` against an app allowlisted in Core — the version should contain two `events` modules whose uids are the subscription handles.

### Post-release steps

- Create the org-scoped exp flag `f_single_subscription_events_modules_cli` before ramping (until then the env var is the only way to enable fan-out).

### Measuring impact

- [x] n/a: measured server-side via Core's `next_gen_events.list_shape_module_validated` metric decline

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible documentation changes
