### PR TITLE
Fix scheduled maintenance runs

### DIFF
--- a/.github/workflows/maintenance-prs.yml
+++ b/.github/workflows/maintenance-prs.yml
@@ -3,8 +3,8 @@ name: maintenance-prs
 on:
   workflow_dispatch:
   schedule:
-    # Everyday at 00:00 UTC
-    - cron: '0 0 * * *'
+    # Monday–Friday at 00:00 UTC
+    - cron: '0 0 * * 1-5'
 
 permissions:
   contents: write
@@ -76,6 +76,8 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          # Scheduled runs can inherit the merge queue bot as their actor.
+          allowed_bots: github-merge-queue
           bot_name: 'github-actions[bot]'
           bot_id: '41898282'
           prompt: |
@@ -128,7 +130,7 @@ jobs:
 
             core.setOutput('payload', JSON.stringify({
               channel: 'C0ARV62K59C', // #devtools-gardener-backlog
-              text: `Maintenance PR (${process.env.MAINTENANCE_TASK}): <${pullRequest.html_url}|${pullRequestTitle}>`,
+              text: `Maintenance PR: <${pullRequest.html_url}|${pullRequestTitle}>`,
               unfurl_links: false,
               unfurl_media: false,
             }));


### PR DESCRIPTION
### WHY are these changes introduced?

Related to https://github.com/Shopify/cli/pull/8509

[Scheduled maintenance](https://github.com/Shopify/cli/actions/runs/34547830363/job/103104159397) fails before Claude starts because the run's actor is `github-merge-queue`, which the action rejects by default. Manual runs pass this check with a human actor.

### WHAT is this pull request doing?

Allow the merge queue bot to run maintenance tasks and schedule them Monday–Friday at 00:00 UTC.

### Checklist

- [x] I've considered possible cross-platform impacts (Mac, Linux, Windows)
- [x] I've considered possible [documentation](https://shopify.dev) changes
- [x] I've considered analytics changes to measure impact
- [ ] The change is user-facing — I've identified the correct [bump type](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#choosing-the-right-bump-type) (`patch` for bug fixes · `minor` for new features · `major` for [breaking changes](https://github.com/Shopify/cli/blob/main/CONTRIBUTING.md#what-counts-as-a-breaking-change)) and added a changeset with `pnpm changeset add`
