### PR TITLE
[Performance] Optimize rejectGeneratedStaticAssets

### DIFF
--- a/packages/theme/src/cli/utilities/asset-checksum.ts
+++ b/packages/theme/src/cli/utilities/asset-checksum.ts
@@ -85,9 +85,12 @@ function md5(content: string | Buffer) {
  * as these are not needed for theme comparison.
  */
 export function rejectGeneratedStaticAssets(themeChecksums: Checksum[]) {
-  const liquidAssetKeys = new Set(
-    themeChecksums.filter(({key}) => key.startsWith('assets/') && key.endsWith('.liquid')).map(({key}) => key),
-  )
+  const liquidAssetKeys = new Set<string>()
+  for (const {key} of themeChecksums) {
+    if (key.startsWith('assets/') && key.endsWith('.liquid')) {
+      liquidAssetKeys.add(key)
+    }
+  }
 
   return themeChecksums.filter(({key}) => {
     const isStaticAsset = key.startsWith('assets/')


### PR DESCRIPTION
Optimized rejectGeneratedStaticAssets in packages/theme/src/cli/utilities/asset-checksum.ts by replacing chained .filter().map() with a single for...of loop when building liquidAssetKeys, eliminating intermediate array allocations and extra iterations.

---
*PR created automatically by Jules for task [1343280872611196807](https://jules.google.com/task/1343280872611196807) started by @gonzaloriestra*