### PR TITLE
[Security] Prevent option injection in removeGitRemote

### DIFF
--- a/packages/cli-kit/src/public/node/git.test.ts
+++ b/packages/cli-kit/src/public/node/git.test.ts
@@ -546,4 +546,14 @@ describe('removeGitRemote()', () => {
     expect(mockedExeca).toHaveBeenCalledWith('git', ['remote'], {cwd: directory})
     expect(mockedExeca).not.toHaveBeenCalledWith('git', ['remote', 'remove', remoteName], {cwd: directory})
   })
+
+  test('throws an error if remoteName starts with a hyphen', async () => {
+    const directory = '/test/directory'
+    const remoteName = '-invalid-remote'
+
+    await expect(git.removeGitRemote(directory, remoteName)).rejects.toThrowError(
+      /Invalid remote name: -invalid-remote. Remote names can't start with a hyphen./,
+    )
+    expect(mockedExeca).not.toHaveBeenCalled()
+  })
 })

--- a/packages/cli-kit/src/public/node/git.ts
+++ b/packages/cli-kit/src/public/node/git.ts
@@ -435,6 +435,11 @@ export async function getLatestTag(directory?: string): Promise<string | undefin
  * @returns A promise that resolves when the remote is removed.
  */
 export async function removeGitRemote(directory: string, remoteName = 'origin'): Promise<void> {
+  // Guard against option injection attacks if remoteName starts with '-'
+  if (remoteName.startsWith('-')) {
+    throw new AbortError(`Invalid remote name: ${remoteName}. Remote names can't start with a hyphen.`)
+  }
+
   outputDebug(outputContent`Removing git remote ${remoteName} from ${outputToken.path(directory)}...`)
   await ensureGitIsPresentOrAbort()
 


### PR DESCRIPTION
### WHY are these changes introduced?

This change hardens `removeGitRemote` against argument and option injection vulnerabilities when removing Git remotes.

### WHAT is this pull request doing?

Validates that `remoteName` passed to `removeGitRemote` does not start with a hyphen (`-`). If it does, an `AbortError` is thrown before calling git.

### How to test your changes?

CI

### Post-release steps

None

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [3642178902839292857](https://jules.google.com/task/3642178902839292857) started by @gonzaloriestra*