### PR TITLE
[Security] Validate git commit author argument

### DIFF
--- a/packages/cli-kit/src/public/node/git.test.ts
+++ b/packages/cli-kit/src/public/node/git.test.ts
@@ -277,6 +277,15 @@ describe('commit()', () => {
 
     expect(mockedExeca).toHaveBeenCalledWith('git', ['commit', '-m', 'msg', '--author', author], {cwd: directory})
   })
+
+  test('throws an error if author starts with a hyphen', async () => {
+    const author = '-invalid-author'
+
+    await expect(git.createGitCommit('msg', {author})).rejects.toThrowError(
+      /Invalid commit author: -invalid-author. Author name\/email can't start with a hyphen./,
+    )
+    expect(mockedExeca).not.toHaveBeenCalled()
+  })
 })
 
 describe('getHeadSymbolicRef()', () => {

--- a/packages/cli-kit/src/public/node/git.ts
+++ b/packages/cli-kit/src/public/node/git.ts
@@ -299,6 +299,10 @@ export interface CreateGitCommitOptions {
 export async function createGitCommit(message: string, options?: CreateGitCommitOptions): Promise<string> {
   const args = ['commit', '-m', message]
   if (options?.author) {
+    // Guard against option injection attacks if author starts with '-'
+    if (options.author.startsWith('-')) {
+      throw new AbortError(`Invalid commit author: ${options.author}. Author name/email can't start with a hyphen.`)
+    }
     args.push('--author', options.author)
   }
   await gitCommand(args, options?.directory)


### PR DESCRIPTION
### WHY are these changes introduced?

Hardens git command execution against option injection vulnerabilities.

### WHAT is this pull request doing?

Validates `options.author` in `createGitCommit` to ensure it does not start with a hyphen (`-`), throwing an `AbortError` if an invalid value is passed.

### How to test your changes?

CI

### Post-release steps

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [7844826945563519319](https://jules.google.com/task/7844826945563519319) started by @gonzaloriestra*