### PR TITLE
Use the latest Opus model in automation workflows

### DIFF
--- a/.github/workflows/gardener-investigate-issue.yml
+++ b/.github/workflows/gardener-investigate-issue.yml
@@ -70,7 +70,7 @@ jobs:
         timeout-minutes: 30
         uses: anthropics/claude-code-action@36a69b6a90b850823f86de06fdfd56264772ad98 # v1
         env:
-          ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
+          ANTHROPIC_BASE_URL: https://proxy.shopify.ai/vendors/anthropic-claude-code
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -86,6 +86,7 @@ jobs:
             Always return an investigation report as the `report` field in your structured output.
             If you identify a straightforward fix, describe the proposed fix in the report instead of implementing it.
           claude_args: |
+            --model claude-opus-4-8
             --json-schema '{"type":"object","properties":{"report":{"type":"string","description":"The full investigation report markdown"}},"required":["report"]}'
 
       - name: Write report to job summary

--- a/.github/workflows/gardener-investigate-issue.yml
+++ b/.github/workflows/gardener-investigate-issue.yml
@@ -70,7 +70,7 @@ jobs:
         timeout-minutes: 30
         uses: anthropics/claude-code-action@36a69b6a90b850823f86de06fdfd56264772ad98 # v1
         env:
-          ANTHROPIC_BASE_URL: https://proxy.shopify.ai/vendors/anthropic-claude-code
+          ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -86,7 +86,7 @@ jobs:
             Always return an investigation report as the `report` field in your structured output.
             If you identify a straightforward fix, describe the proposed fix in the report instead of implementing it.
           claude_args: |
-            --model claude-opus-4-8
+            --model claude-opus-latest
             --json-schema '{"type":"object","properties":{"report":{"type":"string","description":"The full investigation report markdown"}},"required":["report"]}'
 
       - name: Write report to job summary

--- a/.github/workflows/maintenance-prs.yml
+++ b/.github/workflows/maintenance-prs.yml
@@ -70,7 +70,7 @@ jobs:
         if: steps.schedule.outputs.run == 'true'
         uses: anthropics/claude-code-action@36a69b6a90b850823f86de06fdfd56264772ad98 # v1
         env:
-          ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
+          ANTHROPIC_BASE_URL: https://proxy.shopify.ai/vendors/anthropic-claude-code
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CLAUDE_BRANCH: ${{ env.MAINTENANCE_BRANCH }}
         with:
@@ -99,6 +99,7 @@ jobs:
             Keep duplicate-check notes out of the PR body and all template checkboxes unchecked.
             Do not post to Slack; the workflow will announce the PR after it exists.
           claude_args: |
+            --model claude-opus-4-8
             --allowedTools Read,Glob,Grep,Edit,Write,Bash
 
       - name: Find the created PR

--- a/.github/workflows/maintenance-prs.yml
+++ b/.github/workflows/maintenance-prs.yml
@@ -70,7 +70,7 @@ jobs:
         if: steps.schedule.outputs.run == 'true'
         uses: anthropics/claude-code-action@36a69b6a90b850823f86de06fdfd56264772ad98 # v1
         env:
-          ANTHROPIC_BASE_URL: https://proxy.shopify.ai/vendors/anthropic-claude-code
+          ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CLAUDE_BRANCH: ${{ env.MAINTENANCE_BRANCH }}
         with:
@@ -99,7 +99,7 @@ jobs:
             Keep duplicate-check notes out of the PR body and all template checkboxes unchecked.
             Do not post to Slack; the workflow will announce the PR after it exists.
           claude_args: |
-            --model claude-opus-4-8
+            --model claude-opus-latest
             --allowedTools Read,Glob,Grep,Edit,Write,Bash
 
       - name: Find the created PR


### PR DESCRIPTION
### WHY are these changes introduced?

Continuation of https://github.com/Shopify/cli/pull/8509.

The [first run](https://github.com/Shopify/cli/actions/runs/34459626137/job/102814092018) failed before making changes because Claude selected `claude-opus-4-8[1m]`, which the endpoint reported as unavailable or inaccessible.

### WHAT is this pull request doing?

Uses the `claude-opus-latest` alias in the maintenance and issue-investigation workflows, keeping the existing proxy URL and API key secrets.

### How to manually test your changes?

After merge, start a new **maintenance-prs → Run workflow** run and confirm Claude gets past model initialization. Start an issue investigation to confirm the same configuration works there.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`

