### PR TITLE
Allow static theme asset script URLs in app doctor

### DIFF
--- a/.changeset/quiet-assets-repair.md
+++ b/.changeset/quiet-assets-repair.md
@@ -1,0 +1,5 @@
+---
+'@shopify/app': patch
+---
+
+Avoid flagging static theme asset script tags in app doctor.

--- a/packages/app/src/cli/services/app-doctor-engine/rules/liquid-rules.ts
+++ b/packages/app/src/cli/services/app-doctor-engine/rules/liquid-rules.ts
@@ -66,6 +66,7 @@ function liquidExecutableContextVisitor(file: SourceFile) {
       const context = liquidOutputContext(ancestors)
       if (context !== 'javascript' && context !== 'executable_attribute') return undefined
       if (context === 'javascript' && filterNames(node).includes('json')) return undefined
+      if (isStaticScriptAssetUrl(node, ancestors)) return undefined
       return [
         makeLiquidIssue(
           'UNSAFE_INNERHTML',
@@ -116,6 +117,14 @@ function liquidOutputContext(ancestors: LiquidHtmlNode[]): LiquidOutputContext {
 function attributeName(attribute: AttributeNode): string {
   if (!('name' in attribute) || !Array.isArray(attribute.name)) return ''
   return attribute.name.map((part) => ('value' in part && typeof part.value === 'string' ? part.value : '')).join('')
+}
+
+function isStaticScriptAssetUrl(node: LiquidVariableOutput, ancestors: LiquidHtmlNode[]): boolean {
+  const script = ancestors.find((ancestor) => ancestor.type === 'HtmlRawNode' && ancestor.name === 'script')
+  const attribute = ancestors.find((ancestor): ancestor is AttributeNode => ancestor.type.startsWith('Attr'))
+  if (!script || !attribute || attributeName(attribute).toLowerCase() !== 'src') return false
+
+  return /^(['"])(?:\\.|(?!\1)[^\\\n])+\1\s*\|\s*asset_url\s*$/.test(outputSource(node).trim())
 }
 
 function outputSource(node: LiquidVariableOutput): string {

--- a/packages/app/src/cli/services/app-doctor-engine/tests/rule-analysis.test.ts
+++ b/packages/app/src/cli/services/app-doctor-engine/tests/rule-analysis.test.ts
@@ -707,8 +707,16 @@ describe('Liquid public AST analysis', () => {
     ])
     expect(ordinary.issues).toEqual([])
 
+    const staticAsset = scanLiquidSecurity([
+      source('<script src="{{ \'chat.js\' | asset_url }}" defer></script>', 'extensions/theme/blocks/chat.liquid'),
+    ])
+    expect(staticAsset.issues).toEqual([])
+
     const script = scanLiquidSecurity([
-      source('<script src="{{ block.settings.script | escape }}"></script>', 'extensions/theme/blocks/script.liquid'),
+      source(
+        '<script src="{{ block.settings.script | asset_url }}"></script>',
+        'extensions/theme/blocks/script.liquid',
+      ),
     ])
     expect(script.issues.map((finding) => finding.id)).toEqual(['LIQUID_UNSAFE_RENDER', 'UNSAFE_INNERHTML'])
   })


### PR DESCRIPTION
## What changed
- Allow the UNSAFE_INNERHTML Liquid check to skip literal theme asset script URLs like `{{ 'chat.js' | asset_url }}`.
- Keep dynamic script asset URLs flagged, including `{{ block.settings.script | asset_url }}`.
- Add a changeset for the App Doctor false-positive fix.

## Testing
- `pnpm vitest packages/app/src/cli/services/app-doctor-engine/tests/rule-analysis.test.ts --run`
- `pnpm eslint packages/app/src/cli/services/app-doctor-engine/rules/liquid-rules.ts packages/app/src/cli/services/app-doctor-engine/tests/rule-analysis.test.ts`
