### PR TITLE
[Tests] Add unit tests for functionsRequestDoc

### DIFF
--- a/packages/cli-kit/src/public/node/api/functions.test.ts
+++ b/packages/cli-kit/src/public/node/api/functions.test.ts
@@ -1,0 +1,52 @@
+import {functionsRequestDoc} from './functions.js'
+import {handleDeprecations} from './app-management.js'
+import {graphqlRequestDoc} from './graphql.js'
+import {appManagementFqdn} from '../context/fqdn.js'
+import {test, vi, expect, describe, beforeEach} from 'vitest'
+import {TypedDocumentNode} from '@graphql-typed-document-node/core'
+
+vi.mock('./graphql.js')
+vi.mock('../context/fqdn.js')
+
+const mockedResult = {data: {app: {id: '123'}}}
+const appManagementFqdnValue = 'shopify.com'
+const orgId = 'org-123'
+const appId = 'app-456'
+const token = 'test-token'
+const expectedUrl = `https://${appManagementFqdnValue}/functions/unstable/organizations/${orgId}/${appId}/graphql`
+
+beforeEach(() => {
+  vi.mocked(appManagementFqdn).mockResolvedValue(appManagementFqdnValue)
+})
+
+describe('functionsRequestDoc', () => {
+  test('graphqlRequestDoc is called with correct parameters and returns result', async () => {
+    vi.mocked(graphqlRequestDoc).mockResolvedValue(mockedResult)
+
+    const query = 'query' as unknown as TypedDocumentNode<typeof mockedResult, {id: string}>
+    const unauthorizedHandler = {
+      type: 'token_refresh' as const,
+      handler: vi.fn().mockResolvedValue({token}),
+    }
+
+    const result = await functionsRequestDoc({
+      organizationId: orgId,
+      appId,
+      query,
+      token,
+      variables: {id: '123'},
+      unauthorizedHandler,
+    })
+
+    expect(graphqlRequestDoc).toHaveBeenLastCalledWith({
+      query,
+      api: 'Functions',
+      url: expectedUrl,
+      token,
+      variables: {id: '123'},
+      responseOptions: {onResponse: handleDeprecations},
+      unauthorizedHandler,
+    })
+    expect(result).toBe(mockedResult)
+  })
+})


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #0000

Adds unit test coverage for `functionsRequestDoc` in `@shopify/cli-kit`.

### WHAT is this pull request doing?

Adds unit tests in `packages/cli-kit/src/public/node/api/functions.test.ts` to verify:
- GraphQL request delegation to `graphqlRequestDoc` with correct endpoint URL construction using app management FQDN, organization ID, and app ID.
- Argument propagation (API name, token, query, variables, unauthorizedHandler, responseOptions).
- Result propagation from `graphqlRequestDoc`.

### How to test your changes?

CI

### Post-release steps

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [14335710021318174839](https://jules.google.com/task/14335710021318174839) started by @gonzaloriestra*