### PR TITLE
Fix false success message when CLI self-upgrade installs the wrong version

### DIFF
--- a/.changeset/verify-installed-version-after-upgrade.md
+++ b/.changeset/verify-installed-version-after-upgrade.md
@@ -1,0 +1,6 @@
+---
+'@shopify/cli-kit': patch
+'@shopify/cli': patch
+---
+
+Verify the installed version after `shopify upgrade` and fail instead of reporting a false success when the upgrade didn't complete

--- a/packages/cli-kit/src/public/node/upgrade.test.ts
+++ b/packages/cli-kit/src/public/node/upgrade.test.ts
@@ -1,4 +1,4 @@
-import {isDevelopment} from './context/local.js'
+import {isDevelopment, isUnitTest} from './context/local.js'
 import {currentProcessIsGlobal, inferPackageManagerForGlobalCLI} from './is-global.js'
 import {checkForCachedNewVersion, packageManagerFromUserAgent, PackageManager} from './node-package-manager.js'
 import {exec, isCI} from './system.js'
@@ -10,8 +10,10 @@ import {
   versionToAutoUpgrade,
 } from './upgrade.js'
 import {Notification, fetchNotifications} from './notifications-system.js'
-import {isPreReleaseVersion} from './version.js'
+import {globalCLIVersion, isPreReleaseVersion} from './version.js'
+import {mockAndCaptureOutput} from './testing/output.js'
 import {getAutoUpgradeEnabled} from '../../private/node/conf-store.js'
+import {CLI_KIT_VERSION} from '../common/version.js'
 import {vi, describe, test, expect, beforeEach} from 'vitest'
 
 vi.mock('./notifications-system.js', async (importOriginal) => {
@@ -31,6 +33,7 @@ vi.mock('./version.js', async (importOriginal) => {
   return {
     ...actual,
     isPreReleaseVersion: vi.fn(() => false),
+    globalCLIVersion: vi.fn(),
   }
 })
 
@@ -146,6 +149,12 @@ describe('runCLIUpgrade', () => {
   beforeEach(() => {
     // Mock isDevelopment to return false by default (not in CLI development mode)
     vi.mocked(isDevelopment).mockReturnValue(false)
+    // context/local.js is auto-mocked; restore isUnitTest so rendered banners are collected
+    // by mockAndCaptureOutput instead of printed to the real console.
+    vi.mocked(isUnitTest).mockReturnValue(true)
+    // By default the post-install verification finds the current version installed,
+    // which counts as success when no newer version was cached.
+    vi.mocked(globalCLIVersion).mockResolvedValue(CLI_KIT_VERSION)
   })
 
   test('runs the install command via exec for a global npm install', async () => {
@@ -218,6 +227,63 @@ describe('runCLIUpgrade', () => {
 
     // Then
     expect(exec).not.toHaveBeenCalled()
+  })
+
+  test('reports the verified installed version on success', async () => {
+    // Given
+    vi.mocked(currentProcessIsGlobal).mockReturnValue(true)
+    vi.mocked(inferPackageManagerForGlobalCLI).mockReturnValue('npm')
+    vi.mocked(exec).mockResolvedValue()
+    vi.mocked(checkForCachedNewVersion).mockReturnValue('4.7.1')
+    vi.mocked(globalCLIVersion).mockResolvedValue('4.7.1')
+    const outputMock = mockAndCaptureOutput()
+    outputMock.clear()
+
+    // When
+    await runCLIUpgrade()
+
+    // Then
+    expect(outputMock.info()).toContain("You're now on version 4.7.1")
+  })
+
+  test('throws when the install lands an older version than expected (e.g. a stale private registry)', async () => {
+    // Given
+    vi.mocked(currentProcessIsGlobal).mockReturnValue(true)
+    vi.mocked(inferPackageManagerForGlobalCLI).mockReturnValue('npm')
+    vi.mocked(exec).mockResolvedValue()
+    vi.mocked(checkForCachedNewVersion).mockReturnValue('4.7.1')
+    vi.mocked(globalCLIVersion).mockResolvedValue('3.94.3')
+    const outputMock = mockAndCaptureOutput()
+    outputMock.clear()
+
+    // When/Then
+    await expect(runCLIUpgrade()).rejects.toThrow(
+      'Expected to be on version 4.7.1, but version 3.94.3 is now installed',
+    )
+    expect(outputMock.info()).not.toContain('Shopify CLI upgraded')
+  })
+
+  test('throws when the install leaves the CLI on the current version instead of the expected one', async () => {
+    // Given
+    vi.mocked(currentProcessIsGlobal).mockReturnValue(true)
+    vi.mocked(inferPackageManagerForGlobalCLI).mockReturnValue('npm')
+    vi.mocked(exec).mockResolvedValue()
+    vi.mocked(checkForCachedNewVersion).mockReturnValue('4.7.1')
+    vi.mocked(globalCLIVersion).mockResolvedValue(CLI_KIT_VERSION)
+
+    // When/Then
+    await expect(runCLIUpgrade()).rejects.toThrow(`Expected to be on version 4.7.1, but version ${CLI_KIT_VERSION}`)
+  })
+
+  test('throws when the installed version cannot be verified', async () => {
+    // Given
+    vi.mocked(currentProcessIsGlobal).mockReturnValue(true)
+    vi.mocked(inferPackageManagerForGlobalCLI).mockReturnValue('npm')
+    vi.mocked(exec).mockResolvedValue()
+    vi.mocked(globalCLIVersion).mockResolvedValue(undefined)
+
+    // When/Then
+    await expect(runCLIUpgrade()).rejects.toThrow("Couldn't verify the Shopify CLI version after upgrading")
   })
 })
 

--- a/packages/cli-kit/src/public/node/upgrade.test.ts
+++ b/packages/cli-kit/src/public/node/upgrade.test.ts
@@ -14,6 +14,7 @@ import {globalCLIVersion, isPreReleaseVersion} from './version.js'
 import {mockAndCaptureOutput} from './testing/output.js'
 import {getAutoUpgradeEnabled} from '../../private/node/conf-store.js'
 import {CLI_KIT_VERSION} from '../common/version.js'
+import {SemVer} from 'semver'
 import {vi, describe, test, expect, beforeEach} from 'vitest'
 
 vi.mock('./notifications-system.js', async (importOriginal) => {
@@ -265,14 +266,19 @@ describe('runCLIUpgrade', () => {
 
   test('throws when the install leaves the CLI on the current version instead of the expected one', async () => {
     // Given
+    // Derived from CLI_KIT_VERSION rather than hardcoded, so this keeps exercising the
+    // "the install was a no-op" branch after a release bumps the current version.
+    const expectedVersion = new SemVer(CLI_KIT_VERSION).inc('patch').version
     vi.mocked(currentProcessIsGlobal).mockReturnValue(true)
     vi.mocked(inferPackageManagerForGlobalCLI).mockReturnValue('npm')
     vi.mocked(exec).mockResolvedValue()
-    vi.mocked(checkForCachedNewVersion).mockReturnValue('4.7.1')
+    vi.mocked(checkForCachedNewVersion).mockReturnValue(expectedVersion)
     vi.mocked(globalCLIVersion).mockResolvedValue(CLI_KIT_VERSION)
 
     // When/Then
-    await expect(runCLIUpgrade()).rejects.toThrow(`Expected to be on version 4.7.1, but version ${CLI_KIT_VERSION}`)
+    await expect(runCLIUpgrade()).rejects.toThrow(
+      `Expected to be on version ${expectedVersion}, but version ${CLI_KIT_VERSION} is now installed`,
+    )
   })
 
   test('throws when the installed version cannot be verified', async () => {

--- a/packages/cli-kit/src/public/node/upgrade.ts
+++ b/packages/cli-kit/src/public/node/upgrade.ts
@@ -15,9 +15,11 @@ import {outputContent, outputDebug, outputInfo, outputToken, outputWarn} from '.
 import {renderSuccess} from './ui.js'
 import {cwd, moduleDirectory, sniffForPath} from './path.js'
 import {exec, isCI} from './system.js'
-import {isPreReleaseVersion} from './version.js'
+import {globalCLIVersion, isPreReleaseVersion} from './version.js'
+import {AbortError} from './error.js'
 import {getAutoUpgradeEnabled, setAutoUpgradeEnabled, runAtMinimumInterval} from '../../private/node/conf-store.js'
 import {CLI_KIT_VERSION} from '../common/version.js'
+import {lt as semverLt} from 'semver'
 
 export {getAutoUpgradeEnabled, setAutoUpgradeEnabled}
 
@@ -104,9 +106,29 @@ export async function runCLIUpgrade(options: RunCLIUpgradeOptions = {}): Promise
    Now upgrading by running: ${outputToken.genericShellCommand(installCommand)}...`,
     )
     await exec(command, args, {stdio: 'inherit'})
+
+    // A zero exit code doesn't guarantee the right version landed: the version check above
+    // queries the public npm registry, while the install goes through whatever registry the
+    // user has configured. A private registry with a stale `latest` tag (or one that serves
+    // stale metadata on auth errors) can "successfully" install an outdated version. Verify
+    // what's actually installed before claiming success.
+    const installedVersion = await globalCLIVersion()
+    if (!installedVersion) {
+      throw new AbortError(
+        "Couldn't verify the Shopify CLI version after upgrading.",
+        outputContent`Check the installed version by running ${outputToken.genericShellCommand('shopify version')}.`,
+      )
+    }
+    const expectedVersion = newerVersion ?? CLI_KIT_VERSION
+    if (semverLt(installedVersion, expectedVersion)) {
+      throw new AbortError(
+        `Failed to upgrade Shopify CLI. Expected to be on version ${expectedVersion}, but version ${installedVersion} is now installed.`,
+        'Your package manager may be resolving @shopify/cli from a registry with outdated versions. Check your npm registry configuration and try again.',
+      )
+    }
     renderSuccess({
       headline: 'Shopify CLI upgraded.',
-      body: newerVersion ? `You're now on version ${newerVersion}.` : "You're now on the latest version.",
+      body: `You're now on version ${installedVersion}.`,
     })
   } else if (projectDir) {
     await upgradeLocalShopify(projectDir, CLI_KIT_VERSION)


### PR DESCRIPTION
### WHY are these changes introduced?

A user behind a private npm registry ran the CLI self-update on 4.7.0: the registry (401ing against upstream) resolved a stale `latest` tag, so `npm install -g @shopify/cli@latest` **downgraded** them to 3.94.3 with a zero exit code — while the CLI printed "Shopify CLI upgraded. You're now on version 4.7.1."

Root cause: `runCLIUpgrade` built the success banner from the cached version check (which queries the public npm registry) and trusted the install's exit code, but the install resolves through whatever registry the user's npm config points at. The two can disagree, and the exit code alone doesn't prove the right version landed.

### WHAT is this pull request doing?

In `packages/cli-kit/src/public/node/upgrade.ts`, after the package-manager install completes, verify what was actually installed using the existing `globalCLIVersion()` helper (runs the installed `shopify` binary and parses its version):

- If the installed version is older than expected (the cached newer version, or the current version when none was cached), throw an `AbortError` naming both versions, with a hint that the package manager may be resolving `@shopify/cli` from a registry with outdated versions.
- If the version can't be determined, throw an `AbortError` suggesting `shopify version`.
- On success, the banner reports the **verified** installed version instead of the cached prediction.

The auto-upgrade postrun hook already catches errors from `runCLIUpgrade`, so a failed background upgrade now logs, shows the upgrade reminder, records `env_auto_upgrade_success: false`, and reports to Bugsnag instead of silently claiming success.

Minor wording change: `shopify upgrade` when already up to date now says "You're now on version X." (the verified version) instead of "You're now on the latest version."

### How to test your changes?

1. Unit tests: `pnpm vitest run src/public/node/upgrade.test.ts` in `packages/cli-kit` (new cases cover the downgrade, same-version, unverifiable, and verified-success paths).
2. Manually: with a global install, run `shopify upgrade` normally — the success banner should show the actual installed version. To simulate the failure, point npm at a registry serving an older `@shopify/cli` (`npm config set registry ...`) and run `shopify upgrade` — it should abort with "Failed to upgrade Shopify CLI. Expected to be on version X, but version Y is now installed." instead of a success banner.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [x] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

🤖 Generated with [Claude Code](https://claude.com/claude-code)