### PR TITLE
Replace any-casts in command-registry with a typed command lookup

### DIFF
--- a/configurations/vite.config.ts
+++ b/configurations/vite.config.ts
@@ -84,6 +84,7 @@ export const aliases = (packagePath: string) => {
     },
     {find: '@shopify/theme', replacement: path.join(packagePath, '../theme/src/index')},
     {find: '@shopify/organizations', replacement: path.join(packagePath, '../organizations/src/index')},
+    {find: '@shopify/plugin-did-you-mean', replacement: path.join(packagePath, '../plugin-did-you-mean/src/index')},
     {find: '@shopify/store', replacement: path.join(packagePath, '../store/src/index')},
   ]
 }

--- a/packages/cli/src/command-registry.test.ts
+++ b/packages/cli/src/command-registry.test.ts
@@ -1,0 +1,22 @@
+import {loadCommand} from './command-registry.js'
+import {describe, expect, test} from 'vitest'
+
+describe('loadCommand', () => {
+  test('returns undefined for a command id that is not in the manifest', async () => {
+    await expect(loadCommand('definitely:not:a:command')).resolves.toBeUndefined()
+  })
+
+  test('loads an external oclif plugin command from its package command table', async () => {
+    // `commands` is owned by @oclif/plugin-commands, which is loaded through
+    // the full-package fallback rather than per-file loading.
+    const command = await loadCommand('commands')
+
+    expect(command).toBeTypeOf('function')
+  })
+
+  test('loads the plugins command from @oclif/plugin-plugins', async () => {
+    const command = await loadCommand('plugins')
+
+    expect(command).toBeTypeOf('function')
+  })
+})

--- a/packages/cli/src/command-registry.ts
+++ b/packages/cli/src/command-registry.ts
@@ -14,6 +14,19 @@
 import {dirname, joinPath, moduleDirectory} from '@shopify/cli-kit/node/path'
 import {existsSync, readFileSync} from 'fs'
 import {fileURLToPath, pathToFileURL} from 'url'
+import type {Command} from '@oclif/core'
+
+type CommandClass = typeof Command
+
+/**
+ * Look up a command class in the command table exported by an external plugin
+ * package. Each package compiles against its own `@oclif/core`, so its command
+ * classes are not statically assignable to this workspace's `typeof Command`;
+ * this helper is the single place where that boundary is bridged.
+ */
+function commandFromTable(table: unknown, id: string): CommandClass | undefined {
+  return (table as Record<string, CommandClass | undefined>)[id]
+}
 
 interface ManifestCommand {
   customPluginName?: string
@@ -81,8 +94,7 @@ const packagesWithPerFileLoading = new Set(['@shopify/cli', '@shopify/app', '@sh
  * derives the file path from the command ID, and imports only that file.
  * Falls back to importing the full package for external plugins.
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export async function loadCommand(id: string): Promise<any | undefined> {
+export async function loadCommand(id: string): Promise<CommandClass | undefined> {
   const commands = getManifestCommands()
   const entry = commands[id]
   if (!entry) return undefined
@@ -112,39 +124,33 @@ function resolveCommandRoot(id: string, packageName: string): string {
   return resolvePackageDir(packageName)
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-async function loadCommandPerFile(id: string, packageName: string): Promise<any | undefined> {
+async function loadCommandPerFile(id: string, packageName: string): Promise<CommandClass | undefined> {
   const entryPoint = entryPointForCommand(id)
   const root = resolveCommandRoot(id, packageName)
   const modulePath = pathToFileURL(joinPath(root, entryPoint)).href
-  const module = await import(modulePath)
+  const module: {default?: CommandClass} = await import(modulePath)
   return module.default
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-async function loadCommandFromPackage(id: string, packageName: string): Promise<any | undefined> {
+async function loadCommandFromPackage(id: string, packageName: string): Promise<CommandClass | undefined> {
   if (packageName === '@shopify/cli-hydrogen') {
     const {COMMANDS} = await import('@shopify/cli-hydrogen')
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return (COMMANDS as any)?.[id]
+    return commandFromTable(COMMANDS, id)
   }
 
   if (packageName === '@oclif/plugin-commands') {
     const {commands} = await import('@oclif/plugin-commands')
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return (commands as any)[id]
+    return commandFromTable(commands, id)
   }
 
   if (packageName === '@oclif/plugin-plugins') {
     const {commands} = await import('@oclif/plugin-plugins')
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return (commands as any)[id]
+    return commandFromTable(commands, id)
   }
 
   if (packageName === '@shopify/plugin-did-you-mean') {
     const {DidYouMeanCommands} = await import('@shopify/plugin-did-you-mean')
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return (DidYouMeanCommands as any)[id]
+    return commandFromTable(DidYouMeanCommands, id)
   }
 
   return undefined


### PR DESCRIPTION
### WHY are these changes introduced?

`packages/cli/src/command-registry.ts` carried 7 `eslint-disable @typescript-eslint/no-explicit-any` suppressions: the lazy command loader returned `Promise<any | undefined>` and each external plugin branch indexed its command table through `as any`. The module also had no unit tests. Surfaced by the daily maintenance radar (suppression cleanup).

### WHAT is this pull request doing?

- Types the loader against `@oclif/core`'s `Command` class (`CommandClass = typeof Command`), matching the `LazyCommandLoader` contract in cli-kit (`(id: string) => Promise<typeof Command | undefined>`).
- Bridges the external plugin package tables (`@shopify/cli-hydrogen`, `@oclif/plugin-commands`, `@oclif/plugin-plugins`, `@shopify/plugin-did-you-mean`) through a single `commandFromTable` helper — one documented cast at the package boundary instead of four inline `as any`, since each package compiles against its own `@oclif/core`.
- Adds `command-registry.test.ts` covering manifest misses and the full-package fallback path (real imports, no mocks).
- Adds a `@shopify/plugin-did-you-mean` → `src` alias to the shared vitest config so the module under test resolves in vitest, same pattern as the existing `@shopify/theme`/`@shopify/organizations` aliases.

No runtime behavior change: the lookups and fallbacks are identical, only the types changed.

### How to test your changes?

- `pnpm vitest run packages/cli/src/command-registry.test.ts` (3 tests)
- `pnpm --filter @shopify/cli type-check && pnpm --filter @shopify/cli lint`
- Sanity: `pnpm shopify commands` and `pnpm shopify plugins` still resolve through the full-package fallback; any `app`/`theme` command still loads per-file.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

_No changeset: internal refactor + tests, no user-visible change._
