### PR TITLE
Add examples to store create dev

### DIFF
--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -7188,6 +7188,12 @@
       "description": "Creates a new development store in your organization.",
       "descriptionWithMarkdown": "Creates a new development store in your organization.",
       "enableJsonFlag": false,
+      "examples": [
+        "<%= config.bin %> <%= command.id %>",
+        "<%= config.bin %> <%= command.id %> --name \"Lavender Candles\" --organization-id 1234567 --plan basic",
+        "<%= config.bin %> <%= command.id %> --name \"Lavender Candles\" --organization-id 1234567 --plan basic --with-demo-data",
+        "<%= config.bin %> <%= command.id %> --name \"Lavender Candles\" --organization-id 1234567 --plan basic --json"
+      ],
       "flags": {
         "country": {
           "description": "Two-letter country code for the store, such as US, CA, or GB. Follows the ISO 3166-1 alpha-2 standard.",

--- a/packages/store/src/cli/commands/store/create/dev.ts
+++ b/packages/store/src/cli/commands/store/create/dev.ts
@@ -18,6 +18,13 @@ export default class StoreCreateDev extends Command {
 
   static description = this.descriptionWithoutMarkdown()
 
+  static examples = [
+    '<%= config.bin %> <%= command.id %>',
+    '<%= config.bin %> <%= command.id %> --name "Lavender Candles" --organization-id 1234567 --plan basic',
+    '<%= config.bin %> <%= command.id %> --name "Lavender Candles" --organization-id 1234567 --plan basic --with-demo-data',
+    '<%= config.bin %> <%= command.id %> --name "Lavender Candles" --organization-id 1234567 --plan basic --json',
+  ]
+
   static flags = {
     ...globalFlags,
     ...jsonFlag,


### PR DESCRIPTION
Adds `static examples` to `store create dev`, the only `shopify store` command without them.

Split out ahead of #8456, which unhides the command — landing the examples first keeps that PR's diff purely about visibility. Still hidden here, so no changeset; #8456 carries it.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
