### PR TITLE
[Tests] Add unit tests for deprecations store

### DIFF
--- a/packages/cli-kit/src/private/node/context/deprecations-store.test.ts
+++ b/packages/cli-kit/src/private/node/context/deprecations-store.test.ts
@@ -1,0 +1,88 @@
+import {afterEach, beforeEach, describe, expect, test, vi} from 'vitest'
+
+describe('deprecations-store', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  test('getNextDeprecationDate initially returns undefined', async () => {
+    const {getNextDeprecationDate} = await import('./deprecations-store.js')
+    vi.setSystemTime(new Date(2025, 0, 1))
+
+    expect(getNextDeprecationDate()).toBeUndefined()
+  })
+
+  test('setNextDeprecationDate with empty array does not set deprecation date', async () => {
+    const {getNextDeprecationDate, setNextDeprecationDate} = await import('./deprecations-store.js')
+    vi.setSystemTime(new Date(2025, 0, 1))
+
+    setNextDeprecationDate([])
+    expect(getNextDeprecationDate()).toBeUndefined()
+  })
+
+  test('setNextDeprecationDate with past dates does not set deprecation date', async () => {
+    const {getNextDeprecationDate, setNextDeprecationDate} = await import('./deprecations-store.js')
+    vi.setSystemTime(new Date(2025, 0, 15))
+
+    const pastDate = new Date(2025, 0, 1)
+    setNextDeprecationDate([pastDate])
+
+    expect(getNextDeprecationDate()).toBeUndefined()
+  })
+
+  test('setNextDeprecationDate with a future date sets the deprecation date', async () => {
+    const {getNextDeprecationDate, setNextDeprecationDate} = await import('./deprecations-store.js')
+    vi.setSystemTime(new Date(2025, 0, 1))
+
+    const futureDate = new Date(2025, 0, 10)
+    setNextDeprecationDate([futureDate])
+
+    expect(getNextDeprecationDate()).toEqual(futureDate)
+  })
+
+  test('setNextDeprecationDate updates if a new future date is earlier than stored date', async () => {
+    const {getNextDeprecationDate, setNextDeprecationDate} = await import('./deprecations-store.js')
+    vi.setSystemTime(new Date(2025, 0, 1))
+
+    const laterFutureDate = new Date(2025, 0, 20)
+    const earlierFutureDate = new Date(2025, 0, 10)
+
+    setNextDeprecationDate([laterFutureDate])
+    expect(getNextDeprecationDate()).toEqual(laterFutureDate)
+
+    setNextDeprecationDate([earlierFutureDate])
+    expect(getNextDeprecationDate()).toEqual(earlierFutureDate)
+  })
+
+  test('setNextDeprecationDate preserves existing date if new future date is later', async () => {
+    const {getNextDeprecationDate, setNextDeprecationDate} = await import('./deprecations-store.js')
+    vi.setSystemTime(new Date(2025, 0, 1))
+
+    const earlierFutureDate = new Date(2025, 0, 10)
+    const laterFutureDate = new Date(2025, 0, 20)
+
+    setNextDeprecationDate([earlierFutureDate])
+    expect(getNextDeprecationDate()).toEqual(earlierFutureDate)
+
+    setNextDeprecationDate([laterFutureDate])
+    expect(getNextDeprecationDate()).toEqual(earlierFutureDate)
+  })
+
+  test('setNextDeprecationDate selects earliest date when given multiple unsorted future dates', async () => {
+    const {getNextDeprecationDate, setNextDeprecationDate} = await import('./deprecations-store.js')
+    vi.setSystemTime(new Date(2025, 0, 1))
+
+    const futureDate1 = new Date(2025, 0, 30)
+    const futureDate2 = new Date(2025, 0, 10)
+    const futureDate3 = new Date(2025, 0, 20)
+
+    setNextDeprecationDate([futureDate1, futureDate2, futureDate3])
+
+    expect(getNextDeprecationDate()).toEqual(futureDate2)
+  })
+})


### PR DESCRIPTION
Adds unit test coverage for `deprecations-store.ts` in `packages/cli-kit/src/private/node/context/deprecations-store.test.ts`.

### What was done:
- Created `packages/cli-kit/src/private/node/context/deprecations-store.test.ts`.
- Added unit tests for `getNextDeprecationDate` and `setNextDeprecationDate`:
  - Verified default return value is `undefined`.
  - Verified empty date arrays do not set a deprecation date.
  - Verified past dates are filtered out and do not set a deprecation date.
  - Verified valid future dates set `nextDeprecationDate`.
  - Verified updating stored date when an earlier future date is provided.
  - Verified preserving stored date when a later future date is provided.
  - Verified selecting the earliest date when passed multiple unsorted future dates.
- Ensured strict test isolation using `vi.resetModules()` and dynamic imports in each test.

### How to test your changes?
CI

---
*PR created automatically by Jules for task [18068625877429882844](https://jules.google.com/task/18068625877429882844) started by @gonzaloriestra*