### PR TITLE
[Tests] Add unit tests for throttle utility

### DIFF
--- a/packages/cli-kit/src/public/common/function.test.ts
+++ b/packages/cli-kit/src/public/common/function.test.ts
@@ -1,5 +1,5 @@
-import {debounce, memoize} from './function.js'
-import {describe, test, expect} from 'vitest'
+import {debounce, memoize, throttle} from './function.js'
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
 
 describe('memoize', () => {
   test('memoizes the function value', () => {
@@ -33,5 +33,35 @@ describe('debounce', () => {
 
     // Then
     expect(value).toEqual(1)
+  })
+})
+
+describe('throttle', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  test('throttles function executions over time', () => {
+    // Given
+    let count = 0
+    const throttled = throttle(() => {
+      count += 1
+    }, 100)
+
+    // When
+    throttled()
+    throttled()
+    throttled()
+
+    // Then
+    expect(count).toBe(1)
+
+    // Advance time past the wait interval
+    vi.advanceTimersByTime(100)
+    expect(count).toBe(2)
   })
 })


### PR DESCRIPTION
Added unit tests for the `throttle` function in `packages/cli-kit/src/public/common/function.test.ts` to cover rate-limiting function calls using Vitest fake timers.

---
*PR created automatically by Jules for task [15444565716592839597](https://jules.google.com/task/15444565716592839597) started by @gonzaloriestra*