### PR TITLE
Redact store signup JWTs from analytics payloads

### DIFF
--- a/packages/cli-kit/src/public/node/analytics.test.ts
+++ b/packages/cli-kit/src/public/node/analytics.test.ts
@@ -429,6 +429,153 @@ describe('event tracking', () => {
     })
   })
 
+  test('does not send signup JWTs passed as command arguments to Monorail', async () => {
+    await inProjectWithFile('package.json', async (args) => {
+      // Given
+      const signupJwt = 'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJzdG9yZSJ9.s1gn4tur3'
+      const commandContent = {command: 'stripe-auth', topic: 'store'}
+      const argsWithSignup = args.concat(['--signup', signupJwt, '--scopes', `--signup=${signupJwt}`])
+      await startAnalytics({commandContent, args: argsWithSignup, currentTime: currentDate.getTime() - 100})
+
+      // When
+      const config = {
+        runHook: vi.fn().mockResolvedValue({successes: [], failures: []}),
+        plugins: [],
+      } as any
+      await reportAnalyticsEvent({config, exitMode: 'ok'})
+      await sendReportedAnalyticsPayload()
+
+      // Then
+      expect(publishEventMock).toHaveBeenCalledOnce()
+      const sensitivePayload = publishEventMock.mock.calls[0]![2]
+      expect(sensitivePayload.args).toContain('--signup *****')
+      expect(sensitivePayload.args).toContain('--signup=*****')
+      expect(JSON.stringify(sensitivePayload)).not.toContain('s1gn4tur3')
+    })
+  })
+
+  test('does not send signup JWTs that were quoted on the command line to Monorail', async () => {
+    await inProjectWithFile('package.json', async (args) => {
+      // Given
+      const signupJwt = 'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJzdG9yZSJ9.s1gn4tur3'
+      const commandContent = {command: 'stripe-auth', topic: 'store'}
+      const argsWithSignup = args.concat(['--signup', `"${signupJwt}"`])
+      await startAnalytics({commandContent, args: argsWithSignup, currentTime: currentDate.getTime() - 100})
+
+      // When
+      const config = {
+        runHook: vi.fn().mockResolvedValue({successes: [], failures: []}),
+        plugins: [],
+      } as any
+      await reportAnalyticsEvent({config, exitMode: 'ok'})
+      await sendReportedAnalyticsPayload()
+
+      // Then
+      expect(publishEventMock).toHaveBeenCalledOnce()
+      const sensitivePayload = publishEventMock.mock.calls[0]![2]
+      expect(sensitivePayload.args).toContain('--signup *****')
+      expect(JSON.stringify(sensitivePayload)).not.toContain('s1gn4tur3')
+    })
+  })
+
+  test('does not send signup environment flags to Monorail', async () => {
+    await inProjectWithFile('package.json', async (args) => {
+      const commandContent = {command: 'stripe-auth', topic: 'store'}
+      await startAnalytics({commandContent, args, currentTime: currentDate.getTime() - 100})
+      await addSensitiveMetadata(() => ({
+        environmentFlags: JSON.stringify({signup: 'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJzdG9yZSJ9.s1gn4tur3'}),
+      }))
+
+      const config = {
+        runHook: vi.fn().mockResolvedValue({successes: [], failures: []}),
+        plugins: [],
+      } as any
+      await reportAnalyticsEvent({config, exitMode: 'ok'})
+      await sendReportedAnalyticsPayload()
+
+      expect(publishEventMock).toHaveBeenCalledOnce()
+      expect(publishEventMock.mock.calls[0]![2]).toMatchObject({
+        cmd_all_environment_flags: JSON.stringify({signup: '*****'}),
+      })
+    })
+  })
+
+  test('does not send signup credentials carried in an authorization URL to Monorail', async () => {
+    await inProjectWithFile('package.json', async (args) => {
+      // Given
+      const commandContent = {command: 'stripe-auth', topic: 'store'}
+      await startAnalytics({commandContent, args, currentTime: currentDate.getTime() - 100})
+
+      // When
+      const config = {
+        runHook: vi.fn().mockResolvedValue({successes: [], failures: []}),
+        plugins: [],
+      } as any
+      await reportAnalyticsEvent({
+        config,
+        errorMessage:
+          'Could not open https://shop.myshopify.com/admin/oauth/authorize?client_id=abc&signup=eyJhbGciOiJIUzI1NiJ9.s1gn4tur3&state=xyz',
+        exitMode: 'unexpected_error',
+      })
+      await sendReportedAnalyticsPayload()
+
+      // Then
+      expect(publishEventMock).toHaveBeenCalledOnce()
+      const sensitivePayload = publishEventMock.mock.calls[0]![2]
+      expect(sensitivePayload.error_message).toContain('signup=*****&state=xyz')
+      expect(JSON.stringify(sensitivePayload)).not.toContain('s1gn4tur3')
+    })
+  })
+
+  test('sends URLs whose path merely mentions signup without redacting them', async () => {
+    await inProjectWithFile('package.json', async (args) => {
+      // Given
+      const commandContent = {command: 'dev', topic: 'app'}
+      await startAnalytics({commandContent, args, currentTime: currentDate.getTime() - 100})
+
+      // When
+      const config = {
+        runHook: vi.fn().mockResolvedValue({successes: [], failures: []}),
+        plugins: [],
+      } as any
+      await reportAnalyticsEvent({
+        config,
+        errorMessage: 'Create an account at https://partners.shopify.com/signup and retry with from_signup=true',
+        exitMode: 'unexpected_error',
+      })
+      await sendReportedAnalyticsPayload()
+
+      // Then
+      expect(publishEventMock).toHaveBeenCalledOnce()
+      expect(publishEventMock.mock.calls[0]![2].error_message).toBe(
+        'Create an account at https://partners.shopify.com/signup and retry with from_signup=true',
+      )
+    })
+  })
+
+  test('sends analytics when a redacted flag value was quoted on the command line', async () => {
+    await inProjectWithFile('package.json', async (args) => {
+      // Given
+      const commandContent = {command: 'dev', topic: 'app'}
+      const argsWithPassword = args.concat(['--store-password', '"store secret"'])
+      await startAnalytics({commandContent, args: argsWithPassword, currentTime: currentDate.getTime() - 100})
+
+      // When
+      const config = {
+        runHook: vi.fn().mockResolvedValue({successes: [], failures: []}),
+        plugins: [],
+      } as any
+      await reportAnalyticsEvent({config, exitMode: 'ok'})
+      await sendReportedAnalyticsPayload()
+
+      // Then
+      expect(publishEventMock).toHaveBeenCalledOnce()
+      const sensitivePayload = publishEventMock.mock.calls[0]![2]
+      expect(sensitivePayload.args).toContain('--store-password *****')
+      expect(JSON.stringify(sensitivePayload)).not.toContain('store secret')
+    })
+  })
+
   test('sends only allowlisted Shopify environment variables in sensitive payload', async () => {
     const originalShopifyInvokedBy = process.env.SHOPIFY_INVOKED_BY
     const originalShopifyCliAgent = process.env.SHOPIFY_CLI_AGENT

--- a/packages/cli-kit/src/public/node/analytics.ts
+++ b/packages/cli-kit/src/public/node/analytics.ts
@@ -267,11 +267,17 @@ async function buildPayload({
 
 function sanitizePayload<T>(payload: T): T {
   const payloadString = JSON.stringify(payload)
-  // Remove Theme Access passwords from the payload
+  // Redaction runs on the serialized payload, so a flag value that was quoted arrives with its quotes
+  // escaped. Every flag rule below matches that escaped form first, and its bare-value alternative
+  // treats a JSON escape as part of the value, so a value can never be redacted only halfway or leave
+  // behind a string that no longer parses.
   const sanitizedPayloadString = payloadString
     .replace(/shptka_\w*/g, '*****')
-    .replace(/(--store-password(?:=|\s+))(?:"[^"]*"|'[^']*'|[^\s"]+)/g, '$1*****')
+    .replace(/(--store-password(?:=|\s+))(?:\\"[^"\\]*\\"|'[^']*'|(?:\\.|[^\s"\\])+)/g, '$1*****')
     .replace(/((?:store-password|SHOPIFY_FLAG_STORE_PASSWORD)\\?":\\?")[^"\\]*/g, '$1*****')
+    .replace(/(--signup(?:=|\s+))(?:\\"[^"\\]*\\"|'[^']*'|(?:\\.|[^\s"\\])+)/g, '$1*****')
+    .replace(/((?:signup|SHOPIFY_FLAG_SIGNUP)\\?":\\?")[^"\\]*/g, '$1*****')
+    .replace(/(?<![\w-])(signup=)[^&\s"'\\]+/g, '$1*****')
   return JSON.parse(sanitizedPayloadString)
 }
 


### PR DESCRIPTION
### WHY are these changes introduced?

Related to the internal security finding tracked as Vault 69736 (`cli / oauth-client`).

`shopify store stripe-auth` accepts a signup JWT via `--signup`. That JWT is a bearer credential for the target store, and the [Stripe Projects setup guide](https://github.com/shop/world/blob/main/areas/apps/setup-mcp/server/public/provider/llm_context.md) that drives this command classifies it as a server secret that must never be printed.

Command arguments are reported to Monorail verbatim as `sensitive.args` (`prerun.ts` → `startAnalytics({args})` → `args: startArgs.join(' ')`), and `sanitizePayload` only knew about Theme Access passwords and `--store-password`. So the credential left the machine on **every** invocation that passes the flag — not only on the fallback path where the URL is printed.

Reproduced before the change with a fake token and analytics delivery disabled:

```
$ SHOPIFY_CLI_NO_ANALYTICS=1 node packages/cli/bin/dev.js store stripe-auth \
    --store "not a real store!!" --scopes read_products \
    --signup "eyJTOTALLYFAKE.NOTAREALJWT.SIGSEG" --verbose
...
"args": "--store not a real store!! --scopes read_products --signup eyJTOTALLYFAKE.NOTAREALJWT.SIGSEG --verbose"
```

**How this relates to the other two PRs.** This is complementary, not a rival fix — there is no file overlap.

| | Sink | Owner |
|---|---|---|
| #8427 | terminal output when the browser can't open | @dengjeffrey |
| #8428 | `openURL` argv, and the CLI's own argv for stdin callers | @dengjeffrey |
| this PR | analytics payload sent to Monorail | — |

Both of those are confined to `packages/store`; this sink is in `packages/cli-kit`, so it survives either of them landing. Any merge order works. This is a sink-side backstop and does **not** close the finding on its own — the credential still reaches the browser's authorization URL, and it still sits in the invoking shell's history and this process's own argv while `--signup` remains a documented flag.

### WHAT is this pull request doing?

Adds three rules to `sanitizePayload` covering the shapes the payload can carry the credential in, mirroring the three that already exist for `store-password`:

- a command-line flag value — `--signup <jwt>` and `--signup=<jwt>`
- a JSON key — `"signup": "<jwt>"`, as reached via `cmd_all_environment_flags`
- a URL query parameter — `signup=<jwt>` inside a URL in `error_message` or `metadata`

Two deliberate choices worth flagging for review:

**The bare-value alternative changed from `[^\s"]+` to `(?:\\.|[^\s"\\])+`.** Redaction runs on the *serialized* payload, so a value quoted on the command line arrives with its quotes escaped. The old class stops at neither, which had two bad outcomes I verified against the current rule:

| argv | current `--store-password` rule |
|---|---|
| `--store-password "secret"` | `JSON.parse` throws inside `sanitizePayload` → whole event dropped |
| `--store-password 'a"b'` | same |

Simply excluding `\\` would stop the throw but leak the value instead. Treating a JSON escape as part of the value handles both, so I applied it to the existing `store-password` rule too rather than leaving one correct rule next to a broken one. That is the only behaviour change outside `signup`, and it is covered by its own test.

**The URL rule has a `(?<![\w-])` guard.** Without it, an unrelated `from_signup=true` would be masked. With it, `https://partners.shopify.com/signup` and `from_signup=` are untouched — both asserted in tests.

Known limitation, stated so the next reader doesn't over-trust it: this redaction is coupled to the parameter name. If core renames `signup`, the rules go stale with no test failure. That is inherent to sink-side redaction and is why the source-side fix in #8428 still matters — they are complements, not substitutes.

### How to test your changes?

```sh
pnpm vitest run packages/cli-kit/src/public/node/analytics.test.ts
```

5 of the 6 new tests fail without the `analytics.ts` change; the sixth is the over-redaction guard, which passes both before and after by design.

End-to-end, with delivery disabled so nothing is transmitted:

```sh
pnpm nx build cli-kit   # bin/dev.js resolves cli-kit from dist
SHOPIFY_CLI_NO_ANALYTICS=1 node packages/cli/bin/dev.js store stripe-auth \
  --store "not a real store!!" --scopes read_products \
  --signup "eyJTOTALLYFAKE.NOTAREALJWT.SIGSEG" --verbose | grep '"args"'
```

Expect `--signup *****`, and zero occurrences of the token anywhere in the payload. Repeat with `--signup=<jwt>` to cover the other spelling.

Also run locally: `eslint` and `prettier --check` on both files clean, `nx run cli-kit:type-check` clean, `pnpm knip` clean, and the full `packages/cli-kit` suite at 1869 passed. The 2 failures in `hooks/deprecations.test.ts` reproduce on a clean `main` and are unrelated.

### Post-release steps

None.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows) — string sanitization only, no platform-dependent behaviour
- [x] I've considered possible [documentation](https://shopify.dev) changes — none; no command, flag, or output surface changes
- [x] I've considered analytics changes to measure impact — this *is* an analytics change: `sensitive.args`, `cmd_all_environment_flags`, `error_message` and `metadata` now mask `signup` values. No field is added or removed.
- [x] The change is user-facing — no changeset. Monorail payload contents are not user-observable and no command, flag, prompt, output or error behaviour changes; `AGENTS.md` scopes changesets to user-visible behaviour. Same call as 37e3ad36b0 "Prevent GitHub credentials from being logged", which shipped five files with no changeset.
