### PR TITLE
Reuse Shopify CLI app identity and config schemas in App Doctor

### DIFF
--- a/packages/app/src/cli/models/app/config-file-naming.test.ts
+++ b/packages/app/src/cli/models/app/config-file-naming.test.ts
@@ -52,6 +52,8 @@ describe('isValidFormatAppConfigurationFileName', () => {
   test('returns false for invalid filenames', () => {
     expect(isValidFormatAppConfigurationFileName('production')).toBe(false)
     expect(isValidFormatAppConfigurationFileName('shopify.web.toml')).toBe(false)
+    expect(isValidFormatAppConfigurationFileName('shopify.application.toml')).toBe(false)
+    expect(isValidFormatAppConfigurationFileName('shopify.app.foo.bar.toml')).toBe(false)
     expect(isValidFormatAppConfigurationFileName('shopify.app..toml')).toBe(false)
     expect(isValidFormatAppConfigurationFileName('')).toBe(false)
   })

--- a/packages/app/src/cli/models/app/config-file-naming.ts
+++ b/packages/app/src/cli/models/app/config-file-naming.ts
@@ -5,6 +5,9 @@ import {basename} from '@shopify/cli-kit/node/path'
 const appConfigurationFileNameRegex = /^shopify\.app(\.[-\w]+)?\.toml$/
 export type AppConfigurationFileName = 'shopify.app.toml' | `shopify.app.${string}.toml`
 
+/** Glob used to discover app configuration files. Always filter matches with `isValidFormatAppConfigurationFileName`. */
+export const APP_CONFIG_FILE_GLOB = 'shopify.app*.toml'
+
 /**
  * Gets the name of the app configuration file (e.g. `shopify.app.production.toml`) based on a provided config name.
  *

--- a/packages/app/src/cli/models/project/project.ts
+++ b/packages/app/src/cli/models/project/project.ts
@@ -1,4 +1,5 @@
 import {configurationFileNames} from '../../constants.js'
+import {APP_CONFIG_FILE_GLOB, isValidFormatAppConfigurationFileName} from '../app/config-file-naming.js'
 import {TomlFile, TomlFileError} from '@shopify/cli-kit/node/toml/toml-file'
 import {readAndParseDotEnv, DotEnvFile} from '@shopify/cli-kit/node/dot-env'
 import {fileExists, glob, findPathUp, readFile} from '@shopify/cli-kit/node/fs'
@@ -12,8 +13,6 @@ import {joinPath, basename} from '@shopify/cli-kit/node/path'
 import {AbortError} from '@shopify/cli-kit/node/error'
 import {JsonMapType} from '@shopify/cli-kit/node/toml'
 
-const APP_CONFIG_GLOB = 'shopify.app*.toml'
-const APP_CONFIG_REGEX = /^shopify\.app(\.[-\w]+)?\.toml$/
 const EXTENSION_TOML = '*.extension.toml'
 const WEB_TOML = 'shopify.web.toml'
 const DEFAULT_EXTENSION_DIR = 'extensions/*'
@@ -164,8 +163,8 @@ export class Project {
 async function findProjectRoot(startDirectory: string): Promise<string> {
   const found = await findPathUp(
     async (directory) => {
-      const matches = await glob(joinPath(directory, APP_CONFIG_GLOB))
-      if (matches.length > 0) return directory
+      const matches = await glob(joinPath(directory, APP_CONFIG_FILE_GLOB))
+      if (matches.some((path) => isValidFormatAppConfigurationFileName(basename(path)))) return directory
     },
     {
       cwd: startDirectory,
@@ -181,9 +180,9 @@ async function findProjectRoot(startDirectory: string): Promise<string> {
 }
 
 async function discoverAppConfigFiles(directory: string, errors: TomlFileError[]): Promise<TomlFile[]> {
-  const pattern = joinPath(directory, APP_CONFIG_GLOB)
+  const pattern = joinPath(directory, APP_CONFIG_FILE_GLOB)
   const paths = await glob(pattern)
-  const validPaths = paths.filter((filePath) => APP_CONFIG_REGEX.test(basename(filePath)))
+  const validPaths = paths.filter((filePath) => isValidFormatAppConfigurationFileName(basename(filePath)))
   return readTomlFilesCollectingErrors(validPaths, errors)
 }
 

--- a/packages/app/src/cli/prompts/config.ts
+++ b/packages/app/src/cli/prompts/config.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-await-in-loop */
-import {AppConfigurationFileName} from '../models/app/loader.js'
+import {AppConfigurationFileName, isValidFormatAppConfigurationFileName} from '../models/app/loader.js'
 import {
   RenderTextPromptOptions,
   renderConfirmationPrompt,
@@ -43,7 +43,8 @@ function filenameFromName(name: string, highlight = false): AppConfigurationFile
 }
 
 export async function findConfigFiles(directory: string): Promise<string[]> {
-  return glob(joinPath(directory, 'shopify.app*.toml'))
+  const files = await glob(joinPath(directory, 'shopify.app*.toml'))
+  return files.filter((path) => isValidFormatAppConfigurationFileName(basename(path)))
 }
 
 export async function selectConfigFile(directory: string): Promise<Result<string, string>> {

--- a/packages/app/src/cli/prompts/config.ts
+++ b/packages/app/src/cli/prompts/config.ts
@@ -1,4 +1,5 @@
 /* eslint-disable no-await-in-loop */
+import {APP_CONFIG_FILE_GLOB} from '../models/app/config-file-naming.js'
 import {AppConfigurationFileName, isValidFormatAppConfigurationFileName} from '../models/app/loader.js'
 import {
   RenderTextPromptOptions,
@@ -43,7 +44,7 @@ function filenameFromName(name: string, highlight = false): AppConfigurationFile
 }
 
 export async function findConfigFiles(directory: string): Promise<string[]> {
-  const files = await glob(joinPath(directory, 'shopify.app*.toml'))
+  const files = await glob(joinPath(directory, APP_CONFIG_FILE_GLOB))
   return files.filter((path) => isValidFormatAppConfigurationFileName(basename(path)))
 }
 

--- a/packages/app/src/cli/services/app-doctor-engine/scanners/discover.ts
+++ b/packages/app/src/cli/services/app-doctor-engine/scanners/discover.ts
@@ -1,7 +1,9 @@
+import {APP_CONFIG_FILE_GLOB, isValidFormatAppConfigurationFileName} from '../../../models/app/config-file-naming.js'
 import {AppAccessScopesSchema, AppAuthSchema} from '../../../models/extensions/specifications/app_config_app_access.js'
 import {WebhookSubscriptionSchema} from '../../../models/extensions/specifications/app_config_webhook_schemas/webhook_subscription_schema.js'
+import {removeTrailingSlash} from '../../../models/extensions/specifications/validation/common.js'
 import {fileExistsSync, fileSizeSync, globSync, readFileSync} from '@shopify/cli-kit/node/fs'
-import {cwd, dirname, extname, joinPath, relativePath, resolvePath} from '@shopify/cli-kit/node/path'
+import {basename, cwd, dirname, extname, joinPath, relativePath, resolvePath} from '@shopify/cli-kit/node/path'
 import {zod} from '@shopify/cli-kit/node/schema'
 import {decodeToml} from '@shopify/cli-kit/node/toml/codec'
 import {lstatSync} from 'node:fs'
@@ -19,11 +21,12 @@ export class AppRootDiscoveryError extends Error {
 /**
  * Find the nearest app root without ever substituting CWD for a bad explicit path.
  *
- * This is intentionally not `Project.load()`. That loader also reads package,
- * environment, and hidden configuration, and it does not keep the bounded raw
- * bytes App Doctor hashes and reports as coverage. App Doctor reuses the same
- * `shopify.app*.toml` candidate shape, then reads those files through its own
- * repository boundary.
+ * App identity matches the rest of Shopify CLI: walk up for
+ * `shopify.app.toml` / `shopify.app.<name>.toml` using
+ * `isValidFormatAppConfigurationFileName`. This is not `Project.load()` — that
+ * loader also reads package, environment, and hidden configuration, follows
+ * different symlink policy, and does not keep the bounded raw bytes App Doctor
+ * hashes and reports as coverage.
  */
 export function findAppRoot(startPath?: string): string {
   const requestedPath = resolvePath(startPath ?? cwd())
@@ -33,7 +36,7 @@ export function findAppRoot(startPath?: string): string {
 
   let directory = requestedPath
   if (startPath && lstatSync(requestedPath).isFile()) {
-    if (!requestedPath.endsWith('.toml')) {
+    if (!isValidFormatAppConfigurationFileName(basename(requestedPath))) {
       throw new AppRootDiscoveryError(`App path is not a directory or TOML file: ${startPath}`)
     }
     return dirname(requestedPath)
@@ -43,14 +46,7 @@ export function findAppRoot(startPath?: string): string {
   }
 
   while (true) {
-    const tomls = globSync('shopify.app*.toml', {
-      cwd: directory,
-      deep: 1,
-      dot: false,
-      onlyFiles: false,
-      followSymbolicLinks: false,
-    })
-    if (tomls.length > 0) return directory
+    if (listAppConfigFiles(directory).length > 0) return directory
 
     const parent = dirname(directory)
     if (parent === directory) break
@@ -60,22 +56,25 @@ export function findAppRoot(startPath?: string): string {
   throw new AppRootDiscoveryError(`Could not find a shopify.app*.toml from: ${startPath ?? cwd()}`)
 }
 
-/**
- * Find and parse all shopify.app.*.toml files in the app root.
- *
- * Candidate discovery matches `Project.load()`, but parsing stays on bounded
- * raw reads so unreadable files become coverage gaps instead of loader errors.
- */
-export function findAppTomls(appRoot: string): AppTomlContent[] {
-  const files = globSync('shopify.app*.toml', {
-    cwd: appRoot,
+function listAppConfigFiles(directory: string): string[] {
+  return globSync(APP_CONFIG_FILE_GLOB, {
+    cwd: directory,
     deep: 1,
     dot: false,
     onlyFiles: false,
     followSymbolicLinks: false,
-  })
+  }).filter((file) => isValidFormatAppConfigurationFileName(basename(file)))
+}
 
-  return files.flatMap((file) => {
+/**
+ * Find and parse all shopify.app.*.toml files in the app root.
+ *
+ * Candidate discovery uses the same config-file identity as `Project.load()`,
+ * but parsing stays on bounded raw reads so unreadable files become coverage
+ * gaps instead of loader errors.
+ */
+export function findAppTomls(appRoot: string): AppTomlContent[] {
+  return listAppConfigFiles(appRoot).flatMap((file) => {
     const path = joinPath(appRoot, file)
     const content = readRepositoryText(appRoot, path)
     if (content === undefined) return []
@@ -116,6 +115,7 @@ export function loadAppToml(tomlPath: string, appRoot = dirname(tomlPath)): AppT
   }
 }
 
+/** CLI webhook section shape. URI fields stay strings so INSECURE_WEBHOOK_URL can report http. */
 const WebhooksSectionSchema = zod.object({
   api_version: zod.string().optional(),
   privacy_compliance: zod
@@ -128,10 +128,11 @@ const WebhooksSectionSchema = zod.object({
   subscriptions: zod.array(zod.unknown()).optional(),
 })
 
-const EvidenceWebhookSubscriptionSchema = zod.object({
-  uri: zod.string(),
-  topics: zod.array(zod.string()).optional(),
-  compliance_topics: zod.array(zod.string()).optional(),
+const SecurityWebhookSubscriptionSchema = WebhookSubscriptionSchema.extend({
+  uri: zod.preprocess(
+    (arg) => removeTrailingSlash(arg as string),
+    zod.string({invalid_type_error: 'Value must be string'}),
+  ),
 })
 
 export function parseAppToml(
@@ -170,14 +171,11 @@ function projectAccessScopes(value: unknown, path: string, appRoot?: string): st
 function projectRedirectUrls(value: unknown, path: string, appRoot?: string): string[] {
   if (value === undefined) return []
   const parsed = AppAuthSchema.safeParse(value)
-  if (parsed.success) return parsed.data.redirect_urls
-
-  const fallback = zod.object({redirect_urls: zod.array(zod.string())}).safeParse(value)
-  if (!fallback.success) {
+  if (!parsed.success) {
     recordSectionGap(appRoot, path, 'auth section could not be parsed')
     return []
   }
-  return fallback.data.redirect_urls
+  return parsed.data.redirect_urls
 }
 
 function projectWebhooks(
@@ -207,22 +205,12 @@ function projectWebhooks(
 }
 
 function projectWebhookSubscription(value: unknown): WebhookSubscription[] {
-  const strict = WebhookSubscriptionSchema.safeParse(value)
-  if (strict.success) {
-    return [
-      {
-        topics: [...(strict.data.topics ?? []), ...(strict.data.compliance_topics ?? [])],
-        uri: strict.data.uri,
-      },
-    ]
-  }
-
-  const evidence = EvidenceWebhookSubscriptionSchema.safeParse(value)
-  if (!evidence.success) return []
+  const parsed = SecurityWebhookSubscriptionSchema.safeParse(value)
+  if (!parsed.success) return []
   return [
     {
-      topics: [...(evidence.data.topics ?? []), ...(evidence.data.compliance_topics ?? [])],
-      uri: evidence.data.uri,
+      topics: [...(parsed.data.topics ?? []), ...(parsed.data.compliance_topics ?? [])],
+      uri: parsed.data.uri,
     },
   ]
 }
@@ -274,7 +262,7 @@ function normalizePath(path: string): string {
 function findNestedAppDirectories(appRoot: string): string[] {
   return [
     ...new Set(
-      globSync('**/shopify.app*.toml', {
+      globSync(`**/${APP_CONFIG_FILE_GLOB}`, {
         followSymbolicLinks: false,
         cwd: appRoot,
         ignore: IGNORED_DIRECTORIES,
@@ -282,6 +270,7 @@ function findNestedAppDirectories(appRoot: string): string[] {
         dot: false,
         onlyFiles: false,
       })
+        .filter((path) => isValidFormatAppConfigurationFileName(basename(path)))
         .map((path) => normalizePath(dirname(path)))
         .filter((path) => path !== '.' && path.length > 0),
     ),
@@ -300,7 +289,7 @@ function discoveryIgnores(directory: string, projectRoot: string): string[] {
  * Find extension-like repository content under the app root.
  *
  * `Project.load()` only considers paths in each app configuration's
- * `extension_directories`. App Doctor scans every `shopify.extension.toml`
+ * `extension_directories`. App Doctor still scans every `shopify.extension.toml`
  * inside the repository boundary, including unconfigured extensions, because
  * those files can still contain secrets, XSS, and other security evidence.
  * Nested apps, generated output, and test trees remain excluded.

--- a/packages/app/src/cli/services/app-doctor-engine/scanners/discover.ts
+++ b/packages/app/src/cli/services/app-doctor-engine/scanners/discover.ts
@@ -37,7 +37,7 @@ export function findAppRoot(startPath?: string): string {
   let directory = requestedPath
   if (startPath && lstatSync(requestedPath).isFile()) {
     if (!isValidFormatAppConfigurationFileName(basename(requestedPath))) {
-      throw new AppRootDiscoveryError(`App path is not a directory or TOML file: ${startPath}`)
+      throw new AppRootDiscoveryError(`App path is not a directory or Shopify app configuration file: ${startPath}`)
     }
     return dirname(requestedPath)
   }
@@ -190,7 +190,9 @@ function projectWebhooks(
     return {subscriptions: []}
   }
 
-  const webhookSubscriptions = (parsed.data.subscriptions ?? []).flatMap(projectWebhookSubscription)
+  const webhookSubscriptions = (parsed.data.subscriptions ?? []).flatMap((subscription) =>
+    projectWebhookSubscription(subscription, path, appRoot),
+  )
   const privacyCompliance = parsed.data.privacy_compliance
   const privacyComplianceWebhooks = [
     {topic: 'customers/redact', uri: privacyCompliance?.customer_deletion_url},
@@ -204,15 +206,28 @@ function projectWebhooks(
   }
 }
 
-function projectWebhookSubscription(value: unknown): WebhookSubscription[] {
+const WebhookUriOnlySchema = zod.object({
+  uri: zod.preprocess(
+    (arg) => removeTrailingSlash(arg as string),
+    zod.string({invalid_type_error: 'Value must be string'}),
+  ),
+})
+
+function projectWebhookSubscription(value: unknown, path: string, appRoot?: string): WebhookSubscription[] {
   const parsed = SecurityWebhookSubscriptionSchema.safeParse(value)
-  if (!parsed.success) return []
-  return [
-    {
-      topics: [...(parsed.data.topics ?? []), ...(parsed.data.compliance_topics ?? [])],
-      uri: parsed.data.uri,
-    },
-  ]
+  if (parsed.success) {
+    return [
+      {
+        topics: [...(parsed.data.topics ?? []), ...(parsed.data.compliance_topics ?? [])],
+        uri: parsed.data.uri,
+      },
+    ]
+  }
+
+  recordSectionGap(appRoot, path, 'webhook subscription could not be parsed')
+  const uriOnly = WebhookUriOnlySchema.safeParse(value)
+  if (!uriOnly.success) return []
+  return [{topics: [], uri: uriOnly.data.uri}]
 }
 
 function recordSectionGap(appRoot: string | undefined, path: string, detail: string): void {

--- a/packages/app/src/cli/services/app-doctor-engine/tests/deterministic-rules.test.ts
+++ b/packages/app/src/cli/services/app-doctor-engine/tests/deterministic-rules.test.ts
@@ -132,6 +132,19 @@ describe('deterministic rules product contract', () => {
     )
     expect(parsed.webhooks).toEqual([])
   })
+
+  test('keeps an insecure URI when another subscription field is invalid', () => {
+    const parsed = parseAppToml(
+      {
+        webhooks: {
+          api_version: '2023-07',
+          subscriptions: [{topics: ['orders/create'], uri: 'http://insecure.example/webhooks', filter: 42}],
+        },
+      },
+      '/app/shopify.app.toml',
+    )
+    expect(parsed.webhooks).toEqual([{topics: [], uri: 'http://insecure.example/webhooks'}])
+  })
 })
 
 describe('JavaScript regex mode', () => {

--- a/packages/app/src/cli/services/app-doctor-engine/tests/deterministic-rules.test.ts
+++ b/packages/app/src/cli/services/app-doctor-engine/tests/deterministic-rules.test.ts
@@ -107,7 +107,7 @@ describe('deterministic rules product contract', () => {
     expect(parsed.apiVersion).toBeUndefined()
   })
 
-  test('keeps insecure webhook URIs that the CLI schema rejects', () => {
+  test('keeps insecure webhook URIs that the CLI URI validator rejects', () => {
     const parsed = parseAppToml(
       {
         webhooks: {
@@ -118,6 +118,19 @@ describe('deterministic rules product contract', () => {
       '/app/shopify.app.toml',
     )
     expect(parsed.webhooks).toEqual([{topics: ['orders/create'], uri: 'http://insecure.example/webhooks'}])
+  })
+
+  test('drops webhook subscriptions that are not CLI-shaped', () => {
+    const parsed = parseAppToml(
+      {
+        webhooks: {
+          api_version: '2023-07',
+          subscriptions: [{not: 'a-subscription'}, {topics: ['orders/create']}],
+        },
+      },
+      '/app/shopify.app.toml',
+    )
+    expect(parsed.webhooks).toEqual([])
   })
 })
 

--- a/packages/app/src/cli/services/app-doctor-engine/tests/discovery-safety.test.ts
+++ b/packages/app/src/cli/services/app-doctor-engine/tests/discovery-safety.test.ts
@@ -71,6 +71,16 @@ describe.sequential('app root discovery', () => {
     await writeFile(join(root, 'shopify.app.foo.bar.toml'), appConfiguration)
     expect(() => findAppRoot(root)).toThrow(AppRootDiscoveryError)
   })
+
+  test('rejects an explicit non-app TOML path with a configuration-file error', async () => {
+    const root = await makeDirectory()
+    const webToml = join(root, 'shopify.web.toml')
+    await writeFile(webToml, 'type = "frontend"\n')
+    expect(() => findAppRoot(webToml)).toThrow(AppRootDiscoveryError)
+    expect(() => findAppRoot(webToml)).toThrow(
+      `App path is not a directory or Shopify app configuration file: ${webToml}`,
+    )
+  })
 })
 
 describe('repository discovery exclusions', () => {

--- a/packages/app/src/cli/services/app-doctor-engine/tests/discovery-safety.test.ts
+++ b/packages/app/src/cli/services/app-doctor-engine/tests/discovery-safety.test.ts
@@ -64,6 +64,13 @@ describe.sequential('app root discovery', () => {
     expect(() => findAppRoot(missing)).toThrow(AppRootDiscoveryError)
     expect(() => findAppRoot(missing)).toThrow(`App path does not exist: ${missing}`)
   })
+
+  test('ignores files that match the glob but are not CLI app configuration names', async () => {
+    const root = await makeDirectory()
+    await writeFile(join(root, 'shopify.application.toml'), appConfiguration)
+    await writeFile(join(root, 'shopify.app.foo.bar.toml'), appConfiguration)
+    expect(() => findAppRoot(root)).toThrow(AppRootDiscoveryError)
+  })
 })
 
 describe('repository discovery exclusions', () => {


### PR DESCRIPTION
### WHY are these changes introduced?

App Doctor walked up for `shopify.app*.toml` and parsed access, auth, and webhooks with its own schemas and fallbacks. That can disagree with Shopify CLI as those rules change.

Stacked on #8513.

### WHAT is this pull request doing?

Share CLI app-config identity (`isValidFormatAppConfigurationFileName` / `APP_CONFIG_FILE_GLOB`) in Project discovery, config-file prompts, and App Doctor. Parse access, auth, and webhook subscriptions with the CLI schemas. Keep webhook URIs as strings so `INSECURE_WEBHOOK_URL` can still report http.

This is not `Project.load()`. Bounded reads, coverage gaps, no-cwd-fallback, and scanning unconfigured extensions stay Doctor-specific.

No user-facing CLI command change.

### How to manually test your changes?

From an app directory:

```
shopify app doctor
shopify app doctor --path ./shopify.app.toml
```

A directory that only has `shopify.application.toml` should not be treated as an app root.

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`