### PR TITLE
[Tests] Add unit tests for groupBy and partition

### DIFF
--- a/packages/cli-kit/src/public/common/collection.test.ts
+++ b/packages/cli-kit/src/public/common/collection.test.ts
@@ -20,6 +20,19 @@ describe('groupBy', () => {
       Barcelona: [{city: 'Barcelona', name: 'User3'}],
     })
   })
+
+  test('groups elements using a function iteratee', () => {
+    expect(groupBy([6.1, 4.2, 6.3], Math.floor)).toEqual({
+      '4': [4.2],
+      '6': [6.1, 6.3],
+    })
+  })
+
+  test('handles empty, null, or undefined collection', () => {
+    expect(groupBy([], 'city')).toEqual({})
+    expect(groupBy(null, 'city')).toEqual({})
+    expect(groupBy(undefined, 'city')).toEqual({})
+  })
 })
 
 describe('partition', () => {
@@ -42,5 +55,11 @@ describe('partition', () => {
         {user: 'pebbles', age: 1, active: false},
       ],
     ])
+  })
+
+  test('handles empty, null, or undefined collection', () => {
+    expect(partition([], () => true)).toEqual([[], []])
+    expect(partition(null, () => true)).toEqual([[], []])
+    expect(partition(undefined, () => true)).toEqual([[], []])
   })
 })


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #0000

Increases test coverage and confidence for collection utility functions (`groupBy` and `partition`) in `@shopify/cli-kit`.

### WHAT is this pull request doing?

Adds unit tests in `packages/cli-kit/src/public/common/collection.test.ts` covering:
- `groupBy` with custom function iteratees.
- `groupBy` handling of empty array, `null`, and `undefined` inputs.
- `partition` handling of empty array, `null`, and `undefined` inputs.

### How to test your changes?

CI

### Post-release steps

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [16635636750787613929](https://jules.google.com/task/16635636750787613929) started by @gonzaloriestra*