### PR TITLE
Explain the empty-organization store creation prompts in app dev

### DIFF
--- a/packages/app/src/cli/services/dev/select-store.test.ts
+++ b/packages/app/src/cli/services/dev/select-store.test.ts
@@ -12,7 +12,7 @@ import {
 import {testDeveloperPlatformClient} from '../../models/app/app.test-data.js'
 import {ClientName} from '../../utilities/developer-platform-client.js'
 import {sleep} from '@shopify/cli-kit/node/system'
-import {isTTY, renderSuccess, renderTasks, Task} from '@shopify/cli-kit/node/ui'
+import {isTTY, renderInfo, renderSuccess, renderTasks, Task} from '@shopify/cli-kit/node/ui'
 import {AbortError, CancelExecution} from '@shopify/cli-kit/node/error'
 import {createDevStore} from '@shopify/organizations'
 import {beforeEach, describe, expect, vi, test} from 'vitest'
@@ -404,6 +404,8 @@ describe('selectStore', async () => {
       json: false,
       summary: false,
     })
+    // The developer picked the create choice, so no explanatory notice is needed.
+    expect(renderInfo).not.toHaveBeenCalled()
     expect(renderSuccess).toHaveBeenCalledWith({headline: 'Development store "store1" created successfully.'})
   })
 
@@ -477,6 +479,9 @@ describe('selectStore', async () => {
     })
     expect(fetchStore).toHaveBeenCalledTimes(2)
     expect(sleep).toHaveBeenCalledWith(3)
+    expect(renderInfo).toHaveBeenCalledWith({
+      body: "You don't have any dev stores associated with org1's Dev Dashboard. Let's create one.",
+    })
     expect(renderSuccess).toHaveBeenCalledWith({headline: 'Development store "store1" created successfully.'})
   })
 

--- a/packages/app/src/cli/services/dev/select-store.ts
+++ b/packages/app/src/cli/services/dev/select-store.ts
@@ -53,7 +53,12 @@ export async function selectStore(
     if (isTTY() === false) {
       throw new AbortError('No development store was specified.', createDevStoreTryMessage(org.id))
     }
-    onCreateStoreWhenEmpty = createStoreInline
+    // The developer never asked to create a store here, so explain why they are being
+    // prompted. The picker's create choice is self-explanatory and stays quiet.
+    onCreateStoreWhenEmpty = async () => {
+      renderInfo({body: emptyOrgNoticeBody(org)})
+      return createStoreInline()
+    }
   } else if (storeCreationEnabled && storeCreationMode === 'selection-option') {
     if (isTTY() === false && (storesSearch.stores.length > 1 || storesSearch.hasMorePages)) {
       throw new AbortError(
@@ -174,6 +179,10 @@ async function waitForCreatedStore(
 }
 
 const devStoreCapReachedMessage = 'Your organization has reached its development store limit.'
+
+function emptyOrgNoticeBody(org: Organization): string {
+  return `You don't have any dev stores associated with ${org.businessName}'s Dev Dashboard. Let's create one.`
+}
 
 function devStoreCreationCommand(orgId: string): string {
   return `shopify store create dev --organization-id ${orgId} --name <store-name> --plan <plan>`


### PR DESCRIPTION
> [!IMPORTANT]
> **Stacked PR.** Base is `nick/dev-store-demo-data-prompt` (#8459), not `main`. Do not
> merge before #8459.

### WHY are these changes introduced?

Since #8323, an App Management organization with no dev stores drops straight into
"Name for the new development store" when you run `app dev`. The prompt arrives without
context: the developer asked to start a dev session, not to create a store, and the old
flow that explained the situation ("Looks like you don't have any dev stores associated
with …") was replaced by inline creation.

### WHAT is this pull request doing?

Renders a short notice before the creation prompts on the zero-store path:

> You don't have any dev stores associated with `<organization>`'s Dev Dashboard. Let's create one.

```ts
// The developer never asked to create a store here, so explain why they are being
// prompted. The picker's create choice is self-explanatory and stays quiet.
onCreateStoreWhenEmpty = async () => {
  renderInfo({body: emptyOrgNoticeBody(org)})
  return createStoreInline()
}
```

Scoped deliberately to the zero-store path. When a developer picks "Create a new dev
store" from the store picker, they have already expressed the intent, so a notice
explaining why they are being asked would be noise. That is why the message lives in the
`onCreateStoreWhenEmpty` wrapper rather than inside `createStoreInline`, which both paths
share. Wrapping the callback rather than placing `renderInfo` beside the cap and TTY
guards also means the notice cannot print if the prompts never run. Tests assert it both
ways — present on the zero-store path, `expect(renderInfo).not.toHaveBeenCalled()` on the
picker path.

One naming note for reviewers: the message hardcodes "Dev Dashboard", matching the
adjacent copy in `AppManagementClient.getCreateDevStoreLink`. The client also carries a
`webUiName` property whose value is `'Developer Dashboard'`, so the codebase already
disagrees with itself about the product name. Using `webUiName` here would render
"Developer Dashboard" instead. Reconciling the two feels like its own cleanup rather than
part of this change, but say the word if you would rather this PR use `webUiName`.

### How to test your changes?

1. Link an app in an App Management organization that has **no** dev stores.
2. Run `shopify app dev --reset`. The notice appears, naming the organization, before the
   store name prompt.
3. Run `shopify app dev --reset` in an organization that **does** have dev stores and pick
   "Create a new dev store" from the picker. No notice — straight to the name prompt.

### Changelog

No changeset. This builds on the inline dev store creation from #8323 and #8397, which is
not released yet, so the whole flow will be covered by a single changelog entry rather than
one per PR in this stack.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add` — intentionally omitted, see Changelog above
