### PR TITLE
Unhide `store create dev` and `store delete`

### DIFF
--- a/.changeset/unhide-store-create-dev.md
+++ b/.changeset/unhide-store-create-dev.md
@@ -1,0 +1,6 @@
+---
+'@shopify/cli': minor
+'@shopify/store': minor
+---
+
+Add `shopify store create dev` to create a development store in a Shopify organization.

--- a/.changeset/unhide-store-delete.md
+++ b/.changeset/unhide-store-delete.md
@@ -1,0 +1,6 @@
+---
+'@shopify/cli': minor
+'@shopify/store': minor
+---
+
+Add `shopify store delete` to delete a development store from a Shopify organization.

--- a/docs-shopify.dev/generated/generated_docs_data_v2.json
+++ b/docs-shopify.dev/generated/generated_docs_data_v2.json
@@ -5047,6 +5047,98 @@
       "value": "export interface storebulkstatus {\n  /**\n   * The bulk operation ID (numeric ID or full GID). If not provided, lists all bulk operations on this store in the last 7 days.\n   * @environment SHOPIFY_FLAG_ID\n   */\n  '--id <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The myshopify.com domain of the store.\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>': string\n\n  /**\n   * Increase the verbosity of the output. May include sensitive data.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
     }
   },
+  "storecreatedev": {
+    "docs-shopify.dev/commands/interfaces/store-create-dev.interface.ts": {
+      "filePath": "docs-shopify.dev/commands/interfaces/store-create-dev.interface.ts",
+      "name": "storecreatedev",
+      "description": "The following flags are available for the `store create dev` command:",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "docs-shopify.dev/commands/interfaces/store-create-dev.interface.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "--country <value>",
+          "value": "string",
+          "description": "Two-letter country code for the store, such as US, CA, or GB. Follows the ISO 3166-1 alpha-2 standard.",
+          "isOptional": true,
+          "environmentValue": "SHOPIFY_FLAG_STORE_COUNTRY"
+        },
+        {
+          "filePath": "docs-shopify.dev/commands/interfaces/store-create-dev.interface.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "--demo-data",
+          "value": "''",
+          "description": "Populate the new dev store with demo data.",
+          "isOptional": true,
+          "environmentValue": "SHOPIFY_FLAG_STORE_DEMO_DATA"
+        },
+        {
+          "filePath": "docs-shopify.dev/commands/interfaces/store-create-dev.interface.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "--feature-preview <value>",
+          "value": "string",
+          "description": "The handle of a feature preview to enable on the new dev store.",
+          "isOptional": true,
+          "environmentValue": "SHOPIFY_FLAG_STORE_FEATURE_PREVIEW"
+        },
+        {
+          "filePath": "docs-shopify.dev/commands/interfaces/store-create-dev.interface.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "--name <value>",
+          "value": "string",
+          "description": "Name for the new dev store. Required if non interactive.",
+          "isOptional": true,
+          "environmentValue": "SHOPIFY_FLAG_STORE_NAME"
+        },
+        {
+          "filePath": "docs-shopify.dev/commands/interfaces/store-create-dev.interface.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "--no-color",
+          "value": "''",
+          "description": "Disable color output.",
+          "isOptional": true,
+          "environmentValue": "SHOPIFY_FLAG_NO_COLOR"
+        },
+        {
+          "filePath": "docs-shopify.dev/commands/interfaces/store-create-dev.interface.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "--organization-id <value>",
+          "value": "string",
+          "description": "The numeric organization ID. Auto-selects if you belong to a single organization. Required if non interactive.",
+          "isOptional": true,
+          "environmentValue": "SHOPIFY_FLAG_ORGANIZATION_ID"
+        },
+        {
+          "filePath": "docs-shopify.dev/commands/interfaces/store-create-dev.interface.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "--plan <value>",
+          "value": "string",
+          "description": "The Shopify plan to use for the new dev store. Required if non interactive.",
+          "isOptional": true,
+          "environmentValue": "SHOPIFY_FLAG_STORE_PLAN"
+        },
+        {
+          "filePath": "docs-shopify.dev/commands/interfaces/store-create-dev.interface.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "--verbose",
+          "value": "''",
+          "description": "Increase the verbosity of the output. May include sensitive data.",
+          "isOptional": true,
+          "environmentValue": "SHOPIFY_FLAG_VERBOSE"
+        },
+        {
+          "filePath": "docs-shopify.dev/commands/interfaces/store-create-dev.interface.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "-j, --json",
+          "value": "''",
+          "description": "Output the result as JSON. Automatically disables color output.",
+          "isOptional": true,
+          "environmentValue": "SHOPIFY_FLAG_JSON"
+        }
+      ],
+      "value": "export interface storecreatedev {\n  /**\n   * Two-letter country code for the store, such as US, CA, or GB. Follows the ISO 3166-1 alpha-2 standard.\n   * @environment SHOPIFY_FLAG_STORE_COUNTRY\n   */\n  '--country <value>'?: string\n\n  /**\n   * Populate the new dev store with demo data.\n   * @environment SHOPIFY_FLAG_STORE_DEMO_DATA\n   */\n  '--demo-data'?: ''\n\n  /**\n   * The handle of a feature preview to enable on the new dev store.\n   * @environment SHOPIFY_FLAG_STORE_FEATURE_PREVIEW\n   */\n  '--feature-preview <value>'?: string\n\n  /**\n   * Output the result as JSON. Automatically disables color output.\n   * @environment SHOPIFY_FLAG_JSON\n   */\n  '-j, --json'?: ''\n\n  /**\n   * Name for the new dev store. Required if non interactive.\n   * @environment SHOPIFY_FLAG_STORE_NAME\n   */\n  '--name <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The numeric organization ID. Auto-selects if you belong to a single organization. Required if non interactive.\n   * @environment SHOPIFY_FLAG_ORGANIZATION_ID\n   */\n  '--organization-id <value>'?: string\n\n  /**\n   * The Shopify plan to use for the new dev store. Required if non interactive.\n   * @environment SHOPIFY_FLAG_STORE_PLAN\n   */\n  '--plan <value>'?: string\n\n  /**\n   * Increase the verbosity of the output. May include sensitive data.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+    }
+  },
   "storecreatepreview": {
     "docs-shopify.dev/commands/interfaces/store-create-preview.interface.ts": {
       "filePath": "docs-shopify.dev/commands/interfaces/store-create-preview.interface.ts",
@@ -5101,6 +5193,70 @@
         }
       ],
       "value": "export interface storecreatepreview {\n  /**\n   * Two-letter country code for the store, such as US, CA, or GB. Follows the ISO 3166-1 alpha-2 standard.\n   * @environment SHOPIFY_FLAG_STORE_COUNTRY\n   */\n  '--country <value>'?: string\n\n  /**\n   * Output the result as JSON. Automatically disables color output.\n   * @environment SHOPIFY_FLAG_JSON\n   */\n  '-j, --json'?: ''\n\n  /**\n   * The name of the store.\n   * @environment SHOPIFY_FLAG_PREVIEW_STORE_NAME\n   */\n  '--name <value>'?: string\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * Increase the verbosity of the output. May include sensitive data.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+    }
+  },
+  "storedelete": {
+    "docs-shopify.dev/commands/interfaces/store-delete.interface.ts": {
+      "filePath": "docs-shopify.dev/commands/interfaces/store-delete.interface.ts",
+      "name": "storedelete",
+      "description": "The following flags are available for the `store delete` command:",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "docs-shopify.dev/commands/interfaces/store-delete.interface.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "--no-color",
+          "value": "''",
+          "description": "Disable color output.",
+          "isOptional": true,
+          "environmentValue": "SHOPIFY_FLAG_NO_COLOR"
+        },
+        {
+          "filePath": "docs-shopify.dev/commands/interfaces/store-delete.interface.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "--organization-id <value>",
+          "value": "string",
+          "description": "The numeric organization ID. Auto-selects if you belong to a single organization.",
+          "isOptional": true,
+          "environmentValue": "SHOPIFY_FLAG_ORGANIZATION_ID"
+        },
+        {
+          "filePath": "docs-shopify.dev/commands/interfaces/store-delete.interface.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "--verbose",
+          "value": "''",
+          "description": "Increase the verbosity of the output. May include sensitive data.",
+          "isOptional": true,
+          "environmentValue": "SHOPIFY_FLAG_VERBOSE"
+        },
+        {
+          "filePath": "docs-shopify.dev/commands/interfaces/store-delete.interface.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "-f, --force",
+          "value": "''",
+          "description": "Skip confirmation. Required if non interactive.",
+          "isOptional": true,
+          "environmentValue": "SHOPIFY_FLAG_FORCE"
+        },
+        {
+          "filePath": "docs-shopify.dev/commands/interfaces/store-delete.interface.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "-j, --json",
+          "value": "''",
+          "description": "Output the result as JSON. Automatically disables color output.",
+          "isOptional": true,
+          "environmentValue": "SHOPIFY_FLAG_JSON"
+        },
+        {
+          "filePath": "docs-shopify.dev/commands/interfaces/store-delete.interface.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "-s, --store <value>",
+          "value": "string",
+          "description": "The myshopify.com domain of the store.",
+          "environmentValue": "SHOPIFY_FLAG_STORE"
+        }
+      ],
+      "value": "export interface storedelete {\n  /**\n   * Skip confirmation. Required if non interactive.\n   * @environment SHOPIFY_FLAG_FORCE\n   */\n  '-f, --force'?: ''\n\n  /**\n   * Output the result as JSON. Automatically disables color output.\n   * @environment SHOPIFY_FLAG_JSON\n   */\n  '-j, --json'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The numeric organization ID. Auto-selects if you belong to a single organization.\n   * @environment SHOPIFY_FLAG_ORGANIZATION_ID\n   */\n  '--organization-id <value>'?: string\n\n  /**\n   * The myshopify.com domain of the store.\n   * @environment SHOPIFY_FLAG_STORE\n   */\n  '-s, --store <value>': string\n\n  /**\n   * Increase the verbosity of the output. May include sensitive data.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
     }
   },
   "storeexecute": {

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -84,7 +84,9 @@
 * [`shopify store bulk cancel`](#shopify-store-bulk-cancel)
 * [`shopify store bulk execute`](#shopify-store-bulk-execute)
 * [`shopify store bulk status`](#shopify-store-bulk-status)
+* [`shopify store create dev`](#shopify-store-create-dev)
 * [`shopify store create preview`](#shopify-store-create-preview)
+* [`shopify store delete`](#shopify-store-delete)
 * [`shopify store execute`](#shopify-store-execute)
 * [`shopify store graphiql`](#shopify-store-graphiql)
 * [`shopify store info`](#shopify-store-info)
@@ -3655,6 +3657,68 @@ EXAMPLES
   $ shopify store bulk status --store shop.myshopify.com --id 123456789
 ```
 
+## `shopify store create dev`
+
+Create a new dev store.
+
+```
+USAGE
+  $ shopify store create dev [--country <value>] [--demo-data] [--feature-preview <value>] [-j] [--name <value>]
+    [--no-color] [--organization-id <value>] [--plan basic|grow|advanced|plus] [--verbose]
+
+FLAGS
+  -j, --json
+      Output the result as JSON. Automatically disables color output.
+      [env: SHOPIFY_FLAG_JSON]
+
+  --country=<value>
+      Two-letter country code for the store, such as US, CA, or GB. Follows the ISO 3166-1 alpha-2 standard.
+      [env: SHOPIFY_FLAG_STORE_COUNTRY]
+
+  --[no-]demo-data
+      Populate the new dev store with demo data.
+      [env: SHOPIFY_FLAG_STORE_DEMO_DATA]
+
+  --feature-preview=<value>
+      The handle of a feature preview to enable on the new dev store.
+      [env: SHOPIFY_FLAG_STORE_FEATURE_PREVIEW]
+
+  --name=<value>
+      Name for the new dev store. Required if non interactive.
+      [env: SHOPIFY_FLAG_STORE_NAME]
+
+  --no-color
+      Disable color output.
+      [env: SHOPIFY_FLAG_NO_COLOR]
+
+  --organization-id=<value>
+      The numeric organization ID. Auto-selects if you belong to a single organization. Required if non interactive.
+      [env: SHOPIFY_FLAG_ORGANIZATION_ID]
+
+  --plan=<option>
+      The Shopify plan to use for the new dev store. Required if non interactive.
+      [env: SHOPIFY_FLAG_STORE_PLAN]
+      <options: basic|grow|advanced|plus>
+
+  --verbose
+      Increase the verbosity of the output. May include sensitive data.
+      [env: SHOPIFY_FLAG_VERBOSE]
+
+DESCRIPTION
+  Create a new dev store.
+
+  Creates a new dev store in your organization.
+
+EXAMPLES
+  $ shopify store create dev
+
+  $ shopify store create dev --name "Lavender Candles" --organization-id 1234567 --plan basic
+
+  $ shopify store create dev --name "Lavender Candles" --organization-id 1234567 --plan basic --demo-data
+
+  $ shopify store create dev --name "Lavender Candles" --organization-id 1234567 --plan basic --json
+```
+
 ## `shopify store create preview`
 
 Create a preview Shopify store.
@@ -3695,6 +3759,52 @@ EXAMPLES
   $ shopify store create preview --name "Lavender Candles" --country US
 
   $ shopify store create preview --name "Lavender Candles" --json
+```
+
+## `shopify store delete`
+
+Delete a dev store.
+
+```
+USAGE
+  $ shopify store delete -s <value> [-f] [-j] [--no-color] [--organization-id <value>] [--verbose]
+
+FLAGS
+  -f, --force
+      Skip confirmation. Required if non interactive.
+      [env: SHOPIFY_FLAG_FORCE]
+
+  -j, --json
+      Output the result as JSON. Automatically disables color output.
+      [env: SHOPIFY_FLAG_JSON]
+
+  -s, --store=<value>
+      (required) The myshopify.com domain of the store.
+      [env: SHOPIFY_FLAG_STORE]
+
+  --no-color
+      Disable color output.
+      [env: SHOPIFY_FLAG_NO_COLOR]
+
+  --organization-id=<value>
+      The numeric organization ID. Auto-selects if you belong to a single organization.
+      [env: SHOPIFY_FLAG_ORGANIZATION_ID]
+
+  --verbose
+      Increase the verbosity of the output. May include sensitive data.
+      [env: SHOPIFY_FLAG_VERBOSE]
+
+DESCRIPTION
+  Delete a dev store.
+
+  Deletes a dev store from your organization.
+
+EXAMPLES
+  $ shopify store delete --store shop.myshopify.com --organization-id 1234567
+
+  $ shopify store delete --store shop.myshopify.com --organization-id 1234567 --json
+
+  $ shopify store delete --store shop.myshopify.com --organization-id 1234567 --force
 ```
 
 ## `shopify store execute`

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -7559,7 +7559,6 @@
         }
       },
       "hasDynamicHelp": false,
-      "hidden": true,
       "hiddenAliases": [
       ],
       "id": "store:create:dev",
@@ -7705,7 +7704,6 @@
         }
       },
       "hasDynamicHelp": false,
-      "hidden": true,
       "hiddenAliases": [
       ],
       "id": "store:delete",

--- a/packages/e2e/data/snapshots/commands.txt
+++ b/packages/e2e/data/snapshots/commands.txt
@@ -104,7 +104,9 @@
 │  │  ├─ execute
 │  │  └─ status
 │  ├─ create
+│  │  ├─ dev
 │  │  └─ preview
+│  ├─ delete
 │  ├─ execute
 │  ├─ graphiql
 │  ├─ info

--- a/packages/store/src/cli/commands/store/create/dev.ts
+++ b/packages/store/src/cli/commands/store/create/dev.ts
@@ -11,8 +11,6 @@ import {outputResult} from '@shopify/cli-kit/node/output'
 import {Flags} from '@oclif/core'
 
 export default class StoreCreateDev extends Command {
-  static hidden = true
-
   static summary = 'Create a new dev store.'
 
   static descriptionWithMarkdown = 'Creates a new dev store in your organization.'

--- a/packages/store/src/cli/commands/store/delete.ts
+++ b/packages/store/src/cli/commands/store/delete.ts
@@ -9,8 +9,6 @@ import {isTTY, renderDangerousConfirmationPrompt} from '@shopify/cli-kit/node/ui
 import {Flags} from '@oclif/core'
 
 export default class StoreDelete extends Command {
-  static hidden = true
-
   static summary = 'Delete a dev store.'
 
   static descriptionWithMarkdown = 'Deletes a dev store from your organization.'


### PR DESCRIPTION
> Stacked on #8457 (adds `static examples` to `store create dev`). Review that one first.

### WHY are these changes introduced?

These two commands are soon ready to be public, this PR is ready for that event!

### WHAT is this pull request doing?

Unhides the following `shopify store` commands:

- `shopify store create dev`
- `shopify store delete`

To accomplish this:

- Removed `static hidden = true` from both commands.
- Regenerated every artifact that describes the CLI's public command surface:
  - `packages/cli/oclif.manifest.json` (`pnpm refresh-manifests`)
  - `packages/cli/README.md` (`pnpm refresh-readme`)
  - `packages/e2e/data/snapshots/commands.txt` (`pnpm test:regenerate-snapshots`)
  - `docs-shopify.dev/generated/generated_docs_data_v2.json` (`pnpm build-dev-docs`)
- One changeset per newly-public command (`@shopify/cli` + `@shopify/store`, minor).

No behavior changes to either command — only visibility.

#### Learning for the future: generator ordering

`shopify commands --tree` resolves command visibility from the **oclif manifest**,
not from compiled source. So after removing `hidden` and running `pnpm build`,
`bin/check-commands-snapshot.js` still passes against the stale manifest — and
regenerating the snapshot at that point commits one CI will reject. The working
order is:

```
pnpm build → refresh-manifests → test:regenerate-snapshots
           → refresh-code-documentation → build-dev-docs
```

### How to test your changes?

```sh
pnpm shopify store create dev --help   # documented, no longer hidden
pnpm shopify store delete --help
pnpm shopify commands --tree           # both appear under `store`
```

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [x] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
