### PR TITLE
Show `store list` context in an info banner

### DIFF
--- a/.changeset/store-list-info-banner.md
+++ b/.changeset/store-list-info-banner.md
@@ -1,0 +1,5 @@
+---
+'@shopify/store': minor
+---
+
+Show the organization and `shopify store auth list` hint in an info banner in `store list`

--- a/.changeset/store-list-info-banner.md
+++ b/.changeset/store-list-info-banner.md
@@ -2,4 +2,4 @@
 '@shopify/store': minor
 ---
 
-Show the organization and `shopify store auth list` hint in an info banner in `store list`
+Show `store list` context in an info banner, with the organization as a label/value row

--- a/packages/store/src/cli/services/store/list/result.test.ts
+++ b/packages/store/src/cli/services/store/list/result.test.ts
@@ -31,7 +31,7 @@ describe('writeStoreListResult', () => {
       'text',
     )
 
-    expect(output.info()).toContain('Organization: Acme (1234)')
+    expect(output.info()).toContain('Listing stores in Acme (1234).')
     expect(output.info()).toContain('Subdomain')
     expect(output.info()).toContain('my-shop')
     expect(output.info()).not.toContain('my-shop.myshopify.com')
@@ -39,6 +39,50 @@ describe('writeStoreListResult', () => {
     expect(output.info()).toContain('Dev')
     expect(output.info()).toContain('May 22, 2026')
     expect(output.info()).toContain('shopify store auth list')
+  })
+
+  test('renders the organization and the store auth hint in a single info banner above the table', () => {
+    const output = mockAndCaptureOutput()
+
+    writeStoreListResult(
+      {
+        source: 'organization',
+        organization,
+        stores: [
+          {
+            store: 'my-shop.myshopify.com',
+            createdAt: '2026-05-22T00:00:00Z',
+            organizationId: '1234',
+            organizationName: 'Acme',
+            name: 'My Shop',
+            type: 'dev',
+          },
+        ],
+      },
+      'text',
+    )
+
+    // Terminal width in the test environment is quite narrow, so the table columns wrap.
+    const outputWithoutTrailingWhitespace = output
+      .info()
+      .split('\n')
+      .map((line) => line.trimEnd())
+      .join('\n')
+
+    expect(outputWithoutTrailingWhitespace).toMatchInlineSnapshot(`
+      "╭─ info ───────────────────────────────────────────────────────────────────────╮
+      │                                                                              │
+      │  Listing stores in Acme (1234).                                              │
+      │                                                                              │
+      │  To list stores authenticated directly with \`shopify store auth\`, run        │
+      │  \`shopify store auth list\`.                                                  │
+      │                                                                              │
+      ╰──────────────────────────────────────────────────────────────────────────────╯
+
+      Subdomain  Name     Type  Created
+      ─────────  ───────  ────  ────────────
+      my-shop    My Shop  Dev   May 22, 2026"
+    `)
   })
 
   test('renders the subdomain handle for non-myshopify hosts (local dev)', () => {

--- a/packages/store/src/cli/services/store/list/result.test.ts
+++ b/packages/store/src/cli/services/store/list/result.test.ts
@@ -31,7 +31,7 @@ describe('writeStoreListResult', () => {
       'text',
     )
 
-    expect(output.info()).toContain('Listing stores in Acme (1234).')
+    expect(output.info()).toContain('Acme (1234)')
     expect(output.info()).toContain('Subdomain')
     expect(output.info()).toContain('my-shop')
     expect(output.info()).not.toContain('my-shop.myshopify.com')
@@ -41,7 +41,7 @@ describe('writeStoreListResult', () => {
     expect(output.info()).toContain('shopify store auth list')
   })
 
-  test('renders the organization and the store auth hint in a single info banner above the table', () => {
+  test('renders the organization row and the store auth hint in a single info banner above the table', () => {
     const output = mockAndCaptureOutput()
 
     writeStoreListResult(
@@ -62,17 +62,12 @@ describe('writeStoreListResult', () => {
       'text',
     )
 
-    // Terminal width in the test environment is quite narrow, so the table columns wrap.
-    const outputWithoutTrailingWhitespace = output
-      .info()
-      .split('\n')
-      .map((line) => line.trimEnd())
-      .join('\n')
-
-    expect(outputWithoutTrailingWhitespace).toMatchInlineSnapshot(`
+    expect(trimmedLines(output.info())).toMatchInlineSnapshot(`
       "╭─ info ───────────────────────────────────────────────────────────────────────╮
       │                                                                              │
-      │  Listing stores in Acme (1234).                                              │
+      │  Listing stores.                                                             │
+      │                                                                              │
+      │  Organization  Acme (1234)                                                   │
       │                                                                              │
       │  To list stores authenticated directly with \`shopify store auth\`, run        │
       │  \`shopify store auth list\`.                                                  │
@@ -126,21 +121,34 @@ describe('writeStoreListResult', () => {
     expect(output.info()).toContain('shopify store auth list')
   })
 
-  test('renders the selected organization empty state', () => {
+  test('renders the selected organization empty state in the same banner shape', () => {
     const output = mockAndCaptureOutput()
 
     writeStoreListResult({source: 'organization', organization, stores: []}, 'text')
 
-    expect(output.info()).toContain('No stores found in Acme.')
+    expect(trimmedLines(output.info())).toMatchInlineSnapshot(`
+      "╭─ info ───────────────────────────────────────────────────────────────────────╮
+      │                                                                              │
+      │  No stores found.                                                            │
+      │                                                                              │
+      │  Organization  Acme (1234)                                                   │
+      │                                                                              │
+      │  To list stores authenticated directly with \`shopify store auth\`, run        │
+      │  \`shopify store auth list\`.                                                  │
+      │                                                                              │
+      ╰──────────────────────────────────────────────────────────────────────────────╯
+      "
+    `)
   })
 
-  test('renders the fallback organization empty state when no organization is selected', () => {
+  test('omits the organization row from the empty state when no organization is selected', () => {
     const output = mockAndCaptureOutput()
 
     writeStoreListResult({source: 'organization', stores: []}, 'text')
 
-    expect(output.info()).toContain('No stores found in your Shopify organization.')
+    expect(output.info()).toContain('No stores found.')
     expect(output.info()).toContain('shopify store auth list')
+    expect(output.info()).not.toContain('Organization')
   })
 
   test('emits a {stores, organization} JSON document on stdout', () => {
@@ -226,3 +234,12 @@ describe('writeStoreListResult', () => {
     expect(jsonOutput.output()).toContain('"truncated": true')
   })
 })
+
+// The banner pads every line out to the terminal width, which is narrow in the test environment.
+// Trimming keeps the snapshots readable and free of trailing whitespace.
+function trimmedLines(output: string): string {
+  return output
+    .split('\n')
+    .map((line) => line.trimEnd())
+    .join('\n')
+}

--- a/packages/store/src/cli/services/store/list/result.ts
+++ b/packages/store/src/cli/services/store/list/result.ts
@@ -5,8 +5,6 @@ import {storeTypeLabel} from '../store-type.js'
 import {outputResult, outputWarn} from '@shopify/cli-kit/node/output'
 import {renderInfo, renderTable, type AlertCustomSection, type TokenItem} from '@shopify/cli-kit/node/ui'
 
-// Both listing paths point at the separate `shopify store auth` credential store, so the hint is
-// the same whether or not the organization returned any stores.
 const STORE_AUTH_HINT: TokenItem = [
   'To list stores authenticated directly with',
   {command: 'shopify store auth'},
@@ -64,8 +62,6 @@ function textResultHeadline(result: ListStoresResult): string {
   return 'No stores found.'
 }
 
-// The organization is only known once one has been selected, so the unresolved-session path
-// renders the banner without this section.
 function organizationSections(organization: StoreListOrganization | undefined): AlertCustomSection[] {
   if (!organization) return []
 

--- a/packages/store/src/cli/services/store/list/result.ts
+++ b/packages/store/src/cli/services/store/list/result.ts
@@ -1,9 +1,20 @@
 import {STORE_LIST_LIMIT} from './constants.js'
-import {type ListStoresResult, type StoreListEntry} from './types.js'
+import {type ListStoresResult, type StoreListEntry, type StoreListOrganization} from './types.js'
 import {extractSubdomain, formatShortDate} from '../display.js'
 import {storeTypeLabel} from '../store-type.js'
-import {outputInfo, outputResult, outputWarn} from '@shopify/cli-kit/node/output'
-import {renderInfo, renderTable} from '@shopify/cli-kit/node/ui'
+import {outputResult, outputWarn} from '@shopify/cli-kit/node/output'
+import {renderInfo, renderTable, type AlertCustomSection, type TokenItem} from '@shopify/cli-kit/node/ui'
+
+// Both listing paths point at the separate `shopify store auth` credential store, so the hint is
+// the same whether or not the organization returned any stores.
+const STORE_AUTH_HINT: TokenItem = [
+  'To list stores authenticated directly with',
+  {command: 'shopify store auth'},
+  {char: ','},
+  'run',
+  {command: 'shopify store auth list'},
+  {char: '.'},
+]
 
 export function writeStoreListResult(result: ListStoresResult, format: 'text' | 'json'): void {
   // Human diagnostics always go to stderr so they never corrupt the JSON document on stdout, and so
@@ -36,28 +47,36 @@ function truncationWarning(result: ListStoresResult): string {
 }
 
 function renderTextResult(result: ListStoresResult): void {
-  if (result.stores.length === 0) {
-    outputInfo(emptyStateMessage(result))
-    return
-  }
-
-  const headline = result.organization
-    ? `Listing stores in ${result.organization.name} (${result.organization.id}).`
-    : 'Listing stores.'
-
   renderInfo({
-    headline,
-    body: [
-      'To list stores authenticated directly with',
-      {command: 'shopify store auth'},
-      {char: ','},
-      'run',
-      {command: 'shopify store auth list'},
-      {char: '.'},
-    ],
+    headline: textResultHeadline(result),
+    customSections: [...organizationSections(result.organization), {body: STORE_AUTH_HINT}],
   })
 
-  renderOrganizationTable(result.stores)
+  if (result.stores.length > 0) {
+    renderOrganizationTable(result.stores)
+  }
+}
+
+function textResultHeadline(result: ListStoresResult): string {
+  if (result.stores.length > 0) return 'Listing stores.'
+  // The notice explains on stderr why the session couldn't be resolved; this states the outcome.
+  if (result.notice) return 'No stores were returned for the current CLI session.'
+  return 'No stores found.'
+}
+
+// The organization is only known once one has been selected, so the unresolved-session path
+// renders the banner without this section.
+function organizationSections(organization: StoreListOrganization | undefined): AlertCustomSection[] {
+  if (!organization) return []
+
+  return [
+    {
+      body: {
+        tabularData: [['Organization', `${organization.name} (${organization.id})`]],
+        firstColumnSubdued: true,
+      },
+    },
+  ]
 }
 
 function renderOrganizationTable(stores: StoreListEntry[]): void {
@@ -75,26 +94,6 @@ function renderOrganizationTable(stores: StoreListEntry[]): void {
       created: {header: 'Created'},
     },
   })
-}
-
-function emptyStateMessage(result: ListStoresResult): string {
-  if (result.notice) {
-    return [
-      'No stores were returned for the current CLI session.',
-      '',
-      'Run `shopify store auth list` to list stores authenticated directly with `shopify store auth`.',
-    ].join('\n')
-  }
-
-  if (result.organization) {
-    return `No stores found in ${result.organization.name}.`
-  }
-
-  return [
-    'No stores found in your Shopify organization.',
-    '',
-    'Run `shopify store auth list` to list stores authenticated directly with `shopify store auth`.',
-  ].join('\n')
 }
 
 function subdomainFor(store: string): string {

--- a/packages/store/src/cli/services/store/list/result.ts
+++ b/packages/store/src/cli/services/store/list/result.ts
@@ -3,7 +3,7 @@ import {type ListStoresResult, type StoreListEntry} from './types.js'
 import {extractSubdomain, formatShortDate} from '../display.js'
 import {storeTypeLabel} from '../store-type.js'
 import {outputInfo, outputResult, outputWarn} from '@shopify/cli-kit/node/output'
-import {renderTable} from '@shopify/cli-kit/node/ui'
+import {renderInfo, renderTable} from '@shopify/cli-kit/node/ui'
 
 export function writeStoreListResult(result: ListStoresResult, format: 'text' | 'json'): void {
   // Human diagnostics always go to stderr so they never corrupt the JSON document on stdout, and so
@@ -41,12 +41,23 @@ function renderTextResult(result: ListStoresResult): void {
     return
   }
 
-  if (result.organization) {
-    outputInfo(`Organization: ${result.organization.name} (${result.organization.id})`)
-  }
+  const headline = result.organization
+    ? `Listing stores in ${result.organization.name} (${result.organization.id}).`
+    : 'Listing stores.'
+
+  renderInfo({
+    headline,
+    body: [
+      'To list stores authenticated directly with',
+      {command: 'shopify store auth'},
+      {char: ','},
+      'run',
+      {command: 'shopify store auth list'},
+      {char: '.'},
+    ],
+  })
 
   renderOrganizationTable(result.stores)
-  outputInfo('To list stores authenticated directly with `shopify store auth`, run `shopify store auth list`.')
 }
 
 function renderOrganizationTable(stores: StoreListEntry[]): void {


### PR DESCRIPTION
### WHY are these changes introduced?

`shopify store list` printed its context as bare stdout text around the table. The `shopify store auth list` hint ends up flush against the last table row, and the organization line sits directly on top of the header with no separation:

```
Organization: nicks-fermented-milks (214000669)
Subdomain                      Name                           Type   Created
─────────────────────────────  ─────────────────────────────  ─────  ────────────
niche-negotiation-stress-test  niche-negotiation-stress-test  Dev    Sep 03, 2026
To list stores authenticated directly with `shopify store auth`, run `shopify store auth list`.
```

### WHAT is this pull request doing?

Routes every text path through one info banner, with the organization as a label/value row.

Populated:

```
╭─ info ───────────────────────────────────────────────────────────────────────╮
│                                                                              │
│  Listing stores.                                                             │
│                                                                              │
│  Organization  nicks-fermented-milks (214000669)                             │
│                                                                              │
│  To list stores authenticated directly with `shopify store auth`, run        │
│  `shopify store auth list`.                                                  │
│                                                                              │
╰──────────────────────────────────────────────────────────────────────────────╯

Subdomain                      Name                           Type  Created
─────────────────────────────  ─────────────────────────────  ────  ────────────
niche-negotiation-stress-test  niche-negotiation-stress-test  Dev   Sep 03, 2026
```

Empty, with an organization selected — same shape, so the organization is still reported:

```
╭─ info ───────────────────────────────────────────────────────────────────────╮
│                                                                              │
│  No stores found.                                                            │
│                                                                              │
│  Organization  nicks-fermented-milks (214000669)                             │
│                                                                              │
│  To list stores authenticated directly with `shopify store auth`, run        │
│  `shopify store auth list`.                                                  │
│                                                                              │
╰──────────────────────────────────────────────────────────────────────────────╯
```

JSON output and the stderr `notice` / truncation warnings are unchanged.

### How to test your changes?

```
shopify store list                          # organization with stores
shopify store list --organization-id <id>   # an organization with no stores
shopify store list --json                   # unchanged
```

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [x] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

🤖 Generated with [Claude Code](https://claude.com/claude-code)