### PR TITLE
[Refactor] Simplify control flow in getListOfTunnelPlugins

### DIFF
--- a/packages/cli-kit/src/public/node/plugins.ts
+++ b/packages/cli-kit/src/public/node/plugins.ts
@@ -85,7 +85,12 @@ export type FanoutHookFunction<
 export async function getListOfTunnelPlugins(config: Config): Promise<{plugins: string[]; error?: string}> {
   const hooks = await fanoutHooks(config, 'tunnel_provider', {})
   const names = getArrayRejectingUndefined(Object.values(hooks).map((key) => key?.name))
-  if (getArrayContainsDuplicates(names)) return {plugins: names, error: 'multiple-plugins-for-provider'}
+  const hasDuplicates = getArrayContainsDuplicates(names)
+
+  if (hasDuplicates) {
+    return {plugins: names, error: 'multiple-plugins-for-provider'}
+  }
+
   return {plugins: names}
 }
 


### PR DESCRIPTION
### WHAT is this pull request doing?

Refactors `getListOfTunnelPlugins` in `packages/cli-kit/src/public/node/plugins.ts` to improve control flow clarity by extracting duplicate check result to `hasDuplicates` variable and using explicit block guard clause.

### How to test your changes?

CI


---
*PR created automatically by Jules for task [15801288451020594469](https://jules.google.com/task/15801288451020594469) started by @gonzaloriestra*