### PR TITLE
[Tests] Add unit tests for webhooksRequestDoc

### DIFF
--- a/packages/cli-kit/src/public/node/api/webhooks.test.ts
+++ b/packages/cli-kit/src/public/node/api/webhooks.test.ts
@@ -1,0 +1,50 @@
+import {webhooksRequestDoc} from './webhooks.js'
+import {graphqlRequestDoc} from './graphql.js'
+import {appManagementFqdn} from '../context/fqdn.js'
+import {describe, expect, test, vi, beforeEach} from 'vitest'
+import {TypedDocumentNode} from '@graphql-typed-document-node/core'
+
+vi.mock('./graphql.js')
+vi.mock('../context/fqdn.js')
+
+const mockedResult = {data: {webhooks: []}}
+const appManagementFqdnValue = 'app.shopify.com'
+const mockedToken = 'test-token'
+const organizationId = '12345'
+
+beforeEach(() => {
+  vi.mocked(appManagementFqdn).mockResolvedValue(appManagementFqdnValue)
+})
+
+describe('webhooksRequestDoc', () => {
+  test('executes graphqlRequestDoc with correct URL and options', async () => {
+    // Given
+    vi.mocked(graphqlRequestDoc).mockResolvedValue(mockedResult)
+    const query = 'query { webhooks }' as unknown as TypedDocumentNode<object, {variables: string}>
+    const variables = {variables: 'test-variable'}
+    const unauthorizedHandler = {
+      type: 'token_refresh' as const,
+      handler: vi.fn().mockResolvedValue({token: mockedToken}),
+    }
+
+    // When
+    const result = await webhooksRequestDoc({
+      organizationId,
+      query,
+      token: mockedToken,
+      variables,
+      unauthorizedHandler,
+    })
+
+    // Then
+    expect(result).toBe(mockedResult)
+    expect(graphqlRequestDoc).toHaveBeenCalledWith({
+      query,
+      api: 'Webhooks',
+      url: `https://${appManagementFqdnValue}/webhooks/unstable/organizations/${organizationId}/graphql.json`,
+      token: mockedToken,
+      variables,
+      unauthorizedHandler,
+    })
+  })
+})


### PR DESCRIPTION
### WHY are these changes introduced?

`webhooksRequestDoc` in `packages/cli-kit/src/public/node/api/webhooks.ts` was missing co-located unit tests.

### WHAT is this pull request doing?

Adds unit tests in `packages/cli-kit/src/public/node/api/webhooks.test.ts` to verify:
- Endpoint URL construction using `appManagementFqdn` and `organizationId`
- Options delegation (`query`, `token`, `variables`, `unauthorizedHandler`) to `graphqlRequestDoc`
- Propagation of query result

### How to test your changes?

CI

### Post-release steps

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [13196240652730260648](https://jules.google.com/task/13196240652730260648) started by @gonzaloriestra*