### PR TITLE
Recover gracefully when pnpm blocks build scripts during extension generation

### DIFF
--- a/.changeset/graceful-pnpm-blocked-builds-on-generate.md
+++ b/.changeset/graceful-pnpm-blocked-builds-on-generate.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Recover gracefully when pnpm blocks dependency build scripts during `app generate extension`: clean up the partially generated extension and explain how to approve the builds

--- a/.changeset/remove-file-retry-options.md
+++ b/.changeset/remove-file-retry-options.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': minor
+---
+
+Add optional `maxRetries` and `retryDelay` options to `removeFile`, passed through to Node's `fs.rm` to retry transient removal errors

--- a/packages/app/src/cli/services/generate/extension.test.ts
+++ b/packages/app/src/cli/services/generate/extension.test.ts
@@ -31,6 +31,7 @@ import * as file from '@shopify/cli-kit/node/fs'
 import * as git from '@shopify/cli-kit/node/git'
 import {joinPath, dirname} from '@shopify/cli-kit/node/path'
 import {slugify} from '@shopify/cli-kit/common/string'
+import {mockAndCaptureOutput} from '@shopify/cli-kit/node/testing/output'
 
 vi.mock('../../models/app/validation/multi-cli-warning.js')
 vi.mock('@shopify/cli-kit/node/node-package-manager', async () => {
@@ -458,6 +459,76 @@ describe('initialize a extension', async () => {
       expect(file.fileExistsSync(joinPath(tmpDir, 'extensions', name))).toBeFalsy()
     })
   })
+
+  test('cleans up and explains how to recover when pnpm blocks dependency build scripts', async () => {
+    await withTemporaryApp(
+      async (tmpDir) => {
+        // Given
+        const name = 'my-ext-1'
+        vi.mocked(installNodeModules).mockRejectedValueOnce(
+          new Error(
+            'Command failed with exit code 1: pnpm install\nERR_PNPM_IGNORED_BUILDS Ignored build scripts: esbuild@0.24.2.',
+          ),
+        )
+
+        // When
+        const got = createFromTemplate({
+          name,
+          extensionTemplate: checkoutUITemplate,
+          extensionFlavor: 'vanilla-js',
+          appDirectory: tmpDir,
+          specifications,
+          onGetTemplateRepository,
+        })
+
+        // Then
+        await expect(got).rejects.toThrow(
+          "Your extension couldn't be generated because pnpm blocked the build scripts of some of its dependencies.",
+        )
+        expect(file.fileExistsSync(joinPath(tmpDir, 'extensions', name))).toBeFalsy()
+      },
+      {useWorkspaces: true},
+    )
+  })
+
+  test.skipIf(process.platform === 'win32')(
+    'warns and surfaces the original error when the extension directory cleanup fails',
+    async () => {
+      await withTemporaryApp(
+        async (tmpDir) => {
+          // Given
+          const name = 'my-ext-1'
+          const extensionsDirectory = joinPath(tmpDir, 'extensions')
+          const outputMock = mockAndCaptureOutput()
+          vi.mocked(installNodeModules).mockImplementationOnce(async () => {
+            // Make the parent directory read-only so the cleanup can't remove the extension directory.
+            await file.chmod(extensionsDirectory, 0o555)
+            throw new Error('pnpm install failed')
+          })
+
+          try {
+            // When
+            const got = createFromTemplate({
+              name,
+              extensionTemplate: checkoutUITemplate,
+              extensionFlavor: 'vanilla-js',
+              appDirectory: tmpDir,
+              specifications,
+              onGetTemplateRepository,
+            })
+
+            // Then
+            await expect(got).rejects.toThrow('pnpm install failed')
+            expect(outputMock.warn()).toContain("Couldn't remove")
+          } finally {
+            await file.chmod(extensionsDirectory, 0o755)
+            outputMock.clear()
+          }
+        },
+        {useWorkspaces: true},
+      )
+    },
+  )
 
   test('reloads the app after generating the extension', async () => {
     await withTemporaryApp(async (tmpDir) => {

--- a/packages/app/src/cli/services/generate/extension.ts
+++ b/packages/app/src/cli/services/generate/extension.ts
@@ -128,7 +128,7 @@ async function extensionInit(options: ExtensionInitOptions) {
     await removeFile(lockFilePath)
   } catch (error) {
     await removePartiallyGeneratedExtension(options.directory)
-    if (isPnpmBlockedBuildsError(error)) {
+    if (options.project.packageManager === 'pnpm' && isPnpmBlockedBuildsError(error)) {
       throw new AbortError(
         "Your extension couldn't be generated because pnpm blocked the build scripts of some of its dependencies.",
         null,
@@ -146,14 +146,12 @@ async function extensionInit(options: ExtensionInitOptions) {
   }
 }
 
-/**
- * Removes the partially generated extension directory so a failed generation leaves no files
- * behind. The removal is best-effort: if it fails we warn about the leftover directory instead of
- * throwing, so the error that interrupted the generation is still surfaced.
- */
+// Retries transient removal errors, such as an antivirus lock on the freshly written files.
+// If removal still fails, we warn about the leftover directory rather than throwing, so the
+// original error isn't lost.
 async function removePartiallyGeneratedExtension(directory: string): Promise<void> {
   try {
-    await removeFile(directory)
+    await removeFile(directory, {maxRetries: 10, retryDelay: 100})
     // eslint-disable-next-line no-catch-all/no-catch-all
   } catch {
     renderWarning({
@@ -163,9 +161,8 @@ async function removePartiallyGeneratedExtension(directory: string): Promise<voi
   }
 }
 
-// pnpm refuses to run the build scripts of newly installed dependencies until they are approved,
-// and recent pnpm versions fail the install when they can't prompt for that approval, which is
-// the case while dependencies are installed from within the generation tasks.
+// pnpm can't prompt to approve build scripts during a non-interactive install like this one,
+// so recent versions fail the install outright instead.
 function isPnpmBlockedBuildsError(error: unknown): boolean {
   return error instanceof Error && error.message.includes('ERR_PNPM_IGNORED_BUILDS')
 }

--- a/packages/app/src/cli/services/generate/extension.ts
+++ b/packages/app/src/cli/services/generate/extension.ts
@@ -15,12 +15,14 @@ import {
   readAndParsePackageJson,
 } from '@shopify/cli-kit/node/node-package-manager'
 import {recursiveLiquidTemplateCopy} from '@shopify/cli-kit/node/liquid'
-import {renderTasks} from '@shopify/cli-kit/node/ui'
+import {renderTasks, renderWarning} from '@shopify/cli-kit/node/ui'
 import {downloadGitRepository} from '@shopify/cli-kit/node/git'
 import {fileExists, inTemporaryDirectory, mkdir, moveFile, removeFile, glob} from '@shopify/cli-kit/node/fs'
 import {joinPath, relativizePath} from '@shopify/cli-kit/node/path'
 import {slugify} from '@shopify/cli-kit/common/string'
 import {nonRandomUUID} from '@shopify/cli-kit/node/crypto'
+import {AbortError} from '@shopify/cli-kit/node/error'
+import {formatPackageManagerCommand} from '@shopify/cli-kit/node/output'
 
 export interface GenerateExtensionTemplateOptions {
   app: AppLinkedInterface
@@ -125,9 +127,47 @@ async function extensionInit(options: ExtensionInitOptions) {
     const lockFilePath = joinPath(options.directory, configurationFileNames.lockFile)
     await removeFile(lockFilePath)
   } catch (error) {
-    await removeFile(options.directory)
+    await removePartiallyGeneratedExtension(options.directory)
+    if (isPnpmBlockedBuildsError(error)) {
+      throw new AbortError(
+        "Your extension couldn't be generated because pnpm blocked the build scripts of some of its dependencies.",
+        null,
+        [
+          ['Run', {command: 'pnpm approve-builds'}, 'in your app directory to approve the build scripts.'],
+          [
+            'Run',
+            {command: formatPackageManagerCommand(options.project.packageManager, 'shopify app generate extension')},
+            'again.',
+          ],
+        ],
+      )
+    }
     throw error
   }
+}
+
+/**
+ * Removes the partially generated extension directory so a failed generation leaves no files
+ * behind. The removal is best-effort: if it fails we warn about the leftover directory instead of
+ * throwing, so the error that interrupted the generation is still surfaced.
+ */
+async function removePartiallyGeneratedExtension(directory: string): Promise<void> {
+  try {
+    await removeFile(directory)
+    // eslint-disable-next-line no-catch-all/no-catch-all
+  } catch {
+    renderWarning({
+      headline: ["Couldn't remove", {filePath: directory}, {char: '.'}],
+      body: 'Delete this directory manually before generating an extension with the same name.',
+    })
+  }
+}
+
+// pnpm refuses to run the build scripts of newly installed dependencies until they are approved,
+// and recent pnpm versions fail the install when they can't prompt for that approval, which is
+// the case while dependencies are installed from within the generation tasks.
+function isPnpmBlockedBuildsError(error: unknown): boolean {
+  return error instanceof Error && error.message.includes('ERR_PNPM_IGNORED_BUILDS')
 }
 
 async function themeExtensionInit({

--- a/packages/cli-kit/src/public/node/fs.ts
+++ b/packages/cli-kit/src/public/node/fs.ts
@@ -7,7 +7,6 @@ import {
   copy as fsCopy,
   ensureFile as fsEnsureFile,
   ensureFileSync as fsEnsureFileSync,
-  remove as fsRemove,
   removeSync as fsRemoveSync,
   move as fsMove,
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -260,14 +259,29 @@ export function mkdirSync(path: string): void {
   fsMkdirSync(path, {recursive: true})
 }
 
+interface RemoveFileOptions {
+  /**
+   * Number of times Node retries the removal when it hits a transient error
+   * (EBUSY, EMFILE, ENFILE, ENOTEMPTY or EPERM), waiting `retryDelay` milliseconds
+   * longer on each try. Defaults to 0 (no retries).
+   */
+  maxRetries?: number
+  /**
+   * Milliseconds to wait between retries. Defaults to 100.
+   */
+  retryDelay?: number
+}
+
 /**
- * Removes a file at the given path.
+ * Removes a file or directory (recursively) at the given path.
  *
- * @param path - Path to the file to be removed.
+ * @param path - Path to the file or directory to be removed.
+ * @param options - Retry behavior, passed through to Node's `fs.rm`. Useful when the removal can
+ * race with transient locks, such as an antivirus scanning freshly written files.
  */
-export async function removeFile(path: string): Promise<void> {
+export async function removeFile(path: string, options: RemoveFileOptions = {}): Promise<void> {
   outputDebug(outputContent`Removing file at ${outputToken.path(path)}...`)
-  await fsRemove(path)
+  await fsRm(path, {recursive: true, force: true, ...options})
 }
 
 /**


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/shop/issues-develop/issues/23837

Recent pnpm versions refuse to run the build scripts of newly installed dependencies until the user approves them, and they fail the install outright (`ERR_PNPM_IGNORED_BUILDS`) when they can't prompt for approval. Since `shopify app generate extension` installs dependencies from within the generation task UI (non-interactive stdio), the prompt can never be shown, so the install always fails on affected setups.

Verified against pnpm 12.3.4: the install completes resolution and linking (creating `node_modules` inside the new extension directory) and then exits 1. Two problems with how we handled that:

1. The raw `pnpm install` failure was surfaced as-is, with no guidance on how to recover.
2. The cleanup of the partially generated extension (`removeFile(directory)` in `extensionInit`'s catch) was unguarded — if the removal failed for any reason, its error **replaced** the original install error and the partially removed extension directory (e.g. just a `node_modules` folder) was left behind, matching the state reported in the issue.

### WHAT is this pull request doing?

In `packages/app/src/cli/services/generate/extension.ts` (plus a small `@shopify/cli-kit` addition):

- Detects the pnpm blocked-builds failure (`ERR_PNPM_IGNORED_BUILDS`) and raises an `AbortError` with next steps: run `pnpm approve-builds` in the app directory, then generate the extension again. This works because the failed install records the ignored builds in the app root's `node_modules/.modules.yaml`, so `pnpm approve-builds` lists them even after the extension directory is removed (verified locally).
- Makes the cleanup resilient and best-effort: cli-kit's `removeFile` now accepts optional `maxRetries`/`retryDelay` options passed straight through to Node's `fs.rm`, which retries transient errors (EBUSY/ENOTEMPTY/EPERM — e.g. antivirus or indexer locks on the freshly written `node_modules`) with linear backoff, retrying the specific failing entry rather than restarting the walk. The cleanup uses `{maxRetries: 10, retryDelay: 100}` (~5.5s worst case). If removal still fails, a warning names the leftover directory and tells the user to delete it, and the error that actually interrupted the generation is still thrown.

All generation flows (UI, function, theme; workspace and non-workspace installs) go through this catch, so they're all covered.

### How to test your changes?

1. Create an app that uses pnpm workspaces, with pnpm ≥ 12 (or pnpm ≥ 10 with `strictDepBuilds: true`).
2. Ensure at least one extension-template dependency has a build script that isn't approved (no `onlyBuiltDependencies` entry).
3. Run `shopify app generate extension` and pick a JS-flavored template.
4. Before: raw `Command failed with exit code 1: pnpm install` dump. After: an error banner explaining pnpm blocked the build scripts, with `pnpm approve-builds` + regenerate as next steps, and no leftover `extensions/<name>` directory.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [x] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

