### PR TITLE
[Refactor] Use Object.entries().find() in findSessionByAlias

### DIFF
--- a/packages/cli-kit/src/private/node/session/store.ts
+++ b/packages/cli-kit/src/private/node/session/store.ts
@@ -97,11 +97,8 @@ export async function findSessionByAlias(alias: string): Promise<string | undefi
   const fqdnSessions = sessions[fqdn]
   if (!fqdnSessions) return undefined
 
-  for (const [userId, session] of Object.entries(fqdnSessions)) {
-    if (session.identity.alias === alias || userId === alias) {
-      return userId
-    }
-  }
-
-  return undefined
+  const entry = Object.entries(fqdnSessions).find(
+    ([userId, session]) => session.identity.alias === alias || userId === alias,
+  )
+  return entry?.[0]
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Refactoring imperative loop in `findSessionByAlias` to be more declarative and maintainable.

### WHAT is this pull request doing?

Refactored `findSessionByAlias` in `packages/cli-kit/src/private/node/session/store.ts` to replace the imperative `for...of` loop over `Object.entries(fqdnSessions)` with a declarative `Object.entries().find()` lookup.

### How to test your changes?

CI

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [5743815147111530594](https://jules.google.com/task/5743815147111530594) started by @gonzaloriestra*