### PR TITLE
Fix startup crash when the OS can't look up the current user's shell

### DIFF
--- a/.changeset/guard-oclif-shell-detection.md
+++ b/.changeset/guard-oclif-shell-detection.md
@@ -1,0 +1,5 @@
+---
+'@shopify/cli-kit': patch
+---
+
+Fix a startup crash on machines where the OS can't look up the current user's shell

--- a/packages/cli-kit/src/public/node/custom-oclif-loader.test.ts
+++ b/packages/cli-kit/src/public/node/custom-oclif-loader.test.ts
@@ -128,7 +128,6 @@ describe('ShopifyConfig', () => {
   })
 
   test('loads successfully when the OS user lookup fails during shell detection', async () => {
-    // oclif and the guard both only reach os.userInfo() when SHELL is unset.
     vi.stubEnv('SHELL', undefined)
     vi.spyOn(os, 'userInfo').mockImplementation(() => {
       throw osUserLookupError()

--- a/packages/cli-kit/src/public/node/custom-oclif-loader.test.ts
+++ b/packages/cli-kit/src/public/node/custom-oclif-loader.test.ts
@@ -1,6 +1,8 @@
 import {ShopifyConfig} from './custom-oclif-loader.js'
 import {Config} from '@oclif/core'
 import {describe, expect, test, vi} from 'vitest'
+import os from 'node:os'
+import {fileURLToPath} from 'node:url'
 
 describe('ShopifyConfig', () => {
   test('delegates to super.runCommand when no lazy command loader is configured', async () => {
@@ -120,4 +122,46 @@ describe('ShopifyConfig', () => {
     expect(config.findCommand).not.toHaveBeenCalled()
     expect(lazyCommandLoader).toHaveBeenCalledWith('test-command')
   })
+
+  test('loads successfully when the OS user lookup fails during shell detection', async () => {
+    // SHELL short-circuits oclif's `process.env.SHELL ?? userInfo()`, so it has to be unset for the
+    // OS lookup — the call that crashes in production — to run at all.
+    vi.stubEnv('SHELL', undefined)
+    vi.spyOn(os, 'userInfo').mockImplementation(() => {
+      throw osUserLookupError()
+    })
+    const config = new ShopifyConfig({root: fileURLToPath(import.meta.url)})
+
+    await config.load()
+
+    expect(config.shell).toBe('unknown')
+  })
+
+  test('reports the shell oclif detected when the OS user lookup succeeds', async () => {
+    vi.stubEnv('SHELL', undefined)
+    vi.spyOn(os, 'userInfo').mockReturnValue({
+      username: 'test-user',
+      uid: 1000,
+      gid: 1000,
+      homedir: '/home/test-user',
+      shell: '/bin/fish',
+    })
+    const config = new ShopifyConfig({root: fileURLToPath(import.meta.url)})
+
+    await config.load()
+
+    expect(config.shell).toBe('fish')
+  })
 })
+
+/**
+ * The SystemError Node throws from os.userInfo() when the OS can't resolve the current user.
+ *
+ * @returns An error shaped like the real failure reported by affected users.
+ */
+function osUserLookupError(): Error {
+  return Object.assign(new Error('A system error occurred: uv_os_get_passwd returned ENOMEM (not enough memory)'), {
+    code: 'ERR_SYSTEM_ERROR',
+    info: {code: 'ENOMEM', errno: -4057, syscall: 'uv_os_get_passwd'},
+  })
+}

--- a/packages/cli-kit/src/public/node/custom-oclif-loader.test.ts
+++ b/packages/cli-kit/src/public/node/custom-oclif-loader.test.ts
@@ -1,10 +1,14 @@
 import {ShopifyConfig} from './custom-oclif-loader.js'
 import {Config} from '@oclif/core'
-import {describe, expect, test, vi} from 'vitest'
+import {afterEach, describe, expect, test, vi} from 'vitest'
 import os from 'node:os'
 import {fileURLToPath} from 'node:url'
 
 describe('ShopifyConfig', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
   test('delegates to super.runCommand when no lazy command loader is configured', async () => {
     const config = new ShopifyConfig({root: import.meta.url})
     const superRunCommandSpy = vi.spyOn(Config.prototype, 'runCommand').mockResolvedValue('super-result')
@@ -124,8 +128,7 @@ describe('ShopifyConfig', () => {
   })
 
   test('loads successfully when the OS user lookup fails during shell detection', async () => {
-    // SHELL short-circuits oclif's `process.env.SHELL ?? userInfo()`, so it has to be unset for the
-    // OS lookup — the call that crashes in production — to run at all.
+    // oclif and the guard both only reach os.userInfo() when SHELL is unset.
     vi.stubEnv('SHELL', undefined)
     vi.spyOn(os, 'userInfo').mockImplementation(() => {
       throw osUserLookupError()
@@ -154,11 +157,6 @@ describe('ShopifyConfig', () => {
   })
 })
 
-/**
- * The SystemError Node throws from os.userInfo() when the OS can't resolve the current user.
- *
- * @returns An error shaped like the real failure reported by affected users.
- */
 function osUserLookupError(): Error {
   return Object.assign(new Error('A system error occurred: uv_os_get_passwd returned ENOMEM (not enough memory)'), {
     code: 'ERR_SYSTEM_ERROR',

--- a/packages/cli-kit/src/public/node/custom-oclif-loader.ts
+++ b/packages/cli-kit/src/public/node/custom-oclif-loader.ts
@@ -75,7 +75,7 @@ export class ShopifyConfig extends Config {
 }
 
 // oclif reads SHELL and falls back to os.userInfo(), which throws when the OS can't resolve the current
-// user, killing the CLI during load. Remove once oclif guards that call; no released version does.
+// user, killing the CLI during load. Remove once oclif guards that call.
 function setShellVariableWhenUserLookupFails(): void {
   if (process.env.SHELL !== undefined) return
 

--- a/packages/cli-kit/src/public/node/custom-oclif-loader.ts
+++ b/packages/cli-kit/src/public/node/custom-oclif-loader.ts
@@ -25,7 +25,7 @@ export class ShopifyConfig extends Config {
   }
 
   /**
-   * Load the oclif config, after making sure its shell detection can't crash the CLI.
+   * Override load to protect oclif's shell detection from a failing OS user lookup.
    *
    * @returns A promise that resolves once the config is loaded.
    */
@@ -74,13 +74,8 @@ export class ShopifyConfig extends Config {
   }
 }
 
-/**
- * Set SHELL when the OS can't tell us what it is, so that oclif never has to ask.
- *
- * While loading, oclif reads the SHELL environment variable and falls back to Node's `userInfo()`, which
- * throws when the OS can't resolve the current user — taking the CLI down before it runs anything. Drop
- * this once oclif guards that call itself; both 4.8 and 4.11 leave it unguarded.
- */
+// oclif reads SHELL and falls back to os.userInfo(), which throws when the OS can't resolve the current
+// user, killing the CLI during load. Remove once oclif guards that call; 4.8 and 4.11 both don't.
 function setShellVariableWhenUserLookupFails(): void {
   if (process.env.SHELL !== undefined) return
 
@@ -88,7 +83,6 @@ function setShellVariableWhenUserLookupFails(): void {
     os.userInfo()
     // eslint-disable-next-line no-catch-all/no-catch-all
   } catch {
-    // The value oclif itself falls back to for a shell it can't identify.
     process.env.SHELL = 'unknown'
   }
 }

--- a/packages/cli-kit/src/public/node/custom-oclif-loader.ts
+++ b/packages/cli-kit/src/public/node/custom-oclif-loader.ts
@@ -75,7 +75,7 @@ export class ShopifyConfig extends Config {
 }
 
 // oclif reads SHELL and falls back to os.userInfo(), which throws when the OS can't resolve the current
-// user, killing the CLI during load. Remove once oclif guards that call; 4.8 and 4.11 both don't.
+// user, killing the CLI during load. Remove once oclif guards that call; no released version does.
 function setShellVariableWhenUserLookupFails(): void {
   if (process.env.SHELL !== undefined) return
 

--- a/packages/cli-kit/src/public/node/custom-oclif-loader.ts
+++ b/packages/cli-kit/src/public/node/custom-oclif-loader.ts
@@ -1,4 +1,5 @@
 import {Command, Config} from '@oclif/core'
+import os from 'os'
 
 /**
  * Optional lazy command loader function.
@@ -21,6 +22,16 @@ export class ShopifyConfig extends Config {
    */
   setLazyCommandLoader(loader: LazyCommandLoader): void {
     this.lazyCommandLoader = loader
+  }
+
+  /**
+   * Load the oclif config, after making sure its shell detection can't crash the CLI.
+   *
+   * @returns A promise that resolves once the config is loaded.
+   */
+  async load(): Promise<void> {
+    setShellVariableWhenUserLookupFails()
+    return super.load()
   }
 
   /**
@@ -61,27 +72,23 @@ export class ShopifyConfig extends Config {
     await this.runHook('postrun', {argv, Command: commandClass, result})
     return result
   }
+}
 
-  /**
-   * Guard oclif's shell detection, which otherwise crashes the CLI when the OS can't resolve the current user.
-   *
-   * Oclif populates `config.shell` during `Config.load()`. When the SHELL environment variable is unset it
-   * falls back to Node's `userInfo()`, which throws a SystemError whenever the OS passwd lookup fails —
-   * ENOMEM on Windows profiles where the lookup is broken, ENOENT for a container UID with no passwd entry.
-   * The call is unguarded, so it kills the CLI before it can run any command.
-   *
-   * Note when bumping the oclif dependency: 4.11 drops `_shell` from `Config` and moves the logic into a
-   * module-level `getShell()`, so this override stops compiling. The call is still unguarded upstream, so
-   * reinstate the guard at whatever seam replaces it rather than dropping it.
-   *
-   * @returns The name of the active shell, or oclif's own 'unknown' sentinel when detection fails.
-   */
-  protected _shell(): string {
-    try {
-      return super._shell()
-      // eslint-disable-next-line no-catch-all/no-catch-all
-    } catch {
-      return 'unknown'
-    }
+/**
+ * Set SHELL when the OS can't tell us what it is, so that oclif never has to ask.
+ *
+ * While loading, oclif reads the SHELL environment variable and falls back to Node's `userInfo()`, which
+ * throws when the OS can't resolve the current user — taking the CLI down before it runs anything. Drop
+ * this once oclif guards that call itself; both 4.8 and 4.11 leave it unguarded.
+ */
+function setShellVariableWhenUserLookupFails(): void {
+  if (process.env.SHELL !== undefined) return
+
+  try {
+    os.userInfo()
+    // eslint-disable-next-line no-catch-all/no-catch-all
+  } catch {
+    // The value oclif itself falls back to for a shell it can't identify.
+    process.env.SHELL = 'unknown'
   }
 }

--- a/packages/cli-kit/src/public/node/custom-oclif-loader.ts
+++ b/packages/cli-kit/src/public/node/custom-oclif-loader.ts
@@ -61,4 +61,27 @@ export class ShopifyConfig extends Config {
     await this.runHook('postrun', {argv, Command: commandClass, result})
     return result
   }
+
+  /**
+   * Guard oclif's shell detection, which otherwise crashes the CLI when the OS can't resolve the current user.
+   *
+   * Oclif populates `config.shell` during `Config.load()`. When the SHELL environment variable is unset it
+   * falls back to Node's `userInfo()`, which throws a SystemError whenever the OS passwd lookup fails —
+   * ENOMEM on Windows profiles where the lookup is broken, ENOENT for a container UID with no passwd entry.
+   * The call is unguarded, so it kills the CLI before it can run any command.
+   *
+   * Note when bumping the oclif dependency: 4.11 drops `_shell` from `Config` and moves the logic into a
+   * module-level `getShell()`, so this override stops compiling. The call is still unguarded upstream, so
+   * reinstate the guard at whatever seam replaces it rather than dropping it.
+   *
+   * @returns The name of the active shell, or oclif's own 'unknown' sentinel when detection fails.
+   */
+  protected _shell(): string {
+    try {
+      return super._shell()
+      // eslint-disable-next-line no-catch-all/no-catch-all
+    } catch {
+      return 'unknown'
+    }
+  }
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes the top unhandled CLI startup crash in Observe: [shop/issues#75079](https://github.com/shop/issues/issues/75079) — `A system error occurred: uv_os_get_passwd returned ENOMEM (not enough memory)`. P2, 113 events / 53 affected users over 7 days. For these users the CLI does not start at all — no command runs, and no analytics row is emitted.

Also fixes #8497.

### WHAT is this pull request doing?

While loading, oclif resolves the active shell from `process.env.SHELL ?? os.userInfo().shell`. Node's `os.userInfo()` throws a `SystemError` whenever the OS can't resolve the current user, and oclif's call is unguarded — so the process dies inside the `config.load()` we invoke ourselves at `packages/cli-kit/src/public/node/cli-launcher.ts:31`.

Reported instances are Windows (`%APPDATA%\npm` global installs), where `SHELL` is normally unset so the syscall runs on every invocation. Worth noting libuv hardcodes the shell field to `NULL` on Windows, so that call can never return anything useful there — it can only succeed uselessly or crash.

This sets `SHELL` before handing off to oclif, but only when the lookup actually fails:

```ts
function setShellVariableWhenUserLookupFails(): void {
  if (process.env.SHELL !== undefined) return

  try {
    os.userInfo()
  } catch {
    process.env.SHELL = 'unknown'
  }
}
```

**Why the environment variable rather than a guard.** The obvious fix is to override oclif's `_shell()` on our `ShopifyConfig` subclass and catch the throw. That works on the pinned 4.8.3 and nothing else: 4.11 drops `_shell` from `Config` and moves the logic into a module-level `getShell()` (`lib/util/os.js:37`) that a subclass cannot reach. Both versions read the same `process.env.SHELL ?? os.userInfo().shell`, so seeding the variable is the one lever that covers both — and it does not depend on an undocumented protected member.

That also fixes #8497: the `plugins` topic resolves to `@oclif/core` **4.11.14**, whose `Command.run()` re-loads its own `Config`. A subclass override could never reach it; the environment variable does.

Behaviour on healthy machines is unchanged — the probe only runs when `SHELL` is unset, and only a throwing lookup writes anything. On a failing machine, `config.shell` becomes `'unknown'`, which is what oclif's own fallback branch emits, and feeds one consumer: `env_shell` in `packages/cli-kit/src/private/node/analytics.ts:101`. Those users currently send no analytics at all, so this is strictly more data, not less.

### Notes for the reviewer

**The tests drive the real crash path.** They spy on `node:os`'s `userInfo` — the default import is the same `module.exports` object oclif's compiled CJS does a property lookup on — and unset `SHELL`, so `config.load()` runs oclif's actual detection. Mutation-verified three ways: dropping the call from `load()`, having the helper swallow the failure without setting `SHELL`, and setting `SHELL` unconditionally without probing. Each fails exactly the expected test.

**Removal condition.** Drop this once `@oclif/core` guards the call itself. No released version does — it is unguarded in 4.8.3, 4.11.14 and on main. The note lives on the helper.

**Not added to `environmentIssueMessages`.** Leaving this class of report unhandled in Observe is what will tell us if the workaround ever stops working or the failure moves to a different frame.

### How to test your changes?

```bash
pnpm vitest run packages/cli-kit/src/public/node/custom-oclif-loader.test.ts
```

End to end, with the syscall forced to fail against a built CLI:

```bash
cat > /tmp/patch-os.cjs <<'JS'
const os = require('node:os')
os.userInfo = () => { throw new Error('A system error occurred: uv_os_get_passwd returned ENOMEM (not enough memory)') }
JS
env -u SHELL node --require /tmp/patch-os.cjs packages/cli/bin/run.js version
env -u SHELL node --require /tmp/patch-os.cjs packages/cli/bin/run.js plugins
```

Both crash on `main` and pass here.

Verified locally: `tsc --noEmit -p packages/cli-kit`, `nx run cli-kit:build`, `nx run cli:build` and `bin/run-knip-ci.js` all exit 0; eslint clean; full `packages/cli-kit` suite matches a stashed `main` baseline exactly (3 pre-existing failures in `deprecations.test.ts` and `node-package-manager.test.ts`). Two port-binding tests (`tcp.test.ts`, `graphiql/server.test.ts`) flake intermittently under load on my machine — confirmed unrelated by re-running this branch with the two new tests skipped, where they still flake at the same rate.

### Measuring impact

- [x] Error monitoring (Observe)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
