### PR TITLE
Explain why store delete prompts for an organization

### DIFF
--- a/.changeset/store-delete-organization-prompt-notice.md
+++ b/.changeset/store-delete-organization-prompt-notice.md
@@ -1,5 +1,0 @@
----
-'@shopify/store': minor
----
-
-Explain why `store delete` prompts for an organization, naming the store you provided

--- a/.changeset/store-delete-organization-prompt-notice.md
+++ b/.changeset/store-delete-organization-prompt-notice.md
@@ -1,0 +1,5 @@
+---
+'@shopify/store': minor
+---
+
+Explain why `store delete` prompts for an organization, naming the store you provided

--- a/packages/store/src/cli/utilities/store-lookup/organization.test.ts
+++ b/packages/store/src/cli/utilities/store-lookup/organization.test.ts
@@ -3,6 +3,7 @@ import {fetchDestinationsContext} from './destinations.js'
 import {selectOrg} from '@shopify/organizations'
 import {AbortError} from '@shopify/cli-kit/node/error'
 import {terminalSupportsPrompting} from '@shopify/cli-kit/node/system'
+import {mockAndCaptureOutput} from '@shopify/cli-kit/node/testing/output'
 import {describe, expect, test, vi, beforeEach} from 'vitest'
 
 vi.mock('./destinations.js')
@@ -45,6 +46,7 @@ describe('resolveOrganizationForStore', () => {
     vi.mocked(selectOrg).mockResolvedValue(selectedOrg)
     vi.mocked(fetchDestinationsContext).mockResolvedValue({owningOrg: {id: '67890', name: 'Inferred Org'}})
     vi.mocked(terminalSupportsPrompting).mockReturnValue(true)
+    mockAndCaptureOutput().clear()
   })
 
   test('selects the organization by ID when an organization ID is provided', async () => {
@@ -70,6 +72,32 @@ describe('resolveOrganizationForStore', () => {
 
     expect(selectOrg).toHaveBeenCalledWith()
     expect(organization).toEqual(selectedOrg)
+  })
+
+  test('explains why the organization prompt is appearing, naming the store the developer provided', async () => {
+    vi.mocked(fetchDestinationsContext).mockResolvedValue({owningOrg: undefined})
+    const output = mockAndCaptureOutput()
+
+    await resolveOrganizationForStore(STORE)
+
+    expect(output.info()).toMatchInlineSnapshot(`
+      "╭─ info ───────────────────────────────────────────────────────────────────────╮
+      │                                                                              │
+      │  Could not determine which organization owns shop.myshopify.com.             │
+      │                                                                              │
+      │  Select one below, or specify it with \`--organization-id\`.                   │
+      │                                                                              │
+      ╰──────────────────────────────────────────────────────────────────────────────╯
+      "
+    `)
+  })
+
+  test('stays quiet when the owning organization is inferred', async () => {
+    const output = mockAndCaptureOutput()
+
+    await resolveOrganizationForStore(STORE)
+
+    expect(output.info()).toBe('')
   })
 
   test('does not prompt non-interactively when ownership can be inferred', async () => {

--- a/packages/store/src/cli/utilities/store-lookup/organization.ts
+++ b/packages/store/src/cli/utilities/store-lookup/organization.ts
@@ -3,6 +3,7 @@ import {selectOrg, type Organization} from '@shopify/organizations'
 import {AbortError} from '@shopify/cli-kit/node/error'
 import {outputDebug} from '@shopify/cli-kit/node/output'
 import {terminalSupportsPrompting} from '@shopify/cli-kit/node/system'
+import {renderInfo} from '@shopify/cli-kit/node/ui'
 
 interface FindStoreOwningOrganizationOptions {
   store: string
@@ -54,6 +55,13 @@ export async function resolveOrganizationForStore(store: string, organizationId?
       'Provide `--organization-id`, for example `--organization-id 1234567`. Run `shopify organization list` to find IDs.',
     )
   }
+
+  // The developer only gave a store domain, so explain why they're suddenly being asked to
+  // pick an organization. Echoing the domain back also makes a typo in it easy to spot.
+  renderInfo({
+    headline: `Could not determine which organization owns ${store}.`,
+    body: ['Select one below, or specify it with', {command: '--organization-id'}, {char: '.'}],
+  })
 
   return selectOrg()
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Follow-up to a discussion with @nickwesselman on `shopify store delete`.

When you pass only `--store`, the command infers the owning organization from the Destinations API and, if that inference comes up empty, silently drops you into an organization picker. The picker says nothing about why it appeared, so a typo'd domain looks exactly like a store the CLI legitimately can't see.

The non-interactive path already explains itself (`Could not determine which organization owns …` + a `--organization-id` next step); the interactive path just prompts.

Requiring `--organization-id` unconditionally would remove the ambiguity but is burdensome day to day, and the picker is not dead weight — it's the only way through for several real cases:

- **You own the org but aren't a staff user on the store.** Destination visibility needs an active `shop_users` row for *you*; delete permission only needs org ownership. A dev store a teammate created is invisible to your destinations search yet perfectly deletable — not exotic on a team org.
- **Inactive stores.** The destinations search defaults to `status: active`, while the delete's own lookup has no status filter, so a paused or frozen dev store is unfindable but still addressable.
- **Transient failures.** The inference swallows all errors and returns `undefined`, so any Business Platform hiccup lands you in the picker on a store that would have deleted fine.

You can't cheaply tell a typo from an org owner without shop access, so rather than guessing, say *why* you're being asked.

### WHAT is this pull request doing?

Renders an info banner before the organization picker, naming the domain you typed:

```
╭─ info ───────────────────────────────────────────────────────────────────────╮
│                                                                              │
│  Could not determine which organization owns shop.myshopify.com.             │
│                                                                              │
│  Select one below, or specify it with `--organization-id`.                   │
│                                                                              │
╰──────────────────────────────────────────────────────────────────────────────╯
```

Echoing the domain back covers the typo case, and the `--organization-id` pointer covers the people who hit this repeatedly. `packages/store/src/cli/utilities/store-lookup/organization.ts` is the only place that needs to change — the banner sits with the prompt it explains, matching the pattern used for the empty-organization notice in `app dev`. Nothing changes for the `--organization-id`, successful-inference, or non-interactive paths.

The banner renders at info level, which goes to stderr, so `--json` output on stdout is unaffected.

### How to test your changes?

1. `shopify store delete --store some-store-that-does-not-existzzz.myshopify.com`
2. The banner appears above the organization picker, naming the domain you passed.
3. `shopify store delete --store <a store you own> --force` — no banner, inference still resolves the org directly.

### Post-release steps

None.

### Measuring impact

- [x] n/a - this doesn't need measurement, e.g. minor cleanup
