### PR TITLE
Create the post-release docs PR through gitstream instead of GitHub

### DIFF
--- a/bin/create-doc-pr.js
+++ b/bin/create-doc-pr.js
@@ -6,7 +6,7 @@ import {createRequire} from 'node:module'
 import * as path from "pathe"
 import {findUp} from "find-up"
 
-import {withOctokit} from './github-utils.js'
+import {createWorldPullRequest} from './gitstream-utils.js'
 
 const require = createRequire(import.meta.url)
 const {readFile} = require('fs-extra')
@@ -24,32 +24,20 @@ async function createPR() {
     files[`areas/platforms/shopify-dev/db/data/docs/templated_apis/shopify_cli/${fileName}`] = (await readFile(path.join(generatedDirectory, fileName))).toString()
   }
 
-  await withOctokit("shop", async (octokit) => {
-    const response = await octokit
-      .createPullRequest({
-        owner: "shop",
-        repo: "world",
-        title: `[CLI] Update docs for version: ${version}`,
-        body: `We are updating the CLI documentation with the contents of the recently released version of the Shopify CLI [${version}](https://www.npmjs.com/package/@shopify/cli/v/${version})`,
-        head: `shopify-cli-${version}`,
-        base: "main",
-        update: true,
-        forceFork: false,
-        changes: [
-          {
-            files,
-            commit: `Update Shopify CLI documentation to version ${version}`,
-          },
-        ],
-        createWhenEmpty: false,
-      })
-
-    if (response) {
-      console.log(`PR URL: https://github.com/shop/world/pull/${response.data.number}`)
-    } else {
-      console.log("No changes detected, PR not created.")
-    }
+  const pullRequest = await createWorldPullRequest({
+    branch: `shopify-cli-${version}`,
+    base: "main",
+    title: `[CLI] Update docs for version: ${version}`,
+    body: `We are updating the CLI documentation with the contents of the recently released version of the Shopify CLI [${version}](https://www.npmjs.com/package/@shopify/cli/v/${version})`,
+    commitMessage: `Update Shopify CLI documentation to version ${version}`,
+    files,
   })
+
+  if (pullRequest) {
+    console.log(`PR URL: ${pullRequest.url}`)
+  } else {
+    console.log("No changes detected, PR not created.")
+  }
 }
 
 async function versionToRelease() {

--- a/bin/gitstream-utils.js
+++ b/bin/gitstream-utils.js
@@ -1,0 +1,179 @@
+#! /usr/bin/env node
+import {createHash} from 'node:crypto'
+
+import {runCommand} from './run-command.js'
+
+// The monorepo the CLI docs live in, and the repository `gs` targets by default.
+const WORLD_REPO = 'shop/world'
+
+/**
+ * @param {string[]} args
+ * @param {{input?: string}} [options]
+ * @returns {Promise<string>}
+ */
+function runGs(args, {input} = {}) {
+  return runCommand('gs', args, {printOutput: false, input})
+}
+
+/**
+ * Calls gitstream's GitHub-compatible REST API through `gs`, which supplies the credentials.
+ *
+ * @param {string} endpoint
+ * @param {{method?: string, body?: unknown}} [options]
+ * @returns {Promise<any>}
+ */
+async function gsApi(endpoint, {method = 'GET', body} = {}) {
+  const args = ['api', endpoint, '--method', method]
+  if (body !== undefined) args.push('--input', '-')
+
+  return JSON.parse(await runGs(args, {input: body === undefined ? undefined : JSON.stringify(body)}))
+}
+
+/**
+ * As `gsApi`, but returns undefined instead of throwing when the resource doesn't exist.
+ *
+ * @param {string} endpoint
+ * @returns {Promise<any>}
+ */
+async function gsApiAllowingMissing(endpoint) {
+  try {
+    return await gsApi(endpoint)
+  } catch (error) {
+    // `gs api` exits non-zero with the HTTP status in its stderr, which runCommand puts in the message.
+    if (error.message.includes('HTTP 404')) return undefined
+    throw error
+  }
+}
+
+/**
+ * The git blob SHA the given content would have. Comparing it against the SHA gitstream
+ * reports for a path tells us whether a file changed without downloading its contents.
+ *
+ * @param {string} content
+ * @returns {string}
+ */
+export function gitBlobSha(content) {
+  const bytes = Buffer.from(content)
+  return createHash('sha1').update(`blob ${bytes.length}\0`).update(bytes).digest('hex')
+}
+
+/**
+ * @param {string} branch
+ * @returns {Promise<string | undefined>} The branch's head commit SHA, or undefined when it doesn't exist.
+ */
+async function branchHeadSha(branch) {
+  const response = await gsApiAllowingMissing(`repos/${WORLD_REPO}/branches/${branch}`)
+  return response?.commit.sha
+}
+
+/**
+ * @param {Record<string, string>} files
+ * @param {string} commitSha
+ * @returns {Promise<Record<string, string>>} The subset of files whose contents differ from that commit.
+ */
+async function filesDifferingFrom(files, commitSha) {
+  const entries = await Promise.all(
+    Object.entries(files).map(async ([filePath, content]) => {
+      const existing = await gsApiAllowingMissing(`repos/${WORLD_REPO}/contents/${filePath}?ref=${commitSha}`)
+      return existing?.sha === gitBlobSha(content) ? undefined : [filePath, content]
+    }),
+  )
+
+  return Object.fromEntries(entries.filter((entry) => entry !== undefined))
+}
+
+/**
+ * @param {{message: string, files: Record<string, string>, parentSha: string}} options
+ * @returns {Promise<string>} The new commit's SHA.
+ */
+async function createCommit({message, files, parentSha}) {
+  const parentCommit = await gsApi(`repos/${WORLD_REPO}/git/commits/${parentSha}`)
+
+  const tree = await Promise.all(
+    Object.entries(files).map(async ([filePath, content]) => {
+      const blob = await gsApi(`repos/${WORLD_REPO}/git/blobs`, {
+        method: 'POST',
+        body: {content: Buffer.from(content).toString('base64'), encoding: 'base64'},
+      })
+      return {path: filePath, mode: '100644', type: 'blob', sha: blob.sha}
+    }),
+  )
+
+  const newTree = await gsApi(`repos/${WORLD_REPO}/git/trees`, {
+    method: 'POST',
+    body: {base_tree: parentCommit.tree.sha, tree},
+  })
+
+  const commit = await gsApi(`repos/${WORLD_REPO}/git/commits`, {
+    method: 'POST',
+    body: {message, tree: newTree.sha, parents: [parentSha]},
+  })
+
+  return commit.sha
+}
+
+/**
+ * @param {string} branch
+ * @returns {Promise<{number: number} | undefined>}
+ */
+async function openPullRequestForBranch(branch) {
+  const [pullRequest] = JSON.parse(await runGs(['pr', 'list', '--head', branch, '--state', 'open', '--json']))
+  return pullRequest
+}
+
+/**
+ * @param {{branch: string, base: string, title: string, body: string}} options
+ * @returns {Promise<{number: number}>}
+ */
+async function createPullRequest({branch, base, title, body}) {
+  // `gs pr create` creates a draft by default; `--publish` opens it ready for review.
+  const args = ['pr', 'create', '--head', branch, '--base', base, '--title', title, '--publish', '--json']
+
+  return JSON.parse(await runGs([...args, '--body-file', '-'], {input: body}))
+}
+
+/**
+ * Creates a branch in shop/world with the given file contents and opens a pull request for it.
+ *
+ * When the branch already exists the changes are committed on top of it, which updates the
+ * pull request that's already open for it rather than opening a second one.
+ *
+ * @param {{branch: string, base: string, title: string, body: string, commitMessage: string, files: Record<string, string>}} options
+ * @returns {Promise<{number: number, url: string} | undefined>} Undefined when no file changed.
+ */
+export async function createWorldPullRequest({branch, base, title, body, commitMessage, files}) {
+  const existingBranchSha = await branchHeadSha(branch)
+  const parentSha = existingBranchSha ?? (await branchHeadSha(base))
+  if (parentSha === undefined) {
+    throw new Error(`Neither ${branch} nor the base branch ${base} exists in ${WORLD_REPO}.`)
+  }
+
+  const changedFiles = await filesDifferingFrom(files, parentSha)
+  if (Object.keys(changedFiles).length === 0) return undefined
+
+  const commitSha = await createCommit({message: commitMessage, files: changedFiles, parentSha})
+
+  if (existingBranchSha === undefined) {
+    await gsApi(`repos/${WORLD_REPO}/git/refs`, {
+      method: 'POST',
+      body: {ref: `refs/heads/${branch}`, sha: commitSha},
+    })
+  } else {
+    // A fast-forward, since the commit was built on top of the branch's current head.
+    await gsApi(`repos/${WORLD_REPO}/git/refs/heads/${branch}`, {method: 'PATCH', body: {sha: commitSha}})
+  }
+
+  const pullRequest =
+    (await openPullRequestForBranch(branch)) ?? (await createPullRequest({branch, base, title, body}))
+
+  return {number: pullRequest.number, url: await pullRequestUrl(pullRequest.number)}
+}
+
+/**
+ * @param {number} number
+ * @returns {Promise<string>} The pull request's browser URL.
+ */
+async function pullRequestUrl(number) {
+  const {htmlUrl} = JSON.parse(await runGs(['pr', 'view', String(number), '--json']))
+  return htmlUrl
+}

--- a/bin/gitstream-utils.test.js
+++ b/bin/gitstream-utils.test.js
@@ -1,0 +1,25 @@
+import assert from 'node:assert/strict'
+import {execFileSync} from 'node:child_process'
+import {test} from 'node:test'
+
+import {gitBlobSha} from './gitstream-utils.js'
+
+test('computes the same blob SHA that git does', () => {
+  const content = 'Shopify CLI docs\n'
+
+  const sha = execFileSync('git', ['hash-object', '--stdin'], {input: content}).toString().trim()
+
+  assert.equal(gitBlobSha(content), sha)
+})
+
+test('computes the same blob SHA that git does for multi-byte content', () => {
+  const content = 'ünïcödé docs — 日本語\n'
+
+  const sha = execFileSync('git', ['hash-object', '--stdin'], {input: content}).toString().trim()
+
+  assert.equal(gitBlobSha(content), sha)
+})
+
+test('gives different blob SHAs to different contents', () => {
+  assert.notEqual(gitBlobSha('one'), gitBlobSha('two'))
+})

--- a/bin/post-release
+++ b/bin/post-release
@@ -16,10 +16,17 @@ if [[ -n $(git status -s) ]]; then
     exit 1
 fi
 
-# Check if github print-auth is working
+# Check if github print-auth is working (needed for the homebrew and notification PRs)
 if ! $(/opt/dev/bin/dev github print-auth --password > /dev/null 2>&1); then
     echo "Error: GitHub CLI authentication failed"
     echo "Try running \`dev github print-auth\` manually"
+    exit 1
+fi
+
+# Check if gitstream auth is working (needed for the docs PR, which goes to shop/world)
+if ! gs auth status > /dev/null 2>&1; then
+    echo "Error: gitstream authentication failed"
+    echo "Try running \`gs auth login\` manually"
     exit 1
 fi
 

--- a/bin/run-command.js
+++ b/bin/run-command.js
@@ -3,12 +3,14 @@ import {spawn} from 'child_process'
 /**
  * @param {string} command
  * @param {string[]} args
- * @param {{printOutput?: boolean}} [options]
+ * @param {{printOutput?: boolean, input?: string}} [options]
  * @returns {Promise<string>}
  */
-export function runCommand(command, args, {printOutput = true} = {}) {
+export function runCommand(command, args, {printOutput = true, input} = {}) {
   return new Promise((resolve, reject) => {
-    const child = spawn(command, args, {stdio: ['inherit', 'pipe', 'pipe']})
+    const child = spawn(command, args, {stdio: [input === undefined ? 'inherit' : 'pipe', 'pipe', 'pipe']})
+
+    if (input !== undefined) child.stdin.end(input)
 
     let output = ''
     let errorOutput = ''
@@ -21,6 +23,12 @@ export function runCommand(command, args, {printOutput = true} = {}) {
     child.stderr.on('data', (data) => {
       if (printOutput) console.log(data.toString())
       errorOutput += data.toString()
+    })
+
+    // Without this the event is unhandled and takes the whole process down, so a missing
+    // binary looks like a crash instead of a failed command.
+    child.on('error', (error) => {
+      reject(new Error(`Command \`${command}\` could not be run: ${error.message}`))
     })
 
     child.on('close', (code) => {

--- a/bin/run-command.test.js
+++ b/bin/run-command.test.js
@@ -14,3 +14,16 @@ test('captures command output without printing it when requested', async (contex
   assert.equal(output, sensitiveOutput)
   assert.equal(consoleLog.mock.callCount(), 0)
 })
+
+test('rejects instead of crashing when the command does not exist', async () => {
+  await assert.rejects(runCommand('definitely-not-a-real-binary', []), /could not be run/)
+})
+
+test('passes input to the command on stdin', async () => {
+  const output = await runCommand(process.execPath, ['-e', 'process.stdin.pipe(process.stdout)'], {
+    printOutput: false,
+    input: 'piped input',
+  })
+
+  assert.equal(output, 'piped input')
+})


### PR DESCRIPTION
### WHY are these changes introduced?

`shop/world` is served by [gitstream](https://github.com/shop/world/blob/main/system/gitstream/docs/content/users/api.md) now, so the post-release docs PR can't go through GitHub anymore.

### WHAT is this pull request doing?

**`bin/gitstream-utils.js`** (new) does over gitstream's GitHub-compatible REST API what `octokit-plugin-create-pull-request` did for us: blob → tree → commit → ref via `gs api`, then `gs pr create`. It keeps the two behaviours the old call relied on — updating the PR already open for the branch, and skipping the PR when nothing changed (by comparing git blob SHAs, so the 449 KB of generated JSON never gets downloaded). No local `world` checkout needed; `gs` defaults to `shop/world` from any directory.

**`bin/create-doc-pr.js`** swaps `withOctokit` for `createWorldPullRequest` — same branch, base, title and body.

**`bin/run-command.js`** gains an `input` option (JSON bodies for `gs api --input -`) and an `'error'` listener; `spawn` of a missing binary used to kill the process instead of rejecting.

**`bin/post-release`** gains a `gs auth status` preflight. Its GitHub preflight stays — the homebrew and notification PRs still target GitHub repos and are untouched.

No changeset: internal release tooling, no user-visible change.

### How to test your changes?

`node --test bin/*.test.js`.

Also tophatted end-to-end against a scratch base branch in `shop/world` — the PR it produced is [shop/world#2049670](https://meteorite.shopify.io/repos/shop/world/pulls/2049670) (`shopify-cli-tophat-4.8.0` → `cli-docs-tophat-base`, since closed).

⚠️ `bin/create-doc-pr.js` also runs in Shipit (`shipit.production.yml:19`), which now needs `gs` on PATH and gitstream credentials (`GS_GITSTREAM_TOKEN`) where it previously used an injected `GITHUB_TOKEN` — **worth confirming before the next release.**

Out of scope, but adjacent: `.github/workflows/shopify-dev-preview-automation.yml` still dispatches to `api.github.com/repos/shop/world/dispatches`.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
