### PR TITLE
Allow filtering `store list` by store type

### DIFF
--- a/.changeset/store-list-filter-by-store-type.md
+++ b/.changeset/store-list-filter-by-store-type.md
@@ -1,0 +1,5 @@
+---
+'@shopify/store': minor
+---
+
+Add `store list --type` to list only dev, production, client transfer, or collaborator stores

--- a/docs-shopify.dev/generated/generated_docs_data_v2.json
+++ b/docs-shopify.dev/generated/generated_docs_data_v2.json
@@ -5359,6 +5359,15 @@
         {
           "filePath": "docs-shopify.dev/commands/interfaces/store-list.interface.ts",
           "syntaxKind": "PropertySignature",
+          "name": "--type <value>",
+          "value": "string",
+          "description": "List only stores of this type.",
+          "isOptional": true,
+          "environmentValue": "SHOPIFY_FLAG_STORE_TYPE"
+        },
+        {
+          "filePath": "docs-shopify.dev/commands/interfaces/store-list.interface.ts",
+          "syntaxKind": "PropertySignature",
           "name": "--verbose",
           "value": "''",
           "description": "Increase the verbosity of the output. May include sensitive data.",
@@ -5375,7 +5384,7 @@
           "environmentValue": "SHOPIFY_FLAG_JSON"
         }
       ],
-      "value": "export interface storelist {\n  /**\n   * Output the result as JSON. Automatically disables color output.\n   * @environment SHOPIFY_FLAG_JSON\n   */\n  '-j, --json'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The numeric organization ID. Auto-selects if you belong to a single organization. Required if non interactive when more than one organization is available.\n   * @environment SHOPIFY_FLAG_ORGANIZATION_ID\n   */\n  '--organization-id <value>'?: string\n\n  /**\n   * Increase the verbosity of the output. May include sensitive data.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
+      "value": "export interface storelist {\n  /**\n   * Output the result as JSON. Automatically disables color output.\n   * @environment SHOPIFY_FLAG_JSON\n   */\n  '-j, --json'?: ''\n\n  /**\n   * Disable color output.\n   * @environment SHOPIFY_FLAG_NO_COLOR\n   */\n  '--no-color'?: ''\n\n  /**\n   * The numeric organization ID. Auto-selects if you belong to a single organization. Required if non interactive when more than one organization is available.\n   * @environment SHOPIFY_FLAG_ORGANIZATION_ID\n   */\n  '--organization-id <value>'?: string\n\n  /**\n   * List only stores of this type.\n   * @environment SHOPIFY_FLAG_STORE_TYPE\n   */\n  '--type <value>'?: string\n\n  /**\n   * Increase the verbosity of the output. May include sensitive data.\n   * @environment SHOPIFY_FLAG_VERBOSE\n   */\n  '--verbose'?: ''\n}"
     }
   },
   "storeopen": {

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -3872,7 +3872,8 @@ List stores in a Shopify organization.
 
 ```
 USAGE
-  $ shopify store list [-j] [--no-color] [--organization-id <value>] [--verbose]
+  $ shopify store list [-j] [--no-color] [--organization-id <value>] [--type
+    dev|production|client_transfer|collaborator] [--verbose]
 
 FLAGS
   -j, --json
@@ -3887,6 +3888,11 @@ FLAGS
       The numeric organization ID. Auto-selects if you belong to a single organization. Required if non interactive when
       more than one organization is available.
       [env: SHOPIFY_FLAG_ORGANIZATION_ID]
+
+  --type=<option>
+      List only stores of this type.
+      [env: SHOPIFY_FLAG_STORE_TYPE]
+      <options: dev|production|client_transfer|collaborator>
 
   --verbose
       Increase the verbosity of the output. May include sensitive data.
@@ -3906,6 +3912,8 @@ EXAMPLES
   $ shopify store list
 
   $ shopify store list --organization-id 1234567
+
+  $ shopify store list --type dev
 
   $ shopify store list --json
 ```

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -7993,6 +7993,7 @@
       "examples": [
         "<%= config.bin %> <%= command.id %>",
         "<%= config.bin %> <%= command.id %> --organization-id 1234567",
+        "<%= config.bin %> <%= command.id %> --type dev",
         "<%= config.bin %> <%= command.id %> --json"
       ],
       "flags": {
@@ -8019,6 +8020,20 @@
           "hasDynamicHelp": false,
           "multiple": false,
           "name": "organization-id",
+          "type": "option"
+        },
+        "type": {
+          "description": "List only stores of this type.",
+          "env": "SHOPIFY_FLAG_STORE_TYPE",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "name": "type",
+          "options": [
+            "dev",
+            "production",
+            "client_transfer",
+            "collaborator"
+          ],
           "type": "option"
         },
         "verbose": {

--- a/packages/store/src/cli/api/graphql/business-platform-organizations/generated/list_accessible_shops.ts
+++ b/packages/store/src/cli/api/graphql/business-platform-organizations/generated/list_accessible_shops.ts
@@ -5,6 +5,7 @@ import {TypedDocumentNode as DocumentNode} from '@graphql-typed-document-node/co
 
 export type ListAccessibleShopsQueryVariables = Types.Exact<{
   first: Types.Scalars['Int']['input']
+  filters?: Types.InputMaybe<Types.ShopFilterInput[] | Types.ShopFilterInput>
 }>
 
 export type ListAccessibleShopsQuery = {
@@ -42,6 +43,14 @@ export const ListAccessibleShops = {
           variable: {kind: 'Variable', name: {kind: 'Name', value: 'first'}},
           type: {kind: 'NonNullType', type: {kind: 'NamedType', name: {kind: 'Name', value: 'Int'}}},
         },
+        {
+          kind: 'VariableDefinition',
+          variable: {kind: 'Variable', name: {kind: 'Name', value: 'filters'}},
+          type: {
+            kind: 'ListType',
+            type: {kind: 'NonNullType', type: {kind: 'NamedType', name: {kind: 'Name', value: 'ShopFilterInput'}}},
+          },
+        },
       ],
       selectionSet: {
         kind: 'SelectionSet',
@@ -71,31 +80,7 @@ export const ListAccessibleShops = {
                     {
                       kind: 'Argument',
                       name: {kind: 'Name', value: 'filters'},
-                      value: {
-                        kind: 'ListValue',
-                        values: [
-                          {
-                            kind: 'ObjectValue',
-                            fields: [
-                              {
-                                kind: 'ObjectField',
-                                name: {kind: 'Name', value: 'field'},
-                                value: {kind: 'EnumValue', value: 'STORE_STATUS'},
-                              },
-                              {
-                                kind: 'ObjectField',
-                                name: {kind: 'Name', value: 'operator'},
-                                value: {kind: 'EnumValue', value: 'EQUALS'},
-                              },
-                              {
-                                kind: 'ObjectField',
-                                name: {kind: 'Name', value: 'value'},
-                                value: {kind: 'StringValue', value: 'active', block: false},
-                              },
-                            ],
-                          },
-                        ],
-                      },
+                      value: {kind: 'Variable', name: {kind: 'Name', value: 'filters'}},
                     },
                   ],
                   selectionSet: {

--- a/packages/store/src/cli/api/graphql/business-platform-organizations/generated/types.d.ts
+++ b/packages/store/src/cli/api/graphql/business-platform-organizations/generated/types.d.ts
@@ -91,6 +91,62 @@ export type Scalars = {
   URL: { input: string; output: string; }
 };
 
+/** Operators for filter queries. */
+export type Operator =
+  /** Between operator. */
+  | 'BETWEEN'
+  /** Equals operator. */
+  | 'EQUALS'
+  /**
+   * In operator. Accepts a comma-separated string of values (e.g.
+   * "value1,value2,value3"). Not supported for all filter fields.
+   */
+  | 'IN';
+
+/** Field options for filtering shop queries. */
+export type ShopFilterField =
+  /**
+   * The phase of the client transfer process. Requires
+   * `store_type=client_transfer`. Values: `in_development`, `pending`, `completed`.
+   */
+  | 'CLIENT_TRANSFER_PHASE'
+  /**
+   * The status of the collaborator relationship. Requires
+   * `store_type=collaborator`. Values: `active`, `access_pending`, `expired`.
+   */
+  | 'COLLABORATOR_RELATIONSHIP_STATUS'
+  /** The GID of the counterpart organization. Requires `store_type=client_transfer` or `store_type=collaborator`. */
+  | 'COUNTERPART_ORGANIZATION_ID'
+  /** The GID of the owning organization of the shop. */
+  | 'OWNER_ORGANIZATION_ID'
+  /**
+   * The plan of the shop. Values: `basic`, `grow`, `plus`, `frozen`, `advanced`,
+   * `inactive`, `cancelled`, `client_transfer`, `plus_client_transfer`,
+   * `development_legacy`, `custom`, `fraudulent`, `staff`, `trial`,
+   * `plus_development`, `retail`, `shop_pay_commerce_components`, `non_profit`.
+   * With the `In` operator, use raw plan names (e.g. "professional,shopify_plus").
+   */
+  | 'SHOP_PLAN'
+  /** The active/inactive status of the shop. Values: `active`, `inactive`. */
+  | 'STORE_STATUS'
+  /**
+   * The type of the shop. Does not support the `In` operator. Values:
+   * `development`, `production`, `app_development`, `development_superset`,
+   * `client_transfer`, `collaborator`.
+   */
+  | 'STORE_TYPE';
+
+/**
+ * Represents a single filter option for shop queries. When using the `In`
+ * operator, pass a comma-separated string of values (e.g. "value1,value2").
+ * Maximum 20 values.
+ */
+export type ShopFilterInput = {
+  field: ShopFilterField;
+  operator: Operator;
+  value: Scalars['String']['input'];
+};
+
 export type Store =
   | 'APP_DEVELOPMENT'
   | 'CLIENT_TRANSFER'

--- a/packages/store/src/cli/api/graphql/business-platform-organizations/queries/list_accessible_shops.graphql
+++ b/packages/store/src/cli/api/graphql/business-platform-organizations/queries/list_accessible_shops.graphql
@@ -1,12 +1,8 @@
-query ListAccessibleShops($first: Int!) {
+query ListAccessibleShops($first: Int!, $filters: [ShopFilterInput!]) {
   organization {
     id
     name
-    accessibleShops(
-      first: $first
-      sort: SHOP_CREATED_AT_DESC
-      filters: [{field: STORE_STATUS, operator: EQUALS, value: "active"}]
-    ) {
+    accessibleShops(first: $first, sort: SHOP_CREATED_AT_DESC, filters: $filters) {
       edges {
         node {
           id

--- a/packages/store/src/cli/commands/store/list.test.ts
+++ b/packages/store/src/cli/commands/store/list.test.ts
@@ -13,7 +13,7 @@ describe('store list command', () => {
 
     await StoreList.run([])
 
-    expect(listStores).toHaveBeenCalledWith({organizationId: undefined})
+    expect(listStores).toHaveBeenCalledWith({organizationId: undefined, storeType: undefined})
     expect(writeStoreListResult).toHaveBeenCalledWith({stores: [], source: 'organization'}, 'text')
   })
 
@@ -22,7 +22,15 @@ describe('store list command', () => {
 
     await StoreList.run(['--organization-id', '1234567'])
 
-    expect(listStores).toHaveBeenCalledWith({organizationId: 1234567})
+    expect(listStores).toHaveBeenCalledWith({organizationId: 1234567, storeType: undefined})
+  })
+
+  test('passes the store type filter through to the list service', async () => {
+    vi.mocked(listStores).mockResolvedValue({stores: [], source: 'organization'})
+
+    await StoreList.run(['--type', 'client_transfer'])
+
+    expect(listStores).toHaveBeenCalledWith({organizationId: undefined, storeType: 'client_transfer'})
   })
 
   test('writes json output when requested', async () => {
@@ -30,13 +38,14 @@ describe('store list command', () => {
 
     await StoreList.run(['--json'])
 
-    expect(listStores).toHaveBeenCalledWith({organizationId: undefined})
+    expect(listStores).toHaveBeenCalledWith({organizationId: undefined, storeType: undefined})
     expect(writeStoreListResult).toHaveBeenCalledWith({stores: [], source: 'organization'}, 'json')
   })
 
   test('defines the expected flags', () => {
     expect(StoreList.flags.json).toBeDefined()
     expect(StoreList.flags['organization-id']).toBeDefined()
+    expect(StoreList.flags.type?.options).toEqual(['dev', 'production', 'client_transfer', 'collaborator'])
     expect(StoreList.flags).not.toHaveProperty('from')
   })
 })

--- a/packages/store/src/cli/commands/store/list.ts
+++ b/packages/store/src/cli/commands/store/list.ts
@@ -1,5 +1,6 @@
 import {listStores} from '../../services/store/list.js'
 import {writeStoreListResult} from '../../services/store/list/result.js'
+import {storeTypeFilters, type StoreTypeFilter} from '../../services/store/store-type.js'
 import {storeFlags} from '../../flags.js'
 import StoreCommand from '../../utilities/store-command.js'
 import {globalFlags, jsonFlag} from '@shopify/cli-kit/node/cli'
@@ -19,6 +20,7 @@ Run \`<%= config.bin %> organization list\` to find organization IDs.`
   static examples = [
     '<%= config.bin %> <%= command.id %>',
     '<%= config.bin %> <%= command.id %> --organization-id 1234567',
+    '<%= config.bin %> <%= command.id %> --type dev',
     '<%= config.bin %> <%= command.id %> --json',
   ]
 
@@ -29,11 +31,20 @@ Run \`<%= config.bin %> organization list\` to find organization IDs.`
       description: `${storeFlags['organization-id'].description} Required if non interactive when more than one organization is available.`,
       env: 'SHOPIFY_FLAG_ORGANIZATION_ID',
     }),
+    type: Flags.string({
+      description: 'List only stores of this type.',
+      options: storeTypeFilters,
+      env: 'SHOPIFY_FLAG_STORE_TYPE',
+    }),
   }
 
   public async run(): Promise<void> {
     const {flags} = await this.parse(StoreList)
-    const result = await listStores({organizationId: flags['organization-id']})
+    const result = await listStores({
+      organizationId: flags['organization-id'],
+      // oclif validates the value against `storeTypeFilters`, so the cast is safe.
+      storeType: flags.type as StoreTypeFilter | undefined,
+    })
 
     writeStoreListResult(result, flags.json ? 'json' : 'text')
   }

--- a/packages/store/src/cli/services/store/list.test.ts
+++ b/packages/store/src/cli/services/store/list.test.ts
@@ -38,7 +38,11 @@ describe('listStores', () => {
 
     const result = await listStores()
 
-    expect(bpSource.listBusinessPlatformStores).toHaveBeenCalledWith({token: 'bp-token', organization: acme})
+    expect(bpSource.listBusinessPlatformStores).toHaveBeenCalledWith({
+      token: 'bp-token',
+      organization: acme,
+      storeType: undefined,
+    })
     expect(renderAutocompletePrompt).not.toHaveBeenCalled()
     expect(result).toEqual({
       stores: [orgEntry],
@@ -47,13 +51,40 @@ describe('listStores', () => {
     })
   })
 
+  test('passes the requested store type to the source and echoes it in the result', async () => {
+    mockOrganizations([acme])
+    vi.spyOn(bpSource, 'listBusinessPlatformStores').mockResolvedValue({entries: [orgEntry], hasMore: false})
+
+    const result = await listStores({storeType: 'dev'})
+
+    expect(bpSource.listBusinessPlatformStores).toHaveBeenCalledWith({
+      token: 'bp-token',
+      organization: acme,
+      storeType: 'dev',
+    })
+    expect(result.storeType).toBe('dev')
+  })
+
+  test('omits the store type from the result when the listing was not filtered', async () => {
+    mockOrganizations([acme])
+    vi.spyOn(bpSource, 'listBusinessPlatformStores').mockResolvedValue({entries: [orgEntry], hasMore: false})
+
+    const result = await listStores()
+
+    expect(result).not.toHaveProperty('storeType')
+  })
+
   test('uses the requested organization id when provided', async () => {
     mockOrganizations([acme, beta])
     vi.spyOn(bpSource, 'listBusinessPlatformStores').mockResolvedValue({entries: [], hasMore: false})
 
     await listStores({organizationId: 5678})
 
-    expect(bpSource.listBusinessPlatformStores).toHaveBeenCalledWith({token: 'bp-token', organization: beta})
+    expect(bpSource.listBusinessPlatformStores).toHaveBeenCalledWith({
+      token: 'bp-token',
+      organization: beta,
+      storeType: undefined,
+    })
     expect(renderAutocompletePrompt).not.toHaveBeenCalled()
   })
 
@@ -72,7 +103,11 @@ describe('listStores', () => {
         {label: 'Beta', value: '5678'},
       ],
     })
-    expect(bpSource.listBusinessPlatformStores).toHaveBeenCalledWith({token: 'bp-token', organization: beta})
+    expect(bpSource.listBusinessPlatformStores).toHaveBeenCalledWith({
+      token: 'bp-token',
+      organization: beta,
+      storeType: undefined,
+    })
     expect(result.organization).toEqual({id: '5678', name: 'Beta'})
   })
 

--- a/packages/store/src/cli/services/store/list.ts
+++ b/packages/store/src/cli/services/store/list.ts
@@ -1,6 +1,7 @@
 import {listBusinessPlatformStores} from './list/bp-source.js'
 import {STORE_LIST_LIMIT} from './list/constants.js'
 import {type ListStoresResult, type StoreListEntry, type StoreListOrganization} from './list/types.js'
+import {type StoreTypeFilter} from './store-type.js'
 import {AbortError} from '@shopify/cli-kit/node/error'
 import {ensureAuthenticatedBusinessPlatform} from '@shopify/cli-kit/node/session'
 import {isTTY, renderAutocompletePrompt} from '@shopify/cli-kit/node/ui'
@@ -8,6 +9,7 @@ import {fetchOrganizationsWithAccessInfo, type Organization} from '@shopify/orga
 
 interface ListStoresOptions {
   organizationId?: number
+  storeType?: StoreTypeFilter
 }
 
 export async function listStores(options: ListStoresOptions = {}): Promise<ListStoresResult> {
@@ -38,13 +40,18 @@ export async function listStores(options: ListStoresOptions = {}): Promise<ListS
     options.organizationId,
   )
 
-  const result = await listBusinessPlatformStores({token, organization: selectedOrganization})
+  const result = await listBusinessPlatformStores({
+    token,
+    organization: selectedOrganization,
+    storeType: options.storeType,
+  })
   const {stores, truncated} = limitEntries(result.entries, result.hasMore)
 
   return {
     stores,
     source: 'organization',
     organization: storeListOrganization(selectedOrganization),
+    ...(options.storeType ? {storeType: options.storeType} : {}),
     ...(truncated ? {truncated: true} : {}),
   }
 }

--- a/packages/store/src/cli/services/store/list/bp-source.test.ts
+++ b/packages/store/src/cli/services/store/list/bp-source.test.ts
@@ -56,6 +56,8 @@ function latestBusinessPlatformRequestOptions() {
   return requestOptions
 }
 
+const activeStatusFilter = {field: 'STORE_STATUS', operator: 'EQUALS', value: 'active'}
+
 describe('listBusinessPlatformStores', () => {
   beforeEach(() => {
     mockAndCaptureOutput().clear()
@@ -65,11 +67,7 @@ describe('listBusinessPlatformStores', () => {
     vi.mocked(businessPlatformOrganizationsRequestDoc).mockResolvedValue(shopPage())
 
     const result = await listBusinessPlatformStores({token: 'bp-token', organization})
-    const requestOptions = latestBusinessPlatformRequestOptions()
 
-    expect(JSON.stringify(requestOptions.query)).toContain('STORE_STATUS')
-    expect(JSON.stringify(requestOptions.query)).toContain('EQUALS')
-    expect(JSON.stringify(requestOptions.query)).toContain('active')
     expect(result).toEqual({
       entries: [
         {
@@ -86,7 +84,44 @@ describe('listBusinessPlatformStores', () => {
       hasMore: false,
     })
     expect(businessPlatformOrganizationsRequestDoc).toHaveBeenCalledWith(
-      expect.objectContaining({token: 'bp-token', organizationId: '1234', variables: {first: 250}}),
+      expect.objectContaining({
+        token: 'bp-token',
+        organizationId: '1234',
+        variables: {first: 250, filters: [activeStatusFilter]},
+      }),
+    )
+  })
+
+  test('narrows the query to a single store type when one is requested', async () => {
+    vi.mocked(businessPlatformOrganizationsRequestDoc).mockResolvedValue(shopPage())
+
+    await listBusinessPlatformStores({token: 'bp-token', organization, storeType: 'client_transfer'})
+
+    expect(businessPlatformOrganizationsRequestDoc).toHaveBeenCalledWith(
+      expect.objectContaining({
+        variables: {
+          first: 250,
+          filters: [activeStatusFilter, {field: 'STORE_TYPE', operator: 'EQUALS', value: 'client_transfer'}],
+        },
+      }),
+    )
+  })
+
+  // `dev` covers both BP dev store types, and `development_superset` is BP's alias for the pair, so
+  // the filter stays a single query rather than one request per underlying type.
+  test('filters dev stores with the development superset alias', async () => {
+    vi.mocked(businessPlatformOrganizationsRequestDoc).mockResolvedValue(shopPage())
+
+    await listBusinessPlatformStores({token: 'bp-token', organization, storeType: 'dev'})
+
+    expect(businessPlatformOrganizationsRequestDoc).toHaveBeenCalledTimes(1)
+    expect(businessPlatformOrganizationsRequestDoc).toHaveBeenCalledWith(
+      expect.objectContaining({
+        variables: {
+          first: 250,
+          filters: [activeStatusFilter, {field: 'STORE_TYPE', operator: 'EQUALS', value: 'development_superset'}],
+        },
+      }),
     )
   })
 
@@ -151,7 +186,7 @@ describe('listBusinessPlatformStores', () => {
     expect(result.entries.map((entry) => entry.store)).toEqual(['newer.myshopify.com', 'older.myshopify.com'])
     expect(businessPlatformOrganizationsRequestDoc).toHaveBeenCalledTimes(1)
     expect(businessPlatformOrganizationsRequestDoc).toHaveBeenCalledWith(
-      expect.objectContaining({variables: {first: 250}}),
+      expect.objectContaining({variables: {first: 250, filters: [activeStatusFilter]}}),
     )
   })
 

--- a/packages/store/src/cli/services/store/list/bp-source.ts
+++ b/packages/store/src/cli/services/store/list/bp-source.ts
@@ -2,11 +2,12 @@ import {STORE_LIST_LIMIT} from './constants.js'
 import {type StoreListEntry} from './types.js'
 import {businessPlatformTokenRefreshHandler} from '../business-platform.js'
 import {planHandle} from '../plan.js'
-import {storeTypeHandle} from '../store-type.js'
+import {storeTypeFilterValue, storeTypeHandle, type StoreTypeFilter} from '../store-type.js'
 import {
   ListAccessibleShops,
   type ListAccessibleShopsQuery,
 } from '../../../api/graphql/business-platform-organizations/generated/list_accessible_shops.js'
+import {type ShopFilterInput} from '../../../api/graphql/business-platform-organizations/generated/types.js'
 import {businessPlatformOrganizationsRequestDoc} from '@shopify/cli-kit/node/api/business-platform'
 import {extractHost} from '@shopify/cli-kit/common/url'
 import {type Organization} from '@shopify/organizations'
@@ -14,6 +15,7 @@ import {type Organization} from '@shopify/organizations'
 interface ListBusinessPlatformStoresOptions {
   token: string
   organization: Organization
+  storeType?: StoreTypeFilter
 }
 
 interface BusinessPlatformStoreListResult {
@@ -25,7 +27,7 @@ interface BusinessPlatformStoreListResult {
 export async function listBusinessPlatformStores(
   options: ListBusinessPlatformStoresOptions,
 ): Promise<BusinessPlatformStoreListResult> {
-  const {entries, hasMore} = await fetchOrganizationStores(options.token, options.organization)
+  const {entries, hasMore} = await fetchOrganizationStores(options.token, options.organization, options.storeType)
 
   return {
     entries: entries.sort(byCreatedAtDescending),
@@ -38,6 +40,7 @@ export async function listBusinessPlatformStores(
 async function fetchOrganizationStores(
   token: string,
   organization: Organization,
+  storeType: StoreTypeFilter | undefined,
 ): Promise<{entries: StoreListEntry[]; hasMore: boolean}> {
   const unauthorizedHandler = businessPlatformTokenRefreshHandler()
 
@@ -45,7 +48,7 @@ async function fetchOrganizationStores(
     query: ListAccessibleShops,
     token,
     organizationId: organization.id,
-    variables: {first: STORE_LIST_LIMIT},
+    variables: {first: STORE_LIST_LIMIT, filters: shopFilters(storeType)},
     unauthorizedHandler,
   })
 
@@ -59,6 +62,16 @@ async function fetchOrganizationStores(
   }
 
   return {entries, hasMore: accessibleShops.pageInfo.hasNextPage}
+}
+
+function shopFilters(storeType: StoreTypeFilter | undefined): ShopFilterInput[] {
+  const filters: ShopFilterInput[] = [{field: 'STORE_STATUS', operator: 'EQUALS', value: 'active'}]
+
+  if (storeType) {
+    filters.push({field: 'STORE_TYPE', operator: 'EQUALS', value: storeTypeFilterValue(storeType)})
+  }
+
+  return filters
 }
 
 type ShopNode = NonNullable<

--- a/packages/store/src/cli/services/store/list/result.test.ts
+++ b/packages/store/src/cli/services/store/list/result.test.ts
@@ -1,4 +1,5 @@
 import {writeStoreListResult} from './result.js'
+import {storeTypeFilters} from '../store-type.js'
 import {beforeEach, describe, expect, test} from 'vitest'
 import {mockAndCaptureOutput} from '@shopify/cli-kit/node/testing/output'
 
@@ -105,6 +106,52 @@ describe('writeStoreListResult', () => {
     )
 
     expect(trimmedLines(output.info())).toContain('my-shop    My Shop  Dev         May 22, 2026')
+  })
+
+  test('names the active store type filter in the headline', () => {
+    const output = mockAndCaptureOutput()
+
+    writeStoreListResult(
+      {
+        source: 'organization',
+        organization,
+        storeType: 'client_transfer',
+        stores: [
+          {
+            store: 'my-shop.myshopify.com',
+            createdAt: '2026-05-22T00:00:00Z',
+            organizationId: '1234',
+            organizationName: 'Acme',
+            name: 'My Shop',
+            type: 'client_transfer',
+          },
+        ],
+      },
+      'text',
+    )
+
+    expect(output.info()).toContain('Listing client transfer stores.')
+  })
+
+  test('names the active store type filter in the empty state', () => {
+    const output = mockAndCaptureOutput()
+
+    writeStoreListResult({source: 'organization', organization, storeType: 'dev', stores: []}, 'text')
+
+    expect(output.info()).toContain('No dev stores found.')
+  })
+
+  // Every accepted filter has to read as prose, however many underscores a future handle carries.
+  test('humanizes every accepted store type filter', () => {
+    const output = mockAndCaptureOutput()
+
+    for (const storeType of storeTypeFilters) {
+      writeStoreListResult({source: 'organization', organization, storeType, stores: []}, 'text')
+    }
+
+    // Keeps the assertion below from passing vacuously if the filter list is ever emptied.
+    expect(storeTypeFilters.length).toBeGreaterThan(0)
+    expect(output.info()).not.toContain('_')
   })
 
   test('renders the subdomain handle for non-myshopify hosts (local dev)', () => {
@@ -218,6 +265,14 @@ describe('writeStoreListResult', () => {
     })
   })
 
+  test('includes the active store type filter in JSON output', () => {
+    const output = mockAndCaptureOutput()
+
+    writeStoreListResult({source: 'organization', organization, storeType: 'dev', stores: []}, 'json')
+
+    expect(JSON.parse(output.output())).toEqual({stores: [], organization, storeType: 'dev'})
+  })
+
   test('includes unresolved-session notices in JSON output', () => {
     const output = mockAndCaptureOutput()
 
@@ -261,6 +316,31 @@ describe('writeStoreListResult', () => {
     expect(jsonOutput.warn()).toContain('Showing the 250 most recent stores in Acme. More stores exist')
     // The structured truncation flag is part of the JSON document on stdout (prose stays on stderr).
     expect(jsonOutput.output()).toContain('"truncated": true')
+  })
+
+  // The cap applies to the filtered set, so the warning has to say which stores were capped.
+  test('names the active store type filter in the truncation warning', () => {
+    const output = mockAndCaptureOutput()
+
+    writeStoreListResult(
+      {
+        source: 'organization',
+        organization,
+        storeType: 'production',
+        stores: [
+          {
+            store: 'shop.myshopify.com',
+            createdAt: '2026-05-22T00:00:00Z',
+            organizationId: '1234',
+            organizationName: 'Acme',
+          },
+        ],
+        truncated: true,
+      },
+      'text',
+    )
+
+    expect(output.warn()).toContain('Showing the 250 most recent production stores in Acme. More stores exist')
   })
 })
 

--- a/packages/store/src/cli/services/store/list/result.ts
+++ b/packages/store/src/cli/services/store/list/result.ts
@@ -2,7 +2,7 @@ import {STORE_LIST_LIMIT} from './constants.js'
 import {type ListStoresResult, type StoreListEntry, type StoreListOrganization} from './types.js'
 import {extractSubdomain, formatShortDate} from '../display.js'
 import {planLabel} from '../plan.js'
-import {storeTypeLabel} from '../store-type.js'
+import {storeTypeLabel, type StoreTypeFilter} from '../store-type.js'
 import {outputResult, outputWarn} from '@shopify/cli-kit/node/output'
 import {renderInfo, renderTable, type AlertCustomSection, type TokenItem} from '@shopify/cli-kit/node/ui'
 
@@ -27,6 +27,7 @@ export function writeStoreListResult(result: ListStoresResult, format: 'text' | 
         {
           stores: result.stores,
           ...(result.organization ? {organization: result.organization} : {}),
+          ...(result.storeType ? {storeType: result.storeType} : {}),
           ...(result.notice ? {notice: result.notice} : {}),
           ...(result.truncated ? {truncated: true} : {}),
         },
@@ -42,7 +43,13 @@ export function writeStoreListResult(result: ListStoresResult, format: 'text' | 
 
 function truncationWarning(result: ListStoresResult): string {
   const organization = result.organization ? ` in ${result.organization.name}` : ' in this organization'
-  return `Showing the ${STORE_LIST_LIMIT} most recent stores${organization}. More stores exist.`
+  return `Showing the ${STORE_LIST_LIMIT} most recent ${storeNounPhrase(result.storeType)}${organization}. More stores exist.`
+}
+
+// Names what was listed, qualified by the active `--type` filter (`client_transfer` -> `client
+// transfer stores`).
+function storeNounPhrase(storeType: StoreTypeFilter | undefined): string {
+  return storeType ? `${storeType.replaceAll('_', ' ')} stores` : 'stores'
 }
 
 function renderTextResult(result: ListStoresResult): void {
@@ -57,10 +64,11 @@ function renderTextResult(result: ListStoresResult): void {
 }
 
 function textResultHeadline(result: ListStoresResult): string {
-  if (result.stores.length > 0) return 'Listing stores.'
+  const stores = storeNounPhrase(result.storeType)
+  if (result.stores.length > 0) return `Listing ${stores}.`
   // The notice explains on stderr why the session couldn't be resolved; this states the outcome.
-  if (result.notice) return 'No stores were returned for the current CLI session.'
-  return 'No stores found.'
+  if (result.notice) return `No ${stores} were returned for the current CLI session.`
+  return `No ${stores} found.`
 }
 
 function organizationSections(organization: StoreListOrganization | undefined): AlertCustomSection[] {

--- a/packages/store/src/cli/services/store/list/types.ts
+++ b/packages/store/src/cli/services/store/list/types.ts
@@ -1,3 +1,5 @@
+import {type StoreTypeFilter} from '../store-type.js'
+
 export interface StoreListEntry {
   id?: string
   store: string
@@ -18,6 +20,8 @@ export interface ListStoresResult {
   stores: StoreListEntry[]
   source: 'organization'
   organization?: StoreListOrganization
+  // The `--type` filter the listing was narrowed to, echoed back so output can name it.
+  storeType?: StoreTypeFilter
   notice?: string
   truncated?: boolean
 }

--- a/packages/store/src/cli/services/store/store-type.test.ts
+++ b/packages/store/src/cli/services/store/store-type.test.ts
@@ -1,0 +1,45 @@
+import {storeTypeFilters, storeTypeFilterValue, storeTypeHandle, storeTypeLabel} from './store-type.js'
+import {describe, expect, test} from 'vitest'
+
+describe('storeTypeHandle', () => {
+  test('collapses both dev store types, and the superset alias, onto one handle', () => {
+    expect(storeTypeHandle('DEVELOPMENT')).toBe('dev')
+    expect(storeTypeHandle('APP_DEVELOPMENT')).toBe('dev')
+    expect(storeTypeHandle('DEVELOPMENT_SUPERSET')).toBe('dev')
+  })
+
+  test('returns undefined for missing and unrecognized store types', () => {
+    expect(storeTypeHandle(undefined)).toBeUndefined()
+    expect(storeTypeHandle(null)).toBeUndefined()
+    expect(storeTypeHandle('SOMETHING_NEWER_THAN_THE_GENERATED_TYPES')).toBeUndefined()
+  })
+})
+
+describe('storeTypeLabel', () => {
+  test('title-cases a handle and renders a missing one as blank', () => {
+    expect(storeTypeLabel('dev')).toBe('Dev')
+    expect(storeTypeLabel('client_transfer')).toBe('Client Transfer')
+    expect(storeTypeLabel(undefined)).toBe('')
+  })
+})
+
+describe('storeTypeFilterValue', () => {
+  // `dev` has to reach BP as `development_superset`, its alias for "development OR
+  // app_development", or `--type dev` would miss one of the two dev store types.
+  test('maps every accepted filter to its Business Platform STORE_TYPE value', () => {
+    expect(storeTypeFilters.map((filter) => [filter, storeTypeFilterValue(filter)])).toEqual([
+      ['dev', 'development_superset'],
+      ['production', 'production'],
+      ['client_transfer', 'client_transfer'],
+      ['collaborator', 'collaborator'],
+    ])
+  })
+
+  // Every filter has to name a type the listing can render back, so the Type column of a filtered
+  // listing never disagrees with the filter that produced it.
+  test('accepts only handles that store rows can also report', () => {
+    const rowHandles = ['dev', 'production', 'client_transfer', 'collaborator']
+
+    expect(storeTypeFilters.every((filter) => rowHandles.includes(filter))).toBe(true)
+  })
+})

--- a/packages/store/src/cli/services/store/store-type.ts
+++ b/packages/store/src/cli/services/store/store-type.ts
@@ -25,3 +25,24 @@ export function storeTypeHandle(storeType: string | null | undefined): string | 
 export function storeTypeLabel(handle: string | undefined): string {
   return handle ? capitalizeWords(handle) : ''
 }
+
+// The BP `STORE_TYPE` filter value for every public handle `store list --type` accepts. `dev` maps
+// to `development_superset`, BP's alias for "development OR app_development", so one query returns
+// both the legacy partner dev store and the kind `store create dev` makes. `production` is an alias
+// too, folding in the expansion/retail/internal/wholesale/buyer-facing variants. A handle maps to
+// exactly one value because `STORE_TYPE` doesn't support the `In` operator.
+const STORE_TYPE_FILTERS = {
+  dev: 'development_superset',
+  production: 'production',
+  client_transfer: 'client_transfer',
+  collaborator: 'collaborator',
+} as const
+
+export type StoreTypeFilter = keyof typeof STORE_TYPE_FILTERS
+
+// The accepted `--type` values, in the order they appear in help output.
+export const storeTypeFilters = Object.keys(STORE_TYPE_FILTERS) as StoreTypeFilter[]
+
+export function storeTypeFilterValue(filter: StoreTypeFilter): string {
+  return STORE_TYPE_FILTERS[filter]
+}


### PR DESCRIPTION
## What

```
shopify store list --type dev
shopify store list --type production
shopify store list --type client_transfer
shopify store list --type collaborator
```

Values are the public store-type handles the listing **already reports** in its `Type` column and in `--json`, so the filter and the data share one vocabulary and a value read out of `--json` can be passed straight back in.

## Why server-side

The filter goes to Business Platform's `STORE_TYPE` shop filter rather than being applied to the returned rows. That's a correctness fix, not just ergonomics: the listing is capped at 250 stores, so grouping client-side would report "no production stores" for an organization whose matches all sit past the cap.

`filters` moved from a literal in the query document to a `[ShopFilterInput!]` variable to make that possible; the `STORE_STATUS = active` filter is unchanged.

## Output

Filtered listings name the filter in prose, since the 250-cap applies to the filtered set:

- `Listing dev stores.` / `No client transfer stores found.`
- `Showing the 250 most recent production stores in Acme. More stores exist.`
- `--json` gains a `storeType` field when filtered.

## Notes for review

- No back-end work; contained to `list/bp-source.ts`, `list/result.ts`, and the store-type vocabulary in `services/store/store-type.ts`.
- Single-valued on purpose. `--type dev --type production` would need N queries or client-side merging, which reintroduces the cap problem.
- Regenerated: GraphQL types, oclif manifest, README, shopify.dev docs data.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)