### PR TITLE
Fix text prompt underlines in Windows consoles

### DIFF
--- a/.changeset/windows-prompt-underline.md
+++ b/.changeset/windows-prompt-underline.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': patch
+---
+
+Fix text prompt underlines rendering as unsupported characters in Windows consoles.

--- a/packages/cli-kit/src/private/node/ui/components/DangerousConfirmationPrompt.test.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/DangerousConfirmationPrompt.test.tsx
@@ -1,14 +1,37 @@
 import {DangerousConfirmationPrompt} from './DangerousConfirmationPrompt.js'
 import {getLastFrameAfterUnmount, sendInputAndWaitForChange, waitForInputsToBeReady, render} from '../../testing/ui.js'
 import {unstyled} from '../../../../public/node/output.js'
+import colors from '../../../../public/node/colors.js'
+import {platformAndArch} from '../../../../public/node/os.js'
 import React from 'react'
 
-import {describe, expect, test, vi} from 'vitest'
+import {beforeEach, describe, expect, test, vi} from 'vitest'
+
+vi.mock('../../../../public/node/os.js')
+
+beforeEach(() => {
+  vi.mocked(platformAndArch).mockReturnValue({platform: 'darwin', arch: 'arm64'})
+})
 
 const ENTER = '\r'
 const ESC = '\x1b'
 
 describe('DangerousConfirmationPrompt', () => {
+  test.each(['windows', 'darwin', 'linux'] as const)('renders the underline on %s', async (platform) => {
+    vi.mocked(platformAndArch).mockReturnValue({platform, arch: 'amd64'})
+    const renderInstance = render(
+      <DangerousConfirmationPrompt onSubmit={() => {}} message="Test question" confirmation="yes" />,
+    )
+    const underline = (platform === 'windows' ? '─' : '▔').repeat(77)
+
+    expect(renderInstance.lastFrame()).toContain(colors.cyan(underline))
+
+    await waitForInputsToBeReady()
+    await sendInputAndWaitForChange(renderInstance, ENTER)
+
+    expect(renderInstance.lastFrame()).toContain(colors.red(underline))
+  })
+
   test('default state', () => {
     const {lastFrame} = render(
       <DangerousConfirmationPrompt onSubmit={() => {}} message="Test question" confirmation="yes" />,
@@ -19,7 +42,7 @@ describe('DangerousConfirmationPrompt', () => {
 
          Type yes to confirm, or press Escape to cancel.
       >  █
-         ─────────────────────────────────────────────────────────────────────────────
+         ▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔
       "
     `)
   })
@@ -37,7 +60,7 @@ describe('DangerousConfirmationPrompt', () => {
 
          Type [36myes[39m to confirm, or press Escape to cancel.
       [31m>[39m  [31m[41m█[49m[39m
-         [31m─────────────────────────────────────────────────────────────────────────────[39m
+         [31m▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔[39m
          [31mValue must be exactly [36myes[39m
       "
     `)
@@ -48,7 +71,7 @@ describe('DangerousConfirmationPrompt', () => {
 
          Type [36myes[39m to confirm, or press Escape to cancel.
       [36m>[39m  [36mA[46m█[49m[39m
-         [36m─────────────────────────────────────────────────────────────────────────────[39m
+         [36m▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔[39m
       "
     `)
   })
@@ -86,7 +109,7 @@ describe('DangerousConfirmationPrompt', () => {
          Type [36myes[39m to confirm, or press Escape to cancel.
       [36m>[39m  [36mAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA[39m
          [36mBBBBBB[46m█[49m[39m
-         [36m─────────────────────────────────────────────────────────────────────────────[39m
+         [36m▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔[39m
       "
     `)
   })
@@ -101,7 +124,7 @@ describe('DangerousConfirmationPrompt', () => {
 
          Type yes to confirm, or press Escape to cancel.
       >  █
-         ─────────────────────────────────────────────────────────────────────────────
+         ▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔
       "
     `)
   })

--- a/packages/cli-kit/src/private/node/ui/components/DangerousConfirmationPrompt.test.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/DangerousConfirmationPrompt.test.tsx
@@ -19,7 +19,7 @@ describe('DangerousConfirmationPrompt', () => {
 
          Type yes to confirm, or press Escape to cancel.
       >  █
-         ▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔
+         ─────────────────────────────────────────────────────────────────────────────
       "
     `)
   })
@@ -37,7 +37,7 @@ describe('DangerousConfirmationPrompt', () => {
 
          Type [36myes[39m to confirm, or press Escape to cancel.
       [31m>[39m  [31m[41m█[49m[39m
-         [31m▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔[39m
+         [31m─────────────────────────────────────────────────────────────────────────────[39m
          [31mValue must be exactly [36myes[39m
       "
     `)
@@ -48,7 +48,7 @@ describe('DangerousConfirmationPrompt', () => {
 
          Type [36myes[39m to confirm, or press Escape to cancel.
       [36m>[39m  [36mA[46m█[49m[39m
-         [36m▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔[39m
+         [36m─────────────────────────────────────────────────────────────────────────────[39m
       "
     `)
   })
@@ -86,7 +86,7 @@ describe('DangerousConfirmationPrompt', () => {
          Type [36myes[39m to confirm, or press Escape to cancel.
       [36m>[39m  [36mAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA[39m
          [36mBBBBBB[46m█[49m[39m
-         [36m▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔[39m
+         [36m─────────────────────────────────────────────────────────────────────────────[39m
       "
     `)
   })
@@ -101,7 +101,7 @@ describe('DangerousConfirmationPrompt', () => {
 
          Type yes to confirm, or press Escape to cancel.
       >  █
-         ▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔
+         ─────────────────────────────────────────────────────────────────────────────
       "
     `)
   })

--- a/packages/cli-kit/src/private/node/ui/components/DangerousConfirmationPrompt.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/DangerousConfirmationPrompt.tsx
@@ -44,7 +44,6 @@ const DangerousConfirmationPrompt: FunctionComponent<DangerousConfirmationPrompt
   const complete = useComplete()
   const [error, setError] = useState<TokenItem<InlineToken> | undefined>(undefined)
   const color = promptState === PromptState.Error ? 'red' : 'cyan'
-  const underline = new Array(oneThird - 3).fill('▔')
   const {isAborted} = useAbortSignal(abortSignal)
 
   useInput((input, key) => {
@@ -133,9 +132,14 @@ const DangerousConfirmationPrompt: FunctionComponent<DangerousConfirmationPrompt
                 />
               </Box>
             </Box>
-            <Box marginLeft={3}>
-              <Text color={color}>{underline}</Text>
-            </Box>
+            <Box
+              marginLeft={3}
+              borderStyle="single"
+              borderColor={color}
+              borderBottom={false}
+              borderLeft={false}
+              borderRight={false}
+            />
             {promptState === PromptState.Error && error ? (
               <Box marginLeft={3}>
                 <Text color={color}>

--- a/packages/cli-kit/src/private/node/ui/components/DangerousConfirmationPrompt.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/DangerousConfirmationPrompt.tsx
@@ -5,6 +5,7 @@ import {handleCtrlC, useComplete} from '../../ui.js'
 import useLayout from '../hooks/use-layout.js'
 import {messageWithPunctuation} from '../utilities.js'
 import {AbortSignal} from '../../../../public/node/abort.js'
+import {platformAndArch} from '../../../../public/node/os.js'
 import useAbortSignal from '../hooks/use-abort-signal.js'
 import usePrompt, {PromptState} from '../hooks/use-prompt.js'
 
@@ -132,14 +133,20 @@ const DangerousConfirmationPrompt: FunctionComponent<DangerousConfirmationPrompt
                 />
               </Box>
             </Box>
-            <Box
-              marginLeft={3}
-              borderStyle="single"
-              borderColor={color}
-              borderBottom={false}
-              borderLeft={false}
-              borderRight={false}
-            />
+            {platformAndArch().platform === 'windows' ? (
+              <Box
+                marginLeft={3}
+                borderStyle="single"
+                borderColor={color}
+                borderBottom={false}
+                borderLeft={false}
+                borderRight={false}
+              />
+            ) : (
+              <Box marginLeft={3}>
+                <Text color={color}>{'▔'.repeat(oneThird - 3)}</Text>
+              </Box>
+            )}
             {promptState === PromptState.Error && error ? (
               <Box marginLeft={3}>
                 <Text color={color}>

--- a/packages/cli-kit/src/private/node/ui/components/TextPrompt.test.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/TextPrompt.test.tsx
@@ -3,20 +3,40 @@ import {getLastFrameAfterUnmount, sendInputAndWaitForChange, waitForInputsToBeRe
 import {unstyled} from '../../../../public/node/output.js'
 import {AbortController} from '../../../../public/node/abort.js'
 import colors from '../../../../public/node/colors.js'
+import {platformAndArch} from '../../../../public/node/os.js'
 import React from 'react'
 
-import {describe, expect, test, vi} from 'vitest'
+import {beforeEach, describe, expect, test, vi} from 'vitest'
+
+vi.mock('../../../../public/node/os.js')
+
+beforeEach(() => {
+  vi.mocked(platformAndArch).mockReturnValue({platform: 'darwin', arch: 'arm64'})
+})
 
 const ENTER = '\r'
 
 describe('TextPrompt', () => {
+  test.each(['windows', 'darwin', 'linux'] as const)('renders the underline on %s', async (platform) => {
+    vi.mocked(platformAndArch).mockReturnValue({platform, arch: 'amd64'})
+    const renderInstance = render(<TextPrompt onSubmit={() => {}} message="Test question" />)
+    const underline = (platform === 'windows' ? '─' : '▔').repeat(77)
+
+    expect(renderInstance.lastFrame()).toContain(colors.cyan(underline))
+
+    await waitForInputsToBeReady()
+    await sendInputAndWaitForChange(renderInstance, ENTER)
+
+    expect(renderInstance.lastFrame()).toContain(colors.red(underline))
+  })
+
   test('default state', () => {
     const {lastFrame} = render(<TextPrompt onSubmit={() => {}} message="Test question" defaultValue="Placeholder" />)
 
     expect(unstyled(lastFrame()!)).toMatchInlineSnapshot(`
       "?  Test question:
       >  Placeholder
-         ─────────────────────────────────────────────────────────────────────────────
+         ▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔
       "
     `)
   })
@@ -30,7 +50,7 @@ describe('TextPrompt', () => {
     expect(renderInstance.lastFrame()).toMatchInlineSnapshot(`
       "?  Test question:
       [31m>[39m  [31m[41m█[49m[39m
-         [31m─────────────────────────────────────────────────────────────────────────────[39m
+         [31m▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔[39m
          [31mType an answer to the prompt.[39m
       "
     `)
@@ -39,7 +59,7 @@ describe('TextPrompt', () => {
     expect(renderInstance.lastFrame()).toMatchInlineSnapshot(`
       "?  Test question:
       [36m>[39m  [36mA[46m█[49m[39m
-         [36m─────────────────────────────────────────────────────────────────────────────[39m
+         [36m▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔[39m
       "
     `)
   })
@@ -60,7 +80,7 @@ describe('TextPrompt', () => {
     expect(renderInstance.lastFrame()).toMatchInlineSnapshot(`
       "?  Test question:
       [31m>[39m  [31mthis-test-includes-shopify[41m█[49m[39m
-         [31m─────────────────────────────────────────────────────────────────────────────[39m
+         [31m▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔[39m
          [31mApp name can't include the word shopify[39m
       "
     `)
@@ -145,7 +165,7 @@ describe('TextPrompt', () => {
       "?  Test question:
       [36m>[39m  [36mAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA[39m
          [36mBBBBBB[46m█[49m[39m
-         [36m─────────────────────────────────────────────────────────────────────────────[39m
+         [36m▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔[39m
       "
     `)
   })
@@ -158,7 +178,7 @@ describe('TextPrompt', () => {
     expect(renderInstance.lastFrame()).toMatchInlineSnapshot(`
       "?  Test question:
       [36m>[39m  [36m***[46m█[49m[39m
-         [36m─────────────────────────────────────────────────────────────────────────────[39m
+         [36m▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔[39m
       "
     `)
 
@@ -176,7 +196,7 @@ describe('TextPrompt', () => {
     expect(lastFrame()!).toMatchInlineSnapshot(`
       "?  Test question?
       [36m>[39m  [36m[46m█[49m[39m
-         [36m─────────────────────────────────────────────────────────────────────────────[39m
+         [36m▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔[39m
       "
     `)
   })
@@ -223,7 +243,7 @@ describe('TextPrompt', () => {
     expect(renderInstance.lastFrame()).toMatchInlineSnapshot(`
       "?  How tall are you in cm?
       [36m>[39m  [36m180[46m█[49m[39m
-         [36m─────────────────────────────────────────────────────────────────────────────[39m
+         [36m▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔[39m
          You are [36m1.8[39mm tall.
       "
     `)
@@ -248,7 +268,7 @@ describe('TextPrompt', () => {
     expect(renderInstance.lastFrame()!).toMatchInlineSnapshot(`
       "?  How tall are you?
       [36m>[39m  [36muber[46m█[49m[39m
-         [36m─────────────────────────────────────────────────────────────────────────────[39m
+         [36m▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔[39m
          You are [36mincredibly humongously savagely unnaturally monstrously pathetically [39m
          [36marrogantly uber[39m tall.
       "

--- a/packages/cli-kit/src/private/node/ui/components/TextPrompt.test.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/TextPrompt.test.tsx
@@ -16,7 +16,7 @@ describe('TextPrompt', () => {
     expect(unstyled(lastFrame()!)).toMatchInlineSnapshot(`
       "?  Test question:
       >  Placeholder
-         ▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔
+         ─────────────────────────────────────────────────────────────────────────────
       "
     `)
   })
@@ -30,7 +30,7 @@ describe('TextPrompt', () => {
     expect(renderInstance.lastFrame()).toMatchInlineSnapshot(`
       "?  Test question:
       [31m>[39m  [31m[41m█[49m[39m
-         [31m▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔[39m
+         [31m─────────────────────────────────────────────────────────────────────────────[39m
          [31mType an answer to the prompt.[39m
       "
     `)
@@ -39,7 +39,7 @@ describe('TextPrompt', () => {
     expect(renderInstance.lastFrame()).toMatchInlineSnapshot(`
       "?  Test question:
       [36m>[39m  [36mA[46m█[49m[39m
-         [36m▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔[39m
+         [36m─────────────────────────────────────────────────────────────────────────────[39m
       "
     `)
   })
@@ -60,7 +60,7 @@ describe('TextPrompt', () => {
     expect(renderInstance.lastFrame()).toMatchInlineSnapshot(`
       "?  Test question:
       [31m>[39m  [31mthis-test-includes-shopify[41m█[49m[39m
-         [31m▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔[39m
+         [31m─────────────────────────────────────────────────────────────────────────────[39m
          [31mApp name can't include the word shopify[39m
       "
     `)
@@ -145,7 +145,7 @@ describe('TextPrompt', () => {
       "?  Test question:
       [36m>[39m  [36mAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA[39m
          [36mBBBBBB[46m█[49m[39m
-         [36m▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔[39m
+         [36m─────────────────────────────────────────────────────────────────────────────[39m
       "
     `)
   })
@@ -158,7 +158,7 @@ describe('TextPrompt', () => {
     expect(renderInstance.lastFrame()).toMatchInlineSnapshot(`
       "?  Test question:
       [36m>[39m  [36m***[46m█[49m[39m
-         [36m▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔[39m
+         [36m─────────────────────────────────────────────────────────────────────────────[39m
       "
     `)
 
@@ -176,7 +176,7 @@ describe('TextPrompt', () => {
     expect(lastFrame()!).toMatchInlineSnapshot(`
       "?  Test question?
       [36m>[39m  [36m[46m█[49m[39m
-         [36m▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔[39m
+         [36m─────────────────────────────────────────────────────────────────────────────[39m
       "
     `)
   })
@@ -223,7 +223,7 @@ describe('TextPrompt', () => {
     expect(renderInstance.lastFrame()).toMatchInlineSnapshot(`
       "?  How tall are you in cm?
       [36m>[39m  [36m180[46m█[49m[39m
-         [36m▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔[39m
+         [36m─────────────────────────────────────────────────────────────────────────────[39m
          You are [36m1.8[39mm tall.
       "
     `)
@@ -248,7 +248,7 @@ describe('TextPrompt', () => {
     expect(renderInstance.lastFrame()!).toMatchInlineSnapshot(`
       "?  How tall are you?
       [36m>[39m  [36muber[46m█[49m[39m
-         [36m▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔[39m
+         [36m─────────────────────────────────────────────────────────────────────────────[39m
          You are [36mincredibly humongously savagely unnaturally monstrously pathetically [39m
          [36marrogantly uber[39m tall.
       "

--- a/packages/cli-kit/src/private/node/ui/components/TextPrompt.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/TextPrompt.tsx
@@ -4,6 +4,7 @@ import {handleCtrlC, useComplete} from '../../ui.js'
 import useLayout from '../hooks/use-layout.js'
 import {messageWithPunctuation} from '../utilities.js'
 import {AbortSignal} from '../../../../public/node/abort.js'
+import {platformAndArch} from '../../../../public/node/os.js'
 import useAbortSignal from '../hooks/use-abort-signal.js'
 import usePrompt, {PromptState} from '../hooks/use-prompt.js'
 import React, {FunctionComponent, useCallback, useEffect, useState} from 'react'
@@ -127,14 +128,20 @@ const TextPrompt: FunctionComponent<TextPromptProps> = ({
               />
             </Box>
           </Box>
-          <Box
-            marginLeft={3}
-            borderStyle="single"
-            borderColor={color}
-            borderBottom={false}
-            borderLeft={false}
-            borderRight={false}
-          />
+          {platformAndArch().platform === 'windows' ? (
+            <Box
+              marginLeft={3}
+              borderStyle="single"
+              borderColor={color}
+              borderBottom={false}
+              borderLeft={false}
+              borderRight={false}
+            />
+          ) : (
+            <Box marginLeft={3}>
+              <Text color={color}>{'▔'.repeat(oneThird - 3)}</Text>
+            </Box>
+          )}
           {promptState === PromptState.Error ? (
             <Box marginLeft={3}>
               <Text color={color}>{error}</Text>

--- a/packages/cli-kit/src/private/node/ui/components/TextPrompt.tsx
+++ b/packages/cli-kit/src/private/node/ui/components/TextPrompt.tsx
@@ -64,7 +64,6 @@ const TextPrompt: FunctionComponent<TextPromptProps> = ({
   const complete = useComplete()
   const [error, setError] = useState<string | undefined>(undefined)
   const color = promptState === PromptState.Error ? 'red' : 'cyan'
-  const underline = new Array(oneThird - 3).fill('▔')
   const {isAborted} = useAbortSignal(abortSignal)
 
   useInput((input, key) => {
@@ -128,9 +127,14 @@ const TextPrompt: FunctionComponent<TextPromptProps> = ({
               />
             </Box>
           </Box>
-          <Box marginLeft={3}>
-            <Text color={color}>{underline}</Text>
-          </Box>
+          <Box
+            marginLeft={3}
+            borderStyle="single"
+            borderColor={color}
+            borderBottom={false}
+            borderLeft={false}
+            borderRight={false}
+          />
           {promptState === PromptState.Error ? (
             <Box marginLeft={3}>
               <Text color={color}>{error}</Text>


### PR DESCRIPTION
### WHY are these changes introduced?

Text prompts draw their underline with the upper one eighth block character (`▔`), which is unsupported by legacy Windows console fonts used with cmd and PowerShell.

### WHAT is this pull request doing?

Use an Ink `Box` single top border on Windows in both `TextPrompt` and `DangerousConfirmationPrompt`. Ink draws the standard horizontal line (`─`) and handles its width, preserving indentation and idle/error colors. Keep the original `▔` underline on macOS and Linux.

Add rendering coverage for Windows, macOS, and Linux in normal and validation-error states, and include a patch changeset.

### How to test your changes?

Validated locally:
- All 26 tests in `TextPrompt.test.tsx` and `DangerousConfirmationPrompt.test.tsx` pass.
- ESLint passes for the four changed TypeScript files.
- CLI kit `tsc --noEmit` and `git diff --check` pass.

For manual verification, open a CLI text prompt in cmd or PowerShell, enter text, and trigger a validation error. Confirm the underline renders as a continuous line and changes from cyan to red. Native Windows console testing has not been performed on this macOS machine.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible documentation changes
- [x] I've considered analytics changes to measure impact
- [x] The change is user-facing and includes a patch changeset
