### PR TITLE
Show the organization name and ID in `app info`

### DIFF
--- a/.changeset/app-info-organization.md
+++ b/.changeset/app-info-organization.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': minor
+---
+
+Show the organization name and ID in `app info`

--- a/packages/app/src/cli/services/info.test.ts
+++ b/packages/app/src/cli/services/info.test.ts
@@ -265,6 +265,34 @@ describe('info', () => {
       expect(rawResult.usesWorkspaces).toBe(false)
     })
   })
+
+  test('returns the organization name and ID using the default output format', async () => {
+    await inTemporaryDirectory(async (tmp) => {
+      // Given
+      const app = mockApp({directory: tmp})
+
+      // When
+      const result = (await info(app, remoteApp, ORG1, testProject(), infoOptions())) as AlertCustomSection[]
+      const configData = tabularDataSectionFromInfo(result, 'CURRENT APP CONFIGURATION\n')
+
+      // Then
+      expect(configData).toContainEqual(['Organization', 'test (123)'])
+    })
+  })
+
+  test('returns the organization name and ID using the json output format', async () => {
+    await inTemporaryDirectory(async (tmp) => {
+      // Given
+      const app = mockApp({directory: tmp})
+
+      // When
+      const result = await info(app, remoteApp, ORG1, testProject(), {...infoOptions(), format: 'json'})
+
+      // Then
+      const resultObject = JSON.parse((result as TokenizedString).value)
+      expect(resultObject.organization).toEqual({id: '123', businessName: 'test'})
+    })
+  })
 })
 
 function mockApp({

--- a/packages/app/src/cli/services/info.ts
+++ b/packages/app/src/cli/services/info.ts
@@ -37,7 +37,7 @@ export async function info(
   if (options.webEnv) {
     return infoWeb(app, remoteApp, organization, options)
   } else {
-    return infoApp(app, remoteApp, project, options)
+    return infoApp(app, remoteApp, organization, project, options)
   }
 }
 
@@ -53,6 +53,7 @@ async function infoWeb(
 async function infoApp(
   app: AppLinkedInterface,
   remoteApp: OrganizationApp,
+  organization: Organization,
   project: Project,
   options: InfoOptions,
 ): Promise<OutputMessage | AlertCustomSection[]> {
@@ -63,6 +64,7 @@ async function infoApp(
       packageManager: project.packageManager,
       nodeDependencies: project.nodeDependencies,
       usesWorkspaces: project.usesWorkspaces,
+      organization: {id: organization.id, businessName: organization.businessName},
       allExtensions: extensionsInfo,
     }
     if ('realExtensions' in appWithSupportedExtensions) {
@@ -88,7 +90,7 @@ async function infoApp(
       2,
     )}`
   } else {
-    const appInfo = new AppInfo(app, remoteApp, project, options)
+    const appInfo = new AppInfo(app, remoteApp, organization, project, options)
     return appInfo.output()
   }
 }
@@ -120,12 +122,20 @@ const NOT_LOADED_TEXT = 'NOT LOADED'
 class AppInfo {
   private readonly app: AppLinkedInterface
   private readonly remoteApp: OrganizationApp
+  private readonly organization: Organization
   private readonly project: Project
   private readonly options: InfoOptions
 
-  constructor(app: AppLinkedInterface, remoteApp: OrganizationApp, project: Project, options: InfoOptions) {
+  constructor(
+    app: AppLinkedInterface,
+    remoteApp: OrganizationApp,
+    organization: Organization,
+    project: Project,
+    options: InfoOptions,
+  ) {
     this.app = app
     this.remoteApp = remoteApp
+    this.organization = organization
     this.project = project
     this.options = options
   }
@@ -160,6 +170,7 @@ class AppInfo {
           ['Configuration file', {filePath: basename(this.app.configPath) || configurationFileNames.app}],
           ['App name', this.remoteApp.title ? {userInput: this.remoteApp.title} : NOT_CONFIGURED_TOKEN],
           ['Client ID', this.remoteApp.apiKey || NOT_CONFIGURED_TOKEN],
+          ['Organization', `${this.organization.businessName} (${this.organization.id})`],
           ['Access scopes', getAppScopes(this.app.configuration)],
           [
             'Dev store',


### PR DESCRIPTION
### WHY are these changes introduced?

`app info` doesn't tell you which organization the app belongs to. The "Current app configuration" section shows the app name, client ID, dev store and scopes, but nothing about the owning org — so if you work across several organizations, the linked app's org is invisible without going to the dashboard.

Agents looking to create dev stores for an app need the organization ID. This makes it much easier for the agent to resolve it.

### WHAT is this pull request doing?

<img width="1392" height="556" alt="image" src="https://github.com/user-attachments/assets/c32359f0-c39c-4dc5-b15b-704f92eca007" />


### How to test your changes?

In a linked app directory:

```
shopify app info
shopify app info --json | jq .organization
```

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [x] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

🤖 Generated with [Claude Code](https://claude.com/claude-code)