### PR TITLE
[Refactor] Simplify buildSessionChoices with early return and map

### DIFF
--- a/packages/cli-kit/src/public/node/session-prompt.ts
+++ b/packages/cli-kit/src/public/node/session-prompt.ts
@@ -20,19 +20,13 @@ interface SessionChoice {
  * @returns Array of session choices.
  */
 function buildSessionChoices(sessions: Sessions, fqdn: string): SessionChoice[] {
-  const choices: SessionChoice[] = []
   const fqdnSessions = sessions[fqdn]
+  if (!fqdnSessions) return []
 
-  if (fqdnSessions) {
-    for (const [userId, session] of Object.entries(fqdnSessions)) {
-      choices.push({
-        label: session.identity.alias ?? userId,
-        value: userId,
-      })
-    }
-  }
-
-  return choices
+  return Object.entries(fqdnSessions).map(([userId, session]) => ({
+    label: session.identity.alias ?? userId,
+    value: userId,
+  }))
 }
 
 /**


### PR DESCRIPTION
### What this PR does

Refactors `buildSessionChoices` in `packages/cli-kit/src/public/node/session-prompt.ts` to replace imperative loop mutation with an early return guard clause and a declarative `.map()` transform.

### How to test your changes?

CI

---
*PR created automatically by Jules for task [2754549279388059089](https://jules.google.com/task/2754549279388059089) started by @gonzaloriestra*