### PR TITLE
Prevent GitHub credentials from being logged locally

### DIFF
--- a/bin/get-graphql-schemas.js
+++ b/bin/get-graphql-schemas.js
@@ -121,7 +121,7 @@ async function fetchFileForSchema(schema, octokit) {
           path: schema.pathToFile,
           ref: branch,
         })
-        console.log(`LFS download via ${download_url}...`)
+        console.log('Downloading LFS schema content...')
         content = await fetch(download_url).then(res => {
           if (!res.ok) {
             const error = new Error(`HTTP ${res.status}: ${res.statusText}`)

--- a/bin/github-utils.js
+++ b/bin/github-utils.js
@@ -4,16 +4,49 @@ import {runCommand} from './run-command.js'
 import {createPullRequest} from 'octokit-plugin-create-pull-request'
 
 /**
+ * @param {typeof runCommand} executeCommand
  * @returns {Promise<string>}
  */
-async function getGithubPasswordFromDev() {
+async function getGithubTokenFromDev(executeCommand) {
   try {
     // Uses token from `dev`
-    return (await runCommand('/opt/dev/bin/dev', ['github', 'print-auth', '--password'])).trim()
-  } catch (error) {
-    console.warn(`Soft-error fetching password from dev: ${error.message}. Try running \`dev github print-auth\` manually.`)
-    process.exit(0)
+    const token = (
+      await executeCommand('/opt/dev/bin/dev', ['github', 'print-auth', '--password'], {printOutput: false})
+    ).trim()
+    if (!token) throw new Error('The GitHub token returned by dev is empty.')
+    return token
+  } catch {
+    throw new Error('Failed to fetch a GitHub token from dev. Try running `dev github auth`.')
   }
+}
+
+/**
+ * @param {string} owner
+ * @param {{environment?: NodeJS.ProcessEnv, executeCommand?: typeof runCommand, log?: (message: string) => void}} [options]
+ * @returns {Promise<string>}
+ */
+export async function getGithubToken(
+  owner,
+  {environment = process.env, executeCommand = runCommand, log = console.log} = {},
+) {
+  const tokenEnvSources = [
+    `GITHUB_TOKEN_${owner.toUpperCase()}`,
+    `GH_TOKEN_${owner.toUpperCase()}`,
+    'GITHUB_TOKEN',
+    'GH_TOKEN',
+  ]
+
+  for (const source of tokenEnvSources) {
+    const token = environment[source]
+    if (token) {
+      log(`Using GitHub token from ${source}`)
+      return token
+    }
+  }
+
+  const token = await getGithubTokenFromDev(executeCommand)
+  log('Using GitHub token from dev')
+  return token
 }
 
 /**
@@ -22,27 +55,7 @@ async function getGithubPasswordFromDev() {
  * @returns {Promise<boolean>}
  */
 export async function withOctokit(owner, func) {
-  let password = undefined
-
-  const tokenEnvSources = [
-    `GITHUB_TOKEN_${owner.toUpperCase()}`,
-    `GH_TOKEN_${owner.toUpperCase()}`,
-    'GITHUB_TOKEN',
-    'GH_TOKEN',
-  ]
-  let tokenFromEnv = undefined
-  for (const source of tokenEnvSources) {
-    if (process.env[source]) {
-      tokenFromEnv = process.env[source]
-      console.log(`Using token from ${source}: ${tokenFromEnv}`)
-      break
-    }
-  }
-  if (!tokenFromEnv) {
-    password = await getGithubPasswordFromDev()
-    console.log(`Using password from dev: ${password}`)
-  }
-  const authToken = password || tokenFromEnv
+  const authToken = await getGithubToken(owner)
 
   const OctokitWithPlugin = Octokit.plugin(createPullRequest)
   const octokit = new OctokitWithPlugin({

--- a/bin/github-utils.test.js
+++ b/bin/github-utils.test.js
@@ -1,0 +1,50 @@
+import assert from 'node:assert/strict'
+import {test} from 'node:test'
+
+import {getGithubToken} from './github-utils.js'
+
+test('does not print a GitHub token sourced from the environment', async () => {
+  const token = 'environment-secret'
+  const logs = []
+
+  const result = await getGithubToken('shop', {
+    environment: {GITHUB_TOKEN_SHOP: token},
+    log: (message) => logs.push(message),
+  })
+
+  assert.equal(result, token)
+  assert.deepEqual(logs, ['Using GitHub token from GITHUB_TOKEN_SHOP'])
+  assert.equal(logs.join(' ').includes(token), false)
+})
+
+test('captures a GitHub token from dev without printing it', async () => {
+  const token = 'dev-secret'
+  const logs = []
+  const receivedCommands = []
+
+  const result = await getGithubToken('shop', {
+    environment: {},
+    executeCommand: (...command) => {
+      receivedCommands.push(command)
+      return Promise.resolve(`${token}\n`)
+    },
+    log: (message) => logs.push(message),
+  })
+
+  assert.equal(result, token)
+  assert.deepEqual(receivedCommands, [
+    ['/opt/dev/bin/dev', ['github', 'print-auth', '--password'], {printOutput: false}],
+  ])
+  assert.deepEqual(logs, ['Using GitHub token from dev'])
+  assert.equal(logs.join(' ').includes(token), false)
+})
+
+test('fails when dev cannot provide a GitHub token', async () => {
+  await assert.rejects(
+    getGithubToken('shop', {
+      environment: {},
+      executeCommand: () => Promise.reject(new Error('Authentication failed')),
+    }),
+    new Error('Failed to fetch a GitHub token from dev. Try running `dev github auth`.'),
+  )
+})

--- a/bin/run-command.js
+++ b/bin/run-command.js
@@ -3,9 +3,10 @@ import {spawn} from 'child_process'
 /**
  * @param {string} command
  * @param {string[]} args
+ * @param {{printOutput?: boolean}} [options]
  * @returns {Promise<string>}
  */
-export function runCommand(command, args) {
+export function runCommand(command, args, {printOutput = true} = {}) {
   return new Promise((resolve, reject) => {
     const child = spawn(command, args, {stdio: ['inherit', 'pipe', 'pipe']})
 
@@ -13,12 +14,12 @@ export function runCommand(command, args) {
     let errorOutput = ''
 
     child.stdout.on('data', (data) => {
-      console.log(data.toString())
+      if (printOutput) console.log(data.toString())
       output += data.toString()
     })
 
     child.stderr.on('data', (data) => {
-      console.log(data.toString())
+      if (printOutput) console.log(data.toString())
       errorOutput += data.toString()
     })
 

--- a/bin/run-command.test.js
+++ b/bin/run-command.test.js
@@ -1,0 +1,16 @@
+import assert from 'node:assert/strict'
+import {test} from 'node:test'
+
+import {runCommand} from './run-command.js'
+
+test('captures command output without printing it when requested', async (context) => {
+  const sensitiveOutput = 'sensitive command output'
+  const consoleLog = context.mock.method(console, 'log', () => {})
+
+  const output = await runCommand(process.execPath, ['-e', `process.stdout.write('${sensitiveOutput}')`], {
+    printOutput: false,
+  })
+
+  assert.equal(output, sensitiveOutput)
+  assert.equal(consoleLog.mock.callCount(), 0)
+})


### PR DESCRIPTION
### WHY are these changes introduced?

GitHub helper scripts printed authentication tokens and signed download URLs to command output. This could expose credentials in local terminal history or agent transcripts. CI should be safe because it uses secrets instead of `dev` commands.

### WHAT is this pull request doing?

- Captures `dev github print-auth` output without echoing it.
- Logs credential sources without logging credential values.
- Stops printing signed LFS download URLs.
- Fails clearly when `dev` cannot provide a token.
- Adds regression tests for environment and `dev` token paths.

### How to test your changes?

`pnpm graphql-codegen:get-graphql-schemas` and check that it doesn't include any token

### Checklist

- [x] I have considered possible cross-platform impacts.
- [x] I have considered possible documentation changes; none are required.
- [x] I have considered analytics changes; none are required.
- [x] This changes internal tooling only; no changeset is required.