### PR TITLE
[Refactor] Use early returns in dev-server-2024 host function

### DIFF
--- a/packages/cli-kit/src/public/node/vendor/dev_server/dev-server-2024.ts
+++ b/packages/cli-kit/src/public/node/vendor/dev_server/dev-server-2024.ts
@@ -25,15 +25,19 @@ function host(projectName: string, options: HostOptions = {}): string {
 
   const prefix = (options.nonstandardHostPrefix || projectName).replace(/_/g, '-')
 
-  if (projectName === 'shopify') {
-    if (prefix.endsWith('-dev-api')) {
-      const shopName = prefix.replace('-dev-api', '')
-      return `${shopName}.dev-api.shop.dev`
-    }
-    if (!NON_SHOP_PREFIXES.includes(prefix)) {
-      return `${prefix}.my.shop.dev`
-    }
+  if (projectName !== 'shopify') {
+    return `${prefix}.shop.dev`
   }
+
+  if (prefix.endsWith('-dev-api')) {
+    const shopName = prefix.replace('-dev-api', '')
+    return `${shopName}.dev-api.shop.dev`
+  }
+
+  if (!NON_SHOP_PREFIXES.includes(prefix)) {
+    return `${prefix}.my.shop.dev`
+  }
+
   return `${prefix}.shop.dev`
 }
 


### PR DESCRIPTION
### WHY are these changes introduced?

The `host` function in `packages/cli-kit/src/public/node/vendor/dev_server/dev-server-2024.ts` used nested `if` statements to handle different project types and prefix formats.

### WHAT is this pull request doing?

Replaces nested `if` statements in `host` with flat early return guard clauses, simplifying control flow and improving readability without altering observable behavior.

### How to test your changes?

CI

### Post-release steps

N/A

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [7799615596825533171](https://jules.google.com/task/7799615596825533171) started by @gonzaloriestra*