### PR TITLE
[Tests] Add unit tests for global-context module

### DIFF
--- a/packages/cli-kit/src/public/node/global-context.test.ts
+++ b/packages/cli-kit/src/public/node/global-context.test.ts
@@ -1,0 +1,27 @@
+import {getCurrentCommandId, setCurrentCommandId} from './global-context.js'
+import {afterEach, describe, expect, test} from 'vitest'
+
+describe('global-context', () => {
+  afterEach(() => {
+    setCurrentCommandId('')
+  })
+
+  test('getCurrentCommandId returns empty string by default', () => {
+    // When
+    const got = getCurrentCommandId()
+
+    // Then
+    expect(got).toBe('')
+  })
+
+  test('setCurrentCommandId updates current command ID', () => {
+    // Given
+    const commandId = 'app:dev'
+
+    // When
+    setCurrentCommandId(commandId)
+
+    // Then
+    expect(getCurrentCommandId()).toBe('app:dev')
+  })
+})


### PR DESCRIPTION
Add unit tests for `getCurrentCommandId` and `setCurrentCommandId` in `packages/cli-kit/src/public/node/global-context.test.ts`, verifying default state and state updates.

---
*PR created automatically by Jules for task [14926705641586571079](https://jules.google.com/task/14926705641586571079) started by @gonzaloriestra*