### PR TITLE
Dasherize the client transfer store type handle

### DIFF
--- a/.changeset/dasherize-client-transfer-store-type.md
+++ b/.changeset/dasherize-client-transfer-store-type.md
@@ -1,0 +1,5 @@
+---
+'@shopify/store': patch
+---
+
+Report the client transfer store type as `client-transfer` in `store info`

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -3983,7 +3983,7 @@ List stores in a Shopify organization.
 ```
 USAGE
   $ shopify store list [-j] [--no-color] [--organization-id <value>] [--type
-    dev|production|client_transfer|collaborator] [--verbose]
+    dev|production|client-transfer|collaborator] [--verbose]
 
 FLAGS
   -j, --json
@@ -4002,7 +4002,7 @@ FLAGS
   --type=<option>
       List only stores of this type.
       [env: SHOPIFY_FLAG_STORE_TYPE]
-      <options: dev|production|client_transfer|collaborator>
+      <options: dev|production|client-transfer|collaborator>
 
   --verbose
       Increase the verbosity of the output. May include sensitive data.

--- a/packages/cli/oclif.manifest.json
+++ b/packages/cli/oclif.manifest.json
@@ -8029,7 +8029,7 @@
           "options": [
             "dev",
             "production",
-            "client_transfer",
+            "client-transfer",
             "collaborator"
           ],
           "type": "option"

--- a/packages/store/src/cli/commands/store/list.test.ts
+++ b/packages/store/src/cli/commands/store/list.test.ts
@@ -28,9 +28,9 @@ describe('store list command', () => {
   test('passes the store type filter through to the list service', async () => {
     vi.mocked(listStores).mockResolvedValue({stores: [], source: 'organization'})
 
-    await StoreList.run(['--type', 'client_transfer'])
+    await StoreList.run(['--type', 'client-transfer'])
 
-    expect(listStores).toHaveBeenCalledWith({organizationId: undefined, storeType: 'client_transfer'})
+    expect(listStores).toHaveBeenCalledWith({organizationId: undefined, storeType: 'client-transfer'})
   })
 
   test('writes json output when requested', async () => {
@@ -45,7 +45,7 @@ describe('store list command', () => {
   test('defines the expected flags', () => {
     expect(StoreList.flags.json).toBeDefined()
     expect(StoreList.flags['organization-id']).toBeDefined()
-    expect(StoreList.flags.type?.options).toEqual(['dev', 'production', 'client_transfer', 'collaborator'])
+    expect(StoreList.flags.type?.options).toEqual(['dev', 'production', 'client-transfer', 'collaborator'])
     expect(StoreList.flags).not.toHaveProperty('from')
   })
 })

--- a/packages/store/src/cli/services/store/info/index.test.ts
+++ b/packages/store/src/cli/services/store/info/index.test.ts
@@ -470,7 +470,7 @@ The CLI is currently unable to prompt for reauthentication.`)
     ['DEVELOPMENT', 'dev'],
     ['DEVELOPMENT_SUPERSET', 'dev'],
     ['PRODUCTION', 'production'],
-    ['CLIENT_TRANSFER', 'client_transfer'],
+    ['CLIENT_TRANSFER', 'client-transfer'],
     ['COLLABORATOR', 'collaborator'],
   ])('maps the BP %s store type to the `%s` handle', async (storeType, expected) => {
     vi.mocked(fetchOrganizationShop).mockResolvedValue(orgShop({storeType}))

--- a/packages/store/src/cli/services/store/list/bp-source.test.ts
+++ b/packages/store/src/cli/services/store/list/bp-source.test.ts
@@ -95,7 +95,7 @@ describe('listBusinessPlatformStores', () => {
   test('narrows the query to a single store type when one is requested', async () => {
     vi.mocked(businessPlatformOrganizationsRequestDoc).mockResolvedValue(shopPage())
 
-    await listBusinessPlatformStores({token: 'bp-token', organization, storeType: 'client_transfer'})
+    await listBusinessPlatformStores({token: 'bp-token', organization, storeType: 'client-transfer'})
 
     expect(businessPlatformOrganizationsRequestDoc).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/packages/store/src/cli/services/store/list/result.test.ts
+++ b/packages/store/src/cli/services/store/list/result.test.ts
@@ -115,7 +115,7 @@ describe('writeStoreListResult', () => {
       {
         source: 'organization',
         organization,
-        storeType: 'client_transfer',
+        storeType: 'client-transfer',
         stores: [
           {
             store: 'my-shop.myshopify.com',
@@ -123,7 +123,7 @@ describe('writeStoreListResult', () => {
             organizationId: '1234',
             organizationName: 'Acme',
             name: 'My Shop',
-            type: 'client_transfer',
+            type: 'client-transfer',
           },
         ],
       },

--- a/packages/store/src/cli/services/store/list/result.ts
+++ b/packages/store/src/cli/services/store/list/result.ts
@@ -46,10 +46,10 @@ function truncationWarning(result: ListStoresResult): string {
   return `Showing the ${STORE_LIST_LIMIT} most recent ${storeNounPhrase(result.storeType)}${organization}. More stores exist.`
 }
 
-// Names what was listed, qualified by the active `--type` filter (`client_transfer` -> `client
+// Names what was listed, qualified by the active `--type` filter (`client-transfer` -> `client
 // transfer stores`).
 function storeNounPhrase(storeType: StoreTypeFilter | undefined): string {
-  return storeType ? `${storeType.replaceAll('_', ' ')} stores` : 'stores'
+  return storeType ? `${storeType.replaceAll('-', ' ')} stores` : 'stores'
 }
 
 function renderTextResult(result: ListStoresResult): void {

--- a/packages/store/src/cli/services/store/store-type.test.ts
+++ b/packages/store/src/cli/services/store/store-type.test.ts
@@ -18,7 +18,7 @@ describe('storeTypeHandle', () => {
 describe('storeTypeLabel', () => {
   test('title-cases a handle and renders a missing one as blank', () => {
     expect(storeTypeLabel('dev')).toBe('Dev')
-    expect(storeTypeLabel('client_transfer')).toBe('Client Transfer')
+    expect(storeTypeLabel('client-transfer')).toBe('Client Transfer')
     expect(storeTypeLabel(undefined)).toBe('')
   })
 })
@@ -30,7 +30,7 @@ describe('storeTypeFilterValue', () => {
     expect(storeTypeFilters.map((filter) => [filter, storeTypeFilterValue(filter)])).toEqual([
       ['dev', 'development_superset'],
       ['production', 'production'],
-      ['client_transfer', 'client_transfer'],
+      ['client-transfer', 'client_transfer'],
       ['collaborator', 'collaborator'],
     ])
   })
@@ -38,7 +38,7 @@ describe('storeTypeFilterValue', () => {
   // Every filter has to name a type the listing can render back, so the Type column of a filtered
   // listing never disagrees with the filter that produced it.
   test('accepts only handles that store rows can also report', () => {
-    const rowHandles = ['dev', 'production', 'client_transfer', 'collaborator']
+    const rowHandles = ['dev', 'production', 'client-transfer', 'collaborator']
 
     expect(storeTypeFilters.every((filter) => rowHandles.includes(filter))).toBe(true)
   })

--- a/packages/store/src/cli/services/store/store-type.ts
+++ b/packages/store/src/cli/services/store/store-type.ts
@@ -6,7 +6,7 @@ import {capitalizeWords} from '@shopify/cli-kit/common/string'
 // enum fails type-checking here until it's given an explicit handle.
 const STORE_TYPE_HANDLES: {[key in Store]: string} = {
   APP_DEVELOPMENT: 'dev',
-  CLIENT_TRANSFER: 'client_transfer',
+  CLIENT_TRANSFER: 'client-transfer',
   COLLABORATOR: 'collaborator',
   DEVELOPMENT: 'dev',
   DEVELOPMENT_SUPERSET: 'dev',
@@ -20,7 +20,7 @@ export function storeTypeHandle(storeType: string | null | undefined): string | 
   return STORE_TYPE_HANDLES[storeType as Store]
 }
 
-// Title-cased label for the `store list` table column (`dev` -> `Dev`, `client_transfer` ->
+// Title-cased label for the `store list` table column (`dev` -> `Dev`, `client-transfer` ->
 // `Client Transfer`).
 export function storeTypeLabel(handle: string | undefined): string {
   return handle ? capitalizeWords(handle) : ''
@@ -34,7 +34,7 @@ export function storeTypeLabel(handle: string | undefined): string {
 const STORE_TYPE_FILTERS = {
   dev: 'development_superset',
   production: 'production',
-  client_transfer: 'client_transfer',
+  'client-transfer': 'client_transfer',
   collaborator: 'collaborator',
 } as const
 


### PR DESCRIPTION
### WHY are these changes introduced?

`store list --type client_transfer` was the only underscored enumerated flag value in the entire CLI manifest. Every other multi-word one is dashed:

| Command | Flag | Values |
|---|---|---|
| `app generate extension` | `--flavor` | `vanilla-js`, `typescript-react` |
| `app webhook trigger` | `--delivery-method` | `google-pub-sub`, `event-bridge` |
| `theme dev` | `--live-reload` | `hot-reload`, `full-page` |
| `theme dev` | `--reconciliation-strategy` | `keep-local`, `keep-remote` |

The underscore was inherited from Business Platform's `STORE_TYPE` casing, but `STORE_TYPE_HANDLES` was never a passthrough — three BP enum members already collapse onto `dev`, and `dev` already maps back out to BP's `development_superset`. So there was no consistency argument for keeping BP's spelling on the public side, only on the wire.

### WHAT is this pull request doing?

Renames the public handle to `client-transfer`. `STORE_TYPE_FILTERS` spells it back out as BP's `client_transfer` on the way to the API — the same shape the `dev` entry already had.

Two things that travel with the handle:

- `storeNounPhrase` in `list/result.ts` built the "client transfer stores" wording by splitting the handle on `_`; it now splits on `-`.
- `storeTypeLabel` needed no change — `capitalizeWords` is `capitalCase`, which already splits on either separator, so the Type column still reads `Client Transfer`.

`--type` hasn't been released yet (its changeset is still pending), so the flag side of this needs no changeset of its own. The changeset here covers `store info`'s `type` field, which has reported `client_transfer` since 4.2.0 and changes with it, because the two commands deliberately share one handle vocabulary.

Regenerated `oclif.manifest.json` and the CLI README; dev docs produced no diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)