### PR TITLE
[Refactor] Simplify parseEnvNumber helper in environment module

### DIFF
--- a/packages/cli-kit/src/public/node/environment.ts
+++ b/packages/cli-kit/src/public/node/environment.ts
@@ -38,10 +38,9 @@ export function getOrganization(): string | undefined {
 }
 
 function parseEnvNumber(value: string | undefined): number | undefined {
-  if (value && !isNaN(Number(value))) {
-    return Number(value)
-  }
-  return undefined
+  if (!value) return undefined
+  const parsed = Number(value)
+  return Number.isNaN(parsed) ? undefined : parsed
 }
 
 /**


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #0000

In `packages/cli-kit/src/public/node/environment.ts`, `parseEnvNumber` called `Number(value)` twice whenever a valid numeric string was provided and used the legacy global `isNaN()` function instead of standard `Number.isNaN()`.

### WHAT is this pull request doing?

Refactors `parseEnvNumber` in `environment.ts` to:
- Early return `undefined` for empty/falsy inputs
- Compute `Number(value)` once
- Use standard `Number.isNaN` to check for invalid numbers

### How to manually test your changes?

CI

### Post-release steps

### Checklist

- [ ] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [ ] I've considered possible [documentation](https://shopify.dev) changes
- [ ] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

---
*PR created automatically by Jules for task [12271033484687374892](https://jules.google.com/task/12271033484687374892) started by @gonzaloriestra*