### PR TITLE
Fail the build when App Doctor embedded checks are stale

### DIFF
--- a/packages/app/project.json
+++ b/packages/app/project.json
@@ -14,8 +14,23 @@
     },
     "build": {
       "executor": "nx:run-commands",
+      "dependsOn": ["^build", "check-app-doctor-checks"],
       "options": {
         "command": "pnpm tsc -b ./tsconfig.build.json",
+        "cwd": "packages/app"
+      }
+    },
+    "check-app-doctor-checks": {
+      "executor": "nx:run-commands",
+      "cache": true,
+      "inputs": [
+        "{projectRoot}/src/cli/services/app-doctor-engine/embed-checks.mjs",
+        "{projectRoot}/src/cli/services/app-doctor-engine/INSTRUCTIONS.md",
+        "{projectRoot}/src/cli/services/app-doctor-engine/checks/*.md",
+        "{projectRoot}/src/cli/services/app-doctor-engine/checks/embedded.ts"
+      ],
+      "options": {
+        "command": "node src/cli/services/app-doctor-engine/embed-checks.mjs --check",
         "cwd": "packages/app"
       }
     },

--- a/packages/app/src/cli/services/app-doctor-engine/embed-checks.mjs
+++ b/packages/app/src/cli/services/app-doctor-engine/embed-checks.mjs
@@ -3,6 +3,9 @@
 /**
  * Embeds the versioned semantic-check markdown so the bundled CLI does not
  * depend on runtime assets. The markdown files remain the source of truth.
+ *
+ *   node embed-checks.mjs           Write checks/embedded.ts
+ *   node embed-checks.mjs --check   Exit 1 if embedded.ts is stale
  */
 import {readFileSync, readdirSync, writeFileSync} from 'node:fs'
 import {dirname, join} from 'node:path'
@@ -29,7 +32,32 @@ export const EMBEDDED_CHECK_SOURCES: ReadonlyArray<string> = ${JSON.stringify(so
 export const EMBEDDED_APP_DOCTOR_INSTRUCTIONS = ${JSON.stringify(instructions)};
 `
 
-writeFileSync(outputPath, output)
-console.log(
-  `Embedded ${files.length} semantic checks and App Doctor instructions in app-doctor-engine/checks/embedded.ts`,
-)
+if (process.argv.includes('--check')) {
+  let actual = ''
+  try {
+    actual = readFileSync(outputPath, 'utf8')
+  } catch {
+    // Missing generated file is a mismatch.
+  }
+
+  if (actual !== output) {
+    console.error(`App Doctor embedded.ts is out of date.
+
+Markdown checks and instructions are the source of truth, but
+packages/app/src/cli/services/app-doctor-engine/checks/embedded.ts
+does not match what embed-checks.mjs would generate.
+
+Run:
+  pnpm --filter @shopify/app generate:app-doctor-checks
+
+Then commit the updated embedded.ts.`)
+    process.exit(1)
+  }
+
+  console.log(`App Doctor embedded.ts is up to date (${files.length} semantic checks and instructions)`)
+} else {
+  writeFileSync(outputPath, output)
+  console.log(
+    `Embedded ${files.length} semantic checks and App Doctor instructions in app-doctor-engine/checks/embedded.ts`,
+  )
+}

--- a/packages/app/src/cli/services/app-doctor-engine/embed-checks.mjs
+++ b/packages/app/src/cli/services/app-doctor-engine/embed-checks.mjs
@@ -32,15 +32,28 @@ export const EMBEDDED_CHECK_SOURCES: ReadonlyArray<string> = ${JSON.stringify(so
 export const EMBEDDED_APP_DOCTOR_INSTRUCTIONS = ${JSON.stringify(instructions)};
 `
 
-if (process.argv.includes('--check')) {
+const args = process.argv.slice(2)
+const unknownArgs = args.filter((arg) => arg !== '--check')
+
+if (unknownArgs.length > 0) {
+  console.error(`Unknown argument${unknownArgs.length === 1 ? '' : 's'}: ${unknownArgs.join(', ')}
+
+Usage:
+  node embed-checks.mjs           Write checks/embedded.ts
+  node embed-checks.mjs --check   Exit 1 if embedded.ts is stale`)
+  process.exitCode = 1
+} else if (args.includes('--check')) {
   let actual = ''
   try {
     actual = readFileSync(outputPath, 'utf8')
-  } catch {
+  } catch (error) {
+    if (error.code !== 'ENOENT') throw error
     // Missing generated file is a mismatch.
   }
 
-  if (actual !== output) {
+  if (actual === output) {
+    console.log(`App Doctor embedded.ts is up to date (${files.length} semantic checks and instructions)`)
+  } else {
     console.error(`App Doctor embedded.ts is out of date.
 
 Markdown checks and instructions are the source of truth, but
@@ -51,10 +64,8 @@ Run:
   pnpm --filter @shopify/app generate:app-doctor-checks
 
 Then commit the updated embedded.ts.`)
-    process.exit(1)
+    process.exitCode = 1
   }
-
-  console.log(`App Doctor embedded.ts is up to date (${files.length} semantic checks and instructions)`)
 } else {
   writeFileSync(outputPath, output)
   console.log(


### PR DESCRIPTION
### WHY are these changes introduced?

Developers edit App Doctor checks and instructions in Markdown, then run a script that copies that text into `embedded.ts`. If they skip the script, the released CLI keeps serving the old content.

### WHAT is this pull request doing?

Fail the app Nx build when `embedded.ts` does not match the Markdown sources, so local builds and CI catch a missed regenerate.

### How to manually test your changes?

```
pnpm nx run app:check-app-doctor-checks
```

That should pass on this branch. Then change any file under `packages/app/src/cli/services/app-doctor-engine/checks/*.md` or `INSTRUCTIONS.md` without regenerating, and run:

```
pnpm nx run app:build
```

The build should fail and tell you to run `pnpm --filter @shopify/app generate:app-doctor-checks`.

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`