### PR TITLE
[Tests] Add unit tests for storeTypeHandle and storeTypeLabel in store-type.ts

### DIFF
--- a/packages/store/src/cli/services/store/store-type.test.ts
+++ b/packages/store/src/cli/services/store/store-type.test.ts
@@ -1,0 +1,40 @@
+import {storeTypeHandle, storeTypeLabel} from './store-type.js'
+import {describe, expect, test} from 'vitest'
+
+describe('storeTypeHandle', () => {
+  test('returns dev for development store types', () => {
+    expect(storeTypeHandle('APP_DEVELOPMENT')).toBe('dev')
+    expect(storeTypeHandle('DEVELOPMENT')).toBe('dev')
+    expect(storeTypeHandle('DEVELOPMENT_SUPERSET')).toBe('dev')
+  })
+
+  test('returns expected handles for non-dev store types', () => {
+    expect(storeTypeHandle('CLIENT_TRANSFER')).toBe('client_transfer')
+    expect(storeTypeHandle('COLLABORATOR')).toBe('collaborator')
+    expect(storeTypeHandle('PRODUCTION')).toBe('production')
+  })
+
+  test('returns undefined for unrecognized store types', () => {
+    expect(storeTypeHandle('UNKNOWN_STORE_TYPE')).toBeUndefined()
+  })
+
+  test('returns undefined for empty, null, or undefined values', () => {
+    expect(storeTypeHandle('')).toBeUndefined()
+    expect(storeTypeHandle(null)).toBeUndefined()
+    expect(storeTypeHandle(undefined)).toBeUndefined()
+  })
+})
+
+describe('storeTypeLabel', () => {
+  test('returns title-cased labels for store handles', () => {
+    expect(storeTypeLabel('dev')).toBe('Dev')
+    expect(storeTypeLabel('client_transfer')).toBe('Client Transfer')
+    expect(storeTypeLabel('collaborator')).toBe('Collaborator')
+    expect(storeTypeLabel('production')).toBe('Production')
+  })
+
+  test('returns empty string for undefined or empty handle', () => {
+    expect(storeTypeLabel(undefined)).toBe('')
+    expect(storeTypeLabel('')).toBe('')
+  })
+})


### PR DESCRIPTION
### WHY are these changes introduced?

The store helper functions `storeTypeHandle` and `storeTypeLabel` in `packages/store/src/cli/services/store/store-type.ts` lacked direct unit test coverage.

### WHAT is this pull request doing?

Adds unit tests in `packages/store/src/cli/services/store/store-type.test.ts` covering:
- `storeTypeHandle` mapping development store types (`APP_DEVELOPMENT`, `DEVELOPMENT`, `DEVELOPMENT_SUPERSET`) to `'dev'`
- `storeTypeHandle` mapping non-development store types (`CLIENT_TRANSFER`, `COLLABORATOR`, `PRODUCTION`)
- `storeTypeHandle` returning `undefined` for unrecognized store types and empty/null/undefined inputs
- `storeTypeLabel` returning title-cased labels for store handles
- `storeTypeLabel` returning empty strings for undefined or empty handle inputs

### How to test your changes?

CI

### Post-release steps

N/A

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [18205664742232349531](https://jules.google.com/task/18205664742232349531) started by @gonzaloriestra*