### PR TITLE
Fail fast when the store auth URL is withheld

### DIFF
--- a/packages/store/src/cli/services/store/auth/index.test.ts
+++ b/packages/store/src/cli/services/store/auth/index.test.ts
@@ -321,28 +321,63 @@ describe('store auth service', () => {
       return 'abc123'
     })
 
-    await authenticateStoreWithApp(
-      {
-        store: 'shop.myshopify.com',
-        scopes: 'read_products',
-        signup: 'signed.signup.jwt',
-      },
-      {
-        openURL,
-        waitForStoreAuthCode: waitForStoreAuthCodeMock,
-        exchangeStoreAuthCodeForToken: vi.fn().mockResolvedValue({
-          access_token: 'token',
-          scope: 'read_products',
-          expires_in: 86400,
-          associated_user: {id: 42, email: 'test@example.com'},
-        }),
-        presenter,
-      },
-    )
+    await expect(
+      authenticateStoreWithApp(
+        {
+          store: 'shop.myshopify.com',
+          scopes: 'read_products',
+          signup: 'signed.signup.jwt',
+        },
+        {
+          openURL,
+          waitForStoreAuthCode: waitForStoreAuthCodeMock,
+          exchangeStoreAuthCodeForToken: vi.fn().mockResolvedValue({
+            access_token: 'token',
+            scope: 'read_products',
+            expires_in: 86400,
+            associated_user: {id: 42, email: 'test@example.com'},
+          }),
+          presenter,
+        },
+      ),
+    ).rejects.toThrow()
 
     expect(presenter.manualAuthUrl).toHaveBeenCalledWith(expect.stringContaining('signup=signed.signup.jwt'), {
       sensitive: true,
     })
+  })
+
+  test('authenticateStoreWithApp fails immediately instead of waiting for a callback that cannot arrive', async () => {
+    const openURL = vi.fn().mockResolvedValue(false)
+    const presenter = {
+      openingBrowser: vi.fn(),
+      manualAuthUrl: vi.fn(),
+      success: vi.fn(),
+    }
+    const exchangeStoreAuthCodeForToken = vi.fn()
+    const waitForStoreAuthCodeMock = vi.fn().mockImplementation(async (options) => {
+      await options.onListening?.()
+      return 'abc123'
+    })
+
+    await expect(
+      authenticateStoreWithApp(
+        {
+          store: 'shop.myshopify.com',
+          scopes: 'read_products',
+          signup: 'signed.signup.jwt',
+        },
+        {
+          openURL,
+          waitForStoreAuthCode: waitForStoreAuthCodeMock,
+          exchangeStoreAuthCodeForToken,
+          presenter,
+        },
+      ),
+    ).rejects.toThrow("Authentication can't continue without a browser.")
+
+    expect(exchangeStoreAuthCodeForToken).not.toHaveBeenCalled()
+    expect(presenter.success).not.toHaveBeenCalled()
   })
 
   test('authenticateStoreWithApp records fqdn metadata before resolving existing scopes', async () => {

--- a/packages/store/src/cli/services/store/auth/index.ts
+++ b/packages/store/src/cli/services/store/auth/index.ts
@@ -76,7 +76,14 @@ export async function authenticateStoreWithApp(
     ...bootstrap.waitForAuthCodeOptions,
     onListening: async () => {
       const opened = await resolvedDependencies.openURL(authorizationUrl)
-      if (!opened) resolvedDependencies.presenter.manualAuthUrl(authorizationUrl, {sensitive: Boolean(input.signup)})
+      if (opened) return
+
+      const sensitive = Boolean(input.signup)
+      resolvedDependencies.presenter.manualAuthUrl(authorizationUrl, {sensitive})
+
+      // A withheld URL never reaches the browser, so the callback this server is waiting for cannot
+      // arrive. Returning here would leave the command idle until the timeout elapses.
+      if (sensitive) throw new AbortError("Authentication can't continue without a browser.")
     },
   })
   const tokenResponse = await bootstrap.exchangeCodeForToken(code)


### PR DESCRIPTION
### WHY are these changes introduced?

One commit for #8427, kept separate so it can be squashed in rather than pushed over an approved branch. Base is `redact-store-auth-manual-url`.

#8427 stops printing the manual authorization URL when it carries the signup credential, which is right. But withholding the URL leaves the browser with nothing to open, and the code still returns into `waitForStoreAuthCode`'s `onListening` and waits. `callback.ts:222` discards the fulfilled value, so nothing settles the promise. The command sits idle for the full `timeoutMs = 5 * 60 * 1000` (`callback.ts:100`) and then fails with `Timed out waiting for OAuth callback.`

So on #8427 as it stands, `shopify store stripe-auth` in any environment without a browser prints "run this command again in an environment where Shopify CLI can open a browser automatically" and then hangs for five minutes before erroring. There is no escape hatch — `--verbose` doesn't reveal the URL either, since `pkce.ts` only debug-logs the store, scopes and `redirect_uri`.

It is unconditional wherever `openURL` returns false, which includes:

- **Codespaces, Gitpod, Cloud Shell** — `openURL` returns `false` at `system.ts:57` via `isCloudEnvironment()` without attempting to open anything.
- plain SSH sessions and headless hosts, where `open`/`xdg-open` fails and `openURL` catches it.

`--signup` is `required: true` on this branch, so every `stripe-auth` invocation reaches the branch.

Before this commit the behaviour is a trade — no leak, but no authentication either. After it, the user gets an immediate error instead of a five-minute wait.

### WHAT is this pull request doing?

```ts
onListening: async () => {
  const opened = await resolvedDependencies.openURL(authorizationUrl)
  if (opened) return

  const sensitive = Boolean(input.signup)
  resolvedDependencies.presenter.manualAuthUrl(authorizationUrl, {sensitive})

  if (sensitive) throw new AbortError("Authentication can't continue without a browser.")
},
```

Throwing from `onListening` is already handled: `callback.ts:222` catches it and routes it through `settleWithError`, which closes the server and rejects with the `AbortError`. Follows the environment-refusal pattern at `private/node/session/device-authorization.ts:74-79`.

Deliberately small:

- **The presenter is untouched.** It keeps explaining why the URL was withheld and what to do; the `AbortError` only states the outcome, so the guidance isn't repeated. Your `sensitive` option and its `result.ts` behaviour are unchanged.
- **The non-signup path is unchanged** — the URL still prints and the command still waits, which is correct there because the user can act on it. Covered by the existing `shows a manual auth URL when the browser does not open automatically` test, still passing.
- **It composes with #8428.** Once the loopback handoff lands, the URL handed to the presenter is the credential-free handoff URL and `sensitive` is false, so this abort doesn't fire and the headless path works again. Nothing to unwind later.

One existing test had to change: `authenticateStoreWithApp marks manual auth URL as sensitive when signup JWT is present` now awaits a rejection instead of a return. Its `manualAuthUrl` assertion is intact.

### How to test your changes?

```sh
pnpm vitest run packages/store/src/cli/services/store/auth/index.test.ts
```

Both affected tests fail without the `index.ts` change (verified by reverting it in isolation) and pass with it. Full `packages/store`: 374 passed / 55 files. `eslint` and `prettier --check` clean on both files; `nx run store:type-check` 0 errors.

**Expect the same inherited CI failures as #8427** — `Check OCLIF manifests` (dies on `Cannot find module bin/check-commands-snapshot.js`, added to `main` after this branch was cut) and `Check graphql-codegen`, plus the E2E jobs, which are not required checks. Neither is caused by this commit; both clear on rebase. This branch changes no command or flag metadata, so it needs no manifest regeneration.

### Post-release steps

None.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows) — the change is control flow around an existing `openURL` result; if anything it helps Windows and headless Linux, where `open` is likelier to fail
- [x] I've considered possible [documentation](https://shopify.dev) changes — none; `store stripe-auth` is hidden and no command or flag metadata changes
- [x] I've considered analytics changes to measure impact — none. The command now exits non-zero promptly instead of after a timeout, so `cmd_all_exit` shifts from a timeout abort to this abort for the affected runs.
- [x] The change is user-facing — no changeset, consistent with #8427 and #8428, which add none for this hidden command
