### PR TITLE
[Tests] Add unit tests for isEmpty object utility function

### DIFF
--- a/packages/cli-kit/src/public/common/object.test.ts
+++ b/packages/cli-kit/src/public/common/object.test.ts
@@ -5,6 +5,7 @@ import {
   deepDifference,
   deepMergeObjects,
   getPathValue,
+  isEmpty,
   mapValues,
   pickBy,
   setPathValue,
@@ -361,6 +362,26 @@ describe('compact', () => {
 
     // Then
     expect(result).toEqual({})
+  })
+})
+
+describe('isEmpty', () => {
+  test('returns true for empty objects, arrays, maps, sets, strings, and nil values', () => {
+    expect(isEmpty({})).toBe(true)
+    expect(isEmpty([])).toBe(true)
+    expect(isEmpty(new Map())).toBe(true)
+    expect(isEmpty(new Set())).toBe(true)
+    expect(isEmpty('' as unknown as object)).toBe(true)
+    expect(isEmpty(null as unknown as object)).toBe(true)
+    expect(isEmpty(undefined as unknown as object)).toBe(true)
+  })
+
+  test('returns false for non-empty objects, arrays, maps, sets, and strings', () => {
+    expect(isEmpty({key: 'value'})).toBe(false)
+    expect(isEmpty([1])).toBe(false)
+    expect(isEmpty(new Map([['key', 'value']]))).toBe(false)
+    expect(isEmpty(new Set([1]))).toBe(false)
+    expect(isEmpty('text' as unknown as object)).toBe(false)
   })
 })
 


### PR DESCRIPTION
### Why are these changes needed?

The `isEmpty` function in `packages/cli-kit/src/public/common/object.ts` lacked direct unit test coverage in `packages/cli-kit/src/public/common/object.test.ts`.

### How to test your changes?

CI

### Checklist

- [ ] I have evaluated the [impact of this change](https://github.com/Shopify/cli/blob/main/docs/cli-architecture.md#impact-of-changes) and attribute it to a domain.
- [ ] I have added description for changesets or explicitly marked as no changeset required
- [ ] I have updated the documentation if required
- [ ] I have added tests for the changes

---
*PR created automatically by Jules for task [487141054567347593](https://jules.google.com/task/487141054567347593) started by @gonzaloriestra*