### PR TITLE
Skip hidden commands in breaking change detection

### DIFF
--- a/workspace/src/major-change-check.js
+++ b/workspace/src/major-change-check.js
@@ -163,11 +163,24 @@ async function parseManifest(directory) {
   }
 }
 
-function extractManifestSurface(manifest) {
+export function extractManifestSurface(manifest) {
   const surface = {commands: {}, envVars: {}}
   if (!manifest?.commands) return surface
 
   for (const [cmdName, cmd] of Object.entries(manifest.commands)) {
+    // Hidden commands are not part of the stable command surface that
+    // CONTRIBUTING.md defines, so renaming or removing their flags is not a
+    // breaking change. Dropping them here excludes them from the removed
+    // command, flag and env var scans alike, since all three derive from this
+    // surface. An env var shared with a visible command stays tracked through
+    // that command.
+    //
+    // Hidden-ness is read from each manifest independently, on purpose: a
+    // command that was visible in the baseline and is hidden now still reports
+    // as a removed command, so a PR cannot hide a command and strip its flags
+    // in one move without being flagged.
+    if (cmd.hidden) continue
+
     const flags = {}
     if (cmd.flags) {
       for (const [flagName, flag] of Object.entries(cmd.flags)) {

--- a/workspace/src/major-change-check.test.js
+++ b/workspace/src/major-change-check.test.js
@@ -17,7 +17,13 @@ import {mkdtemp, rm, writeFile, mkdir} from 'node:fs/promises'
 import os from 'node:os'
 import * as path from 'pathe'
 
-import {checkChangesets, extractSchemaFields, resolveContext, stripStringsAndComments} from './major-change-check.js'
+import {
+  checkChangesets,
+  extractManifestSurface,
+  extractSchemaFields,
+  resolveContext,
+  stripStringsAndComments,
+} from './major-change-check.js'
 
 test('extracts top-level keys from a flat .object({...})', () => {
   const src = `
@@ -269,4 +275,57 @@ test('resolveContext: no GITHUB_BASE_REF falls back to scanning main (local invo
   assert.equal(ctx.baselineRef, 'main')
   assert.equal(ctx.changedFiles, null)
   assert.equal(called, false, 'must not shell out to git when no base ref is known')
+})
+
+test('manifest surface omits hidden commands and their flags', () => {
+  const surface = extractManifestSurface({
+    commands: {
+      'app:dev': {flags: {store: {type: 'option'}}},
+      'store:create:dev': {hidden: true, flags: {'with-demo-data': {type: 'boolean'}}},
+    },
+  })
+
+  assert.deepEqual(Object.keys(surface.commands), ['app:dev'])
+  assert.equal(surface.commands['store:create:dev'], undefined)
+})
+
+test('manifest surface omits env vars used only by hidden commands', () => {
+  const surface = extractManifestSurface({
+    commands: {
+      'store:create:dev': {
+        hidden: true,
+        flags: {'with-demo-data': {type: 'boolean', env: 'SHOPIFY_FLAG_STORE_WITH_DEMO_DATA'}},
+      },
+    },
+  })
+
+  assert.deepEqual(surface.envVars, {})
+})
+
+test('manifest surface keeps an env var shared with a visible command', () => {
+  // Only the hidden command drops out; the visible command keeps the env var
+  // under watch, so removing it there is still reported.
+  const surface = extractManifestSurface({
+    commands: {
+      'app:dev': {flags: {store: {type: 'option', env: 'SHOPIFY_FLAG_STORE'}}},
+      'store:create:dev': {hidden: true, flags: {store: {type: 'option', env: 'SHOPIFY_FLAG_STORE'}}},
+    },
+  })
+
+  assert.deepEqual(surface.envVars.SHOPIFY_FLAG_STORE, [{command: 'app:dev', flag: 'store'}])
+})
+
+test('manifest surface still tracks a command that is visible in one manifest and hidden in another', () => {
+  // Reading `hidden` per manifest is what stops a PR from hiding a command and
+  // stripping its flags in one move: the baseline still lists it, so the
+  // removal surfaces.
+  const baseline = extractManifestSurface({
+    commands: {'app:dev': {flags: {store: {type: 'option'}}}},
+  })
+  const current = extractManifestSurface({
+    commands: {'app:dev': {hidden: true, flags: {}}},
+  })
+
+  assert.deepEqual(Object.keys(baseline.commands), ['app:dev'])
+  assert.deepEqual(Object.keys(current.commands), [])
 })


### PR DESCRIPTION
### WHY are these changes introduced?

The breaking change check treats every command in `packages/cli/oclif.manifest.json` as
public surface. `extractManifestSurface` never reads a command's `hidden` field, so
renaming a flag on a hidden command fails `Breaking change detection` even though nothing
users can discover has changed.

`CONTRIBUTING.md` scopes the stable **Command surface** to what the CLI exposes; a command
marked `static hidden = true` isn't part of it. The check is currently stricter than the
written policy.

This surfaced on #8459, which renames `--with-demo-data` to `--demo-data` on
`store store create dev` — a `hidden` command whose flag only reached `main` alongside
unreleased work. The check reported a removed flag and a removed env var and failed the PR.

### WHAT is this pull request doing?

Skips hidden commands when building the manifest surface:

```js
if (cmd.hidden) continue
```

Because `removedCommands`, `removedFlags` and `removedEnvVars` all derive from that
surface, one guard covers all three scans.

Two deliberate details:

- **`hidden` is read from each manifest independently**, not unioned across baseline and
  current. A command that was visible in the baseline and is hidden now still reports as a
  removed command. That keeps the obvious loophole closed — a PR can't hide a command and
  strip its flags in the same change without being flagged — and it errs the way the rest
  of this file already errs, "widening rather than silently skipping potential removals."
- **An env var shared with a visible command stays tracked** through that command, so
  removing it there is still reported.

`extractManifestSurface` is now exported so it can be tested directly.

### How to test your changes?

`node --test workspace/src/major-change-check.test.js` — 20 tests pass, including four new
ones covering hidden-command omission, env vars used only by hidden commands, env vars
shared with a visible command, and the per-manifest `hidden` reading.

I also ran the extractor against the real manifests to confirm both directions:

- `main` vs #8459's branch (the hidden-command flag rename) → `removedCommands: []`,
  `removedFlags: []`, `removedEnvVars: []`, so the check passes.
- `main` with a flag deleted from `app build` (a visible command) → still reports
  `app:build --auth-alias`, so genuine breaking changes are unaffected.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add` — not user-facing, CI tooling only
