### PR TITLE
Say "dev store" instead of "development store"

### DIFF
--- a/packages/app/src/cli/services/dev/select-store.test.ts
+++ b/packages/app/src/cli/services/dev/select-store.test.ts
@@ -406,7 +406,7 @@ describe('selectStore', async () => {
     })
     // The developer picked the create choice, so no explanatory notice is needed.
     expect(renderInfo).not.toHaveBeenCalled()
-    expect(renderSuccess).toHaveBeenCalledWith({headline: 'Development store "store1" created successfully.'})
+    expect(renderSuccess).toHaveBeenCalledWith({headline: 'Dev store "store1" created successfully.'})
   })
 
   test('passes an affirmative demo data answer through to store creation', async () => {
@@ -482,7 +482,7 @@ describe('selectStore', async () => {
     expect(renderInfo).toHaveBeenCalledWith({
       body: "You don't have any dev stores associated with org1's Dev Dashboard. Let's create one.",
     })
-    expect(renderSuccess).toHaveBeenCalledWith({headline: 'Development store "store1" created successfully.'})
+    expect(renderSuccess).toHaveBeenCalledWith({headline: 'Dev store "store1" created successfully.'})
   })
 
   test('reports how to select a created store after provisioning retries are exhausted', async () => {

--- a/packages/app/src/cli/services/dev/select-store.ts
+++ b/packages/app/src/cli/services/dev/select-store.ts
@@ -39,7 +39,7 @@ export async function selectStore(
     const withDemoData = await devStoreDemoDataPrompt()
     const domain = await createDevStore({name, plan, withDemoData, organization: org, json: false, summary: false})
     const createdStore = await waitForCreatedStoreByDomain(org, domain, developerPlatformClient)
-    renderSuccess({headline: `Development store "${createdStore.shopName}" created successfully.`})
+    renderSuccess({headline: `Dev store "${createdStore.shopName}" created successfully.`})
     return createdStore
   }
 

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -7185,8 +7185,8 @@
       "args": {
       },
       "customPluginName": "@shopify/store",
-      "description": "Creates a new development store in your organization.",
-      "descriptionWithMarkdown": "Creates a new development store in your organization.",
+      "description": "Creates a new dev store in your organization.",
+      "descriptionWithMarkdown": "Creates a new dev store in your organization.",
       "enableJsonFlag": false,
       "examples": [
         "<%= config.bin %> <%= command.id %>",
@@ -7206,13 +7206,13 @@
         },
         "demo-data": {
           "allowNo": true,
-          "description": "Populate the new development store with demo data.",
+          "description": "Populate the new dev store with demo data.",
           "env": "SHOPIFY_FLAG_STORE_DEMO_DATA",
           "name": "demo-data",
           "type": "boolean"
         },
         "feature-preview": {
-          "description": "The handle of a feature preview to enable on the new development store.",
+          "description": "The handle of a feature preview to enable on the new dev store.",
           "env": "SHOPIFY_FLAG_STORE_FEATURE_PREVIEW",
           "hasDynamicHelp": false,
           "multiple": false,
@@ -7229,7 +7229,7 @@
           "type": "boolean"
         },
         "name": {
-          "description": "Name for the new development store. Required if non interactive.",
+          "description": "Name for the new dev store. Required if non interactive.",
           "env": "SHOPIFY_FLAG_STORE_NAME",
           "hasDynamicHelp": false,
           "multiple": false,
@@ -7253,7 +7253,7 @@
           "type": "option"
         },
         "plan": {
-          "description": "The Shopify plan to use for the new development store. Required if non interactive.",
+          "description": "The Shopify plan to use for the new dev store. Required if non interactive.",
           "env": "SHOPIFY_FLAG_STORE_PLAN",
           "hasDynamicHelp": false,
           "multiple": false,
@@ -7284,7 +7284,7 @@
       "pluginName": "@shopify/cli",
       "pluginType": "core",
       "strict": true,
-      "summary": "Create a new development store."
+      "summary": "Create a new dev store."
     },
     "store:create:preview": {
       "aliases": [
@@ -7360,8 +7360,8 @@
       "args": {
       },
       "customPluginName": "@shopify/store",
-      "description": "Deletes a development store from your organization.",
-      "descriptionWithMarkdown": "Deletes a development store from your organization.",
+      "description": "Deletes a dev store from your organization.",
+      "descriptionWithMarkdown": "Deletes a dev store from your organization.",
       "enableJsonFlag": false,
       "examples": [
         "<%= config.bin %> <%= command.id %> --store shop.myshopify.com --organization-id 1234567",
@@ -7430,7 +7430,7 @@
       "pluginName": "@shopify/cli",
       "pluginType": "core",
       "strict": true,
-      "summary": "Delete a development store."
+      "summary": "Delete a dev store."
     },
     "store:execute": {
       "aliases": [

--- a/packages/organizations/src/cli/prompts/dev.ts
+++ b/packages/organizations/src/cli/prompts/dev.ts
@@ -10,7 +10,7 @@ const PLAN_LABELS: {[plan in DevStorePlan]: string} = {
 }
 
 export function devStoreNamePrompt(): Promise<string> {
-  return ui.renderTextPrompt({message: 'Name for the new development store'})
+  return ui.renderTextPrompt({message: 'Name for the new dev store'})
 }
 
 export function devStorePlanPrompt(): Promise<DevStorePlan> {

--- a/packages/organizations/src/cli/services/dev/create-dev-store.ts
+++ b/packages/organizations/src/cli/services/dev/create-dev-store.ts
@@ -86,7 +86,7 @@ export async function createDevStore(options: CreateDevStoreOptions): Promise<st
   const userErrors = createAppDevelopmentStore.userErrors
   if (userErrors && userErrors.length > 0) {
     const messages = userErrors.map((error) => error.message).join(', ')
-    throw new AbortError(`Failed to create development store: ${messages}`)
+    throw new AbortError(`Failed to create dev store: ${messages}`)
   }
 
   const {shopDomain, shopAdminUrl} = createAppDevelopmentStore
@@ -167,7 +167,7 @@ export async function createDevStore(options: CreateDevStoreOptions): Promise<st
     pushRow(rows, 'Demo data', options.withDemoData ? 'enabled' : 'disabled')
 
     renderSuccess({
-      headline: `Development store "${name}" created successfully.`,
+      headline: `Dev store "${name}" created successfully.`,
       customSections: [{body: {tabularData: rows, firstColumnSubdued: true}}],
     })
   }

--- a/packages/store/src/cli/commands/store/create/dev.ts
+++ b/packages/store/src/cli/commands/store/create/dev.ts
@@ -13,9 +13,9 @@ import {Flags} from '@oclif/core'
 export default class StoreCreateDev extends Command {
   static hidden = true
 
-  static summary = 'Create a new development store.'
+  static summary = 'Create a new dev store.'
 
-  static descriptionWithMarkdown = 'Creates a new development store in your organization.'
+  static descriptionWithMarkdown = 'Creates a new dev store in your organization.'
 
   static description = this.descriptionWithoutMarkdown()
 
@@ -31,24 +31,24 @@ export default class StoreCreateDev extends Command {
     ...jsonFlag,
     name: requiredIfNonInteractive(
       Flags.string({
-        description: 'Name for the new development store.',
+        description: 'Name for the new dev store.',
         env: 'SHOPIFY_FLAG_STORE_NAME',
       }),
     ),
     'organization-id': requiredIfNonInteractive(storeFlags['organization-id']),
     plan: requiredIfNonInteractive(
       Flags.string({
-        description: 'The Shopify plan to use for the new development store.',
+        description: 'The Shopify plan to use for the new dev store.',
         options: devStorePlanHandles,
         env: 'SHOPIFY_FLAG_STORE_PLAN',
       }),
     ),
     'feature-preview': Flags.string({
-      description: 'The handle of a feature preview to enable on the new development store.',
+      description: 'The handle of a feature preview to enable on the new dev store.',
       env: 'SHOPIFY_FLAG_STORE_FEATURE_PREVIEW',
     }),
     'demo-data': Flags.boolean({
-      description: 'Populate the new development store with demo data.',
+      description: 'Populate the new dev store with demo data.',
       allowNo: true,
       env: 'SHOPIFY_FLAG_STORE_DEMO_DATA',
     }),

--- a/packages/store/src/cli/commands/store/delete.test.ts
+++ b/packages/store/src/cli/commands/store/delete.test.ts
@@ -80,7 +80,7 @@ describe('store delete command', () => {
     await StoreDelete.run(['--store', 'my-store.myshopify.com', '--organization-id', '12345'])
 
     expect(renderDangerousConfirmationPrompt).toHaveBeenCalledWith({
-      message: `Delete development store my-store.myshopify.com? This can't be undone.`,
+      message: `Delete dev store my-store.myshopify.com? This can't be undone.`,
       confirmation: 'my-store.myshopify.com',
     })
     expect(deleteDevStore).toHaveBeenCalled()
@@ -132,7 +132,7 @@ describe('store delete command', () => {
     const parsed = JSON.parse(call)
     expect(parsed).toEqual({
       error: true,
-      message: 'Deleting the development store my-store.myshopify.com requires confirmation.',
+      message: 'Deleting the dev store my-store.myshopify.com requires confirmation.',
       nextSteps: ['Use the `--force` flag to skip confirmation when running non-interactively.'],
       exitCode: 1,
     })

--- a/packages/store/src/cli/commands/store/delete.ts
+++ b/packages/store/src/cli/commands/store/delete.ts
@@ -11,9 +11,9 @@ import {Flags} from '@oclif/core'
 export default class StoreDelete extends Command {
   static hidden = true
 
-  static summary = 'Delete a development store.'
+  static summary = 'Delete a dev store.'
 
-  static descriptionWithMarkdown = 'Deletes a development store from your organization.'
+  static descriptionWithMarkdown = 'Deletes a dev store from your organization.'
 
   static description = this.descriptionWithoutMarkdown()
 
@@ -43,7 +43,7 @@ export default class StoreDelete extends Command {
       // Deleting a store is irreversible: in non-interactive runs (CI, agents, piped
       // input) confirmation is impossible, so an explicit --force is required instead.
       if (!flags.force && !isTTY()) {
-        throw new AbortError(`Deleting the development store ${flags.store} requires confirmation.`, null, [
+        throw new AbortError(`Deleting the dev store ${flags.store} requires confirmation.`, null, [
           'Use the `--force` flag to skip confirmation when running non-interactively.',
         ])
       }
@@ -52,7 +52,7 @@ export default class StoreDelete extends Command {
 
       if (!flags.force) {
         const confirmed = await renderDangerousConfirmationPrompt({
-          message: `Delete development store ${flags.store}? This can't be undone.`,
+          message: `Delete dev store ${flags.store}? This can't be undone.`,
           confirmation: flags.store,
         })
         if (!confirmed) throw new AbortSilentError()

--- a/packages/store/src/cli/prompts/store.test.ts
+++ b/packages/store/src/cli/prompts/store.test.ts
@@ -11,9 +11,7 @@ describe('storeNamePrompt', () => {
     const result = await storeNamePrompt()
 
     expect(result).toBe('my-store')
-    expect(renderTextPrompt).toHaveBeenCalledWith(
-      expect.objectContaining({message: 'Name for the new development store'}),
-    )
+    expect(renderTextPrompt).toHaveBeenCalledWith(expect.objectContaining({message: 'Name for the new dev store'}))
   })
 })
 

--- a/packages/store/src/cli/services/store/delete/dev.test.ts
+++ b/packages/store/src/cli/services/store/delete/dev.test.ts
@@ -145,7 +145,7 @@ describe('deleteDevStore', () => {
       },
     })
 
-    await expect(deleteDevStore(defaultOptions)).rejects.toThrow('Failed to delete development store: Store not found')
+    await expect(deleteDevStore(defaultOptions)).rejects.toThrow('Failed to delete dev store: Store not found')
 
     expect(renderSingleTask).not.toHaveBeenCalled()
     expect(mutationRequests()).toHaveLength(1)
@@ -169,7 +169,7 @@ describe('deleteDevStore', () => {
     })
 
     await expect(deleteDevStore(defaultOptions)).rejects.toThrow(
-      'Failed to delete development store: Store management from the Shopify CLI is not yet enabled for your organization.',
+      'Failed to delete dev store: Store management from the Shopify CLI is not yet enabled for your organization.',
     )
 
     expect(renderSingleTask).not.toHaveBeenCalled()

--- a/packages/store/src/cli/services/store/delete/dev.ts
+++ b/packages/store/src/cli/services/store/delete/dev.ts
@@ -54,7 +54,7 @@ export async function deleteDevStore(options: DeleteDevStoreOptions): Promise<vo
   const userErrors = deleteAppDevelopmentStore.userErrors
   if (userErrors && userErrors.length > 0) {
     const messages = userErrors.map((error) => error.message).join(', ')
-    throw new AbortError(`Failed to delete development store: ${messages}`)
+    throw new AbortError(`Failed to delete dev store: ${messages}`)
   }
   if (deleteAppDevelopmentStore.success === false) {
     throw new AbortError('Store deletion failed.')
@@ -75,12 +75,12 @@ export async function deleteDevStore(options: DeleteDevStoreOptions): Promise<vo
     outputResult(deletionResultJson({store, organization: org, deletionConfirmed}))
   } else if (deletionConfirmed) {
     renderSuccess({
-      headline: `Development store "${store}" deleted successfully.`,
+      headline: `Dev store "${store}" deleted successfully.`,
       body: ['The store was deleted.'],
     })
   } else {
     renderWarning({
-      headline: `Development store "${store}" deletion was requested, but not confirmed.`,
+      headline: `Dev store "${store}" deletion was requested, but not confirmed.`,
       body: [
         'Shopify accepted the deletion request, but deletion was not confirmed before the CLI stopped waiting.',
         'The store may still finish deleting asynchronously.',
@@ -113,7 +113,7 @@ async function waitForStoreDeletionConfirmation(options: StoreDeletionConfirmati
   const organizationsShopifyShopId = toOrganizationsShopifyShopId(options.shopifyShopId)
 
   return renderSingleTask({
-    title: outputContent`Development store deletion requested. Waiting for deletion confirmation`,
+    title: outputContent`Dev store deletion requested. Waiting for deletion confirmation`,
     task: async (updateStatus) => {
       const startTime = Date.now()
       while (true) {


### PR DESCRIPTION
### WHY are these changes introduced?

The dev store commands under `shopify store` were the only place calling them "development stores". `app dev`, the `--store` flag help, and the `Type` column in `store list` all say "dev store".

### WHAT is this pull request doing?

Renaming the user-facing text to "dev store" in `store create dev` and `store delete` — success banners, prompts, errors, the deletion task title, and command/flag help.

`app dev` shares the name prompt via `@shopify/organizations`, so its creation banner moves too; otherwise it would prompt for a "dev store" and confirm a "development store".

Untouched: the Admin API's own `partnerDevelopment` plan wording, and the remaining `app dev` selection messages.

Both commands are `hidden`, so `oclif.manifest.json` is the only generated file that changes. No changeset, as requested.

### How to test your changes?

```
shopify store create dev --organization-id <id>
shopify store delete --store <domain>
```

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)