### PR TITLE
[Refactor] Use Set for tracking present keys in patchEnvFile

### DIFF
--- a/packages/cli-kit/src/public/node/dot-env.ts
+++ b/packages/cli-kit/src/public/node/dot-env.ts
@@ -56,7 +56,7 @@ export function patchEnvFile(envFileContent: string | null, updatedValues: Recor
   const outputLines: string[] = []
   const envFileLines = envFileContent === null ? [] : envFileContent.split('\n')
 
-  const alreadyPresentKeys: string[] = []
+  const alreadyPresentKeys = new Set<string>()
 
   let multilineVariable:
     | {
@@ -76,7 +76,7 @@ export function patchEnvFile(envFileContent: string | null, updatedValues: Recor
         )
         const newValue = updatedValues[multilineVariable.key]
         if (newValue) {
-          alreadyPresentKeys.push(multilineVariable.key)
+          alreadyPresentKeys.add(multilineVariable.key)
           lineToWrite = createDotEnvFileLine(multilineVariable.key, newValue)
         }
         outputLines.push(lineToWrite)
@@ -105,7 +105,7 @@ export function patchEnvFile(envFileContent: string | null, updatedValues: Recor
 
       const newValue = updatedValues[key]
       if (newValue) {
-        alreadyPresentKeys.push(key)
+        alreadyPresentKeys.add(key)
         lineToWrite = createDotEnvFileLine(key, newValue)
       }
     }
@@ -118,7 +118,7 @@ export function patchEnvFile(envFileContent: string | null, updatedValues: Recor
   }
 
   for (const [patchKey, updatedValue] of Object.entries(updatedValues)) {
-    if (!alreadyPresentKeys.includes(patchKey)) {
+    if (!alreadyPresentKeys.has(patchKey)) {
       outputLines.push(createDotEnvFileLine(patchKey, updatedValue))
     }
   }


### PR DESCRIPTION
Refactored `patchEnvFile` in `packages/cli-kit/src/public/node/dot-env.ts` to replace `alreadyPresentKeys: string[]` with `Set<string>`. This optimizes lookup performance from O(N) to O(1) and improves code clarity while preserving exact observable behavior.

---
*PR created automatically by Jules for task [12155047810128763718](https://jules.google.com/task/12155047810128763718) started by @gonzaloriestra*